### PR TITLE
promtail: Add ServiceMonitor and headless Service

### DIFF
--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/service-headless.yaml
+++ b/production/helm/promtail/templates/service-headless.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "promtail.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "promtail.name" . }}
+    chart: {{ template "promtail.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.config.server.http_listen_port }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app: {{ template "promtail.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/production/helm/promtail/templates/servicemonitor.yaml
+++ b/production/helm/promtail/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "promtail.fullname" . }}
+  labels:
+    app: {{ template "promtail.name" . }}
+    chart: {{ template "promtail.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "promtail.name" . }}
+      release: {{ .Release.Name | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http-metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+{{- end }}

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -124,3 +124,7 @@ config:
   target_config:
     # Period to resync directories being watched and files being tailed
     sync_period: 10s
+
+serviceMonitor:
+  enabled: false
+  interval: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Prometheus operator `ServiceMonitor` object (which necessitated a headless `Service` object for endpoints). These are optional objects guarded by `serviceMonitor.enabled`.

**Special notes for your reviewer**:

Completes Prometheus operator support started in https://github.com/grafana/loki/pull/824.

Chart minor version also receives a bump.