### PR TITLE
promtail: restore ability to show target labels in promtail UI

### DIFF
--- a/pkg/promtail/server/server.go
+++ b/pkg/promtail/server/server.go
@@ -149,6 +149,10 @@ func (s *Server) targets(rw http.ResponseWriter, _ *http.Request) {
 				// you can't cast with a text template in go so this is a helper
 				return details.(map[string]int64)
 			},
+			"journalTargetDetails": func(details interface{}) map[string]string {
+				// you can't cast with a text template in go so this is a helper
+				return details.(map[string]string)
+			},
 			"numReady": func(ts []targets.Target) (readies int) {
 				for _, t := range ts {
 					if t.Ready() {

--- a/pkg/promtail/server/ui/templates/targets.html
+++ b/pkg/promtail/server/ui/templates/targets.html
@@ -50,20 +50,37 @@
               <span class="cursor-pointer" data-toggle="tooltip" title="" data-html=true data-original-title="<b>Before relabeling:</b>{{range $k, $v := .DiscoveredLabels}}<br>{{$ev := $v | html}}{{$k}}=&quot;{{$ev}}&quot;{{end}}">
                 {{range $label, $value := .Labels}}
                   <span class="badge badge-primary">{{$label}}="{{$value}}"</span>
-                {{else}} 
+                {{else}}
                   <span class="badge badge-default">none</span>
                 {{end}}
               </span>
             </td>
             <td class="details">
               {{if eq .Type "File"}}
-              
                 {{$files := fileTargetDetails .Details}}
                 <table class="table">
                     <thead>
                       <tr>
                         <th scope="col">Path</th>
                         <th scope="col">Position</th>
+                      </tr>
+                    </thead>
+                  <tbody>
+                {{range $path, $position := $files}}
+                  <tr>
+                    <td>{{$path}}</td>
+                    <td>{{$position}}</td>
+                  </tr>
+                {{end}}
+                </tbody>
+              </table>
+              {{else if eq .Type "Journal" }}
+                {{$files := journalTargetDetails .Details}}
+                <table class="table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Key</th>
+                        <th scope="col">Value</th>
                       </tr>
                     </thead>
                   <tbody>

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -130,6 +130,16 @@ func (t *FileTarget) Type() TargetType {
 	return FileTargetType
 }
 
+// DiscoveredLabels implements a Target
+func (t *FileTarget) DiscoveredLabels() model.LabelSet {
+	return t.discoveredLabels
+}
+
+// Labels implements a Target
+func (t *FileTarget) Labels() model.LabelSet {
+	return t.labels
+}
+
 // Details implements a Target
 func (t *FileTarget) Details() interface{} {
 	files := map[string]int64{}

--- a/pkg/promtail/targets/journaltarget.go
+++ b/pkg/promtail/targets/journaltarget.go
@@ -186,9 +186,24 @@ func (t *JournalTarget) Ready() bool {
 	return true
 }
 
-// Details returns target-specific details (currently nil).
-func (t *JournalTarget) Details() interface{} {
+// DiscoveredLabels returns the set of labels discovered by
+// the JournalTarget, which is always nil. Implements
+// Target.
+func (t *JournalTarget) DiscoveredLabels() model.LabelSet {
 	return nil
+}
+
+// Labels returns the set of labels that statically apply to
+// all log entries produced by the JournalTarget.
+func (t *JournalTarget) Labels() model.LabelSet {
+	return t.labels
+}
+
+// Details returns target-specific details.
+func (t *JournalTarget) Details() interface{} {
+	return map[string]string{
+		"position": t.positions.GetString(t.positionPath),
+	}
 }
 
 // Stop shuts down the JournalTarget.

--- a/pkg/promtail/targets/target.go
+++ b/pkg/promtail/targets/target.go
@@ -22,6 +22,10 @@ const (
 type Target interface {
 	// Type of the target
 	Type() TargetType
+	// DiscoveredLabels returns labels discovered before any relabeling.
+	DiscoveredLabels() model.LabelSet
+	// Labels returns labels that are added to this target and its stream.
+	Labels() model.LabelSet
 	// Ready tells if the targets is ready
 	Ready() bool
 	// Details is additional information about this target specific to its type
@@ -49,6 +53,16 @@ func newDroppedTarget(reason string, discoveredLabels model.LabelSet) Target {
 // Type implements Target
 func (d *droppedTarget) Type() TargetType {
 	return DroppedTargetType
+}
+
+// DiscoveredLabels implements Target
+func (d *droppedTarget) DiscoveredLabels() model.LabelSet {
+	return d.discoveredLabels
+}
+
+// Labels implements Target
+func (d *droppedTarget) Labels() model.LabelSet {
+	return nil
 }
 
 // Ready implements Target


### PR DESCRIPTION
PR #791 accidentally removed the ability to use the promtail UI by removing methods from the Target interface that were only used within the HTML templates.

Along with restoring the methods in the Target interface, this commit also introduces details for the JournalTarget, which currently only provides the position in the journal being tracked.
