### PR TITLE
Fix failing test `TestGlobWithMultipleFiles` in pkg/promtail/targets

### DIFF
--- a/pkg/promtail/targets/filetarget_test.go
+++ b/pkg/promtail/targets/filetarget_test.go
@@ -2,7 +2,6 @@ package targets
 
 import (
 	"fmt"
-	"github.com/go-kit/kit/log/level"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/log/level"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"

--- a/pkg/promtail/targets/filetarget_test.go
+++ b/pkg/promtail/targets/filetarget_test.go
@@ -2,6 +2,7 @@ package targets
 
 import (
 	"fmt"
+	"github.com/go-kit/kit/log/level"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 
@@ -729,10 +729,11 @@ type TestClient struct {
 }
 
 func (c *TestClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	level.Debug(c.log).Log("msg", "received log", "log", s)
+
 	c.Lock()
 	defer c.Unlock()
 	c.messages = append(c.messages, s)
-	level.Debug(c.log).Log("msg", "received log", "log", s)
 	return nil
 }
 

--- a/pkg/promtail/targets/filetarget_test.go
+++ b/pkg/promtail/targets/filetarget_test.go
@@ -11,9 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
-
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 

--- a/pkg/promtail/targets/filetarget_test.go
+++ b/pkg/promtail/targets/filetarget_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -724,9 +725,12 @@ func TestMissing(t *testing.T) {
 type TestClient struct {
 	log      log.Logger
 	messages []string
+	sync.Mutex
 }
 
 func (c *TestClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	c.Lock()
+	defer c.Unlock()
 	c.messages = append(c.messages, s)
 	level.Debug(c.log).Log("msg", "received log", "log", s)
 	return nil


### PR DESCRIPTION
TestClient used for watching log file events appends logs to a list
Due to race condition in appending those logs, some of the logs goes missing
Adding a Mutex to it to lock messages before adding logs to it