### PR TITLE
Rename instance to tenant to avoid clash with Prom

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -34,13 +34,13 @@ var (
 	bytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "distributor_bytes_received_total",
-		Help:      "The total number of uncompressed bytes received per instance",
-	}, []string{"instance"})
+		Help:      "The total number of uncompressed bytes received per tenant",
+	}, []string{"tenant"})
 	linesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "distributor_lines_received_total",
-		Help:      "The total number of lines received per instance",
-	}, []string{"instance"})
+		Help:      "The total number of lines received per tenant",
+	}, []string{"tenant"})
 )
 
 // Config for a Distributor.

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -32,13 +32,13 @@ var (
 	streamsCreatedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "ingester_streams_created_total",
-		Help:      "The total number of streams created per instance in the ingester.",
-	}, []string{"instance"})
+		Help:      "The total number of streams created per tenant.",
+	}, []string{"tenant"})
 	streamsRemovedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "ingester_streams_removed_total",
-		Help:      "The total number of streams removed per instance by the ingester.",
-	}, []string{"instance"})
+		Help:      "The total number of streams removed per tenant.",
+	}, []string{"tenant"})
 )
 
 type instance struct {


### PR DESCRIPTION
The label clashes with the Prometheus instance label.