### PR TITLE
provide Cassandra Index Store Example

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -98,6 +98,33 @@ The chunks are stored under `/tmp/loki/chunks`.
 Loki has support for Google Cloud storage.
 Take a look at our [production setup](https://github.com/grafana/loki/blob/a422f394bb4660c98f7d692e16c3cc28747b7abd/production/ksonnet/loki/config.libsonnet#L55) for the relevant configuration fields.
 
+### Cassandra
+
+Loki can use Cassandra for the index storage. Please pull the **latest** Loki docker image or build from **latest** source code. Example config for using Cassandra:
+
+```yaml
+schema_config:
+  configs:
+  - from: 2018-04-15
+    store: cassandra
+    object_store: filesystem
+    schema: v9
+    index:
+      prefix: cassandra_table
+      period: 168h
+
+storage_config:
+  cassandra:
+    username: cassandra
+    password: cassandra
+    addresses: 127.0.0.1
+    auth: true
+    keyspace: lokiindex
+
+  filesystem:
+    directory: /tmp/loki/chunks
+```
+
 ### AWS S3 & DynamoDB
 
 Example config for using S3 & DynamoDB:


### PR DESCRIPTION
Mentioned in title. 

It's really time-consuming to config Cassandra without example, user have to figure out from the source code.
To save new beginner's time, provide one config example for use Cassandra as Index Storage.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

