### PR TITLE
promtail: clarify Linux build instructions in docs

### DIFF
--- a/production/README.md
+++ b/production/README.md
@@ -64,10 +64,31 @@ $ ./loki -config.file=./cmd/loki/loki-local-config.yaml
 ...
 ```
 
-To run Promtail, use the following commands:
+To build Promtail on non-Linux platforms, use the following command:
 
 ```bash
 $ go build ./cmd/promtail
+```
+
+On Linux, promtail requires the systemd headers to be installed for
+Journal support. Promtail can be built with Journal support on Ubuntu
+with the following commands:
+
+```bash
+$ sudo apt install libsystemd-dev
+$ go build ./cmd/promtail
+```
+
+Otherwise, to build promtail without Journal support, run `go build`
+with CGO disabled:
+
+```bash
+$ CGO_ENABLED=0 go build ./cmd/promtail
+```
+
+Once Promtail is built, to run Promtail, use the following command:
+
+```bash
 $ ./promtail -config.file=./cmd/promtail/promtail-local-config.yaml
 ...
 ```


### PR DESCRIPTION
This commit changes the docs to note dependency on systemd headers being installed on Linux and provides a fallback. 

This temporarily addresses #789, although we might want to consider having a journal tag that is used to build promtail with journal support so Linux users don't start getting compilation errors around the journal.
