### PR TITLE
Set requests=limits to make ingesters guaranteed pods

### DIFF
--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -14,7 +14,7 @@
     container.mixin.readinessProbe.httpGet.withPort(80) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
-    $.util.resourcesRequests('1', '5Gi') +
+    $.util.resourcesRequests('2', '10Gi') +
     $.util.resourcesLimits('2', '10Gi'),
 
   local deployment = $.apps.v1beta1.deployment,


### PR DESCRIPTION
Setting cpu and memory requests = limits to make ingesters guaranteed pods and less susceptible to eviction:

https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#evicting-end-user-pods