### PR TITLE
doc(install/tanka): install ksonnet-lib

### DIFF
--- a/docs/installation/tanka.md
+++ b/docs/installation/tanka.md
@@ -27,6 +27,9 @@ Grab the Loki module using `jb`:
 
 ```bash
 $ go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+# Ksonnet kubernetes libraries
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k8s.libsonnet
 $ jb install github.com/grafana/loki/production/ksonnet/loki
 ```
 


### PR DESCRIPTION
Fix below error:
```
# tk show environments/loki
Evaluating jsonnet: RUNTIME ERROR: couldn't open import "k.libsonnet": no match locally or in the Jsonnet library paths
	/root/loki/vendor/ksonnet-util/kausal.libsonnet:2:11-31	thunk <k> from <$>
	/root/loki/vendor/ksonnet-util/kausal.libsonnet:4:1-2	$
	/root/loki/vendor/loki/loki.libsonnet:1:2-40	$
	main.jsonnet:2:14-42	thunk <loki> from <$>
	main.jsonnet:5:1-5	$
	During evaluation	
```
Signed-off-by: Xiang Dai <764524258@qq.com>


