### PR TITLE
bigtable-backup: update docker image for bigtable-backup tool

### DIFF
--- a/tools/bigtable-backup/Dockerfile
+++ b/tools/bigtable-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM       grafana/bigtable-backup:master-418c0dd
+FROM       grafana/bigtable-backup:master-63aad9c
 RUN        apk add --update --no-cache python3 python3-dev git \
             && pip3 install --no-cache-dir --upgrade pip
 COPY       bigtable-backup.py bigtable-backup.py


### PR DESCRIPTION
**What this PR does / why we need it**:
Update base docker image used by bigtable-backup tool

