### PR TITLE
bump up golangci to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 .defaults: &defaults
   docker:
-    - image: grafana/loki-build-image:0.7.2
+    - image: grafana/loki-build-image:0.7.3
   working_directory: /src/loki
 
 jobs:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -5,19 +5,19 @@ steps:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.7.2
+  image: grafana/loki-build-image:0.7.3
   name: test
 - commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.7.2
+  image: grafana/loki-build-image:0.7.3
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.7.2
+  image: grafana/loki-build-image:0.7.3
   name: check-generated-files
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -25,7 +25,7 @@ steps:
   - clone
   - test
   - lint
-  image: grafana/loki-build-image:0.7.2
+  image: grafana/loki-build-image:0.7.3
   name: check-mod
 workspace:
   base: /src
@@ -492,7 +492,7 @@ steps:
   environment:
     CIRCLE_TOKEN:
       from_secret: circle_token
-  image: grafana/loki-build-image:0.7.2
+  image: grafana/loki-build-image:0.7.3
   name: trigger
 trigger:
   ref:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,
 # make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable
 BUILD_IN_CONTAINER ?= true
-BUILD_IMAGE_VERSION := 0.7.2
+BUILD_IMAGE_VERSION := 0.7.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ publish: dist
 ########
 
 lint:
-	GO111MODULE=on GOGC=10 golangci-lint run -j 4
+	GO111MODULE=on GOGC=10 golangci-lint run --timeout=5m
 
 ########
 # Test #

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ publish: dist
 ########
 
 lint:
-	GO111MODULE=on GOGC=10 golangci-lint run --timeout=5m
+	GO111MODULE=on GOGC=10 golangci-lint run --timeout=5m -j 16
 
 ########
 # Test #

--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.2
+ARG BUILD_IMAGE=grafana/loki-build-image:0.7.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.2
+ARG BUILD_IMAGE=grafana/loki-build-image:0.7.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.2
+ARG BUILD_IMAGE=grafana/loki-build-image:0.7.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/promtail/Dockerfile.cross
+++ b/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.7.2
+ARG BUILD_IMAGE=grafana/loki-build-image:0.7.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache curl && \
 FROM alpine as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.19.1
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
 
 FROM alpine:edge as docker
 RUN apk add --no-cache docker-cli


### PR DESCRIPTION
Fix following warn:
```
+ make BUILD_IN_CONTAINER=false lint
GO111MODULE=on GOGC=10 golangci-lint run -j 4
level=warning msg="[runner/golint] Golint: can't lint 5 files: no file name for file &{Doc:<nil> Package:54184492 Name:main Decls:[0xc033cb7d40 0xc033cb7dc0 0xc03c4ccd50 0xc033cb7f40 0xc033cb7fc0 0xc033b9a000 0xc033b9a240 0xc03bde19b0] Scope:scope 0xc03bfe6ca0 {\n\tvar defaultClientCfg\n\ttype ConfigGetter\n\ttype format\n\tconst jsonFormat\n\tconst kvPairFormat\n\ttype config\n\tfunc parseConfig\n}\n Imports:[0xc03c4cc720 0xc03c4cc810 0xc03c4cc840 0xc03c4cc870 0xc03c4cc8a0 0xc03c4cc8d0 0xc03c4cc9c0 0xc03c4cc9f0 0xc03c4cca20 0xc03c4cca80 0xc03c4ccab0 0xc03c4ccba0 0xc03c4ccc00] Unresolved:[client flagext string string int iota client logging string string bool string error flagext nil nil errors strconv nil nil fmt time time strconv nil nil fmt logql nil nil make model model model lokiflag logging nil nil fmt strings strings false true nil fmt nil fmt ioutil nil nil fmt json nil nil fmt nil nil] Comments:[0xc0372bc660]}"
```

Details refer to [issue](https://github.com/golangci/golangci-lint/issues/755), it is fixed in v1.20.

Signed-off-by: Xiang Dai <764524258@qq.com>