### PR TITLE
Fixed broken logql request filtering

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -378,10 +378,11 @@ func (q *Querier) validateQueryRequest(ctx context.Context, req *logproto.QueryR
 		return err
 	}
 
-	matchers, err := logql.ParseMatchers(req.Selector)
+	selector, err := logql.ParseLogSelector(req.Selector)
 	if err != nil {
 		return err
 	}
+	matchers := selector.Matchers()
 
 	maxStreamMatchersPerQuery := q.limits.MaxStreamsMatchersPerQuery(userID)
 	if len(matchers) > maxStreamMatchersPerQuery {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -250,7 +250,7 @@ func defaultLimitsTestConfig() validation.Limits {
 
 func TestQuerier_validateQueryRequest(t *testing.T) {
 	request := logproto.QueryRequest{
-		Selector:  "{type=\"test\", fail=\"yes\"}",
+		Selector:  "{type=\"test\", fail=\"yes\"} |= \"foo\"",
 		Limit:     10,
 		Start:     time.Now().Add(-1 * time.Minute),
 		End:       time.Now(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Logql request filtering is broken on the tip of master due to the new validateQueryRequest failing.
