### PR TITLE
Loki as statefulset or deployment

### DIFF
--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.mode "standalone" }}
-apiVersion: apps/v1
-kind: Deployment
+{{- if eq .Values.mode "distributed" }}
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{ template "loki.fullname" . }}
   labels:
@@ -72,7 +72,7 @@ spec:
             readOnlyRootFilesystem: true
           env:
             - name: JAEGER_AGENT_HOST
-              value: "{{ .Values.tracing.jaegerAgentHost }}"
+              value: "{{ .Values.tracing.jaegerAgentHost }}"      
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -61,6 +61,9 @@ config:
 
 deploymentStrategy: RollingUpdate
 
+## Use a deployment (standalone mode) or use a statefulset (distributed mode) as Kubernetes workload
+mode: standalone
+
 image:
   repository: grafana/loki
   tag: latest


### PR DESCRIPTION
Allow Loki to be deployed as statefulset. This should resolve issues with PV/PVC. Another benefit of a statefulset is a stable hostname, which allows the use of consul as ring store (the hostname is used as ingester ID by default).

fixes #570