### PR TITLE
Add CRI log format support

### DIFF
--- a/pkg/promtail/api/entry_parser.go
+++ b/pkg/promtail/api/entry_parser.go
@@ -79,6 +79,7 @@ func (e EntryParser) Wrap(next EntryHandler) EntryHandler {
 				return fmt.Errorf("CRI timestamp '%s' does not match RFC3339Nano", parts[1])
 			}
 
+			labels = labels.Merge(model.LabelSet{"stream": model.LabelValue(parts[2])})
 			return next.Handle(labels, timestamp, parts[4])
 		})
 	case Docker:

--- a/pkg/promtail/api/entry_parser.go
+++ b/pkg/promtail/api/entry_parser.go
@@ -15,9 +15,9 @@ type EntryParser int
 
 // Different supported EntryParsers.
 const (
-	CRI    EntryParser = iota
 	Docker EntryParser = iota
 	Raw
+	CRI
 )
 
 var (

--- a/pkg/promtail/api/entry_parser_test.go
+++ b/pkg/promtail/api/entry_parser_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+var (
+	TestTimeStr = "2019-01-01T01:00:00.000000001Z"
+	TestTime, _ = time.Parse(time.RFC3339Nano, TestTimeStr)
+)
+
+type Entry struct {
+	Time time.Time
+	Log  string
+}
+
+var containerdTestCases = []struct {
+	Line     string // input
+	Error    bool
+	Expected Entry
+}{
+	{"", true, Entry{}},
+	{TestTimeStr, true, Entry{}},
+	{TestTimeStr + " stdout", true, Entry{}},
+	{TestTimeStr + " stderr F", true, Entry{}},
+	{TestTimeStr + " invalid F message", true, Entry{}},
+	{"2019-01-01 01:00:00.000000001 stdout F message", true, Entry{}},
+	{" " + TestTimeStr + " stdout F message", true, Entry{}},
+	{TestTimeStr + " stdout F message", false, Entry{TestTime, "message"}},
+	{TestTimeStr + " stderr P message", false, Entry{TestTime, "message"}},
+	{TestTimeStr + " stderr P message1\nmessage2", false, Entry{TestTime, "message1\nmessage2"}},
+}
+
+func TestContainerd(t *testing.T) {
+	for _, tc := range containerdTestCases {
+		client := &TestClient{
+			Entries: make([]Entry, 0),
+		}
+
+		EntryParser := Containerd.Wrap(client)
+		err := EntryParser.Handle(model.LabelSet{}, time.Now(), tc.Line)
+		hasError := err != nil
+
+		if tc.Error != hasError {
+			t.Error("For", tc.Line, "expected", tc.Error, "got", hasError)
+		}
+
+		if !tc.Error {
+			if len(client.Entries) != 1 {
+				t.Error("Handler did not receive the correct number of Entries, expected 1 received", len(client.Entries))
+			}
+
+			entry := client.Entries[0]
+
+			if tc.Expected.Time != entry.Time {
+				t.Error("For", tc.Line, "expected", tc.Expected.Time, "got", entry.Time)
+			}
+
+			if tc.Expected.Log != entry.Log {
+				t.Error("For", tc.Line, "expected", tc.Expected.Log, "got", entry.Log)
+			}
+		}
+	}
+}
+
+type TestClient struct {
+	Entries []Entry
+}
+
+func (c *TestClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	c.Entries = append(c.Entries, Entry{t, s})
+	return nil
+}

--- a/pkg/promtail/api/entry_parser_test.go
+++ b/pkg/promtail/api/entry_parser_test.go
@@ -17,7 +17,7 @@ type Entry struct {
 	Log  string
 }
 
-var containerdTestCases = []struct {
+var criTestCases = []struct {
 	Line     string // input
 	Error    bool
 	Expected Entry
@@ -34,13 +34,13 @@ var containerdTestCases = []struct {
 	{TestTimeStr + " stderr P message1\nmessage2", false, Entry{TestTime, "message1\nmessage2"}},
 }
 
-func TestContainerd(t *testing.T) {
-	for _, tc := range containerdTestCases {
+func TestCRI(t *testing.T) {
+	for _, tc := range criTestCases {
 		client := &TestClient{
 			Entries: make([]Entry, 0),
 		}
 
-		EntryParser := Containerd.Wrap(client)
+		EntryParser := CRI.Wrap(client)
 		err := EntryParser.Handle(model.LabelSet{}, time.Now(), tc.Line)
 		hasError := err != nil
 


### PR DESCRIPTION
Fixes #358

Support CRI as a new type of entry parser. Implementation uses a regex to extract the timestamp, stream label and application log message and ignore the rest. Tests were added to verify functionality. I could've gone down the approach of using a generic regex parser, but I figured since both containerd and CRI-O implement the [standard](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md) that it should be supported directly as Loki does for Docker log format.