### PR TITLE
Speed up Loki shutdown when using the sample local config

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -10,6 +10,7 @@ ingester:
       kvstore:
         store: inmemory
       replication_factor: 1
+    final_sleep: 0s
   chunk_idle_period: 5m
   chunk_retain_period: 30s
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When running `loki` with the sample config `loki-local-config.yaml`, it takes 30 ~~minutes~~ seconds to shutdown due to the default ingester's final sleep set to 30s to allow the scraping of the final metrics from Prometheus. However, this is usually not a real use case for the local run and I would suggest to set it to zero to have a nearly-instant shutdown.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

