### PR TITLE
set helm chart appVersion while release

### DIFF
--- a/tools/release_prepare.sh
+++ b/tools/release_prepare.sh
@@ -58,6 +58,11 @@ echo "Updating helm charts"
 sed -i '' "s/^version:.*/version: ${LOKI_VERSION}/" production/helm/loki/Chart.yaml
 sed -i '' "s/^version:.*/version: ${PROMTAIL_VERSION}/" production/helm/promtail/Chart.yaml
 sed -i '' "s/^version:.*/version: ${LOKI_STACK_VERSION}/" production/helm/loki-stack/Chart.yaml
+
+sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki/Chart.yaml
+sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/promtail/Chart.yaml
+sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki-stack/Chart.yaml
+
 echo
 echo "######################################################################################################"
 echo "NEXT STEPS"


### PR DESCRIPTION
**What this PR does / why we need it**:

Release script `tools/release_prepare.sh` doesn't updates appVersion in helm charts while release. This MR fixes this.

before:
```
$ helm search loki
NAME            	CHART VERSION	APP VERSION	DESCRIPTION
loki/loki       	0.13.0       	0.0.1      	Loki: like Prometheus, but for logs.
loki/loki-stack 	0.14.0       	0.0.1      	Loki: like Prometheus, but for logs.
...
```

after:
```
$ helm search loki
NAME            	CHART VERSION	APP VERSION	DESCRIPTION
local/loki      	0.14.0       	v0.2.0     	Loki: like Prometheus, but for logs.
local/loki-stack	0.15.0       	v0.2.0     	Loki: like Prometheus, but for logs.
...
```

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

I have run fixed `tools/release_prepare.sh` locally and this is why `local/loki` package shown  in the example.

**Checklist**
not needed
