### PR TITLE
Add fluent-plugin-kubernetes_metadata_filter in fluentd plugin

### DIFF
--- a/fluentd/fluent-plugin-loki/docker/Gemfile
+++ b/fluentd/fluent-plugin-loki/docker/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'fluent-plugin-systemd', '~> 1.0.1'
+gem 'fluent-plugin-kubernetes_metadata_filter', '~> 0.7.0'
 gem 'fluentd', '1.3.2'


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

This add [fluent-plugin-kubernetes_metadata_filter](https://rubygems.org/gems/fluent-plugin-kubernetes_metadata_filter/versions/0.7.0) to be able to use the plugin on kubernetes.