### PR TITLE
Fix panic in tailer when an ingester is removed from the ring while tailing

### DIFF
--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -246,6 +246,15 @@ func mockReadRingWithOneActiveIngester() *readRingMock {
 	})
 }
 
+func mockIngesterDesc(addr string, state ring.IngesterState) ring.IngesterDesc {
+	return ring.IngesterDesc{
+		Addr:      addr,
+		Timestamp: time.Now().UnixNano(),
+		State:     state,
+		Tokens:    []uint32{1, 2, 3},
+	}
+}
+
 // mockStreamIterator returns an iterator with 1 stream and quantity entries,
 // where entries timestamp and line string are constructed as sequential numbers
 // starting at from

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -160,6 +161,97 @@ func TestQuerier_Tail_QueryTimeoutConfigFlag(t *testing.T) {
 	assert.WithinDuration(t, deadline, time.Now().Add(queryTimeout), 1*time.Second)
 
 	store.AssertExpectations(t)
+}
+
+func TestQuerier_tailDisconnectedIngesters(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		connectedIngestersAddr []string
+		ringIngesters          []ring.IngesterDesc
+		expectedClientsAddr    []string
+	}{
+		"no connected ingesters and empty ring": {
+			connectedIngestersAddr: []string{},
+			ringIngesters:          []ring.IngesterDesc{},
+			expectedClientsAddr:    []string{},
+		},
+		"no connected ingesters and ring containing new ingesters": {
+			connectedIngestersAddr: []string{},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE)},
+			expectedClientsAddr:    []string{"1.1.1.1"},
+		},
+		"connected ingesters and ring contain the same ingesters": {
+			connectedIngestersAddr: []string{"1.1.1.1", "2.2.2.2"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("2.2.2.2", ring.ACTIVE), mockIngesterDesc("1.1.1.1", ring.ACTIVE)},
+			expectedClientsAddr:    []string{},
+		},
+		"ring contains new ingesters compared to the connected one": {
+			connectedIngestersAddr: []string{"1.1.1.1"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE), mockIngesterDesc("2.2.2.2", ring.ACTIVE), mockIngesterDesc("3.3.3.3", ring.ACTIVE)},
+			expectedClientsAddr:    []string{"2.2.2.2", "3.3.3.3"},
+		},
+		"connected ingesters contain ingesters not in the ring anymore": {
+			connectedIngestersAddr: []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE), mockIngesterDesc("3.3.3.3", ring.ACTIVE)},
+			expectedClientsAddr:    []string{},
+		},
+		"connected ingesters contain ingesters not in the ring anymore and the ring contains new ingesters too": {
+			connectedIngestersAddr: []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE), mockIngesterDesc("3.3.3.3", ring.ACTIVE), mockIngesterDesc("4.4.4.4", ring.ACTIVE)},
+			expectedClientsAddr:    []string{"4.4.4.4"},
+		},
+		"ring contains ingester in LEAVING state not listed in the connected ingesters": {
+			connectedIngestersAddr: []string{"1.1.1.1"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE), mockIngesterDesc("2.2.2.2", ring.LEAVING)},
+			expectedClientsAddr:    []string{},
+		},
+		"ring contains ingester in PENDING state not listed in the connected ingesters": {
+			connectedIngestersAddr: []string{"1.1.1.1"},
+			ringIngesters:          []ring.IngesterDesc{mockIngesterDesc("1.1.1.1", ring.ACTIVE), mockIngesterDesc("2.2.2.2", ring.PENDING)},
+			expectedClientsAddr:    []string{},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			req := logproto.TailRequest{
+				Query:    "{type=\"test\"}",
+				Regex:    "",
+				DelayFor: 0,
+				Limit:    10,
+				Start:    time.Now(),
+			}
+
+			// For this test's purpose, whenever a new ingester client needs to
+			// be created, the factory will always return the same mock instance
+			ingesterClient := newQuerierClientMock()
+			ingesterClient.On("Tail", mock.Anything, &req, mock.Anything).Return(newTailClientMock(), nil)
+
+			q, err := newQuerier(
+				mockQuerierConfig(),
+				mockIngesterClientConfig(),
+				newIngesterClientMockFactory(ingesterClient),
+				newReadRingMock(testData.ringIngesters),
+				newStoreMock())
+			require.NoError(t, err)
+
+			actualClients, err := q.tailDisconnectedIngesters(context.Background(), &req, testData.connectedIngestersAddr)
+			require.NoError(t, err)
+
+			actualClientsAddr := make([]string, 0, len(actualClients))
+			for addr, client := range actualClients {
+				actualClientsAddr = append(actualClientsAddr, addr)
+
+				// The returned map of clients should never contain nil values
+				assert.NotNil(t, client)
+			}
+
+			assert.ElementsMatch(t, testData.expectedClientsAddr, actualClientsAddr)
+		})
+	}
 }
 
 func mockQuerierConfig() Config {


### PR DESCRIPTION
**What this PR does / why we need it**:

If an ingester is removed from the ring while tailing, `tailDisconnectedIngesters()` returns the tail clients map containing the removed ingester with `nil` value, causing a panic.

**Which issue(s) this PR fixes**:
Fixes #845

**Checklist**
- [ ] Documentation added
- [x] Tests updated

