### PR TITLE
Clarify journal warning

### DIFF
--- a/pkg/promtail/targets/journaltargetmanager.go
+++ b/pkg/promtail/targets/journaltargetmanager.go
@@ -21,7 +21,7 @@ func NewJournalTargetManager(
 	client api.EntryHandler,
 	scrapeConfigs []scrape.Config,
 ) (*JournalTargetManager, error) {
-	level.Warn(logger).Log("msg", "WARNING!!! Journal target manager initialized on platform without Journal support!")
+	level.Warn(logger).Log("msg", "WARNING!!! Journal target was configured but support for reading the systemd journal is not compiled into this build of promtail!")
 	return &JournalTargetManager{}, nil
 }
 


### PR DESCRIPTION
The current journal warning makes it seem like you're running promtail on a machine that doesn't have systemd. This PR tries to clarify that warning to instead specify that the promtail you are running wasn't compiled with journal support.

Journal support in promtail still requires being built on Linux with CGO_ENABLED=1.
