### PR TITLE
helm: fix grafana image tag by pinning it

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/values.yaml
+++ b/production/helm/loki-stack/values.yaml
@@ -9,6 +9,8 @@ grafana:
   sidecar:
     datasources:
       enabled: true
+  image:
+    tag: 6.3.0-beta2
 
 prometheus:
   enabled: false


### PR DESCRIPTION
Somehow the current chart was pointing to a non existing tag plus I think it is a better experience to use 6.3.