### PR TITLE
rename __filename__ label to filename

### DIFF
--- a/docs/promtail.md
+++ b/docs/promtail.md
@@ -21,7 +21,8 @@ The term "label" here is used in more than one different way and they can be eas
   will have a label \_\_meta_kubernetes_pod_label_name with value set to "foobar".
 * There are other \_\_meta_kubernetes_* labels based on the Kubernetes metadadata, such as the namespace the pod is
   running (\_\_meta_kubernetes_namespace) or the name of the container inside the pod (\_\_meta_kubernetes_pod_container_name)
-* The label \_\_path\_\_ is a special label which Promtail will read to find out where the log files are to be read in.
+* The label \_\_path\_\_ is a special label which Promtail will read to find out where the log files are to be read in,
+  it will be translated into a label named `filename` to ensure uniqueness of the streams.
 
 The most important part of each entry is the *relabel_configs* which are a list of operations which creates,
 renames, modifies or alters labels. A single scrape_config can also reject logs by doing an "action: drop" if

--- a/docs/promtail.md
+++ b/docs/promtail.md
@@ -21,8 +21,8 @@ The term "label" here is used in more than one different way and they can be eas
   will have a label \_\_meta_kubernetes_pod_label_name with value set to "foobar".
 * There are other \_\_meta_kubernetes_* labels based on the Kubernetes metadadata, such as the namespace the pod is
   running (\_\_meta_kubernetes_namespace) or the name of the container inside the pod (\_\_meta_kubernetes_pod_container_name)
-* The label \_\_path\_\_ is a special label which Promtail will read to find out where the log files are to be read in,
-  it will be translated into a label named `filename` to ensure uniqueness of the streams.
+* The label \_\_path\_\_ is a special label which Promtail will read to find out where the log files are to be read in.
+* The label `filename` is added for every file found in \_\_path\_\_ to ensure uniqueness of the streams. It contains the absolute path of the file being tailed.
 
 The most important part of each entry is the *relabel_configs* which are a list of operations which creates,
 renames, modifies or alters labels. A single scrape_config can also reject logs by doing an "action: drop" if

--- a/pkg/promtail/promtail_test.go
+++ b/pkg/promtail/promtail_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/grafana/loki/pkg/promtail/config"
 	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/grafana/loki/pkg/promtail/targets"
 )
 
 func TestPromtail(t *testing.T) {
@@ -379,7 +380,7 @@ func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		file := ""
 		for _, label := range labels {
-			if label.Name == "filename" {
+			if label.Name == targets.FilenameLabel {
 				file = label.Value
 				continue
 			}

--- a/pkg/promtail/promtail_test.go
+++ b/pkg/promtail/promtail_test.go
@@ -379,13 +379,13 @@ func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		file := ""
 		for _, label := range labels {
-			if label.Name == "__filename__" {
+			if label.Name == "filename" {
 				file = label.Value
 				continue
 			}
 		}
 		if file == "" {
-			h.t.Error("Expected to find a label with name __filename__ but did not!")
+			h.t.Error("Expected to find a label with name `filename` but did not!")
 			return
 		}
 		if _, ok := h.receivedMap[file]; ok {

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -46,7 +46,7 @@ var (
 )
 
 const (
-	filenameLabel = "__filename__"
+	filenameLabel = "filename"
 )
 
 // Config describes behavior for Target

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -46,7 +46,7 @@ var (
 )
 
 const (
-	filenameLabel = "filename"
+	FilenameLabel = "filename"
 )
 
 // Config describes behavior for Target

--- a/pkg/promtail/targets/tailer.go
+++ b/pkg/promtail/targets/tailer.go
@@ -51,7 +51,7 @@ func newTailer(logger log.Logger, handler api.EntryHandler, positions *positions
 
 	tailer := &tailer{
 		logger:    logger,
-		handler:   api.AddLabelsMiddleware(model.LabelSet{filenameLabel: model.LabelValue(path)}).Wrap(handler),
+		handler:   api.AddLabelsMiddleware(model.LabelSet{FilenameLabel: model.LabelValue(path)}).Wrap(handler),
 		positions: positions,
 
 		path: path,


### PR DESCRIPTION
This rename __filename__ label to filename so it's not protected anymore, also updated the doc.