### PR TITLE
fluentd-plugin-grafana-loki: change log.info to log.debug

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -97,7 +97,7 @@ module Fluent
         opts = {
           use_ssl: uri.scheme == 'https'
         }
-        log.info "sending #{req.body.length} bytes"
+        log.debug "sending #{req.body.length} bytes to loki"
         res = Net::HTTP.start(uri.hostname, uri.port, **opts) { |http| http.request(req) }
         unless res && res.is_a?(Net::HTTPSuccess)
           res_summary = if res


### PR DESCRIPTION
Reduces background chatter which in turn can trigger more log writes

Signed-off-by: Brian Candler <b.candler@pobox.com>

**What this PR does / why we need it**:

When fluentd writes a block to loki, it also writes a message to syslog at 'info' level.  If you're feeding your syslogs via fluentd then this can cause a background stream of messages every 10 seconds, even if the system is otherwise idle.

```
...
2019-07-15T07:18:35+00:00       syslog  {"message":"<30>Jul 15 07:18:35 fluentd fluentd[15866]: 2019-07-15 07:18:35 +0000 [info]: #0 sending 226 bytes","instance":"
10.12.255.39"}
2019-07-15T07:18:46+00:00       syslog  {"message":"<30>Jul 15 07:18:46 fluentd fluentd[15866]: 2019-07-15 07:18:46 +0000 [info]: #0 sending 226 bytes","instance":"10.12.255.39"}
2019-07-15T07:18:57+00:00       syslog  {"message":"<30>Jul 15 07:18:57 fluentd fluentd[15866]: 2019-07-15 07:18:57 +0000 [info]: #0 sending 226 bytes","instance":"10.12.255.39"}
2019-07-15T07:19:08+00:00       syslog  {"message":"<30>Jul 15 07:19:08 fluentd fluentd[15866]: 2019-07-15 07:19:08 +0000 [info]: #0 sending 226 bytes","instance":"10.12.255.39"}
...
```

**Which issue(s) this PR fixes**:

N/A
