### PR TITLE
fluent-plugin-grafana-loki: Fixes the issue when sorting entries with the same timestamps

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.1.0'
+  spec.version = '1.1.1'
   spec.authors = %w[woodsaj briangann]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -161,7 +161,7 @@ module Fluent
           # 'labels' => '{worker="0"}',
           payload.push(
             'labels' => labels_to_protocol(k),
-            'entries' => v.sort_by { |hsh| Time.parse(hsh['ts']) }
+            'entries' => v.sort_by.with_index { |hsh, i| [Time.parse(hsh['ts']), i] }
           )
         end
         payload


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the entries sorting issue. When fluentd reads lines with the same timestamp, the plugin sorts them using method "sort_by". But Ruby documentation says that
> When two keys are equal, the order of the corresponding elements is unpredictable

Thus the resulting lines can be sent to the Loki in wrong order.
So I added the second sorting field: index.

**Special notes for your reviewer**:
1. There is a comment inside
> Additionally sort the entries by timestamp just incase we got them out of order

But I didn't find any information about input records order. Can we really get the out of order?

2. Loki config, td-agent config and sample log for reproducing the issue are attached.
[loki-local-config.zip](https://github.com/grafana/loki/files/3553333/loki-local-config.zip)
[td-agent.zip](https://github.com/grafana/loki/files/3553330/td-agent.zip)
[myapp.log](https://github.com/grafana/loki/files/3553324/myapp.log)

With these configs using original plugin code I always get the following results in Loki

2019-08-29 03:29:54	worker="0" message="fluentd worker is now running worker=0"
2019-08-27 04:43:35	message="Message #11"
2019-08-27 04:43:35	message="Message #12"
2019-08-27 04:43:32	message="Message #9"
2019-08-27 04:43:32	message="Message #10"
2019-08-27 04:43:22	message="Message #8"
2019-08-27 04:43:22	message="Message #7"
2019-08-27 04:42:49	message="Message #6"
2019-08-27 04:42:49	message="Message #5"
2019-08-27 04:42:49	message="Message #3"
2019-08-27 04:42:49	message="Message #4"
2019-08-27 04:42:48	message="Message #2"
2019-08-27 04:42:48	message="Message #1"
`