### PR TITLE
Switch docker base image to alpine 3.9

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,5 +1,5 @@
-FROM       alpine:3.4
-RUN        apk add --update --no-cache ca-certificates && rm /var/cache/apk/*
+FROM       alpine:3.9
+RUN        apk add --update --no-cache ca-certificates
 COPY       loki /bin/loki
 COPY       loki-local-config.yaml /etc/loki/local-config.yaml
 EXPOSE     80

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,5 +1,5 @@
-FROM       alpine:3.4
-RUN        apk add --update --no-cache ca-certificates && rm /var/cache/apk/*
+FROM       alpine:3.9
+RUN        apk add --update --no-cache ca-certificates
 ADD        promtail /usr/bin
 COPY       promtail-local-config.yaml /etc/promtail/local-config.yaml
 COPY       promtail-docker-config.yaml /etc/promtail/docker-config.yaml


### PR DESCRIPTION
alpine:3.4 only contains a docker image for arm64, so building for other
architectures doesn't work. The newest alpine release, 3.9, is therefore
better.

Also, since the `--no-cache` flag us used, `apk` doesn't save any cache.

The official fluentd image used as the base image for fluent-plugin-loki isn't a multi-arch image, so this only helps for promtail and loki.