### PR TITLE
ingester: remove unused loki_ingester_sent_chunks metric

### DIFF
--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -20,10 +20,6 @@ import (
 )
 
 var (
-	sentChunks = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "loki_ingester_sent_chunks",
-		Help: "The total number of chunks sent by this ingester whilst leaving.",
-	})
 	receivedChunks = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "loki_ingester_received_chunks",
 		Help: "The total number of chunks received by this ingester whilst joining.",
@@ -200,8 +196,6 @@ func (i *Ingester) transferOut(ctx context.Context) error {
 				level.Error(util.Logger).Log("msg", "failed sending stream's chunks to ingester", "to_ingester", targetIngester.Addr, "err", err)
 				return err
 			}
-
-			sentChunks.Add(float64(len(chunks)))
 		}
 	}
 


### PR DESCRIPTION
While `loki_ingester_sent_chunks` was given a value, by the time Prometheus would scrape it, the ingester would have already shut down and would never have a non-zero value.

`loki_ingester_received_chunks` stores the same value on the receiving end and lives long enough to be picked up by Prometheus.