### PR TITLE
chore(packaging): deploy from drone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,6 @@ workflows:
           requires: [ lint, test ]
           filters: { <<: *only-tags }
 
-      - deploy:
-          filters: {<<: *tag-or-master}
-
       - test-helm:
           requires: [ lint, test ]
           filters: {<<: *tags}
@@ -112,16 +109,6 @@ jobs:
       - run:
           name: github release
           command: make BUILD_IN_CONTAINER=false publish
-
-  deploy:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: |
-                curl -s --header "Content-Type: application/json" \
-                  --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$(make print-images)\"}}" \
-                  --request POST \
-                  https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
 
   test-helm:
     environment:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -378,7 +378,6 @@ depends_on:
 - docker-amd64
 - docker-arm64
 - docker-arm
-- check
 kind: pipeline
 name: manifest
 steps:
@@ -418,6 +417,27 @@ steps:
     target: loki-canary
     username:
       from_secret: docker_username
+trigger:
+  ref:
+    include:
+    - refs/heads/master
+    - refs/tags/v*
+---
+depends_on:
+- manifest
+kind: pipeline
+name: deploy
+steps:
+- commands:
+  - apk add --no-cache curl
+  - 'curl -s --header "Content-Type: application/json" --data "{"build_parameters":
+    {"CIRCLE_JOB": "deploy", "IMAGE_NAMES": "$(make print-images)"}}" --request POST
+    https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN'
+  environment:
+    CIRLCE_TOKEN:
+      from_secret: circle_token
+  image: alpine
+  name: trigger
 trigger:
   ref:
     include:


### PR DESCRIPTION
Moves the continuous deploy call from CircleCI to drone, because the images are
now built there.
