### PR TITLE
fluent-plugin: Add prometheus for metrics and upgrade some of the outdated gems.

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/docker/Gemfile
+++ b/fluentd/fluent-plugin-grafana-loki/docker/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'fluent-plugin-kubernetes_metadata_filter', '~> 0.7.0'
+gem 'fluent-plugin-kubernetes_metadata_filter', '~> 2.1.6'
 gem 'fluent-plugin-systemd', '~> 1.0.1'
-gem 'fluentd', '1.3.2'
+gem 'fluentd', '1.6.2'
+gem 'fluent-plugin-multi-format-parser', '~>1.0.0'
+gem 'fluent-plugin-prometheus', '~>1.4.0'


### PR DESCRIPTION
**What this PR does / why we need it**:

Just upgrades some outdated gems and adds in prometheus metrics so you can overwrite the docker container with this one for the `stable/fluentd` chart.

**Special notes for your reviewer**:

**Checklist**
- [NA] Documentation added
- [NA] Tests updated

