### PR TITLE
need to bump helm chart after PR #598

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."


### PR DESCRIPTION
The schema data was updated in #598 but the helm chart version was not changed, this should publish a new chart to fix that issue

Fixes #607 
