### PR TITLE
Do not retry chunks transferring on shutdown in the local dev env

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -13,6 +13,7 @@ ingester:
     final_sleep: 0s
   chunk_idle_period: 5m
   chunk_retain_period: 30s
+  max_transfer_retries: 1
 
 schema_config:
   configs:


### PR DESCRIPTION
**What this PR does / why we need it**:

When running Loki with the sample config `loki-local-config.yaml`, it takes about 10 seconds to shutdown due to the default ingester's `max_transfer_retries` setting. However, this is usually not a real use case for the local run and I would suggest to set it to `1` (`0` would mean "infinite) to have a nearly-instant shutdown.

**Special notes for your reviewer**:

- The same concept has been previously applied in the PR https://github.com/grafana/loki/pull/784

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

