### PR TITLE
Fix helm test error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
           name: Install k3s
           command: |
             curl -sfL https://get.k3s.io | sh -
+            sudo chmod 755 /etc/rancher/k3s/k3s.yaml
             mkdir -p ~/.kube
             cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
       - run:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Now k3s install k3s yaml as 600, can not cp directly, so chmod it first.
Error log is as following:
```
#!/bin/bash -eo pipefail
curl -sfL https://get.k3s.io | sh -
ls -l /etc/rancher/k3s/k3s.yaml
mkdir -p ~/.kube
cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
[INFO]  Finding latest release
[INFO]  Using 0.6.0 as release
[INFO]  Downloading hash https://github.com/rancher/k3s/releases/download/0.6.0/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/rancher/k3s/releases/download/0.6.0/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink from /etc/systemd/system/multi-user.target.wants/k3s.service to /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
-rw------- 1 root root 1764 Jun 19 01:55 /etc/rancher/k3s/k3s.yaml  <===
cp: cannot open '/etc/rancher/k3s/k3s.yaml' for reading: Permission denied
Exited with code 1
```

