### PR TITLE
Fix intermittent ingester test failure

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -49,7 +49,7 @@ func TestIngester(t *testing.T) {
 			Timestamp: time.Unix(0, 0),
 			Line:      fmt.Sprintf("line %d", i),
 		})
-		req.Streams[1].Entries = append(req.Streams[0].Entries, logproto.Entry{
+		req.Streams[1].Entries = append(req.Streams[1].Entries, logproto.Entry{
 			Timestamp: time.Unix(0, 0),
 			Line:      fmt.Sprintf("line %d", i),
 		})
@@ -71,11 +71,36 @@ func TestIngester(t *testing.T) {
 		End:   time.Unix(1, 0),
 	}, &result)
 	require.NoError(t, err)
-
 	require.Len(t, result.resps, 1)
 	require.Len(t, result.resps[0].Streams, 2)
+
+	result = mockQuerierServer{
+		ctx: ctx,
+	}
+	err = i.Query(&logproto.QueryRequest{
+		Query: `{foo="bar",bar="baz1"}`,
+		Limit: 100,
+		Start: time.Unix(0, 0),
+		End:   time.Unix(1, 0),
+	}, &result)
+	require.NoError(t, err)
+	require.Len(t, result.resps, 1)
+	require.Len(t, result.resps[0].Streams, 1)
 	require.Equal(t, `{foo="bar", bar="baz1"}`, result.resps[0].Streams[0].Labels)
-	require.Equal(t, `{foo="bar", bar="baz2"}`, result.resps[0].Streams[1].Labels)
+
+	result = mockQuerierServer{
+		ctx: ctx,
+	}
+	err = i.Query(&logproto.QueryRequest{
+		Query: `{foo="bar",bar="baz2"}`,
+		Limit: 100,
+		Start: time.Unix(0, 0),
+		End:   time.Unix(1, 0),
+	}, &result)
+	require.NoError(t, err)
+	require.Len(t, result.resps, 1)
+	require.Len(t, result.resps[0].Streams, 1)
+	require.Equal(t, `{foo="bar", bar="baz2"}`, result.resps[0].Streams[0].Labels)
 }
 
 type mockStore struct {


### PR DESCRIPTION
Fixes #373 

There was one small bug also fixed in generating the test data, though I don't think it was related to the issue.

I believe the query to the ingester is not totally deterministic in the order which it returns multiple streams when multiple streams match the query.

I broke up the test to include a test for multiple streams but only count the results, and then additionally query by specific labels to make sure each stream is returned with the correct labels.