### PR TITLE
fix(Makefile): allow setting GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ clean:
 
 assets:
 	@echo ">> writing assets"
-	GOOS=$(shell go env GOHOSTOS) go generate -x -v ./pkg/promtail/server/ui
+	GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) go generate -x -v ./pkg/promtail/server/ui
 
 check_assets: assets
 	@echo ">> checking that assets are up-to-date"


### PR DESCRIPTION
To make cross compiling easier, the `Makefile` should allow to set `GOOS` and `GOARCH`.
However, the `assets` task is generating a binary that has to be executed locally. If the two environment variables would be left as they for this target, it would fail because of an `exec-format error`, as the compiled binary is not for the Host OS anymore.

To prevent this `GOARCH` and `GOOS` are overwritten with `GOHOSTARCH` and `GOHOSTOS` respectively.

This also simplifies building for `arm(64)`, as requested by #653 