### PR TITLE
Changes to promtail logging

### DIFF
--- a/pkg/logentry/stages/output.go
+++ b/pkg/logentry/stages/output.go
@@ -64,16 +64,12 @@ func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interf
 	if v, ok := extracted[o.cfgs.Source]; ok {
 		s, err := getString(v)
 		if err != nil {
-			if Debug {
-				level.Debug(o.logger).Log("msg", "extracted output could not be converted to a string", "err", err, "type", reflect.TypeOf(v).String())
-			}
+			level.Warn(o.logger).Log("msg", "extracted output could not be converted to a string", "source", o.cfgs.Source, "err", err, "type", reflect.TypeOf(v).String())
 			return
 		}
 		*entry = s
 	} else {
-		if Debug {
-			level.Debug(o.logger).Log("msg", "extracted data did not contain output source")
-		}
+		level.Warn(o.logger).Log("msg", "extracted data did not contain output source", "source", o.cfgs.Source)
 	}
 }
 

--- a/pkg/logentry/stages/output.go
+++ b/pkg/logentry/stages/output.go
@@ -67,6 +67,10 @@ func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interf
 			level.Warn(o.logger).Log("msg", "extracted output could not be converted to a string", "source", o.cfgs.Source, "err", err, "type", reflect.TypeOf(v).String())
 			return
 		}
+
+		if Debug {
+			level.Debug(o.logger).Log("msg", "set output", "output", s)
+		}
 		*entry = s
 	} else {
 		level.Warn(o.logger).Log("msg", "extracted data did not contain output source", "source", o.cfgs.Source)

--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -90,18 +90,14 @@ func (o *templateStage) Process(labels model.LabelSet, extracted map[string]inte
 	if v, ok := extracted[o.cfgs.Source]; ok {
 		s, err := getString(v)
 		if err != nil {
-			if Debug {
-				level.Debug(o.logger).Log("msg", "extracted template could not be converted to a string", "err", err, "type", reflect.TypeOf(v).String())
-			}
+			level.Warn(o.logger).Log("msg", "extracted template could not be converted to a string", "err", err, "type", reflect.TypeOf(v).String())
 			return
 		}
 		td := templateData{s}
 		buf := &bytes.Buffer{}
 		err = o.template.Execute(buf, td)
 		if err != nil {
-			if Debug {
-				level.Debug(o.logger).Log("msg", "failed to execute template on extracted value", "err", err, "value", v)
-			}
+			level.Warn(o.logger).Log("msg", "failed to execute template on extracted value", "err", err, "value", v)
 			return
 		}
 		st := buf.String()
@@ -112,20 +108,27 @@ func (o *templateStage) Process(labels model.LabelSet, extracted map[string]inte
 			extracted[o.cfgs.Source] = st
 		}
 
+		if Debug {
+			level.Debug(o.logger).Log("msg", "template output", "out", st)
+		}
 	} else {
 		td := templateData{}
 		buf := &bytes.Buffer{}
 		err := o.template.Execute(buf, td)
 		if err != nil {
-			if Debug {
-				level.Debug(o.logger).Log("msg", "failed to execute template on extracted value", "err", err, "value", v)
-			}
+			level.Warn(o.logger).Log("msg", "failed to execute template on extracted value", "err", err, "value", v)
 			return
 		}
 		st := buf.String()
 		// Do not set extracted data with empty values
 		if st != "" {
 			extracted[o.cfgs.Source] = st
+
+			if Debug {
+				level.Debug(o.logger).Log("msg", "template output", "out", st)
+			}
+		} else if Debug {
+			level.Debug(o.logger).Log("msg", "template output is empty, ignoring")
 		}
 	}
 }

--- a/pkg/logentry/stages/timestamp.go
+++ b/pkg/logentry/stages/timestamp.go
@@ -89,23 +89,20 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]in
 	if v, ok := extracted[ts.cfgs.Source]; ok {
 		s, err := getString(v)
 		if err != nil {
-			if Debug {
-				level.Debug(ts.logger).Log("msg", "failed to convert extracted time to string", "err", err, "type", reflect.TypeOf(v).String())
-			}
+			level.Warn(ts.logger).Log("msg", "failed to convert extracted time to string", "err", err, "type", reflect.TypeOf(v).String())
 		}
 
 		parsedTs, err := ts.parser(s)
 		if err != nil {
-			if Debug {
-				level.Debug(ts.logger).Log("msg", "failed to parse time", "err", err, "format", ts.cfgs.Format, "value", s)
-			}
+			level.Warn(ts.logger).Log("msg", "failed to parse time", "err", err, "format", ts.cfgs.Format, "value", s)
 		} else {
 			*t = parsedTs
+			if Debug {
+				level.Debug(ts.logger).Log("msg", "parsed time", "time", parsedTs)
+			}
 		}
 	} else {
-		if Debug {
-			level.Debug(ts.logger).Log("msg", "extracted data did not contain a timestamp")
-		}
+		level.Warn(ts.logger).Log("msg", "extracted data did not contain a timestamp", "source", ts.cfgs.Source)
 	}
 }
 


### PR DESCRIPTION
- Errors occuring during stage processing are reported as warnings now.
- Debug messages are used to log output of the stage.

**What this PR does / why we need it**:
Unless you run promtail with -log.level debug, finding out what went wrong when processing the log files is currently difficult, because all errors are logged at debug level.

My patch changes that. Errors that occur during line processing are logged with a warning level, and debug level is used to log the output of the stage (which wasn't previously logged at all), eg. parsed timestamp, parsed regexp groups or parsed json expressions.

It adds log lines like:

> level=debug ts=2019-09-25T09:00:25.113827Z caller=regex.go:131 component=file_pipeline component=stage type=regex msg="extracted groups" datetime="2002-05-02 17:42:15" content="172.22.255.255 GET /images/picture.jpg - 200 Mozilla/4.0+(compatible;MSIE+5.5;+Windows+2000+Server)"

for regex, and

> level=debug ts=2019-09-25T09:00:25.113851Z caller=timestamp.go:101 component=file_pipeline msg="parsed time" time=2002-05-02T17:42:15Z

for timestamp.

**Which issue(s) this PR fixes**:
There is no issue.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added -- no documentation added
- [ ] Tests updated -- nope, we don't have tests for log messages.

