### PR TITLE
Fixed RFC3339Nano examples in doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,12 +26,12 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
 
   For doing queries, accepts the following parameters in the query-string:
 
-  - `query`: a logQL query
+  - `query`: a [logQL query](./usage.md) (eg: `{name=~"mysql.+"}` or `{name=~"mysql.+"} |= "error"`)
   - `limit`: max number of entries to return
-  - `start`: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999Z07:00"). Default is always one hour ago.
-  - `end`: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999Z07:00"). Default is current time.
+  - `start`: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999-07:00"). Default is always one hour ago.
+  - `end`: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999-07:00"). Default is current time.
   - `direction`: `forward` or `backward`, useful when specifying a limit. Default is backward.
-  - `regexp`: a regex to filter the returned results, will eventually be rolled into the query language
+  - `regexp`: a regex to filter the returned results
 
   Loki needs to query the index store in order to find log streams for particular labels and the store is spread out by time,
   so you need to specify the start and end labels accordingly. Querying a long time into the history will cause additional

--- a/docs/logentry/processing-log-lines.md
+++ b/docs/logentry/processing-log-lines.md
@@ -250,8 +250,8 @@ RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
 RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
 RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
 RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
-RFC3339     = "2006-01-02T15:04:05Z07:00"
-RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+RFC3339     = "2006-01-02T15:04:05-07:00"
+RFC3339Nano = "2006-01-02T15:04:05.999999999-07:00"
 ```
 
 Additionally support for common Unix timestamps is supported:


### PR DESCRIPTION
**What this PR does / why we need it**:

If you call the query API copying/pasting the `start` or `end` from the doc example (`2006-01-02T15:04:05.999999999Z07:00`) you get this:
```
strconv.ParseInt: parsing "2006-01-02T15:04:05.999999999Z07:00": invalid syntax
```

The timestamp string example has been copied from the [golang doc](https://golang.org/pkg/time/#Parse) which I believe is also incorrect. I took a look at the [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt): the time offset can be `Z` or the offset, but not both combined. Valid timestamps are:

```
2006-01-02T15:04:05.999999999Z
2006-01-02T15:04:05.999999999+07:00
2006-01-02T15:04:05.999999999-07:00
```

I've updated the doc accordingly.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

