### PR TITLE
Fix helm install error

### DIFF
--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -26,7 +26,7 @@ $ helm install . -n loki --namespace <YOUR-NAMESPACE>
 To install Grafana on your cluster with helm, use the following command:
 
 ```bash
-$ helm install stable/grafana -n loki-grafana -f grafana.yaml --namespace <YOUR-NAMESPACE> 
+$ helm install stable/grafana -n loki-grafana -f grafana.yaml --namespace <YOUR-NAMESPACE>
 ```
 
 To get the admin password for the Grafana pod, run the following command:

--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.loki.image.repository }}:{{ .Values.loki.image.tag }}"
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
-          args: 
+          args:
             - "-config.file=/etc/loki/loki.yaml"
           volumeMounts:
             - name: config

--- a/production/helm/templates/promtail/clusterrole.yaml
+++ b/production/helm/templates/promtail/clusterrole.yaml
@@ -19,6 +19,6 @@ rules:
   - nodes/proxy
   - services
   - endpoints
-  - pods  
+  - pods
   verbs: ["get", "watch", "list"]
 {{- end}}

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.promtail.image.repository }}:{{ .Values.promtail.image.tag }}"
           imagePullPolicy: {{ .Values.promtail.image.pullPolicy }}
-          args: 
+          args:
             - "-config.file=/etc/promtail/promtail.yaml"
             - "-client.url=http://{{ template "loki.fullname" . }}:{{ .Values.loki.service.port }}/api/prom/push"
           volumeMounts:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -4,9 +4,9 @@ rbac:
 
 serviceAccount:
   create: true
-  name: 
+  name:
 
-loki: 
+loki:
   replicas: 1
   deploymentStrategy: RollingUpdate
 
@@ -99,7 +99,7 @@ promtail:
 
   image:
     repository: grafana/promtail
-    tag: master 
+    tag: master
     pullPolicy: IfNotPresent
 
   service:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -58,13 +58,15 @@ loki:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
+  ## If you set enabled as "True", you need :
+  ## - create a pv which above 10Gi and has same namespace with loki
+  ## - keep storageClassName same with below setting
   persistence:
-    enabled: true
+    enabled: false
     accessModes:
       - ReadWriteOnce
     size: 10Gi
-    # storageClassName: default
+    storageClassName: default
     # annotations: {}
     # subPath: ""
     # existingClaim:


### PR DESCRIPTION
When deploy with default setting, loki is always in pending status:
```
Name:          loki
Namespace:     skydiscovery
StorageClass:  
Status:        Pending
Volume:        
Labels:        app=loki
               chart=loki-0.0.1
               heritage=Tiller
               release=loki
Annotations:   <none>
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
Events:
  Type    Reason         Age               From                         Message
  ----    ------         ----              ----                         -------
  Normal  FailedBinding  8s (x4 over 35s)  persistentvolume-controller  no persistent volumes available for this claim and no storage class is set
```

Since pvc need a pv, so the default value should be "false".

Besides, even if pv exists, since storage class has been commented, loki is still in pending status, so need to change it.