### PR TITLE
ksonnet: update ingester config to transfer chunks on rollout

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -40,6 +40,7 @@
       ingester: {
         chunk_idle_period: '15m',
         chunk_block_size: 262144,
+        max_transfer_retries: 60,
 
         lifecycler: {
           ring: {
@@ -58,8 +59,8 @@
 
           num_tokens: 512,
           heartbeat_period: '5s',
-          join_after: '10s',
-          claim_on_rollout: false,
+          join_after: '30s',
+          claim_on_rollout: true,
           interface_names: ['eth0'],
         },
       },


### PR DESCRIPTION
`ingester.max_transfer_retries` and `ingester.lifecycler.{join_after, claim_on_rollout}` have been
added and set to match values proven to work for Cortex in production.
