### PR TITLE
promtail: Use ticker instead of timer for batch wait

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -109,7 +109,7 @@ func New(cfg Config, logger log.Logger) (Client, error) {
 func (c *client) run() {
 	batch := map[model.Fingerprint]*logproto.Stream{}
 	batchSize := 0
-	maxWait := time.NewTimer(c.cfg.BatchWait)
+	maxWait := time.NewTicker(c.cfg.BatchWait)
 
 	defer func() {
 		if len(batch) > 0 {
@@ -120,7 +120,6 @@ func (c *client) run() {
 	}()
 
 	for {
-		maxWait.Reset(c.cfg.BatchWait)
 		select {
 		case <-c.quit:
 			return


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation does not match the [description](https://github.com/grafana/loki/blob/master/pkg/promtail/client/config.go#L30) of the `client.batch-wait` flag. Instead it only sends a batch if it has not received a log entry in the time being. I observed this as an issue with a really minimal scrape config, I would only get logs after a really long time (until the default `batchSize` was reached) because I just had one pod continually output write some lines.

**Which issue(s) this PR fixes**:
Fixes #280