### PR TITLE
Support CRI 1.14+ directory change

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,23 +23,6 @@ This can have several reasons:
   - Detect this by turning on debug logging and then look for `dropping target, no labels` or `ignoring target` messages.
 - Promtail cannot find the location of your log files. Check that the scrape_configs contains valid path setting for finding the logs in your worker nodes.
 - Your pods are running but not with the labels Promtail is expecting. Check the Promtail scape_configs.
-- Kubernetes 1.14+ and GKE 1.12+: the default scape_configs need to be adapted to work. 
-From
-```
-        - replacement: /var/log/pods/$1/*.log
-          separator: /
-          source_labels:
-          - __meta_kubernetes_pod_uid
-          - __meta_kubernetes_pod_container_name
-          target_label: __path__
-```
-to
-```
-        - replacement: /var/log/pods/*$1*/*/*.log
-          source_labels:
-          - __meta_kubernetes_pod_uid
-          target_label: __path__
-```
 
 ## Troubleshooting targets
 

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -160,7 +160,7 @@ config:
       target_label: container_name
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
-    - replacement: /var/log/pods/$1/*.log
+    - replacement: /var/log/pods/*$1/*.log
       separator: /
       source_labels:
       - __meta_kubernetes_pod_uid
@@ -206,7 +206,7 @@ config:
       target_label: container_name
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
-    - replacement: /var/log/pods/$1/*.log
+    - replacement: /var/log/pods/*$1/*.log
       separator: /
       source_labels:
       - __meta_kubernetes_pod_uid
@@ -258,7 +258,7 @@ config:
       target_label: container_name
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
-    - replacement: /var/log/pods/$1/*.log
+    - replacement: /var/log/pods/*$1/*.log
       separator: /
       source_labels:
       - __meta_kubernetes_pod_uid
@@ -312,7 +312,7 @@ config:
       target_label: container_name
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
-    - replacement: /var/log/pods/$1/*.log
+    - replacement: /var/log/pods/*$1/*.log
       separator: /
       source_labels:
       - __meta_kubernetes_pod_uid
@@ -359,10 +359,9 @@ config:
       target_label: container_name
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)
-    - replacement: /var/log/pods/$1/*.log
+    - replacement: /var/log/pods/*$1/*.log
       separator: /
       source_labels:
       - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
       - __meta_kubernetes_pod_container_name
       target_label: __path__
-

--- a/production/ksonnet/promtail/scrape_config.libsonnet
+++ b/production/ksonnet/promtail/scrape_config.libsonnet
@@ -64,7 +64,7 @@ config + {
         source_labels: [pod_uid, '__meta_kubernetes_pod_container_name'],
         target_label: '__path__',
         separator: '/',
-        replacement: '/var/log/pods/$1/*.log',
+        replacement: '/var/log/pods/*$1/*.log',
       },
     ],
   },

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -53,7 +53,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1/*.log
+      - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid
@@ -99,7 +99,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1/*.log
+      - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid
@@ -151,7 +151,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1/*.log
+      - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid
@@ -205,7 +205,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1/*.log
+      - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_uid
@@ -252,7 +252,7 @@ data:
         target_label: container_name
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - replacement: /var/log/pods/$1/*.log
+      - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
         - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror


### PR DESCRIPTION
Fixes #393

`< 1.14`
```bash
/var/log/pods/${POD_UID}/${POD_CONTAINER_NAME}/*.log
```

`>= 1.14`
```bash
/var/log/pods/${POD_NAMESPACE}_${POD_NAME}_${POD_UID}/${POD_CONTAINER_NAME}/*.log
```

The fix is to add a wildcard to ignore the `${POD_NAMESPACE}_${POD_NAME}_` prefix. A pod UID is already unique enough to identify a pod, so we don't have to also match the namespace or pod name. This change is fully backwards compatible with <1.14 as well so we don't need add separate scrape configs specific to Kubernetes versions.

Note the workaround in the ticket (and docs/troubleshooting.md) is incorrect for any k8s version since it doesn't match pod_container_name and the target for each container will match the logs of every container in the pod.