### PR TITLE
Use prometheus pool for line buffer.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -904,7 +904,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5fc7e79142258f1ce47429c00fedb9ee04d8562e7fd477f2d9ae28a692e80969"
+  digest = "1:43edb14ccbe0d18f38bd55511250c39ccc3917c64a514a0e791408ac19a71558"
   name = "github.com/prometheus/prometheus"
   packages = [
     "discovery",
@@ -925,6 +925,7 @@
     "pkg/gate",
     "pkg/labels",
     "pkg/modtimevfs",
+    "pkg/pool",
     "pkg/relabel",
     "pkg/textparse",
     "pkg/timestamp",
@@ -1608,7 +1609,9 @@
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promauto",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_golang/prometheus/testutil",
+    "github.com/prometheus/client_model/go",
     "github.com/prometheus/common/config",
     "github.com/prometheus/common/expfmt",
     "github.com/prometheus/common/model",
@@ -1618,6 +1621,7 @@
     "github.com/prometheus/prometheus/discovery/targetgroup",
     "github.com/prometheus/prometheus/pkg/labels",
     "github.com/prometheus/prometheus/pkg/modtimevfs",
+    "github.com/prometheus/prometheus/pkg/pool",
     "github.com/prometheus/prometheus/pkg/relabel",
     "github.com/prometheus/prometheus/pkg/textparse",
     "github.com/prometheus/prometheus/promql",
@@ -1637,8 +1641,9 @@
     "github.com/weaveworks/common/user",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
     "google.golang.org/grpc/health/grpc_health_v1",
-    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/status",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/fsnotify.v1",
     "gopkg.in/yaml.v2",

--- a/pkg/chunkenc/gzip.go
+++ b/pkg/chunkenc/gzip.go
@@ -532,7 +532,7 @@ func (si *bufferedIterator) moveNext() (int64, []byte, bool) {
 
 	// If the buffer is not yet initialize or too small, we get a new one.
 	if si.buf == nil || lineSize > cap(si.buf) {
-		// in case of replacement
+		// in case of a replacement we replace back the buffer in the pool
 		if si.buf != nil {
 			BytesBufferPool.Put(si.buf)
 		}

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -29,7 +29,7 @@ var (
 	}
 	// BytesBufferPool is a bytes buffer used for lines decompressed.
 	// Buckets [0.5KB,1KB,2KB,4KB,8KB]
-	BytesBufferPool = pool.New(1<<10, 1<<13, 2, func(size int) interface{} { return make([]byte, 0, size) })
+	BytesBufferPool = pool.New(1<<9, 1<<13, 2, func(size int) interface{} { return make([]byte, 0, size) })
 )
 
 // GzipPool is a gun zip compression pool

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -28,7 +28,8 @@ var (
 		},
 	}
 	// BytesBufferPool is a bytes buffer used for lines decompressed.
-	BytesBufferPool = pool.New(1024, 16384, 2, func(size int) interface{} { return make([]byte, 0, size) })
+	// Buckets [0.5KB,1KB,2KB,4KB,8KB]
+	BytesBufferPool = pool.New(2e9, 2e13, 2, func(size int) interface{} { return make([]byte, 0, size) })
 )
 
 // GzipPool is a gun zip compression pool

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -29,7 +29,7 @@ var (
 	}
 	// BytesBufferPool is a bytes buffer used for lines decompressed.
 	// Buckets [0.5KB,1KB,2KB,4KB,8KB]
-	BytesBufferPool = pool.New(2e9, 2e13, 2, func(size int) interface{} { return make([]byte, 0, size) })
+	BytesBufferPool = pool.New(1<<10, 1<<13, 2, func(size int) interface{} { return make([]byte, 0, size) })
 )
 
 // GzipPool is a gun zip compression pool

--- a/vendor/github.com/prometheus/prometheus/pkg/pool/pool.go
+++ b/vendor/github.com/prometheus/prometheus/pkg/pool/pool.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// Pool is a bucketed pool for variably sized byte slices.
+type Pool struct {
+	buckets []sync.Pool
+	sizes   []int
+	// make is the function used to create an empty slice when none exist yet.
+	make func(int) interface{}
+}
+
+// New returns a new Pool with size buckets for minSize to maxSize
+// increasing by the given factor.
+func New(minSize, maxSize int, factor float64, makeFunc func(int) interface{}) *Pool {
+	if minSize < 1 {
+		panic("invalid minimum pool size")
+	}
+	if maxSize < 1 {
+		panic("invalid maximum pool size")
+	}
+	if factor < 1 {
+		panic("invalid factor")
+	}
+
+	var sizes []int
+
+	for s := minSize; s <= maxSize; s = int(float64(s) * factor) {
+		sizes = append(sizes, s)
+	}
+
+	p := &Pool{
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
+	}
+
+	return p
+}
+
+// Get returns a new byte slices that fits the given size.
+func (p *Pool) Get(sz int) interface{} {
+	for i, bktSize := range p.sizes {
+		if sz > bktSize {
+			continue
+		}
+		b := p.buckets[i].Get()
+		if b == nil {
+			b = p.make(bktSize)
+		}
+		return b
+	}
+	return p.make(sz)
+}
+
+// Put adds a slice to the right bucket in the pool.
+func (p *Pool) Put(s interface{}) {
+	slice := reflect.ValueOf(s)
+
+	if slice.Kind() != reflect.Slice {
+		panic(fmt.Sprintf("%+v is not a slice", slice))
+	}
+	for i, size := range p.sizes {
+		if slice.Cap() > size {
+			continue
+		}
+		p.buckets[i].Put(slice.Slice(0, 0).Interface())
+		return
+	}
+}


### PR DESCRIPTION
Fixes #787 

I was confused by the `bytes.Buffer`, it will only grow if we use the `buffer.Write`. I replaced it with `prometheus.Pool` which contains bucketed pool for variably sized byte slices. 

The cool things is big line not falling into any bucket will not be kept in the pool.


