### PR TITLE
Added call to StrorageConfig.RegisterFlags

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -50,6 +50,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Querier.RegisterFlags(f)
 	c.IngesterClient.RegisterFlags(f)
 	c.Ingester.RegisterFlags(f)
+	c.StorageConfig.RegisterFlags(f)
 	c.ChunkStoreConfig.RegisterFlags(f)
 	c.SchemaConfig.RegisterFlags(f)
 	c.LimitsConfig.RegisterFlags(f)


### PR DESCRIPTION
Added a call to StrorageConfig.RegisterFlags, in main.go for Loki. This sets sensible defaults for storage options, such as the backoff/retry settings for DyanmoDB. Without it the default is undefined and leads to panic errors when DynamoDB throttles index write flushes.