### PR TITLE
fluent-bit: edge case tests

### DIFF
--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -199,6 +199,22 @@ func Test_labelMapping(t *testing.T) {
 		want    model.LabelSet
 	}{
 		{
+			"empty record",
+			map[string]interface{}{},
+			map[string]interface{}{},
+			model.LabelSet{},
+		},
+		{
+			"empty subrecord",
+			map[string]interface{}{
+				"kubernetes": map[interface{}]interface{}{
+					"foo": []byte("buzz"),
+				},
+			},
+			map[string]interface{}{},
+			model.LabelSet{},
+		},
+		{
 			"bytes string",
 			map[string]interface{}{
 				"kubernetes": map[interface{}]interface{}{
@@ -215,6 +231,39 @@ func Test_labelMapping(t *testing.T) {
 				"nope":   "nope",
 			},
 			model.LabelSet{"test": "buzz", "output": "stderr"},
+		},
+		{
+			"numeric label",
+			map[string]interface{}{
+				"kubernetes": map[interface{}]interface{}{
+					"integer":        42,
+					"floating_point": 42.42,
+				},
+				"stream": "stderr",
+			},
+			map[string]interface{}{
+				"kubernetes": map[string]interface{}{
+					"integer":        "integer",
+					"floating_point": "floating_point",
+				},
+				"stream": "output",
+				"nope":   "nope",
+			},
+			model.LabelSet{"integer": "42", "floating_point": "42.42", "output": "stderr"},
+		},
+		{
+			"list label",
+			map[string]interface{}{
+				"kubernetes": map[interface{}]interface{}{
+					"integers": []int{42, 43},
+				},
+			},
+			map[string]interface{}{
+				"kubernetes": map[string]interface{}{
+					"integers": "integers",
+				},
+			},
+			model.LabelSet{"integers": "[42 43]"},
 		},
 		{
 			"deep string",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR adds some edge case tests to the fluent-bit Loki shipping plugin I added in my draft of the nested JSON relabeling code. All of them run successfully without any code fixes, but they somewhat define the expected behavior for non-string contents. fluent-bit can parse JSON and put it into labels, so one must expect arbitrary JSON (and thus nested maps) with integers, arrays and so on.

If the current behavior (like list `{42, 43}` passed as `[42 43]` to Loki) are not desired, what should they look like? Does Loki support numeric labels? Currently, the plugin just converts them to strings.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

