### PR TITLE
Fix promtail panic

### DIFF
--- a/cmd/promtail/promtail-docker-config.yaml
+++ b/cmd/promtail/promtail-docker-config.yaml
@@ -4,6 +4,7 @@ server:
 
 positions:
   filename: /tmp/positions.yaml
+  sync_period: 10ms
 
 clients:
   - url: http://loki:3100/api/prom/push

--- a/cmd/promtail/promtail-local-config.yaml
+++ b/cmd/promtail/promtail-local-config.yaml
@@ -4,6 +4,7 @@ server:
 
 positions:
   filename: /tmp/positions.yaml
+  sync_period: 10ms
 
 clients:
   - url: http://localhost:3100/api/prom/push


### PR DESCRIPTION
Fix below panic error:
```
./promtail -config.file cmd/promtail/promtail-local-config.yaml 
panic: non-positive interval for NewTicker

goroutine 144 [running]:
time.NewTicker(0x0, 0x2524468)
	/usr/lib/golang/src/time/tick.go:23 +0x190
github.com/grafana/loki/pkg/promtail/positions.(*Positions).run(0xc0004050e0)
	/deploy/go/src/github.com/grafana/loki/pkg/promtail/positions/positions.go:107 +0x71
created by github.com/grafana/loki/pkg/promtail/positions.New
	/deploy/go/src/github.com/grafana/loki/pkg/promtail/positions/positions.go:60 +0x130
```