### PR TITLE
Helm Chart Production Improvements.

### DIFF
--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -79,6 +79,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.loki.terminationGracePeriodSeconds}}
+      terminationGracePeriodSeconds: {{ .Values.loki.terminationGracePeriodSeconds }}
+    {{- end }}
       volumes:
         - name: config
           configMap:

--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -13,9 +13,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.loki.replicas }}
-  {{- if .Values.loki.minReadySeconds}}
   minReadySeconds: {{ .Values.loki.minReadySeconds }}
-  {{- end }}
   selector:
     matchLabels:
       app: {{ template "loki.name" . }}
@@ -80,9 +78,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.loki.terminationGracePeriodSeconds}}
       terminationGracePeriodSeconds: {{ .Values.loki.terminationGracePeriodSeconds }}
-    {{- end }}
       volumes:
         - name: config
           configMap:

--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -13,6 +13,9 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.loki.replicas }}
+  {{- if .Values.loki.minReadySeconds}}
+  minReadySeconds: {{ .Values.loki.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "loki.name" . }}

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -25,7 +25,7 @@ loki:
   readinessProbe: {}
     # httpGet:
     #     path: /ready
-    #     port: 80
+    #     port: 3100
     #   initialDelaySeconds: 15
 
   livenessProbe: {}

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -8,7 +8,8 @@ serviceAccount:
 
 loki:
   replicas: 1
-  minReadySeconds: 60
+  # minReadySeconds: 60
+  # terminationGracePeriodSeconds: 3600
   deploymentStrategy: RollingUpdate
 
   image:
@@ -22,11 +23,14 @@ loki:
     labels: {}
 
   readinessProbe: {}
+    # httpGet:
+    #     path: /ready
+    #     port: 80
+    #   initialDelaySeconds: 15
 
   livenessProbe: {}
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -57,7 +61,16 @@ loki:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity: {}
-
+    # podAntiAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #   - labelSelector:
+    #       matchExpressions:
+    #       - key: app
+    #         operator: In
+    #         values:
+    #         - loki
+    #     topologyKey: "kubernetes.io/hostname"
+  
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ## If you set enabled as "True", you need :
@@ -112,8 +125,7 @@ promtail:
 
   livenessProbe: {}
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -8,8 +8,8 @@ serviceAccount:
 
 loki:
   replicas: 1
-  # minReadySeconds: 60
-  # terminationGracePeriodSeconds: 3600
+  minReadySeconds: 0
+  terminationGracePeriodSeconds: 30
   deploymentStrategy: RollingUpdate
 
   image:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -8,6 +8,7 @@ serviceAccount:
 
 loki:
   replicas: 1
+  minReadySeconds: 60
   deploymentStrategy: RollingUpdate
 
   image:


### PR DESCRIPTION
Trying to make the helm template able to follow the production practices, from https://github.com/grafana/loki/blob/ffe109384ba6124b1dc3011ea859797beb117aa8/production/ksonnet/loki/ingester.libsonnet

- Adds ability to specify deployment minReadySeconds 
- Add ability to specify  Loki pod terminationGracePeriodSeconds
- Add example for Loki readiness probe
- Add example for Loki  podAntiAffinity

