### PR TITLE
Add Drone CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center"><img src="docs/logo_and_name.png" alt="Loki Logo"></p>
 
+<a href="https://cloud.drone.io/grafana/loki"><img src="https://cloud.drone.io/api/badges/grafana/loki/status.svg" alt="Drone CI" /></a>
 <a href="https://circleci.com/gh/grafana/loki/tree/master"><img src="https://circleci.com/gh/grafana/loki.svg?style=shield&circle-token=618193e5787b2951c1ea3352ad5f254f4f52313d" alt="CircleCI" /></a>
 <a href="https://goreportcard.com/report/github.com/grafana/loki"><img src="https://goreportcard.com/badge/github.com/grafana/loki" alt="Go Report Card" /></a>
 <a href="http://slack.raintank.io/"><img src="https://img.shields.io/badge/join%20slack-%23loki-brightgreen.svg" alt="Slack" /></a>


### PR DESCRIPTION
Since we're slowly moving to Drone CI for all of our CI tasks, it makes sense to include the build status badge in the README.