### PR TITLE
loki: Allow to set custom AWS_REGION when using custom S3 url (#759)

### DIFF
--- a/vendor/github.com/weaveworks/common/aws/config.go
+++ b/vendor/github.com/weaveworks/common/aws/config.go
@@ -45,7 +45,7 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 	}
 
 	if strings.Contains(awsURL.Host, ".") {
-		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion("dummy"), nil
+		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)), nil
 	}
 
 	// Let AWS generate default endpoint based on region passed as a host in URL.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when setting custom S3 endpoint, region is set to `dummy` ignoring environment variable AWS_REGION, which make it unusable with several S3-compatible providers.
This PR removes the code that set region to `dummy` when custom endpoint is used.

**Which issue(s) this PR fixes**:
Fixes #759 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

