### PR TITLE
pkg/promtail/positions: remove executable bit from positions file

### DIFF
--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -15,7 +15,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const positionFileMode = 0700
+const positionFileMode = 0600
 
 // Config describes where to get postition information from.
 type Config struct {


### PR DESCRIPTION
File permissions on creation of positions.yaml will now be 0600 instead of 0700.

Fixes #892.