### PR TITLE
Skip ingester tailer filtering if no filter is set

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -128,9 +128,14 @@ func (t *tailer) send(stream logproto.Stream) {
 }
 
 func (t *tailer) filterEntriesInStream(stream *logproto.Stream) {
+	// Optimization: skip filtering entirely, if no filter is set
+	if t.filter == nil {
+		return
+	}
+
 	var filteredEntries []logproto.Entry
 	for _, e := range stream.Entries {
-		if t.filter == nil || t.filter([]byte(e.Line)) {
+		if t.filter([]byte(e.Line)) {
 			filteredEntries = append(filteredEntries, e)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In the (probably unfrequent) case no filter is set (ie. query `{type="test"}`), there's no need to go through all log entries filtering while tailing in `filterEntriesInStream()`.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

