### PR TITLE
feat(logcli): query from absolute timestamp

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -24,6 +24,7 @@ var (
 	regexpStr       = queryCmd.Arg("regex", "").String()
 	limit           = queryCmd.Flag("limit", "Limit on number of entries to print.").Default("30").Int()
 	since           = queryCmd.Flag("since", "Lookback window.").Default("1h").Duration()
+	from            = queryCmd.Flag("from", "Start looking for logs at this absolute time").String()
 	forward         = queryCmd.Flag("forward", "Scan forwards through logs.").Default("false").Bool()
 	tail            = queryCmd.Flag("tail", "Tail the logs").Short('t').Default("false").Bool()
 	delayFor        = queryCmd.Flag("delay-for", "Delay in tailing by number of seconds to accumulate logs").Default("0").Int()

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -27,7 +27,7 @@ func doQuery() {
 	start := end.Add(-*since)
 	if *from != "" {
 		var err error
-		start, err = time.Parse(time.RFC3339, *from)
+		start, err = time.Parse(time.RFC3339Nano, *from)
 		if err != nil {
 			log.Fatalf("error parsing date '%s': %s", *from, err)
 		}

--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -25,6 +25,14 @@ func doQuery() {
 
 	end := time.Now()
 	start := end.Add(-*since)
+	if *from != "" {
+		var err error
+		start, err = time.Parse(time.RFC3339, *from)
+		if err != nil {
+			log.Fatalf("error parsing date '%s': %s", *from, err)
+		}
+	}
+
 	d := logproto.BACKWARD
 	if *forward {
 		d = logproto.FORWARD


### PR DESCRIPTION
Adds a new flag `--from` to complement `--since`.
While since subtracts a relative duration from the current time, from allows to
specify the absolute start of the lookback window.

Note: `--from` takes precedence over `--since`, but only if set.

Resolves #724 