### PR TITLE
Rollback changes to Makefile and build/Dockerfile from #730

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ loki-build-image/$(UPTODATE): loki-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
-CGO_ENABLED := 0
 # RM is parameterized to allow CircleCI to run builds, as it
 # currently disallows `docker run --rm`. This value is overridden
 # in circle.yml
@@ -150,13 +149,13 @@ $(EXES) $(DEBUG_EXES) $(PROTO_GOS) $(YACC_GOS) lint test shell check-generated-f
 else
 
 $(DEBUG_EXES): loki-build-image/$(UPTODATE)
-	CGO_ENABLED=$(CGO_ENABLED) go build $(DEBUG_GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=0 go build $(DEBUG_GO_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 	# Copy the delve binary to make it easily available to put in the binary's container.
 	[ -f "/go/bin/dlv" ] && mv "/go/bin/dlv" $(@D)/dlv
 
 $(EXES): loki-build-image/$(UPTODATE)
-	CGO_ENABLED=$(CGO_ENABLED) go build $(GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
 %.pb.go: loki-build-image/$(UPTODATE)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@ RUN touch loki-build-image/.uptodate &&\
 # production image
 FROM golang as builder-production
 ARG APP
-RUN make CGO_ENABLED=1 BUILD_IN_CONTAINER=false cmd/${APP}/${APP} &&\
+RUN make BUILD_IN_CONTAINER=false cmd/${APP}/${APP} &&\
   mv cmd/${APP}/${APP} /build/${APP}
 
 FROM scratch as production
@@ -28,7 +28,7 @@ COPY --from=builder-production /build/${APP} /usr/bin/${APP}
 FROM golang as builder-debug
 ARG APP
 RUN go get github.com/go-delve/delve/cmd/dlv &&\
-  make CGO_ENBALED=1 BUILD_IN_CONTAINER=false cmd/promtail/promtail-debug &&\
+  make BUILD_IN_CONTAINER=false cmd/promtail/promtail-debug &&\
   mv cmd/${APP}/${APP}-debug /build/app-debug &&\
   mv cmd/${APP}/dlv /build/dlv
 


### PR DESCRIPTION
This commit rolls back the changes to the Makefile and build/Dockerfile that caused CGO_ENABLED=1 to be present during some builds. This commit also causes the journal support to be disabled in any build produced through the Makefile.

For now, journal support can still be enabled in a manual build:

```bash
go build -o cmd/promtail/promtail cmd/promtail
```