### PR TITLE
live-tailing: Fix querying historic entries while live tailing logs

### DIFF
--- a/pkg/iter/iterator_test.go
+++ b/pkg/iter/iterator_test.go
@@ -252,3 +252,23 @@ func TestMostCommon(t *testing.T) {
 	}
 	require.Equal(t, "c", mostCommon(tuples).Entry.Line)
 }
+
+func TestEntryIteratorForward(t *testing.T) {
+	itr1 := mkStreamIterator(inverse(offset(testSize, identity)), defaultLabels)
+	itr2 := mkStreamIterator(inverse(offset(testSize, identity)), "{foobar: \"bazbar\"}")
+
+	heapIterator := NewHeapIterator([]EntryIterator{itr1, itr2}, logproto.BACKWARD)
+	forwardIterator, err := NewEntryIteratorForward(heapIterator, testSize)
+	require.NoError(t, err)
+
+	for i := int64((testSize / 2) + 1); i <= testSize; i++ {
+		assert.Equal(t, true, forwardIterator.Next())
+		assert.Equal(t, identity(i), forwardIterator.Entry(), fmt.Sprintln("iteration", i))
+		assert.Equal(t, true, forwardIterator.Next())
+		assert.Equal(t, identity(i), forwardIterator.Entry(), fmt.Sprintln("iteration", i))
+	}
+
+	assert.Equal(t, false, forwardIterator.Next())
+	assert.Equal(t, nil, forwardIterator.Error())
+	assert.NoError(t, forwardIterator.Close())
+}

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -37,7 +37,7 @@ type TailResponse struct {
 type Tailer struct {
 	// openStreamIterator is for streams already open
 	openStreamIterator iter.HeapIterator
-	streamMtx sync.Mutex // for synchronizing access to openStreamIterator
+	streamMtx          sync.Mutex // for synchronizing access to openStreamIterator
 
 	currEntry  logproto.Entry
 	currLabels string
@@ -264,7 +264,7 @@ func newTailer(
 	tailMaxDuration time.Duration,
 ) *Tailer {
 	t := Tailer{
-		openStreamIterator: iter.NewHeapIterator([]iter.EntryIterator{historicEntries}, logproto.FORWARD),
+		openStreamIterator:        iter.NewHeapIterator([]iter.EntryIterator{historicEntries}, logproto.FORWARD),
 		querierTailClients:        querierTailClients,
 		delayFor:                  delayFor,
 		responseChan:              make(chan *TailResponse, bufferSizeForTailResponse),

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -327,13 +327,13 @@ func (t *Tailer) getCloseErrorChan() <-chan error {
 func newTailer(
 	delayFor time.Duration,
 	querierTailClients map[string]logproto.Querier_TailClient,
-	historicEntries []iter.EntryIterator,
+	historicEntries iter.EntryIterator,
 	queryDroppedStreams func(from, to time.Time, labels string) (iter.EntryIterator, error),
 	tailDisconnectedIngesters func([]string) (map[string]logproto.Querier_TailClient, error),
 	tailMaxDuration time.Duration,
 ) *Tailer {
 	t := Tailer{
-		openStreamIterator: iter.NewHeapIterator(historicEntries, logproto.FORWARD),
+		openStreamIterator: iter.NewHeapIterator([]iter.EntryIterator{}, logproto.FORWARD),
 		//droppedStreamsIterator:    &droppedStreamsIterator{},
 		querierTailClients:        querierTailClients,
 		queryDroppedStreams:       queryDroppedStreams,
@@ -343,6 +343,8 @@ func newTailer(
 		tailDisconnectedIngesters: tailDisconnectedIngesters,
 		tailMaxDuration:           tailMaxDuration,
 	}
+
+	t.openStreamIterator.Push(historicEntries)
 
 	t.readTailClients()
 	go t.loop()


### PR DESCRIPTION
**What this PR does / why we need it**:
Querying logs in backward direction, then fetching all the logs upto the query limit and
then iterating over it in reverse order
It also take care of #833

**Checklist**
- [X] Tests updated

