### PR TITLE
Altered helm installation command for loki and promtail

### DIFF
--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -33,13 +33,13 @@ $ helm upgrade --install loki loki/loki-stack --set "key1=val1,key2=val2,..."
 ## Deploy Loki only
 
 ```bash
-$ helm upgrade --install loki loki/loki --set "loki.serviceName=my-loki"
+$ helm upgrade --install loki loki/loki
 ```
 
 ## Deploy Promtail only
 
 ```bash
-$ helm upgrade --install promtail loki/promtail
+$ helm upgrade --install promtail loki/promtail --set "loki.serviceName=loki"
 ```
 
 ## Deploy Grafana to your cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
There is no configurable serviceName key in loki/loki helm chart:
`helm upgrade --install loki loki/loki --set "loki.serviceName=my-loki"`

The configurable serviceName for loki should be in the loki/promtail helm chart installation command:
`helm upgrade --install promtail loki/promtail --set "loki.serviceName=loki"`

**Checklist**
- [x] Documentation added

