### PR TITLE
build: enable journal in promtail linux release build 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,13 @@ cmd/promtail/promtail-debug: $(APP_GO_FILES) pkg/promtail/server/ui/assets_vfsda
 # Releasing #
 #############
 # concurrency is limited to 4 to prevent CircleCI from OOMing. Sorry
-GOX = gox $(GO_FLAGS) -parallel=4 -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -arch="amd64 arm64 arm" -os="linux"
-CGO_GOX = gox $(DYN_GO_FLAGS) -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -arch="amd64" -os="linux"
+GOX = gox $(GO_FLAGS) -parallel=4 -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}"
+CGO_GOX = gox $(DYN_GO_FLAGS) -cgo -parallel=4 -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}"
 dist: clean
-	CGO_ENABLED=0 $(GOX) -osarch="windows/amd64" ./cmd/loki
-	CGO_ENABLED=0 $(GOX) -osarch="darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/promtail ./cmd/logcli
-	CGO_ENABLED=1 $(CGO_GOX) ./cmd/promtail
+	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm windows/amd64" ./cmd/loki
+	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/logcli
+	CGO_ENABLED=0 $(GOX) -osarch="linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/promtail
+	CGO_ENABLED=1 $(CGO_GOX) -osarch="linux/amd64" ./cmd/promtail
 	gzip dist/*
 	pushd dist && sha256sum * > SHA256SUMS && popd
 

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,11 @@ cmd/promtail/promtail-debug: $(APP_GO_FILES) pkg/promtail/server/ui/assets_vfsda
 #############
 # concurrency is limited to 4 to prevent CircleCI from OOMing. Sorry
 GOX = gox $(GO_FLAGS) -parallel=4 -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -arch="amd64 arm64 arm" -os="linux"
+CGO_GOX = gox $(DYN_GO_FLAGS) -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -arch="amd64" -os="linux"
 dist: clean
 	CGO_ENABLED=0 $(GOX) -osarch="windows/amd64" ./cmd/loki
 	CGO_ENABLED=0 $(GOX) -osarch="darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/promtail ./cmd/logcli
+	CGO_ENABLED=1 $(CGO_GOX) ./cmd/promtail
 	gzip dist/*
 	pushd dist && sha256sum * > SHA256SUMS && popd
 


### PR DESCRIPTION
The published binary of promtail for linux/amd64 was not built with CGO support, so journal tailing could not be used.

Fixes #1057.