### PR TITLE
Return 200 on / when ready

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -203,6 +203,17 @@ func (i *Ingester) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// RootReadinessHandler is used to indicate to k8s when the ingesters are ready for
+// the addition removal of another ingester. Returns 200 when the ingester is
+// ready, 500 otherwise.
+func (i *Ingester) RootReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	if err := i.lifecycler.CheckReady(r.Context()); err == nil {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
 func (i *Ingester) getInstanceByID(id string) (*instance, bool) {
 	i.instancesMtx.RLock()
 	defer i.instancesMtx.RUnlock()

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -146,6 +146,7 @@ func (t *Loki) initIngester() (err error) {
 	logproto.RegisterQuerierServer(t.server.GRPC, t.ingester)
 	grpc_health_v1.RegisterHealthServer(t.server.GRPC, t.ingester)
 	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(t.ingester.ReadinessHandler))
+	t.server.HTTP.Path("/").Handler(http.HandlerFunc(t.ingester.RootReadinessHandler))
 	t.server.HTTP.Path("/flush").Handler(http.HandlerFunc(t.ingester.FlushHandler))
 	return
 }


### PR DESCRIPTION
This is for playing nicely with Google's Load balancer, which requires that pods respond with 200 on `/`. Reuses the `/ready` response with 200 instead of 204 on ready.