### PR TITLE
docs(helm): fix broken link to grafana datasource

### DIFF
--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -85,7 +85,7 @@ $ kubectl port-forward --namespace <YOUR-NAMESPACE> service/loki-grafana 3000:80
 ```
 
 Navigate to http://localhost:3000 and login with `admin` and the password output above.
-Then follow the [instructions for adding the loki datasource](/docs/querying.md#grafana), using the URL `http://loki:3100/`.
+Then follow the [instructions for adding the loki datasource](/docs/getting-started/grafana.md), using the URL `http://loki:3100/`.
 
 ## Run Loki behind https ingress
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**: Updates a broken link in `production/helm/README.md` that is supposed to point to instructions on adding Loki as a datasource to Grafana.

**Which issue(s) this PR fixes**: N/A (trivial fix)

**Special notes for your reviewer**: I have not scanned the docs for other similar broken links. 

**Checklist**
- [ ] Documentation added - N/A (trivial fix)
- [ ] Tests updated - N/A (trivial fix)

