### PR TITLE
fix(loki): panic on missing config

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,3 +4,4 @@ COPY       loki /bin/loki
 COPY       loki-local-config.yaml /etc/loki/local-config.yaml
 EXPOSE     80
 ENTRYPOINT [ "/bin/loki" ]
+CMD        ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -15,3 +15,4 @@ RUN apk add --no-cache libc6-compat
 #   Pass flags to the program you are debugging using --, for example:`
 #   dlv exec ./hello -- server --config conf/config.toml`
 ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/bin/loki-debug", "--"]
+CMD        ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -43,9 +43,11 @@ func main() {
 
 	util.InitLogger(&cfg.Server)
 
-	if err := helpers.LoadConfig(configFile, &cfg); err != nil {
-		level.Error(util.Logger).Log("msg", "error loading config", "filename", configFile, "err", err)
-		os.Exit(1)
+	if configFile != "" {
+		if err := helpers.LoadConfig(configFile, &cfg); err != nil {
+			level.Error(util.Logger).Log("msg", "error loading config", "filename", configFile, "err", err)
+			os.Exit(1)
+		}
 	}
 
 	// Re-init the logger which will now honor a different log level set in cfg.Server

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -43,11 +43,9 @@ func main() {
 
 	util.InitLogger(&cfg.Server)
 
-	if configFile != "" {
-		if err := helpers.LoadConfig(configFile, &cfg); err != nil {
-			level.Error(util.Logger).Log("msg", "error loading config", "filename", configFile, "err", err)
-			os.Exit(1)
-		}
+	if err := helpers.LoadConfig(configFile, &cfg); err != nil {
+		level.Error(util.Logger).Log("msg", "error loading config", "filename", configFile, "err", err)
+		os.Exit(1)
 	}
 
 	// Re-init the logger which will now honor a different log level set in cfg.Server


### PR DESCRIPTION
So far, `loki` produced a SEGFAULT in case the config file was not specified by hand (default behaviour of the container). See #714 

This PR addresses this in two ways:

1. ~~It removes the `configFile == ""` pseudo-check, which caused the config not to be parsed but continued anyways. Now the config is parsed every time and in case it does not exists the *actual* readable error is returned to the user.~~ See https://github.com/grafana/loki/pull/720#discussion_r300849571
2. The docker container defaults to the config path. Nobody should ever experience the above ;)

Prevents #714 from occuring
:warning: However, #714 is only fully fixed once #721 and on cortexproject/cortex#1492 are merged