### PR TITLE
removing incorrect calling of positions.Stop from within a target as …

### DIFF
--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -52,5 +52,6 @@ func (p *Promtail) Run() error {
 func (p *Promtail) Shutdown() {
 	p.server.Shutdown()
 	p.targetManager.Stop()
+	p.positions.Stop()
 	p.client.Stop()
 }

--- a/pkg/promtail/target.go
+++ b/pkg/promtail/target.go
@@ -136,10 +136,9 @@ func (t *Target) run() {
 	defer func() {
 		helpers.LogError("closing watcher", t.watcher.Close)
 		for _, v := range t.tails {
+			helpers.LogError("updating tailer last position", v.markPosition)
 			helpers.LogError("stopping tailer", v.stop)
 		}
-		//Save positions
-		t.positions.Stop()
 		level.Debug(t.logger).Log("msg", "watcher closed, tailer stopped, positions saved")
 		close(t.done)
 	}()

--- a/pkg/promtail/target_test.go
+++ b/pkg/promtail/target_test.go
@@ -69,6 +69,7 @@ func TestLongSyncDelayStillSavesCorrectPosition(t *testing.T) {
 	}
 
 	target.Stop()
+	positions.Stop()
 
 	buf, err := ioutil.ReadFile(filepath.Clean(positionsFileName))
 	if err != nil {
@@ -161,6 +162,7 @@ func TestWatchEntireDirectory(t *testing.T) {
 	}
 
 	target.Stop()
+	positions.Stop()
 
 	buf, err := ioutil.ReadFile(filepath.Clean(positionsFileName))
 	if err != nil {
@@ -269,6 +271,7 @@ func TestFileRolls(t *testing.T) {
 	}
 
 	target.Stop()
+	positions.Stop()
 
 	if len(client.messages) != 20 {
 		t.Error("Handler did not receive the correct number of messages, expected 20 received", len(client.messages))
@@ -339,6 +342,7 @@ func TestResumesWhereLeftOff(t *testing.T) {
 	}
 
 	target.Stop()
+	positions.Stop()
 
 	// Create another positions (so that it loads from the previously saved positions file).
 	positions2, err := NewPositions(logger, PositionsConfig{
@@ -367,6 +371,7 @@ func TestResumesWhereLeftOff(t *testing.T) {
 	}
 
 	target2.Stop()
+	positions2.Stop()
 
 	if len(client.messages) != 20 {
 		t.Error("Handler did not receive the correct number of messages, expected 20 received", len(client.messages))
@@ -449,6 +454,7 @@ func TestGlobWithMultipleFiles(t *testing.T) {
 	}
 
 	target.Stop()
+	positions.Stop()
 
 	buf, err := ioutil.ReadFile(filepath.Clean(positionsFileName))
 	if err != nil {


### PR DESCRIPTION
This should fix #249 

Instead of calling Stop() on the positions (which is a singleton instance for promtail) within an individual target shutdown, the Stop() method has been moved to the promtail Shutdown method