### PR TITLE
added option to enable/disable promtail component

### DIFF
--- a/production/helm/Chart.yaml
+++ b/production/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/templates/promtail/clusterrole.yaml
+++ b/production/helm/templates/promtail/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.promtail.enabled .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/production/helm/templates/promtail/clusterrolebinding.yaml
+++ b/production/helm/templates/promtail/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.promtail.enabled .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/production/helm/templates/promtail/configmap.yaml
+++ b/production/helm/templates/promtail/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.promtail.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,3 +91,4 @@ data:
           - __meta_kubernetes_pod_uid
           - __meta_kubernetes_pod_container_name
           target_label: __path__
+{{- end -}}

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.promtail.enabled -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -95,3 +96,4 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+{{- end -}}

--- a/production/helm/templates/promtail/podsecuritypolicy.yaml
+++ b/production/helm/templates/promtail/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.promtail.enabled .Values.rbac.pspEnabled }}
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -27,4 +27,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
-  {{- end }}
+{{- end }}

--- a/production/helm/templates/promtail/role.yaml
+++ b/production/helm/templates/promtail/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.promtail.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/production/helm/templates/promtail/rolebinding.yaml
+++ b/production/helm/templates/promtail/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.promtail.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -94,6 +94,7 @@ loki:
         directory: /data/loki/chunks
 
 promtail:
+  enabled: true
   nameOverride: promtail
   deploymentStrategy: RollingUpdate
 


### PR DESCRIPTION
With the addition of the fluent-plugin-loki it is no longer mandatory to deploy promtail. With loki.enabled and promtail.enabled you can now disable deploying both loki and promtail to your k8s cluster. 