### PR TITLE
Helm: Remove default value of storageClassName in loki/loki helm chart

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.16.3
+version: 0.16.4
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: 0.14.2
+version: 0.14.3
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -96,7 +96,6 @@ persistence:
   accessModes:
   - ReadWriteOnce
   size: 10Gi
-  storageClassName: default
   annotations: {}
   # subPath: ""
   # existingClaim:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes that remove default value of storageClassName in loki/loki helm chart, in order to leverage the default storage class feature.

**Which issue(s) this PR fixes**:
Fixes #1050

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated