### PR TITLE
Don't push docker images on forks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ workflows:
         - test
         - build
         - lint
+        filters:
+          branches:
+            only: master
     - publish-master:
         requires:
         - test
@@ -103,8 +106,10 @@ jobs:
       - run:
           name: Push Images
           command: |
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-            make push-images
+            if [ -n "$DOCKER_USER" ]; then
+              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
+              make push-images
+            fi
 
   publish-master:
     <<: *defaults


### PR DESCRIPTION
Should allow CI to pass for other contributors.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>