### PR TITLE
Use the example fluentd conf files, and show a way to use them

### DIFF
--- a/fluentd/fluent-plugin-loki/Dockerfile
+++ b/fluentd/fluent-plugin-loki/Dockerfile
@@ -10,26 +10,29 @@ ENV FLUENTD_DISABLE_BUNDLER_INJECTION 1
 
 COPY docker/Gemfile* /fluentd/
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
- && apt-get update \
- && apt-get install -y --no-install-recommends \
-        $buildDeps libsystemd0 net-tools libjemalloc1 \
- && gem install bundler --version 1.16.2 \
- && bundle config silence_root_warning true \
- && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
- && sudo gem sources --clear-all \
- && SUDO_FORCE_REMOVE=yes \
-    apt-get purge -y --auto-remove \
-                  -o APT::AutoRemove::RecommendsImportant=false \
-                  $buildDeps \
- && rm -rf /var/lib/apt/lists/* \
-           /home/fluent/.gem/ruby/2.3.0/cache/*.gem \
-           /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
-
-ENV FLUENTD_CONF="/fluentd/etc/fluentd.conf"
-ENV FLUENTD_OPT=""
+       && apt-get update \
+       && apt-get install -y --no-install-recommends \
+       $buildDeps libsystemd0 net-tools libjemalloc1 \
+       && gem install bundler --version 1.16.2 \
+       && bundle config silence_root_warning true \
+       && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
+       && sudo gem sources --clear-all \
+       && SUDO_FORCE_REMOVE=yes \
+       apt-get purge -y --auto-remove \
+       -o APT::AutoRemove::RecommendsImportant=false \
+       $buildDeps \
+       && rm -rf /var/lib/apt/lists/* \
+       /home/fluent/.gem/ruby/2.3.0/cache/*.gem \
+       /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 COPY docker/entrypoint.sh /fluentd/entrypoint.sh
 COPY lib/fluent/plugin/out_loki.rb /fluentd/plugins/out_loki.rb
+COPY docker/conf/ /fluentd/etc/loki/
+
+ENV FLUENTD_CONF="/fluentd/etc/loki/fluentd.conf"
+ENV FLUENTD_OPT=""
+
+ENV LOKI_URL "https://logs-us-west1.grafana.net"
 
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"

--- a/fluentd/fluent-plugin-loki/README.md
+++ b/fluentd/fluent-plugin-loki/README.md
@@ -29,6 +29,44 @@ In your Fluentd configuration, use `@type loki`. Additional configuration is opt
 </match>
 ```
 
+## Docker Image
+
+There is a Docker image `grafana/fluent-plugin-loki:master` which contains default configuration files to git log information
+a host's `/var/log` dir, and from the host's Journald. To use it, you can set the `LOKI_URL`, `LOKI_USERNAME`, and `LOKI_PASSWORD` environment variables (you can leave the USERNAME and PASSWORD blank if they're not used.)
+
+
+A Docker Swarm Compose configuration that will work looks like:
+
+```
+services:
+  fluentd:
+    image: grafana/fluent-plugin-loki:master
+    command:
+      - "fluentd"
+      - "-v"
+      - "-p"
+      - "/fluentd/plugins"
+    environment:
+      LOKI_URL: http://loki:3100
+      LOKI_USERNAME:
+      LOKI_PASSWORD:
+    deploy:
+      mode: global
+    configs:
+      - source: loki_config
+        target: /fluentd/etc/loki/loki.conf
+    networks:
+      - loki
+    volumes:
+      - host_logs:/var/log
+      # Needed for journald log ingestion:
+      - /etc/machine-id:/etc/machine-id
+      - /dev/log:/dev/log
+      - /var/run/systemd/journal/:/var/run/systemd/journal/
+    logging:
+      options:
+         tag: infra.monitoring
+```
 
 ## Configuration
 

--- a/fluentd/fluent-plugin-loki/docker/conf/loki.conf
+++ b/fluentd/fluent-plugin-loki/docker/conf/loki.conf
@@ -1,6 +1,6 @@
 <match journald>
   @type loki
-  url "https://logs-us-west1.grafana.net"
+  url "#{ENV['LOKI_URL']}"
   username "#{ENV['LOKI_USERNAME']}"
   password "#{ENV['LOKI_PASSWORD']}"
   extra_labels {"env":"dev"}


### PR DESCRIPTION
You guys have made functional default config files - by putting them into the image you build, users can have a quicker onboarding, and then learn to customise from a working base.

I _am_ working on using loki as a replacement for basic elasticsearch for logs with Docker Swarm and Journald, I'll have to write it up somewhere for #224 too :)