### PR TITLE
Updated stream json objects to be more parse friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ lint:
 ########
 
 test: all
-	go test -p=6 ./...
+	GOGC=20 go test -p=6 ./...
 
 #########
 # Clean #

--- a/docs/loki/api.md
+++ b/docs/loki/api.md
@@ -23,7 +23,7 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
 
   ```
 
-- `GET /api/v1/query`
+- `GET /loki/api/v1/query`
 
   For doing instant queries at a single point in time, accepts the following parameters in the query-string:
 
@@ -51,7 +51,7 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   Examples:
 
   ```bash
-  $ curl -G -s  "http://localhost:3100/api/v1/query" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+  $ curl -G -s  "http://localhost:3100/loki/api/v1/query" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
   {
     "status" : "success",
     "data": {
@@ -88,31 +88,31 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   ```
 
   ```bash
-  curl -G -s  "http://localhost:3100/api/v1/query" --data-urlencode 'query={job="varlogs"}' | jq
+  curl -G -s  "http://localhost:3100/loki/api/v1/query" --data-urlencode 'query={job="varlogs"}' | jq
   {
-    "status" : "success",
-    "data": {
-        "resultType": "streams",
-        "result": [
-          {
-            "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
-            "entries": [
-              {
-                "ts": "2019-06-06T19:25:41.972739Z",
-                "line": "foo"
-              },
-              {
-                "ts": "2019-06-06T19:25:41.972722Z",
-                "line": "bar"
-              }
-            ]
-          }
+    "resultType": "streams",
+    "result": [
+      {
+        "stream": {
+          "filename": "/var/hostlog/syslog",
+          "job": "varlogs"
+        },
+        "values": [
+          [
+            "1568234281726420425",
+            "foo"
+          ],
+          [
+            "1568234269716526880",
+            "bar"
+          ]
         ]
       }
+    ]
   }
   ```
 
-- `GET /api/v1/query_range`
+- `GET /loki/api/v1/query_range`
 
   For doing queries over a range of time, accepts the following parameters in the query-string:
 
@@ -142,7 +142,7 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   Examples:
 
   ```bash
-  $ curl -G -s  "http://localhost:3100/api/v1/query_range" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' --data-urlencode 'step=300' | jq
+  $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' --data-urlencode 'step=300' | jq
   {
     "status" : "success",
     "data": {
@@ -192,69 +192,31 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   ```
 
   ```bash
-  curl -G -s  "http://localhost:3100/api/v1/query_range" --data-urlencode 'query={job="varlogs"}' | jq
+  curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query={job="varlogs"}' | jq
   {
-    "status" : "success",
-    "data": {
-      "resultType": "streams",
-      "result": [
-        {
-          "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
-          "entries": [
-            {
-              "ts": "2019-06-06T19:25:41.972739Z",
-              "line": "foo"
-            },
-            {
-              "ts": "2019-06-06T19:25:41.972722Z",
-              "line": "bar"
-            }
-          ]
-        }
-      ]
-    }
-  }
-  ```
-
-- `GET /api/prom/query`
-
-  For doing queries, accepts the following parameters in the query-string:
-
-  - `query`: a [logQL query](../querying.md) (eg: `{name=~"mysql.+"}` or `{name=~"mysql.+"} |= "error"`)
-  - `limit`: max number of entries to return
-  - `start`: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999-07:00"). Default is always one hour ago.
-  - `end`: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970) or as RFC3339Nano (eg: "2006-01-02T15:04:05.999999999-07:00"). Default is current time.
-  - `direction`: `forward` or `backward`, useful when specifying a limit. Default is backward.
-  - `regexp`: a regex to filter the returned results
-
-  Loki needs to query the index store in order to find log streams for particular labels and the store is spread out by time,
-  so you need to specify the start and end labels accordingly. Querying a long time into the history will cause additional
-  load to the index server and make the query slower.
-
-  > This endpoint will be deprecated in the future you should use `api/v1/query_range` instead.
-  > You can only query for logs, it doesn't accept [queries returning metrics](../querying.md#counting-logs).
-
-  Responses looks like this:
-
-  ```json
-  {
-    "streams": [
+    "resultType": "streams",
+    "result": [
       {
-        "labels": "{instance=\"...\", job=\"...\", namespace=\"...\"}",
-        "entries": [
-          {
-            "ts": "2018-06-27T05:20:28.699492635Z",
-            "line": "..."
-          },
-          ...
+        "stream": {
+          "filename": "/var/hostlog/syslog",
+          "job": "varlogs"
+        },
+        "values": [
+          [
+            "1568234281726420425",
+            "foo"
+          ],
+          [
+            "1568234269716526880",
+            "bar"
+          ]
         ]
-      },
-      ...
+      }
     ]
   }
   ```
 
-- `GET /api/prom/label`
+- `GET /loki/api/v1/label`
 
   For doing label name queries, accepts the following parameters in the query-string:
 
@@ -273,7 +235,7 @@ The Loki server has the following API endpoints (_Note:_ Authentication is out o
   }
   ```
 
-- `GET /api/prom/label/<name>/values`
+- `GET /loki/api/v1/label/<name>/values`
 
   For doing label values queries, accepts the following parameters in the query-string:
 

--- a/docs/loki/api.md
+++ b/docs/loki/api.md
@@ -2,7 +2,7 @@
 
 The Loki server has the following API endpoints (_Note:_ Authentication is out of scope for this project):
 
-- `POST /api/prom/push`
+- `POST /loki/api/v1/push`
 
   For sending log entries, expects a snappy compressed proto in the HTTP Body:
 

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -17,3 +17,17 @@ func (e *Entry) MarshalJSON() ([]byte, error) {
 	}
 	return []byte(fmt.Sprintf("[%s,%s]", t, l)), nil
 }
+
+// MarshalJSON converts a Stream object to be prom compatible for http queries
+func (s *Stream) MarshalJSON() ([]byte, error) {
+	l, err := json.Marshal(s.Labels)
+	if err != nil {
+		return nil, err
+	}
+	e, err := json.Marshal(s.Entries)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(fmt.Sprintf("{\"labels\":%s,\"values\":%s}", l, e)), nil
+}

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -5,9 +5,8 @@ import (
 	fmt "fmt"
 )
 
-// MasrshalJSON converts an Entry object to be prom compatible for http queries
+// MarshalJSON converts an Entry object to be prom compatible for http queries
 func (e *Entry) MarshalJSON() ([]byte, error) {
-
 	t, err := json.Marshal(float64(e.Timestamp.UnixNano()) / 1e+9)
 	if err != nil {
 		return nil, err

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -1,0 +1,19 @@
+package logproto
+
+import (
+	"encoding/json"
+	fmt "fmt"
+)
+
+func (e *Entry) MarshalJSON() ([]byte, error) {
+
+	t, err := json.Marshal(float64(e.Timestamp.UnixNano()) / 1e+9)
+	if err != nil {
+		return nil, err
+	}
+	l, err := json.Marshal(e.Line)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(fmt.Sprintf("[%s,%s]", t, l)), nil
+}

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -5,6 +5,7 @@ import (
 	fmt "fmt"
 )
 
+// MasrshalJSON converts an Entry object to be prom compatible for http queries
 func (e *Entry) MarshalJSON() ([]byte, error) {
 
 	t, err := json.Marshal(float64(e.Timestamp.UnixNano()) / 1e+9)

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -3,6 +3,8 @@ package logproto
 import (
 	"encoding/json"
 	fmt "fmt"
+
+	"github.com/prometheus/prometheus/promql"
 )
 
 // MarshalJSON converts an Entry object to be prom compatible for http queries
@@ -20,7 +22,11 @@ func (e *Entry) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON converts a Stream object to be prom compatible for http queries
 func (s *Stream) MarshalJSON() ([]byte, error) {
-	l, err := json.Marshal(s.Labels)
+	parsedLabels, err := promql.ParseMetric(s.Labels)
+	if err != nil {
+		return nil, err
+	}
+	l, err := json.Marshal(parsedLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -29,5 +35,5 @@ func (s *Stream) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return []byte(fmt.Sprintf("{\"labels\":%s,\"values\":%s}", l, e)), nil
+	return []byte(fmt.Sprintf("{\"stream\":%s,\"values\":%s}", l, e)), nil
 }

--- a/pkg/logproto/marshal.go
+++ b/pkg/logproto/marshal.go
@@ -9,15 +9,11 @@ import (
 
 // MarshalJSON converts an Entry object to be prom compatible for http queries
 func (e *Entry) MarshalJSON() ([]byte, error) {
-	t, err := json.Marshal(float64(e.Timestamp.UnixNano()) / 1e+9)
-	if err != nil {
-		return nil, err
-	}
 	l, err := json.Marshal(e.Line)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(fmt.Sprintf("[%s,%s]", t, l)), nil
+	return []byte(fmt.Sprintf("[\"%d\",%s]", e.Timestamp.UnixNano(), l)), nil
 }
 
 // MarshalJSON converts a Stream object to be prom compatible for http queries

--- a/pkg/logproto/marshal_test.go
+++ b/pkg/logproto/marshal_test.go
@@ -2,6 +2,7 @@ package logproto
 
 import (
 	"encoding/json"
+	fmt "fmt"
 	reflect "reflect"
 	"testing"
 	time "time"
@@ -44,14 +45,14 @@ func Test_EntryMarshalJSON(t *testing.T) {
 		err = json.Unmarshal(bytes, &array)
 		require.NoError(t, err)
 
-		timestamp, ok := array[0].(float64)
+		timestamp, ok := array[0].(string)
 		require.True(t, ok)
 
 		line, ok := array[1].(string)
 		require.True(t, ok)
 
 		// only test to the microsecond level.  json's number type (float64) does not have enough precision to store nanoseconds
-		require.Equal(t, entry.Timestamp.UnixNano()/int64(time.Microsecond), int64(timestamp*1e9)/int64(time.Microsecond), "Timestamps not equal ", array[0])
+		require.Equal(t, fmt.Sprint(entry.Timestamp.UnixNano()), timestamp, "Timestamps not equal ", array[0])
 		require.Equal(t, entry.Line, line, "Lines are not equal ", array[1])
 	}
 }

--- a/pkg/logproto/marshal_test.go
+++ b/pkg/logproto/marshal_test.go
@@ -51,7 +51,6 @@ func Test_EntryMarshalJSON(t *testing.T) {
 		line, ok := array[1].(string)
 		require.True(t, ok)
 
-		// only test to the microsecond level.  json's number type (float64) does not have enough precision to store nanoseconds
 		require.Equal(t, fmt.Sprint(entry.Timestamp.UnixNano()), timestamp, "Timestamps not equal ", array[0])
 		require.Equal(t, entry.Line, line, "Lines are not equal ", array[1])
 	}

--- a/pkg/logproto/marshal_test.go
+++ b/pkg/logproto/marshal_test.go
@@ -13,21 +13,21 @@ import (
 
 var (
 	entries = []Entry{
-		Entry{
+		{
 			Timestamp: time.Now(),
 			Line:      "testline",
 		},
-		Entry{
+		{
 			Timestamp: time.Date(2019, 9, 10, 1, 1, 1, 1, time.UTC),
 			Line:      "{}\"'!@$%&*^(_)(",
 		},
 	}
 	streams = []Stream{
-		Stream{
+		{
 			Labels:  "{}",
 			Entries: []Entry{},
 		},
-		Stream{
+		{
 			Labels:  "{name=\"value\",name1=\"value1\"}",
 			Entries: []Entry{},
 		},

--- a/pkg/logproto/marshal_test.go
+++ b/pkg/logproto/marshal_test.go
@@ -1,0 +1,44 @@
+package logproto
+
+import (
+	"encoding/json"
+	"testing"
+	time "time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	entries = []Entry{
+		Entry{
+			Timestamp: time.Now(),
+			Line:      "testline",
+		},
+		Entry{
+			Timestamp: time.Date(2019, 9, 10, 1, 1, 1, 1, time.UTC),
+			Line:      "{}\"'!@$%&*^(_)(",
+		},
+	}
+)
+
+func Test_EntryMarshalJSON(t *testing.T) {
+
+	var array []interface{}
+
+	for _, entry := range entries {
+
+		bytes, err := entry.MarshalJSON()
+		require.NoError(t, err)
+
+		err = json.Unmarshal(bytes, &array)
+
+		timestamp, ok := array[0].(float64)
+		require.True(t, ok)
+
+		line, ok := array[1].(string)
+		require.True(t, ok)
+
+		require.Equal(t, entry.Timestamp.UnixNano(), int64(timestamp*1e9), "Timestamps not equal ", array[0])
+		require.Equal(t, entry.Line, line, "Lines are not equal ", array[1])
+	}
+}

--- a/pkg/logproto/marshal_test.go
+++ b/pkg/logproto/marshal_test.go
@@ -38,7 +38,8 @@ func Test_EntryMarshalJSON(t *testing.T) {
 		line, ok := array[1].(string)
 		require.True(t, ok)
 
-		require.Equal(t, entry.Timestamp.UnixNano(), int64(timestamp*1e9), "Timestamps not equal ", array[0])
+		// only test to the microsecond level.  json's number type (float64) does not have enough precision to store nanoseconds
+		require.Equal(t, entry.Timestamp.UnixNano()/int64(time.Microsecond), int64(timestamp*1e9)/int64(time.Microsecond), "Timestamps not equal ", array[0])
 		require.Equal(t, entry.Line, line, "Lines are not equal ", array[1])
 	}
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -127,9 +127,13 @@ func (t *Loki) initDistributor() (err error) {
 	}
 
 	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(t.distributor.ReadinessHandler))
+	t.server.HTTP.Handle("/loki/api/v1/push", middleware.Merge(
+		t.httpAuthMiddleware,
+	).Wrap(http.HandlerFunc(t.distributor.PushHandler)))
 	t.server.HTTP.Handle("/api/prom/push", middleware.Merge(
 		t.httpAuthMiddleware,
 	).Wrap(http.HandlerFunc(t.distributor.PushHandler)))
+
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated the "streams" type returned from the query endpoints to reflect requests in #273 
- Added testing for the custom Marshal methods that make this possible
- Pathed `/loki/v1/api/push` to the push handler.
- Cleaned up documentation to reflect changes and removed deprecated endpoints.
- Set GOGC=20 on test to avoid OOM in circleci

**Which issue(s) this PR fixes**:
Fixes #273

**Special notes for your reviewer**:
- Unmarshal methods will be added and testing improved after this and #987 are merged.  This upcoming PR will add support to logcli for these changes.

**Checklist**
- [x] Documentation added
- [x] Tests updated

