### PR TITLE
Fix compiled logproto protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,8 @@ endif
 
 protos: $(PROTO_GOS)
 
+# Ensure protobuf is recompiled when the tooling is updated and proto sources are not
+.PHONY: $(PROTO_DEFS)
 %.pb.go: $(PROTO_DEFS)
 ifeq ($(BUILD_IN_CONTAINER),true)
 	@mkdir -p $(shell pwd)/.pkg

--- a/pkg/logproto/logproto.pb.go
+++ b/pkg/logproto/logproto.pb.go
@@ -1459,9 +1459,9 @@ func (this *Stream) GoString() string {
 	s = append(s, "&logproto.Stream{")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Entries != nil {
-		vs := make([]*Entry, len(this.Entries))
+		vs := make([]Entry, len(this.Entries))
 		for i := range vs {
-			vs[i] = &this.Entries[i]
+			vs[i] = this.Entries[i]
 		}
 		s = append(s, "Entries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -4857,6 +4857,7 @@ func (m *TransferChunksResponse) Unmarshal(dAtA []byte) error {
 func skipLogproto(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -4888,10 +4889,8 @@ func skipLogproto(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -4912,55 +4911,30 @@ func skipLogproto(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthLogproto
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthLogproto
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowLogproto
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipLogproto(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthLogproto
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupLogproto
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthLogproto
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthLogproto = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowLogproto   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthLogproto        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowLogproto          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupLogproto = fmt.Errorf("proto: unexpected end of group")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR https://github.com/grafana/loki/pull/1133 has upgraded `golangci-lint` and thus the `loki-build-image` has been rebuilded and a new version published (`0.7.3`).

The rebuild of the image has installed the latest versions of the deps specified in the `loki-build-image/Dockerfile`, including `protoc-gen-gogoslick` which I think is the cause of a change to `pkg/logproto/logproto.pb.go`.

We didn't notice it, because in the `Makefile` the `%.pb.go` target is not a phony one, so the `logproto.proto` is recompiled only once its timestamp change. However, it should be recompiled also whenever the tooling change and it may be quite difficult to remember it, so I'm proposing to add it as a phony target given `protoc` is relatively quick. I'm open to any better suggestion, cause I haven't found a better way to enforce it.

**Special notes for your reviewer**:
- I started investigating it when I've seen that the build https://cloud.drone.io/grafana/loki/815 failed, but a restart https://cloud.drone.io/grafana/loki/816 succeeded and wanted to find the root of the flaky build

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

