### PR TITLE
Loki pod needs secret mounting privileges

### DIFF
--- a/production/helm/templates/loki/podsecuritypolicy.yaml
+++ b/production/helm/templates/loki/podsecuritypolicy.yaml
@@ -15,6 +15,7 @@ spec:
     - 'configMap'
     - 'emptyDir'
     - 'persistentVolumeClaim'
+    - 'secret'
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
Hi,
The loki replicaset reports that that it cannot create the pod because it cannot mount the secret volume. So I added secret to the psp for loki.