### PR TITLE
loki: Fixed out of order entries allowed in a chunk on edge case

### DIFF
--- a/pkg/chunkenc/gzip_test.go
+++ b/pkg/chunkenc/gzip_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/stretchr/testify/require"
 )
@@ -214,6 +216,47 @@ func TestGZIPChunkFilling(t *testing.T) {
 	}
 
 	require.Equal(t, int64(lines), i)
+}
+
+func TestMemChunk_AppendOutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	type tester func(t *testing.T, chk *MemChunk)
+
+	tests := map[string]tester{
+		"append out of order in the same block": func(t *testing.T, chk *MemChunk) {
+			assert.NoError(t, chk.Append(logprotoEntry(5, "test")))
+			assert.NoError(t, chk.Append(logprotoEntry(6, "test")))
+
+			assert.EqualError(t, chk.Append(logprotoEntry(1, "test")), ErrOutOfOrder.Error())
+		},
+		"append out of order in a new block right after cutting the previous one": func(t *testing.T, chk *MemChunk) {
+			assert.NoError(t, chk.Append(logprotoEntry(5, "test")))
+			assert.NoError(t, chk.Append(logprotoEntry(6, "test")))
+			assert.NoError(t, chk.cut())
+
+			assert.EqualError(t, chk.Append(logprotoEntry(1, "test")), ErrOutOfOrder.Error())
+		},
+		"append out of order in a new block after multiple cuts": func(t *testing.T, chk *MemChunk) {
+			assert.NoError(t, chk.Append(logprotoEntry(5, "test")))
+			assert.NoError(t, chk.cut())
+
+			assert.NoError(t, chk.Append(logprotoEntry(6, "test")))
+			assert.NoError(t, chk.cut())
+
+			assert.EqualError(t, chk.Append(logprotoEntry(1, "test")), ErrOutOfOrder.Error())
+		},
+	}
+
+	for testName, tester := range tests {
+		tester := tester
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			tester(t, NewMemChunk(EncGZIP))
+		})
+	}
 }
 
 var result []Chunk


### PR DESCRIPTION
**What this PR does / why we need it**:
A chunk can contain log entries out of order (leading also to incorrect values returned by `.Bounds()`) if an out of order log entry is pushed as first entry of a new block, right after the previous block has been cut.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

