### PR TITLE
Fix orderedDeps() order stability

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -238,38 +238,50 @@ func listDeps(m moduleName) []moduleName {
 
 // orderedDeps gets a list of all dependencies ordered so that items are always after any of their dependencies.
 func orderedDeps(m moduleName) []moduleName {
-	deps := listDeps(m)
+	// get a unique list of dependencies and init a map to keep whether they have been added to our result
+	deps := uniqueDeps(listDeps(m))
+	added := map[moduleName]bool{}
 
-	// get a unique list of moduleNames, with a flag for whether they have been added to our result
-	uniq := map[moduleName]bool{}
-	for _, dep := range deps {
-		uniq[dep] = false
-	}
-
-	result := make([]moduleName, 0, len(uniq))
+	result := make([]moduleName, 0, len(deps))
 
 	// keep looping through all modules until they have all been added to the result.
-
-	for len(result) < len(uniq) {
+	for len(result) < len(deps) {
 	OUTER:
-		for name, added := range uniq {
-			if added {
+		for _, name := range deps {
+			if added[name] {
 				continue
 			}
+
 			for _, dep := range modules[name].deps {
 				// stop processing this module if one of its dependencies has
 				// not been added to the result yet.
-				if !uniq[dep] {
+				if !added[dep] {
 					continue OUTER
 				}
 			}
 
 			// if all of the module's dependencies have been added to the result slice,
 			// then we can safely add this module to the result slice as well.
-			uniq[name] = true
+			added[name] = true
 			result = append(result, name)
 		}
 	}
+
+	return result
+}
+
+// uniqueDeps returns the unique list of input dependencies, guaranteeing input order stability
+func uniqueDeps(deps []moduleName) []moduleName {
+	result := make([]moduleName, 0, len(deps))
+	uniq := map[moduleName]bool{}
+
+	for _, dep := range deps {
+		if !uniq[dep] {
+			result = append(result, dep)
+			uniq[dep] = true
+		}
+	}
+
 	return result
 }
 

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -2,9 +2,11 @@ package loki
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDeps(t *testing.T) {
+func TestOrderedDeps(t *testing.T) {
 	for _, m := range []moduleName{All, Distributor, Ingester, Querier} {
 		deps := orderedDeps(m)
 		seen := make(map[moduleName]struct{})
@@ -18,4 +20,18 @@ func TestGetDeps(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestOrderedDepsShouldGuaranteeStabilityAcrossMultipleRuns(t *testing.T) {
+	initial := orderedDeps(All)
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, initial, orderedDeps(All))
+	}
+}
+
+func TestUniqueDeps(t *testing.T) {
+	input := []moduleName{Server, Overrides, Distributor, Overrides, Server, Ingester, Server}
+	expected := []moduleName{Server, Overrides, Distributor, Ingester}
+	assert.Equal(t, expected, uniqueDeps(input))
 }


### PR DESCRIPTION
**What this PR does**:
While investigating https://github.com/grafana/loki/issues/714 (intentionally not fixed in this PR), I've realized that `orderedDeps()` output is not stable across different runs. The reason of the instability is that go maps iteration order is not guaranteed.

To give you an example, if you run multiple times `loki` without `--config.file` you may randomly end up with two different outputs, depending on which module is initialized first:

```
$ ./loki -server.http-listen-port 8080

level=info ts=2019-07-06T20:42:48.329391Z caller=loki.go:125 msg=initialising module=server
level=info ts=2019-07-06T20:42:48.329594Z caller=server.go:120 http=[::]:8080 grpc=[::]:9095 msg="server listening on addresses"
level=info ts=2019-07-06T20:42:48.329989Z caller=loki.go:125 msg=initialising module=overrides
level=info ts=2019-07-06T20:42:48.330019Z caller=override.go:48 msg="per-tenant overides disabled"
level=info ts=2019-07-06T20:42:48.330084Z caller=loki.go:125 msg=initialising module=table-manager
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1c96f1a]
[...]
```

```
$ ./loki -server.http-listen-port 8080

level=info ts=2019-07-06T20:34:22.25622Z caller=loki.go:127 msg=initialising module=overrides
level=info ts=2019-07-06T20:34:22.256469Z caller=override.go:48 msg="per-tenant overides disabled"
level=info ts=2019-07-06T20:34:22.256562Z caller=loki.go:127 msg=initialising module=store
level=error ts=2019-07-06T20:34:22.256715Z caller=main.go:71 msg="error initialising loki" err="error initialising module: store: error creating index client: Must set -dynamodb.url in aws mode"
```




**Checklist**
- [ ] Documentation added
- [x] Tests updated

