### PR TITLE
Helm: Be able to customize the Namespace

### DIFF
--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -24,6 +24,12 @@ $ helm repo update
 $ helm upgrade --install loki loki/loki-stack
 ```
 
+### Deploy in a custom namespace
+
+```bash
+$ helm upgrade --install loki --namespace=loki-stack loki/loki-stack
+```
+
 ### Deploy with custom config
 
 ```bash

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.11.1
+version: 0.12.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/templates/datasources.yaml
+++ b/production/helm/loki-stack/templates/datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "loki-stack.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki-stack.name" . }}
     chart: {{ template "loki-stack.chart" . }}

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/pdb.yaml
+++ b/production/helm/loki/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     heritage: {{ .Release.Service }}

--- a/production/helm/loki/templates/podsecuritypolicy.yaml
+++ b/production/helm/loki/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/role.yaml
+++ b/production/helm/loki/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/rolebinding.yaml
+++ b/production/helm/loki/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/secret.yaml
+++ b/production/helm/loki/templates/secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/service-headless.yaml
+++ b/production/helm/loki/templates/service-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "loki.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/service.yaml
+++ b/production/helm/loki/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/templates/serviceaccount.yaml
+++ b/production/helm/loki/templates/serviceaccount.yaml
@@ -8,5 +8,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "loki.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "loki.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "loki.name" . }}
     chart: {{ template "loki.chart" . }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -91,10 +91,10 @@ nodeSelector: {}
 ## - create a pv which above 10Gi and has same namespace with loki
 ## - keep storageClassName same with below setting
 persistence:
-  enabled: true
+  enabled: false
   accessModes:
   - ReadWriteOnce
-  size: 100Gi
+  size: 10Gi
   storageClassName: default
   annotations: {}
   # subPath: ""

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -91,10 +91,10 @@ nodeSelector: {}
 ## - create a pv which above 10Gi and has same namespace with loki
 ## - keep storageClassName same with below setting
 persistence:
-  enabled: false
+  enabled: true
   accessModes:
   - ReadWriteOnce
-  size: 10Gi
+  size: 100Gi
   storageClassName: default
   annotations: {}
   # subPath: ""

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.8.1
+version: 0.9.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/clusterrole.yaml
+++ b/production/helm/promtail/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "promtail.fullname" . }}-clusterrole
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources:

--- a/production/helm/promtail/templates/configmap.yaml
+++ b/production/helm/promtail/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "promtail.name" . }}
     chart: {{ template "promtail.chart" . }}

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "promtail.name" . }}
     chart: {{ template "promtail.chart" . }}

--- a/production/helm/promtail/templates/podsecuritypolicy.yaml
+++ b/production/helm/promtail/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "promtail.name" . }}
     chart: {{ template "promtail.chart" . }}

--- a/production/helm/promtail/templates/role.yaml
+++ b/production/helm/promtail/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "promtail.name" . }}
     chart: {{ template "promtail.chart" . }}

--- a/production/helm/promtail/templates/rolebinding.yaml
+++ b/production/helm/promtail/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "promtail.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "promtail.name" . }}
     chart: {{ template "promtail.chart" . }}

--- a/production/helm/promtail/templates/serviceaccount.yaml
+++ b/production/helm/promtail/templates/serviceaccount.yaml
@@ -8,5 +8,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "promtail.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When I run the command `helm upgrade --install loki --namespace=loki-stack loki/loki-stack`, I expect to have loki installed in the `loki-stack` namespace.

This PR allows users to customize namespace installation with flag `--namespace`.

**Checklist**
- [x] Documentation added
- [ ] ~Tests updated~

