### PR TITLE
Make sure the default for EnforceMetricName is ✅

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -27,6 +27,3 @@ storage_config:
 
   filesystem:
     directory: /tmp/loki/chunks
-
-limits_config:
-  enforce_metric_name: false

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -29,6 +29,9 @@ func main() {
 	flagext.RegisterFlags(&cfg)
 	flag.Parse()
 
+	// The flags set the EnforceMetricName to be true, but in loki it _should_ be false.
+	cfg.LimitsConfig.EnforceMetricName = false
+
 	util.InitLogger(&cfg.Server)
 
 	if configFile != "" {

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -32,8 +32,6 @@ config:
       #     prefix: ""
       #     httpclienttimeout: "20s"
       #     consistentreads: true
-  limits_config:
-    enforce_metric_name: false
   schema_config:
     configs:
     - from: 0

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -29,10 +29,6 @@
         grpc_server_max_recv_msg_size: 1024 * 1024 * 64,
       },
 
-      limits_config: {
-        enforce_metric_name: false,
-      },
-
       ingester: {
         chunk_idle_period: '15m',
 


### PR DESCRIPTION
The defaults set by the flags are sane, but we need to override the `EnforceMetricName` as it should always be false for Loki, but it should be true in Cortex.

Now the issue is with recent changes in cortex, if we set even one value, the other values also need to be specified, hence instead of specifying all the values, we can just remove it in the default config and enforce the default in code.