### PR TITLE
promtail: initialize extracted map with initial labels

### DIFF
--- a/docs/clients/promtail/pipelines.md
+++ b/docs/clients/promtail/pipelines.md
@@ -24,7 +24,7 @@ stages:
 Typical pipelines will start with a parsing stage (such as a
 [regex](./stages/regex.md) or [json](./stages/json.md) stage) to extract data
 from the log line. Then, a series of action stages will be present to do
-something with that extract data. The most common action stage will be a
+something with that extracted data. The most common action stage will be a
 [labels](./stages/labels.md) stage to turn extracted data into a label.
 
 A common stage will also be the [match](./stages/match.md) stage to selectively
@@ -153,7 +153,7 @@ scrape_configs:
 The following sections further describe the types that are accessible to each
 stage (although not all may be used):
 
-##### Label Set
+#### Label Set
 
 The current set of labels for the log line. Initialized to be the set of labels
 that were scraped along with the log line. The label set is only modified by an
@@ -161,7 +161,7 @@ action stage, but filtering stages read from it.
 
 The final label set will be index by Loki and can be used for queries.
 
-##### Extracted Map
+#### Extracted Map
 
 A collection of key-value pairs extracted during a parsing stage. Subsequent
 stages operate on the extracted map, either transforming them or taking action
@@ -169,14 +169,22 @@ with them. At the end of a pipeline, the extracted map is discarded; for a
 parsing stage to be useful, it must always be paired with at least one action
 stage.
 
-##### Log Timestamp
+The extracted map is initialized with the same set of initial labels that were
+scraped along with the log line. This initial data allows for taking action on
+the values of labels inside pipeline stages that only manipulate the extracted
+map. For example, log entries tailed from files have the label `filename` whose
+value is the file path that was tailed. When a pipeline executes for that log
+entry, the initial extracted map would contain `filename` using the same value
+as the label.
+
+#### Log Timestamp
 
 The current timestamp for the log line. Action stages can modify this value.
 If left unset, it defaults to the time when the log was scraped.
 
 The final value for the timestamp is sent to Loki.
 
-##### Log Line
+#### Log Line
 
 The current log line, represented as text. Initialized to be the text that
 Promtail scraped. Action stages can modify this value.

--- a/pkg/logentry/stages/pipeline.go
+++ b/pkg/logentry/stages/pipeline.go
@@ -77,6 +77,13 @@ func NewPipeline(logger log.Logger, stgs PipelineStages, jobName *string, regist
 // Process implements Stage allowing a pipeline stage to also be an entire pipeline
 func (p *Pipeline) Process(labels model.LabelSet, extracted map[string]interface{}, ts *time.Time, entry *string) {
 	start := time.Now()
+
+	// Initialize the extracted map with the initial labels (ie. "filename"),
+	// so that stages can operate on initial labels too
+	for labelName, labelValue := range labels {
+		extracted[string(labelName)] = string(labelValue)
+	}
+
 	for i, stage := range p.stages {
 		if Debug {
 			level.Debug(p.logger).Log("msg", "processing pipeline", "stage", i, "name", stage.Name(), "labels", labels, "time", ts, "entry", entry)

--- a/pkg/logentry/stages/regex.go
+++ b/pkg/logentry/stages/regex.go
@@ -85,7 +85,7 @@ func parseRegexConfig(config interface{}) (*RegexConfig, error) {
 // Process implements Stage
 func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
 	// If a source key is provided, the regex stage should process it
-	// from the exctracted map, otherwise should fallback to the entry
+	// from the extracted map, otherwise should fallback to the entry
 	input := entry
 
 	if r.cfg.Source != nil {
@@ -117,7 +117,7 @@ func (r *regexStage) Process(labels model.LabelSet, extracted map[string]interfa
 	match := r.expression.FindStringSubmatch(*input)
 	if match == nil {
 		if Debug {
-			level.Debug(r.logger).Log("msg", "regex did not match")
+			level.Debug(r.logger).Log("msg", "regex did not match", "input", *input, "regex", r.expression)
 		}
 		return
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Initial labels (populated before the pipeline stages run) are unaccessible from the pipeline stages, thus it's not possible to operate on them (ie. `filename` initial label). The idea proposed in this PR is to initially populate the `extracted` map with the initial labels.

**Which issue(s) this PR fixes**:
Fixes #775

**Special notes for your reviewer**:
- This is an alternative approach to the PR #1013 (which is regex specific)

**Checklist**
- [ ] Documentation added
- [x] Tests updated

