### PR TITLE
Fixed inline YAML indentation for promtail

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -47,7 +47,7 @@ data:
         - __meta_kubernetes_container_name
         target_label: container_name
       - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
+        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/$1/0.log
         separator: /
         source_labels:


### PR DESCRIPTION
This PR resolves #254 by fixing the indentation of the `promtail.sh` YAML that causes a linting error upon the pod's creation.

![promtail error](https://user-images.githubusercontent.com/7495133/51956880-5d51cb00-2417-11e9-919b-7a1f08ff8a89.png)