### PR TITLE
bigtable-backup-tool: Added namespace to label value of job exported from bigtable backup cronjob

### DIFF
--- a/tools/bigtable-backup/Dockerfile
+++ b/tools/bigtable-backup/Dockerfile
@@ -1,5 +1,5 @@
 FROM       grafana/bigtable-backup:master-418c0dd
-RUN        apk add --update --no-cache python3 python3-dev \
+RUN        apk add --update --no-cache python3 python3-dev git \
             && pip3 install --no-cache-dir --upgrade pip
 COPY       bigtable-backup.py bigtable-backup.py
 COPY       requirements.txt requirements.txt

--- a/tools/bigtable-backup/requirements.txt
+++ b/tools/bigtable-backup/requirements.txt
@@ -1,2 +1,2 @@
-prometheus-client==0.7.1
+-e git://github.com/prometheus/client_python.git@a8f5c80f651ea570577c364203e0edbef67db727#egg=prometheus_client
 pytz==2019.1


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed for ease in monitoring bigtable backup jobs running for each namespace