### PR TITLE
Adds network policy to Helm chart for promtail to reach loki

### DIFF
--- a/production/helm/Chart.yaml
+++ b/production/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/templates/loki/networkpolicy.yaml
+++ b/production/helm/templates/loki/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "loki.fullname" . }}
+  labels:
+    app: {{ template "loki.name" . }}
+    chart: {{ template "loki.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ template "loki.fullname" . }}
+      app: {{ template "loki.name" . }}
+      release: {{ .Release.Name }}
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: {{ template "promtail.name" . }}
+            release: {{ .Release.Name }}
+    - ports:
+      - port: {{ .Values.loki.service.port }}
+{{- end -}}

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -2,6 +2,9 @@ rbac:
   create: true
   pspEnabled: true
 
+networkPolicy:
+  enabled: false
+
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
Defaulted to disabled. Considered adding Grafana -> Loki NetPol too but I believe that's out of scope.