### PR TITLE
promtail: Add discovery for standalone pods

### DIFF
--- a/production/helm/promtail/templates/configmap.yaml
+++ b/production/helm/promtail/templates/configmap.yaml
@@ -261,4 +261,41 @@ data:
         - __meta_kubernetes_pod_annotation_kubernetes_io_config_mirror
         - __meta_kubernetes_pod_container_name
         target_label: __path__
+    - job_name: kubernetes-pods-standalone
+      pipeline_stages:
+        {{- toYaml .Values.pipelineStages | nindent 8 }}
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: .+
+        separator: ''
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+        - __meta_kubernetes_pod_label_app
+        - __meta_kubernetes_pod_controller_name
+        - __meta_kubernetes_pod_label_component
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
     {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Configuring promtail/prometheus discovery rules can be quite hard. It seems that previously a pod without any controller was not discovered and thus its logs were not processed. This PR changes the kubernetes-pods-name discovery rule so that it picks up all pods without any controller.

~~It also adds a common "pod" label to every other rule which will contain a "namespace/pod_name" pair. This ensures that one can always find the pod logs regardless of the way it was discovered by knowing its namespace and name.~~

There might be other ways to improve the current discovery rules. I'm open for hearing opinions how they can be made easier to understand while still covering all the cases which are needed. For me it's a bit mystery what kind of reasoning has been to formulate the current rules.
