### PR TITLE
Build binaries with default users.

### DIFF
--- a/loki-build-image/build.sh
+++ b/loki-build-image/build.sh
@@ -14,4 +14,4 @@ echo "grafana:x:$uid:$gid::$SRC_PATH:/bin/bash" >>/etc/passwd
 echo "grafana:*:::::::" >>/etc/shadow
 echo "grafana	ALL=(ALL)	NOPASSWD: ALL" >>/etc/sudoers
 
-su grafana -c "PATH=$PATH make -C $SRC_PATH BUILD_IN_CONTAINER=false $*"
+make -C $SRC_PATH BUILD_IN_CONTAINER=false $*


### PR DESCRIPTION
Any reason why we build them with the grafana user? 

This fixes https://github.com/grafana/loki/issues/42