### PR TITLE
deploy promtail on master node as default

### DIFF
--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -122,7 +122,10 @@ promtail:
   ## Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations: []
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
It is better to monitor master node in k8s cluster as default.

Signed-off-by: Xiang Dai <764524258@qq.com>