### PR TITLE
Feature: Add extra containers to loki helm chart

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.5
+version: 0.17.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.3
+version: 0.15.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/service-headless.yaml
+++ b/production/helm/loki/templates/service-headless.yaml
@@ -15,6 +15,9 @@ spec:
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+{{- if .Values.extraPorts }}
+{{ toYaml .Values.extraPorts | indent 4}}
+{{- end }}
   selector:
     app: {{ template "loki.name" . }}
     release: {{ .Release.Name }}

--- a/production/helm/loki/templates/service.yaml
+++ b/production/helm/loki/templates/service.yaml
@@ -26,6 +26,9 @@ spec:
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
+{{- if .Values.extraPorts }}
+{{ toYaml .Values.extraPorts | indent 4}}
+{{- end }}
   selector:
     app: {{ template "loki.name" . }}
     release: {{ .Release.Name }}

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -73,6 +73,9 @@ spec:
             - name: JAEGER_AGENT_HOST
               value: "{{ .Values.tracing.jaegerAgentHost }}"
             {{- end }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8}}
+{{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:
@@ -84,6 +87,9 @@ spec:
         - name: config
           secret:
             secretName: {{ template "loki.fullname" . }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8}}
+{{- end }}
   {{- if not .Values.persistence.enabled }}
         - name: storage
           emptyDir: {}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -170,3 +170,32 @@ serviceMonitor:
   interval: ""
   additionalLabels: {}
   # scrapeTimeout: 10s
+
+extraContainers: []
+## Additional containers to be added to the loki pod.
+# - name: reverse-proxy
+#   image: angelbarrera92/basic-auth-reverse-proxy:dev
+#   args:
+#     - "serve"
+#     - "--upstream=http://localhost:3100"
+#     - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
+#   ports:
+#     - name: http
+#       containerPort: 11811
+#       protocol: TCP
+#   volumeMounts:
+#     - name: reverse-proxy-auth-config
+#       mountPath: /etc/reverse-proxy-conf
+
+extraVolumes: []
+## Additional volumes to the loki pod.
+# - name: reverse-proxy-auth-config
+#   secret:
+#     secretName: reverse-proxy-auth-config
+
+extraPorts: []
+## Additional ports to the loki services. Useful to expose extra container ports.
+# - port: 11811
+#   protocol: TCP
+#   name: http
+#   targetPort: http


### PR DESCRIPTION
**What this PR does / why we need it**:
This merge request adds the possibility to define sidecar containers to loki stateful set. Makes easy to deploy a loki server in a multi-tenant way.

**Which issue(s) this PR fixes**:
Fixes #908

**Special notes for your reviewer**:
I can build a go proxy like: https://github.com/angelbarrera92/basic-auth-reverse-proxy/tree/feature/grafana_loki_multitenant and write about the POC i did if you want!

**Checklist**
- [x] Documentation added
Added at chart values file for each new input

Thanks!