### PR TITLE
fluent-plugin: ability to specify keys to remove

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/README.md
+++ b/fluentd/fluent-plugin-grafana-loki/README.md
@@ -89,10 +89,11 @@ Loki is a multi-tenant log storage platform and all requests sent must include a
 ### output format
 Loki is intended to index and group log streams using only a small set of labels.  It is not intended for full-text indexing.  When sending logs to Loki the majority of log message will be sent as a single log "line".
 
-There are 3 configurations settings to control the output format.
+There are few configurations settings to control the output format.
  - extra_labels: (default: nil) set of labels to include with every Loki stream. eg `{"env":"dev", "datacenter": "dc1"}`
- - label_keys: (default: "job,instance") comma separated list of keys to use as stream labels.  All other keys will be placed into the log line
- - line_format: format to use when flattening the record to a log line. Valid values are "json" or "key_value".  If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json.  If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format `<key>=<value>`.
+ - remove_keys: (default: nil) comma separated list of needless record keys to remove. All other keys will be placed into the log line
+ - label_keys: (default: "job,instance") comma separated list of keys to use as stream labels. All other keys will be placed into the log line
+ - line_format: format to use when flattening the record to a log line. Valid values are "json" or "key_value". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format `<key>=<value>`.
  - drop_single_key: if set to true and after extracting label_keys a record only has a single key remaining, the log line sent to Loki will just be the value of the record key.
 
 ### Buffer options

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -48,6 +48,9 @@ module Fluent
       # comma separated list of keys to use as stream lables.  All other keys will be placed into the log line
       config_param :label_keys, :string, default: 'job,instance'
 
+      # comma separated list of needless record keys to remove
+      config_param :remove_keys, :string, default: nil
+
       # if a record only has 1 key, then just set the log line to the value and discard the key.
       config_param :drop_single_key, :bool, default: false
 
@@ -61,6 +64,7 @@ module Fluent
         super
 
         @label_keys = @label_keys.split(/\s*,\s*/) if @label_keys
+        @remove_keys = @remove_keys.split(',').map(&:strip) if @remove_keys
       end
 
       def http_opts(uri)
@@ -172,6 +176,10 @@ module Fluent
         chunk_labels = {}
         line = ''
         if record.is_a?(Hash)
+          # remove needless keys.
+          @remove_keys.each { |v|
+            record.delete(v)
+          }
           # extract white listed record keys into labels.
           @label_keys.each do |k|
             if record.key?(k)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This change allow us to specify keys which should be removed before sending to loki.

```
remove_keys "thread_name,level_value,@version,HOSTNAME"
```

Example use case. Current log looks like this:
```
2019-06-14 20:25:25
@version="1" message="This is very important audit log" logger_name="log.audit.simple.app" thread_name="main" level_value="20000" HOSTNAME="351b3521603a"
2019-06-14 20:25:25
@version="1" message="This is very important audit log" logger_name="log.audit.simple.app" thread_name="main" level_value="20000" HOSTNAME="351b3521603a"
```

after change:
```
2019-06-14 21:39:34
message="This is very important audit log" logger_name="log.audit.simple.app"
2019-06-14 21:39:33
message="This is very important audit log" logger_name="log.audit.simple.app"
```



**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

