### PR TITLE
sync release pkgs name with release note

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ cmd/promtail/promtail-debug: $(APP_GO_FILES) pkg/promtail/server/ui/assets_vfsda
 # Releasing #
 #############
 # concurrency is limited to 4 to prevent CircleCI from OOMing. Sorry
-GOX = gox $(GO_FLAGS) -parallel=4 -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -arch="amd64 arm64 arm" -os="linux"
+GOX = gox $(GO_FLAGS) -parallel=4 -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -arch="amd64 arm64 arm" -os="linux"
 dist: clean
 	CGO_ENABLED=0 $(GOX) ./cmd/loki
 	CGO_ENABLED=0 $(GOX) -osarch="darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/promtail ./cmd/logcli


### PR DESCRIPTION
In release note(tools/release-note.md):
```
#### Binary:
```bash
# download a binary (adapt app, os and arch as needed)
$ curl -fSL -o "/usr/local/bin/loki.gz" "https://github.com/grafana/loki/releases/download/${CIRCLE_TAG}/loki-linux-amd64.gz"
$ gunzip "/usr/local/bin/loki.gz"
```

So sync it.

Signed-off-by: Xiang Dai <764524258@qq.com>
