### PR TITLE
Helm chart tracing variable fix

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,5 +83,5 @@ We support (jaeger)[https://www.jaegertracing.io/] to trace loki, just add env `
 If you deploy with helm, refer to following command:
 
 ```bash
-$ helm upgrade --install loki loki/loki --set "loki.jaegerAgentHost=YOUR_JAEGER_AGENT_HOST"
+$ helm upgrade --install loki loki/loki --set "loki.tracing.jaegerAgentHost=YOUR_JAEGER_AGENT_HOST"
 ```

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.8.4
+version: 0.8.5
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/deployment.yaml
+++ b/production/helm/loki/templates/deployment.yaml
@@ -70,8 +70,10 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           env:
+            {{- if .Values.tracing.jaegerAgentHost }}
             - name: JAEGER_AGENT_HOST
               value: "{{ .Values.tracing.jaegerAgentHost }}"
+            {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:

If the tracing variable isn't set, loki fails to start the pod.

**Which issue(s) this PR fixes**:

Fixes #620.