### PR TITLE
Updated README to mention the required go version for build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Example queries:
 
 Loki can be run in a single host, no-dependencies mode using the following commands.
 
+You need `go` v1.10+
+
 ```bash
 $ go build ./cmd/loki
 $ ./loki -config.file=./docs/loki-local-config.yaml


### PR DESCRIPTION
Go 1.10+ version is required. I was trying to build using 1.9 and it failed with below error
`# github.com/grafana/loki/vendor/github.com/cortexproject/cortex/pkg/chunk/aws
vendor/github.com/cortexproject/cortex/pkg/chunk/aws/dynamodb_storage_client.go:691:9: undefined: strings.Builder`

string.Builder is available only after 1.10 version.