### PR TITLE
Documentation: logcli: fixed URL

### DIFF
--- a/docs/getting-started/logcli.md
+++ b/docs/getting-started/logcli.md
@@ -13,7 +13,7 @@ and download the `logcli` binary for your OS:
 ```bash
 # download a binary (adapt app, os and arch as needed)
 # installs v0.3.0. For up to date URLs refer to the release's description
-$ curl -fSL -o "/usr/local/bin/logcli.gz" "https://github.com/grafana/loki/releases/download/v0.3.0/logcli_linux_amd64.gz"
+$ curl -fSL -o "/usr/local/bin/logcli.gz" "https://github.com/grafana/loki/releases/download/v1.0.0/logcli-linux-amd64.gz"
 $ gunzip "/usr/local/bin/logcli.gz"
 
 # make sure it is executable

--- a/docs/getting-started/logcli.md
+++ b/docs/getting-started/logcli.md
@@ -13,7 +13,7 @@ and download the `logcli` binary for your OS:
 ```bash
 # download a binary (adapt app, os and arch as needed)
 # installs v0.3.0. For up to date URLs refer to the release's description
-$ curl -fSL -o "/usr/local/bin/logcli.gz" "https://github.com/grafana/logcli/releases/download/v0.3.0/logcli-linux-amd64.gz"
+$ curl -fSL -o "/usr/local/bin/logcli.gz" "https://github.com/grafana/loki/releases/download/v0.3.0/logcli_linux_amd64.gz"
 $ gunzip "/usr/local/bin/logcli.gz"
 
 # make sure it is executable


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the URL in curl command to retrieve logcli binary.
Needed because documentation's example did not work.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

