### PR TITLE
doc: Add permissions that IAM roles for Loki need

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -180,6 +180,12 @@ storage_config:
     s3forcepathstyle: true
 ```
 
+To write to S3, Loki will require the following permissions on the bucket:
+
+* s3:ListBucket
+* s3:PutObject
+* s3:GetObject
+
 #### DynamoDB
 
 Loki uses DynamoDB for the index storage. It is used for querying logs, make
@@ -213,3 +219,18 @@ table_manager:
     provisioned_write_throughput: 10
     provisioned_read_throughput: 10
 ```
+
+For DynamoDB, Loki will require the following permissions on the table:
+
+* dynamodb:BatchGetItem
+* dynamodb:BatchWriteItem
+* dynamodb:DeleteItem
+* dynamodb:DescribeTable
+* dynamodb:GetItem
+* dynamodb:ListTagsOfResource
+* dynamodb:PutItem
+* dynamodb:Query
+* dynamodb:TagResource
+* dynamodb:UntagResource
+* dynamodb:UpdateItem
+* dynamodb:UpdateTable


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Currently, it's difficult to determine what permissions Loki needs to operate against S3 and DynamoDB from the provided documentation. This commit adds the permissions necessary to operator Loki, to provide admins guidance on how they can run Loki with the least possible privilege.

