### PR TITLE
fix app label miss

### DIFF
--- a/production/helm/values.yaml
+++ b/production/helm/values.yaml
@@ -376,10 +376,6 @@ promtail:
         - source_labels:
           - __meta_kubernetes_pod_node_name
           target_label: __host__
-        - action: drop
-          regex: ^$
-          source_labels:
-          - __service__
         - action: replace
           replacement: $1
           separator: /


### PR DESCRIPTION
Fix `app` label can not be scraped.

igned-off-by: Xiang Dai <764524258@qq.com>