### PR TITLE
cleanup rake warnings, bump version

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/Gemfile
+++ b/fluentd/fluent-plugin-grafana-loki/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/fluentd/fluent-plugin-grafana-loki/Rakefile
+++ b/fluentd/fluent-plugin-grafana-loki/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/fluentd/fluent-plugin-grafana-loki/docker/Gemfile
+++ b/fluentd/fluent-plugin-grafana-loki/docker/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'fluent-plugin-kubernetes_metadata_filter', '~> 0.7.0'

--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.0.0'
+  spec.version = '1.0.1'
   spec.authors = %w[woodsaj briangann]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright 2018- Grafana Labs
 #
@@ -27,7 +29,7 @@ module Fluent
 
       helpers :compat_parameters
 
-      DEFAULT_BUFFER_TYPE = 'memory'.freeze
+      DEFAULT_BUFFER_TYPE = 'memory'
 
       # url of loki server
       config_param :url, :string, default: 'https://logs-us-west1.grafana.net'

--- a/fluentd/fluent-plugin-grafana-loki/spec/gems/fluent/plugin/loki_output_spec.rb
+++ b/fluentd/fluent-plugin-grafana-loki/spec/gems/fluent/plugin/loki_output_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'time'
 require 'yajl'

--- a/fluentd/fluent-plugin-grafana-loki/spec/spec_helper.rb
+++ b/fluentd/fluent-plugin-grafana-loki/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 require 'rubocop/rspec/support'
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up some rake spec warnings and bumps the version to 1.0.1.

**Which issue(s) this PR fixes**:
Fixes #719 

**Special notes for your reviewer**:

v1.0.1 has been published to rubygems.org

