### PR TITLE
Added a flag --no-labels to skip printing labels in the output from l…

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -21,6 +21,7 @@ var (
 	since     = queryCmd.Flag("since", "Lookback window.").Default("1h").Duration()
 	forward   = queryCmd.Flag("forward", "Scan forwards through logs.").Default("false").Bool()
 	tail      = queryCmd.Flag("tail", "Tail the logs").Short('t').Default("false").Bool()
+	noLabels  = queryCmd.Flag("no-labels", "Do not print labels").Default("false").Bool()
 
 	labelsCmd = app.Command("labels", "Find values for a given label.")
 	labelName = labelsCmd.Arg("label", "The name of the label.").HintAction(listLabels).String()

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -61,9 +61,15 @@ func doQuery() {
 	for i.Next() {
 		ls := labelsCache(i.Labels())
 		ls = subtract(ls, common)
+
+		labels := ""
+		if !*noLabels {
+			labels = color.RedString(padLabel(ls, maxLabelsLen))
+		}
+
 		fmt.Println(
 			color.BlueString(i.Entry().Timestamp.Format(time.RFC3339)),
-			color.RedString(padLabel(ls, maxLabelsLen)),
+			labels,
 			strings.TrimSpace(i.Entry().Line),
 		)
 	}


### PR DESCRIPTION
When viewing logs via the `logcli` command, the labels are automatically printed with each line.  If the labels aren't needed in the output, they can get in the way and make it visually harder to read the logs. 

This adds a `--no-labels` flag to the `logcli` the query command.  If not set, then behaviour is like before.  If set, then labels are not included with the logs fetched with `logcli query ...`

Example usage:
```logcli query --no-labels ...'