### PR TITLE
Add an URL to the third party client library to the docs (fixes #220)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,7 @@ There are 4 API endpoints:
 
   - [ProtoBuffer definition](/pkg/logproto/logproto.proto)
   - [Golang client library](/pkg/promtail/client.go)
+  - [Third party client library](https://github.com/afiskon/promtail-client)
 
   Also accepts JSON formatted requests when the header `Content-Type: application/json` is sent.  Example of the JSON format:
 


### PR DESCRIPTION
I believe that the Golang library recommended in the documentation is currently not quite in the working condition, see https://github.com/grafana/loki/issues/220. Since we needed a client library "yesterday", and there is no information regarding whether this issue is going to be fixed, I've implemented a third party library that has no vendored packages, which caused the issue in the first place.

Proposed patch adds a link to this library to the documentation in case someone will be looking for an existing client implementations.