### PR TITLE
helm chart: Add missing operator to promtail

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.2
+version: 0.16.3
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.12.1
+version: 0.12.2
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -77,6 +77,7 @@ serviceAccount:
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations:
 - key: node-role.kubernetes.io/master
+  operator: Exists
   effect: NoSchedule
 
 # Extra volumes to scrape logs from


### PR DESCRIPTION
The default toleration value in the promtail helm chart is missing `operator` and thereby promtail does not schedule correctly.
This PR fixes this scheduling issue.
