### PR TITLE
pkg/canary: use default HTTP client when reading from Loki

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -109,8 +109,6 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	}
 	_, _ = fmt.Fprintf(r.w, "Querying loki for missing values with query: %v\n", u.String())
 
-	client := &http.Client{}
-
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -118,7 +116,7 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 
 	req.SetBasicAuth(r.user, r.pass)
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The [documentation](https://golang.org/pkg/net/http/#Client) for net/http.Client says the following:

> A Client is an HTTP client. Its zero value (DefaultClient) is a usable client that uses DefaultTransport.
>
> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines.
>
> A Client is higher-level than a RoundTripper (such as Transport) and additionally handles HTTP details such as cookies and redirects.

Canary was creating a new `http.Client` every time a query request was made to Loki, causing a new TCP connection to be established each time. If Loki has an outage, it's possible to get into a situation where all websocket requests are failing and for a high volume of requests to go through the normal query route. This can possibly lead to networking issues like socket starvation.
