### PR TITLE
helm: add data root option

### DIFF
--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -47,8 +47,8 @@ spec:
               mountPath: /etc/promtail
             - name: varlog
               mountPath: /var/log
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
+            - name: dockercontainers
+              mountPath: {{ .Values.promtail.dataRoot }}/containers
               readOnly: true
           env:
           - name: HOSTNAME
@@ -92,6 +92,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: varlibdockercontainers
+        - name: dockercontainers
           hostPath:
-            path: /var/lib/docker/containers
+            path: {{ .Values.promtail.dataRoot }}/containers

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -99,6 +99,8 @@ promtail:
 
   entryParser: docker
 
+  dataRoot: /var/lib/docker
+
   image:
     repository: grafana/promtail
     tag: master


### PR DESCRIPTION
If custom docker data root, promtail can not add target as expected.

Signed-off-by: Xiang Dai <764524258@qq.com>