### PR TITLE
Add selector as required by k8s 1.8 and higher.

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -274,6 +274,9 @@ metadata:
   name: promtail
 spec:
   minReadySeconds: 10
+  selector:
+    matchLabels:
+      name: promtail
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes #715 based on the docs at https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector

