### PR TITLE
Add a /ready endpoint to promtail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ helm:
 		helm dependency build $$chart; \
 		helm package $$chart; \
 	done
+	rm -f production/helm/*/requirements.lock
 
 helm-publish: helm
 	cp production/helm/README.md index.md

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -1,6 +1,8 @@
 package promtail
 
 import (
+	"net/http"
+
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/weaveworks/common/server"
 
@@ -39,6 +41,14 @@ func New(cfg config.Config) (*Promtail, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	server.HTTP.Path("/ready").Handler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if tms.Ready() {
+			rw.WriteHeader(http.StatusNoContent)
+		} else {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
 
 	return &Promtail{
 		client:         client,

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -106,6 +106,11 @@ func NewFileTarget(logger log.Logger, handler api.EntryHandler, positions *posit
 	return t, nil
 }
 
+// Ready if at least one file is being tailed
+func (t *FileTarget) Ready() bool {
+	return len(t.tails) > 0
+}
+
 // Stop the target.
 func (t *FileTarget) Stop() {
 	close(t.quit)

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -100,6 +100,16 @@ func (tm *FileTargetManager) run() {
 	}
 }
 
+// Ready if there's at least one file target
+func (tm *FileTargetManager) Ready() bool {
+	for _, s := range tm.syncers {
+		if s.ready() {
+			return true
+		}
+	}
+	return false
+}
+
 // Stop the TargetManager.
 func (tm *FileTargetManager) Stop() {
 	tm.quit()
@@ -194,6 +204,14 @@ func (s *syncer) newTarget(path string, labels model.LabelSet) (*FileTarget, err
 	return NewFileTarget(s.log, s.entryHandler, s.positions, path, labels, s.targetConfig)
 }
 
+func (s *syncer) ready() bool {
+	for _, target := range s.targets {
+		if target.Ready() {
+			return true
+		}
+	}
+	return false
+}
 func (s *syncer) stop() {
 	for key, target := range s.targets {
 		level.Info(s.log).Log("msg", "Removing target", "key", key)

--- a/pkg/promtail/targets/manager.go
+++ b/pkg/promtail/targets/manager.go
@@ -10,6 +10,7 @@ import (
 )
 
 type targetManager interface {
+	Ready() bool
 	Stop()
 }
 
@@ -45,6 +46,16 @@ func NewTargetManagers(
 
 	return &TargetManagers{targetManagers: targetManagers}, nil
 
+}
+
+// Ready if there's at least one ready FileTargetManager
+func (tm *TargetManagers) Ready() bool {
+	for _, t := range tm.targetManagers {
+		if t.Ready() {
+			return true
+		}
+	}
+	return false
 }
 
 // Stop the TargetManagers.

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -13,15 +13,7 @@ image:
   tag: latest
   pullPolicy: Always # Always pull while in BETA
 
-livenessProbe:
-  failureThreshold: 5
-  httpGet:
-    path: /ready
-    port: http-metrics
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  successThreshold: 1
-  timeoutSeconds: 1
+livenessProbe: {}
 
 loki:
   serviceName: "" # Defaults to "${RELEASE}-loki" if not set

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -16,7 +16,7 @@ image:
 livenessProbe:
   failureThreshold: 5
   httpGet:
-    path: /metrics
+    path: /ready
     port: http-metrics
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -50,7 +50,7 @@ rbac:
 readinessProbe:
   failureThreshold: 5
   httpGet:
-    path: /metrics
+    path: /ready
     port: http-metrics
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -44,6 +44,14 @@ k + config + scrape_config {
     container.withEnv([
       container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),
     ]) +
+    container.mixin.livenessProbe.httpGet.withPath('/ready') +
+    container.mixin.livenessProbe.httpGet.withPort(80) +
+    container.mixin.livenessProbe.withInitialDelaySeconds(10) +
+    container.mixin.livenessProbe.withTimeoutSeconds(1) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.withInitialDelaySeconds(10) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1) +
     container.mixin.securityContext.withPrivileged(true) +
     container.mixin.securityContext.withRunAsUser(0),
 

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -44,10 +44,6 @@ k + config + scrape_config {
     container.withEnv([
       container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),
     ]) +
-    container.mixin.livenessProbe.httpGet.withPath('/ready') +
-    container.mixin.livenessProbe.httpGet.withPort(80) +
-    container.mixin.livenessProbe.withInitialDelaySeconds(10) +
-    container.mixin.livenessProbe.withTimeoutSeconds(1) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort(80) +
     container.mixin.readinessProbe.withInitialDelaySeconds(10) +

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -215,7 +215,7 @@ kind: ConfigMap
 metadata:
   name: promtail
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: promtail
@@ -236,8 +236,20 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         image: grafana/promtail:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: promtail
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: http-metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http-metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
         ports:
         - containerPort: 80
           name: http-metrics

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -238,12 +238,6 @@ spec:
         image: grafana/promtail:latest
         imagePullPolicy: Always
         name: promtail
-        livenessProbe:
-          httpGet:
-            path: /ready
-            port: http-metrics
-            scheme: HTTP
-          initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /ready


### PR DESCRIPTION
Currently promtail has a liveness probe that queries the /metrics endpoint instead of a proper /ready endpoint that is specific to probes. This PR adds an endpoint patterned after Loki's /ready endpoint. Current logic is promtail is ready if it is tailing at least one file. If it's not then something is wrong with permissions, volumes, scrape_config, etc. and it should retry. This will let the user know instantly that promtail is not working instead of not finding out until Grafana says can't connect to datasource. I'm open to feedback if there's a better way to calculate readiness.