### PR TITLE
Add comment about external_labels

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -58,9 +58,10 @@ type Config struct {
 	BatchWait time.Duration
 	BatchSize int
 
-	BackoffConfig  util.BackoffConfig `yaml:"backoff_config"`
-	ExternalLabels model.LabelSet     `yaml:"external_labels,omitempty"`
-	Timeout        time.Duration      `yaml:"timeout"`
+	BackoffConfig util.BackoffConfig `yaml:"backoff_config"`
+	// The labels to add to any time series or alerts when communicating with loki
+	ExternalLabels model.LabelSet `yaml:"external_labels,omitempty"`
+	Timeout        time.Duration  `yaml:"timeout"`
 }
 
 // RegisterFlags registers flags.


### PR DESCRIPTION
model.LabelSet is from promtheus and it can not covert to Value type, so can not register it in func RegisterFlags, add this comment to clear what it is.

Signed-off-by: Xiang Dai <764524258@qq.com>