### PR TITLE
Fix unused parameter warning for Fluentd

### DIFF
--- a/fluentd/fluent-plugin-loki/README.md
+++ b/fluentd/fluent-plugin-loki/README.md
@@ -22,7 +22,7 @@ In your Fluentd configuration, use `@type loki`. Additional configuration is opt
   url "https://logs-us-west1.grafana.net"
   username "#{ENV['LOKI_USERNAME']}"
   password "#{ENV['LOKI_PASSWORD']}"
-  labels {"env":"dev"}
+  extra_labels {"env":"dev"}
   flush_interval 10s
   flush_at_shutdown true
   buffer_chunk_limit 1m


### PR DESCRIPTION
Documentation uses `labels {"env":"dev"}` in Fluentd configuration but I think it should be `extra_labels {"env":"dev"}`:
https://github.com/grafana/loki/blob/master/fluentd/fluent-plugin-loki/lib/fluent/plugin/out_loki.rb#L43

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>