### PR TITLE
Limiting query start time with config

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -30,3 +30,6 @@ storage_config:
 
 limits_config:
   enforce_metric_name: false
+
+querier:
+  max_look_back_period: 672h

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -32,4 +32,4 @@ limits_config:
   enforce_metric_name: false
 
 querier:
-  max_look_back_period: 672h
+  max_look_back_period: 0

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"context"
 	"flag"
+	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	cortex_client "github.com/cortexproject/cortex/pkg/ingester/client"
@@ -18,10 +19,12 @@ import (
 
 // Config for a querier.
 type Config struct {
+	MaxLookBackPeriod time.Duration `yaml:"max_look_back_period"`
 }
 
 // RegisterFlags register flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.DurationVar(&cfg.MaxLookBackPeriod, "querier.max-look_back_period", 0, "")
 }
 
 // Querier handlers queries.
@@ -92,6 +95,11 @@ func (q *Querier) forAllIngesters(f func(logproto.QuerierClient) (interface{}, e
 
 // Query does the heavy lifting for an actual query.
 func (q *Querier) Query(ctx context.Context, req *logproto.QueryRequest) (*logproto.QueryResponse, error) {
+	oldestStartTime := time.Now().Add(-q.cfg.MaxLookBackPeriod)
+	if oldestStartTime.After(req.Start) {
+		req.Start = oldestStartTime
+	}
+
 	ingesterIterators, err := q.queryIngesters(ctx, req)
 	if err != nil {
 		return nil, err

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -19,7 +19,7 @@ import (
 
 // Config for a querier.
 type Config struct {
-	// Limits query start time to be greater than now() - MaxLookBackPeriod, if set
+	// Limits query start time to be greater than now() - MaxLookBackPeriod, if set.
 	MaxLookBackPeriod time.Duration `yaml:"max_look_back_period"`
 }
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -96,7 +96,7 @@ func (q *Querier) forAllIngesters(f func(logproto.QuerierClient) (interface{}, e
 
 // Query does the heavy lifting for an actual query.
 func (q *Querier) Query(ctx context.Context, req *logproto.QueryRequest) (*logproto.QueryResponse, error) {
-	if q.cfg.MaxLookBackPeriod !=0 {
+	if q.cfg.MaxLookBackPeriod != 0 {
 		oldestStartTime := time.Now().Add(-q.cfg.MaxLookBackPeriod)
 		if oldestStartTime.After(req.Start) {
 			req.Start = oldestStartTime

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -57,7 +57,7 @@ config:
     filesystem:
       directory: /data/loki/chunks
   querier:
-    max_look_back_period: '720h'
+    max_look_back_period: '672h'
 
 deploymentStrategy: RollingUpdate
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -56,6 +56,8 @@ config:
       directory: /data/loki/index
     filesystem:
       directory: /data/loki/chunks
+  querier:
+    max_look_back_period: '720h'
 
 deploymentStrategy: RollingUpdate
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -57,7 +57,7 @@ config:
     filesystem:
       directory: /data/loki/chunks
   querier:
-    max_look_back_period: '672h'
+    max_look_back_period: 0
 
 deploymentStrategy: RollingUpdate
 


### PR DESCRIPTION
Added maxLookBackPeriod in config to limit query start time