### PR TITLE
added a variable for storing periodic table duration as an int to be …

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -15,6 +15,7 @@
     ],
 
     table_prefix: $._config.namespace,
+    index_period_hours: 168,  // 1 week
 
     // Bigtable variables
     bigtable_instance: error 'must specify bigtable instance',
@@ -196,7 +197,7 @@
           schema: 'v9',
           index: {
             prefix: '%s_index_' % $._config.table_prefix,
-            period: '168h',
+            period: '%dh' % $._config.index_period_hours,
           },
         }],
       },


### PR DESCRIPTION
having periodic table duration as an int would make it easier to be able to reuse it wherever required