### PR TITLE
Limits: Reject entries based on age set in limits

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -31,6 +31,8 @@ storage_config:
 
 limits_config:
   enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 24h
 
 chunk_store_config:
   max_look_back_period: 0

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -32,7 +32,7 @@ storage_config:
 limits_config:
   enforce_metric_name: false
   reject_old_samples: true
-  reject_old_samples_max_age: 24h
+  reject_old_samples_max_age: 168h
 
 chunk_store_config:
   max_look_back_period: 0

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -41,7 +41,7 @@ config:
   limits_config:
     enforce_metric_name: false
     reject_old_samples: true
-    reject_old_samples_max_age: 24h
+    reject_old_samples_max_age: 168h
   schema_config:
     configs:
     - from: 2018-04-15

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -40,6 +40,8 @@ config:
       #     consistentreads: true
   limits_config:
     enforce_metric_name: false
+    reject_old_samples: true
+    reject_old_samples_max_age: 24h
   schema_config:
     configs:
     - from: 2018-04-15

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -33,6 +33,8 @@
 
       limits_config: {
         enforce_metric_name: false,
+        reject_old_samples: true,
+        reject_old_samples_max_age: '168h',
       },
 
       ingester: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit age of log entries to the configured value.

**Checklist**
- [x] Config and helm chart versions updated

