### PR TITLE
feat(docker): multi-arch Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# These may be overwritten by --build-arg to build promtail or debug images
+ARG APP=loki
+ARG TYPE=production
+
+# ca-certificates
+FROM alpine:3.9 as ssl
+RUN apk add --update --no-cache ca-certificates
+
+# use grafana/loki-build-image to compile binaries
+FROM grafana/loki-build-image as golang
+ARG GOARCH="amd64"
+COPY . /go/src/github.com/grafana/loki
+WORKDIR /go/src/github.com/grafana/loki
+RUN touch loki-build-image/.uptodate &&\
+    mkdir /build
+
+# production image
+FROM golang as builder-production
+ARG APP
+RUN make BUILD_IN_CONTAINER=false cmd/${APP}/${APP} &&\
+  mv cmd/${APP}/${APP} /build/${APP}
+
+FROM scratch as production
+COPY --from=ssl /etc/ssl /etc/ssl
+COPY --from=builder-production /build/${APP} /usr/bin/${APP}
+
+# debug image (only arm64 supported, because of go-delve/delve#118)
+FROM golang as builder-debug
+ARG APP
+RUN go get github.com/go-delve/delve/cmd/dlv &&\
+  make BUILD_IN_CONTAINER=false cmd/promtail/promtail-debug &&\
+  mv cmd/${APP}/${APP}-debug /build/app-debug &&\
+  mv cmd/${APP}/dlv /build/dlv
+
+FROM alpine:3.9 as debug
+COPY --from=ssl /etc/ssl /etc/ssl
+COPY --from=builder-debug /build/app-debug /usr/bin/app-debug
+COPY --from=builder-debug /build/dlv /usr/bin/dlv
+RUN apk add --no-cache libc6-compat
+EXPOSE 40000
+ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/usr/bin/app-debug", "--"]
+
+# final image with configuration
+FROM ${TYPE} as promtail
+COPY cmd/promtail/promtail-local-config.yaml cmd/promtail/promtail-docker-config.yaml /etc/promtail/
+ENTRYPOINT ["/usr/bin/promtail"]
+
+FROM ${TYPE} as loki
+COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+EXPOSE 80
+ENTRYPOINT ["/usr/bin/loki"]
+
+FROM ${APP}


### PR DESCRIPTION
Tracking PR for part two of #659 

#### ✅  Advanced Dockerfile
This new image is heavily based on recent `Dockerfile` features. Especially multi-stages have been used to abstract both `loki` and `promtail` into a **single Dockerfile**, which is able to produce individual images for these two components. Thanks to `BuildKit`, nothing that is not required is built.

- **DRY:** building promtail and loki from the same image
- **portable, slim, minimal attack-vector:** based on `scratch`, so that the final image can be executed on every supported
  GOARCH

Please note that this Dockerfile should always be built using
BuildKit (`buildctl` or `DOCKER_BUILDKIT=1` in recent versions) for maximum
performance, as BuildKit's DAG allows for smart skipping of unneeded stages.

**⚠️ Whoever has the time may do some extensive testing of this new image, please. I have tried to work as close to the original one as possible, but I still may have broken something.**

#### ~~☑️ CI + Makefile~~
- [x] ~~Use BuildKit in CircleCI~~
- [x] ~~Create Manifest v2 in Makefile (`docker manifest`)~~
  - [x] ~~enable `docker-cli` experimental features~~
- [x] ~~Rework `image` sections of Makefile~~
- [x] ~~semantic release on tags, `latest` equals `master`~~

**Update**: Will be addressed in a subsequent PR