### PR TITLE
tests: Set default value for BatchWait as ticker does not accept 0

### DIFF
--- a/pkg/promtail/client/multi_test.go
+++ b/pkg/promtail/client/multi_test.go
@@ -22,8 +22,8 @@ func TestNewMulti(t *testing.T) {
 	}
 	host1, _ := url.Parse("http://localhost:3100")
 	host2, _ := url.Parse("https://grafana.com")
-	expectedCfg1 := Config{BatchSize: 20, URL: flagext.URLValue{URL: host1}}
-	expectedCfg2 := Config{BatchSize: 10, URL: flagext.URLValue{URL: host2}}
+	expectedCfg1 := Config{BatchSize: 20, BatchWait: 1 * time.Second, URL: flagext.URLValue{URL: host1}}
+	expectedCfg2 := Config{BatchSize: 10, BatchWait: 1 * time.Second, URL: flagext.URLValue{URL: host2}}
 
 	clients, err := NewMulti(util.Logger, expectedCfg1, expectedCfg2)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
I have seen that my PR (https://github.com/grafana/loki/pull/969) got merged and the tests broke on master, sorry about that. I have no idea why it did not fail in my branch though. 

**Which issue(s) this PR fixes**:
The failing test as the ticker cannot take a zero value.