### PR TITLE
Add readiness probe to Helm chart and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .pkg
 .cache
 *.output
+*.tgz
 mixin/vendor/
 cmd/loki/loki
 cmd/promtail/promtail

--- a/production/helm/Chart.yaml
+++ b/production/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/templates/loki/_helpers.tpl
+++ b/production/helm/templates/loki/_helpers.tpl
@@ -46,7 +46,7 @@ Create the name of the service account
 auth_enabled: {{ .Values.loki.config.auth_enabled }}
 
 server:
-  http_listen_port: {{ .Values.loki.service.port }}
+  http_listen_port: {{ .Values.loki.port }}
 
 limits_config:
   enforce_metric_name: false

--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.loki.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "loki.fullname" . }}
@@ -8,10 +8,8 @@ metadata:
     chart: {{ template "loki.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.loki.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.loki.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.loki.replicas }}
   minReadySeconds: {{ .Values.loki.minReadySeconds }}
@@ -32,14 +30,14 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/loki/secret.yaml") . | sha256sum }}
-{{- with .Values.loki.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "loki.serviceAccountName" . }}
-{{- if .Values.loki.priorityClassName }}
+    {{- if .Values.loki.priorityClassName }}
       priorityClassName: {{ .Values.loki.priorityClassName }}
-{{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.loki.image.repository }}:{{ .Values.loki.image.tag }}"
@@ -53,33 +51,21 @@ spec:
               mountPath: "/data"
               subPath: {{ .Values.loki.persistence.subPath }}
           ports:
-            - name: {{ template "loki.name" . }}-metrics
-              containerPort: {{ .Values.loki.service.port }}
+            - name: http-metrics
+              containerPort: {{ .Values.loki.port }}
               protocol: TCP
-{{- with .Values.loki.livenessProbe }}
           livenessProbe:
-{{ toYaml . | indent 12 }}
-{{- end }}
-{{- with .Values.loki.readinessProbe }}
+            {{- toYaml .Values.loki.livenessProbe | nindent 12 }}
           readinessProbe:
-{{ toYaml . | indent 12 }}
-{{- end }}
-{{- with .Values.loki.resources }}
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
           resources:
-{{ toYaml . | indent 12 }}
-{{- end }}
-    {{- with .Values.loki.nodeSelector }}
+            {{- toYaml .Values.loki.resources | nindent 12 }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.loki.affinity }}
+        {{- toYaml .Values.loki.nodeSelector | nindent 8 }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.loki.tolerations }}
+        {{- toYaml .Values.loki.affinity | nindent 8 }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml .Values.loki.tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.loki.terminationGracePeriodSeconds }}
       volumes:
         - name: config
@@ -93,3 +79,4 @@ spec:
           emptyDir: {}
       {{- end }}
 {{- end }}
+

--- a/production/helm/templates/loki/podsecuritypolicy.yaml
+++ b/production/helm/templates/loki/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.loki.enabled }}
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "loki.fullname" . }}

--- a/production/helm/templates/loki/role.yaml
+++ b/production/helm/templates/loki/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.loki.enabled }}
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "loki.fullname" . }}

--- a/production/helm/templates/loki/rolebinding.yaml
+++ b/production/helm/templates/loki/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.loki.enabled }}
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "loki.fullname" . }}

--- a/production/helm/templates/loki/service.yaml
+++ b/production/helm/templates/loki/service.yaml
@@ -8,19 +8,17 @@ metadata:
     chart: {{ template "loki.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.loki.service.labels }}
-{{ toYaml .Values.loki.service.labels | indent 4 }}
-{{- end }}
-{{- with .Values.loki.service.annotations }}
+    {{- with .Values.loki.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.loki.service.annotations | nindent 4 }}
 spec:
   ports:
-    - name: {{ template "loki.name" . }}
+    - name: http-metrics
       port: {{ .Values.loki.service.port }}
       protocol: TCP
-      targetPort: {{ .Values.loki.service.port }}
+      targetPort: http-metrics
   selector:
     app: {{ template "loki.name" . }}
     release: {{ .Release.Name }}

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.promtail.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "promtail.fullname" . }}
@@ -8,10 +8,8 @@ metadata:
     chart: {{ template "promtail.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.promtail.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.promtail.annotations | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -27,17 +25,15 @@ spec:
       labels:
         app: {{ template "promtail.name" . }}
         release: {{ .Release.Name }}
-{{- with .Values.promtail.podAnnotations }}
       annotations:
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.promtail.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ template "promtail.serviceAccountName" . }}
-{{- if .Values.promtail.priorityClassName }}
+    {{- if .Values.promtail.priorityClassName }}
       priorityClassName: {{ .Values.promtail.priorityClassName }}
-{{- end }}
+    {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: promtail
           image: "{{ .Values.promtail.image.repository }}:{{ .Values.promtail.image.tag }}"
           imagePullPolicy: {{ .Values.promtail.image.pullPolicy }}
           args:
@@ -46,9 +42,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/promtail
-          {{- if .Values.promtail.volumeMounts -}}
-          {{ toYaml .Values.promtail.volumeMounts | nindent 12 }}
-          {{- end }}
+            {{- with .Values.promtail.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
           - name: HOSTNAME
             valueFrom:
@@ -60,35 +56,24 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
-{{- with .Values.promtail.livenessProbe }}
           livenessProbe:
-{{ toYaml . | indent 12 }}
-{{- end }}
-{{- with .Values.promtail.readinessProbe }}
+            {{- toYaml .Values.promtail.livenessProbe | nindent 12 }}
           readinessProbe:
-{{ toYaml . | indent 12 }}
-{{- end }}
-{{- with .Values.promtail.resources }}
+            {{- toYaml .Values.promtail.readinessProbe | nindent 12 }}
           resources:
-{{ toYaml . | indent 12 }}
-{{- end }}
-    {{- with .Values.promtail.nodeSelector }}
+            {{- toYaml .Values.promtail.resources | nindent 12 }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.promtail.affinity }}
+        {{- toYaml .Values.promtail.nodeSelector | nindent 8 }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.promtail.tolerations }}
+        {{- toYaml .Values.promtail.affinity | nindent 8 }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml .Values.promtail.tolerations | nindent 8 }}
       volumes:
         - name: config
           configMap:
             name: {{ template "promtail.fullname" . }}
-        {{- if .Values.promtail.volumes -}}
-        {{ toYaml .Values.promtail.volumes | nindent 8 }}
+        {{- with .Values.promtail.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
+

--- a/production/helm/templates/promtail/podsecuritypolicy.yaml
+++ b/production/helm/templates/promtail/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.promtail.enabled }}
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "promtail.fullname" . }}

--- a/production/helm/templates/promtail/role.yaml
+++ b/production/helm/templates/promtail/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.promtail.enabled }}
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "promtail.fullname" . }}

--- a/production/helm/templates/promtail/rolebinding.yaml
+++ b/production/helm/templates/promtail/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.promtail.enabled }}
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "promtail.fullname" . }}

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -16,6 +16,7 @@ loki:
   minReadySeconds: 0
   terminationGracePeriodSeconds: 30
   deploymentStrategy: RollingUpdate
+  port: 3100
 
   image:
     repository: grafana/loki
@@ -25,29 +26,35 @@ loki:
   service:
     port: 3100
     annotations: {}
+    #  prometheus.io/scrape: "true"
+    #  prometheus.io/port: "http-metrics"
     labels: {}
 
-  readinessProbe: {}
-    # httpGet:
-    #     path: /ready
-    #     port: 3100
-    #   initialDelaySeconds: 15
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
 
-  livenessProbe: {}
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
 
   resources: {}
     # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
+    #   cpu: 200m
+    #   memory: 256Mi
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
 
   ## Pod Annotations
-  # podAnnotations: {}
+  podAnnotations: {}
 
   ## Deployment annotations
-  # annotations: {}
+  annotations: {}
 
   ## Assign a PriorityClassName to pods if set
   # priorityClassName:
@@ -140,28 +147,25 @@ promtail:
       mountPath: /var/lib/docker/containers
       readOnly: true
 
-  service:
-    port: 3100
-    annotations: {}
-    labels: {}
+  readinessProbe: null
 
-  readinessProbe: {}
-
-  livenessProbe: {}
+  livenessProbe: null
 
   resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  #  limits:
+  #    cpu: 200m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
 
   ## Pod Annotations
-  # podAnnotations: {}
+  podAnnotations: {}
+  #  prometheus.io/scrape: "true"
+  #  prometheus.io/port: "http-metrics"
 
   ## Deployment annotations
-  # annotations: {}
+  annotations: {}
 
   ## Assign a PriorityClassName to pods if set
   # priorityClassName:
@@ -182,3 +186,4 @@ promtail:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity: {}
+


### PR DESCRIPTION
- Add readiness and liveness probes to Loki
- Add example to enable Prometheus scrape annotations. Please let me know if you want these enabled by default
- Bump some of the example resource limits to be more realistic. Please let me know if they should be tweaked further
- Fix incorrect promtail container name
- Git ignore packaged helm charts
- Removes non-existent promtail service from values.yaml (Fixes #396)
- Separate Loki service port from container port
- Set more defaults in values.yaml so we can remove if/with and directly toYaml
- Use named ports to avoid duplication and unnecessary templating
- Use nindent for cleaner indenting
- Use stable apiVersion for all resources since minimum Kubernetes version is 1.10

Appreciate a review @davkal 