### PR TITLE
Allow additional pod labels

### DIFF
--- a/production/helm/loki/templates/deployment.yaml
+++ b/production/helm/loki/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         app: {{ template "loki.name" . }}
         name: {{ template "loki.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}  
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -91,6 +91,9 @@ persistence:
   # subPath: ""
   # existingClaim:
 
+## Pod Labels
+podLabels: {}
+
 ## Pod Annotations
 podAnnotations: {}
 #  prometheus.io/scrape: "true"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -24,6 +24,9 @@ spec:
       labels:
         app: {{ template "promtail.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}          
       annotations:
         {{ toYaml .Values.podAnnotations | nindent 8 }}
     spec:

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -25,6 +25,9 @@ nameOverride: promtail
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+## Pod Labels
+podLabels: {}
+
 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "http-metrics"


### PR DESCRIPTION
Allows additional pod labels for Loki and Promtail charts being supplied with values. fix #508 