### PR TITLE
Adding metric and alert to notify promtail falling behind

### DIFF
--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -26,6 +26,11 @@ var (
 		Name:      "read_bytes_total",
 		Help:      "Number of bytes read.",
 	}, []string{"path"})
+	totalBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "promtail",
+		Name:      "file_bytes_total",
+		Help:      "Number of bytes total.",
+	}, []string{"path"})
 
 	readLines = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",

--- a/pkg/promtail/targets/tailer.go
+++ b/pkg/promtail/targets/tailer.go
@@ -87,7 +87,14 @@ func (t *tailer) run() {
 	for {
 		select {
 		case <-positionWait.C:
-			err := t.markPosition()
+			fi, err := os.Stat(t.filename)
+			if err != nil {
+				level.Error(t.logger).Log("msg", "failed to stat log file being tailed, "+
+					"cannot report size or mark position", t.filename, "error", err)
+				continue
+			}
+			totalBytes.WithLabelValues(t.path).Set(float64(fi.Size()))
+			err = t.markPosition()
 			if err != nil {
 				level.Error(t.logger).Log("msg", "error getting tail position", "path", t.path, "error", err)
 				continue
@@ -103,7 +110,10 @@ func (t *tailer) run() {
 			}
 
 			readLines.WithLabelValues(t.path).Inc()
-			readBytes.WithLabelValues(t.path).Add(float64(len(line.Text)))
+			// The line we receive from the tailer is stripped of the newline character, which causes counts to be
+			// off between the file size and this metric of bytes read, so we are adding back a byte to represent the newline
+			// If you are reading this you are probably using Windows which has a 2 byte /r/n newline string.... sorry
+			readBytes.WithLabelValues(t.path).Add(float64(len(line.Text) + 1))
 			if err := t.handler.Handle(model.LabelSet{}, line.Time, line.Text); err != nil {
 				level.Error(t.logger).Log("msg", "error handling line", "path", t.path, "error", err)
 			}

--- a/pkg/promtail/targets/tailer.go
+++ b/pkg/promtail/targets/tailer.go
@@ -87,14 +87,7 @@ func (t *tailer) run() {
 	for {
 		select {
 		case <-positionWait.C:
-			fi, err := os.Stat(t.filename)
-			if err != nil {
-				level.Error(t.logger).Log("msg", "failed to stat log file being tailed, "+
-					"cannot report size or mark position", t.filename, "error", err)
-				continue
-			}
-			totalBytes.WithLabelValues(t.path).Set(float64(fi.Size()))
-			err = t.markPosition()
+			err := t.markPosition()
 			if err != nil {
 				level.Error(t.logger).Log("msg", "error getting tail position", "path", t.path, "error", err)
 				continue

--- a/production/loki-mixin/alerts.libsonnet
+++ b/production/loki-mixin/alerts.libsonnet
@@ -113,6 +113,21 @@
               |||,
             },
           },
+          {
+            alert: 'PromtailFileLagging',
+            expr: |||
+              promtail_file_bytes_total - promtail_read_bytes_total > 100000
+            |||,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: |||
+                {{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} has been lagging by more than 100kb for more than 15m.
+              |||,
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
Alert will fire whenever the total bytes for a file is 100kb or more ahead the read bytes for more than 15mins.

Added an additional metric to track client bytes ready to send (encoded bytes) vs actually sent so we can add an alert on promtail sending failures and still track stats on encoded bytes being sent.  Will follow up with a PR on this once best figure out how to write the alert and graph it as well.