### PR TITLE
chore(packaging): set tag length to 7

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -6,7 +6,7 @@ set -o pipefail
 
 WIP=$(git diff --quiet || echo '-WIP')
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed s#/#-#g)
-SHA=$(git rev-parse --short HEAD)
+SHA=$(git rev-parse --short HEAD | head -c7)
 
 # If this is a tag, use it,                      otherwise branch-hash
 TAG=$(git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}")

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -6,7 +6,7 @@ set -o pipefail
 
 WIP=$(git diff --quiet || echo '-WIP')
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed s#/#-#g)
-SHA=$(git rev-parse --short HEAD | head -c7)
+SHA=$(git rev-parse --short=7 HEAD | head -c7)
 
 # If this is a tag, use it,                      otherwise branch-hash
 TAG=$(git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}")


### PR DESCRIPTION
relied on git approximation before, which causes problems with other parts of
the automation.

Because we do not need the tag to be strictly unique, but just to identify the
latest version, limiting to 7 is fine.

If this ever causes problems, raise the limit but make sure to update all other
places as well.
