### PR TITLE
Change label used to keep issues from being marked as stale to keepalive

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ daysUntilClose: 7
 
 # Labels that prevent issues from being marked as stale
 exemptLabels:
-  - important
+  - keepalive
 
 # Label to use to identify a stale issue
 staleLabel: stale


### PR DESCRIPTION
The label used previously, important, implied precedence rather than just a desire to keep an issue or PR alive.
