### PR TITLE
chore(packaging/docker): Support multiple architectures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ workflows:
       - build/promtail:
           requires: [ lint, test ]
           filters: {<<: *no-master}
+      - build/promtail-windows:
+          requires: [ lint, test ]
       - publish/promtail:
           requires: [ lint, test ]
           filters: { <<: *tag-or-master }
@@ -157,6 +159,14 @@ jobs:
     <<: *container
     environment:
       APP: promtail
+
+  build/promtail-windows:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: build
+          command: make GOOS=windows promtail
 
   publish/promtail:
     <<: *publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,13 @@ workflows:
           requires: [ lint, test ]
           filters: { <<: *tag-or-master }
 
+      - build/canary:
+          requires: [ lint, test ]
+          filters: {<<: *no-master}
+      - publish/canary:
+          requires: [ lint, test ]
+          filters: { <<: *tag-or-master }
+
       - build/promtail:
           requires: [ lint, test ]
           filters: {<<: *no-master}
@@ -128,6 +135,17 @@ jobs:
     <<: *publish
     environment:
       APP: loki
+
+  # Loki
+  build/canary:
+    <<: *container
+    environment:
+      APP: loki-canary
+
+  publish/canary:
+    <<: *publish
+    environment:
+      APP: loki-canary
 
   # Promtail
   build/promtail:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,12 @@ workflows:
           requires: [ lint, test ]
           filters: { <<: *tag-or-master }
     
-      # - test-helm:
-      #     requires: [ lint, test ]
-      #     filters: {<<: *tags}
-      # - publish-helm:
-      #     requires: [ test-helm ]
-      #     filters: {<<: *tags}
+      - test-helm:
+          requires: [ lint, test ]
+          filters: {<<: *tags}
+      - publish-helm:
+          requires: [ test-helm ]
+          filters: {<<: *tag-or-master}
 
 
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
@@ -158,76 +158,44 @@ jobs:
     environment:
       APP: promtail
 
-  # test-helm:
-  #   environment:
-  #     CT_VERSION: 2.3.3
-  #   machine:
-  #     image: ubuntu-1604:201903-01
-  #   steps:
-  #     - checkout
-  #     - run:
-  #         name: Install k3s
-  #         command: |
-  #           curl -sfL https://get.k3s.io | sh -
-  #           sudo chmod 755 /etc/rancher/k3s/k3s.yaml
-  #           mkdir -p ~/.kube
-  #           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-  #     - run:
-  #         name: Install Helm
-  #         command: |
-  #           curl -L https://git.io/get_helm.sh | bash
-  #           kubectl apply -f tools/helm.yaml
-  #           helm init --service-account helm --wait
-  #     - run:
-  #         name: Install Chart Testing tool
-  #         command: |
-  #           pip install yamale yamllint
-  #           curl -Lo ct.tgz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
-  #           sudo tar -C /usr/local/bin -xvf ct.tgz
-  #           sudo mv /usr/local/bin/etc /etc/ct/
-  #     - run:
-  #         name: Run Chart Tests
-  #         command: |
-  #           ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-  #           ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
+  test-helm:
+    environment:
+      CT_VERSION: 2.3.3
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Install k3s
+          command: |
+            curl -sfL https://get.k3s.io | sh -
+            sudo chmod 755 /etc/rancher/k3s/k3s.yaml
+            mkdir -p ~/.kube
+            cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+      - run:
+          name: Install Helm
+          command: |
+            curl -L https://git.io/get_helm.sh | bash
+            kubectl apply -f tools/helm.yaml
+            helm init --service-account helm --wait
+      - run:
+          name: Install Chart Testing tool
+          command: |
+            pip install yamale yamllint
+            curl -Lo ct.tgz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
+            sudo tar -C /usr/local/bin -xvf ct.tgz
+            sudo mv /usr/local/bin/etc /etc/ct/
+      - run:
+          name: Run Chart Tests
+          command: |
+            ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
+            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
 
-  # publish-helm:
-  #   <<: *defaults
-  #   steps:
-  #     - add_ssh_keys:
-  #         fingerprints:
-  #           - "5a:d3:08:5e:f7:53:a0:c4:e9:5d:83:c6:02:6a:d9:bd"
-  #     - checkout
-  #     - run: make helm-publish
-
-  # deploy:
-  #   <<: *defaults
-  #   steps:
-  #     - checkout
-
-  #     - run: |
-  #         curl -s --header "Content-Type: application/json" \
-  #           --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$(make images)\"}}" \
-  #           --request POST \
-  #           https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
-
-  # release:
-  #   <<: *defaults
-  #   steps:
-  #     - checkout
-  #     - setup_remote_docker
-  #     - restore_cache:
-  #         key: v1-loki-{{ .Branch }}-{{ .Revision }}
-  #     - run:
-  #         name: Load Images
-  #         command: |
-  #           touch loki-build-image/.uptodate &&
-  #           make BUILD_IN_CONTAINER=false load-images
-  #     - run:
-  #         name: "Print Tag"
-  #         command: echo ${CIRCLE_TAG}
-  #     - run:
-  #         name: "Release"
-  #         command: |
-  #           docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-  #           make VERSION=${CIRCLE_TAG} release-perform
+  publish-helm:
+    <<: *defaults
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "5a:d3:08:5e:f7:53:a0:c4:e9:5d:83:c6:02:6a:d9:bd"
+      - checkout
+      - run: make helm-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,21 @@
 version: 2
 
-.tags: &tags
+.tags: &tags # tags need to be explicitely defined (whitelist)
   tags: {only: "/.*/"}
 
 .tag-or-master: &tag-or-master
   branches: { only: master }
   <<: *tags
 
-.no-master: &no-master
+.no-master: &no-master # contrary to tags, the branches must be excluded (blacklist)
   branches: { ignore: master }
 
 workflows:
   version: 2
   containers:
     jobs:
+      # publish jobs depend on this as well,
+      # thus tags need to be allowed for these
       - lint: {filters: {<<: *tags}}
       - test: {filters: {<<: *tags}}
 
@@ -35,6 +37,13 @@ workflows:
           requires: [ lint, test ]
           filters: {<<: *no-master}
       - publish/promtail:
+          requires: [ lint, test ]
+          filters: { <<: *tag-or-master }
+
+      - build/docker-driver:
+          requires: [ lint, test ]
+          filters: {<<: *no-master}
+      - publish/docker-driver:
           requires: [ lint, test ]
           filters: { <<: *tag-or-master }
     
@@ -157,6 +166,28 @@ jobs:
     <<: *publish
     environment:
       APP: promtail
+
+  # Docker driver
+  build/docker-driver:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: docker-driver
+          command: make docker-driver
+
+  publish/docker-driver:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: login
+          command: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+      - run:
+          name: docker-driver
+          command: make docker-driver-push
 
   test-helm:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,256 +1,215 @@
 version: 2
 
+.tags: &tags
+  tags: {only: "/.*/"}
+
+.tag-or-master: &tag-or-master
+  branches: { only: master }
+  <<: *tags
+
+.no-master: &no-master
+  branches: { ignore: master }
+
 workflows:
   version: 2
   containers:
     jobs:
-      - build/loki
-      - build/promtail
-  # test-build-deploy:
-  #   jobs:
-  #   - test
-  #   - test-helm
-  #   - build
-  #   - lint
-  #   - publish:
-  #       requires:
-  #       - test
-  #       - test-helm
-  #       - build
-  #       - lint
-  #       filters:
-  #         branches:
-  #           only: master
-  #   - publish-master:
-  #       requires:
-  #       - test
-  #       - test-helm
-  #       - build
-  #       - lint
-  #       filters:
-  #         branches:
-  #           only: master
-  #   - publish-helm:
-  #       requires:
-  #       - test
-  #       - test-helm
-  #       - build
-  #       - lint
-  #       filters:
-  #         branches:
-  #           only: master
-  #   - deploy:
-  #       requires:
-  #       - publish
-  #       filters:
-  #         branches:
-  #           only: master
+      - lint: {filters: {<<: *tags}}
+      - test: {filters: {<<: *tags}}
+
+      - build/loki:
+          requires: [ lint, test ]
+          filters: {<<: *no-master}
+      - publish/loki:
+          requires: [ lint, test ]
+          filters: { <<: *tag-or-master }
+
+      - build/promtail:
+          requires: [ lint, test ]
+          filters: {<<: *no-master}
+      - publish/promtail:
+          requires: [ lint, test ]
+          filters: { <<: *tag-or-master }
+    
+      # - test-helm:
+      #     requires: [ lint, test ]
+      #     filters: {<<: *tags}
+      # - publish-helm:
+      #     requires: [ test-helm ]
+      #     filters: {<<: *tags}
+
 
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
-defaults: &defaults
+.defaults: &defaults
   docker:
     - image: grafana/loki-build-image:0.3.0
   working_directory: /go/src/github.com/grafana/loki
 
-container: &container
+.machine: &machine
   machine:
     image: ubuntu-1604:201903-01
   working_directory: ~/go/src/github.com/grafana/loki
   environment:
-    APP: loki
+    APP: to-be-set
     GOPATH: /home/circleci/go
+
+.rootless: &rootless
+  run:
+    name: rootless
+    command: |
+      sudo apt-get install -qy uidmap libseccomp-dev binfmt-support go-bindata
+      sudo docker run --privileged linuxkit/binfmt:v0.6
+
+.img: &img
+  run:
+    name: img
+    # TODO: switch to https://github.com/genuinetools/img once 5a8119fb4ce7d712ca2ed589a345213fdf576268 is released
+    command: |
+      sudo curl -fSL "https://github.com/sh0rez/img/releases/download/v0.5.8/img-linux-amd64" -o "/usr/local/bin/img"
+      sudo chmod a+x "/usr/local/bin/img"
+
+# builds a container
+.container: &container
+  <<: *machine
   steps:
     - checkout
-    - run:
-        name: rootless
-        command: |
-          sudo apt-get install -qy uidmap libseccomp-dev binfmt-support go-bindata
-          sudo docker run --privileged linuxkit/binfmt:v0.6
-    - run:
-        name: img
-        command: |
-          export GOPATH=~/go
-          go get -u github.com/jteeuwen/go-bindata/...
-          mkdir -p $GOPATH/src/github.com/genuinetools
-          cd $GOPATH/src/github.com/genuinetools
-          git clone https://github.com/genuinetools/img
-          cd img
-          make
-          sudo mv img /bin
-          cd $GOPATH/src/github.com/grafana/loki
+    - <<: *rootless
+    - <<: *img
     - run:
         name: container
         command: |
           make $APP-image
+
+# builds and pushes a container
+.publish: &publish
+  <<: *machine
+  steps:
+    - checkout
+    - <<: *rootless
+    - <<: *img
+    - run:
+        name: login
+        command: img login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+    - run:
+        name: container
+        command: |
+          make $APP-image
+    - run:
+        name: push image
+        command: make $APP-push
 
 jobs:
   test:
     <<: *defaults
     steps:
       - checkout
-
       - run:
-          name: Run Unit Tests
-          command: |
-            make test
+          name: Unit Tests
+          command: make test
 
   lint:
     <<: *defaults
     steps:
       - checkout
-
       - run:
           name: Lint
-          command: |
-            make lint
-
+          command: make lint
       - run:
-          name: Check Generated Fies
-          command: |
-            make BUILD_IN_CONTAINER=false check-generated-files
+          name: Check Generated Files
+          command: make BUILD_IN_CONTAINER=false check-generated-files
 
+  # Loki
   build/loki:
     <<: *container
     environment:
       APP: loki
 
+  publish/loki:
+    <<: *publish
+    environment:
+      APP: loki
+
+  # Promtail
   build/promtail:
     <<: *container
     environment:
       APP: promtail
 
-  publish:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker
-
-      - restore_cache:
-          key: v1-loki-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: v1-loki-plugin-{{ .Branch }}-{{ .Revision }}
-
-      - run:
-          name: Load Images
-          command: |
-            make load-images
-
-      - run:
-          name: Push Images
-          command: |
-            if [ -n "$DOCKER_USER" ]; then
-              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-              make push-images
-            fi
-
-      - run:
-          name: Push Docker Plugin
-          command: |
-            if [ -n "$DOCKER_USER" ]; then
-              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-              make BUILD_IN_CONTAINER=false docker-driver-push
-            fi
-
-  publish-master:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker
-
-      - restore_cache:
-          key: v1-loki-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: v1-loki-plugin-{{ .Branch }}-{{ .Revision }}
-
-      - run:
-          name: Load Images
-          command: |
-            make load-images
-
-      - run:
-          name: Push Images
-          command: |
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-            make push-latest
-
-      - run:
-          name: Push Docker Plugin
-          command: |
-            if [ -n "$DOCKER_USER" ]; then
-              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-              PLUGIN_TAG=master make BUILD_IN_CONTAINER=false docker-driver-push && PLUGIN_TAG=latest make BUILD_IN_CONTAINER=false docker-driver-push
-            fi
-
-  test-helm:
+  publish/promtail:
+    <<: *publish
     environment:
-      CT_VERSION: 2.3.3
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - run:
-          name: Install k3s
-          command: |
-            curl -sfL https://get.k3s.io | sh -
-            sudo chmod 755 /etc/rancher/k3s/k3s.yaml
-            mkdir -p ~/.kube
-            cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-      - run:
-          name: Install Helm
-          command: |
-            curl -L https://git.io/get_helm.sh | bash
-            kubectl apply -f tools/helm.yaml
-            helm init --service-account helm --wait
-      - run:
-          name: Install Chart Testing tool
-          command: |
-            pip install yamale yamllint
-            curl -Lo ct.tgz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
-            sudo tar -C /usr/local/bin -xvf ct.tgz
-            sudo mv /usr/local/bin/etc /etc/ct/
-      - run:
-          name: Run Chart Tests
-          command: |
-            ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
+      APP: promtail
 
-  publish-helm:
-    <<: *defaults
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "5a:d3:08:5e:f7:53:a0:c4:e9:5d:83:c6:02:6a:d9:bd"
-      - checkout
-      - run: make helm-publish
+  # test-helm:
+  #   environment:
+  #     CT_VERSION: 2.3.3
+  #   machine:
+  #     image: ubuntu-1604:201903-01
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Install k3s
+  #         command: |
+  #           curl -sfL https://get.k3s.io | sh -
+  #           sudo chmod 755 /etc/rancher/k3s/k3s.yaml
+  #           mkdir -p ~/.kube
+  #           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+  #     - run:
+  #         name: Install Helm
+  #         command: |
+  #           curl -L https://git.io/get_helm.sh | bash
+  #           kubectl apply -f tools/helm.yaml
+  #           helm init --service-account helm --wait
+  #     - run:
+  #         name: Install Chart Testing tool
+  #         command: |
+  #           pip install yamale yamllint
+  #           curl -Lo ct.tgz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
+  #           sudo tar -C /usr/local/bin -xvf ct.tgz
+  #           sudo mv /usr/local/bin/etc /etc/ct/
+  #     - run:
+  #         name: Run Chart Tests
+  #         command: |
+  #           ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
+  #           ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
 
-  deploy:
-    <<: *defaults
-    steps:
-      - checkout
+  # publish-helm:
+  #   <<: *defaults
+  #   steps:
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - "5a:d3:08:5e:f7:53:a0:c4:e9:5d:83:c6:02:6a:d9:bd"
+  #     - checkout
+  #     - run: make helm-publish
 
-      - run: |
-          curl -s --header "Content-Type: application/json" \
-            --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$(make images)\"}}" \
-            --request POST \
-            https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
+  # deploy:
+  #   <<: *defaults
+  #   steps:
+  #     - checkout
 
-  release:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-loki-{{ .Branch }}-{{ .Revision }}
-      - run:
-          name: Load Images
-          command: |
-            touch loki-build-image/.uptodate &&
-            make BUILD_IN_CONTAINER=false load-images
-      - run:
-          name: "Print Tag"
-          command: echo ${CIRCLE_TAG}
-      - run:
-          name: "Release"
-          command: |
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-            make VERSION=${CIRCLE_TAG} release-perform
+  #     - run: |
+  #         curl -s --header "Content-Type: application/json" \
+  #           --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$(make images)\"}}" \
+  #           --request POST \
+  #           https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
+
+  # release:
+  #   <<: *defaults
+  #   steps:
+  #     - checkout
+  #     - setup_remote_docker
+  #     - restore_cache:
+  #         key: v1-loki-{{ .Branch }}-{{ .Revision }}
+  #     - run:
+  #         name: Load Images
+  #         command: |
+  #           touch loki-build-image/.uptodate &&
+  #           make BUILD_IN_CONTAINER=false load-images
+  #     - run:
+  #         name: "Print Tag"
+  #         command: echo ${CIRCLE_TAG}
+  #     - run:
+  #         name: "Release"
+  #         command: |
+  #           docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
+  #           make VERSION=${CIRCLE_TAG} release-perform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,51 +2,86 @@ version: 2
 
 workflows:
   version: 2
-  test-build-deploy:
+  containers:
     jobs:
-    - test
-    - test-helm
-    - build
-    - lint
-    - publish:
-        requires:
-        - test
-        - test-helm
-        - build
-        - lint
-        filters:
-          branches:
-            only: master
-    - publish-master:
-        requires:
-        - test
-        - test-helm
-        - build
-        - lint
-        filters:
-          branches:
-            only: master
-    - publish-helm:
-        requires:
-        - test
-        - test-helm
-        - build
-        - lint
-        filters:
-          branches:
-            only: master
-    - deploy:
-        requires:
-        - publish
-        filters:
-          branches:
-            only: master
+      - build/loki
+      - build/promtail
+  # test-build-deploy:
+  #   jobs:
+  #   - test
+  #   - test-helm
+  #   - build
+  #   - lint
+  #   - publish:
+  #       requires:
+  #       - test
+  #       - test-helm
+  #       - build
+  #       - lint
+  #       filters:
+  #         branches:
+  #           only: master
+  #   - publish-master:
+  #       requires:
+  #       - test
+  #       - test-helm
+  #       - build
+  #       - lint
+  #       filters:
+  #         branches:
+  #           only: master
+  #   - publish-helm:
+  #       requires:
+  #       - test
+  #       - test-helm
+  #       - build
+  #       - lint
+  #       filters:
+  #         branches:
+  #           only: master
+  #   - deploy:
+  #       requires:
+  #       - publish
+  #       filters:
+  #         branches:
+  #           only: master
 
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
     - image: grafana/loki-build-image:0.3.0
   working_directory: /go/src/github.com/grafana/loki
+
+container: &container
+  machine:
+    image: ubuntu-1604:201903-01
+  working_directory: ~/go/src/github.com/grafana/loki
+  environment:
+    APP: loki
+    GOPATH: /home/circleci/go
+  steps:
+    - checkout
+    - run:
+        name: rootless
+        command: |
+          sudo apt-get install -qy uidmap libseccomp-dev binfmt-support go-bindata
+          sudo docker run --privileged linuxkit/binfmt:v0.6
+    - run:
+        name: img
+        command: |
+          export GOPATH=~/go
+          go get -u github.com/jteeuwen/go-bindata/...
+          mkdir -p $GOPATH/src/github.com/genuinetools
+          cd $GOPATH/src/github.com/genuinetools
+          git clone https://github.com/genuinetools/img
+          cd img
+          make
+          sudo mv img /bin
+          cd $GOPATH/src/github.com/grafana/loki
+    - run:
+        name: container
+        command: |
+          make $APP-image
 
 jobs:
   test:
@@ -74,38 +109,15 @@ jobs:
           command: |
             make BUILD_IN_CONTAINER=false check-generated-files
 
-  build:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker
+  build/loki:
+    <<: *container
+    environment:
+      APP: loki
 
-      - run:
-          name: Promtail cross platform
-          command: |
-            make GOOS=linux BUILD_IN_CONTAINER=false promtail
-            rm cmd/promtail/promtail
-            make GOOS=windows BUILD_IN_CONTAINER=false promtail
-
-      - run:
-          name: Build Images
-          command: |
-            make images
-
-      - run:
-          name: Save Images
-          command: |
-            make save-images
-
-      - save_cache:
-          key: v1-loki-{{ .Branch }}-{{ .Revision }}
-          paths:
-          - images/
-
-      - save_cache:
-          key: v1-loki-plugin-{{ .Branch }}-{{ .Revision }}
-          paths:
-          - cmd/docker-driver/docker-driver
+  build/promtail:
+    <<: *container
+    environment:
+      APP: promtail
 
   publish:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ version: 2
 
 workflows:
   version: 2
-  containers:
+  default:
     jobs:
       # publish jobs depend on this as well,
       # thus tags need to be allowed for these

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,6 @@ workflows:
         name: login
         command: img login -u "$DOCKER_USER" -p "$DOCKER_PASS"
     - run:
-        name: container
-        command: |
-          make $APP-image
-    - run:
         name: push image
         command: make $APP-push
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - checkout
       - run:
           name: Unit Tests
-          command: make test
+          command: make BUILD_IN_CONTAINER=false test
 
   lint:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ BUILD_IN_CONTAINER ?= true
 BUILD_IMAGE_VERSION := "0.2.1"
 
 # Docker image info
-IMAGE_PREFIX ?= grafana
+# IMAGE_PREFIX ?= grafana
+IMAGE_PREFIX ?= shorez
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries
@@ -76,7 +77,7 @@ TTY := --tty
 DOCKER_BUILDKIT=1
 OCI_PLATFORMS=--platform=linux/amd64 --platform=linux/arm64 --platform=linux/arm/7
 ifeq ($(CI), true)
-	BUILD_OCI=img build $(OCI_PLATFORMS)
+	BUILD_OCI=img build --no-console $(OCI_PLATFORMS)
 	PUSH_OCI=img push
 else
 	BUILD_OCI=docker build
@@ -312,7 +313,8 @@ docker-driver-clean:
 
 images: promtail-image loki-image loki-canary-image docker-driver
 
-IMAGE_NAMES := grafana/loki grafana/promtail grafana/loki-canary
+# IMAGE_NAMES := grafana/loki grafana/promtail grafana/loki-canary
+IMAGE_NAMES := shorez/loki shorez/promtail shorez/loki-canary
 
 save-images:
 	@set -e; \
@@ -353,6 +355,9 @@ promtail-debug-image: OCI_PLATFORMS=
 promtail-debug-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/promtail:$(IMAGE_TAG)-debug -f cmd/promtail/Dockerfile.debug .
 
+promtail-push:
+	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/promtail:$(IMAGE_TAG)
+
 # loki
 loki-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile .
@@ -360,6 +365,9 @@ loki-image:
 loki-debug-image: OCI_PLATFORMS=
 loki-debug-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)-debug -f cmd/loki/Dockerfile.debug .
+
+loki-push:
+	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
 
 # loki-canary
 loki-canary-image:

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ promtail-debug-image: OCI_PLATFORMS=
 promtail-debug-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/promtail:$(IMAGE_TAG)-debug -f cmd/promtail/Dockerfile.debug .
 
-promtail-push:
+promtail-push: promtail-image
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/promtail:$(IMAGE_TAG)
 
 # loki
@@ -365,13 +365,13 @@ loki-debug-image: OCI_PLATFORMS=
 loki-debug-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)-debug -f cmd/loki/Dockerfile.debug .
 
-loki-push:
+loki-push: loki-image
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
 
 # loki-canary
 loki-canary-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki-canary:$(IMAGE_TAG) -f cmd/loki-canary/Dockerfile .
-loki-canary-push:
+loki-canary-push: loki-canary-image
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/loki-canary:$(IMAGE_TAG)
 
 # build-image (only amd64)

--- a/Makefile
+++ b/Makefile
@@ -282,9 +282,9 @@ helm-clean:
 
 PLUGIN_TAG ?= $(IMAGE_TAG)
 
-docker-driver: docker-driver-clean cmd/docker-driver/docker-driver
+docker-driver: docker-driver-clean 
 	mkdir cmd/docker-driver/rootfs
-	docker build -t rootfsimage cmd/docker-driver
+	docker build -t rootfsimage -f cmd/docker-driver/Dockerfile .
 	ID=$$(docker create rootfsimage true) && \
 	(docker export $$ID | tar -x -C cmd/docker-driver/rootfs) && \
 	docker rm -vf $$ID

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,12 @@ TTY := --tty
 
 DOCKER_BUILDKIT=1
 OCI_PLATFORMS=--platform=linux/amd64 --platform=linux/arm64 --platform=linux/arm/7
+BUILD_IMAGE = BUILD_IMAGE=grafana/loki-build-image:0.2.1
 ifeq ($(CI), true)
-	BUILD_OCI=img build --no-console $(OCI_PLATFORMS)
+	BUILD_OCI=img build --no-console $(OCI_PLATFORMS) --build-arg $(BUILD_IMAGE)
 	PUSH_OCI=img push
 else
-	BUILD_OCI=docker build
+	BUILD_OCI=docker build --build-arg $(BUILD_IMAGE)
 	PUSH_OCI=img push
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ BUILD_IN_CONTAINER ?= true
 BUILD_IMAGE_VERSION := "0.2.1"
 
 # Docker image info
-# IMAGE_PREFIX ?= grafana
-IMAGE_PREFIX ?= shorez
+IMAGE_PREFIX ?= grafana
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries
@@ -313,8 +312,7 @@ docker-driver-clean:
 
 images: promtail-image loki-image loki-canary-image docker-driver
 
-# IMAGE_NAMES := grafana/loki grafana/promtail grafana/loki-canary
-IMAGE_NAMES := shorez/loki shorez/promtail shorez/loki-canary
+IMAGE_NAMES := grafana/loki grafana/promtail grafana/loki-canary
 
 save-images:
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_IMAGE_VERSION := 0.2.1
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-IMAGE_TAG := $(shell git describe --exact-match 2> /dev/null || git rev-parse --abbrev-ref HEAD)
+IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries
 GIT_REVISION := $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,
 # make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := "0.2.1"
+BUILD_IMAGE_VERSION := 0.2.1
 
 # Docker image info
 IMAGE_PREFIX ?= grafana
@@ -75,7 +75,7 @@ TTY := --tty
 
 DOCKER_BUILDKIT=1
 OCI_PLATFORMS=--platform=linux/amd64 --platform=linux/arm64 --platform=linux/arm/7
-BUILD_IMAGE = BUILD_IMAGE=grafana/loki-build-image:0.2.1
+BUILD_IMAGE = BUILD_IMAGE=$(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
 ifeq ($(CI), true)
 	BUILD_OCI=img build --no-console $(OCI_PLATFORMS) --build-arg $(BUILD_IMAGE)
 	PUSH_OCI=img push

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,8 @@ loki-push:
 # loki-canary
 loki-canary-image:
 	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki-canary:$(IMAGE_TAG) -f cmd/loki-canary/Dockerfile .
+loki-canary-push:
+	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/loki-canary:$(IMAGE_TAG)
 
 # build-image (only amd64)
 build-image: OCI_PLATFORMS=

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,
 # make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := 0.2.1
+BUILD_IMAGE_VERSION := 0.3.0
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -1,5 +1,23 @@
-FROM       alpine:3.9
-RUN        apk add --update --no-cache ca-certificates
-COPY       docker-driver /bin/docker-driver
+# Directories in this file are referenced from the root of the project not this folder
+# This file is intented to be called from the root like so:
+# docker build -t grafana/loki -f cmd/loki/Dockerfile .
+
+# TODO: really add cross-platform support
+
+# FROM golang:1.11.4-alpine as goenv
+# RUN go env GOARCH > /goarch && \
+#   go env GOARM > /goarm
+
+# FROM --platform=linux/amd64 grafana/loki-build-image as build
+FROM grafana/loki-build-image as build
+# COPY --from=goenv /goarch /goarm /
+COPY . /go/src/github.com/grafana/loki
+WORKDIR /go/src/github.com/grafana/loki
+# RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make cmd/docker-driver/docker-driver
+RUN make clean && make cmd/docker-driver/docker-driver
+
+FROM alpine:3.9
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /go/src/github.com/grafana/loki/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/
 ENTRYPOINT [ "/bin/docker-driver" ]

--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -1,19 +1,12 @@
+ARG BUILD_IMAGE=grafana/loki-build-image:0.2.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
 
-# TODO: really add cross-platform support
-
-# FROM golang:1.11.4-alpine as goenv
-# RUN go env GOARCH > /goarch && \
-#   go env GOARM > /goarm
-
-# FROM --platform=linux/amd64 grafana/loki-build-image as build
-FROM grafana/loki-build-image as build
-# COPY --from=goenv /goarch /goarm /
+# TODO: add cross-platform support
+FROM $BUILD_IMAGE as build
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-# RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make cmd/docker-driver/docker-driver
 RUN make clean && make cmd/docker-driver/docker-driver
 
 FROM alpine:3.9

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=grafana/loki-build-image:0.2.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
@@ -5,7 +6,7 @@ FROM golang:1.11.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 
-FROM --platform=linux/amd64 grafana/loki-build-image as build
+FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,14 +1,17 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
+FROM golang:1.11.4-alpine as goenv
+RUN go env GOARCH > /goarch && \
+  go env GOARM > /goarm
 
-FROM grafana/loki-build-image:0.2.1 as build
-ARG GOARCH="amd64"
+FROM --platform=linux/amd64 grafana/loki-build-image as build
+COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN make clean && make loki-canary
+RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make loki-canary
 
-FROM       alpine:3.9
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /go/src/github.com/grafana/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
+FROM alpine:3.9
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /go/src/github.com/grafana/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=grafana/loki-build-image:0.2.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
@@ -5,7 +6,7 @@ FROM golang:1.11.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 
-FROM --platform=linux/amd64 grafana/loki-build-image as build
+FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,17 +1,20 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
+FROM golang:1.11.4-alpine as goenv
+RUN go env GOARCH > /goarch && \
+    go env GOARM > /goarm
 
-FROM grafana/loki-build-image:0.2.1 as build
-ARG GOARCH="amd64"
+FROM --platform=linux/amd64 grafana/loki-build-image as build
+COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN make clean && make loki
+RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make loki
 
-FROM       alpine:3.9
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /go/src/github.com/grafana/loki/cmd/loki/loki /usr/bin/loki
-COPY       cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE     80
+FROM alpine:3.9
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /go/src/github.com/grafana/loki/cmd/loki/loki /usr/bin/loki
+COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/loki" ]
-CMD        ["-config.file=/etc/loki/local-config.yaml"]
+CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /go/src/github.com/grafana/loki
 RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make promtail
 
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates
+# tzdata required for the timestamp stage to work
+RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /go/src/github.com/grafana/loki/cmd/promtail/promtail /usr/bin/promtail
 COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
 COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,16 +1,19 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
+FROM golang:1.11.4-alpine as goenv
+RUN go env GOARCH > /goarch && \
+    go env GOARM > /goarm
 
-FROM grafana/loki-build-image:0.2.1 as build
-ARG GOARCH="amd64"
+FROM --platform=linux/amd64 grafana/loki-build-image as build
+COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN make clean && make promtail
+RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make promtail
 
-FROM       alpine:3.9
-RUN        apk add --update --no-cache ca-certificates tzdata
-COPY       --from=build /go/src/github.com/grafana/loki/cmd/promtail/promtail /usr/bin/promtail
-COPY       cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
-COPY       cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+FROM alpine:3.9
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /go/src/github.com/grafana/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
+COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
 ENTRYPOINT ["/usr/bin/promtail"]

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_IMAGE=grafana/loki-build-image:0.2.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
@@ -5,7 +6,7 @@ FROM golang:1.11.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 
-FROM --platform=linux/amd64 grafana/loki-build-image as build
+FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -1,28 +1,31 @@
-FROM golang:1.11.4-stretch
-RUN apt-get update && apt-get install -y file jq unzip protobuf-compiler libprotobuf-dev libsystemd-dev && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV DOCKER_VER="17.03.0-ce"
-RUN curl -L -o /tmp/docker-$DOCKER_VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VER.tgz && \
-	tar -xz -C /tmp -f /tmp/docker-$DOCKER_VER.tgz && \
-	mv /tmp/docker/* /usr/bin && \
-	rm /tmp/docker-$DOCKER_VER.tgz
-ENV HELM_VER="v2.13.1"
-RUN curl -L -o /tmp/helm-$HELM_VER.tgz http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VER}-linux-amd64.tar.gz && \
-	tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
-	mv /tmp/linux-amd64/helm /usr/bin/helm && \
-	rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
+FROM alpine as helm
+ARG HELM_VER="v2.13.1"
+RUN apk add --no-cache curl && \
+    curl -L -o /tmp/helm-$HELM_VER.tgz http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VER}-linux-amd64.tar.gz && \
+    tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
+    mv /tmp/linux-amd64/helm /usr/bin/helm && \
+    rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
+
+FROM alpine as golangci
+RUN apk add --no-cache curl && \
+    cd / && \
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
+
+FROM golang:1.11.4-alpine
+RUN sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories && \
+    apk update && apk upgrade &&\
+    apk add --no-cache file jq unzip protobuf protobuf-dev git bash coreutils make grep
+COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY --from=golangci /bin/golangci-lint /usr/local/bin
 RUN go get \
-	github.com/golang/protobuf/protoc-gen-go \
-	github.com/gogo/protobuf/protoc-gen-gogoslick \
-	github.com/gogo/protobuf/gogoproto \
-	github.com/go-delve/delve/cmd/dlv \
-	golang.org/x/tools/cmd/goyacc && \
-	rm -rf /go/pkg /go/src
-ENV GOLANGCI_LINT_COMMIT="692dacb773b703162c091c2d8c59f9cd2d6801db"
-RUN mkdir -p $(go env GOPATH)/src/github.com/golangci/ && git clone https://github.com/golangci/golangci-lint.git $(go env GOPATH)/src/github.com/golangci/golangci-lint && \
-	cd $(go env GOPATH)/src/github.com/golangci/golangci-lint  && git checkout ${GOLANGCI_LINT_COMMIT} && cd cmd/golangci-lint/  &&\
-	GO111MODULE=on go install && \
-	golangci-lint help
-#COPY build.sh /
+    github.com/golang/protobuf/protoc-gen-go \
+    github.com/gogo/protobuf/protoc-gen-gogoslick \
+    github.com/gogo/protobuf/gogoproto \
+    github.com/go-delve/delve/cmd/dlv \
+    golang.org/x/tools/cmd/goyacc && \
+    rm -rf /go/pkg /go/src
 ENV GOCACHE=/go/cache
-#ENTRYPOINT ["/build.sh"]
+
+# COPY build.sh /
+# RUN chmod +x /build.sh
+# ENTRYPOINT ["/build.sh"]

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -14,7 +14,11 @@ RUN apk add --no-cache curl && \
 FROM golang:1.11.4-alpine
 RUN sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories && \
     apk update && apk upgrade &&\
-    apk add --no-cache file jq unzip protobuf protobuf-dev git bash coreutils make grep
+    apk add --no-cache \
+      coreutils file bash unzip\
+      git make grep jq \
+      protobuf protobuf-dev \
+      docker-cli
 COPY --from=helm /usr/bin/helm /usr/bin/helm
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 RUN go get \

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -30,6 +30,6 @@ RUN go get \
     rm -rf /go/pkg /go/src
 ENV GOCACHE=/go/cache
 
-# COPY build.sh /
-# RUN chmod +x /build.sh
-# ENTRYPOINT ["/build.sh"]
+COPY build.sh /
+RUN chmod +x /build.sh
+ENTRYPOINT ["/build.sh"]

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -11,14 +11,18 @@ RUN apk add --no-cache curl && \
     cd / && \
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
 
-FROM golang:1.11.4-alpine
-RUN sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories && \
-    apk update && apk upgrade &&\
-    apk add --no-cache \
-      coreutils file bash unzip\
-      git make grep jq \
-      protobuf protobuf-dev \
-      docker-cli
+FROM alpine:edge as docker
+RUN apk add --no-cache docker-cli
+
+FROM golang:1.11.4-stretch
+RUN apt-get update && \
+    apt-get install -qy \
+      file unzip jq \
+      protobuf-compiler libprotobuf-dev \
+      libsystemd-dev && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=docker /usr/bin/docker /usr/bin/docker
 COPY --from=helm /usr/bin/helm /usr/bin/helm
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 RUN go get \

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WIP=$(git diff --quiet || echo 'WIP')
+WIP=$(git diff --quiet || echo '-WIP')
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHA=$(git rev-parse --short HEAD)
 
 # If this is a tag, use it,                otherwise branch-hash
 TAG=$(git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}")
-echo ${TAG}-${WIP}
+echo ${TAG}${WIP}

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -4,8 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+WIP=$(git diff --quiet || echo 'WIP')
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHA=$(git rev-parse --short HEAD)
 
 # If this is a tag, use it,                otherwise branch-hash
-git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}"
+TAG=$(git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}")
+echo ${TAG}-${WIP}

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
-BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
-echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse --short HEAD)
+
+# If this is a tag, use it,                otherwise branch-hash
+git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}"


### PR DESCRIPTION
### :heavy_check_mark: Ready to be merged :heavy_check_mark: 

---

This is take 2 on multiple architectures. It includes the following:

- [x] clean `loki-build-image` that is based on `golang:1.11.4-alpine`
- [x] `Dockerfile` for `promtail` that is capable of being built for multiple architectures, based on `alpine`
- [x] `Dockerfile` for `loki` that is capable of being built for multiple architectures, based on `alpine`
- [x] `Makefile` adaptations that allow building the `Dockerfiles` as cross-platform, but only when run in CI
  - set `CI=true` to trigger the cross-platform run
  - uses `img` instead of `docker` under the hood, because of better support for `--platform`.
- [x] Adapt CircleCI to `build` and `push` the images for `loki` and `promtail` for `amd64`, `arm64` and `armv7`
  - [x] install `img` and `binfmt-support`
  - use it


### Notes
#### BuildKit
One might have noticed that Docker has introduced a new architecture for building `OCI` container images called *BuildKit*. It comes with a lot of improvements over the traditional `docker build` including a **DAG-Solver** (builds only what's required, parallelizes as much as possible), **better caching**, **frontends** (not only `Dockerfile`, dynamic syntax extensions) and especially **cross-platform support** using `--platform`. As long as the host is capable of executing the `ELF` binaries, BuildKit can build every `arch`

#### `binfmt`
A Linux kernel feature that allows the kernel to dynamically recognize what to use to execute an `ELF` binary. This is especially useful with `buildkit` and `qemu`. By running `sudo docker run --privileged linuxkit/binfmt:v0.6`, `qemu-static-ARCH` executors are registered with the kernel and suddenly it is possible to execute a `armhf`/ `arm64` / whatever binary as if it was native.

#### `img`
Although `buildkit` is usable as a standalone daemon, it is a really handy library as well. The awesome folks over at https://github.com/genuinetools/img used this to build a *daemonless* cli that builds `Dockerfiles` using buildkit **without root privileges**. Because it is still BuildKit, we get all the awesome features above include `--platform`.

Although BuildKit is going to be fully integrated into Docker Engine in `19.03`, it will still be experimental, so it is easier for the moment to use it standalone.
