### PR TITLE
bigtable-backup: verify backups to work on latest list of backups

### DIFF
--- a/tools/bigtable-backup/bigtable-backup.py
+++ b/tools/bigtable-backup/bigtable-backup.py
@@ -62,7 +62,10 @@ def ensure_backups(args):
             bigtable_backup_job_last_active_table_backup_time_seconds.set_to_current_time()
 
     num_backups_deleted = 0
-            
+
+    # list backups again to verify them below
+    backups = list_backups(args.destination_path)
+
     print("Checking whether all the backups are created after their period is over and deleting old unwanted backups")
     for table_id, timestamps in backups.items():
         table_number = int(table_id.rsplit("_", 1)[-1])


### PR DESCRIPTION
**What this PR does / why we need it**:

When tables rotate, it creates a final backup of last active table.
Verify backups was not having that last backup in the list so this change makes sure it has latest list of backups.
Without this change an additional unwanted backup was retained which was causing alerts to fire.

