### PR TITLE
rounds nanoseconds boundaries to milliseconds

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/grafana/loki/pkg/chunkenc"
+	loki_util "github.com/grafana/loki/pkg/util"
 )
 
 var (
@@ -261,12 +262,12 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 
 	wireChunks := make([]chunk.Chunk, 0, len(cs))
 	for _, c := range cs {
-		firstTime, lastTime := c.chunk.Bounds()
+		firstTime, lastTime := loki_util.RoundToMilliseconds(c.chunk.Bounds())
 		c := chunk.NewChunk(
 			userID, fp, metric,
 			chunkenc.NewFacade(c.chunk),
-			model.TimeFromUnixNano(firstTime.UnixNano()),
-			model.TimeFromUnixNano(lastTime.UnixNano()),
+			firstTime,
+			lastTime,
 		)
 
 		start := time.Now()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/util"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -56,7 +57,7 @@ func (s *store) LazyQuery(ctx context.Context, req *logproto.QueryRequest) (iter
 		}
 
 		matchers = append(matchers, nameLabelMatcher)
-		from, through := model.TimeFromUnixNano(req.Start.UnixNano()), model.TimeFromUnixNano(req.End.UnixNano())
+		from, through := util.RoundToMilliseconds(req.Start, req.End)
 		chks, fetchers, err := s.GetChunkRefs(ctx, from, through, matchers...)
 		if err != nil {
 			return nil, err

--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logql"
@@ -40,4 +42,11 @@ func ModelLabelSetToMap(m model.LabelSet) map[string]string {
 		result[string(k)] = string(v)
 	}
 	return result
+}
+
+// RoundToMilliseconds returns milliseconds precision time from nanoseconds.
+// from will be rounded down to the nearest milliseconds while through is rounded up.
+func RoundToMilliseconds(from, through time.Time) (model.Time, model.Time) {
+	return model.Time(int64(math.Floor(float64(from.UnixNano()) / float64(time.Millisecond)))),
+		model.Time(int64(math.Ceil(float64(through.UnixNano()) / float64(time.Millisecond))))
 }

--- a/pkg/util/conv_test.go
+++ b/pkg/util/conv_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestRoundToMilliseconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		from        time.Time
+		through     time.Time
+		wantFrom    model.Time
+		wantThrough model.Time
+	}{
+		{
+			"0",
+			time.Unix(0, 0),
+			time.Unix(0, 1),
+			model.Time(0),
+			model.Time(1),
+		},
+		{
+			"equal",
+			time.Unix(0, time.Millisecond.Nanoseconds()),
+			time.Unix(0, time.Millisecond.Nanoseconds()),
+			model.Time(1),
+			model.Time(1),
+		},
+		{
+			"exact",
+			time.Unix(0, time.Millisecond.Nanoseconds()),
+			time.Unix(0, 2*time.Millisecond.Nanoseconds()),
+			model.Time(1),
+			model.Time(2),
+		},
+		{
+			"rounding",
+			time.Unix(0, time.Millisecond.Nanoseconds()+10),
+			time.Unix(0, 2*time.Millisecond.Nanoseconds()+10),
+			model.Time(1),
+			model.Time(3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, through := RoundToMilliseconds(tt.from, tt.through)
+			if !reflect.DeepEqual(from, tt.wantFrom) {
+				t.Errorf("RoundToMilliseconds() from = %v, want %v", from, tt.wantFrom)
+			}
+			if !reflect.DeepEqual(through, tt.wantThrough) {
+				t.Errorf("RoundToMilliseconds() through = %v, want %v", through, tt.wantThrough)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`model.Time` supports only milliseconds precise time, but entries in chunks are nanoseconds precise, so previously a chunks boundaries could not account for all entries.

This was probably causing some entries to be missed by the time filtering here or the overlapping code using chunks boundaries.

https://github.com/grafana/loki/blob/c08ec795a73985cefc93d657f35e2ee38d1c359c/pkg/storage/store.go#L250

and also here

https://github.com/grafana/loki/blob/c08ec795a73985cefc93d657f35e2ee38d1c359c/pkg/storage/store.go#L92 

This is also going to be useful for my work on batching chunks iteration.