### PR TITLE
fluentd: Refactor label_keys and and add extract_kubernetes_labels configuration

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/README.md
+++ b/fluentd/fluent-plugin-grafana-loki/README.md
@@ -56,14 +56,14 @@ You can rewrite the label keys as well as the following
 </match>
 ```
 
-You can use record accessor syntax for nested field. https://docs.fluentd.org/filter/record_transformer#use-dig-method-for-nested-field
+You can use record accessor syntax for nested field. https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor#syntax
 
 ```
 <match mytag>
   @type loki
   # ...
   <label>
-    container ${record.dig("kubernetes", "container")}
+    container $.kubernetes.container
   </label>
   # ...
 </match>
@@ -81,7 +81,7 @@ Use with the `remove_keys kubernetes` option to eliminate metadata from the log.
   extract_kubernetes_labels true
   remove_keys kubernetes
   <label>
-    container ${record.dig("kubernetes", "container")}
+    container $.kubernetes.container
   </label>
   # ...
 </match>
@@ -172,8 +172,7 @@ Loki is intended to index and group log streams using only a small set of labels
 
 There are few configurations settings to control the output format.
  - extra_labels: (default: nil) set of labels to include with every Loki stream. eg `{"env":"dev", "datacenter": "dc1"}`
- - remove_keys: (default: nil) comma separated list of needless record keys to remove. All other keys will be placed into the log line
- - label_keys: (default: "job,instance") comma separated list of keys to use as stream labels. All other keys will be placed into the log line
+ - remove_keys: (default: nil) comma separated list of needless record keys to remove. All other keys will be placed into the log line. You can use [record_accessor syntax](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor#syntax).
  - line_format: format to use when flattening the record to a log line. Valid values are "json" or "key_value". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format `<key>=<value>`.
  - drop_single_key: if set to true and after extracting label_keys a record only has a single key remaining, the log line sent to Loki will just be the value of the record key.
 

--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.0.2'
+  spec.version = '1.1.0'
   spec.authors = %w[woodsaj briangann]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # spec.test_files    = test_files
   # spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.10', '< 2']

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -147,7 +147,7 @@ module Fluent
         data_labels = data_labels.merge(@extra_labels)
 
         data_labels.each do |k, v|
-          formatted_labels.push(%(#{k}="#{v}")) if v
+          formatted_labels.push(%(#{k}="#{v.gsub('"', '\\"')}")) if v
         end
         '{' + formatted_labels.join(',') + '}'
       end
@@ -193,7 +193,7 @@ module Fluent
         line = ''
         if record.is_a?(Hash)
           @record_accessors&.each do |name, accessor|
-            new_key = name.gsub(%r{/[.\-\/]/}, '_')
+            new_key = name.gsub(%r{[.\-\/]}, '_')
             chunk_labels[new_key] = accessor.call(record)
             accessor.delete(record)
           end
@@ -201,7 +201,7 @@ module Fluent
           if @extract_kubernetes_labels && record.key?('kubernetes')
             kubernetes_labels = record['kubernetes']['labels']
             kubernetes_labels.each_key do |l|
-              new_key = l.gsub(%r{/[.\-\/]/}, '_')
+              new_key = l.gsub(%r{[.\-\/]}, '_')
               chunk_labels[new_key] = kubernetes_labels[l]
             end
           end


### PR DESCRIPTION
**What this PR does / why we need it**:
- Refactoring label_keys to `<label>` block allows to use [record_accessor](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor#syntax) to define your labels.
It is a flexible way to extract record or nested record information
- Refactor remove_keys to allow [record_accessor syntax](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor#syntax).
- Add extract_kubernetes_labels to easily extract Kubernetes metadata as Loki labels.

**Checklist**
- [x] Documentation added
- [x] Tests updated

