### PR TITLE
Shutdown module before shutting down HTTP server

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -139,8 +139,8 @@ func (t *Loki) Run() error {
 // Stop gracefully stops a Loki.
 func (t *Loki) Stop() error {
 	t.stopping(t.cfg.Target)
-	t.server.Shutdown()
 	t.stop(t.cfg.Target)
+	t.server.Shutdown()
 	return nil
 }
 


### PR DESCRIPTION
Shutting the module down before shutting down the HTTP server enables metrics to continue to be collected while the module terminates.

This change syncs up with how Cortex modules are shut down; the module is always terminated before the HTTP server.

Fixes #819.
