### PR TITLE
Moved client docs and add serilog example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ And these endpoints are exposed by just the ingester:
 
 The API endpoints starting with `/loki/` are [Prometheus API-compatible](https://prometheus.io/docs/prometheus/latest/querying/api/) and the result formats can be used interchangeably.
 
-[Example clients](#example-clients) can be found at the bottom of this document.
+A [list of clients](./clients) can be found in the clients documentation.
 
 ## Matrix, Vector, And Streams
 
@@ -628,12 +628,3 @@ In microservices mode, the `/flush` endpoint is exposed by the ingester.
 for a list of exported metrics.
 
 In microservices mode, the `/metrics` endpoint is exposed by all components.
-
-## Example Clients
-
-Please note that the Loki API is not stable yet and breaking changes may occur
-when using or writing a third-party client.
-
-- [Promtail](https://github.com/grafana/loki/tree/master/pkg/promtail) (Official, Go)
-- [promtail-client](https://github.com/afiskon/promtail-client) (Go)
-- [push-to-loki.py](https://github.com/sleleko/devops-kb/blob/master/python/push-to-loki.py) (Python 3)

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -41,3 +41,11 @@ and you already have configured `Parser` and `Filter` plugins.
 Fluentd also works well for extracting metrics from logs when using its
 Prometheus plugin.
 
+# Unofficial Clients
+
+Please note that the Loki API is not stable yet and breaking changes may occur
+when using or writing a third-party client.
+
+- [promtail-client](https://github.com/afiskon/promtail-client) (Go)
+- [push-to-loki.py](https://github.com/sleleko/devops-kb/blob/master/python/push-to-loki.py) (Python 3)
+- [Serilog-Sinks-Loki](https://github.com/JosephWoodward/Serilog-Sinks-Loki) (C#)


### PR DESCRIPTION
- Moved example clients to the clients doc and renamed them to "Unofficial Clients"
- Modified link in the api docs to link there
- Added Serilog client

**Checklist**
- [x] Documentation added
- [ ] Tests updated

