### PR TITLE
Makefile changes to allow easy builds with or without vendoring. Also fixes version bug for both cases.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 .defaults: &defaults
   docker:
-    - image: grafana/loki-build-image:0.7.4
+    - image: grafana/loki-build-image:0.8.0
   working_directory: /src/loki
 
 jobs:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -12,28 +12,28 @@ workspace:
 
 steps:
 - name: test
-  image: grafana/loki-build-image:0.7.4
+  image: grafana/loki-build-image:0.8.0
   commands:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
 
 - name: lint
-  image: grafana/loki-build-image:0.7.4
+  image: grafana/loki-build-image:0.8.0
   commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
 
 - name: check-generated-files
-  image: grafana/loki-build-image:0.7.4
+  image: grafana/loki-build-image:0.8.0
   commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
 
 - name: check-mod
-  image: grafana/loki-build-image:0.7.4
+  image: grafana/loki-build-image:0.8.0
   commands:
   - make BUILD_IN_CONTAINER=false check-mod
   depends_on:
@@ -526,7 +526,7 @@ platform:
 
 steps:
 - name: trigger
-  image: grafana/loki-build-image:0.7.4
+  image: grafana/loki-build-image:0.8.0
   commands:
   - ./tools/deploy.sh
   environment:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@
 
 # options for analysis running
 run:
-  # trust vendored dependencies
-  modules-download-mode: vendor
-
   # default concurrency is a available CPU number
   concurrency: 16
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DONT_FIND := -name tools -prune -o -name vendor -prune -o -name .git -prune -o -
 APP_GO_FILES := $(shell find . $(DONT_FIND) -name .y.go -prune -o -name .pb.go -prune -o -name cmd -prune -o -type f -name '*.go' -print)
 
 # Build flags
-VPREFIX := github.com/grafana/loki/vendor/github.com/prometheus/common/version
+VPREFIX := github.com/grafana/loki/pkg/loki
 GO_LDFLAGS   := -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GO_FLAGS     := -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags netgo $(MOD_VENDOR)
 DYN_GO_FLAGS := -ldflags "$(GO_LDFLAGS)" -tags netgo $(MOD_VENDOR)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,
 # make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := 0.7.4
+BUILD_IMAGE_VERSION := 0.7.5
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DONT_FIND := -name tools -prune -o -name vendor -prune -o -name .git -prune -o -
 APP_GO_FILES := $(shell find . $(DONT_FIND) -name .y.go -prune -o -name .pb.go -prune -o -name cmd -prune -o -type f -name '*.go' -print)
 
 # Build flags
-VPREFIX := github.com/grafana/loki/pkg/loki
+VPREFIX := github.com/grafana/loki/pkg/build
 GO_LDFLAGS   := -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GO_FLAGS     := -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags netgo $(MOD_FLAG)
 DYN_GO_FLAGS := -ldflags "$(GO_LDFLAGS)" -tags netgo $(MOD_FLAG)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@
 .PHONY: benchmark-store, drone, check-mod
 
 SHELL = /usr/bin/env bash
-MOD_VENDOR ?= -mod=vendor
+
+VENDOR?=true
+MOD_VENDOR=
+ifeq ($(VENDOR),true)
+  MOD_VENDOR=-mod=vendor
+endif
+
 #############
 # Variables #
 #############

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,21 @@
 
 SHELL = /usr/bin/env bash
 
-VENDOR?=true
-MOD_VENDOR=
-ifeq ($(VENDOR),true)
-  MOD_VENDOR=-mod=vendor
+# Empty value = no -mod parameter is used.
+# If not empty, GOMOD is passed to -mod= parameter.
+# In Go 1.13, "readonly" and "vendor" are accepted.
+# In Go 1.14, "readonly", "vendor" and "mod" values are accepted.
+# If no value is specified, defaults to "vendor".
+#
+# Can be used from command line by using "GOMOD= make" (empty = no -mod parameter), or "GOMOD=vendor make" (default).
+
+GOMOD?=vendor
+ifeq ($(strip $(GOMOD)),) # Is empty?
+	MOD_VENDOR=
+	GOLANGCI_ARG=
+else
+	MOD_VENDOR=-mod=$(GOMOD)
+	GOLANGCI_ARG=--modules-download-mode=$(GOMOD)
 endif
 
 #############
@@ -226,7 +237,7 @@ publish: dist
 ########
 
 lint:
-	GO111MODULE=on GOGC=10 golangci-lint run -v
+	GO111MODULE=on GOGC=10 golangci-lint run -v $(GOLANGCI_ARG)
 
 ########
 # Test #

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 .PHONY: benchmark-store, drone, check-mod
 
 SHELL = /usr/bin/env bash
-MOD_VENDOR=-mod=vendor
+MOD_VENDOR ?= -mod=vendor
 #############
 # Variables #
 #############

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,
 # make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := 0.7.5
+BUILD_IMAGE_VERSION := 0.8.0
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.4
+ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/docker-driver/main.go
+++ b/cmd/docker-driver/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/go-plugins-helpers/sdk"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/prometheus/common/version"
 	"github.com/weaveworks/common/logging"
 )

--- a/cmd/fluent-bit/out_loki.go
+++ b/cmd/fluent-bit/out_loki.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"C"
+	"fmt"
 	"time"
 	"unsafe"
 
 	"github.com/fluent/fluent-bit-go/output"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/prometheus/common/version"
 	"github.com/weaveworks/common/logging"
 )
-import "fmt"
 
 var plugin *loki
 var logger log.Logger

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/labelquery"
 	"github.com/grafana/loki/pkg/logcli/output"

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.4
+ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	if *printVersion {
-		fmt.Print(version.Print("loki-canary"))
+		fmt.Println(version.Print("loki-canary"))
 		os.Exit(0)
 	}
 

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/canary/comparator"
 	"github.com/grafana/loki/pkg/canary/reader"
 	"github.com/grafana/loki/pkg/canary/writer"

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.4
+ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/go-kit/kit/log/level"
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/cfg"
 	"github.com/grafana/loki/pkg/loki"
 	"github.com/prometheus/client_golang/prometheus"

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 	if *printVersion {
-		fmt.Print(version.Print("loki"))
+		fmt.Println(version.Print("loki"))
 		os.Exit(0)
 	}
 

--- a/cmd/promtail/Dockerfile.cross
+++ b/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.4
+ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/weaveworks/common/logging"
 
+	_ "github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/cfg"
 	"github.com/grafana/loki/pkg/logentry/stages"
 	"github.com/grafana/loki/pkg/promtail"

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -9,12 +9,12 @@ RUN apk add --no-cache curl && \
 FROM alpine as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.21.0
 
 FROM alpine:edge as docker
 RUN apk add --no-cache docker-cli
 
-FROM golang:1.13.1-stretch
+FROM golang:1.13.4-stretch
 RUN apt-get update && \
     apt-get install -qy \
       musl \

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,4 +1,4 @@
-package loki
+package build
 
 import "github.com/prometheus/common/version"
 

--- a/pkg/loki/build.go
+++ b/pkg/loki/build.go
@@ -1,0 +1,23 @@
+package loki
+
+import "github.com/prometheus/common/version"
+
+// Version information passed to Prometheus version package.
+// Package path as used by linker changes based on vendoring being used or not,
+// so it's easier just to use stable Loki path, and pass it to
+// Prometheus in the code.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+)
+
+func init() {
+	version.Version = Version
+	version.Revision = Revision
+	version.Branch = Branch
+	version.BuildUser = BuildUser
+	version.BuildDate = BuildDate
+}

--- a/pkg/promtail/server/ui/doc.go
+++ b/pkg/promtail/server/ui/doc.go
@@ -7,4 +7,4 @@ import (
 	_ "github.com/shurcooL/vfsgen"
 )
 
-//go:generate go run -tags=dev assets_generate.go -build_flags=-mod=vendor
+//go:generate go run -tags=dev assets_generate.go -build_flags="$GOFLAGS"


### PR DESCRIPTION
This PR modifies Makefile to handle builds with or without vendoring.

It uses GOMOD env. variable to set vendoring or not. Content of GOMOD, if defined, is passed to -mod parameter of Go tools. If not defined, it defaults to “vendor”.

Since vendoring or not vendoring modifies import path of `common.Version` (from Prometheus) as visible by linker, versioning information is now stored directly in loki.Version, and passed to `common.Version` on start.
