### PR TITLE
cmd/docker-driver/README.md: fix typo

### DIFF
--- a/cmd/docker-driver/README.md
+++ b/cmd/docker-driver/README.md
@@ -154,7 +154,7 @@ docker plugin enable loki
 
 ## Troubleshooting
 
-Plugin logs can be found as docker daemon log. To enable debug mode, export environment variable LOGGIN_LEVEL=DEBUG in docker engine environment. See the Docker documentation for information about how to enable debug mode in your docker environment: https://docs.docker.com/config/daemon/
+Plugin logs can be found as docker daemon log. To enable debug mode, export environment variable LOGGING_LEVEL=DEBUG in docker engine environment. See the Docker documentation for information about how to enable debug mode in your docker environment: https://docs.docker.com/config/daemon/
 
 Stdout of a plugin is redirected to Docker logs. Such entries have a plugin= suffix.
 


### PR DESCRIPTION
I'm not sure 100% sure about this. I'm guessing it's a typo that you borrowed from https://docker.pkg.github.com/splunk/docker-logging-plugin#enable-debug-mode-to-find-log-errors.

I'm guessing it's a typo since it looked weird, google search for "LOGGIN_LEVEL" has less than 100 results, and that I wasn't able to find mention of it in Docker's doc (I wasn't able to find "LOGGIND_LEVEL" either).