### PR TITLE
Fix helm

### DIFF
--- a/production/helm/templates/loki/deployment.yaml
+++ b/production/helm/templates/loki/deployment.yaml
@@ -37,6 +37,8 @@ spec:
       serviceAccountName: {{ template "loki.serviceAccountName" . }}
     {{- if .Values.loki.priorityClassName }}
       priorityClassName: {{ .Values.loki.priorityClassName }}
+      securityContext:
+        {{- toYaml .Values.loki.securityContext | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -61,7 +63,7 @@ spec:
           resources:
             {{- toYaml .Values.loki.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.loki.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: true
       nodeSelector:
         {{- toYaml .Values.loki.nodeSelector | nindent 8 }}
       affinity:

--- a/production/helm/templates/loki/podsecuritypolicy.yaml
+++ b/production/helm/templates/loki/podsecuritypolicy.yaml
@@ -23,10 +23,7 @@ spec:
   runAsUser:
     rule: 'MustRunAsNonRoot'
   seLinux:
-    rule: 'MustRunAs'
-    ranges:
-    - min: 1
-      max: 65535
+    rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -57,14 +57,6 @@ spec:
               name: http-metrics
           securityContext:
             {{- toYaml .Values.promtail.securityContext | nindent 12 }}
-          {{- if .Values.promtail.livenessProbe }}
-          livenessProbe:
-            {{- toYaml .Values.promtail.livenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.promtail.livenessProbe }}
-          readinessProbe:
-            {{- toYaml .Values.promtail.readinessProbe | nindent 12 }}
-          {{- end }}
           resources:
             {{- toYaml .Values.promtail.resources | nindent 12 }}
       nodeSelector:

--- a/production/helm/templates/promtail/daemonset.yaml
+++ b/production/helm/templates/promtail/daemonset.yaml
@@ -57,10 +57,14 @@ spec:
               name: http-metrics
           securityContext:
             {{- toYaml .Values.promtail.securityContext | nindent 12 }}
+          {{- if .Values.promtail.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.promtail.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.promtail.livenessProbe }}
           readinessProbe:
             {{- toYaml .Values.promtail.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.promtail.resources | nindent 12 }}
       nodeSelector:

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -51,7 +51,6 @@ loki:
     #   memory: 128Mi
 
   securityContext:
-    fsGroup: 10001
     readOnlyRootFilesystem: true
     runAsGroup: 10001
     runAsNonRoot: true
@@ -180,7 +179,6 @@ promtail:
   #    memory: 128Mi
 
   securityContext:
-    fsGroup: 0
     readOnlyRootFilesystem: true
     runAsGroup: 0
     runAsUser: 0

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -166,10 +166,6 @@ promtail:
       mountPath: /var/lib/docker/containers
       readOnly: true
 
-  readinessProbe: null
-
-  livenessProbe: null
-
   resources: {}
   #  limits:
   #    cpu: 200m

--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -51,7 +51,7 @@ loki:
     #   memory: 128Mi
 
   securityContext:
-    readOnlyRootFilesystem: true
+    fsGroup: 10001
     runAsGroup: 10001
     runAsNonRoot: true
     runAsUser: 10001


### PR DESCRIPTION
* Remove fsGroup from pod SecurityContext - not a valid option 
* Set SeLinux to RunAsAny in psp, as "ranges" is not a valid option for seLinux. Someone fee free to add correct seLinux options, but restoring this to RunAsAny so it is not broken,
* Wrapped promtail ds liveness and readiness probes in if statement as having empty {} for probes results in kubectl errors of the following

```DaemonSet "loki-promtail" is invalid: 
* spec.template.spec.containers[0].livenessProbe: Required value: must specify a handler type
* spec.template.spec.containers[0].readinessProbe: Required value: must specify a handler type
```