### PR TITLE
promtail: added action_on_failure support to timestamp stage

### DIFF
--- a/docs/clients/promtail/stages/timestamp.md
+++ b/docs/clients/promtail/stages/timestamp.md
@@ -19,6 +19,11 @@ timestamp:
 
   # IANA Timezone Database string.
   [location: <string>]
+
+  # Which action should be taken in case the timestamp can't
+  # be extracted or parsed. Valid values are: [skip, fudge].
+  # Defaults to "fudge".
+  [action_on_failure: <string>]
 ```
 
 The `format` field can be provided as an "example" of what timestamps look like
@@ -67,6 +72,15 @@ should be used in the custom format.
 | Timezone name       | `MST`                                                                                                                                |
 | Timezone offset     | `-0700`, `-070000` (with seconds), `-07`, `07:00`, `-07:00:00` (with seconds)                                                        |
 | Timezone ISO-8601   | `Z0700` (Z for UTC or time offset), `Z070000`, `Z07`, `Z07:00`, `Z07:00:00`                                                          |
+
+The `action_on_failure` setting defines which action should be taken by the
+stage in case the `source` field doesn't exist in the extracted data or the
+timestamp parsing fails. The supported actions are:
+
+- `fudge` (default): change the timestamp to the last known timestamp, summing
+  up 1 nanosecond (to guarantee log entries ordering)
+- `skip`: do not change the timestamp and keep the time when the log entry has
+  been scraped by Promtail
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.9.6 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hpcloud/tail v1.0.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/json-iterator/go v1.1.7

--- a/pkg/logentry/stages/extensions.go
+++ b/pkg/logentry/stages/extensions.go
@@ -24,9 +24,8 @@ func NewDocker(logger log.Logger, registerer prometheus.Registerer) (Stage, erro
 			}},
 		PipelineStage{
 			StageTypeTimestamp: TimestampConfig{
-				"timestamp",
-				RFC3339Nano,
-				nil,
+				Source: "timestamp",
+				Format: RFC3339Nano,
 			}},
 		PipelineStage{
 			StageTypeOutput: OutputConfig{
@@ -51,9 +50,8 @@ func NewCRI(logger log.Logger, registerer prometheus.Registerer) (Stage, error) 
 		},
 		PipelineStage{
 			StageTypeTimestamp: TimestampConfig{
-				"time",
-				RFC3339Nano,
-				nil,
+				Source: "time",
+				Format: RFC3339Nano,
 			},
 		},
 		PipelineStage{

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -1,0 +1,15 @@
+package util
+
+func StringRef(value string) *string {
+	return &value
+}
+
+func StringSliceContains(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringSliceContains(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		inputSlice []string
+		inputValue string
+		expected   bool
+	}{
+		"should return false on missing value in the slice": {
+			inputSlice: []string{"one", "two"},
+			inputValue: "three",
+			expected:   false,
+		},
+		"should return true on existing value in the slice": {
+			inputSlice: []string{"one", "two"},
+			inputValue: "two",
+			expected:   true,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			actual := StringSliceContains(testData.inputSlice, testData.inputValue)
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when the timestamp stage fails to parse the timestamp on a log entry, it keeps the time of when the entry has been scraped by Promtail. This may cause logs to fail to ingest due to out of order timestamps, because the "scrape timestamp" of an entry which failed parsing may be more recent than the "parsed timestamp" of a subsequent log entry.

In this PR I'm introducing the timestamp stage setting `action_on_failure` which can be:
- `fudge` (new default): change the timestamp to the last known timestamp, summing up 1 nanosecond
- `skip` (old behavior): do not change the timestamp and keep the time when the log entry has been scraped by Promtail

Unfortunately, just keeping an overall "last parsed timestamp" is not enough, because a single pipeline instance can process multiple targets (ie. logs from multiple files) and log timestamps should be expected to be ordered per single file only. For this reason, I've introduced an LRU cache to keep the "last known timestamp per target file" (the reason why I used an LRU is to add a cap to the max number of entries stored). So far, I haven't found a good solution for the journal target: any suggestion?

**Which issue(s) this PR fixes**:
Fixes #1093

**Special notes for your reviewer**:
- I've picked `github.com/hashicorp/golang-lru` for the LRU, which is already a dependency of other dependecies we have 

**Checklist**
- [x] Documentation added
- [x] Tests updated

