### PR TITLE
Make binaries actually static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ $(EXES) $(PROTO_GOS) $(YACC_GOS) lint test shell check-generated-files: loki-bui
 else
 
 $(EXES): loki-build-image/$(UPTODATE)
-	go build $(GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
 %.pb.go: loki-build-image/$(UPTODATE)


### PR DESCRIPTION
https://github.com/grafana/loki/pull/49 broke promtail with
`standard_init_linux.go:178: exec user process caused "no such file or directory"`

From https://medium.com/@diogok/on-golang-static-binaries-cross-compiling-and-plugins-1aed33499671
CGO_ENABLED=0 makes it static, afaics

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>