### PR TITLE
Switch README example datasource to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ apiVersion: 1
 
 datasources:
   - name: Loki
-    type: loki
+    type: logging
     access: proxy
     url: http://localhost:3100
     editable: false
@@ -183,7 +183,7 @@ apiVersion: 1
 
 datasources:
   - name: Loki
-    type: loki
+    type: logging
     access: proxy
     url: http://localhost:3100
     editable: false


### PR DESCRIPTION
The type used for "Grafana Logs"  in the latest version appears to be "logger" rather than "loki" for provisioning templates - this PR corrects the example to a working one. 
Please ignore/close if non applicable & Thanks for Loki!

```
- name: Loki
  type: logging
  access: proxy
  url: http://loki:3100
  editable: true
```