### PR TITLE
Helm: Integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
           name: Run Chart Tests
           command: |
             ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack --upgrade
+            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
 
   publish-helm:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,13 @@ workflows:
   test-build-deploy:
     jobs:
     - test
+    - test-helm
     - build
     - lint
     - publish:
         requires:
         - test
+        - test-helm
         - build
         - lint
         filters:
@@ -18,6 +20,7 @@ workflows:
     - publish-master:
         requires:
         - test
+        - test-helm
         - build
         - lint
         filters:
@@ -26,6 +29,7 @@ workflows:
     - publish-helm:
         requires:
         - test
+        - test-helm
         - build
         - lint
         filters:
@@ -147,6 +151,38 @@ jobs:
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
             make push-latest
+
+  test-helm:
+    environment:
+      CT_VERSION: 2.3.3
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Install k3s
+          command: |
+            curl -sfL https://get.k3s.io | sh -
+            mkdir -p ~/.kube
+            cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+      - run:
+          name: Install Helm
+          command: |
+            curl -L https://git.io/get_helm.sh | bash
+            kubectl apply -f tools/helm.yaml
+            helm init --service-account helm --wait
+      - run:
+          name: Install Chart Testing tool
+          command: |
+            pip install yamale yamllint
+            curl -Lo ct.tgz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
+            sudo tar -C /usr/local/bin -xvf ct.tgz
+            sudo mv /usr/local/bin/etc /etc/ct/
+      - run:
+          name: Run Chart Tests
+          command: |
+            ct lint --chart-dirs=production/helm --validate-maintainers=false
+            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack --upgrade
 
   publish-helm:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - run:
           name: Run Chart Tests
           command: |
-            ct lint --chart-dirs=production/helm --validate-maintainers=false
+            ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
             ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack --upgrade
 
   publish-helm:

--- a/production/helm/loki-stack/templates/tests/loki-test-configmap.yaml
+++ b/production/helm/loki-stack/templates/tests/loki-test-configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "loki-stack.fullname" . }}-test
+  labels:
+    app: {{ template "loki-stack.name" . }}
+    chart: {{ template "loki-stack.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  test.sh: |
+    #!/usr/bin/env bash
+
+    LOKI_URI="http://${LOKI_SERVICE}:${LOKI_PORT}"
+
+    function setup() {
+      apk add -u curl jq
+      until (curl -s ${LOKI_URI}/api/prom/label/app/values | jq -e '.values[] | select(. == "loki")'); do
+        sleep 1
+      done
+    }
+
+    @test "Has labels" {
+      curl -s ${LOKI_URI}/api/prom/label | \
+      jq -e '.values[] | select(. == "app")'
+    }
+
+    @test "Query log entry" {
+      curl -sG ${LOKI_URI}/api/prom/query?limit=10 --data-urlencode 'query={app="loki"}' | \
+      jq -e '.streams[].entries | length >= 1'
+    }
+
+    @test "Push log entry" {
+      local timestamp=$(date -Iseconds -u | sed 's/UTC/.000000000+00:00/')
+      local data=$(jq -n --arg timestamp "${timestamp}" '{"streams": [{"labels": "{app=\"loki-test\"}", "entries": [{"ts": $timestamp, "line": "foobar"}]}]}')
+
+      curl -s -X POST -H "Content-Type: application/json" ${LOKI_URI}/api/prom/push -d "${data}"
+
+      curl -sG ${LOKI_URI}/api/prom/query?limit=1 --data-urlencode 'query={app="loki-test"}' | \
+      jq -e '.streams[].entries[].line == "foobar"'
+    }
+

--- a/production/helm/loki-stack/templates/tests/loki-test-pod.yaml
+++ b/production/helm/loki-stack/templates/tests/loki-test-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    "helm.sh/hook": test-success
+  labels:
+    app: {{ template "loki-stack.name" . }}
+    chart: {{ template "loki-stack.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "loki-stack.fullname" . }}-test
+spec:
+  containers:
+  - name: test
+    image: bats/bats:v1.1.0
+    args:
+    - /var/lib/loki/test.sh
+    env:
+    - name: LOKI_SERVICE
+      value: {{ template "loki.serviceName" . }}
+    - name: LOKI_PORT
+      value: "{{ .Values.loki.service.port }}"
+    volumeMounts:
+    - name: tests
+      mountPath: /var/lib/loki
+  restartPolicy: Never
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "loki-stack.fullname" . }}-test

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -105,8 +105,8 @@ podLabels: {}
 
 ## Pod Annotations
 podAnnotations:
- prometheus.io/scrape: "true"
- prometheus.io/port: "http-metrics"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "http-metrics"
 
 podManagementPolicy: OrderedReady
 

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -14,7 +14,7 @@ image:
 livenessProbe: {}
 
 loki:
-  serviceName: "" # Defaults to "${RELEASE}-loki" if not set
+  serviceName: ""  # Defaults to "${RELEASE}-loki" if not set
   servicePort: 3100
   serviceScheme: http
   # user: user
@@ -32,9 +32,9 @@ pipelineStages:
 ## Pod Labels
 podLabels: {}
 
-podAnnotations: 
- prometheus.io/scrape: "true"
- prometheus.io/port: "http-metrics"
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "http-metrics"
 
 # This should match config.server.http_listen_port
 port: 3101
@@ -127,4 +127,3 @@ config:
   target_config:
     # Period to resync directories being watched and files being tailed
     sync_period: 10s
-


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Helm chart integration testing via CircleCI.

- Spins up an Ubuntu VM
- Installs [k3s](https://k3s.io) based cluster
- Installs Helm
- Installs [Chart Testing](https://github.com/helm/chart-testing) tools (same tools [helm/charts ](https://github.com/helm/charts/) uses)
- Runs lint on all charts
- Does a fresh chart install of loki-stack
- Runs new chart integration tests that verify Loki has labels, label values, can query and push logs
- Chart tests can also be ran standalone via `helm test <release>`.
- Chart tests written using [BATS](https://github.com/bats-core/bats-core/)
- Execution time is around 3m

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Changes to charts were necessary to pass stricter linting rules used by CT

**Checklist**
- [ ] Documentation added
- [x] Tests updated

