### PR TITLE
fluent-plugin: Mark as multi-workers ready

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/README.md
+++ b/fluentd/fluent-plugin-grafana-loki/README.md
@@ -29,6 +29,27 @@ In your Fluentd configuration, use `@type loki`. Additional configuration is opt
 </match>
 ```
 
+### Multi-worker usage
+
+Loki doesn't currently support out-of-order inserts - if you try to insert a log entry an earlier timestamp after a log entry with with identical labels but a later timestamp, the insert will fail with `HTTP status code: 500, message: rpc error: code = Unknown desc = Entry out of order`. Therefore, in order to use this plugin in a multi worker Fluentd setup, you'll need to include the worker ID in the labels.
+
+For example, using [fluent-plugin-record-modifier](https://github.com/repeatedly/fluent-plugin-record-modifier):
+```
+<filter mytag>
+    @type record_modifier
+    <record>
+        fluentd_worker "#{worker_id}"
+    </record>
+</filter>
+
+<match mytag>
+  @type loki
+  # ...
+  label_keys "fluentd_worker"
+  # ...
+</match>
+```
+
 ## Docker Image
 
 There is a Docker image `grafana/fluent-plugin-grafana-loki:master` which contains default configuration files to git log information

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -63,6 +63,10 @@ module Fluent
         @label_keys = @label_keys.split(/\s*,\s*/) if @label_keys
       end
 
+      def multi_workers_ready?
+        true
+      end
+
       def http_opts(uri)
         opts = {
           use_ssl: uri.scheme == 'https'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Currently, the fluent plugin is not marked as multi-workers ready.

There doesn't seem to be anything that would cause problems (race conditions, etc.) when using the plugin in a multi-worker setup. Therefore, we can safely just mark the plugin as multi-worker ready.

**Which issue(s) this PR fixes**:

No issues

**Special notes for your reviewer**:

**Checklist**
- [x] No need to add documentation
- [x] No tests to update

