### PR TITLE
loki-stack: Add release name to prometheus service name.

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,5 +1,5 @@
 name: loki-stack
-version: 0.17.2
+version: 0.17.3
 appVersion: v0.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/templates/_helpers.tpl
+++ b/production/helm/loki-stack/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "loki-stack.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Override the naming defined by the prometheus chart.
+Added as a fix for https://github.com/grafana/loki/issues/1169
+*/}}
+{{- define "prometheus.fullname" -}}
+{{- printf "%s-%s" .Release.Name "prometheus-server" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/production/helm/loki-stack/templates/datasources.yaml
+++ b/production/helm/loki-stack/templates/datasources.yaml
@@ -25,7 +25,7 @@ data:
     - name: Prometheus
       type: prometheus
       access: proxy
-      url: http://{{ .Values.prometheus.server.fullnameOverride }}:{{ .Values.prometheus.server.service.servicePort }}
+      url: http://{{ include "prometheus.fullname" .}}:{{ .Values.prometheus.server.service.servicePort }}
       version: 1
 {{- end }}
 {{- end }}

--- a/production/helm/loki-stack/values.yaml
+++ b/production/helm/loki-stack/values.yaml
@@ -17,5 +17,3 @@ grafana:
 
 prometheus:
   enabled: false
-  server:
-    fullnameOverride: prometheus-server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Previously the prometheus service name was hard-coded to `prometheus-server` which would cause a conflict if attempting to `helm install` more than one release or namespace. For example

```
helm install release-one
helm install release-two
```

Would result in 

```
Error: release release-two failed: clusterroles.rbac.authorization.k8s.io "prometheus-server" already exists
```

This PR incorporates the `{{ .Release.Name }}` into the service name to make it consistent with other generated names.

Note that the `prometheus.fullname` template defined in `_helpers.tpl` is named specifically to override the one defined by the normal prometheus chart. This allows the prometheus chart and templates in loki-stack to use the same logic for getting the prometheus service name.

**Which issue(s) this PR fixes**:
Fixes #1169

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

