### PR TITLE
fixes rspec dependencies and rubocop warnings

### DIFF
--- a/fluentd/fluent-plugin-loki/.rspec
+++ b/fluentd/fluent-plugin-loki/.rspec
@@ -1,3 +1,3 @@
+--require spec_helper
 --format documentation
 --color
---require spec_helper

--- a/fluentd/fluent-plugin-loki/Gemfile
+++ b/fluentd/fluent-plugin-loki/Gemfile
@@ -2,5 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'fluentd', '1.4.0'
 gem 'rubocop-rspec'
 gem 'simplecov', require: false, group: :test
+gem 'test-unit'

--- a/fluentd/fluent-plugin-loki/docker/Gemfile
+++ b/fluentd/fluent-plugin-loki/docker/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'fluent-plugin-systemd', '~> 1.0.1'
 gem 'fluent-plugin-kubernetes_metadata_filter', '~> 0.7.0'
+gem 'fluent-plugin-systemd', '~> 1.0.1'
 gem 'fluentd', '1.3.2'

--- a/fluentd/fluent-plugin-loki/fluent-plugin-loki.gemspec
+++ b/fluentd/fluent-plugin-loki/fluent-plugin-loki.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   # test_files, files  = `git ls-files -z`.split("\x0").partition do |f|
   #   f.match(%r{^(test|spec|features)/})
   # end
-  spec.files         = Dir.glob('{bin,lib}/**/*') + %w[LICENSE.txt README.md]
+  spec.files         = Dir.glob('{bin,lib}/**/*') + %w[../../LICENSE README.md]
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 

--- a/fluentd/fluent-plugin-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-loki/lib/fluent/plugin/out_loki.rb
@@ -142,7 +142,7 @@ module Fluent
           # 'labels' => '{worker="0"}',
           payload.push(
             'labels' => labels_to_protocol(k),
-	    'entries' => v.sort_by { |hsh| Time.parse(hsh["ts"])}
+            'entries' => v.sort_by { |hsh| Time.parse(hsh['ts']) }
           )
         end
         payload


### PR DESCRIPTION
* Gemfile was missing fluentd and test-unit
* rubocop warns about ordering of gems
* reference to license file was incorrect
* formatting for timestamp fix corrected (rubocop)