### PR TITLE
Use image tagged with master in docker-compose.yaml

### DIFF
--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:master-8fa9461
+    image: grafana/loki:master
     ports:
       - "3100:3100"
     volumes:


### PR DESCRIPTION
This pull request makes the image used in the `docker-compose.yaml` the same as the one used in the `README.md`. The currently used loki image in the `docker-compose.yaml` makes the service crash.