### PR TITLE
When running inside a container, use promtail-docker-config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To test locally using `docker run`:
 
 3. Then start the Promtail agent. The default config polls the contents of your `/var/log` directory.
     ```bash
-    docker run --name promtail --network=loki --volume "$PWD/docs:/etc/promtail" --volume "/var/log:/var/log" grafana/promtail:master -config.file=/etc/promtail/promtail-local-config.yaml
+    docker run --name promtail --network=loki --volume "$PWD/docs:/etc/promtail" --volume "/var/log:/var/log" grafana/promtail:master -config.file=/etc/promtail/promtail-docker-config.yaml
     ```
 
 4. If you also want to run Grafana in docker:


### PR DESCRIPTION
This uses the loki DNS name within the configuration. Otherwise, it attempts to call on localhost.

Signed-off-by: Ben Hall <ben@benhall.me.uk>