### PR TITLE
doc: skip jb init when using Tanka

### DIFF
--- a/docs/installation/tanka.md
+++ b/docs/installation/tanka.md
@@ -27,7 +27,6 @@ Grab the Loki module using `jb`:
 
 ```bash
 $ go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-$ jb init
 $ jb install github.com/grafana/loki/production/ksonnet/loki
 ```
 


### PR DESCRIPTION
`tk init` would create file and make `jb init` return error:
```
[root config]# tk init
Directory structure set up! Remember to configure the API endpoint:
`tk env set environments/default --server=127.0.0.1:6443`
[root config]# tk env add environments/default
[root config]# jb init
jb: error: jsonnetfile.json already exists
```

Signed-off-by: Xiang Dai <764524258@qq.com>
