### PR TITLE
<Examples>: Deploy prometheys from helm chart

### DIFF
--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -39,14 +39,14 @@ $ helm upgrade --install loki loki/loki --set "key1=val1,key2=val2,..."
 ### Deploy Loki Stack (Loki, Promtail, Grafana, Prometheus)
 
 ```bash
-$ helm upgrade --install loki loki/loki-stack  --set grafana.enabled=true
+$ helm upgrade --install loki loki/loki-stack  --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false
 ```
 
 ### Deploy Loki Stack (Loki, fluent-bit, Grafana, Prometheus)
 
 ```bash
 $ helm upgrade --install loki loki/loki-stack \
-    --set fluent-bit.enabled=true,promtail.enabled=false,grafana.enabled=true
+    --set fluent-bit.enabled=true,promtail.enabled=false,grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false
 ```
 
 ## Deploy Grafana to your cluster


### PR DESCRIPTION
Add chart values to deploy prometheus locally. 
This disables persistentVolumes as it'd fail if deployed locally


**What this PR does / why we need it**:

Allows to deploy loki to either `kind` or `k3d` locally to try it out

