### PR TITLE
Rename 'instance' label to 'pod_name' in Helm

### DIFF
--- a/production/helm/templates/promtail/configmap.yaml
+++ b/production/helm/templates/promtail/configmap.yaml
@@ -77,7 +77,7 @@ data:
         - action: replace
           source_labels:
           - __meta_kubernetes_pod_name
-          target_label: instance
+          target_label: pod_name
         - action: replace
           source_labels:
           - __meta_kubernetes_pod_container_name


### PR DESCRIPTION
It's just to allow Grafana to autofill this label in the Explore tabs, when we use Prometheus and Cadvisor