### PR TITLE
Make Loki HTTP API more compatible with Prometheus

### DIFF
--- a/docs/loki/api.md
+++ b/docs/loki/api.md
@@ -40,8 +40,11 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
 
   ```json
   {
-    "resultType": "vector" | "streams",
-    "result": <value>
+    "status" : "success",
+    "data": {
+        "resultType": "vector" | "streams",
+        "result": <value>
+    }
   }
   ```
 
@@ -50,56 +53,63 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   ```bash
   $ curl -G -s  "http://localhost:3100/api/v1/query" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
   {
-    "resultType": "vector",
-    "result": [
-      {
-        "metric": {},
-        "value": [
-          1559848867745737,
-          "1267.1266666666666"
-        ]
-      },
-      {
-        "metric": {
-          "level": "warn"
+    "status" : "success",
+    "data": {
+      "resultType": "vector",
+      "result": [
+        {
+          "metric": {},
+          "value": [
+            1559848867745737,
+            "1267.1266666666666"
+          ]
         },
-        "value": [
-          1559848867745737,
-          "37.77166666666667"
-        ]
-      },
-      {
-        "metric": {
-          "level": "info"
+        {
+          "metric": {
+            "level": "warn"
+          },
+          "value": [
+            1559848867745737,
+            "37.77166666666667"
+          ]
         },
-        "value": [
-          1559848867745737,
-          "37.69"
-        ]
-      }
-    ]
+        {
+          "metric": {
+            "level": "info"
+          },
+          "value": [
+            1559848867745737,
+            "37.69"
+          ]
+        }
+      ]
+    }
   }
   ```
 
   ```bash
   curl -G -s  "http://localhost:3100/api/v1/query" --data-urlencode 'query={job="varlogs"}' | jq
   {
-    "resultType": "streams",
-    "result": [
-      {
-        "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
-        "entries": [
+    "status" : "success",
+    "data": {
+        "resultType": "streams",
+        "result": [
           {
-            "ts": "2019-06-06T19:25:41.972739Z",
-            "line": "foo"
-          },
-          {
-            "ts": "2019-06-06T19:25:41.972722Z",
-            "line": "bar"
+            "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
+            "entries": [
+              {
+                "ts": "2019-06-06T19:25:41.972739Z",
+                "line": "foo"
+              },
+              {
+                "ts": "2019-06-06T19:25:41.972722Z",
+                "line": "bar"
+              }
+            ]
           }
         ]
       }
-    ]
+  }
   ```
 
 - `GET /api/v1/query_range`
@@ -121,8 +131,11 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
 
   ```json
   {
-    "resultType": "matrix" | "streams",
-    "result": <value>
+    "status" : "success",
+    "data": {
+      "resultType": "matrix" | "streams",
+      "result": <value>
+    }
   }
   ```
 
@@ -131,69 +144,76 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   ```bash
   $ curl -G -s  "http://localhost:3100/api/v1/query_range" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' --data-urlencode 'step=300' | jq
   {
-    "resultType": "matrix",
-    "result": [
-    {
-       "metric": {
-          "level": "info"
-        },
-        "values": [
-          [
-            1559848958663735,
-            "137.95"
-          ],
-          [
-            1559849258663735,
-            "467.115"
-          ],
-          [
-            1559849558663735,
-            "658.8516666666667"
-          ]
-        ]
-      },
+    "status" : "success",
+    "data": {
+      "resultType": "matrix",
+      "result": [
       {
         "metric": {
-          "level": "warn"
-        },
-        "values": [
-          [
-            1559848958663735,
-            "137.27833333333334"
-          ],
-          [
-            1559849258663735,
-            "467.69"
-          ],
-          [
-            1559849558663735,
-            "660.6933333333334"
+            "level": "info"
+          },
+          "values": [
+            [
+              1559848958663735,
+              "137.95"
+            ],
+            [
+              1559849258663735,
+              "467.115"
+            ],
+            [
+              1559849558663735,
+              "658.8516666666667"
+            ]
           ]
-        ]
-      }
-    ]
+        },
+        {
+          "metric": {
+            "level": "warn"
+          },
+          "values": [
+            [
+              1559848958663735,
+              "137.27833333333334"
+            ],
+            [
+              1559849258663735,
+              "467.69"
+            ],
+            [
+              1559849558663735,
+              "660.6933333333334"
+            ]
+          ]
+        }
+      ]
+    }
   }
   ```
 
   ```bash
   curl -G -s  "http://localhost:3100/api/v1/query_range" --data-urlencode 'query={job="varlogs"}' | jq
   {
-    "resultType": "streams",
-    "result": [
-      {
-        "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
-        "entries": [
-          {
-            "ts": "2019-06-06T19:25:41.972739Z",
-            "line": "foo"
-          },
-          {
-            "ts": "2019-06-06T19:25:41.972722Z",
-            "line": "bar"
-          }
-        ]
-      }
-    ]
+    "status" : "success",
+    "data": {
+      "resultType": "streams",
+      "result": [
+        {
+          "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
+          "entries": [
+            {
+              "ts": "2019-06-06T19:25:41.972739Z",
+              "line": "foo"
+            },
+            {
+              "ts": "2019-06-06T19:25:41.972722Z",
+              "line": "bar"
+            }
+          ]
+        }
+      ]
+    }
+  }
   ```
 
 - `GET /api/prom/query`

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -147,6 +147,13 @@ func (ng *Engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
 	defer cancel()
 
+	if q.qs == "1+1" {
+		if q.isInstant() {
+			return promql.Vector{}, nil
+		}
+		return promql.Matrix{}, nil
+	}
+
 	expr, err := ParseExpr(q.qs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR makes it possible to add Loki as a Prometheus datasource to send metrics queries to Loki.

Example:

![image](https://user-images.githubusercontent.com/1053421/64712959-16868200-d48a-11e9-8fe3-f1c2a6f7b9f2.png)

- Tricks the LogQL engine to not returns error when querying "1+1"
- Support for seconds timestamp by either checking the if there is a dot in the timestamp (which never happens for int64 nano) or by checking if the value is less or equal than 10 digit (which is not the case for nanoseconds)
- Add a wrapper object in response result.

```json
{
    "status" : "success",
    "data": {
      "resultType": "matrix" | "streams" | "vector",
      "result": <value>
    }
  }
```


This affects only the new API.

/cc @joe-elliott Sorry another change.
