### PR TITLE
ksonnet changes for running loki in single binary

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -34,3 +34,18 @@ limits_config:
 
 chunk_store_config:
   max_look_back_period: 0
+
+table_manager:
+  chunk_tables_provisioning:
+    inactive_read_throughput: 0
+    inactive_write_throughput: 0
+    provisioned_read_throughput: 0
+    provisioned_write_throughput: 0
+  index_tables_provisioning:
+    inactive_read_throughput: 0
+    inactive_write_throughput: 0
+    provisioned_read_throughput: 0
+    provisioned_write_throughput: 0
+  retention_deletes_enabled: false
+  retention_period: 0
+

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.9.4
+version: 0.9.5
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.8.3
+version: 0.8.4
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -59,6 +59,9 @@ config:
       directory: /data/loki/chunks
   chunk_store_config:
     max_look_back_period: 0
+  table_manager:
+    retention_deletes_enabled: false
+    retention_period: 0
 
 deploymentStrategy: RollingUpdate
 

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -108,6 +108,7 @@
             service: 'memcached-client',
           },
         },
+        max_look_back_period: 0,
       },
 
       schema_config: {
@@ -121,6 +122,23 @@
             period: '168h',
           },
         }],
+      },
+
+      table_manager: {
+        retention_period: 0,
+        retention_deletes_enabled: false,
+        index_tables_provisioning: {
+          inactive_read_throughput: 0,
+          inactive_write_throughput: 0,
+          provisioned_read_throughput: 0,
+          provisioned_write_throughput: 0,
+        },
+        chunk_tables_provisioning: {
+          inactive_read_throughput: 0,
+          inactive_write_throughput: 0,
+          provisioned_read_throughput: 0,
+          provisioned_write_throughput: 0,
+        },
       },
     },
   },

--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -4,13 +4,11 @@
     memcached: 'memcached:1.5.6-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.4.1',
 
-    // Our services.
-    tableManager: 'grafana/cortex-table-manager:r56-bd83f04a',
-
     loki: 'grafana/loki:latest',
 
     distributor: self.loki,
     ingester: self.loki,
     querier: self.loki,
+    tableManager: self.loki,
   },
 }

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -1,28 +1,10 @@
 {
   local container = $.core.v1.container,
 
-  table_manager_args:: {
-    'bigtable.project': $._config.bigtable_project,
-    'bigtable.instance': $._config.bigtable_instance,
-    'chunk.storage-client': $._config.storage_backend,
-
-    'dynamodb.original-table-name': '%s_index' % $._config.table_prefix,
-    'dynamodb.use-periodic-tables': true,
-    'dynamodb.periodic-table.prefix': '%s_index_' % $._config.table_prefix,
-    'dynamodb.chunk-table.prefix': '%s_chunks_' % $._config.table_prefix,
-    'dynamodb.periodic-table.from': $._config.schema_start_date,
-    'dynamodb.chunk-table.from': $._config.schema_start_date,
-    'dynamodb.v9-schema-from': $._config.schema_start_date,
-    // Cassandra / BigTable doesn't use these fields, so set them to zero
-    'dynamodb.chunk-table.inactive-read-throughput': 0,
-    'dynamodb.chunk-table.inactive-write-throughput': 0,
-    'dynamodb.chunk-table.read-throughput': 0,
-    'dynamodb.chunk-table.write-throughput': 0,
-    'dynamodb.periodic-table.inactive-read-throughput': 0,
-    'dynamodb.periodic-table.inactive-write-throughput': 0,
-    'dynamodb.periodic-table.read-throughput': 0,
-    'dynamodb.periodic-table.write-throughput': 0,
-  },
+  table_manager_args::
+  $._config.commonArgs {
+          target: 'table-manager',
+        },
 
   table_manager_container::
     container.new('table-manager', $._images.tableManager) +
@@ -34,7 +16,9 @@
   local deployment = $.apps.v1beta1.deployment,
 
   table_manager_deployment:
-    deployment.new('table-manager', 1, [$.table_manager_container]),
+    deployment.new('table-manager', 1, [$.table_manager_container]) +
+    $.config_hash_mixin +
+    $.util.configVolumeMount('loki', '/etc/loki'),
 
   table_manager_service:
     $.util.serviceFor($.table_manager_deployment),

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -3,8 +3,8 @@
 
   table_manager_args::
   $._config.commonArgs {
-          target: 'table-manager',
-        },
+    target: 'table-manager',
+  },
 
   table_manager_container::
     container.new('table-manager', $._images.tableManager) +


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently table manager was made available to run in loki single binary.
These ksonnet changes are needed to make use of that instead of using cortex image
Table manager would now use same config as other services instead of command-line args
Added retention config with default values in ksonnet and helm

**Checklist**
- [x] Updated helm chart version in loki and loki-stack