### PR TITLE
Helm: Run with reduced privileges

### DIFF
--- a/production/helm/Chart.yaml
+++ b/production/helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -60,6 +60,8 @@ spec:
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.loki.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.loki.securityContext | nindent 12 }}
       nodeSelector:
         {{- toYaml .Values.loki.nodeSelector | nindent 8 }}
       affinity:

--- a/production/helm/templates/loki/podsecuritypolicy.yaml
+++ b/production/helm/templates/loki/podsecuritypolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "loki.fullname" . }}
   labels:
     app: {{ template "loki.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
@@ -21,13 +21,24 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    rule: 'RunAsAny'
+    rule: 'MustRunAsNonRoot'
   seLinux:
-    rule: 'RunAsAny'
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
   supplementalGroups:
-    rule: 'RunAsAny'
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: 'RunAsAny'
-  readOnlyRootFilesystem: false
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
 {{- end }}
 {{- end }}

--- a/production/helm/templates/loki/pvc.yaml
+++ b/production/helm/templates/loki/pvc.yaml
@@ -6,13 +6,11 @@ metadata:
   name: {{ template "loki.fullname" . }}
   labels:
     app: {{ template "loki.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- with .Values.loki.persistence.annotations  }}
   annotations:
-{{ toYaml . | indent 4 }}
-  {{- end }}
+    {{- toYaml .Values.loki.persistence.annotations | nindent 4 }}
 spec:
   accessModes:
     {{- range .Values.loki.persistence.accessModes }}

--- a/production/helm/templates/loki/role.yaml
+++ b/production/helm/templates/loki/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "loki.fullname" . }}
   labels:
     app: {{ template "loki.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- if .Values.rbac.pspEnabled }}

--- a/production/helm/templates/loki/rolebinding.yaml
+++ b/production/helm/templates/loki/rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "loki.fullname" . }}
   labels:
     app: {{ template "loki.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/production/helm/templates/loki/serviceaccount.yaml
+++ b/production/helm/templates/loki/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "loki.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "loki.serviceAccountName" . }}

--- a/production/helm/templates/promtail/clusterrole.yaml
+++ b/production/helm/templates/promtail/clusterrole.yaml
@@ -8,10 +8,8 @@ metadata:
     chart: {{ template "promtail.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.promtail.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.promtail.annotations | nindent 4 }}
   name: {{ template "promtail.fullname" . }}-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group

--- a/production/helm/templates/promtail/clusterrolebinding.yaml
+++ b/production/helm/templates/promtail/clusterrolebinding.yaml
@@ -9,10 +9,8 @@ metadata:
     chart: {{ template "promtail.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.promtail.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.promtail.annotations | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "promtail.serviceAccountName" . }}

--- a/production/helm/templates/promtail/configmap.yaml
+++ b/production/helm/templates/promtail/configmap.yaml
@@ -14,7 +14,10 @@ data:
       minbackoff: {{ .Values.promtail.config.backoff_config.minbackoff }}
       maxbackoff: {{ .Values.promtail.config.backoff_config.maxbackoff }}
       maxretries: {{ .Values.promtail.config.backoff_config.maxretries }}
-
+    server:
+      http_listen_port: {{ .Values.promtail.port }}
+    positions:
+      filename: /run/promtail/positions.yaml
     scrape_configs:
       - entry_parser: '{{ .Values.promtail.entryParser }}'
         job_name: kubernetes-pods-name

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -42,6 +42,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/promtail
+            - name: run
+              mountPath: /run/promtail
             {{- with .Values.promtail.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -51,11 +53,10 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: {{ .Values.promtail.port }}
               name: http-metrics
           securityContext:
-            privileged: true
-            runAsUser: 0
+            {{- toYaml .Values.promtail.securityContext | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.promtail.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -72,6 +73,9 @@ spec:
         - name: config
           configMap:
             name: {{ template "promtail.fullname" . }}
+        - name: run
+          hostPath:
+            path: /run/promtail
         {{- with .Values.promtail.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/templates/promtail/podsecuritypolicy.yaml
+++ b/production/helm/templates/promtail/podsecuritypolicy.yaml
@@ -6,12 +6,12 @@ metadata:
   name: {{ template "promtail.fullname" . }}
   labels:
     app: {{ template "promtail.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "promtail.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  privileged: true
-  allowPrivilegeEscalation: true
+  privileged: false
+  allowPrivilegeEscalation: false
   volumes:
     - 'secret'
     - 'configMap'
@@ -27,6 +27,8 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
   {{- end }}
 {{- end }}

--- a/production/helm/templates/promtail/role.yaml
+++ b/production/helm/templates/promtail/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "promtail.fullname" . }}
   labels:
     app: {{ template "promtail.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "promtail.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- if .Values.rbac.pspEnabled }}

--- a/production/helm/templates/promtail/rolebinding.yaml
+++ b/production/helm/templates/promtail/rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "promtail.fullname" . }}
   labels:
     app: {{ template "promtail.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "promtail.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -50,6 +50,13 @@ loki:
     #   cpu: 100m
     #   memory: 128Mi
 
+  securityContext:
+    fsGroup: 10001
+    readOnlyRootFilesystem: true
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001
+
   ## Pod Annotations
   podAnnotations: {}
 
@@ -94,7 +101,7 @@ loki:
       - ReadWriteOnce
     size: 10Gi
     storageClassName: default
-    # annotations: {}
+    annotations: {}
     # subPath: ""
     # existingClaim:
 
@@ -141,18 +148,22 @@ promtail:
     tag: latest
     pullPolicy: Always # Always pull while in BETA
 
+  port: 3101
+
+  # Extra volumes to scrape logs from
   volumes:
-    - name: varlog
+    - name: pods
       hostPath:
-        path: /var/log
-    - name: varlibdockercontainers
+        path: /var/log/pods
+    - name: docker
       hostPath:
         path: /var/lib/docker/containers
 
   volumeMounts:
-    - name: varlog
-      mountPath: /var/log
-    - name: varlibdockercontainers
+    - name: pods
+      mountPath: /var/log/pods
+      readOnly: true
+    - name: docker
       mountPath: /var/lib/docker/containers
       readOnly: true
 
@@ -167,6 +178,12 @@ promtail:
   #  requests:
   #    cpu: 100m
   #    memory: 128Mi
+
+  securityContext:
+    fsGroup: 0
+    readOnlyRootFilesystem: true
+    runAsGroup: 0
+    runAsUser: 0
 
   ## Pod Annotations
   podAnnotations: {}


### PR DESCRIPTION
- Adds a configurable port for promtail and changed default from 80 so it can bind as non-root
- Fix resources using `{{ .Chart.Name }}-{{ .Chart.Version }}` instead of `{{ template "loki.chart" . }}`
- Moved `/var/log/positions.yaml` to new hostPath volume at `/run/promtail` until a better approach can be agreed upon in https://github.com/grafana/loki/issues/416
- Since positions moved out of `/var/log`, we now only need to mount sub-directory `/var/log/pods` and can mark it as read-only
- Run Loki and promtail with a read only root filesystem
- Run Loki as non-root user and group (10001 as recommended by [kubesec.io](https://kubesec.io))
- Drop privileged=true in favor of runAsUser=0 for Promtail.
- Unfortunately still needs to run as root for most users since hostPath volumes can have various permission levels
   - For example:
      - if `/var/log/pods/*/*/*.log` is 644, then you can `runAsUser: 1000` `runAsGroup: 1000`
      - if `/var/log/pods/*/*/*.log` is 640, then you can `runAsUser: 1000` `runAsGroup: 0`
      - If `/var/log/pods/*/*/*.log` is 600, then have to `runAsuser: 0` `runAsGroup: 0`