### PR TITLE
Reorder relabeling rules to prevent pod label from overwriting config define labels

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.14.0
+version: 0.15.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/configmap.yaml
+++ b/production/helm/promtail/templates/configmap.yaml
@@ -31,6 +31,8 @@ data:
         regex: ^$
         source_labels:
         - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - action: replace
         replacement: $1
         separator: /
@@ -50,8 +52,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -78,6 +78,8 @@ data:
         regex: ^$
         source_labels:
         - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - action: replace
         replacement: $1
         separator: /
@@ -97,8 +99,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -131,6 +131,8 @@ data:
         regex: ^$
         source_labels:
         - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - action: replace
         replacement: $1
         separator: /
@@ -150,8 +152,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -186,6 +186,8 @@ data:
         regex: ^$
         source_labels:
         - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - action: replace
         replacement: $1
         separator: /
@@ -205,8 +207,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -234,6 +234,8 @@ data:
         regex: ^$
         source_labels:
         - __service__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - action: replace
         replacement: $1
         separator: /
@@ -253,8 +255,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:

--- a/production/ksonnet/promtail/scrape_config.libsonnet
+++ b/production/ksonnet/promtail/scrape_config.libsonnet
@@ -23,6 +23,14 @@ config + {
         regex: '^$',
       },
 
+      // Include all the other labels on the pod.
+      // Perform this mapping before applying additional label replacement rules
+      // to prevent a supplied label from overwriting any of the following labels.
+      {
+        action: 'labelmap',
+        regex: '__meta_kubernetes_pod_label_(.+)',
+      },
+
       // Rename jobs to be <namespace>/<name, from pod name label>
       {
         source_labels: ['__meta_kubernetes_namespace', '__service__'],
@@ -51,12 +59,6 @@ config + {
         source_labels: ['__meta_kubernetes_pod_container_name'],
         action: 'replace',
         target_label: 'container_name',
-      },
-
-      // Also include all the other labels on the pod.
-      {
-        action: 'labelmap',
-        regex: '__meta_kubernetes_pod_label_(.+)',
       },
 
       // Kubernetes puts logs under subdirectories keyed pod UID and container_name.


### PR DESCRIPTION
The current ordering of relabel rules will cause any of the defined labels:

`job`, `namespace`, `instance`, `container_name` and `__path__`

To be overwritten by pod labels of the same name if they are present.

This change puts the `labelmap` rule before the rules which set the above labels and thus prevents any existing pod label from overwriting any of those labels.