### PR TITLE
Removing the pre-allocation of a buffer when serializing blocks

### DIFF
--- a/pkg/chunkenc/gzip.go
+++ b/pkg/chunkenc/gzip.go
@@ -97,7 +97,7 @@ func (hb *headBlock) append(ts int64, line string) error {
 }
 
 func (hb *headBlock) serialise(cw func(w io.Writer) CompressionWriter) ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0, 1<<15)) // 32K. Pool it later.
+	buf := &bytes.Buffer{}
 	encBuf := make([]byte, binary.MaxVarintLen64)
 	compressedWriter := cw(buf)
 	for _, logEntry := range hb.entries {


### PR DESCRIPTION
Looking at some heap profiles for Loki:

![profile001](https://user-images.githubusercontent.com/10332331/59611635-a4500c80-90e9-11e9-9d7e-6a46f6b899f4.png)

A lot of memory was being allocated in the `serialise` function of the `chunkenc` package.

Looking at that function we were default allocating a buffer with 32kb of space.  

I did some empirical testing with a debugger locally and found in most cases the buffer would only be filled to 9kb leaving a lot of allocated but unused space.

Based on the comment in the code I'm thinking maybe cortex has an optimization to re-use a set of pre-allocated memory pooled for this purpose? 

At any rate, I think we can recover a lot of unused memory by not pre-allocating any space for the Buffer and let it handle the allocations, and revisit pooling memory for the buffer at a later date?