### PR TITLE
Add source support to regex and json stages

### DIFF
--- a/pkg/logentry/stages/extensions.go
+++ b/pkg/logentry/stages/extensions.go
@@ -40,7 +40,7 @@ func NewCRI(logger log.Logger, registerer prometheus.Registerer) (Stage, error) 
 	stages := PipelineStages{
 		PipelineStage{
 			StageTypeRegex: RegexConfig{
-				"^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$",
+				Expression: "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$",
 			},
 		},
 		PipelineStage{

--- a/pkg/logentry/stages/json.go
+++ b/pkg/logentry/stages/json.go
@@ -25,7 +25,7 @@ const (
 // JSONConfig represents a JSON Stage configuration
 type JSONConfig struct {
 	Expressions map[string]string `mapstructure:"expressions"`
-	Source      string            `mapstructure:"source"`
+	Source      *string           `mapstructure:"source"`
 }
 
 // validateJSONConfig validates a json config and returns a map of necessary jmespath expressions.
@@ -94,15 +94,15 @@ func (j *jsonStage) Process(labels model.LabelSet, extracted map[string]interfac
 	// from the exctracted map, otherwise should fallback to the entry
 	input := entry
 
-	if j.cfg.Source != "" {
-		if _, ok := extracted[j.cfg.Source]; !ok {
-			level.Debug(j.logger).Log("msg", "source does not exist in the set of extracted values", "source", j.cfg.Source)
+	if j.cfg.Source != nil {
+		if _, ok := extracted[*j.cfg.Source]; !ok {
+			level.Debug(j.logger).Log("msg", "source does not exist in the set of extracted values", "source", *j.cfg.Source)
 			return
 		}
 
-		value, err := getString(extracted[j.cfg.Source])
+		value, err := getString(extracted[*j.cfg.Source])
 		if err != nil {
-			level.Debug(j.logger).Log("msg", "failed to convert source value to string", "source", j.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[j.cfg.Source]).String())
+			level.Debug(j.logger).Log("msg", "failed to convert source value to string", "source", *j.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[*j.cfg.Source]).String())
 			return
 		}
 

--- a/pkg/logentry/stages/json.go
+++ b/pkg/logentry/stages/json.go
@@ -20,6 +20,7 @@ const (
 	ErrExpressionsRequired  = "JMES expression is required"
 	ErrCouldNotCompileJMES  = "could not compile JMES expression"
 	ErrEmptyJSONStageConfig = "empty json stage configuration"
+	ErrEmptyJSONStageSource = "empty source"
 )
 
 // JSONConfig represents a JSON Stage configuration
@@ -36,6 +37,10 @@ func validateJSONConfig(c *JSONConfig) (map[string]*jmespath.JMESPath, error) {
 
 	if len(c.Expressions) == 0 {
 		return nil, errors.New(ErrExpressionsRequired)
+	}
+
+	if c.Source != nil && *c.Source == "" {
+		return nil, errors.New(ErrEmptyJSONStageSource)
 	}
 
 	expressions := map[string]*jmespath.JMESPath{}

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -124,8 +124,9 @@ func TestYamlMapStructure(t *testing.T) {
 
 func TestJSONConfig_validate(t *testing.T) {
 	t.Parallel()
+
 	tests := map[string]struct {
-		config        *JSONConfig
+		config        interface{}
 		wantExprCount int
 		err           error
 	}{
@@ -135,13 +136,13 @@ func TestJSONConfig_validate(t *testing.T) {
 			errors.New(ErrExpressionsRequired),
 		},
 		"no expressions": {
-			&JSONConfig{},
+			map[string]interface{}{},
 			0,
 			errors.New(ErrExpressionsRequired),
 		},
 		"invalid expression": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]interface{}{
 					"extr1": "3##@$#33",
 				},
 			},
@@ -149,8 +150,8 @@ func TestJSONConfig_validate(t *testing.T) {
 			errors.Wrap(errors.New("SyntaxError: Unknown char: '#'"), ErrCouldNotCompileJMES),
 		},
 		"valid without source": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"expr1": "expr",
 					"expr2": "",
 					"expr3": "expr1.expr2",
@@ -160,13 +161,13 @@ func TestJSONConfig_validate(t *testing.T) {
 			nil,
 		},
 		"valid with source": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"expr1": "expr",
 					"expr2": "",
 					"expr3": "expr1.expr2",
 				},
-				Source: "log",
+				"source": "log",
 			},
 			3,
 			nil,
@@ -216,14 +217,14 @@ func TestJSONParser_Parse(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		config          *JSONConfig
+		config          interface{}
 		extracted       map[string]interface{}
 		entry           string
 		expectedExtract map[string]interface{}
 	}{
 		"successfully decode json on entry": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"time":      "",
 					"app":       "",
 					"component": "",
@@ -252,8 +253,8 @@ func TestJSONParser_Parse(t *testing.T) {
 			},
 		},
 		"successfully decode json on extracted[source]": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"time":      "",
 					"app":       "",
 					"component": "",
@@ -265,7 +266,7 @@ func TestJSONParser_Parse(t *testing.T) {
 					"message":   "",
 					"complex":   "complex.log.array[1].test3",
 				},
-				Source: "log",
+				"source": "log",
 			},
 			map[string]interface{}{
 				"log": logFixture,
@@ -286,19 +287,19 @@ func TestJSONParser_Parse(t *testing.T) {
 			},
 		},
 		"missing extracted[source]": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"app": "",
 				},
-				Source: "log",
+				"source": "log",
 			},
 			map[string]interface{}{},
 			logFixture,
 			map[string]interface{}{},
 		},
 		"invalid json on entry": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"expr1": "",
 				},
 			},
@@ -307,11 +308,11 @@ func TestJSONParser_Parse(t *testing.T) {
 			map[string]interface{}{},
 		},
 		"invalid json on extracted[source]": {
-			&JSONConfig{
-				Expressions: map[string]string{
+			map[string]interface{}{
+				"expressions": map[string]string{
 					"app": "",
 				},
-				Source: "log",
+				"source": "log",
 			},
 			map[string]interface{}{
 				"log": "not a json",

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -48,6 +48,8 @@ var testJSONLogLine = `
 `
 
 func TestPipeline_JSON(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		config          string
 		entry           string
@@ -74,7 +76,11 @@ func TestPipeline_JSON(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			pl, err := NewPipeline(util.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -130,7 +130,7 @@ func TestJSONConfig_validate(t *testing.T) {
 		wantExprCount int
 		err           error
 	}{
-		"empty": {
+		"empty config": {
 			nil,
 			0,
 			errors.New(ErrExpressionsRequired),
@@ -148,6 +148,16 @@ func TestJSONConfig_validate(t *testing.T) {
 			},
 			0,
 			errors.Wrap(errors.New("SyntaxError: Unknown char: '#'"), ErrCouldNotCompileJMES),
+		},
+		"empty source": {
+			map[string]interface{}{
+				"expressions": map[string]interface{}{
+					"extr1": "expr",
+				},
+				"source": "",
+			},
+			0,
+			errors.New(ErrEmptyJSONStageSource),
 		},
 		"valid without source": {
 			map[string]interface{}{

--- a/pkg/logentry/stages/regex.go
+++ b/pkg/logentry/stages/regex.go
@@ -17,6 +17,7 @@ const (
 	ErrExpressionRequired    = "expression is required"
 	ErrCouldNotCompileRegex  = "could not compile regular expression"
 	ErrEmptyRegexStageConfig = "empty regex stage configuration"
+	ErrEmptyRegexStageSource = "empty source"
 )
 
 // RegexConfig contains a regexStage configuration
@@ -33,6 +34,10 @@ func validateRegexConfig(c *RegexConfig) (*regexp.Regexp, error) {
 
 	if c.Expression == "" {
 		return nil, errors.New(ErrExpressionRequired)
+	}
+
+	if c.Source != nil && *c.Source == "" {
+		return nil, errors.New(ErrEmptyRegexStageSource)
 	}
 
 	expr, err := regexp.Compile(c.Expression)

--- a/pkg/logentry/stages/regex.go
+++ b/pkg/logentry/stages/regex.go
@@ -21,8 +21,8 @@ const (
 
 // RegexConfig contains a regexStage configuration
 type RegexConfig struct {
-	Expression string `mapstructure:"expression"`
-	Source     string `mapstructure:"source"`
+	Expression string  `mapstructure:"expression"`
+	Source     *string `mapstructure:"source"`
 }
 
 // validateRegexConfig validates the config and return a regex
@@ -83,15 +83,15 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 	// from the exctracted map, otherwise should fallback to the entry
 	input := entry
 
-	if r.cfg.Source != "" {
-		if _, ok := extracted[r.cfg.Source]; !ok {
-			level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", r.cfg.Source)
+	if r.cfg.Source != nil {
+		if _, ok := extracted[*r.cfg.Source]; !ok {
+			level.Debug(r.logger).Log("msg", "source does not exist in the set of extracted values", "source", *r.cfg.Source)
 			return
 		}
 
-		value, err := getString(extracted[r.cfg.Source])
+		value, err := getString(extracted[*r.cfg.Source])
 		if err != nil {
-			level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", r.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[r.cfg.Source]).String())
+			level.Debug(r.logger).Log("msg", "failed to convert source value to string", "source", *r.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[*r.cfg.Source]).String())
 			return
 		}
 

--- a/pkg/logentry/stages/regex_test.go
+++ b/pkg/logentry/stages/regex_test.go
@@ -31,6 +31,8 @@ pipeline_stages:
 var testRegexLogLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
 
 func TestPipeline_Regex(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		config          string
 		entry           string
@@ -74,7 +76,11 @@ func TestPipeline_Regex(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			pl, err := NewPipeline(util.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/logentry/stages/regex_test.go
+++ b/pkg/logentry/stages/regex_test.go
@@ -124,7 +124,7 @@ func TestRegexConfig_validate(t *testing.T) {
 		config interface{}
 		err    error
 	}{
-		"empty": {
+		"empty config": {
 			nil,
 			errors.New(ErrExpressionRequired),
 		},
@@ -137,6 +137,13 @@ func TestRegexConfig_validate(t *testing.T) {
 				"expression": "(?P<ts[0-9]+).*",
 			},
 			errors.New(ErrCouldNotCompileRegex + ": error parsing regexp: invalid named capture: `(?P<ts[0-9]+).*`"),
+		},
+		"empty source": {
+			map[string]interface{}{
+				"expression": "(?P<ts>[0-9]+).*",
+				"source":     "",
+			},
+			errors.New(ErrEmptyRegexStageSource),
 		},
 		"valid without source": {
 			map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

Following up the idea shared in https://github.com/grafana/loki/issues/703, in this PR I'm proposing to add a config property called `source` both to `regex` and `json` stages. When `source` is valued, the regex/json parsing is done based on `extracted[source]` instead of the default `entry`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/703

**Checklist**
- [x] Documentation added
- [x] Tests updated
