### PR TITLE
Make images work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ RM := --rm
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-GO_FLAGS := -ldflags "-extldflags \"-static\" -linkmode=external -s -w" -tags netgo -i
+GO_FLAGS := -ldflags "-extldflags \"-static\" -s -w" -tags netgo -i
 NETGO_CHECK = @strings $@ | grep cgo_stub\\\.go >/dev/null || { \
        rm $@; \
        echo "\nYour go standard library was built without the 'netgo' build tag."; \


### PR DESCRIPTION
No clue what the flag is and what fixed it.

With `-linkmode=external`, this is printed while building the image
```
# github.com/grafana/loki/cmd/loki
loadinternal: cannot find runtime/cgo
```

When you try to run the image there is a coredump, see
```
```➜  loki git:(master) ✗ strace ./cmd/loki/loki
execve("./cmd/loki/loki", ["./cmd/loki/loki"], 0x7ffe400edb30 /* 36 vars */) = 0
arch_prctl(0x3001 /* ARCH_??? */, 0x7ffef5e69200) = -1 EINVAL (Invalid argument)
brk(NULL)                               = 0x3140000
brk(0x31411c0)                          = 0x31411c0
arch_prctl(ARCH_SET_FS, 0x3140880)      = 0
uname({sysname="Linux", nodename="nomad", ...}) = 0
readlink("/proc/self/exe", "/home/goutham/go/src/github.com/"..., 4096) = 58
brk(0x31621c0)                          = 0x31621c0
brk(0x3163000)                          = 0x3163000
arch_prctl(ARCH_SET_FS, 0x12012b0)      = 0
--- SIGTRAP {si_signo=SIGTRAP, si_code=SI_KERNEL} ---
+++ killed by SIGTRAP (core dumped) +++
[1]    14848 trace trap (core dumped)  strace ./cmd/loki/loki```
```

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>