### PR TITLE
client output buffer

### DIFF
--- a/pkg/promtail/client/config.go
+++ b/pkg/promtail/client/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	// The labels to add to any time series or alerts when communicating with loki
 	ExternalLabels lokiflag.LabelSet `yaml:"external_labels,omitempty"`
 	Timeout        time.Duration     `yaml:"timeout"`
+	OutBufferCap int `yaml:"out_buffer_cap,omitempty"`
 }
 
 // RegisterFlags registers flags.
@@ -34,6 +35,7 @@ func (c *Config) RegisterFlags(flags *flag.FlagSet) {
 	flag.DurationVar(&c.BackoffConfig.MinBackoff, "client.min-backoff", 100*time.Millisecond, "Initial backoff time between retries.")
 	flag.DurationVar(&c.BackoffConfig.MaxBackoff, "client.max-backoff", 5*time.Second, "Maximum backoff time between retries.")
 	flag.DurationVar(&c.Timeout, "client.timeout", 10*time.Second, "Maximum time to wait for server to respond to a request")
+	flag.IntVar(&c.OutBufferCap, "client.out-buffer-cap", 10, "Client sender buffer capacity.")
 	flags.Var(&c.ExternalLabels, "client.external-labels", "list of external labels to add to each log (e.g: --client.external-labels=lb1=v1,lb2=v2)")
 }
 
@@ -55,6 +57,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			BatchSize: 100 * 1024,
 			BatchWait: 1 * time.Second,
 			Timeout:   10 * time.Second,
+			OutBufferCap: 10,
 		}
 	}
 


### PR DESCRIPTION
This edit makes Promtail client really async.

I understand that send has to be done in order, but I think it does not have to block

`out_buffer_cap` default capacity is 10, the client will behave absolutely the same when the capacity will be 0.

This change can help high throughput clients because send to the channel may block when the client is actually sending the data which leads to waiting (CPU cannot be utilized effectively).
