### PR TITLE
loki: Improve Tailer loop

### DIFF
--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -156,7 +156,7 @@ func TestEntryNeverReceived(t *testing.T) {
 	found := []time.Time{t1, t3, t4, t5}
 
 	mr := &mockReader{found}
-	maxWait := 5 * time.Millisecond
+	maxWait := 50 * time.Millisecond
 	c := NewComparator(actual, maxWait, 2*time.Millisecond, 1, make(chan time.Time), make(chan time.Time), mr)
 
 	c.entrySent(t1)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -20,6 +20,13 @@ import (
 	"github.com/grafana/loki/pkg/storage"
 )
 
+const (
+	// How long the Tailer should wait - once there are no entries to read from ingesters -
+	// before checking if a new entry is available (to avoid spinning the CPU in a continuous
+	// check loop)
+	tailerWaitEntryThrottle = time.Second / 2
+)
+
 var readinessProbeSuccess = []byte("Ready")
 
 // Config for a querier.
@@ -308,6 +315,7 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer,
 			return q.tailDisconnectedIngesters(tailCtx, req, connectedIngestersAddr)
 		},
 		q.cfg.TailMaxDuration,
+		tailerWaitEntryThrottle,
 	), nil
 }
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -107,10 +108,13 @@ func (c *queryClientMock) RecvMsg(m interface{}) error {
 type tailClientMock struct {
 	util.ExtendedMock
 	logproto.Querier_TailClient
+	recvTrigger chan time.Time
 }
 
 func newTailClientMock() *tailClientMock {
-	return &tailClientMock{}
+	return &tailClientMock{
+		recvTrigger: make(chan time.Time, 10),
+	}
 }
 
 func (c *tailClientMock) Recv() (*logproto.TailResponse, error) {
@@ -136,6 +140,20 @@ func (c *tailClientMock) SendMsg(m interface{}) error {
 
 func (c *tailClientMock) RecvMsg(m interface{}) error {
 	return nil
+}
+
+func (c *tailClientMock) mockRecvWithTrigger(response *logproto.TailResponse) *tailClientMock {
+	c.On("Recv").WaitUntil(c.recvTrigger).Return(response, nil)
+
+	return c
+}
+
+// triggerRecv triggers the Recv() mock to return from the next invocation
+// or from the current invocation if was already called and waiting for the
+// trigger. This method works if and only if the Recv() has been mocked with
+// mockRecvWithTrigger().
+func (c *tailClientMock) triggerRecv() {
+	c.recvTrigger <- time.Now()
 }
 
 // storeMock is a mockable version of Loki's storage, used in querier unit tests
@@ -226,4 +244,29 @@ func mockReadRingWithOneActiveIngester() *readRingMock {
 	return newReadRingMock([]ring.IngesterDesc{
 		{Addr: "test", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{1, 2, 3}},
 	})
+}
+
+// mockStreamIterator returns an iterator with 1 stream and quantity entries,
+// where entries timestamp and line string are constructed as sequential numbers
+// starting at from
+func mockStreamIterator(from int, quantity int) iter.EntryIterator {
+	return iter.NewStreamIterator(mockStream(from, quantity))
+}
+
+// mockStream return a stream with quantity entries, where entries timestamp and
+// line string are constructed as sequential numbers starting at from
+func mockStream(from int, quantity int) *logproto.Stream {
+	entries := make([]logproto.Entry, 0, quantity)
+
+	for i := from; i < from+quantity; i++ {
+		entries = append(entries, logproto.Entry{
+			Timestamp: time.Unix(int64(i), 0),
+			Line:      fmt.Sprintf("line %d", i),
+		})
+	}
+
+	return &logproto.Stream{
+		Entries: entries,
+		Labels:  `{type="test"}`,
+	}
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -30,10 +29,10 @@ func TestQuerier_Query_QueryTimeoutConfigFlag(t *testing.T) {
 	}
 
 	store := newStoreMock()
-	store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(), nil)
+	store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(1, 2), nil)
 
 	queryClient := newQueryClientMock()
-	queryClient.On("Recv").Return(mockQueryResponse([]*logproto.Stream{mockStream()}), nil)
+	queryClient.On("Recv").Return(mockQueryResponse([]*logproto.Stream{mockStream(1, 2)}), nil)
 
 	ingesterClient := newQuerierClientMock()
 	ingesterClient.On("Query", mock.Anything, &request, mock.Anything).Return(queryClient, nil)
@@ -119,13 +118,13 @@ func TestQuerier_Tail_QueryTimeoutConfigFlag(t *testing.T) {
 	}
 
 	store := newStoreMock()
-	store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(), nil)
+	store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(1, 2), nil)
 
 	queryClient := newQueryClientMock()
-	queryClient.On("Recv").Return(mockQueryResponse([]*logproto.Stream{mockStream()}), nil)
+	queryClient.On("Recv").Return(mockQueryResponse([]*logproto.Stream{mockStream(1, 2)}), nil)
 
 	tailClient := newTailClientMock()
-	tailClient.On("Recv").Return(mockTailResponse(mockStream()), nil)
+	tailClient.On("Recv").Return(mockTailResponse(mockStream(1, 2)), nil)
 
 	ingesterClient := newQuerierClientMock()
 	ingesterClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(queryClient, nil)
@@ -170,24 +169,6 @@ func mockQuerierConfig() Config {
 	}
 }
 
-func mockStreamIterator() iter.EntryIterator {
-	return iter.NewStreamIterator(mockStream())
-}
-
-func mockStream() *logproto.Stream {
-	entries := []logproto.Entry{
-		{Timestamp: time.Now(), Line: "line 1"},
-		{Timestamp: time.Now(), Line: "line 2"},
-	}
-
-	labels := "{type=\"test\"}"
-
-	return &logproto.Stream{
-		Entries: entries,
-		Labels:  labels,
-	}
-}
-
 func mockQueryResponse(streams []*logproto.Stream) *logproto.QueryResponse {
 	return &logproto.QueryResponse{
 		Streams: streams,
@@ -197,12 +178,5 @@ func mockQueryResponse(streams []*logproto.Stream) *logproto.QueryResponse {
 func mockLabelResponse(values []string) *logproto.LabelResponse {
 	return &logproto.LabelResponse{
 		Values: values,
-	}
-}
-
-func mockTailResponse(stream *logproto.Stream) *logproto.TailResponse {
-	return &logproto.TailResponse{
-		Stream:         stream,
-		DroppedStreams: []*logproto.DroppedStream{},
 	}
 }

--- a/pkg/querier/tail_mock_test.go
+++ b/pkg/querier/tail_mock_test.go
@@ -1,0 +1,10 @@
+package querier
+
+import "github.com/grafana/loki/pkg/logproto"
+
+func mockTailResponse(stream *logproto.Stream) *logproto.TailResponse {
+	return &logproto.TailResponse{
+		Stream:         stream,
+		DroppedStreams: []*logproto.DroppedStream{},
+	}
+}

--- a/pkg/querier/tail_test.go
+++ b/pkg/querier/tail_test.go
@@ -1,0 +1,252 @@
+package querier
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	timeout  = 1 * time.Second
+	throttle = 10 * time.Millisecond
+)
+
+func TestTailer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		historicEntries iter.EntryIterator
+		tailClient      *tailClientMock
+		tester          func(t *testing.T, tailer *Tailer, tailClient *tailClientMock)
+	}{
+		"tail logs from historic entries only (no tail clients provided)": {
+			historicEntries: mockStreamIterator(1, 2),
+			tailClient:      nil,
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				responses, err := readFromTailer(tailer, 2)
+				require.NoError(t, err)
+
+				actual := flattenStreamsFromResponses(responses)
+
+				assert.Equal(t, []logproto.Stream{
+					*mockStream(1, 1),
+					*mockStream(2, 1),
+				}, actual)
+			},
+		},
+		"tail logs from tail clients only (no historic entries provided)": {
+			historicEntries: mockStreamIterator(0, 0),
+			tailClient:      newTailClientMock().mockRecvWithTrigger(mockTailResponse(mockStream(1, 1))),
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				tailClient.triggerRecv()
+
+				responses, err := readFromTailer(tailer, 1)
+				require.NoError(t, err)
+
+				actual := flattenStreamsFromResponses(responses)
+
+				assert.Equal(t, []logproto.Stream{
+					*mockStream(1, 1),
+				}, actual)
+			},
+		},
+		"tail logs both from historic entries and tail clients": {
+			historicEntries: mockStreamIterator(1, 2),
+			tailClient:      newTailClientMock().mockRecvWithTrigger(mockTailResponse(mockStream(3, 1))),
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				tailClient.triggerRecv()
+
+				responses, err := readFromTailer(tailer, 3)
+				require.NoError(t, err)
+
+				actual := flattenStreamsFromResponses(responses)
+
+				assert.Equal(t, []logproto.Stream{
+					*mockStream(1, 1),
+					*mockStream(2, 1),
+					*mockStream(3, 1),
+				}, actual)
+			},
+		},
+		"honor max entries per tail response": {
+			historicEntries: mockStreamIterator(1, maxEntriesPerTailResponse+1),
+			tailClient:      nil,
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				responses, err := readFromTailer(tailer, maxEntriesPerTailResponse+1)
+				require.NoError(t, err)
+
+				require.Equal(t, 2, len(responses))
+				assert.Equal(t, maxEntriesPerTailResponse, countEntriesInStreams(responses[0].Streams))
+				assert.Equal(t, 1, countEntriesInStreams(responses[1].Streams))
+				assert.Equal(t, 0, len(responses[1].DroppedEntries))
+			},
+		},
+		"honor max buffered tail responses": {
+			historicEntries: mockStreamIterator(1, (maxEntriesPerTailResponse*maxBufferedTailResponses)+5),
+			tailClient:      newTailClientMock().mockRecvWithTrigger(mockTailResponse(mockStream(1, 1))),
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				err := waitUntilTailerOpenStreamsHaveBeenConsumed(tailer)
+				require.NoError(t, err)
+
+				// Since the response channel is full/blocked, we do expect that all responses
+				// are "full" and extra entries from historic entries have been dropped
+				responses, err := readFromTailer(tailer, (maxEntriesPerTailResponse * maxBufferedTailResponses))
+				require.NoError(t, err)
+
+				require.Equal(t, maxBufferedTailResponses, len(responses))
+				for i := 0; i < maxBufferedTailResponses; i++ {
+					assert.Equal(t, maxEntriesPerTailResponse, countEntriesInStreams(responses[i].Streams))
+					assert.Equal(t, 0, len(responses[1].DroppedEntries))
+				}
+
+				// Since we'll not receive dropped entries until the next tail response, we're now
+				// going to trigger a Recv() from the tail client
+				tailClient.triggerRecv()
+
+				responses, err = readFromTailer(tailer, 1)
+				require.NoError(t, err)
+
+				require.Equal(t, 1, len(responses))
+				assert.Equal(t, 1, countEntriesInStreams(responses[0].Streams))
+				assert.Equal(t, 5, len(responses[0].DroppedEntries))
+			},
+		},
+		"honor max dropped entries per tail response": {
+			historicEntries: mockStreamIterator(1, (maxEntriesPerTailResponse*maxBufferedTailResponses)+maxDroppedEntriesPerTailResponse+5),
+			tailClient:      newTailClientMock().mockRecvWithTrigger(mockTailResponse(mockStream(1, 1))),
+			tester: func(t *testing.T, tailer *Tailer, tailClient *tailClientMock) {
+				err := waitUntilTailerOpenStreamsHaveBeenConsumed(tailer)
+				require.NoError(t, err)
+
+				// Since the response channel is full/blocked, we do expect that all responses
+				// are "full" and extra entries from historic entries have been dropped
+				responses, err := readFromTailer(tailer, (maxEntriesPerTailResponse * maxBufferedTailResponses))
+				require.NoError(t, err)
+
+				require.Equal(t, maxBufferedTailResponses, len(responses))
+				for i := 0; i < maxBufferedTailResponses; i++ {
+					assert.Equal(t, maxEntriesPerTailResponse, countEntriesInStreams(responses[i].Streams))
+					assert.Equal(t, 0, len(responses[1].DroppedEntries))
+				}
+
+				// Since we'll not receive dropped entries until the next tail response, we're now
+				// going to trigger a Recv() from the tail client
+				tailClient.triggerRecv()
+
+				responses, err = readFromTailer(tailer, 1)
+				require.NoError(t, err)
+
+				require.Equal(t, 1, len(responses))
+				assert.Equal(t, 1, countEntriesInStreams(responses[0].Streams))
+				assert.Equal(t, maxDroppedEntriesPerTailResponse, len(responses[0].DroppedEntries))
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			tailDisconnectedIngesters := func([]string) (map[string]logproto.Querier_TailClient, error) {
+				return map[string]logproto.Querier_TailClient{}, nil
+			}
+
+			tailClients := map[string]logproto.Querier_TailClient{}
+			if test.tailClient != nil {
+				tailClients["test"] = test.tailClient
+			}
+
+			tailer := newTailer(0, tailClients, test.historicEntries, tailDisconnectedIngesters, timeout, throttle)
+			defer tailer.close()
+
+			test.tester(t, tailer, test.tailClient)
+		})
+	}
+}
+
+func readFromTailer(tailer *Tailer, maxEntries int) ([]*TailResponse, error) {
+	responses := make([]*TailResponse, 0)
+	entriesCount := 0
+
+	// Ensure we do not wait indefinitely
+	timeoutTicker := time.NewTicker(timeout)
+	defer timeoutTicker.Stop()
+
+	for !tailer.stopped && entriesCount < maxEntries {
+		select {
+		case <-timeoutTicker.C:
+			return nil, errors.New("timeout expired while reading responses from Tailer")
+		case response := <-tailer.getResponseChan():
+			responses = append(responses, response)
+			entriesCount += countEntriesInStreams(response.Streams)
+		default:
+			time.Sleep(throttle)
+		}
+	}
+
+	return responses, nil
+}
+
+func waitUntilTailerOpenStreamsHaveBeenConsumed(tailer *Tailer) error {
+	// Ensure we do not wait indefinitely
+	timeoutTicker := time.NewTicker(timeout)
+	defer timeoutTicker.Stop()
+
+	for {
+		if isTailerOpenStreamsConsumed(tailer) {
+			return nil
+		}
+
+		select {
+		case <-timeoutTicker.C:
+			return errors.New("timeout expired while reading responses from Tailer")
+		default:
+			time.Sleep(throttle)
+		}
+	}
+}
+
+// isTailerOpenStreamsConsumed returns whether the input Tailer has fully
+// consumed all streams from the openStreamIterator, which means the
+// Tailer.loop() is now throttling
+func isTailerOpenStreamsConsumed(tailer *Tailer) bool {
+	tailer.streamMtx.Lock()
+	defer tailer.streamMtx.Unlock()
+
+	return tailer.openStreamIterator.Len() == 0 || tailer.openStreamIterator.Peek() == time.Unix(0, 0)
+}
+
+func countEntriesInStreams(streams []logproto.Stream) int {
+	count := 0
+
+	for _, stream := range streams {
+		count += len(stream.Entries)
+	}
+
+	return count
+}
+
+// flattenStreamsFromResponses returns an array of streams each one containing
+// one and only one entry from the input list of responses. This function is used
+// to abstract away implementation details in the Tailer when testing for the output
+// regardless how the responses have been generated (ie. multiple entries grouped
+// into the same stream)
+func flattenStreamsFromResponses(responses []*TailResponse) []logproto.Stream {
+	result := make([]logproto.Stream, 0)
+
+	for _, response := range responses {
+		for _, stream := range response.Streams {
+			for _, entry := range stream.Entries {
+				result = append(result, logproto.Stream{
+					Entries: []logproto.Entry{entry},
+					Labels:  stream.Labels,
+				})
+			}
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The current `Tailer.loop()` implementation is a bit hard to follow and presents some issues which I'm trying to address in this PR:

1. Fix: `isBlocked()` was always returning `false` because `t.blocked` was never set to `true`: now switched to `isResponseChanBlocked()`
2. Fix: `droppedEntries` was not populated with all entries in case of a dropped `tailResponse` containing multiple streams/entries (was just populated with the current one)
3. Fix: On a stuck client and high message rate, `droppedEntries` could grow indefinitely: now introduced an hard cap `maxDroppedEntriesPerTailResponse`
4. Refactoring: I tried to refactor `Tailer.loop()` to make it easier to follow reading the code (and hopefully easier to maintain over the future)

**Notes to reviewers**:

This is a **draft PR** cause I would like to hear if you believe the proposed changes make sense. If so, I will work on adding tests (we have no tests on the tailer right now, it's time to show it some ❤️ ).

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

