### PR TITLE
promtail: fix error message displaying on invalid config file

### DIFF
--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -25,19 +25,22 @@ func init() {
 func main() {
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 
+	// Load config, merging config file and CLI flags
 	var config config.Config
 	if err := cfg.Parse(&config); err != nil {
-		level.Error(util.Logger).Log("msg", "parsing config", "error", err)
+		fmt.Println("Unable to parse config:", err)
 		os.Exit(1)
 	}
+
+	// Handle -version CLI flag
 	if *printVersion {
-		fmt.Print(version.Print("promtail"))
+		fmt.Println(version.Print("promtail"))
 		os.Exit(0)
 	}
 
 	// Init the logger which will honor the log level set in cfg.Server
 	if reflect.DeepEqual(&config.ServerConfig.Config.LogLevel, &logging.Level{}) {
-		level.Error(util.Logger).Log("msg", "invalid log level")
+		fmt.Println("Invalid log level")
 		os.Exit(1)
 	}
 	util.InitLogger(&config.ServerConfig.Config)


### PR DESCRIPTION
**What this PR does / why we need it**:

If the YAML config file is invalid (ie. invalid syntax), promtail silently fails because currently the error is displayed using the logger, which has not been initialized yet. I've switched the logging before initializing the logger into a `fmt.Println()`.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

