### PR TITLE
Add logql filter to match stages and drop capability

### DIFF
--- a/docs/clients/promtail/pipelines.md
+++ b/docs/clients/promtail/pipelines.md
@@ -18,7 +18,7 @@ stages:
     2. Change the timestamp of the log line
     3. Change the content of the log line
     4. Create a metric based on the extracted data
-4. **Filtering stages** optionally apply a subset of stages based on some
+4. **Filtering stages** optionally apply a subset of stages or drop entries based on some
    condition.
 
 Typical pipelines will start with a parsing stage (such as a
@@ -28,7 +28,7 @@ something with that extract data. The most common action stage will be a
 [labels](./stages/labels.md) stage to turn extracted data into a label.
 
 A common stage will also be the [match](./stages/match.md) stage to selectively
-apply stages based on the current labels.
+apply stages or drop entries based on a [LogQL stream selector and filter expressions](../../logql.md).
 
 Note that pipelines can not currently be used to deduplicate logs; Loki will
 receive the same log line multiple times if, for example:
@@ -76,9 +76,9 @@ scrape_configs:
           source: timestamp
 
   # This stage is only going to run if the scraped target has a label of
-  # "name" with a value of "nginx".
+  # "name" with a value of "nginx" and if the log line contains the word "GET"
   - match:
-      selector: '{name="nginx"}'
+      selector: '{name="nginx"} |= "GET"'
       stages:
       # This regex stage extracts a new output by matching against some
       # values and capturing the rest.
@@ -126,10 +126,10 @@ scrape_configs:
           level:
           component:
 
-  # This stage will only run if the scraped target has a label of "app"
-  # and a value of "some-app".
+  # This stage will only run if the scraped target has a label "app"
+  # with a value of "some-app" and the log line doesn't contains the word "info"
   - match:
-      selector: '{app="some-app"}'
+      selector: '{app="some-app"} != "info"'
       stages:
       # The regex stage tries to extract a Go panic by looking for panic:
       # in the log message.
@@ -207,4 +207,3 @@ Action stages:
 Filtering stages:
 
   * [match](./stages/match.md): Conditionally run stages based on the label set.
-

--- a/docs/clients/promtail/stages/match.md
+++ b/docs/clients/promtail/stages/match.md
@@ -16,9 +16,9 @@ match:
   # concatenated with job_name using an underscore.
   [pipeline_name: <string>]
 
-  # When set to true (default to false), all entries matching the selector will
+  # When set to drop (default to keep), all entries matching the selector will
   # be dropped. Stages must not be defined when dropping entries.
-  [drop_entries: <bool>]
+  [action: <keep|drop>]
 
   # Nested set of pipeline stages only if the selector
   # matches the labels of the log entries:
@@ -58,13 +58,14 @@ pipeline_stages:
 - match:
     pipeline_name: "app2"
     selector: '{app="pokey"}'
+    action: keep
     stages:
     - json:
         expressions:
           msg: msg
 - match:
     selector: '{app="promtail"} |~ ".*noisy error.*"'
-    drop_entries: true
+    action: drop
 - output:
     source: msg
 ```

--- a/docs/clients/promtail/stages/match.md
+++ b/docs/clients/promtail/stages/match.md
@@ -1,20 +1,24 @@
 # `match` stage
 
 The match stage is a filtering stage that conditionally applies a set of stages
-when a log entry matches a configurable [LogQL](../../../logql.md) stream
-selector.
+or drop entries when a log entry matches a configurable [LogQL](../../../logql.md)
+stream selector and filter expressions.
 
 ## Schema
 
 ```yaml
 match:
-  # LogQL stream selector.
+  # LogQL stream selector and filter expressions.
   selector: <string>
 
   # Names the pipeline. When defined, creates an additional label in
   # the pipeline_duration_seconds histogram, where the value is
   # concatenated with job_name using an underscore.
-  [pipieline_name: <string>]
+  [pipeline_name: <string>]
+
+  # When set to true (default to false), all entries matching the selector will
+  # be dropped. Stages must not be defined when dropping entries.
+  [drop_entries: <bool>]
 
   # Nested set of pipeline stages only if the selector
   # matches the labels of the log entries:
@@ -46,39 +50,47 @@ pipeline_stages:
 - labels:
     app:
 - match:
-    selector: "{app=\"loki\"}"
+    selector: '{app="loki"}'
     stages:
     - json:
         expressions:
           msg: message
 - match:
     pipeline_name: "app2"
-    selector: "{app=\"pokey\"}"
+    selector: '{app="pokey"}'
     stages:
     - json:
         expressions:
           msg: msg
+- match:
+    selector: '{app="promtail"} |~ ".*noisy error.*"'
+    drop_entries: true
 - output:
     source: msg
 ```
 
-And the given log line:
+And given log lines:
 
-```
+```json
 { "time":"2012-11-01T22:08:41+00:00", "app":"loki", "component": ["parser","type"], "level" : "WARN", "message" : "app1 log line" }
+{ "time":"2012-11-01T22:08:41+00:00", "app":"promtail", "component": ["parser","type"], "level" : "ERROR", "message" : "foo noisy error" }
 ```
 
-The first stage will add `app` with a value of `loki` into the extracted map,
+The first stage will add `app` with a value of `loki` into the extracted map for the first log line,
 while the second stage will add `app` as a label (again with the value of `loki`).
+The second line will follow the same flow and will be added the label `app` with a value of `promtail`.
 
 The third stage uses LogQL to only execute the nested stages when there is a
-label of `app` whose value is `loki`. This matches in our case; the nested
+label of `app` whose value is `loki`. This matches the first line in our case; the nested
 `json` stage then adds `msg` into the extracted map with a value of `app1 log
 line`.
 
 The fourth stage uses LogQL to only executed the nested stages when there is a
 label of `app` whose value is `pokey`. This does **not** match in our case, so
 the nested `json` stage is not ran.
+
+The fifth stage will drop any entries from the application `promtail` that matches
+the regex `.*noisy error`.
 
 The final `output` stage changes the contents of the log line to be the value of
 `msg` from the extracted map. In this case, the log line is changed to `app1 log

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -114,7 +114,7 @@ func (m *matcherStage) Process(labels model.LabelSet, extracted map[string]inter
 	if m.filter == nil || m.filter([]byte(*entry)) {
 		// Adds the drop label to not be sent by the api.EntryHandler
 		if m.drop {
-			labels[dropLabel] = "true"
+			labels[dropLabel] = ""
 			return
 		}
 		m.pipeline.Process(labels, extracted, t, entry)

--- a/pkg/logentry/stages/match_test.go
+++ b/pkg/logentry/stages/match_test.go
@@ -101,57 +101,55 @@ func TestMatcher(t *testing.T) {
 	tests := []struct {
 		selector string
 		labels   map[string]string
-		drop     bool
+		action   string
 
 		shouldDrop bool
 		shouldRun  bool
 		wantErr    bool
 	}{
-		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, false, false, false, false},
-		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, false, false, false, false},
-		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, false, false, false, false},
-		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, true, true, false, false},
-		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, true, true, false, false},
-		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, true, false, false, false},
-		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, true, false, false, false},
-		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, true, true, false, false},
-		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, true, true, false, false},
-		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, true, false, false, false},
-		{`{foo="bar"} !~ "[]"`, map[string]string{"foo": "bar"}, false, false, false, true},
-		{"foo", map[string]string{"foo": "bar"}, false, false, false, true},
-		{"{}", map[string]string{"foo": "bar"}, false, false, false, true},
-		{"{", map[string]string{"foo": "bar"}, false, false, false, true},
-		{"", map[string]string{"foo": "bar"}, false, false, true, true},
-		{`{foo="bar"}`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo=""}`, map[string]string{"foo": "bar"}, false, false, false, false},
-		{`{foo=""}`, map[string]string{}, false, false, true, false},
-		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, false, false, false, false},
-		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, true, false, false, false},
-		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, false, false, true, false},
-		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, true, true, false, false},
-		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, false, false},
-		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, true, true, false, false},
-		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, true, false},
-		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, false, false},
-		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, true, false, false, false},
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar"} !~ "[]"`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, true},
+		{"foo", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"{}", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"{", map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
+		{"", map[string]string{"foo": "bar"}, MatchActionKeep, false, true, true},
+		{`{foo="bar"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo=""}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo=""}`, map[string]string{}, MatchActionKeep, false, true, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, MatchActionDrop, false, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, MatchActionKeep, false, true, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, MatchActionDrop, true, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionDrop, true, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, true, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionKeep, false, false, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionDrop, false, false, false},
 
-		{`{foo=""}`, map[string]string{}, false, false, true, false},
+		{`{foo=""}`, map[string]string{}, MatchActionKeep, false, true, false},
 	}
 
 	for _, tt := range tests {
-		name := fmt.Sprintf("%s/%s", tt.selector, tt.labels)
-		if tt.drop {
-			name += "_drop"
-		}
+		name := fmt.Sprintf("%s/%s/%s", tt.selector, tt.labels, tt.action)
+
 		t.Run(name, func(t *testing.T) {
 			// Build a match config which has a simple label stage that when matched will add the test_label to
 			// the labels in the pipeline.
 			var stages PipelineStages
-			if !tt.drop {
+			if tt.action != MatchActionDrop {
 				stages = PipelineStages{
 					PipelineStage{
 						StageTypeLabel: LabelsConfig{
@@ -164,7 +162,7 @@ func TestMatcher(t *testing.T) {
 				nil,
 				tt.selector,
 				stages,
-				tt.drop,
+				tt.action,
 			}
 			s, err := newMatcherStage(util.Logger, nil, matchConfig, prometheus.DefaultRegisterer)
 			if (err != nil) != tt.wantErr {
@@ -206,12 +204,13 @@ func Test_validateMatcherConfig(t *testing.T) {
 		{"empty", nil, true},
 		{"pipeline name required", &MatcherConfig{PipelineName: &empty}, true},
 		{"selector required", &MatcherConfig{PipelineName: &notempty, Selector: ""}, true},
-		{"nil stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: nil}, true},
-		{"empty stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: []interface{}{}}, true},
-		{"stages with dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: true, Stages: []interface{}{""}}, true},
-		{"empty stages dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: true, Stages: []interface{}{}}, false},
-		{"stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: []interface{}{""}}, false},
-		{"bad selector", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo}`, DropEntries: false, Stages: []interface{}{""}}, true},
+		{"nil stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: nil}, true},
+		{"empty stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: []interface{}{}}, true},
+		{"stages with dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: []interface{}{""}}, true},
+		{"empty stages dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, Action: MatchActionDrop, Stages: []interface{}{}}, false},
+		{"stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, Action: MatchActionKeep, Stages: []interface{}{""}}, false},
+		{"bad selector", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo}`, Action: MatchActionKeep, Stages: []interface{}{""}}, true},
+		{"bad action", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo}`, Action: "nope", Stages: []interface{}{""}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/logentry/stages/match_test.go
+++ b/pkg/logentry/stages/match_test.go
@@ -99,43 +99,72 @@ func TestMatchPipeline(t *testing.T) {
 func TestMatcher(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		matcher string
-		labels  map[string]string
+		selector string
+		labels   map[string]string
+		drop     bool
 
-		shouldRun bool
-		wantErr   bool
+		shouldDrop bool
+		shouldRun  bool
+		wantErr    bool
 	}{
-		{"{foo=\"bar\"} |= \"foo\"", map[string]string{"foo": "bar"}, false, true},
-		{"{foo=\"bar\"} |~ \"foo\"", map[string]string{"foo": "bar"}, false, true},
-		{"foo", map[string]string{"foo": "bar"}, false, true},
-		{"{}", map[string]string{"foo": "bar"}, false, true},
-		{"{", map[string]string{"foo": "bar"}, false, true},
-		{"", map[string]string{"foo": "bar"}, true, true},
-		{"{foo=\"bar\"}", map[string]string{"foo": "bar"}, true, false},
-		{"{foo=\"\"}", map[string]string{"foo": "bar"}, false, false},
-		{"{foo=\"\"}", map[string]string{}, true, false},
-		{"{foo!=\"bar\"}", map[string]string{"foo": "bar"}, false, false},
-		{"{foo=\"bar\",bar!=\"test\"}", map[string]string{"foo": "bar"}, true, false},
-		{"{foo=\"bar\",bar!=\"test\"}", map[string]string{"foo": "bar", "bar": "test"}, false, false},
-		{"{foo=\"bar\",bar=~\"te.*\"}", map[string]string{"foo": "bar", "bar": "test"}, true, false},
-		{"{foo=\"bar\",bar!~\"te.*\"}", map[string]string{"foo": "bar", "bar": "test"}, false, false},
-		{"{foo=\"\"}", map[string]string{}, true, false},
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, false, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, false, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, false, false, false, false},
+		{`{foo="bar"} |= "foo"`, map[string]string{"foo": "bar"}, true, true, false, false},
+		{`{foo="bar"} |~ "foo"`, map[string]string{"foo": "bar"}, true, true, false, false},
+		{`{foo="bar"} |= "bar"`, map[string]string{"foo": "bar"}, true, false, false, false},
+		{`{foo="bar"} |~ "bar"`, map[string]string{"foo": "bar"}, true, false, false, false},
+		{`{foo="bar"} != "bar"`, map[string]string{"foo": "bar"}, true, true, false, false},
+		{`{foo="bar"} !~ "bar"`, map[string]string{"foo": "bar"}, true, true, false, false},
+		{`{foo="bar"} != "foo"`, map[string]string{"foo": "bar"}, true, false, false, false},
+		{`{foo="bar"} !~ "[]"`, map[string]string{"foo": "bar"}, false, false, false, true},
+		{"foo", map[string]string{"foo": "bar"}, false, false, false, true},
+		{"{}", map[string]string{"foo": "bar"}, false, false, false, true},
+		{"{", map[string]string{"foo": "bar"}, false, false, false, true},
+		{"", map[string]string{"foo": "bar"}, false, false, true, true},
+		{`{foo="bar"}`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo=""}`, map[string]string{"foo": "bar"}, false, false, false, false},
+		{`{foo=""}`, map[string]string{}, false, false, true, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, false, false, false, false},
+		{`{foo!="bar"}`, map[string]string{"foo": "bar"}, true, false, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, false, false, true, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar"}, true, true, false, false},
+		{`{foo="bar",bar!="test"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, true, true, false, false},
+		{`{foo="bar",bar=~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, true, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, false, false, false, false},
+		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, true, false, false, false},
+
+		{`{foo=""}`, map[string]string{}, false, false, true, false},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s/%s", tt.matcher, tt.labels), func(t *testing.T) {
+		name := fmt.Sprintf("%s/%s", tt.selector, tt.labels)
+		if tt.drop {
+			name += "_drop"
+		}
+		t.Run(name, func(t *testing.T) {
 			// Build a match config which has a simple label stage that when matched will add the test_label to
 			// the labels in the pipeline.
-			matchConfig := MatcherConfig{
-				nil,
-				tt.matcher,
-				PipelineStages{
+			var stages PipelineStages
+			if !tt.drop {
+				stages = PipelineStages{
 					PipelineStage{
 						StageTypeLabel: LabelsConfig{
 							"test_label": nil,
 						},
 					},
-				},
+				}
+			}
+			matchConfig := MatcherConfig{
+				nil,
+				tt.selector,
+				stages,
+				tt.drop,
 			}
 			s, err := newMatcherStage(util.Logger, nil, matchConfig, prometheus.DefaultRegisterer)
 			if (err != nil) != tt.wantErr {
@@ -143,7 +172,7 @@ func TestMatcher(t *testing.T) {
 				return
 			}
 			if s != nil {
-				ts, entry := time.Now(), ""
+				ts, entry := time.Now(), "foo"
 				extracted := map[string]interface{}{
 					"test_label": "unimportant value",
 				}
@@ -156,6 +185,40 @@ func TestMatcher(t *testing.T) {
 						t.Error("stage ran but should have not")
 					}
 				}
+				if tt.shouldDrop {
+					if _, ok := labels[dropLabel]; !ok {
+						t.Error("stage should have been dropped")
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_validateMatcherConfig(t *testing.T) {
+	empty := ""
+	notempty := "test"
+	tests := []struct {
+		name    string
+		cfg     *MatcherConfig
+		wantErr bool
+	}{
+		{"empty", nil, true},
+		{"pipeline name required", &MatcherConfig{PipelineName: &empty}, true},
+		{"selector required", &MatcherConfig{PipelineName: &notempty, Selector: ""}, true},
+		{"nil stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: nil}, true},
+		{"empty stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: []interface{}{}}, true},
+		{"stages with dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: true, Stages: []interface{}{""}}, true},
+		{"empty stages dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: true, Stages: []interface{}{}}, false},
+		{"stages without dropping", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo"}`, DropEntries: false, Stages: []interface{}{""}}, false},
+		{"bad selector", &MatcherConfig{PipelineName: &notempty, Selector: `{app="foo}`, DropEntries: false, Stages: []interface{}{""}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateMatcherConfig(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMatcherConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 		})
 	}

--- a/pkg/logentry/stages/pipeline.go
+++ b/pkg/logentry/stages/pipeline.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/loki/pkg/promtail/api"
 )
 
+const dropLabel = "__drop__"
+
 // PipelineStages contains configuration for each stage within a pipeline
 type PipelineStages = []interface{}
 
@@ -102,6 +104,10 @@ func (p *Pipeline) Wrap(next api.EntryHandler) api.EntryHandler {
 	return api.EntryHandlerFunc(func(labels model.LabelSet, timestamp time.Time, line string) error {
 		extracted := map[string]interface{}{}
 		p.Process(labels, extracted, &timestamp, &line)
+		// if the labels set contains the __drop__ label we don't send this entry to the next EntryHandler
+		if _, ok := labels[dropLabel]; ok {
+			return nil
+		}
 		return next.Handle(labels, timestamp, line)
 	})
 }

--- a/pkg/logentry/stages/pipeline_test.go
+++ b/pkg/logentry/stages/pipeline_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/yaml.v2"
 )
 
@@ -165,6 +164,67 @@ func BenchmarkPipeline(b *testing.B) {
 				extracted := map[string]interface{}{}
 				pl.Process(lb, extracted, &ts, &entry)
 			}
+		})
+	}
+}
+
+type stubHandler struct {
+	bool
+}
+
+func (s *stubHandler) Handle(labels model.LabelSet, time time.Time, entry string) error {
+	s.bool = true
+	return nil
+}
+
+func TestPipeline_Wrap(t *testing.T) {
+	now := time.Now()
+	var config map[string]interface{}
+	err := yaml.Unmarshal([]byte(testYaml), &config)
+	if err != nil {
+		panic(err)
+	}
+	p, err := NewPipeline(util.Logger, config["pipeline_stages"].([]interface{}), nil, prometheus.DefaultRegisterer)
+	if err != nil {
+		panic(err)
+	}
+
+	tests := map[string]struct {
+		labels     model.LabelSet
+		shouldSend bool
+	}{
+		"should drop": {
+			map[model.LabelName]model.LabelValue{
+				"__drop__":    "true",
+				"stream":      "stderr",
+				"action":      "GET",
+				"status_code": "200",
+			},
+			false,
+		},
+		"should send": {
+			map[model.LabelName]model.LabelValue{
+				"stream":      "stderr",
+				"action":      "GET",
+				"status_code": "200",
+			},
+			true,
+		},
+	}
+
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			extracted := map[string]interface{}{}
+			p.Process(tt.labels, extracted, &now, &rawTestLine)
+			stub := &stubHandler{}
+			handler := p.Wrap(stub)
+			if err := handler.Handle(tt.labels, now, rawTestLine); err != nil {
+				t.Fatalf("failed to handle entry: %v", err)
+			}
+			assert.Equal(t, stub.bool, tt.shouldSend)
+
 		})
 	}
 }

--- a/pkg/logentry/stages/pipeline_test.go
+++ b/pkg/logentry/stages/pipeline_test.go
@@ -195,7 +195,7 @@ func TestPipeline_Wrap(t *testing.T) {
 	}{
 		"should drop": {
 			map[model.LabelName]model.LabelValue{
-				"__drop__":    "true",
+				dropLabel:     "true",
 				"stream":      "stderr",
 				"action":      "GET",
 				"status_code": "200",


### PR DESCRIPTION
This adds filter expressions to the match stage such as :

 - `{job="mysql"} |= "error"`
- `{name="kafka"} |~ "tsdb-ops.*io:2003"`
- `{instance=~"kafka-[23]",name="kafka"} != kafka.server:type=ReplicaManager`

but also introduces a new property `action` that when set to `drop` will drop all matching entries.

Fixes https://github.com/grafana/loki/issues/1092 and https://github.com/grafana/loki/issues/553
