### PR TITLE
Ingester: add usage of flags in ingester.go

### DIFF
--- a/docs/config-explain/ingester-config.md
+++ b/docs/config-explain/ingester-config.md
@@ -1,0 +1,32 @@
+Below is the loki part of a Loki sample config:
+```yaml
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: consul
+        consul:
+          host: 127.0.0.1:8500
+          prefix: ''
+          httpclienttimeout: 20s
+          consistentreads: true
+      replication_factor: 1
+  concurrent_flushes: 20
+  flush_check_period: 30s
+  flush_op_timeout: 10s
+  chunk_retain_period: 1m
+  chunk_idle_period: 5m
+  chunk_block_size: 524288
+```
+
+Explain all except lifecycler part as below:
+
+| config | usage | default |
+| --- | --- | --- |
+| concurrent_flushes | Number of concurrent goroutines used for flushing | 16 |
+| flush_check_period | Period with which to attempt to flush chunks | 30s |
+| flush_op_timeout | Timeout for individual flush operations | 10s |
+| chunk_retain_period | Period chunks will remain in memory after flushing | 15m |
+| chunk_idle_period | Maximum chunk idle time before flushing | 30m |
+| chunk_block_size | Size of a chunk used for holding logs | 256*1024 |

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -43,12 +43,12 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.LifecyclerConfig.RegisterFlags(f)
 
-	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushed", 16, "")
-	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-check-period", 30*time.Second, "")
-	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 10*time.Second, "")
-	f.DurationVar(&cfg.RetainPeriod, "ingester.chunks-retain-period", 15*time.Minute, "")
-	f.DurationVar(&cfg.MaxChunkIdle, "ingester.chunks-idle-period", 30*time.Minute, "")
-	f.IntVar(&cfg.BlockSize, "ingester.chunks-block-size", 256*1024, "")
+	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 16, "Number of concurrent goroutines used for flushing.")
+	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-check-period", 30*time.Second, "Period with which to attempt to flush chunks.")
+	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 10*time.Second, "Timeout for individual flush operations.")
+	f.DurationVar(&cfg.RetainPeriod, "ingester.chunks-retain-period", 15*time.Minute, "Period chunks will remain in memory after flushing.")
+	f.DurationVar(&cfg.MaxChunkIdle, "ingester.chunks-idle-period", 30*time.Minute, "Maximum chunk idle time before flushing.")
+	f.IntVar(&cfg.BlockSize, "ingester.chunks-block-size", 256*1024, "Size of a chunk used for holding logs.")
 }
 
 // Ingester builds chunks for incoming log streams.


### PR DESCRIPTION
Adding usage content to better describe the meaning of every flag.

1. Most of them are just copied from Cortex similar flags.
2. Fix one typo issue of "concurrent-flushed".
3. Add docs to explain them.