### PR TITLE
Include the stream's labels in OOO error responses.

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -3,10 +3,7 @@ package chunkenc
 import (
 	"errors"
 	"io"
-	"net/http"
 	"time"
-
-	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
@@ -14,8 +11,8 @@ import (
 
 // Errors returned by the chunk interface.
 var (
-	ErrChunkFull       = errors.New("Chunk full")
-	ErrOutOfOrder      = httpgrpc.Errorf(http.StatusBadRequest, "Entry out of order")
+	ErrChunkFull       = errors.New("chunk full")
+	ErrOutOfOrder      = errors.New("entry out of order")
 	ErrInvalidSize     = errors.New("invalid size")
 	ErrInvalidFlag     = errors.New("invalid flag")
 	ErrInvalidChecksum = errors.New("invalid checksum")

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/logproto"
 )
 
@@ -197,7 +198,7 @@ func (c *Client) send(ctx context.Context, buf []byte) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	defer resp.Body.Close()
+	defer helpers.LogError("closing watcher", resp.Body.Close)
 
 	if resp.StatusCode/100 != 2 {
 		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -198,7 +198,7 @@ func (c *Client) send(ctx context.Context, buf []byte) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	defer helpers.LogError("closing watcher", resp.Body.Close)
+	defer helpers.LogError("closing response body", resp.Body.Close)
 
 	if resp.StatusCode/100 != 2 {
 		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))


### PR DESCRIPTION
Also, read the body of error responses and log them.  And retries 500s and connection errors.

Fixes #298, fixes #250

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>