### PR TITLE
chore(packaging): fix GOPATH being overwritten

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -102,8 +102,8 @@ local manifest(apps) = pipeline('manifest') {
 local drone = [
   pipeline('check') {
     workspace: {
-      base: "/go",
-      path: "src/github.com/grafana/loki"
+      base: "/go/src",
+      path: "github.com/grafana/loki"
     },
     steps: [
       make('test', container=false) { depends_on: ['clone'] },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -20,8 +20,8 @@ steps:
   image: grafana/loki-build-image:0.5.0
   name: check-generated-files
 workspace:
-  base: /go
-  path: src/github.com/grafana/loki
+  base: /go/src
+  path: github.com/grafana/loki
 ---
 depends_on:
 - check


### PR DESCRIPTION
Drone workspace was overwriting whole GOPATH, which made our executables go away

(See https://github.com/drone/drone/issues/2202)
