### PR TITLE
Helm: Be able to add custom environment variables on Loki

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.0
+version: 0.17.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.0
+version: 0.15.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -73,6 +73,10 @@ spec:
             - name: JAEGER_AGENT_HOST
               value: "{{ .Values.tracing.jaegerAgentHost }}"
             {{- end }}
+{{- range $key, $value := .Values.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+{{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -133,6 +133,9 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+## Extra environment variables that will be passed onto loki StatefulSet pod
+env: {}
+
 securityContext:
   fsGroup: 10001
   runAsGroup: 10001


### PR DESCRIPTION
**What this PR does / why we need it**:

Including the ability to add custom variables to Loki statefulSet.

In our use case, we use Azure Cosmos DB [Cassandra API](https://docs.microsoft.com/en-us/azure/cosmos-db/cassandra-introduction) as index storage and it's necessary to set some environment variables such as `SSL_VERSION=TLSv1_2  and `SSL_VALIDATE=false` otherwise the connection will fail.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

