### PR TITLE
fix(loki): honor log level from config file

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -48,6 +48,9 @@ func main() {
 		}
 	}
 
+	// Re-init the logger which will now honor a different log level set in cfg.Server
+	util.InitLogger(&cfg.Server)
+
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace := tracing.NewFromEnv(fmt.Sprintf("loki-%s", cfg.Target))
 	defer func() {


### PR DESCRIPTION
Because of the logger being initialized before the configuration file is parsed,
the `log_level` from the config file is ignored.
To solve this, the logger is reinitialized after the file is parsed, as it is
already being done in `promtail`.

Fixes #652 