### PR TITLE
Various improvements to unit tests.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -900,8 +900,8 @@
   version = "v2.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:81403343bc9a102e3c924f87ad81e5a13bb7c36211714475c906853f4e887933"
+  branch = "server-listen-addr"
+  digest = "1:0184d699d4cbbbc3073fbbdd7cc0c8592d484c6f23914c89fb6d218e90de171a"
   name = "github.com/weaveworks/common"
   packages = [
     "aws",
@@ -918,7 +918,8 @@
     "user",
   ]
   pruneopts = "UT"
-  revision = "81a1a4d158e60de72dbead600ec011fb90344f8c"
+  revision = "5bf824591a6567784789cf9b2169f74f162bf80d"
+  source = "https://github.com/tomwilkie/weaveworks-common"
 
 [[projects]]
   digest = "1:bb40f7ff970145324f2a2acafdff3a23ed3f05db49cb5eb519b3d6bee86a5887"
@@ -1413,6 +1414,7 @@
     "github.com/prometheus/prometheus/pkg/modtimevfs",
     "github.com/prometheus/prometheus/pkg/relabel",
     "github.com/prometheus/prometheus/pkg/textparse",
+    "github.com/prometheus/prometheus/promql",
     "github.com/prometheus/prometheus/relabel",
     "github.com/prometheus/prometheus/template",
     "github.com/shurcooL/httpfs/filter",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,8 @@
 
 [[constraint]]
   name = "github.com/weaveworks/common"
-  branch = "master"
+  source = "https://github.com/tomwilkie/weaveworks-common"
+  branch = "server-listen-addr"
 
 [[constraint]]
   name = "gopkg.in/fsnotify.v1"

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -2,7 +2,6 @@ package ingester
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -10,9 +9,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ring"
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	"github.com/go-kit/kit/log"
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
@@ -27,7 +24,7 @@ const (
 )
 
 func init() {
-	util.Logger = log.NewLogfmtLogger(os.Stdout)
+	//util.Logger = log.NewLogfmtLogger(os.Stdout)
 }
 
 func TestChunkFlushingIdle(t *testing.T) {
@@ -81,6 +78,7 @@ func defaultIngesterTestConfig() Config {
 	cfg.LifecyclerConfig.ListenPort = func(i int) *int { return &i }(0)
 	cfg.LifecyclerConfig.Addr = "localhost"
 	cfg.LifecyclerConfig.ID = "localhost"
+	cfg.LifecyclerConfig.FinalSleep = 0
 	return cfg
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -13,19 +13,10 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/ring"
-	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 func TestIngester(t *testing.T) {
-	var ingesterConfig Config
-	flagext.DefaultValues(&ingesterConfig)
-	ingesterConfig.LifecyclerConfig.RingConfig.Mock = ring.NewInMemoryKVClient()
-	ingesterConfig.LifecyclerConfig.NumTokens = 1
-	ingesterConfig.LifecyclerConfig.ListenPort = func(i int) *int { return &i }(0)
-	ingesterConfig.LifecyclerConfig.Addr = "localhost"
-	ingesterConfig.LifecyclerConfig.ID = "localhost"
-
+	ingesterConfig := defaultIngesterTestConfig()
 	store := &mockStore{
 		chunks: map[string][]chunk.Chunk{},
 	}

--- a/vendor/github.com/weaveworks/common/logging/level.go
+++ b/vendor/github.com/weaveworks/common/logging/level.go
@@ -49,6 +49,11 @@ func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return l.Set(level)
 }
 
+// MarshalYAML implements yaml.Marshaler.
+func (l Level) MarshalYAML() (interface{}, error) {
+	return l.String(), nil
+}
+
 // Set updates the value of the allowed level.  Implments flag.Value.
 func (l *Level) Set(s string) error {
 	switch s {

--- a/vendor/github.com/weaveworks/common/middleware/grpc_logging.go
+++ b/vendor/github.com/weaveworks/common/middleware/grpc_logging.go
@@ -31,7 +31,11 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 		if s.WithRequest {
 			entry = entry.WithField("request", req)
 		}
-		entry.WithField(errorKey, err).Warnln(gRPC)
+		if err == context.Canceled {
+			entry.WithField(errorKey, err).Debugln(gRPC)
+		} else {
+			entry.WithField(errorKey, err).Warnln(gRPC)
+		}
 	} else {
 		entry.Debugf("%s (success)", gRPC)
 	}
@@ -44,7 +48,11 @@ func (s GRPCServerLog) StreamServerInterceptor(srv interface{}, ss grpc.ServerSt
 	err := handler(srv, ss)
 	entry := user.LogWith(ss.Context(), s.Log).WithFields(logging.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
 	if err != nil {
-		entry.WithField(errorKey, err).Warnln(gRPC)
+		if err == context.Canceled {
+			entry.WithField(errorKey, err).Debugln(gRPC)
+		} else {
+			entry.WithField(errorKey, err).Warnln(gRPC)
+		}
 	} else {
 		entry.Debugf("%s (success)", gRPC)
 	}

--- a/vendor/github.com/weaveworks/common/middleware/logging.go
+++ b/vendor/github.com/weaveworks/common/middleware/logging.go
@@ -63,8 +63,9 @@ func dumpRequest(req *http.Request) ([]byte, error) {
 
 	// Exclude some headers for security, or just that we don't need them when debugging
 	err := req.Header.WriteSubset(&b, map[string]bool{
-		"Cookie":       true,
-		"X-Csrf-Token": true,
+		"Cookie":        true,
+		"X-Csrf-Token":  true,
+		"Authorization": true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Stop ingester tests from taking 60s, by setting Cortex shutdown wait period to 0 (its theres to allow one final scrape of metrics in production)
- Listen on localhost in promtail tests, to prevent dialog warning on MacOS (probably cause of #558)