### PR TITLE
Promtail: Autodetect log format

### DIFF
--- a/pkg/promtail/scrape/scrape.go
+++ b/pkg/promtail/scrape/scrape.go
@@ -19,7 +19,7 @@ type Config struct {
 
 // DefaultScrapeConfig is the default Config.
 var DefaultScrapeConfig = Config{
-	EntryParser: api.Docker,
+	EntryParser: api.Auto,
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -79,7 +79,8 @@ func NewFileTargetManager(
 			relabelConfig: cfg.RelabelConfigs,
 			targets:       map[string]*FileTarget{},
 			hostname:      hostname,
-			entryHandler:  cfg.EntryParser.Wrap(client),
+			entryHandler:  client,
+			entryParser:   cfg.EntryParser,
 			targetConfig:  targetConfig,
 		}
 		tm.syncers[cfg.JobName] = s
@@ -124,6 +125,7 @@ type syncer struct {
 	log          log.Logger
 	positions    *positions.Positions
 	entryHandler api.EntryHandler
+	entryParser  api.EntryParser
 	hostname     string
 
 	targets       map[string]*FileTarget
@@ -201,7 +203,7 @@ func (s *syncer) sync(groups []*targetgroup.Group) {
 }
 
 func (s *syncer) newTarget(path string, labels model.LabelSet) (*FileTarget, error) {
-	return NewFileTarget(s.log, s.entryHandler, s.positions, path, labels, s.targetConfig)
+	return NewFileTarget(s.log, s.entryParser.Wrap(s.entryHandler), s.positions, path, labels, s.targetConfig)
 }
 
 func (s *syncer) ready() bool {

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -6,7 +6,7 @@ annotations: {}
 
 deploymentStrategy: RollingUpdate
 
-entryParser: docker
+entryParser: auto
 
 image:
   repository: grafana/promtail

--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -12,7 +12,7 @@
       hostname: 'logs-us-west1.grafana.net',
       container_root_path: '/var/lib/docker',
       external_labels: {},
-      entry_parser: 'docker',
+      entry_parser: 'auto',
     },
 
     service_url:

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -5,7 +5,7 @@ APIKEY="${2:-}"
 INSTANCEURL="${3:-}"
 NAMESPACE="${4:-default}"
 CONTAINERROOT="${5:-/var/lib/docker}"
-PARSER="${6:-docker}"
+PARSER="${6:-auto}"
 
 if [ -z "$INSTANCEID" -o -z "$APIKEY" -o -z "$INSTANCEURL" -o -z "$NAMESPACE" -o -z "$CONTAINERROOT" -o -z "$PARSER" ]; then
     echo "usage: $0 <instanceId> <apiKey> <url> [<namespace>[<container_root_path>[<parser>]]]"


### PR DESCRIPTION
Fixes #357

- Adds a new EntryParser "auto" that tries each parser and chooses the first one that parses successfully
- Order of autodetection is: Docker -> CRI -> Raw
- Auto detection is only performed on the first log entry of that file then cached to avoid the performance overhead
- Create a new EntryHandler for every file target since each file could potentially be a different log format
- Adds test cases for auto and raw parser
- Switches default parser to auto both in code and in Helm chart

cc @slim-bean @tomwilkie 