### PR TITLE
promtail: add "max_age" field to configure cutoff for journal reading

### DIFF
--- a/docs/promtail-examples.md
+++ b/docs/promtail-examples.md
@@ -89,7 +89,7 @@ clients:
 scrape_configs:
   - job_name: journal
     journal:
-      cutoff: 12h
+      max_age: 12h
       path: /var/log/journal
       labels:
         job: systemd-journal
@@ -104,10 +104,10 @@ Just like the Docker example, the `scrape_configs` sections holds various
 jobs for parsing logs. A job with a `journal` key configures it for systemd
 journal reading.
 
-`cutoff` is an optional string specifying the earliest entry that will be
-read. If unspecified, `cutoff` defaults to `7h`. Even if the position in the
+`max_age` is an optional string specifying the earliest entry that will be
+read. If unspecified, `max_age` defaults to `7h`. Even if the position in the
 journal is saved, if the entry corresponding to that position is older than
-the cutoff, the position won't be used.
+the max_age, the position won't be used.
 
 `path` is an optional string specifying the path to read journal entries
 from. If unspecified, defaults to the system default (`/var/log/journal`).

--- a/docs/promtail-examples.md
+++ b/docs/promtail-examples.md
@@ -89,6 +89,7 @@ clients:
 scrape_configs:
   - job_name: journal
     journal:
+      cutoff: 12h
       path: /var/log/journal
       labels:
         job: systemd-journal
@@ -102,6 +103,11 @@ scrape_configs:
 Just like the Docker example, the `scrape_configs` sections holds various
 jobs for parsing logs. A job with a `journal` key configures it for systemd
 journal reading.
+
+`cutoff` is an optional string specifying the earliest entry that will be
+read. If unspecified, `cutoff` defaults to `7h`. Even if the position in the
+journal is saved, if the entry corresponding to that position is older than
+the cutoff, the position won't be used.
 
 `path` is an optional string specifying the path to read journal entries
 from. If unspecified, defaults to the system default (`/var/log/journal`).

--- a/pkg/promtail/scrape/scrape.go
+++ b/pkg/promtail/scrape/scrape.go
@@ -25,6 +25,14 @@ type Config struct {
 
 // JournalTargetConfig describes systemd journal records to scrape.
 type JournalTargetConfig struct {
+	// Cutoff determines the oldest relative time from process start that will
+	// be read and sent to Loki. Values like 14h means no entry older than
+	// 14h will be read. If unspecified, defaults to 7h.
+	//
+	// A relative time specified here takes precedence over the saved position;
+	// if the cursor is older than the Cutoff value, it will not be used.
+	Cutoff string `yaml:"cutoff"`
+
 	// Labels optionally holds labels to associate with each record coming out
 	// of the journal.
 	Labels model.LabelSet `yaml:"labels"`

--- a/pkg/promtail/scrape/scrape.go
+++ b/pkg/promtail/scrape/scrape.go
@@ -25,13 +25,13 @@ type Config struct {
 
 // JournalTargetConfig describes systemd journal records to scrape.
 type JournalTargetConfig struct {
-	// Cutoff determines the oldest relative time from process start that will
+	// MaxAge determines the oldest relative time from process start that will
 	// be read and sent to Loki. Values like 14h means no entry older than
 	// 14h will be read. If unspecified, defaults to 7h.
 	//
 	// A relative time specified here takes precedence over the saved position;
-	// if the cursor is older than the Cutoff value, it will not be used.
-	Cutoff string `yaml:"cutoff"`
+	// if the cursor is older than the MaxAge value, it will not be used.
+	MaxAge string `yaml:"max_age"`
 
 	// Labels optionally holds labels to associate with each record coming out
 	// of the journal.

--- a/pkg/promtail/targets/journaltarget.go
+++ b/pkg/promtail/targets/journaltarget.go
@@ -204,6 +204,15 @@ func (t *JournalTarget) generateJournalConfig(
 		Formatter: t.formatter,
 	}
 
+	// When generating the JournalReaderConfig, we want to preferably
+	// use the Cursor, since it's guaranteed unique to a given journal
+	// entry. When we don't know the cursor position (or want to set
+	// a start time), we'll fall back to the less-precise Since, which
+	// takes a negative duration back from the current system time.
+	//
+	// The presence of Since takes precedence over Cursor, so we only
+	// ever set one and not both here.
+
 	if cb.Position == "" {
 		cfg.Since = -1 * cb.MaxAge
 		return cfg

--- a/pkg/promtail/targets/journaltarget_test.go
+++ b/pkg/promtail/targets/journaltarget_test.go
@@ -142,7 +142,7 @@ func TestJournalTarget_Since(t *testing.T) {
 	}
 
 	cfg := scrape.JournalTargetConfig{
-		Cutoff: "4h",
+		MaxAge: "4h",
 	}
 
 	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,

--- a/pkg/promtail/targets/journaltarget_test.go
+++ b/pkg/promtail/targets/journaltarget_test.go
@@ -41,6 +41,12 @@ func (r *mockJournalReader) Follow(until <-chan time.Time, writer io.Writer) err
 	return nil
 }
 
+func newMockJournalEntry(entry *sdjournal.JournalEntry) journalEntryFunc {
+	return func(c sdjournal.JournalReaderConfig, cursor string) (*sdjournal.JournalEntry, error) {
+		return entry, nil
+	}
+}
+
 func (r *mockJournalReader) Write(msg string, fields map[string]string) {
 	allFields := make(map[string]string, len(fields))
 	for k, v := range fields {
@@ -94,7 +100,7 @@ func TestJournalTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	jt, err := journalTargetWithReader(logger, client, ps, "test", relabels,
-		&scrape.JournalTargetConfig{}, newMockJournalReader)
+		&scrape.JournalTargetConfig{}, newMockJournalReader, newMockJournalEntry(nil))
 	require.NoError(t, err)
 
 	r := jt.r.(*mockJournalReader)
@@ -109,4 +115,125 @@ func TestJournalTarget(t *testing.T) {
 
 	assert.Len(t, client.messages, 10)
 	require.NoError(t, jt.Stop())
+}
+
+func TestJournalTarget_Since(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	initRandom()
+	dirName := "/tmp/" + randName()
+	positionsFileName := dirName + "/positions.yml"
+
+	// Set the sync period to a really long value, to guarantee the sync timer
+	// never runs, this way we know everything saved was done through channel
+	// notifications when target.stop() was called.
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: positionsFileName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &TestClient{
+		log:      logger,
+		messages: make([]string, 0),
+	}
+
+	cfg := scrape.JournalTargetConfig{
+		Cutoff: "4h",
+	}
+
+	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+		&cfg, newMockJournalReader, newMockJournalEntry(nil))
+	require.NoError(t, err)
+
+	r := jt.r.(*mockJournalReader)
+	require.Equal(t, r.config.Since, -1*time.Hour*4)
+}
+
+func TestJournalTarget_Cursor_TooOld(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	initRandom()
+	dirName := "/tmp/" + randName()
+	positionsFileName := dirName + "/positions.yml"
+
+	// Set the sync period to a really long value, to guarantee the sync timer
+	// never runs, this way we know everything saved was done through channel
+	// notifications when target.stop() was called.
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: positionsFileName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps.PutString("journal-test", "foobar")
+
+	client := &TestClient{
+		log:      logger,
+		messages: make([]string, 0),
+	}
+
+	cfg := scrape.JournalTargetConfig{}
+
+	entryTs := time.Date(1980, time.July, 3, 12, 0, 0, 0, time.UTC)
+	journalEntry := newMockJournalEntry(&sdjournal.JournalEntry{
+		Cursor:            "foobar",
+		Fields:            nil,
+		RealtimeTimestamp: uint64(entryTs.UnixNano()),
+	})
+
+	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+		&cfg, newMockJournalReader, journalEntry)
+	require.NoError(t, err)
+
+	r := jt.r.(*mockJournalReader)
+	require.Equal(t, r.config.Since, -1*time.Hour*7)
+}
+
+func TestJournalTarget_Cursor_NotTooOld(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	initRandom()
+	dirName := "/tmp/" + randName()
+	positionsFileName := dirName + "/positions.yml"
+
+	// Set the sync period to a really long value, to guarantee the sync timer
+	// never runs, this way we know everything saved was done through channel
+	// notifications when target.stop() was called.
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: positionsFileName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps.PutString("journal-test", "foobar")
+
+	client := &TestClient{
+		log:      logger,
+		messages: make([]string, 0),
+	}
+
+	cfg := scrape.JournalTargetConfig{}
+
+	entryTs := time.Now().Add(-time.Hour)
+	journalEntry := newMockJournalEntry(&sdjournal.JournalEntry{
+		Cursor:            "foobar",
+		Fields:            nil,
+		RealtimeTimestamp: uint64(entryTs.UnixNano() / int64(time.Microsecond)),
+	})
+
+	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+		&cfg, newMockJournalReader, journalEntry)
+	require.NoError(t, err)
+
+	r := jt.r.(*mockJournalReader)
+	require.Equal(t, r.config.Since, time.Duration(0))
+	require.Equal(t, r.config.Cursor, "foobar")
 }


### PR DESCRIPTION
The journal scrape config in promtail has been updated to support a "`max_age`" field. `max_age` determines the oldest journal entry promtail will read when starting the journal reader. When unspecified, `max_age` defaults to 7h.

Even if a position in the journal is saved in the promtail positions file, that position may be ignored if the entry corresponding to that position is older than the cutoff time.

Closes #918.

Example promtail config for getting up to the last 12h of journal entries:

```yaml
server:
  http_listen_port: 9080
  grpc_listen_port: 0

positions:
  filename: /tmp/positions.yaml

clients:
  - url: http://localhost:3100/api/prom/push

scrape_configs:
- job_name: journal
  journal:
    max_age: 12h
    path: /var/log/journal
    labels:
      job: systemd-journal
  relabel_configs:
    - source_labels: ['__journal__systemd_unit']
      target_label: 'unit'
```

**Checklist**
- [x] Documentation added
- [x] Tests updated

