### PR TITLE
Support using an IPv6 in the Loki push url

### DIFF
--- a/fluentd/fluent-plugin-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-loki/lib/fluent/plugin/out_loki.rb
@@ -90,7 +90,7 @@ module Fluent
           use_ssl: uri.scheme == 'https'
         }
         log.info "sending #{req.body.length} bytes"
-        res = Net::HTTP.start(uri.host, uri.port, **opts) { |http| http.request(req) }
+        res = Net::HTTP.start(uri.hostname, uri.port, **opts) { |http| http.request(req) }
         unless res && res.is_a?(Net::HTTPSuccess)
           res_summary = if res
                           "#{res.code} #{res.message} #{res.body}"


### PR DESCRIPTION
Because the plugin is using `URL.host`, which is the literal HTTP host, it fails to connect to an IPv6 host when host is specified directly in the URL. This PR uses `URL.hostname` instead, which is the real hostname, and is thus unbracketed in case of an IPv6.