### PR TITLE
pkg/logql: fix panic on invalid regex in matcher

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -120,10 +120,16 @@ func (e *filterExpr) Eval(q Querier) (iter.EntryIterator, error) {
 	return next, nil
 }
 
-func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
+func mustNewMatcher(l *lexer, t labels.MatchType, n, v string) *labels.Matcher {
 	m, err := labels.NewMatcher(t, n, v)
 	if err != nil {
-		panic(err)
+		perr := ParseError{msg: err.Error()}
+		if l != nil {
+			perr.line = l.Line
+			perr.col = l.Column
+		}
+
+		panic(perr)
 	}
 	return m
 }

--- a/pkg/logql/expr.y
+++ b/pkg/logql/expr.y
@@ -57,9 +57,9 @@ matchers:
     ;
 
 matcher:
-      IDENTIFIER EQ STRING             { $$ = mustNewMatcher(labels.MatchEqual, $1, $3) }
-    | IDENTIFIER NEQ STRING            { $$ = mustNewMatcher(labels.MatchNotEqual, $1, $3) }
-    | IDENTIFIER RE STRING             { $$ = mustNewMatcher(labels.MatchRegexp, $1, $3) }
-    | IDENTIFIER NRE STRING            { $$ = mustNewMatcher(labels.MatchNotRegexp, $1, $3) }
+      IDENTIFIER EQ STRING             { $$ = mustNewMatcher(exprlex.(*lexer), labels.MatchEqual, $1, $3) }
+    | IDENTIFIER NEQ STRING            { $$ = mustNewMatcher(exprlex.(*lexer), labels.MatchNotEqual, $1, $3) }
+    | IDENTIFIER RE STRING             { $$ = mustNewMatcher(exprlex.(*lexer), labels.MatchRegexp, $1, $3) }
+    | IDENTIFIER NRE STRING            { $$ = mustNewMatcher(exprlex.(*lexer), labels.MatchNotRegexp, $1, $3) }
     ;
 %%

--- a/pkg/logql/expr.y.go
+++ b/pkg/logql/expr.y.go
@@ -542,25 +542,25 @@ exprdefault:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:60
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchEqual, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Matcher = mustNewMatcher(exprlex.(*lexer), labels.MatchEqual, exprDollar[1].str, exprDollar[3].str)
 		}
 	case 16:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:61
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchNotEqual, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Matcher = mustNewMatcher(exprlex.(*lexer), labels.MatchNotEqual, exprDollar[1].str, exprDollar[3].str)
 		}
 	case 17:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:62
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchRegexp, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Matcher = mustNewMatcher(exprlex.(*lexer), labels.MatchRegexp, exprDollar[1].str, exprDollar[3].str)
 		}
 	case 18:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:63
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchNotRegexp, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Matcher = mustNewMatcher(exprlex.(*lexer), labels.MatchNotRegexp, exprDollar[1].str, exprDollar[3].str)
 		}
 	}
 	goto exprstack /* stack new state and value */

--- a/pkg/logql/parser.go
+++ b/pkg/logql/parser.go
@@ -19,7 +19,17 @@ func init() {
 }
 
 // ParseExpr parses a string and returns an Expr.
-func ParseExpr(input string) (Expr, error) {
+func ParseExpr(input string) (expr Expr, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				panic(r)
+			}
+		}
+	}()
+
 	l := lexer{
 		parser: exprNewParser().(*exprParserImpl),
 	}

--- a/pkg/logql/parser_test.go
+++ b/pkg/logql/parser_test.go
@@ -52,35 +52,35 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			in:  `{foo="bar"}`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchEqual, "foo", "bar")}},
 		},
 		{
 			in:  `{ foo = "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchEqual, "foo", "bar")}},
 		},
 		{
 			in:  `{ foo != "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchNotEqual, "foo", "bar")}},
+			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchNotEqual, "foo", "bar")}},
 		},
 		{
 			in:  `{ foo =~ "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchRegexp, "foo", "bar")}},
+			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchRegexp, "foo", "bar")}},
 		},
 		{
 			in:  `{ foo !~ "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchNotRegexp, "foo", "bar")}},
+			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchNotRegexp, "foo", "bar")}},
 		},
 		{
 			in: `{ foo = "bar", bar != "baz" }`,
 			exp: &matchersExpr{matchers: []*labels.Matcher{
-				mustNewMatcher(labels.MatchEqual, "foo", "bar"),
-				mustNewMatcher(labels.MatchNotEqual, "bar", "baz"),
+				mustNewMatcher(nil, labels.MatchEqual, "foo", "bar"),
+				mustNewMatcher(nil, labels.MatchNotEqual, "bar", "baz"),
 			}},
 		},
 		{
 			in: `{foo="bar"} |= "baz"`,
 			exp: &filterExpr{
-				left:  &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+				left:  &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchEqual, "foo", "bar")}},
 				ty:    labels.MatchEqual,
 				match: "baz",
 			},
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 				left: &filterExpr{
 					left: &filterExpr{
 						left: &filterExpr{
-							left:  &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+							left:  &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(nil, labels.MatchEqual, "foo", "bar")}},
 							ty:    labels.MatchEqual,
 							match: "baz",
 						},
@@ -145,6 +145,14 @@ func TestParse(t *testing.T) {
 				msg:  "syntax error: unexpected IDENTIFIER, expecting != or !~ or |~ or |=",
 				line: 1,
 				col:  13,
+			},
+		},
+		{
+			in: `{foo=~"*"}`,
+			err: ParseError{
+				msg:  "error parsing regexp: missing argument to repetition operator: `*`",
+				line: 1,
+				col:  7,
 			},
 		},
 	} {


### PR DESCRIPTION
`loqgl.ParseExpr` has been modified to use a defer/recover to recover from a panic caused by a failed regex parse in the parser.

A defer and panic were used over adding an error return into `mustNewMatcher` by imitating how [Go's parser](https://golang.org/src/go/parser/interface.go#L92) works: the exposed interface returns an error while the internal mechanisms use panic. This simplifies the design and implementation of the parser.

Fixes #949.
