### PR TITLE
fluentd-plugin-grafana-loki: avoid exception when remove/label_keys is unset

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -183,14 +183,14 @@ module Fluent
           # remove needless keys.
           @remove_keys.each { |v|
             record.delete(v)
-          }
+          } if @remove_keys
           # extract white listed record keys into labels.
           @label_keys.each do |k|
             if record.key?(k)
               chunk_labels[k] = record[k]
               record.delete(k)
             end
-          end
+          end if @label_keys
           line = record_to_line(record)
         else
           line = record.to_s


### PR DESCRIPTION
Fixes #749

Signed-off-by: Brian Candler <b.candler@pobox.com>