### PR TITLE
chore(packaging): wrong executable format

### DIFF
--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -10,7 +10,7 @@ FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make loki-canary
+RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make loki-canary
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -10,7 +10,7 @@ FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make loki
+RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make loki
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -10,7 +10,7 @@ FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /go/src/github.com/grafana/loki
 WORKDIR /go/src/github.com/grafana/loki
-RUN GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make clean && make promtail
+RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:stretch-slim


### PR DESCRIPTION
Due to an invalid usage of bash, the binary was always built for amd64.
This fixes that and builds the correct one.

Fixes #885 