### PR TITLE
bigtable-backup: list backups just before starting deletion of wanted backups

### DIFF
--- a/tools/bigtable-backup/bigtable-backup.py
+++ b/tools/bigtable-backup/bigtable-backup.py
@@ -63,10 +63,7 @@ def ensure_backups(args):
 
     num_backups_deleted = 0
 
-    # list backups again to verify them below
-    backups = list_backups(args.destination_path)
-
-    print("Checking whether all the backups are created after their period is over and deleting old unwanted backups")
+    print("Checking whether all the backups are created after their period is over")
     for table_id, timestamps in backups.items():
         table_number = int(table_id.rsplit("_", 1)[-1])
         last_timestamp_from_table_number = find_last_timestamp_from_table_number(table_number,
@@ -75,6 +72,13 @@ def ensure_backups(args):
         # Checking whether backup is created after last timestamp of tables period.
         if last_timestamp_from_table_number > timestamps[-1]:
             create_backup(table_id, args)
+
+    # list backups again to consider for deletion of unwanted backups since new backups might have been created above
+    backups = list_backups(args.destination_path)
+
+    print("Deleting old unwanted backups")
+    for table_id, timestamps in backups.items():
+        table_number = int(table_id.rsplit("_", 1)[-1])
 
         # Retain only most recent backup for non active table
         if table_number != active_table_number and len(timestamps) > 1:


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete backup was not working on latest list of backups which was causing more backups to be retained. This fix makes sure deletion of old unwanted backups happen on latest list of backups.

