### PR TITLE
Added date without year support to timestamp stage

### DIFF
--- a/docs/logentry/processing-log-lines.md
+++ b/docs/logentry/processing-log-lines.md
@@ -360,7 +360,7 @@ A match stage will take the provided label `selector` and determine if a group o
 
 ### timestamp
 
-A timestamp stage will parse data from the `extracted` map and set the `time` value which will be stored by Loki.
+A timestamp stage will parse data from the `extracted` map and set the `time` value which will be stored by Loki. The timestamp stage is important for having log entries in the correct order. In the absence of this stage, promtail will associate the current timestamp to the log entry.
 
 ```yaml
 - timestamp:
@@ -394,7 +394,7 @@ UnixMs = 1562708916414
 UnixNs = 1562708916000000123
 ```
 
-Finally any custom format can be supplied, and will be passed directly in as the layout parameter in time.Parse()
+Finally any custom format can be supplied, and will be passed directly in as the layout parameter in `time.Parse()`. If the custom format has no year component specified (ie. syslog's default logs), promtail will assume the current year should be used, correctly handling the edge cases around new year's eve.
 
 __Read the [time.parse](https://golang.org/pkg/time/#Parse) docs closely if passing a custom format and make sure your custom format uses the special date they specify: `Mon Jan 2 15:04:05 -0700 MST 2006`__
 

--- a/pkg/logentry/stages/timestamp_test.go
+++ b/pkg/logentry/stages/timestamp_test.go
@@ -73,7 +73,7 @@ func TestTimestampValidation(t *testing.T) {
 			testString:   "2012-11-01T22:08:41-04:00",
 			expectedTime: time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)),
 		},
-		"custom format": {
+		"custom format with year": {
 			config: &TimestampConfig{
 				Source: "source1",
 				Format: "2006-01-02",
@@ -81,6 +81,15 @@ func TestTimestampValidation(t *testing.T) {
 			err:          nil,
 			testString:   "2009-01-01",
 			expectedTime: time.Date(2009, 01, 01, 00, 00, 00, 0, time.UTC),
+		},
+		"custom format without year": {
+			config: &TimestampConfig{
+				Source: "source1",
+				Format: "Jan 02 15:04:05",
+			},
+			err:          nil,
+			testString:   "Jul 15 01:02:03",
+			expectedTime: time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, time.UTC),
 		},
 		"unix_ms": {
 			config: &TimestampConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
Syslog by default logs to filesystem using the following timestamp format:
`Jul 16 06:37:51`

The timestamp doesn't contain the year, leading to promtail's `timestamp` stage to parse it as year `0000` and thus having it discarded during the ingestion to Loki.

In this PR I'm adopting a strategy to handle timestamps without year, assuming the timestamp is related to a point in time close to "now", and handling the edge cases around new year's eve.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/692

**Checklist**
- [x] Documentation added
- [x] Tests updated

