### PR TITLE
doc: unify GOPATH

### DIFF
--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -28,13 +28,13 @@ $ chmod a+x "/usr/local/bin/loki"
 Clone Loki to `$GOPATH/src/github.com/grafana/loki`:
 
 ```bash
-$ git clone https://github.com/grafana/loki $(go env GOPATH)/src/github.com/grafana/loki
+$ git clone https://github.com/grafana/loki $GOPATH/src/github.com/grafana/loki
 ```
 
 Then change into that directory and run `make loki`:
 
 ```bash
-$ cd $(go env GOPATH)/src/github.com/grafana/loki
+$ cd $GOPATH/src/github.com/grafana/loki
 $ make loki
 
 # A file at ./cmd/loki/loki will be created and is the


### PR DESCRIPTION
All other docs use `$GOPATH` rather that `$(go env GOPATH)`, unify them.

Signed-off-by: Xiang Dai <764524258@qq.com>
