### PR TITLE
[promtail] Fix #810 . Set stderr as a default output for klog library

### DIFF
--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"reflect"
 
+	"k8s.io/klog"
+
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +46,9 @@ func main() {
 		os.Exit(1)
 	}
 	util.InitLogger(&config.ServerConfig.Config)
+
+	// Use Stderr instead of files for the klog.
+	klog.SetOutput(os.Stderr)
 
 	// Set the global debug variable in the stages package which is used to conditionally log
 	// debug messages which otherwise cause huge allocations processing log lines for log messages never printed

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
+	k8s.io/klog v0.4.0
 )
 
 replace github.com/weaveworks/common => github.com/sandlis/weaveworks-common v0.0.0-20190822064708-8fa0a1ca9d89


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a Promtail crash when the K8s cluster is not accessible.
 
**Which issue(s) this PR fixes**:
#810 

**Special notes for your reviewer**:

**Checklist**


