### PR TITLE
add container_name label to logs

### DIFF
--- a/production/helm/templates/promtail/configmap.yaml
+++ b/production/helm/templates/promtail/configmap.yaml
@@ -36,6 +36,12 @@ data:
           source_labels:
           - __meta_kubernetes_pod_name
           target_label: instance
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_container_name
+          target_label: container_name
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
         - replacement: /var/log/pods/$1/0.log
           separator: /
           source_labels:
@@ -68,6 +74,10 @@ data:
           source_labels:
           - __meta_kubernetes_pod_name
           target_label: instance
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_container_name
+          target_label: container_name
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - replacement: /var/log/pods/$1/0.log

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -82,6 +82,19 @@ k {
             target_label: 'instance',
           },
 
+          // Include container_name label
+          {
+            source_labels: ['__meta_kubernetes_container_name'],
+            action: 'replace',
+            target_label: 'container_name',
+          },
+
+          // Also include all the other labels on the pod.
+          {
+            action: 'labelmap',
+            regex: '__meta_kubernetes_pod_label_(.+)',
+          },
+
           // Kubernetes puts logs under subdirectories keyed pod UID and container_name.
           {
             source_labels: ['__meta_kubernetes_pod_uid', '__meta_kubernetes_pod_container_name'],
@@ -133,6 +146,13 @@ k {
             source_labels: ['__meta_kubernetes_pod_name'],
             action: 'replace',
             target_label: 'instance',
+          },
+
+          // Include container_name label
+          {
+            source_labels: ['__meta_kubernetes_container_name'],
+            action: 'replace',
+            target_label: 'container_name',
           },
 
           // Also include all the other labels on the pod.

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -42,6 +42,12 @@ data:
         source_labels:
         - __meta_kubernetes_pod_name
         target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_container_name
+        target_label: container_name
+      - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/$1
         separator: /
         source_labels:
@@ -74,6 +80,10 @@ data:
         source_labels:
         - __meta_kubernetes_pod_name
         target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_container_name
+        target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/$1


### PR DESCRIPTION
fixes #190
Pods can have multiple containers. This fix ensures that we collect
logs for all containers.