### PR TITLE
Logcli: Add Support for New Query Path

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/loki/pkg/logcli/client"
+	"github.com/grafana/loki/pkg/logcli/labelquery"
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/logcli/query"
 	"github.com/prometheus/common/config"
@@ -99,12 +100,12 @@ func main() {
 		}
 
 	case labelsCmd.FullCommand():
-		query.DoLabels(*labelName, *quiet, queryClient)
+		labelquery.DoLabels(*labelName, *quiet, queryClient)
 	}
 }
 
 func hintActionLabelNames() []string {
-	return query.ListLabels(*quiet, newQueryClient())
+	return labelquery.ListLabels(*quiet, newQueryClient())
 }
 
 func newQueryClient() *client.Client {

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -84,7 +84,6 @@ func main() {
 			End:             end,
 			Limit:           *limit,
 			Forward:         *forward,
-			Tail:            *tail,
 			Quiet:           *quiet,
 			DelayFor:        *delayFor,
 			NoLabels:        *noLabels,
@@ -93,7 +92,12 @@ func main() {
 			FixedLabelsLen:  *fixedLabelsLen,
 		}
 
-		query.DoQuery(q, queryClient, out)
+		if *tail {
+			q.TailQuery(queryClient, out)
+		} else {
+			q.DoQuery(queryClient, out)
+		}
+
 	case labelsCmd.FullCommand():
 		query.DoLabels(*labelName, *quiet, queryClient)
 	}

--- a/docs/logcli.md
+++ b/docs/logcli.md
@@ -45,7 +45,7 @@ cortex-ops/consul
 cortex-ops/cortex-gw
 ...
 $ logcli query '{job="cortex-ops/consul"}'
-https://logs-dev-ops-tools1.grafana.net/api/prom/query?query=%7Bjob%3D%22cortex-ops%2Fconsul%22%7D&limit=30&start=1529928228&end=1529931828&direction=backward&regexp=
+https://logs-dev-ops-tools1.grafana.net/api/v1/query_range?query=%7Bjob%3D%22cortex-ops%2Fconsul%22%7D&limit=30&start=1529928228&end=1529931828&direction=backward&regexp=
 Common labels: {job="cortex-ops/consul", namespace="cortex-ops"}
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Snapshot to 475409 complete
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169

--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -292,6 +292,15 @@ func (i *heapIterator) Len() int {
 	return i.heap.Len()
 }
 
+// NewStreamsIterator returns an iterator over logproto.Stream
+func NewStreamsIterator(streams []*logproto.Stream, direction logproto.Direction) EntryIterator {
+	is := make([]EntryIterator, 0, len(streams))
+	for i := range streams {
+		is = append(is, NewStreamIterator(streams[i]))
+	}
+	return NewHeapIterator(is, direction)
+}
+
 // NewQueryResponseIterator returns an iterator over a QueryResponse.
 func NewQueryResponseIterator(resp *logproto.QueryResponse, direction logproto.Direction) EntryIterator {
 	is := make([]EntryIterator, 0, len(resp.Streams))

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	queryPath       = "/api/prom/query?query=%s&limit=%d&start=%d&end=%d&direction=%s"
-	labelsPath      = "/api/prom/label"
-	labelValuesPath = "/api/prom/label/%s/values"
+	labelsPath      = "/api/v1/label"
+	labelValuesPath = "/api/v1/label/%s/values"
 	tailPath        = "/api/prom/tail?query=%s&delay_for=%d&limit=%d&start=%d"
 )
 

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -1,4 +1,4 @@
-package main
+package client
 
 import (
 	"encoding/base64"
@@ -11,56 +11,92 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/loki/pkg/logql"
+
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/common/config"
+	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/querier"
 )
 
 const (
-	queryPath       = "/api/prom/query?query=%s&limit=%d&start=%d&end=%d&direction=%s"
-	labelsPath      = "/api/prom/label"
-	labelValuesPath = "/api/prom/label/%s/values"
+	queryPath       = "/api/v1/query_range?query=%s&limit=%d&start=%d&end=%d&direction=%s"
+	labelsPath      = "/api/v1/label"
+	labelValuesPath = "/api/v1/label/%s/values"
 	tailPath        = "/api/prom/tail?query=%s&delay_for=%d&limit=%d&start=%d"
 )
 
-func query(from, through time.Time, direction logproto.Direction) (*logproto.QueryResponse, error) {
+type Client struct {
+	TLSConfig config.TLSConfig
+	Username  string
+	Password  string
+	Address   string
+}
+
+func (c *Client) QueryRange(queryStr string, limit int, from, through time.Time, direction logproto.Direction, quiet bool) (*querier.QueryResponse, error) {
+	var err error
+
 	path := fmt.Sprintf(queryPath,
-		url.QueryEscape(*queryStr), // query
-		*limit,                     // limit
-		from.UnixNano(),            // start
-		through.UnixNano(),         // end
-		direction.String(),         // direction
+		url.QueryEscape(queryStr), // query
+		limit,                     // limit
+		from.UnixNano(),           // start
+		through.UnixNano(),        // end
+		direction.String(),        // direction
 	)
 
-	var resp logproto.QueryResponse
-	if err := doRequest(path, &resp); err != nil {
+	unmarshal := struct {
+		Type   promql.ValueType `json:"resultType"`
+		Result json.RawMessage  `json:"result"`
+	}{}
+
+	if err = c.doRequest(path, quiet, &unmarshal); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	var value promql.Value
+
+	// unmarshal results
+	switch unmarshal.Type {
+	case logql.ValueTypeStreams:
+		var s logql.Streams
+		err = json.Unmarshal(unmarshal.Result, &s)
+		value = s
+	default:
+		return nil, fmt.Errorf("Unknown type: %s", unmarshal.Type)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &querier.QueryResponse{
+		ResultType: unmarshal.Type,
+		Result:     value,
+	}, nil
 }
 
-func listLabelNames() (*logproto.LabelResponse, error) {
+func (c *Client) ListLabelNames(quiet bool) (*logproto.LabelResponse, error) {
 	var labelResponse logproto.LabelResponse
-	if err := doRequest(labelsPath, &labelResponse); err != nil {
+	if err := c.doRequest(labelsPath, quiet, &labelResponse); err != nil {
 		return nil, err
 	}
 	return &labelResponse, nil
 }
 
-func listLabelValues(name string) (*logproto.LabelResponse, error) {
+func (c *Client) ListLabelValues(name string, quiet bool) (*logproto.LabelResponse, error) {
 	path := fmt.Sprintf(labelValuesPath, url.PathEscape(name))
 	var labelResponse logproto.LabelResponse
-	if err := doRequest(path, &labelResponse); err != nil {
+	if err := c.doRequest(path, quiet, &labelResponse); err != nil {
 		return nil, err
 	}
 	return &labelResponse, nil
 }
 
-func doRequest(path string, out interface{}) error {
-	us := *addr + path
-	if !*quiet {
+func (c *Client) doRequest(path string, quiet bool, out interface{}) error {
+	us := c.Address + path
+	if !quiet {
 		log.Print(us)
 	}
 
@@ -69,21 +105,11 @@ func doRequest(path string, out interface{}) error {
 		return err
 	}
 
-	req.SetBasicAuth(*username, *password)
+	req.SetBasicAuth(c.Username, c.Password)
 
 	// Parse the URL to extract the host
-	u, err := url.Parse(us)
-	if err != nil {
-		return err
-	}
 	clientConfig := config.HTTPClientConfig{
-		TLSConfig: config.TLSConfig{
-			CAFile:             *tlsCACertPath,
-			CertFile:           *tlsClientCertPath,
-			KeyFile:            *tlsClientCertKeyPath,
-			ServerName:         u.Host,
-			InsecureSkipVerify: *tlsSkipVerify,
-		},
+		TLSConfig: c.TLSConfig,
 	}
 
 	client, err := config.NewClientFromConfig(clientConfig, "logcli")
@@ -109,31 +135,20 @@ func doRequest(path string, out interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
-func liveTailQueryConn() (*websocket.Conn, error) {
+func (c *Client) LiveTailQueryConn(queryStr string, delayFor int, limit int, from int64, quiet bool) (*websocket.Conn, error) {
 	path := fmt.Sprintf(tailPath,
-		url.QueryEscape(*queryStr),      // query
-		*delayFor,                       // delay_for
-		*limit,                          // limit
-		getStart(time.Now()).UnixNano(), // start
+		url.QueryEscape(queryStr), // query
+		delayFor,                  // delay_for
+		limit,                     // limit
+		from,                      // start
 	)
-	return wsConnect(path)
+	return c.wsConnect(path, quiet)
 }
 
-func wsConnect(path string) (*websocket.Conn, error) {
-	us := *addr + path
+func (c *Client) wsConnect(path string, quiet bool) (*websocket.Conn, error) {
+	us := c.Address + path
 
-	// Parse the URL to extract the host
-	u, err := url.Parse(us)
-	if err != nil {
-		return nil, err
-	}
-	tlsConfig, err := config.NewTLSConfig(&config.TLSConfig{
-		CAFile:             *tlsCACertPath,
-		CertFile:           *tlsClientCertPath,
-		KeyFile:            *tlsClientCertKeyPath,
-		ServerName:         u.Host,
-		InsecureSkipVerify: *tlsSkipVerify,
-	})
+	tlsConfig, err := config.NewTLSConfig(&c.TLSConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -143,17 +158,17 @@ func wsConnect(path string) (*websocket.Conn, error) {
 	} else if strings.HasPrefix(us, "http") {
 		us = strings.Replace(us, "http", "ws", 1)
 	}
-	if !*quiet {
+	if !quiet {
 		log.Println(us)
 	}
 
-	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(*username+":"+*password))}}
+	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(c.Username+":"+c.Password))}}
 
 	ws := websocket.Dialer{
 		TLSClientConfig: tlsConfig,
 	}
 
-	c, resp, err := ws.Dial(us, h)
+	conn, resp, err := ws.Dial(us, h)
 
 	if err != nil {
 		if resp == nil {
@@ -163,5 +178,5 @@ func wsConnect(path string) (*websocket.Conn, error) {
 		return nil, fmt.Errorf("Error response from server: %s (%v)", string(buf), err)
 	}
 
-	return c, nil
+	return conn, nil
 }

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -1,19 +1,25 @@
-package main
+package labelquery
 
 import (
 	"fmt"
 	"log"
 
+	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-func doLabels() {
+type LabelQuery struct {
+	LabelName string
+	Quiet     bool
+}
+
+func (q *LabelQuery) DoLabels(c *client.Client) {
 	var labelResponse *logproto.LabelResponse
 	var err error
-	if len(*labelName) > 0 {
-		labelResponse, err = listLabelValues(*labelName)
+	if len(q.LabelName) > 0 {
+		labelResponse, err = c.ListLabelValues(q.LabelName, q.Quiet)
 	} else {
-		labelResponse, err = listLabelNames()
+		labelResponse, err = c.ListLabelNames(q.Quiet)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)
@@ -23,8 +29,8 @@ func doLabels() {
 	}
 }
 
-func listLabels() []string {
-	labelResponse, err := listLabelNames()
+func (q *LabelQuery) ListLabels(c *client.Client) []string {
+	labelResponse, err := c.ListLabelNames(q.Quiet)
 	if err != nil {
 		log.Fatalf("Error fetching labels: %+v", err)
 	}

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -1,25 +1,19 @@
-package labelquery
+package main
 
 import (
 	"fmt"
 	"log"
 
-	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-type LabelQuery struct {
-	LabelName string
-	Quiet     bool
-}
-
-func (q *LabelQuery) DoLabels(c *client.Client) {
+func doLabels() {
 	var labelResponse *logproto.LabelResponse
 	var err error
-	if len(q.LabelName) > 0 {
-		labelResponse, err = c.ListLabelValues(q.LabelName, q.Quiet)
+	if len(*labelName) > 0 {
+		labelResponse, err = listLabelValues(*labelName)
 	} else {
-		labelResponse, err = c.ListLabelNames(q.Quiet)
+		labelResponse, err = listLabelNames()
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)
@@ -29,8 +23,8 @@ func (q *LabelQuery) DoLabels(c *client.Client) {
 	}
 }
 
-func (q *LabelQuery) ListLabels(c *client.Client) []string {
-	labelResponse, err := c.ListLabelNames(q.Quiet)
+func listLabels() []string {
+	labelResponse, err := listLabelNames()
 	if err != nil {
 		log.Fatalf("Error fetching labels: %+v", err)
 	}

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -8,13 +8,18 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-func DoLabels(labelName string, quiet bool, c *client.Client) {
+type LabelQuery struct {
+	LabelName string
+	Quiet     bool
+}
+
+func (q *LabelQuery) DoLabels(c *client.Client) {
 	var labelResponse *logproto.LabelResponse
 	var err error
-	if len(labelName) > 0 {
-		labelResponse, err = c.ListLabelValues(labelName, quiet)
+	if len(q.LabelName) > 0 {
+		labelResponse, err = c.ListLabelValues(q.LabelName, q.Quiet)
 	} else {
-		labelResponse, err = c.ListLabelNames(quiet)
+		labelResponse, err = c.ListLabelNames(q.Quiet)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)
@@ -24,8 +29,8 @@ func DoLabels(labelName string, quiet bool, c *client.Client) {
 	}
 }
 
-func ListLabels(quiet bool, c *client.Client) []string {
-	labelResponse, err := c.ListLabelNames(quiet)
+func (q *LabelQuery) ListLabels(c *client.Client) []string {
+	labelResponse, err := c.ListLabelNames(q.Quiet)
 	if err != nil {
 		log.Fatalf("Error fetching labels: %+v", err)
 	}

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -1,4 +1,4 @@
-package query
+package labelquery
 
 import (
 	"fmt"

--- a/pkg/logcli/query/labels.go
+++ b/pkg/logcli/query/labels.go
@@ -1,19 +1,20 @@
-package main
+package query
 
 import (
 	"fmt"
 	"log"
 
+	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-func doLabels() {
+func DoLabels(labelName string, quiet bool, c *client.Client) {
 	var labelResponse *logproto.LabelResponse
 	var err error
-	if len(*labelName) > 0 {
-		labelResponse, err = listLabelValues(*labelName)
+	if len(labelName) > 0 {
+		labelResponse, err = c.ListLabelValues(labelName, quiet)
 	} else {
-		labelResponse, err = listLabelNames()
+		labelResponse, err = c.ListLabelNames(quiet)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)
@@ -23,8 +24,8 @@ func doLabels() {
 	}
 }
 
-func listLabels() []string {
-	labelResponse, err := listLabelNames()
+func ListLabels(quiet bool, c *client.Client) []string {
+	labelResponse, err := c.ListLabelNames(quiet)
 	if err != nil {
 		log.Fatalf("Error fetching labels: %+v", err)
 	}

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -21,7 +21,6 @@ type Query struct {
 	End             time.Time
 	Limit           int
 	Forward         bool
-	Tail            bool
 	Quiet           bool
 	DelayFor        int
 	NoLabels        bool
@@ -30,12 +29,7 @@ type Query struct {
 	FixedLabelsLen  int
 }
 
-func DoQuery(q *Query, c *client.Client, out output.LogOutput) {
-	if q.Tail {
-		tailQuery(q, c, out)
-		return
-	}
-
+func (q *Query) DoQuery(c *client.Client, out output.LogOutput) {
 	var (
 		i      iter.EntryIterator
 		common labels.Labels

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -92,7 +92,7 @@ func (q *Query) DoQuery(c *client.Client, out output.LogOutput) {
 		}
 	}
 
-	i = newStreamsIterator(streams, d)
+	i = iter.NewStreamsIterator(streams, d)
 
 	for i.Next() {
 		ls := labelsCache(i.Labels())
@@ -102,12 +102,4 @@ func (q *Query) DoQuery(c *client.Client, out output.LogOutput) {
 	if err := i.Error(); err != nil {
 		log.Fatalf("Error from iterator: %v", err)
 	}
-}
-
-func newStreamsIterator(streams logql.Streams, direction logproto.Direction) iter.EntryIterator {
-	is := make([]iter.EntryIterator, 0, len(streams))
-	for i := range streams {
-		is = append(is, iter.NewStreamIterator(streams[i]))
-	}
-	return iter.NewHeapIterator(is, direction)
 }

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -29,7 +29,6 @@ type Query struct {
 	IgnoreLabelsKey []string
 	ShowLabelsKey   []string
 	FixedLabelsLen  int
-	Addr            string
 }
 
 func getStart(end time.Time, from string, since time.Duration) time.Time {

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -1,4 +1,4 @@
-package main
+package query
 
 import (
 	"reflect"

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -13,7 +13,7 @@ import (
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 )
 
-func tailQuery(q *Query, c *client.Client, out output.LogOutput) {
+func (q *Query) TailQuery(c *client.Client, out output.LogOutput) {
 	conn, err := c.LiveTailQueryConn(q.QueryString, q.DelayFor, q.Limit, q.Start.UnixNano(), q.Quiet)
 	if err != nil {
 		log.Fatalf("Tailing logs failed: %+v", err)

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -1,10 +1,12 @@
-package main
+package query
 
 import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/querier"
 
@@ -12,20 +14,21 @@ import (
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 )
 
-func tailQuery(out output.LogOutput) {
-	conn, err := liveTailQueryConn()
+func tailQuery(q *Query, c *client.Client, out output.LogOutput) {
+	start := getStart(time.Now(), q.From, q.Since).UnixNano()
+	conn, err := c.LiveTailQueryConn(q.QueryString, q.DelayFor, q.Limit, start, q.Quiet)
 	if err != nil {
 		log.Fatalf("Tailing logs failed: %+v", err)
 	}
 
 	tailReponse := new(querier.TailResponse)
 
-	if len(*ignoreLabelsKey) > 0 {
-		log.Println("Ingoring labels key:", color.RedString(strings.Join(*ignoreLabelsKey, ",")))
+	if len(q.IgnoreLabelsKey) > 0 {
+		log.Println("Ignoring labels key:", color.RedString(strings.Join(q.IgnoreLabelsKey, ",")))
 	}
 
-	if len(*showLabelsKey) > 0 {
-		log.Println("Print only labels key:", color.RedString(strings.Join(*showLabelsKey, ",")))
+	if len(q.ShowLabelsKey) > 0 {
+		log.Println("Print only labels key:", color.RedString(strings.Join(q.ShowLabelsKey, ",")))
 	}
 
 	for {
@@ -38,18 +41,18 @@ func tailQuery(out output.LogOutput) {
 		labels := ""
 		parsedLabels := promlabels.Labels{}
 		for _, stream := range tailReponse.Streams {
-			if !*noLabels {
+			if q.NoLabels {
 
-				if len(*ignoreLabelsKey) > 0 || len(*showLabelsKey) > 0 {
+				if len(q.IgnoreLabelsKey) > 0 || len(q.ShowLabelsKey) > 0 {
 
 					ls := mustParseLabels(stream.GetLabels())
 
-					if len(*showLabelsKey) > 0 {
-						ls = ls.MatchLabels(true, *showLabelsKey...)
+					if len(q.ShowLabelsKey) > 0 {
+						ls = ls.MatchLabels(true, q.ShowLabelsKey...)
 					}
 
-					if len(*ignoreLabelsKey) > 0 {
-						ls = ls.MatchLabels(false, *ignoreLabelsKey...)
+					if len(q.IgnoreLabelsKey) > 0 {
+						ls = ls.MatchLabels(false, q.IgnoreLabelsKey...)
 					}
 
 					labels = ls.String()

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/output"
@@ -15,8 +14,7 @@ import (
 )
 
 func tailQuery(q *Query, c *client.Client, out output.LogOutput) {
-	start := getStart(time.Now(), q.From, q.Since).UnixNano()
-	conn, err := c.LiveTailQueryConn(q.QueryString, q.DelayFor, q.Limit, start, q.Quiet)
+	conn, err := c.LiveTailQueryConn(q.QueryString, q.DelayFor, q.Limit, q.Start.UnixNano(), q.Quiet)
 	if err != nil {
 		log.Fatalf("Tailing logs failed: %+v", err)
 	}

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -39,7 +39,7 @@ func tailQuery(q *Query, c *client.Client, out output.LogOutput) {
 		labels := ""
 		parsedLabels := promlabels.Labels{}
 		for _, stream := range tailReponse.Streams {
-			if q.NoLabels {
+			if !q.NoLabels {
 
 				if len(q.IgnoreLabelsKey) > 0 || len(q.ShowLabelsKey) > 0 {
 

--- a/pkg/logcli/query/utils.go
+++ b/pkg/logcli/query/utils.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"sort"
 
-	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 )
@@ -19,10 +19,10 @@ func mustParseLabels(labels string) labels.Labels {
 }
 
 // parse labels from response stream
-func parseLabels(resp *logproto.QueryResponse) (map[string]labels.Labels, []labels.Labels) {
-	cache := make(map[string]labels.Labels, len(resp.Streams))
-	lss := make([]labels.Labels, 0, len(resp.Streams))
-	for _, stream := range resp.Streams {
+func parseLabels(streams logql.Streams) (map[string]labels.Labels, []labels.Labels) {
+	cache := make(map[string]labels.Labels, len(streams))
+	lss := make([]labels.Labels, 0, len(streams))
+	for _, stream := range streams {
 		ls := mustParseLabels(stream.Labels)
 		cache[stream.Labels] = ls
 		lss = append(lss, ls)

--- a/pkg/logcli/query/utils.go
+++ b/pkg/logcli/query/utils.go
@@ -1,4 +1,4 @@
-package main
+package query
 
 import (
 	"log"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds support for new `query_range` api.
- Refactored logcli for better segregation of parts.  Basic code paths/structure has been kept.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
The refactor was a medium effort, medium value, low risk change.  Certainly more time could be spent building a better, more generic Loki API client for future use.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

