### PR TITLE
Helm chart: Allow additional scrape_configs to be added

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.17.0
+version: 0.17.1
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,5 +1,5 @@
 name: promtail
-version: 0.12.2
+version: 0.12.3
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/configmap.yaml
+++ b/production/helm/promtail/templates/configmap.yaml
@@ -262,3 +262,6 @@ data:
         - __meta_kubernetes_pod_container_name
         target_label: __path__
     {{- end }}
+    {{- if .Values.extraScrapeConfigs }}
+    {{- toYaml .Values.extraScrapeConfigs | nindent 4 }}
+    {{- end }}

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -64,6 +64,9 @@ resources: {}
 # Custom scrape_configs to override the default ones in the configmap
 scrapeConfigs: []
 
+# Custom scrape_configs together with the default ones in the configmap
+extraScrapeConfigs: []
+
 securityContext:
   readOnlyRootFilesystem: true
   runAsGroup: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When I need to add additional scrape_configs for promtail, I'll need to override the default ones. This PR allows the scrape_configs to be added instead of replacing the default ones.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

