### PR TITLE
fix: loki/loki helm chart

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.2
+version: 0.14.3
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -43,15 +43,15 @@ Create the name of the service account
 {{- end -}}
 
 {{/*
-Create the app name of the collectors. Defaults to the same logic as "loki.fullname", and default collector expects "promtail".
+Create the app name of loki clients. Defaults to the same logic as "loki.fullname", and default client expects "promtail".
 */}}
-{{- define "collector.name" -}}
-{{- if .Values.collector.name -}}
-{{- .Values.collector.name -}}
-{{- else if .Values.collector.fullnameOverride -}}
-{{- .Values.collector.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "client.name" -}}
+{{- if .Values.client.name -}}
+{{- .Values.client.name -}}
+{{- else if .Values.client.fullnameOverride -}}
+{{- .Values.client.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default "promtail" .Values.collector.nameOverride -}}
+{{- $name := default "promtail" .Values.client.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -41,3 +41,21 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the app name of the collectors. Defaults to the same logic as "loki.fullname", and default collector expects "promtail".
+*/}}
+{{- define "collector.name" -}}
+{{- if .Values.collector.name -}}
+{{- .Values.collector.name -}}
+{{- else if .Values.collector.fullnameOverride -}}
+{{- .Values.collector.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "promtail" .Values.collector.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -19,7 +19,7 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            app: {{ template "promtail.name" . }}
+            app: {{ template "collector.name" . }}
             release: {{ .Release.Name }}
     - ports:
       - port: {{ .Values.service.port }}

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -19,7 +19,7 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            app: {{ template "collector.name" . }}
+            app: {{ template "client".name" . }}
             release: {{ .Release.Name }}
     - ports:
       - port: {{ .Values.service.port }}

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -19,7 +19,7 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            app: {{ template "client".name" . }}
+            app: {{ template "client.name" . }}
             release: {{ .Release.Name }}
     - ports:
       - port: {{ .Values.service.port }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -83,8 +83,8 @@ livenessProbe:
 networkPolicy:
   enabled: false
 
-## If you set enabled as "True" of networkPolicy, you may have to configure the app name for log collectors
-collector: {}
+## If you set enabled as "True" of networkPolicy, you may have to configure the app name for client.
+client: {}
   # name:
 
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -80,9 +80,12 @@ livenessProbe:
     port: http-metrics
   initialDelaySeconds: 45
 
-## Enable persistence using Persistent Volume Claims
 networkPolicy:
   enabled: false
+
+## If you set enabled as "True" of networkPolicy, you may have to configure the app name for log collectors
+collector: {}
+  # name:
 
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the reference error in loki/loki helm chart caused by undeclarated variable "promtail.name".
Instead of declare the variable "promtail.name", I propose that add new variable "collector.name".
For Promtail, the destination for sending logs is always expected to be Loki, but for Loki, log collectors are not always Promtail.
That said, I wrote the default app name as “promtail”, because in standard use cases such as loki-stack, log collectors are expected to be promtail.

**Which issue(s) this PR fixes**:
Fixes #878

**Special notes for your reviewer**:
Although not directly related to the subject above, I recommend to remove (or move to the appropriate location) the comment about PVC on networkPolicy section in values.yaml.
This is because it is not directly related to the network policy (I'm sorry if my understanding is wrong).

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
