### PR TITLE
fix(loki|promtail): logger re-init nil config panic

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -4,12 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/loki"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
+	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/tracing"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -49,6 +51,10 @@ func main() {
 	}
 
 	// Re-init the logger which will now honor a different log level set in cfg.Server
+	if reflect.DeepEqual(&cfg.Server.LogLevel, &logging.Level{}) {
+		level.Error(util.Logger).Log("msg", "invalid log level")
+		os.Exit(1)
+	}
 	util.InitLogger(&cfg.Server)
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing

--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"flag"
 	"os"
+	"reflect"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
+	"github.com/weaveworks/common/logging"
 
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/promtail"
@@ -38,6 +40,10 @@ func main() {
 	}
 
 	// Re-init the logger which will now honor a different log level set in ServerConfig.Config
+	if reflect.DeepEqual(&config.ServerConfig.Config.LogLevel, &logging.Level{}) {
+		level.Error(util.Logger).Log("msg", "invalid log level")
+		os.Exit(1)
+	}
 	util.InitLogger(&config.ServerConfig.Config)
 
 	p, err := promtail.New(config)


### PR DESCRIPTION
When a more or less invalid config (e.g. `null`) is supplied, the log level prop
of the config receives an invalid value which causes the logger to panic on
re-init.

Prevents this by checking for a nil log-level and notifies the user in case

Fixes #695 