### PR TITLE
fix backward compatibility with client config

### DIFF
--- a/pkg/promtail/client/config.go
+++ b/pkg/promtail/client/config.go
@@ -37,17 +37,24 @@ func (c *Config) RegisterFlags(flags *flag.FlagSet) {
 // UnmarshalYAML implement Yaml Unmarshaler
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type raw Config
-	// force sane defaults.
-	cfg := raw{
-		BackoffConfig: util.BackoffConfig{
-			MaxBackoff: 5 * time.Second,
-			MaxRetries: 5,
-			MinBackoff: 100 * time.Millisecond,
-		},
-		BatchSize: 100 * 1024,
-		BatchWait: 1 * time.Second,
-		Timeout:   10 * time.Second,
+	var cfg raw
+	if c.URL.URL != nil {
+		// we used flags to set that value, it's the only way before
+		cfg = raw(*c)
+	} else {
+		// force sane defaults.
+		cfg = raw{
+			BackoffConfig: util.BackoffConfig{
+				MaxBackoff: 5 * time.Second,
+				MaxRetries: 5,
+				MinBackoff: 100 * time.Millisecond,
+			},
+			BatchSize: 100 * 1024,
+			BatchWait: 1 * time.Second,
+			Timeout:   10 * time.Second,
+		}
 	}
+
 	if err := unmarshal(&cfg); err != nil {
 		return err
 	}

--- a/pkg/promtail/client/config.go
+++ b/pkg/promtail/client/config.go
@@ -39,7 +39,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type raw Config
 	var cfg raw
 	if c.URL.URL != nil {
-		// we used flags to set that value, it's the only way before
+		// we used flags to set that value, which already has sane default.
 		cfg = raw(*c)
 	} else {
 		// force sane defaults.


### PR DESCRIPTION
Before we have default via flag, I added default in the yaml unmarshaler which cause a problem by overriding flags, this is an ugly hack until we improve config management specially defaults.

