### PR TITLE
docs: update stages README with the docker and cri stages

### DIFF
--- a/docs/clients/promtail/stages/README.md
+++ b/docs/clients/promtail/stages/README.md
@@ -5,6 +5,8 @@ This section is a collection of all stages Promtail supports in a
 
 Parsing stages:
 
+  * [docker](./docker.md): Extract data by parsing the log line using the standard Docker format.
+  * [cri](./cri.md): Extract data by parsing the log line using the standard CRI format.
   * [regex](./regex.md): Extract data using a regular expression.
   * [json](./json.md): Extract data by parsing the log line as JSON.
 


### PR DESCRIPTION
The newly documented `docker` and `cri` stages need to be included in the `stages/README.md` file as well.