### PR TITLE
Helm: Allow custom loki config

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.6.2
+version: 0.7.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -42,38 +42,3 @@ Create the name of the service account
 {{- end -}}
 {{- end -}}
 
-{{- define "configSecret" }}
-auth_enabled: {{ .Values.config.auth_enabled }}
-
-server:
-  http_listen_port: {{ .Values.port }}
-
-limits_config:
-  enforce_metric_name: false
-
-ingester:
-  lifecycler:
-    ring:
-{{ toYaml .Values.config.ingester.lifecycler.ring | indent 6 }}    
-  chunk_idle_period: 15m
-
-{{- if .Values.config.schema_configs }}
-schema_config:
-  configs:
-{{- range .Values.config.schema_configs }}
-  - from: {{ .from }}
-    store: {{ .store }}
-    object_store: {{ .object_store }}
-    schema: {{ .schema }}
-    index:
-      prefix: {{ .index.prefix }}
-      period: {{ .index.period }}
-{{- end -}}
-{{- end -}}
-
-{{- with .Values.config.storage_config }}
-storage_config:
-{{ toYaml . | indent 2 }}
-{{- end }}
-
-{{- end}}

--- a/production/helm/loki/templates/deployment.yaml
+++ b/production/helm/loki/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
           ports:
             - name: http-metrics
-              containerPort: {{ .Values.port }}
+              containerPort: {{ .Values.config.server.http_listen_port }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/production/helm/loki/templates/secret.yaml
+++ b/production/helm/loki/templates/secret.yaml
@@ -8,4 +8,4 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  loki.yaml: {{ include "configSecret" . | b64enc}}
+  loki.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -17,6 +17,7 @@ annotations: {}
 config:
   auth_enabled: false
   ingester:
+    chunk_idle_period: 15m
     lifecycler:
       ring:
         store: inmemory
@@ -31,14 +32,19 @@ config:
       #     prefix: ""
       #     httpclienttimeout: "20s"
       #     consistentreads: true
-  schema_configs:
-  - from: 0
-    store: boltdb
-    object_store: filesystem
-    schema: v9
-    index:
-      prefix: index_
-      period: 168h
+  limits_config:
+    enforce_metric_name: false
+  schema_config:
+    configs:
+    - from: 0
+      store: boltdb
+      object_store: filesystem
+      schema: v9
+      index:
+        prefix: index_
+        period: 168h
+  server:
+    http_listen_port: 3100
   storage_config:
     boltdb:
       directory: /data/loki/index
@@ -85,8 +91,6 @@ persistence:
 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "http-metrics"
-
-port: 3100
 
 ## Assign a PriorityClassName to pods if set
 # priorityClassName:


### PR DESCRIPTION
This PR allows any value in `loki.yaml` to be changed by the user by moving its definition from `_helpers.tpl` back to `values.yaml`, while still templating it. This fixes #444 in a more generic way that will hopefully be more future proof. It is mostly backwards compatible except port was removed in favor of using `config.server.http_listen_port` and that `schema_config.configs` was added to nest it properly.