### PR TITLE
promtail: fix handling of JMESPath expression returning nil while parsing JSON

### DIFF
--- a/pkg/logentry/stages/json.go
+++ b/pkg/logentry/stages/json.go
@@ -151,6 +151,8 @@ func (j *jsonStage) Process(labels model.LabelSet, extracted map[string]interfac
 			extracted[n] = r
 		case bool:
 			extracted[n] = r
+		case nil:
+			extracted[n] = nil
 		default:
 			// If the value wasn't a string or a number, marshal it back to json
 			jm, err := json.Marshal(r)

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -21,6 +21,7 @@ pipeline_stages:
       app:
       nested:
       duration:
+      unknown:
 `
 
 var testJSONYamlMultiStageWithSource = `
@@ -63,6 +64,7 @@ func TestPipeline_JSON(t *testing.T) {
 				"app":      "loki",
 				"nested":   "{\"child\":\"value\"}",
 				"duration": float64(125),
+				"unknown":  nil,
 			},
 		},
 		"successfully run a pipeline with 2 json stages with source": {

--- a/pkg/logentry/stages/labels.go
+++ b/pkg/logentry/stages/labels.go
@@ -64,8 +64,7 @@ type labelStage struct {
 // Process implements Stage
 func (l *labelStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
 	for lName, lSrc := range l.cfgs {
-		if _, ok := extracted[*lSrc]; ok {
-			lValue := extracted[*lSrc]
+		if lValue, ok := extracted[*lSrc]; ok {
 			s, err := getString(lValue)
 			if err != nil {
 				if Debug {

--- a/pkg/logentry/stages/util_test.go
+++ b/pkg/logentry/stages/util_test.go
@@ -65,6 +65,9 @@ func TestGetString(t *testing.T) {
 	assert.Equal(t, "1", s64)
 	assert.Equal(t, "2.02", s32)
 	assert.Equal(t, "1562723913000", s64_1)
+
+	_, err = getString(nil)
+	assert.Error(t, err)
 }
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when a JMESPath expression - executed by the json stage - returns `nil`, the value stored in the extracted data map is JSON encoded, thus `nil` gets encoded into the string `null`.

Further stages working on the extracted data (ie. `labels`) will read that value as a string containing `null`, causing some weird side effects.

In this PR I propose to keep the `nil` value in the extracted map: the `getString(nil)` returns error, so subsequent stages working with string will skip it.

The reason why I didn't skip storing the `nil` in the extracted map (which is another option) is because then there would be any difference between a `json` stage expression returning `nil` and not having that expression at all in the config. Right now there would be no difference, but in the future may be handy to be able to differentiate them (ie. think about a stage re-encoding into JSON).

**Example of the issue**:

Currently, given this pipeline:
```
pipeline_stages:
- json:
    expressions:
      app:
      message:
- labels:
    app:
```

And this input log:
`{"message":"hello"}`

At the end of the pipeline there's a label `app` whose value is the string `null`.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

