### PR TITLE
promtail: fix wrong config path

### DIFF
--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -21,7 +21,7 @@ func init() {
 
 func main() {
 	var (
-		configFile = "docs/promtail-local-config.yaml"
+		configFile = "cmd/promtail/promtail-local-config.yaml"
 		config     config.Config
 	)
 	flag.StringVar(&configFile, "config.file", "promtail.yml", "The config file.")


### PR DESCRIPTION
The basic config file has moved:
```
$ ls docs/promtail-local-config.yaml
ls: cannot access 'docs/promtail-local-config.yaml': No such file or directory
ls cmd/promtail/promtail-local-config.yaml
cmd/promtail/promtail-local-config.yaml
```

Signed-off-by: Xiang Dai <764524258@qq.com>