### PR TITLE
fix broken jsonnet for querier

### DIFF
--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -9,11 +9,11 @@
   querier_container::
     container.new('querier', $._images.querier) +
     container.withPorts($.util.defaultPorts) +
-    container.withArgsMixin($.util.mapToFlags($.querier_args)),
+    container.withArgsMixin($.util.mapToFlags($.querier_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort(80) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1),
 
   local deployment = $.apps.v1beta1.deployment,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A recent PR broke ksonnet. https://github.com/grafana/loki/pull/854
This is needed for fixing it back.

