### PR TITLE
Helm default ingester config

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.0
+version: 0.16.1
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.0
+version: 0.14.1
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -21,8 +21,9 @@ tracing:
 config:
   auth_enabled: false
   ingester:
-    chunk_idle_period: 15m
+    chunk_idle_period: 3m
     chunk_block_size: 262144
+    chunk_retain_period: 1m
     lifecycler:
       ring:
         kvstore:


### PR DESCRIPTION
as discussed in #613 this is better defaults value for single binary deployment.

Right now ingesters run OOM very quickly with substantial load. This configs allow at least 30k log per sec to run smoothly.
