### PR TITLE
BREAKING fix(loki-mixin): rename rules key

### DIFF
--- a/production/loki-mixin/recording_rules.libsonnet
+++ b/production/loki-mixin/recording_rules.libsonnet
@@ -1,7 +1,7 @@
 local utils = import "mixin-utils/utils.libsonnet";
 
 {
-  prometheus_rules+:: {
+  prometheusRules+:: {
     groups+: [{
       name: 'loki_rules',
       rules:


### PR DESCRIPTION
Renames the `prometheus_rules` key to `prometheusRules` to comply to the
spec (https://github.com/monitoring-mixins/docs/blob/master/design.pdf)

**BREAKING `prometheus_rules` is not available anymore**

Fixes #679 