### PR TITLE
pkg/ingester: limit total number of errors a stream can return on push

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -296,6 +296,10 @@ The `ingester_config` block configures Ingesters.
 # this chunk rollover doesn't happen.
 [sync_period: <duration> | default = 0]
 [sync_min_utilization: <float> | Default = 0]
+
+# The maximum number of errors a stream will report to the user
+# when a push fails. 0 to make unlimited.
+[max_ignored_stream_errors: <int> | default = 10]
 ```
 
 ### lifecycler_config

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -299,7 +299,7 @@ The `ingester_config` block configures Ingesters.
 
 # The maximum number of errors a stream will report to the user
 # when a push fails. 0 to make unlimited.
-[max_ignored_stream_errors: <int> | default = 10]
+[max_returned_stream_errors: <int> | default = 10]
 ```
 
 ### lifecycler_config

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -56,7 +56,7 @@ type Config struct {
 	SyncPeriod         time.Duration `yaml:"sync_period"`
 	SyncMinUtilization float64       `yaml:"sync_min_utilization"`
 
-	MaxIgnoredErrors int `yaml:"max_ignored_stream_errors"`
+	MaxReturnedErrors int `yaml:"max_returned_stream_errors"`
 
 	// For testing, you can override the address and ID of this ingester.
 	ingesterClientFactory func(cfg client.Config, addr string) (grpc_health_v1.HealthClient, error)
@@ -77,7 +77,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", chunkenc.EncGZIP.String(), fmt.Sprintf("The algorithm to use for compressing chunk. (%s)", chunkenc.SupportedEncoding()))
 	f.DurationVar(&cfg.SyncPeriod, "ingester.sync-period", 0, "How often to cut chunks to synchronize ingesters.")
 	f.Float64Var(&cfg.SyncMinUtilization, "ingester.sync-min-utilization", 0, "Minimum utilization of chunk when doing synchronization.")
-	f.IntVar(&cfg.MaxIgnoredErrors, "ingester.max-ignored-stream-errors", 10, "Maximum number of ignored stream errors to return. 0 to return all errors.")
+	f.IntVar(&cfg.MaxReturnedErrors, "ingester.max-ignored-stream-errors", 10, "Maximum number of ignored stream errors to return. 0 to return all errors.")
 }
 
 // Ingester builds chunks for incoming log streams.

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -28,7 +28,7 @@ func TestLabelsCollisions(t *testing.T) {
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	i := newInstance("test", defaultFactory, limiter, 0, 0)
+	i := newInstance(&Config{}, "test", defaultFactory, limiter, 0, 0)
 
 	// avoid entries from the future.
 	tt := time.Now().Add(-5 * time.Minute)
@@ -55,7 +55,7 @@ func TestConcurrentPushes(t *testing.T) {
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
 
-	inst := newInstance("test", defaultFactory, limiter, 0, 0)
+	inst := newInstance(&Config{}, "test", defaultFactory, limiter, 0, 0)
 
 	const (
 		concurrent          = 10
@@ -113,7 +113,7 @@ func TestSyncPeriod(t *testing.T) {
 		minUtil    = 0.20
 	)
 
-	inst := newInstance("test", defaultFactory, limiter, syncPeriod, minUtil)
+	inst := newInstance(&Config{}, "test", defaultFactory, limiter, syncPeriod, minUtil)
 	lbls := makeRandomLabels()
 
 	tt := time.Now()

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -185,7 +185,7 @@ func (s *stream) Push(_ context.Context, entries []logproto.Entry, synchronizePe
 			streamName := s.labels.String()
 
 			limitedFailedEntries := failedEntriesWithError
-			if maxIgnore := s.cfg.MaxIgnoredErrors; maxIgnore > 0 && len(limitedFailedEntries) > maxIgnore {
+			if maxIgnore := s.cfg.MaxReturnedErrors; maxIgnore > 0 && len(limitedFailedEntries) > maxIgnore {
 				limitedFailedEntries = limitedFailedEntries[:maxIgnore]
 			}
 

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 )
 
-func TestMaxIgnoredStreamsErrors(t *testing.T) {
+func TestMaxReturnedStreamsErrors(t *testing.T) {
 	numLogs := 100
 
 	tt := []struct {
@@ -32,7 +32,7 @@ func TestMaxIgnoredStreamsErrors(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newStream(
-				&Config{MaxIgnoredErrors: tc.limit},
+				&Config{MaxReturnedErrors: tc.limit},
 				model.Fingerprint(0),
 				labels.Labels{
 					{Name: "foo", Value: "bar"},


### PR DESCRIPTION
**What this PR does / why we need it**: Stops ingesters returning a giant error message on Loki clusters with large amounts of traffic.

**Checklist**
- [x] Documentation added
- [x] Tests updated
