### PR TITLE
set __path__ correctly in promtail config

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -48,7 +48,7 @@ data:
         target_label: container_name
       - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1
+      - replacement: /var/log/pods/$1/0.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid
@@ -86,7 +86,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1
+      - replacement: /var/log/pods/$1/0.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid


### PR DESCRIPTION
__path__ is now expected to be a `glob` match, not a directory.  In k8s the "glob" expression needed is just the exact file path of the container log, which is `/var/log/pods/<podUID>/<container_name>/0.log`