### PR TITLE
loki: add back new `/loki/api/v1/push` endpoint

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -127,6 +127,9 @@ func (t *Loki) initDistributor() (err error) {
 	}
 
 	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(t.distributor.ReadinessHandler))
+	t.server.HTTP.Handle("/loki/api/v1/push", middleware.Merge(
+		t.httpAuthMiddleware,
+	).Wrap(http.HandlerFunc(t.distributor.PushHandler)))
 	t.server.HTTP.Handle("/api/prom/push", middleware.Merge(
 		t.httpAuthMiddleware,
 	).Wrap(http.HandlerFunc(t.distributor.PushHandler)))


### PR DESCRIPTION
`/loki/api/v1/push` was added in #1010 but was temporarily reverted. #1022 reintroduced changes from #1010 but inadvertently did not reintroduce the new push endpoint.
