### PR TITLE
Change unit of duration params to hours to align it with duration config at other places in Loki

### DIFF
--- a/tools/bigtable-backup/Dockerfile
+++ b/tools/bigtable-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM       grafana/bigtable-backup:master-63aad9c
+FROM       grafana/bigtable-backup:master-c32bd7b
 RUN        apk add --update --no-cache python3 python3-dev git \
             && pip3 install --no-cache-dir --upgrade pip
 COPY       bigtable-backup.py bigtable-backup.py


### PR DESCRIPTION
**What this PR does / why we need it**:
Other configurations like periodic table duration, retention are set in hours so this change makes duration config for backup tool consistent and easy to manage configurations.

Also, update parent docker image of bigtable backup tool to latest.