### PR TITLE
optimize image tag script

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 WIP=$(git diff --quiet || echo '-WIP')
-BRANCH=$(git rev-parse --abbrev-ref HEAD | sed s#/#-#g)
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's#/#-#g')
 SHA=$(git rev-parse --short=7 HEAD | head -c7)
 
 # If this is a tag, use it,                      otherwise branch-hash

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -6,6 +6,8 @@ set -o pipefail
 
 WIP=$(git diff --quiet || echo '-WIP')
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's#/#-#g')
+# When 7 chars are not enough to be unique, git automatically uses more.
+# We are forcing to 7 here, as we are doing for grafana/grafana as well.
 SHA=$(git rev-parse --short=7 HEAD | head -c7)
 
 # If this is a tag, use it,                      otherwise branch-hash


### PR DESCRIPTION
From `man git rev-parse` and `man head`, no need to run `head` again.
```
$ git rev-parse --short=7 HEAD
ae35d2c
```

Also, `sed` should better add quota.

Signed-off-by: Xiang Dai <764524258@qq.com>

