### PR TITLE
feat: -version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ APP_GO_FILES := $(shell find . $(DONT_FIND) -name .y.go -prune -o -name .pb.go -
 
 # Build flags
 VPREFIX := github.com/grafana/loki/vendor/github.com/prometheus/common/version
-GO_LDFLAGS   := -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION)
+GO_LDFLAGS   := -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GO_FLAGS     := -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags netgo
 DYN_GO_FLAGS := -ldflags "$(GO_LDFLAGS)" -tags netgo
 # Per some websites I've seen to add `-gcflags "all=-N -l"`, the gcflags seem poorly if at all documented

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -11,12 +11,13 @@ import (
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/logcli/query"
 	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/version"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
-	app        = kingpin.New("logcli", "A command-line for loki.")
+	app        = kingpin.New("logcli", "A command-line for loki.").Version(version.Print("logcli"))
 	quiet      = app.Flag("quiet", "suppress everything but log lines").Default("false").Short('q').Bool()
 	outputMode = app.Flag("output", "specify output mode [default, raw, jsonl]").Default("default").Short('o').Enum("default", "raw", "jsonl")
 	timezone   = app.Flag("timezone", "Specify the timezone to use when formatting output timestamps [Local, UTC]").Default("Local").Short('z').Enum("Local", "UTC")

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 
 	"github.com/grafana/loki/pkg/canary/comparator"
 	"github.com/grafana/loki/pkg/canary/reader"
@@ -32,7 +33,15 @@ func main() {
 	wait := flag.Duration("wait", 60*time.Second, "Duration to wait for log entries before reporting them lost")
 	pruneInterval := flag.Duration("pruneinterval", 60*time.Second, "Frequency to check sent vs received logs, also the frequency which queries for missing logs will be dispatched to loki")
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
+
+	printVersion := flag.Bool("version", false, "Print this builds version information")
+
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Print(version.Print("loki-canary"))
+		os.Exit(0)
+	}
 
 	if *addr == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "Must specify a Loki address with -addr\n")

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -30,7 +30,14 @@ func main() {
 	)
 	flag.StringVar(&configFile, "config.file", "", "Configuration file to load.")
 	flagext.RegisterFlags(&cfg)
+
+	printVersion := flag.Bool("version", false, "Print this builds version information")
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Print(version.Print("loki"))
+		os.Exit(0)
+	}
 
 	// LimitsConfig has a customer UnmarshalYAML that will set the defaults to a global.
 	// This global is set to the config passed into the last call to `NewOverrides`. If we don't

--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 
@@ -29,7 +30,14 @@ func main() {
 	)
 	flag.StringVar(&configFile, "config.file", "promtail.yml", "The config file.")
 	flagext.RegisterFlags(&config)
+
+	printVersion := flag.Bool("version", false, "Print this builds version information")
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Print(version.Print("promtail"))
+		os.Exit(0)
+	}
 
 	util.InitLogger(&config.ServerConfig.Config)
 


### PR DESCRIPTION
While we were already setting the version on the built binaries, this now also
exposes them as a user-facing flag (`-version`).

The already used Prometheus package `github.com/prometheus/common/version` is
used for generated the printed string.

Fixes #1035 