### PR TITLE
Adds build info to loki and promtail in logs and metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -698,13 +698,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b799e9ea3170ff5e789dd1eabf918bfa0c2b128f45018cd755eb1dc3389ab988"
+  digest = "1:0e732cbc80b0781f353137dfcf8813a470c5049a99bf96d8a3b32d0feda96423"
   name = "github.com/prometheus/common"
   packages = [
     "config",
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
     "model",
+    "version",
   ]
   pruneopts = "UT"
   revision = "aeab699e26f4d4089dba5e522e5d9babd2adbaf7"
@@ -1312,6 +1313,7 @@
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/prometheus/common/model",
+    "github.com/prometheus/common/version",
     "github.com/prometheus/prometheus/config",
     "github.com/prometheus/prometheus/discovery",
     "github.com/prometheus/prometheus/discovery/config",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,3 +67,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/prometheus/common"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 IMAGE_PREFIX ?= grafana/
 IMAGE_TAG := $(shell ./tools/image-tag)
 UPTODATE := .uptodate
+GIT_REVISION := $(shell git rev-parse --short HEAD)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
 
 # Building Docker images is now automated. The convention is every directory
 # with a Dockerfile in it builds an image calls quay.io/grafana/loki-<dirname>.
@@ -78,7 +81,10 @@ RM := --rm
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-GO_FLAGS := -ldflags "-extldflags \"-static\" -s -w" -tags netgo
+
+VPREFIX := github.com/grafana/loki/vendor/github.com/prometheus/common/version
+GO_FLAGS := -ldflags "-extldflags \"-static\" -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION)" -tags netgo
+
 NETGO_CHECK = @strings $@ | grep cgo_stub\\\.go >/dev/null || { \
        rm $@; \
        echo "\nYour go standard library was built without the 'netgo' build tag."; \

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -7,10 +7,16 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/loki"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
+
+func init() {
+	prometheus.MustRegister(version.NewCollector("loki"))
+}
 
 func main() {
 	var (
@@ -35,6 +41,8 @@ func main() {
 		level.Error(util.Logger).Log("msg", "error initialising loki", "err", err)
 		os.Exit(1)
 	}
+
+	level.Info(util.Logger).Log("msg", "Starting Loki", "version", version.Info())
 
 	if err := t.Run(); err != nil {
 		level.Error(util.Logger).Log("msg", "error running loki", "err", err)

--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -12,6 +14,10 @@ import (
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/promtail"
 )
+
+func init() {
+	prometheus.MustRegister(version.NewCollector("promtail"))
+}
 
 func main() {
 	var (
@@ -36,6 +42,8 @@ func main() {
 		level.Error(util.Logger).Log("msg", "error creating loki", "error", err)
 		os.Exit(1)
 	}
+
+	level.Info(util.Logger).Log("msg", "Starting Promtail", "version", version.Info())
 
 	if err := p.Run(); err != nil {
 		level.Error(util.Logger).Log("msg", "error starting loki", "error", err)

--- a/vendor/github.com/prometheus/common/version/info.go
+++ b/vendor/github.com/prometheus/common/version/info.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+	GoVersion = runtime.Version()
+)
+
+// NewCollector returns a collector which exports metrics about current version information.
+func NewCollector(program string) *prometheus.GaugeVec {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: program,
+			Name:      "build_info",
+			Help: fmt.Sprintf(
+				"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
+				program,
+			),
+		},
+		[]string{"version", "revision", "branch", "goversion"},
+	)
+	buildInfo.WithLabelValues(Version, Revision, Branch, GoVersion).Set(1)
+	return buildInfo
+}
+
+// versionInfoTmpl contains the template used by Info.
+var versionInfoTmpl = `
+{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
+  build user:       {{.buildUser}}
+  build date:       {{.buildDate}}
+  go version:       {{.goVersion}}
+`
+
+// Print returns version information.
+func Print(program string) string {
+	m := map[string]string{
+		"program":   program,
+		"version":   Version,
+		"revision":  Revision,
+		"branch":    Branch,
+		"buildUser": BuildUser,
+		"buildDate": BuildDate,
+		"goVersion": GoVersion,
+	}
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", m); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// Info returns version, branch and revision information.
+func Info() string {
+	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, Revision)
+}
+
+// BuildContext returns goVersion, buildUser and buildDate information.
+func BuildContext() string {
+	return fmt.Sprintf("(go=%s, user=%s, date=%s)", GoVersion, BuildUser, BuildDate)
+}


### PR DESCRIPTION
During start 
```
level=info ts=2018-12-19T15:45:33.495594953Z caller=main.go:45 msg="Starting Loki" version="(version=build_info_metrics-e864cd1, branch=build_info_metrics, revision=e864cd1)"
```

New metrics 
```
# HELP loki_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which loki was built.
# TYPE loki_build_info gauge
loki_build_info{branch="build_info_metrics",goversion="go1.11.2",revision="e864cd1",version="build_info_metrics-e864cd1"} 1
```

I think this will become more useful once we start cutting releases.