### PR TITLE
Explain log_messages_total

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -8,10 +8,10 @@ for more information.
 
 All components of Loki expose the following metrics:
 
-| Metric Name                     | Metric Type | Description                              |
-| ------------------------------- | ----------- | ---------------------------------------- |
-| `log_messages_total`            | Counter     | Total number of messages logged by Loki. |
-| `loki_request_duration_seconds` | Histogram   | Number of received HTTP requests.        |
+| Metric Name                     | Metric Type | Description                                                                                              |
+| ------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `log_messages_total`            | Counter     | Total number of messages logged by Loki. Those are internal Loki logs (not connected to ingest or store) |
+| `loki_request_duration_seconds` | Histogram   | Number of received HTTP requests.                                                                        |
 
 The Loki Distributors expose the following metrics:
 


### PR DESCRIPTION
I was confused and thought that this metric means how many logs messages were processed by Loki. I hope this is clearer now