### PR TITLE
Makefile: skip check vendor lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ $(EXES): loki-build-image/$(UPTODATE)
 	goyacc -p $(basename $(notdir $<)) -o $@ $<
 
 lint: loki-build-image/$(UPTODATE)
-	gometalinter ./...
+	gometalinter --vendor ./...
 
 check-generated-files: loki-build-image/$(UPTODATE) yacc protos
 	@git diff-files || (echo "changed files; failing check" && exit 1)


### PR DESCRIPTION
--vendor                 Enable vendoring support (skips 'vendor' directories and sets GO15VENDOREXPERIMENT=1).

Signed-off-by: Xiang Dai <764524258@qq.com>