### PR TITLE
start and stop modules in correct order

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -70,15 +70,12 @@ type Loki struct {
 	store       chunk.Store
 
 	httpAuthMiddleware middleware.Interface
-
-	inited map[moduleName]struct{}
 }
 
 // New makes a new Loki.
 func New(cfg Config) (*Loki, error) {
 	loki := &Loki{
-		cfg:    cfg,
-		inited: map[moduleName]struct{}{},
+		cfg: cfg,
 	}
 
 	loki.setupAuthMiddleware()
@@ -128,8 +125,6 @@ func (t *Loki) initModule(m moduleName) error {
 			return errors.Wrap(err, fmt.Sprintf("error initialising module: %s", m))
 		}
 	}
-
-	t.inited[m] = struct{}{}
 	return nil
 }
 
@@ -161,5 +156,4 @@ func (t *Loki) stopModule(m moduleName) {
 			level.Error(util.Logger).Log("msg", "error stopping", "module", m, "err", err)
 		}
 	}
-	delete(t.inited, m)
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -112,7 +112,7 @@ func (t *Loki) setupAuthMiddleware() {
 
 func (t *Loki) init(m moduleName) error {
 	// initialize all of our dependencies first
-	for _, dep := range getDeps(m) {
+	for _, dep := range orderedDeps(m) {
 		if err := t.initModule(dep); err != nil {
 			return err
 		}
@@ -122,10 +122,6 @@ func (t *Loki) init(m moduleName) error {
 }
 
 func (t *Loki) initModule(m moduleName) error {
-	if _, ok := t.inited[m]; ok {
-		return nil
-	}
-
 	level.Info(util.Logger).Log("msg", "initialising", "module", m)
 	if modules[m].init != nil {
 		if err := modules[m].init(t); err != nil {
@@ -151,7 +147,7 @@ func (t *Loki) Stop() error {
 
 func (t *Loki) stop(m moduleName) {
 	t.stopModule(m)
-	deps := getDeps(m)
+	deps := orderedDeps(m)
 	// iterate over our deps in reverse order and call stopModule
 	for i := len(deps) - 1; i >= 0; i-- {
 		t.stopModule(deps[i])
@@ -159,9 +155,6 @@ func (t *Loki) stop(m moduleName) {
 }
 
 func (t *Loki) stopModule(m moduleName) {
-	if _, ok := t.inited[m]; !ok {
-		return
-	}
 	level.Info(util.Logger).Log("msg", "stopping", "module", m)
 	if modules[m].stop != nil {
 		if err := modules[m].stop(t); err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -197,7 +197,7 @@ func orderedDeps(m moduleName) []moduleName {
 		uniq[dep] = false
 	}
 
-	result := make([]moduleName, 0)
+	result := make([]moduleName, 0, len(uniq))
 
 	// keep looping through all modules until they have all been added to the result.
 

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestGetDeps(t *testing.T) {
 	for _, m := range []moduleName{All, Distributor, Ingester, Querier} {
-		deps := getDeps(m)
+		deps := orderedDeps(m)
 		seen := make(map[moduleName]struct{})
 		// make sure that getDeps always orders dependencies correctly.
 		for _, d := range deps {

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -1,0 +1,21 @@
+package loki
+
+import (
+	"testing"
+)
+
+func TestGetDeps(t *testing.T) {
+	for _, m := range []moduleName{All, Distributor, Ingester, Querier} {
+		deps := getDeps(m)
+		seen := make(map[moduleName]struct{})
+		// make sure that getDeps always orders dependencies correctly.
+		for _, d := range deps {
+			seen[d] = struct{}{}
+			for _, dep := range modules[d].deps {
+				if _, ok := seen[dep]; !ok {
+					t.Errorf("module %s has dependency %s which has not been seen.", d, dep)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When starting up, start all dependencies first then start the target
module.  When stopping, reverse the order to ensure we dont try and
stop a module while there is still something running that needs it.

fixes #105