### PR TITLE
feat(cli): order flags by categories

### DIFF
--- a/pkg/cfg/flag.go
+++ b/pkg/cfg/flag.go
@@ -2,7 +2,10 @@ package cfg
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/pkg/errors"
@@ -31,6 +34,7 @@ func dDefaults(fs *flag.FlagSet) Source {
 // Flags parses the flag from the command line, setting only user-supplied
 // values on the flagext.Registerer passed to Defaults()
 func Flags() Source {
+	flag.Usage = categorizedUsage(flag.CommandLine)
 	return dFlags(flag.CommandLine, os.Args[1:])
 }
 
@@ -39,5 +43,66 @@ func dFlags(fs *flag.FlagSet, args []string) Source {
 	return func(dst interface{}) error {
 		// parse the final flagset
 		return fs.Parse(args)
+	}
+}
+
+func categorizedUsage(fs *flag.FlagSet) func() {
+	categories := make(map[string][]string)
+	return func() {
+		if fs.Name() == "" {
+			fmt.Fprintf(fs.Output(), "Usage:\n")
+		} else {
+			fmt.Fprintf(fs.Output(), "Usage of %s:\n", fs.Name())
+		}
+
+		fs.VisitAll(func(f *flag.Flag) {
+			id := ""
+			if strings.Contains(f.Name, ".") {
+				id = strings.Split(f.Name, ".")[0]
+			}
+
+			kind, usage := flag.UnquoteUsage(f)
+			if kind != "" {
+				kind = " " + kind
+			}
+			def := f.DefValue
+			if def != "" {
+				def = fmt.Sprintf(" (default %s)", def)
+			}
+			categories[id] = append(categories[id], fmt.Sprintf("   -%s%s:\n      %s%s", f.Name, kind, usage, def))
+		})
+
+		for name, flags := range categories {
+			if len(flags) == 1 {
+				categories[""] = append(categories[""], flags[0])
+				delete(categories, name)
+			}
+		}
+
+		for name := range categories {
+			sort.Strings(categories[name])
+		}
+
+		for _, u := range categories[""] {
+			fmt.Fprintln(fs.Output(), u)
+		}
+		fmt.Fprintln(fs.Output())
+
+		keys := make([]string, 0, len(categories))
+		for k := range categories {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, name := range keys {
+			if name == "" {
+				continue
+			}
+			fmt.Fprintf(fs.Output(), " %s:\n", strings.Title(name))
+			for _, u := range categories[name] {
+				fmt.Fprintln(fs.Output(), u)
+			}
+			fmt.Fprintln(fs.Output())
+		}
 	}
 }


### PR DESCRIPTION
We have many flags of the form `<category>.<name>`. This change orders them
groups flags by category.

All flags with no categories and all categories with a single flag only won't be
grouped and will be printed at the top:

```
Usage of /tmp/go-build531611363/b001/exe/promtail:
   -config.file string:
      yaml file to load
   -log.level value:
      Only log messages with the given severity or above. Valid levels: [debug, info, warn, error] (default info)
   -target.sync-period duration:
      Period to resync directories being watched and files being tailed. (default 10s)
   -version:
      Print this builds version information (default false)

 Client:
   -client.batch-size-bytes int:
      Maximum batch size to accrue before sending.  (default 102400)
   -client.batch-wait duration:
      Maximum wait period before sending batch. (default 1s)
   -client.external-labels value:
      list of external labels to add to each log (e.g: --client.external-labels=lb1=v1,lb2=v2)
   -client.max-backoff duration:
      Maximum backoff time between retries. (default 5s)
   -client.max-retries int:
      Maximum number of retires when sending batches. (default 5)
   -client.min-backoff duration:
      Initial backoff time between retries. (default 100ms)
   -client.timeout duration:
      Maximum time to wait for server to respond to a request (default 10s)
   -client.url value:
      URL of log server

 Positions:
   -positions.file string:
      Location to read/write positions from. (default /var/log/positions.yaml)
   -positions.sync-period duration:
      Period with this to sync the position file. (default 10s)

 Server:
   -server.graceful-shutdown-timeout duration:
      Timeout for graceful shutdowns (default 30s)
   -server.grpc-listen-host string:
      gRPC server listen host.
   -server.grpc-listen-port int:
      gRPC server listen port. (default 9095)
   -server.grpc-max-concurrent-streams uint:
      Limit on the number of concurrent streams for gRPC calls (0 = unlimited) (default 100)
   -server.grpc-max-recv-msg-size-bytes int:
      Limit on the size of a gRPC message this server can receive (bytes). (default 4194304)
   -server.grpc-max-send-msg-size-bytes int:
      Limit on the size of a gRPC message this server can send (bytes). (default 4194304)
   -server.http-idle-timeout duration:
      Idle timeout for HTTP server (default 2m0s)
   -server.http-listen-host string:
      HTTP server listen host.
   -server.http-listen-port int:
      HTTP server listen port. (default 80)
   -server.http-read-timeout duration:
      Read timeout for HTTP server (default 30s)
   -server.http-write-timeout duration:
      Write timeout for HTTP server (default 30s)
   -server.path-prefix string:
      Base path to serve all API routes from (e.g. /v1/)
   -server.register-instrumentation:
      Register the intrumentation handlers (/metrics etc). (default true)

exit status 2
```
Don't know if it's cool, wanted to try it