### PR TITLE
Eliminate vendored dependencies in promtail client

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -76,10 +76,11 @@ func BuildLabelSet(labels map[string]string) model.LabelSet {
 }
 
 // SetURL sets Loki URL
-func (c *Config) SetURL(url string) {
+func (c *Config) SetURL(url string) error {
 	urlValue := flagext.URLValue{}
-	urlValue.Set(url)
+	err := urlValue.Set(url)
 	c.URL = urlValue
+	return err
 }
 
 // SetMaxRetriesBackoff sets maximum number of retires when sending batches

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -89,12 +89,12 @@ func (c *Config) SetMaxRetriesBackoff(maxRetries int) {
 
 // SetMaxBackoff sets maximum backoff time between retries
 func (c *Config) SetMaxBackoff(maxBackoff int) {
-	c.BackoffConfig.MaxBackoff = maxBackoff * time.Second
+	c.BackoffConfig.MaxBackoff = time.Duration(maxBackoff) * time.Second
 }
 
 // SetMinBackoff sets initial backoff time between retries
 func (c *Config) SetMinBackoff(minBackoff int) {
-	c.BackoffConfig.MinBackoff = minBackoff * time.Millisecond
+	c.BackoffConfig.MinBackoff = time.Duration(minBackoff) * time.Millisecond
 }
 
 // SetExternalLabels sets client ExternalLabels

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -64,6 +64,45 @@ type Config struct {
 	Timeout        time.Duration  `yaml:"timeout"`
 }
 
+// BuildLabelSet generates prometheus LabelSet form map
+func BuildLabelSet(labels map[string]string) model.LabelSet {
+	ls := model.LabelSet{}
+
+	for k, v := range labels {
+		ls[model.LabelName(k)] = model.LabelValue(v)
+	}
+
+	return ls
+}
+
+// SetURL sets Loki URL
+func (c *Config) SetURL(url string) {
+	urlValue := flagext.URLValue{}
+	urlValue.Set(url)
+	c.URL = urlValue
+}
+
+// SetMaxRetriesBackoff sets maximum number of retires when sending batches
+func (c *Config) SetMaxRetriesBackoff(maxRetries int) {
+	c.BackoffConfig.MaxRetries = maxRetries
+}
+
+// SetMaxBackoff sets maximum backoff time between retries
+func (c *Config) SetMaxBackoff(maxBackoff int) {
+	c.BackoffConfig.MaxBackoff = maxBackoff * time.Second
+}
+
+// SetMinBackoff sets initial backoff time between retries
+func (c *Config) SetMinBackoff(minBackoff int) {
+	c.BackoffConfig.MinBackoff = minBackoff * time.Millisecond
+}
+
+// SetExternalLabels sets client ExternalLabels
+func (c *Config) SetExternalLabels(labels map[string]string) {
+	ls := BuildLabelSet(labels)
+	c.ExternalLabels = ls
+}
+
 // RegisterFlags registers flags.
 func (c *Config) RegisterFlags(flags *flag.FlagSet) {
 	flags.Var(&c.URL, "client.url", "URL of log server")


### PR DESCRIPTION
When using promtail go client, the following  dependencies will be needed to use the client:

* `github.com/cortexproject/cortex/pkg/util/flagext`
* `github.com/prometheus/common/model`
* `github.com/cortexproject/cortex/pkg/util`

The previous dependencies exist already in `vendor` which cause a problem of different two versions in the vendor of promtail go client and the code or project tries to use the client itself.

These small change will eliminate the need for using any of these dependencies.