### PR TITLE
use server time for determening when to flush idle chunks

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -94,7 +94,7 @@ func (s *stream) Push(_ context.Context, entries []logproto.Entry) error {
 		if err := chunk.chunk.Append(&entries[i]); err != nil {
 			appendErr = err
 		}
-		chunk.lastUpdated = entries[i].Timestamp
+		chunk.lastUpdated = time.Now()
 	}
 
 	if appendErr == chunkenc.ErrOutOfOrder {


### PR DESCRIPTION
using the timestamp from the log file might lead to undesired behavior as it could be way in the past or future depending on the clock for the source system generating the logs. Given that it's compared to the servers time.Now() when looking for idle chunks it's probably best to use the server time when setting the value.