### PR TITLE
Allow to pass max-size and max-file to the docker driver

### DIFF
--- a/cmd/docker-driver/README.md
+++ b/cmd/docker-driver/README.md
@@ -47,6 +47,9 @@ docker run --log-driver=loki \
     grafana/grafana
 ```
 
+> **Note**: The Loki logging driver still uses the json-log driver in combination with sending logs to Loki, this is mainly useful to keep the `docker logs` command working.
+> You can adjust file size and rotation using the respective log option `max-size` and `max-file`.
+
 ### Configure the default logging driver
 
 To configure the Docker daemon to default to Loki logging driver, set the value of `log-driver` to `loki` logging driver in the `daemon.json` file, which is located in `/etc/docker/`. The following example explicitly sets the default logging driver to Loki:
@@ -129,6 +132,8 @@ To specify additional logging driver options, you can use the --log-opt NAME=VAL
 | `loki-tls-server-name`          | No        |                      | Name used to validate the server certificate.
 | `loki-tls-insecure-skip-verify`           | No        | `false`                | Allow to skip tls verification.
 | `loki-proxy-url`                       | No        |           | Proxy URL use to connect to Loki.
+| `max-size`                       | No        |       -1    | The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g). Defaults to -1 (unlimited). This is used by json-log required to keep the `docker log` command working.
+| `max-file`                       | No        |       1    | The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. Only effective when max-size is also set. A positive integer. Defaults to 1.
 | `labels`                   | No | | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for container.
 | `env`                   | No | | Comma-separated list of keys of environment variables to be included in message if they specified for a container.
 | `env-regex`                   | No | | A regular expression to match logging-related environment variables. Used for advanced log label options. If there is collision between the label and env keys, the value of the env takes precedence. Both options add additional fields to the labels of a logging message.

--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -95,6 +95,8 @@ func validateDriverOpt(loggerInfo logger.Info) error {
 		case "labels":
 		case "env":
 		case "env-regex":
+		case "max-size":
+		case "max-file":
 		default:
 			return fmt.Errorf("%s: wrong log-opt: '%s' - %s", driverName, opt, loggerInfo.ContainerID)
 		}


### PR DESCRIPTION
This allows docker driver users to control `max-file` and `max-size` of the json-log driver used by Loki driver.

I didn't remove the json-log as it allows users to keep using `docker logs` in combination of Loki driver.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #966 

**Special notes for your reviewer**:

**Checklist**
- [ x] Documentation added
- [ x] Tests updated

