### PR TITLE
Improved compression ratio histogram

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -44,7 +44,7 @@ var (
 	chunkCompressionRatio = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "loki_ingester_chunk_compression_ratio",
 		Help:    "Compression ratio of chunks (when stored).",
-		Buckets: prometheus.LinearBuckets(1, 1.5, 6),
+		Buckets: prometheus.LinearBuckets(.75, 2, 10),
 	})
 	chunksPerTenant = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "loki_ingester_chunks_stored_total",

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -312,7 +312,7 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 		compressedSize := float64(len(byt))
 		uncompressedSize, ok := chunkenc.UncompressedSize(wc.Data)
 
-		if ok {
+		if ok && compressedSize > 0 {
 			chunkCompressionRatio.Observe(float64(uncompressedSize) / compressedSize)
 		}
 

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -35,6 +35,12 @@ func init() {
 	//util.Logger = log.NewLogfmtLogger(os.Stdout)
 }
 
+func Test(t *testing.T) {
+	blerg := 132 / 0
+
+	fmt.Println(blerg)
+}
+
 func TestChunkFlushingIdle(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.FlushCheckPeriod = 20 * time.Millisecond

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -35,12 +35,6 @@ func init() {
 	//util.Logger = log.NewLogfmtLogger(os.Stdout)
 }
 
-func Test(t *testing.T) {
-	blerg := 132 / 0
-
-	fmt.Println(blerg)
-}
-
 func TestChunkFlushingIdle(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.FlushCheckPeriod = 20 * time.Millisecond


### PR DESCRIPTION
**What this PR does / why we need it**:
- Improves compression ratio histogram to better report actual ratios
- Guards against divide by 0 in the ingester

Fixes #1138 