### PR TITLE
Configurable Loki scheme in helm file, with optional basic auth

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -37,7 +37,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
-            - "-client.url=http://{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
+            {{- if .Values.loki.useBasicAuth }}
+            - "-client.url={{ .Values.loki.serviceScheme }}://{{ .Values.loki.basicAuthUser }}:{{ .Values.loki.basicAuthPass }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
+            {{- else }}
+            - "-client.url={{ .Values.loki.serviceScheme }}://{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/promtail

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -37,8 +37,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
-            {{- if .Values.loki.useBasicAuth }}
-            - "-client.url={{ .Values.loki.serviceScheme }}://{{ .Values.loki.basicAuthUser }}:{{ .Values.loki.basicAuthPass }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
+            {{- if and .Values.loki.user .Values.loki.password }}
+            - "-client.url={{ .Values.loki.serviceScheme }}://{{ .Values.loki.user }}:{{ .Values.loki.password }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
             {{- else }}
             - "-client.url={{ .Values.loki.serviceScheme }}://{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/api/prom/push"
             {{- end }}

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -19,9 +19,8 @@ loki:
   serviceName: "" # Defaults to "${RELEASE}-loki" if not set
   servicePort: 3100
   serviceScheme: http
-  # useBasicAuth: false
-  # basicAuthUser: user
-  # basicAuthPass: pass
+  # user: user
+  # password: pass
 
 nameOverride: promtail
 

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -18,6 +18,10 @@ livenessProbe: {}
 loki:
   serviceName: "" # Defaults to "${RELEASE}-loki" if not set
   servicePort: 3100
+  serviceScheme: http
+  # useBasicAuth: false
+  # basicAuthUser: user
+  # basicAuthPass: pass
 
 nameOverride: promtail
 


### PR DESCRIPTION
Make Loki url scheme configurable and add option for basic authentication. This is usefull if Loki is running in a different cluster than promtail behind a https url