### PR TITLE
add support for RFC3339Nano in query timestamps

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,8 +28,8 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
 
   - `query`: a logQL query
   - `limit`: max number of entries to return
-  - `start`: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970). Default is always one hour ago.
-  - `end`: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970). Default is current time.
+  - `start`: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999Z07:00"). Default is always one hour ago.
+  - `end`: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999Z07:00"). Default is current time.
   - `direction`: `forward` or `backward`, useful when specifying a limit. Default is backward.
   - `regexp`: a regex to filter the returned results, will eventually be rolled into the query language
 

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -48,6 +48,9 @@ func unixNanoTimeParam(values url.Values, name string, def time.Time) (time.Time
 
 	nanos, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts, nil
+		}
 		return time.Time{}, err
 	}
 


### PR DESCRIPTION
As per requested for context https://github.com/grafana/loki/issues/597#issuecomment-497411021

This adds support for ISO date in query timestamps.
