### PR TITLE
Helm: Use latest version of loki

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -66,7 +66,7 @@ config:
 
 image:
   repository: grafana/loki
-  tag: v0.1.0
+  tag: master
   pullPolicy: IfNotPresent
 
 ## Additional Loki container arguments, e.g. log level (debug, info, warn, error)


### PR DESCRIPTION
**What this PR does / why we need it ?**:
Image used in helm is not having the latest code. It's better to use `master` tagged image so that users won't get errors like #823  

**Which issue(s) this PR fixes**:
Fixes #823 


