### PR TITLE
Redirect / to /targets in promtail server

### DIFF
--- a/pkg/promtail/server/server.go
+++ b/pkg/promtail/server/server.go
@@ -55,6 +55,7 @@ func New(cfg Config, tms *targets.TargetManagers) (*Server, error) {
 		externalURL: externalURL,
 	}
 
+	serv.HTTP.Path("/").Handler(http.RedirectHandler("/targets", 303))
 	serv.HTTP.Path("/ready").Handler(http.HandlerFunc(serv.ready))
 	serv.HTTP.PathPrefix("/static/").Handler(http.FileServer(ui.Assets))
 	serv.HTTP.Path("/service-discovery").Handler(http.HandlerFunc(serv.serviceDiscovery))


### PR DESCRIPTION
**What this PR does / why we need it**:

A first time user is likely will open the `/` path on the promtail server, to explore it. We currently don't handle that route, so it's returning a `404`.

In this PR I propose to redirect `/` to `/targets`.
