### PR TITLE
feat(logcli): output modes

### DIFF
--- a/cmd/logcli/client.go
+++ b/cmd/logcli/client.go
@@ -55,7 +55,9 @@ func listLabelValues(name string) (*logproto.LabelResponse, error) {
 
 func doRequest(path string, out interface{}) error {
 	url := *addr + path
-	log.Print(url)
+	if !*quiet {
+		log.Print(url)
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/cmd/logcli/client.go
+++ b/cmd/logcli/client.go
@@ -123,7 +123,9 @@ func wsConnect(path string) (*websocket.Conn, error) {
 	} else if strings.HasPrefix(url, "http") {
 		url = strings.Replace(url, "http", "ws", 1)
 	}
-	log.Println(url)
+	if !*quiet {
+		log.Println(url)
+	}
 
 	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(*username+":"+*password))}}
 

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	app = kingpin.New("logcli", "A command-line for loki.")
+	app        = kingpin.New("logcli", "A command-line for loki.")
 	quiet      = app.Flag("quiet", "suppress everything but log lines").Default("false").Short('q').Bool()
+	outputMode = app.Flag("output", "specify output mode [default, raw, jsonl]").Default("default").Short('o').Enum("default", "raw", "jsonl")
 
 	addr     = app.Flag("addr", "Server address.").Default("https://logs-us-west1.grafana.net").Envar("GRAFANA_ADDR").String()
 	username = app.Flag("username", "Username for HTTP basic auth.").Default("").Envar("GRAFANA_USERNAME").String()

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	app = kingpin.New("logcli", "A command-line for loki.")
+	quiet      = app.Flag("quiet", "suppress everything but log lines").Default("false").Short('q').Bool()
 
 	addr     = app.Flag("addr", "Server address.").Default("https://logs-us-west1.grafana.net").Envar("GRAFANA_ADDR").String()
 	username = app.Flag("username", "Username for HTTP basic auth.").Default("").Envar("GRAFANA_USERNAME").String()

--- a/cmd/logcli/output.go
+++ b/cmd/logcli/output.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Outputs is an enum with all possible output modes
+var Outputs = map[string]LogOutput{
+	"default": &DefaultOutput{},
+	"jsonl":   &JSONLOutput{},
+	"raw":     &RawOutput{},
+}
+
+// LogOutput is the interface any output mode must implement
+type LogOutput interface {
+	Print(ts time.Time, lbls *labels.Labels, line string)
+}
+
+// DefaultOutput provides logs and metadata in human readable format
+type DefaultOutput struct {
+	MaxLabelsLen int
+	CommonLabels labels.Labels
+}
+
+// Print a log entry in a human readable format
+func (f DefaultOutput) Print(ts time.Time, lbls *labels.Labels, line string) {
+	ls := subtract(*lbls, f.CommonLabels)
+	if len(*ignoreLabelsKey) > 0 {
+		ls = ls.MatchLabels(false, *ignoreLabelsKey...)
+	}
+
+	labels := ""
+	if !*noLabels {
+		labels = padLabel(ls, f.MaxLabelsLen)
+	}
+	fmt.Println(
+		color.BlueString(ts.Format(time.RFC3339)),
+		color.RedString(labels),
+		strings.TrimSpace(line),
+	)
+}
+
+// JSONLOutput prints logs and metadata as JSON Lines, suitable for scripts
+type JSONLOutput struct{}
+
+// Print a log entry as json line
+func (f JSONLOutput) Print(ts time.Time, lbls *labels.Labels, line string) {
+	entry := map[string]interface{}{
+		"timestamp": ts,
+		"labels":    lbls,
+		"line":      line,
+	}
+	out, err := json.Marshal(entry)
+	if err != nil {
+		log.Fatalf("error marshalling entry: %s", err)
+	}
+	fmt.Println(string(out))
+}
+
+// RawOutput prints logs in their original form, without any metadata
+type RawOutput struct{}
+
+// Print a log entry as is
+func (f RawOutput) Print(ts time.Time, lbls *labels.Labels, line string) {
+	fmt.Println(line)
+}

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -86,7 +86,7 @@ func doQuery() {
 
 		switch *outputMode {
 		case "jsonl":
-			printLogEntryJSONL(i.Entry().Timestamp, fullls, i.Entry().Line)
+			printLogEntryJSONL(i.Entry().Timestamp, &fullls, i.Entry().Line)
 		case "raw":
 			fmt.Println(i.Entry().Line)
 		default:

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -72,26 +71,14 @@ func doQuery() {
 
 	i = iter.NewQueryResponseIterator(resp, d)
 
+	Outputs["default"] = DefaultOutput{
+		MaxLabelsLen: maxLabelsLen,
+		CommonLabels: common,
+	}
+
 	for i.Next() {
-		fullls := labelsCache(i.Labels())
-		ls := subtract(fullls, common)
-		if len(*ignoreLabelsKey) > 0 {
-			ls = ls.MatchLabels(false, *ignoreLabelsKey...)
-		}
-
-		labels := ""
-		if !*noLabels {
-			labels = padLabel(ls, maxLabelsLen)
-		}
-
-		switch *outputMode {
-		case "jsonl":
-			printLogEntryJSONL(i.Entry().Timestamp, &fullls, i.Entry().Line)
-		case "raw":
-			fmt.Println(i.Entry().Line)
-		default:
-			printLogEntry(i.Entry().Timestamp, labels, i.Entry().Line)
-		}
+		ls := labelsCache(i.Labels())
+		Outputs[*outputMode].Print(i.Entry().Timestamp, &ls, i.Entry().Line)
 	}
 
 	if err := i.Error(); err != nil {

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -72,8 +73,8 @@ func doQuery() {
 	i = iter.NewQueryResponseIterator(resp, d)
 
 	for i.Next() {
-		ls := labelsCache(i.Labels())
-		ls = subtract(ls, common)
+		fullls := labelsCache(i.Labels())
+		ls := subtract(fullls, common)
 		if len(*ignoreLabelsKey) > 0 {
 			ls = ls.MatchLabels(false, *ignoreLabelsKey...)
 		}
@@ -83,7 +84,14 @@ func doQuery() {
 			labels = padLabel(ls, maxLabelsLen)
 		}
 
-		printLogEntry(i.Entry().Timestamp, labels, i.Entry().Line)
+		switch *outputMode {
+		case "jsonl":
+			printLogEntryJSONL(i.Entry().Timestamp, fullls, i.Entry().Line)
+		case "raw":
+			fmt.Println(i.Entry().Line)
+		default:
+			printLogEntry(i.Entry().Timestamp, labels, i.Entry().Line)
+		}
 	}
 
 	if err := i.Error(); err != nil {

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -48,11 +48,11 @@ func doQuery() {
 		common = common.MatchLabels(false, *showLabelsKey...)
 	}
 
-	if len(common) > 0 {
+	if len(common) > 0 && !*quiet {
 		log.Println("Common labels:", color.RedString(common.String()))
 	}
 
-	if len(*ignoreLabelsKey) > 0 {
+	if len(*ignoreLabelsKey) > 0 && !*quiet {
 		log.Println("Ignoring labels key:", color.RedString(strings.Join(*ignoreLabelsKey, ",")))
 	}
 

--- a/cmd/logcli/tail.go
+++ b/cmd/logcli/tail.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -58,15 +57,8 @@ func tailQuery() {
 			}
 
 			for _, entry := range stream.Entries {
-				switch *outputMode {
-				case "jsonl":
-					lbls := mustParseLabels(labels)
-					printLogEntryJSONL(entry.Timestamp, &lbls, entry.Line)
-				case "raw":
-					fmt.Println(entry.Line)
-				default:
-					printLogEntry(entry.Timestamp, labels, entry.Line)
-				}
+				lbls := mustParseLabels(labels)
+				Outputs[*outputMode].Print(entry.Timestamp, &lbls, entry.Line)
 			}
 
 		}

--- a/cmd/logcli/tail.go
+++ b/cmd/logcli/tail.go
@@ -60,8 +60,8 @@ func tailQuery() {
 			for _, entry := range stream.Entries {
 				switch *outputMode {
 				case "jsonl":
-					// TODO: include labels as a map[string]string
-					printLogEntryJSONL(entry.Timestamp, nil, entry.Line)
+					lbls := mustParseLabels(labels)
+					printLogEntryJSONL(entry.Timestamp, &lbls, entry.Line)
 				case "raw":
 					fmt.Println(entry.Line)
 				default:

--- a/cmd/logcli/tail.go
+++ b/cmd/logcli/tail.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -55,9 +56,19 @@ func tailQuery() {
 					labels = stream.Labels
 				}
 			}
+
 			for _, entry := range stream.Entries {
-				printLogEntry(entry.Timestamp, labels, entry.Line)
+				switch *outputMode {
+				case "jsonl":
+					// TODO: include labels as a map[string]string
+					printLogEntryJSONL(entry.Timestamp, nil, entry.Line)
+				case "raw":
+					fmt.Println(entry.Line)
+				default:
+					printLogEntry(entry.Timestamp, labels, entry.Line)
+				}
 			}
+
 		}
 		if len(tailReponse.DroppedEntries) != 0 {
 			log.Println("Server dropped following entries due to slow client")

--- a/cmd/logcli/utils.go
+++ b/cmd/logcli/utils.go
@@ -1,41 +1,14 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 	"sort"
 	"strings"
-	"time"
 
-	"github.com/fatih/color"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 )
-
-// print a log entry
-func printLogEntry(ts time.Time, lbls string, line string) {
-	fmt.Println(
-		color.BlueString(ts.Format(time.RFC3339)),
-		color.RedString(lbls),
-		strings.TrimSpace(line),
-	)
-}
-
-// print a log entry as json line
-func printLogEntryJSONL(ts time.Time, lbls *labels.Labels, line string) {
-	entry := map[string]interface{}{
-		"timestamp": ts,
-		"labels":    lbls,
-		"line":      line,
-	}
-	out, err := json.Marshal(entry)
-	if err != nil {
-		log.Fatalf("error marshalling entry: %s", err)
-	}
-	fmt.Println(string(out))
-}
 
 // add some padding after labels
 func padLabel(ls labels.Labels, maxLabelsLen int) string {
@@ -67,7 +40,7 @@ func parseLabels(resp *logproto.QueryResponse) (map[string]labels.Labels, []labe
 	return cache, lss
 }
 
-// return common labels between given lavels set
+// return commonLabels labels between given lavels set
 func commonLabels(lss []labels.Labels) labels.Labels {
 	if len(lss) == 0 {
 		return nil

--- a/cmd/logcli/utils.go
+++ b/cmd/logcli/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -20,6 +21,20 @@ func printLogEntry(ts time.Time, lbls string, line string) {
 		color.RedString(lbls),
 		strings.TrimSpace(line),
 	)
+}
+
+// print a log entry as json line
+func printLogEntryJSONL(ts time.Time, lbls labels.Labels, line string) {
+	entry := map[string]interface{}{
+		"timestamp": ts,
+		"labels":    lbls,
+		"line":      line,
+	}
+	out, err := json.Marshal(entry)
+	if err != nil {
+		log.Fatalf("error marshalling entry: %s", err)
+	}
+	fmt.Println(string(out))
 }
 
 // add some padding after labels

--- a/cmd/logcli/utils.go
+++ b/cmd/logcli/utils.go
@@ -24,7 +24,7 @@ func printLogEntry(ts time.Time, lbls string, line string) {
 }
 
 // print a log entry as json line
-func printLogEntryJSONL(ts time.Time, lbls labels.Labels, line string) {
+func printLogEntryJSONL(ts time.Time, lbls *labels.Labels, line string) {
 	entry := map[string]interface{}{
 		"timestamp": ts,
 		"labels":    lbls,


### PR DESCRIPTION
This PR improves the output of LogCLI, to address #725 

* `-q` / `--quiet` mode: suppresses all debug messages. They were going to stderr anyways but now they can be fully gone
* `-o` / `--output`: allows specifying another output mode. Currently supported:
  * `default`: the one used so far
  * `raw`: print the logs as they were written to the file
  * `jsonl`: print as json line, with time and labels, meant for scripts

Resolves #725