### PR TITLE
Fixed the promtail Helm Template - DaemonSet doesn't support replicas and strategy statement 

### DIFF
--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -16,11 +16,6 @@ spec:
     matchLabels:
       app: {{ template "promtail.name" . }}
       release: {{ .Release.Name }}
-  strategy:
-    type: {{ .Values.promtail.deploymentStrategy }}
-  {{- if ne .Values.promtail.deploymentStrategy "RollingUpdate" }}
-    rollingUpdate: null
-  {{- end }}
   template:
     metadata:
       labels:

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -12,7 +12,6 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: {{ .Values.promtail.replicas }}
   selector:
     matchLabels:
       app: {{ template "promtail.name" . }}


### PR DESCRIPTION

```
helm template . --name loki -f values.yaml > loki.yml
k create -f loki.yml --dry-run=true                                                                                                                                                                                                                        
configmap "loki" created (dry run)
configmap "loki-promtail" created (dry run)
serviceaccount "loki" created (dry run)
serviceaccount "loki-promtail" created (dry run)
clusterrole.rbac.authorization.k8s.io "loki-promtail-clusterrole" created (dry run)
clusterrolebinding.rbac.authorization.k8s.io "loki-promtail-clusterrolebinding" created (dry run)
role.rbac.authorization.k8s.io "loki" created (dry run)
role.rbac.authorization.k8s.io "loki-promtail" created (dry run)
rolebinding.rbac.authorization.k8s.io "loki" created (dry run)
rolebinding.rbac.authorization.k8s.io "loki-promtail" created (dry run)
service "loki" created (dry run)
error: error validating "loki.yml": error validating data: [ValidationError(DaemonSet.spec): unknown field "replicas" in io.k8s.api.extensions.v1beta1.DaemonSetSpec, ValidationError(DaemonSet.spec): unknown field "strategy" in io.k8s.api.extensions.v1beta1.DaemonSetSpec]; if you choose to ignore these errors, turn validation off with --validate=false
```
```
k create -f loki.yml --dry-run=true                                                                                                                                                                                                                        [15:55:38]
configmap "loki" created (dry run)
configmap "loki-promtail" created (dry run)
serviceaccount "loki" created (dry run)
serviceaccount "loki-promtail" created (dry run)
clusterrole.rbac.authorization.k8s.io "loki-promtail-clusterrole" created (dry run)
clusterrolebinding.rbac.authorization.k8s.io "loki-promtail-clusterrolebinding" created (dry run)
role.rbac.authorization.k8s.io "loki" created (dry run)
role.rbac.authorization.k8s.io "loki-promtail" created (dry run)
rolebinding.rbac.authorization.k8s.io "loki" created (dry run)
rolebinding.rbac.authorization.k8s.io "loki-promtail" created (dry run)
service "loki" created (dry run)
error: error validating "loki.yml": error validating data: ValidationError(DaemonSet.spec): unknown field "strategy" in io.k8s.api.extensions.v1beta1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

Removing ```replicas``` and ```strategy``` statement from the daemonset.yaml , the kubectl create command works good!