### PR TITLE
fix(distributor): parseError BadRequest

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -15,6 +15,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -221,9 +222,10 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 func (d *Distributor) validateLabels(userID, labels string) error {
 	ls, err := util.ToClientLabels(labels)
 	if err != nil {
-		return err
+		return httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
+	// everything in `ValidateLabels` returns `httpgrpc.Errorf` errors, no sugaring needed
 	return validation.ValidateLabels(d.overrides, userID, ls)
 }
 


### PR DESCRIPTION
When the label validation in the distributor failed, it was reported as `500 Internal Server Error` instead of `400 BadRequest`. 

Fixes #929 