### PR TITLE
WIP: Tidy up error handling

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -1,22 +1,23 @@
 package chunkenc
 
 import (
-	"errors"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/util"
 )
 
 // Errors returned by the chunk interface.
 var (
-	ErrChunkFull       = errors.New("chunk full")
-	ErrOutOfOrder      = errors.New("entry out of order")
-	ErrInvalidSize     = errors.New("invalid size")
-	ErrInvalidFlag     = errors.New("invalid flag")
-	ErrInvalidChecksum = errors.New("invalid checksum")
+	ErrChunkFull       = util.NewCodedError(http.StatusInternalServerError, "chunk full")
+	ErrOutOfOrder      = util.NewCodedError(http.StatusBadRequest, "entry out of order")
+	ErrInvalidSize     = util.NewCodedError(http.StatusInternalServerError, "invalid size")
+	ErrInvalidFlag     = util.NewCodedError(http.StatusInternalServerError, "invalid flag")
+	ErrInvalidChecksum = util.NewCodedError(http.StatusInternalServerError, "invalid checksum")
 )
 
 // Encoding is the identifier for a chunk encoding.

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -3,6 +3,7 @@ package ingester
 import (
 	"encoding/binary"
 	"hash/fnv"
+	"net/http"
 	"sync"
 	"time"
 
@@ -41,11 +42,11 @@ type tailer struct {
 func newTailer(orgID, query string, conn logproto.Querier_TailServer) (*tailer, error) {
 	expr, err := logql.ParseLogSelector(query)
 	if err != nil {
-		return nil, err
+		return nil, util.NewCodedError(http.StatusBadRequest, err.Error())
 	}
 	filter, err := expr.Filter()
 	if err != nil {
-		return nil, err
+		return nil, util.NewCodedError(http.StatusBadRequest, err.Error())
 	}
 	matchers := expr.Matchers()
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -4,9 +4,62 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type CodedError interface {
+	error
+	Code() int
+}
+
+type codedError struct {
+	code    int
+	message string
+}
+
+func NewCodedError(code int, message string) CodedError {
+	return codedError{
+		code:    code,
+		message: message,
+	}
+}
+
+func NewCodedErrorf(code int, message string, args ...interface{}) CodedError {
+	return codedError{
+		code:    code,
+		message: fmt.Sprintf(message, args...),
+	}
+}
+
+func (h codedError) Error() string {
+	return fmt.Sprintf("%v: %v", h.code, h.message)
+}
+
+func (h codedError) Code() int {
+	return h.code
+}
+
+// IsCodedError will tell you if the provided error implements the CodedError interface.
+// It will also return the status code of the CodedError, note that if the return is false the status code defaults to 500
+func IsCodedError(err error) (bool, int) {
+	wasCoded, ce := getCodedError(err)
+	return wasCoded, ce.code
+}
+
+func getCodedError(err error) (bool, *codedError) {
+	err = errors.Cause(err)
+	if ce, ok := err.(CodedError); ok {
+		err := ce.(codedError)
+		return true, &err
+	} else {
+		level.Error(util.Logger).Log("msg", "non CodedError found, please convert this to a CodedError so it can be properly returned at the GRPC and HTTP client interfaces with an accurate status code", "error", err)
+		return false, &codedError{message: err.Error(), code: 500}
+	}
+}
 
 // The MultiError type implements the error interface, and contains the
 // Errors used to construct it.
@@ -65,4 +118,89 @@ func IsConnCanceled(err error) bool {
 	}
 
 	return false
+}
+
+// CodedErrorSampler keeps a sample of entries giving priority to entries which implement CodedError and have a code >= 500
+// errors which do not implement CodedError are treated the same as code == 500
+type CodedErrorSampler struct {
+	keepMax int
+	codes   []int
+	errors  []error
+}
+
+func NewCodedErrorSampler(keepMax int) *CodedErrorSampler {
+	return &CodedErrorSampler{
+		keepMax: keepMax,
+		codes:   []int{},
+		errors:  []error{},
+	}
+}
+
+// IsFull will return true when the sampler is full of 4xx errors and the passed error is 4xx
+// or will return true if the passed error is 5xx and the sampled error array is not full or contains 4xx errors
+func (e *CodedErrorSampler) IsFull(err error) bool {
+	_, ce := getCodedError(err)
+	// 4xx error and sampler is full
+	if ce.code < 500 && len(e.errors) == e.keepMax {
+		return true
+	}
+	// Look for any 4xx errors which can be replaced by 5xx
+	for _, cd := range e.codes {
+		if cd < 500 && ce.code >= 500 {
+			return false
+		}
+	}
+	// Check if array is full, which at this point would all be 5xx's
+	return len(e.errors) == e.keepMax
+}
+
+// AddEntry will add the error to the sample if there is space,
+// if the error has a 5xx code it will replace any 4xx code errors
+func (e *CodedErrorSampler) AddEntry(err error) {
+	_, ce := getCodedError(err)
+
+	if len(e.errors) < e.keepMax {
+		e.errors = append(e.errors, err)
+		e.codes = append(e.codes, ce.code)
+	}
+
+	// Look for any 4xx errors which can be replaced by 5xx
+	for i, cd := range e.codes {
+		if cd < 500 && ce.code >= 500 {
+			e.errors[i] = ce
+			e.codes[i] = cd
+			return
+		}
+	}
+
+	// If there wasn't room in the array and none of the errors could be replaced then the sampler is full
+}
+
+// Error returns a concatenation of all the Error() strings in the sample, each on a separate line
+func (e *CodedErrorSampler) Error() string {
+	if len(e.errors) == 0 {
+		return ""
+	}
+	buf := &bytes.Buffer{}
+	for _, err := range e.errors {
+		fmt.Fprintln(buf, err.Error())
+	}
+	return buf.String()
+}
+
+// Code returns the highest numbered status code from the list of errors in the sample.
+// This is a little strange as higher numbered codes do not indicated higher severity,
+// however we want to favor 500's vs 400's and this was the easiest implementation.
+func (e *CodedErrorSampler) Code() int {
+	code := 0
+	for _, cd := range e.codes {
+		if cd > code {
+			code = cd
+		}
+	}
+	return code
+}
+
+func (e *CodedErrorSampler) Size() int {
+	return len(e.codes)
 }

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -1,9 +1,38 @@
 package validation
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"net/http"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/util/extract"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/util"
+)
+
+var (
+	errMissingMetricName = util.NewCodedError(http.StatusBadRequest, "sample missing metric name")
+)
 
 const (
 	discardReasonLabel = "reason"
+
+	errInvalidMetricName = "sample invalid metric name: %.200q"
+	errInvalidLabel      = "sample invalid label: %.200q metric %.200q"
+	errLabelNameTooLong  = "label name too long: %.200q metric %.200q"
+	errLabelValueTooLong = "label value too long: %.200q metric %.200q"
+	errTooManyLabels     = "stream '%s' has %d label names; limit %d"
+	errTooOld            = "log entry for stream '%s' has timestamp too old: %d"
+	errTooNew            = "log entry for stream '%s' has timestamp too new: %d"
+
+	greaterThanMaxSampleAge = "greater_than_max_sample_age"
+	maxLabelNamesPerSeries  = "max_label_names_per_series"
+	tooFarInFuture          = "too_far_in_future"
+	invalidLabel            = "label_invalid"
+	labelNameTooLong        = "label_name_too_long"
+	labelValueTooLong       = "label_value_too_long"
 
 	// RateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
@@ -21,4 +50,80 @@ var DiscardedSamples = prometheus.NewCounterVec(
 
 func init() {
 	prometheus.MustRegister(DiscardedSamples)
+}
+
+// SampleValidationConfig helps with getting required config to validate sample.
+type SampleValidationConfig interface {
+	RejectOldSamples(userID string) bool
+	RejectOldSamplesMaxAge(userID string) time.Duration
+	CreationGracePeriod(userID string) time.Duration
+}
+
+// ValidateSample returns an err if the sample is invalid.
+func ValidateSample(cfg SampleValidationConfig, userID string, streamLabels string, s client.Sample) error {
+	if cfg.RejectOldSamples(userID) && model.Time(s.TimestampMs) < model.Now().Add(-cfg.RejectOldSamplesMaxAge(userID)) {
+		DiscardedSamples.WithLabelValues(greaterThanMaxSampleAge, userID).Inc()
+		return util.NewCodedErrorf(http.StatusBadRequest, errTooOld, streamLabels, model.Time(s.TimestampMs))
+	}
+
+	if model.Time(s.TimestampMs) > model.Now().Add(cfg.CreationGracePeriod(userID)) {
+		DiscardedSamples.WithLabelValues(tooFarInFuture, userID).Inc()
+		return util.NewCodedErrorf(http.StatusBadRequest, errTooNew, streamLabels, model.Time(s.TimestampMs))
+	}
+
+	return nil
+}
+
+// LabelValidationConfig helps with getting required config to validate labels.
+type LabelValidationConfig interface {
+	EnforceMetricName(userID string) bool
+	MaxLabelNamesPerSeries(userID string) int
+	MaxLabelNameLength(userID string) int
+	MaxLabelValueLength(userID string) int
+}
+
+// ValidateLabels returns an err if the labels are invalid.
+func ValidateLabels(cfg LabelValidationConfig, userID string, streamLabels string, ls []client.LabelAdapter) error {
+	metricName, err := extract.MetricNameFromLabelAdapters(ls)
+	if cfg.EnforceMetricName(userID) {
+		if err != nil {
+			return errMissingMetricName
+		}
+		//TODO should this be simplifed to validate that the metric name always == logs??
+		if !model.IsValidMetricName(model.LabelValue(metricName)) {
+			return util.NewCodedErrorf(http.StatusBadRequest, errInvalidMetricName, metricName)
+		}
+	}
+
+	numLabelNames := len(ls)
+	if numLabelNames > cfg.MaxLabelNamesPerSeries(userID) {
+		DiscardedSamples.WithLabelValues(maxLabelNamesPerSeries, userID).Inc()
+		return util.NewCodedErrorf(http.StatusBadRequest, errTooManyLabels, streamLabels, numLabelNames, cfg.MaxLabelNamesPerSeries(userID))
+	}
+
+	maxLabelNameLength := cfg.MaxLabelNameLength(userID)
+	maxLabelValueLength := cfg.MaxLabelValueLength(userID)
+	for _, l := range ls {
+		var errTemplate string
+		var reason string
+		var cause interface{}
+		if !model.LabelName(l.Name).IsValid() {
+			reason = invalidLabel
+			errTemplate = errInvalidLabel
+			cause = l.Name
+		} else if len(l.Name) > maxLabelNameLength {
+			reason = labelNameTooLong
+			errTemplate = errLabelNameTooLong
+			cause = l.Name
+		} else if len(l.Value) > maxLabelValueLength {
+			reason = labelValueTooLong
+			errTemplate = errLabelValueTooLong
+			cause = l.Value
+		}
+		if errTemplate != "" {
+			DiscardedSamples.WithLabelValues(reason, userID).Inc()
+			return util.NewCodedErrorf(http.StatusBadRequest, errTemplate, cause, client.FromLabelAdaptersToMetric(ls).String())
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
* attempt to make all GRPC methods return httpgrpc.ErrorFromHTTPResponse
    * This allows the web layers to easily convert errors back to clients without any knowledge of error types.
* aggregate errors per entry and stream into an "error sampler" which only keeps a sample of errors to return to client
    * The full list of errors we are sending now is a little too cumbersome for a client to really gain useful info from
* add a CodedError type which can be used to communicate the HTTP error code used in the httpgrpc.ErrorFromHTTPResponse and ultimately in the http response to the client
copied the validation code from cortex to make the messages more loki specific and allow changing the error return type for easier sampling

