### PR TITLE
allow additional container args for Loki

### DIFF
--- a/production/helm/loki/templates/deployment.yaml
+++ b/production/helm/loki/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-config.file=/etc/loki/loki.yaml"
+          {{- range $key, $value := .Values.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+          {{- end }}            
           volumeMounts:
             - name: config
               mountPath: /etc/loki

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -58,6 +58,10 @@ image:
   tag: latest
   pullPolicy: Always # Always pull while in BETA
 
+## Additional Loki container arguments, e.g. log level (debug, info, warn, error) 
+extraArgs: {}
+  # log.level: debug
+
 livenessProbe:
   httpGet:
     path: /ready


### PR DESCRIPTION
This addresses the issue raised in #502 .

Added log level config as example to the values.yaml instead of a more specific log level key.