### PR TITLE
Use grpc client config from cortex for Ingester to get more control

### DIFF
--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
 	cortex_client "github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
@@ -65,8 +67,10 @@ func mockIngesterClientConfig() client.Config {
 			HealthCheckIngesters: false,
 			RemoteTimeout:        1 * time.Second,
 		},
-		MaxRecvMsgSize: 1024,
-		RemoteTimeout:  1 * time.Second,
+		GRPCClientConfig: grpcclient.Config{
+			MaxRecvMsgSize: 1024,
+		},
+		RemoteTimeout: 1 * time.Second,
 	}
 }
 

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -88,7 +88,9 @@
     },
 
     ingester_client_config: {
-      max_recv_msg_size: 1024 * 1024 * 64,
+      grpc_client_config: {
+        max_recv_msg_size: 1024 * 1024 * 64,
+      },
       remote_timeout: '1s',
     },
 

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -87,13 +87,6 @@
       'config.file': '/etc/loki/config.yaml',
     },
 
-    ingester_client_config: {
-      grpc_client_config: {
-        max_recv_msg_size: 1024 * 1024 * 64,
-      },
-      remote_timeout: '1s',
-    },
-
     loki: {
       server: {
         graceful_shutdown_timeout: '5s',
@@ -132,6 +125,13 @@
           claim_on_rollout: true,
           interface_names: ['eth0'],
         },
+      },
+
+      ingester_client: {
+        grpc_client_config: {
+          max_recv_msg_size: 1024 * 1024 * 64,
+        },
+        remote_timeout: '1s',
       },
 
       storage_config: {


### PR DESCRIPTION
:warning: Breaking change in the parsing of flags since `max_recv_msg_size` is moved.

Ignoring the use of gzip compression flag and turning it ON always by default like how we were doing already without the flag. The current value of it is false in Cortex, do we want to honour it? If we do its default value should ideally be true and there is no clean way to change the default without changing code in cortex project.