### PR TITLE
Clarify number of requests in observability docs

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -8,10 +8,10 @@ for more information.
 
 All components of Loki expose the following metrics:
 
-| Metric Name                     | Metric Type | Description                              |
-| ------------------------------- | ----------- | ---------------------------------------- |
-| `log_messages_total`            | Counter     | Total number of messages logged by Loki. |
-| `loki_request_duration_seconds` | Histogram   | Number of received HTTP requests.        |
+| Metric Name                           | Metric Type | Description                              |
+| ------------------------------------- | ----------- | ---------------------------------------- |
+| `log_messages_total`                  | Counter     | Total number of messages logged by Loki. |
+| `loki_request_duration_seconds_count` | Histogram   | Number of received HTTP requests.        |
 
 The Loki Distributors expose the following metrics:
 


### PR DESCRIPTION
when we are talking about `Number of received HTTP requests.` we should use count (like with `promtail_request_duration_seconds_count`)
