### PR TITLE
add readLines metric

### DIFF
--- a/cmd/promtail/promtail-docker-config.yaml
+++ b/cmd/promtail/promtail-docker-config.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 0
+  http_listen_port: 9080
   grpc_listen_port: 0
 
 positions:

--- a/cmd/promtail/promtail-local-config.yaml
+++ b/cmd/promtail/promtail-local-config.yaml
@@ -1,5 +1,5 @@
 server:
-  http_listen_port: 0
+  http_listen_port: 9080
   grpc_listen_port: 0
 
 positions:

--- a/pkg/promtail/target.go
+++ b/pkg/promtail/target.go
@@ -22,6 +22,12 @@ var (
 		Name:      "read_bytes_total",
 		Help:      "Number of bytes read.",
 	}, []string{"path"})
+
+	readLines = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "read_lines_total",
+		Help:      "Number of lines read.",
+	}, []string{"path"})
 )
 
 const (
@@ -30,6 +36,7 @@ const (
 
 func init() {
 	prometheus.MustRegister(readBytes)
+	prometheus.MustRegister(readLines)
 }
 
 // Target describes a particular set of logs.
@@ -204,6 +211,7 @@ func (t *tailer) run() {
 				level.Error(t.logger).Log("msg", "error reading line", "error", line.Err)
 			}
 
+			readLines.WithLabelValues(t.path).Inc()
 			readBytes.WithLabelValues(t.path).Add(float64(len(line.Text)))
 			if err := t.handler.Handle(model.LabelSet{}, line.Time, line.Text); err != nil {
 				level.Error(t.logger).Log("msg", "error handling line", "error", err)


### PR DESCRIPTION
Add a metric readLines to present the number of the line read by log tailer. 
But it's kind of confused which metric type is better. Counter or Gauge? 
And I change the default http port from 0 to 9080 in promtail to expose the metrics