### PR TITLE
fluent-plugin-grafana-loki: Escape double-quotes in labels, and suppress labels with value nil

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -135,10 +135,8 @@ module Fluent
         data_labels = {} if data_labels.nil?
         data_labels = data_labels.merge(@extra_labels)
 
-        unless data_labels.nil?
-          data_labels.each do |k, v|
-            formatted_labels.push("#{k}=\"#{v}\"")
-          end
+        data_labels.each do |k, v|
+          formatted_labels.push("#{k}=\"#{v.gsub('"','\\"')}\"") if v
         end
         '{' + formatted_labels.join(',') + '}'
       end


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #927

* Double-quotes within label values are escaped
* Label values of nil suppress the label (but empty string is still passed through as label)

**Special notes for your reviewer**:

The condition `unless data_labels.nil?` is superfluous, as it was checked two lines earlier, so I have removed this.

If you want to suppress empty strings as well as nil, then `... if v and v != ""`

If you want to keep nil as empty string, then `v.to_s.gsub(...)` (since nil.gsub gives an error)