### PR TITLE
feat(logcli): extended tailing

### DIFF
--- a/cmd/logcli/query.go
+++ b/cmd/logcli/query.go
@@ -13,11 +13,6 @@ import (
 )
 
 func doQuery() {
-	if *tail {
-		tailQuery()
-		return
-	}
-
 	var (
 		i      iter.EntryIterator
 		common labels.Labels
@@ -88,5 +83,9 @@ func doQuery() {
 
 	if err := i.Error(); err != nil {
 		log.Fatalf("Error from iterator: %v", err)
+	}
+
+	if *tail {
+		tailQuery()
 	}
 }


### PR DESCRIPTION
Runs a regular query before tailing the websocket.
This enables a more docker / kubectl like behaviour, which is what a regular user expects:
A configurable amount of historic messages printed and new messages following up at the bottom.

**BREAKING**: tailing now prints some historic log messages. Use `--count 0` to suppress.

Fixes #726 