### PR TITLE
removes design doc from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loki: Like Prometheus, but for logs.
 
-[![CircleCI](https://circleci.com/gh/grafana/loki/tree/master.svg?style=svg&circle-token=618193e5787b2951c1ea3352ad5f254f4f52313d)](https://circleci.com/gh/grafana/loki/tree/master) [Design doc](https://docs.google.com/document/d/11tjK_lvp1-SVsFZjgOTr1vV3-q6vBAsZYIQ5ZeYBkyM/edit)
+[![CircleCI](https://circleci.com/gh/grafana/loki/tree/master.svg?style=svg&circle-token=618193e5787b2951c1ea3352ad5f254f4f52313d)](https://circleci.com/gh/grafana/loki/tree/master) 
 
 Loki is a horizontally-scalable, highly-available, multi-tenant, log aggregation
 system inspired by Prometheus.  It is designed to be very cost effective, as it does


### PR DESCRIPTION
the design doc contains none public information, rather than cleaning it up
I suggest we remove it from the readme.