### PR TITLE
Track the right number of streams!

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -152,7 +152,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	}
 
 	tracker := pushTracker{
-		samplesPending: int32(len(samplesByIngester)),
+		samplesPending: int32(len(streams)),
 		done:           make(chan struct{}),
 		err:            make(chan error),
 	}
@@ -173,6 +173,8 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		return nil, err
 	case <-tracker.done:
 		return &logproto.PushResponse{}, validationErr
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 


### PR DESCRIPTION
And cancel the push when the request is cancelled.

This was broken in a422f394bb4660c98f7d692e16c3cc28747b7abd.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>