### PR TITLE
Helm: Add imagePullSecrets to loki and promtail charts

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.0
+version: 0.17.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.0
+version: 0.15.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -39,6 +39,11 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
@@ -105,4 +110,3 @@ spec:
           storage: {{ .Values.persistence.size | quote }}
       storageClassName: {{ .Values.persistence.storageClassName }}
   {{- end }}
-

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -69,6 +69,13 @@ image:
   tag: v0.3.0
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 ## Additional Loki container arguments, e.g. log level (debug, info, warn, error)
 extraArgs: {}
   # log.level: debug

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.12.0
+version: 0.13.0
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         release: {{ .Release.Name }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}          
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
@@ -38,6 +38,11 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
       containers:
         - name: promtail
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -93,4 +98,3 @@ spec:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -11,6 +11,13 @@ image:
   tag: v0.3.0
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 livenessProbe: {}
 
 loki:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Adds pull secrets to the loki and promtail charts, allows private image repositories to be used for the loki/promtail images. 

**Which issue(s) this PR fixes**:

 N/A

**Special notes for your reviewer**:

Copied the way pull secrets are done from the stable/grafana chart.

**Checklist**
- [ Y ] Documentation added
- [ X ] Tests updated

