### PR TITLE
docs: fix loki api url for promtai configration example

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -897,7 +897,7 @@ positions:
   filename: /tmp/positions.yaml
 
 client:
-  url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
+  url: http://ip_or_hostname_where_Loki_run:3100/api/prom/push
 
 scrape_configs:
  - job_name: system
@@ -934,7 +934,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: http://ip_or_hostname_where_loki_runns:3100/loki/api/v1/push
+  - url: http://ip_or_hostname_where_loki_runns:3100/api/prom/push
 
 scrape_configs:
   - job_name: journal


### PR DESCRIPTION
Changes:
* docs: fix Loki API url to `/api/prom/push`

fixes #1150
