### PR TITLE
Chunk iterator performance improvement

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -489,6 +489,7 @@ github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
+github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/go.sum
+++ b/go.sum
@@ -489,7 +489,6 @@ github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
-github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/chunkenc/gzip.go
+++ b/pkg/chunkenc/gzip.go
@@ -486,6 +486,10 @@ func (li *listIterator) Next() bool {
 }
 
 func (li *listIterator) Entry() logproto.Entry {
+	if li.cur < 0 || li.cur >= len(li.entries) {
+		return logproto.Entry{}
+	}
+
 	cur := li.entries[li.cur]
 
 	return logproto.Entry{

--- a/pkg/chunkenc/gzip.go
+++ b/pkg/chunkenc/gzip.go
@@ -468,6 +468,7 @@ func (hb *headBlock) iterator(mint, maxt int64, filter logql.Filter) iter.EntryI
 
 	return &listIterator{
 		entries: entries,
+		cur:     -1,
 	}
 }
 
@@ -475,25 +476,21 @@ var emptyIterator = &listIterator{}
 
 type listIterator struct {
 	entries []entry
-
-	cur entry
+	cur     int
 }
 
 func (li *listIterator) Next() bool {
-	if len(li.entries) > 0 {
-		li.cur = li.entries[0]
-		li.entries = li.entries[1:]
+	li.cur++
 
-		return true
-	}
-
-	return false
+	return li.cur < len(li.entries)
 }
 
 func (li *listIterator) Entry() logproto.Entry {
+	cur := li.entries[li.cur]
+
 	return logproto.Entry{
-		Timestamp: time.Unix(0, li.cur.t),
-		Line:      li.cur.s,
+		Timestamp: time.Unix(0, cur.t),
+		Line:      cur.s,
 	}
 }
 

--- a/pkg/chunkenc/gzip_test.go
+++ b/pkg/chunkenc/gzip_test.go
@@ -274,7 +274,24 @@ func BenchmarkReadGZIP(b *testing.B) {
 		}
 		wg.Wait()
 	}
+}
 
+func BenchmarkHeadBlockIterator(b *testing.B) {
+	h := headBlock{}
+
+	// insert 10k entries
+	for i := 0; i < 10000; i++ {
+		h.append(int64(i), "this is the append string")
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		iter := h.iterator(0, 10000, nil)
+
+		for iter.Next() {
+			//e := iter.Entry()
+		}
+	}
 }
 
 func randSizeEntry(ts int64) *logproto.Entry {

--- a/pkg/chunkenc/gzip_test.go
+++ b/pkg/chunkenc/gzip_test.go
@@ -279,7 +279,7 @@ func BenchmarkReadGZIP(b *testing.B) {
 
 func BenchmarkHeadBlockIterator(b *testing.B) {
 
-	for _, j := range []int{10000, 15000, 50000, 100000} {
+	for _, j := range []int{100000, 50000, 15000, 10000} {
 		b.Run(fmt.Sprintf("Size %d", j), func(b *testing.B) {
 
 			h := headBlock{}

--- a/pkg/chunkenc/gzip_test.go
+++ b/pkg/chunkenc/gzip_test.go
@@ -2,6 +2,7 @@ package chunkenc
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/rand"
 	"sync"
@@ -277,20 +278,26 @@ func BenchmarkReadGZIP(b *testing.B) {
 }
 
 func BenchmarkHeadBlockIterator(b *testing.B) {
-	h := headBlock{}
 
-	// insert 10k entries
-	for i := 0; i < 10000; i++ {
-		h.append(int64(i), "this is the append string")
-	}
+	for _, j := range []int{10000, 15000, 50000, 100000} {
+		b.Run(fmt.Sprintf("Size %d", j), func(b *testing.B) {
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		iter := h.iterator(0, 10000, nil)
+			h := headBlock{}
 
-		for iter.Next() {
-			_ = iter.Entry()
-		}
+			for i := 0; i < j; i++ {
+				h.append(int64(i), "this is the append string")
+			}
+
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				iter := h.iterator(0, math.MaxInt64, nil)
+
+				for iter.Next() {
+					_ = iter.Entry()
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/chunkenc/gzip_test.go
+++ b/pkg/chunkenc/gzip_test.go
@@ -289,7 +289,7 @@ func BenchmarkHeadBlockIterator(b *testing.B) {
 		iter := h.iterator(0, 10000, nil)
 
 		for iter.Next() {
-			//e := iter.Entry()
+			_ = iter.Entry()
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the headblock iterator performance by storing an index instead of a current item.

Before:
```
go test -bench=BenchmarkHead. -benchmem
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/chunkenc
BenchmarkHeadBlockIterator/Size_100000-8         	     501	   2384544 ns/op	 2400311 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_50000-8          	     916	   1155438 ns/op	 1204272 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_15000-8          	    3272	    331680 ns/op	  360496 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_10000-8          	    5660	    232224 ns/op	  245808 B/op	       2 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/chunkenc	8.534s
```

After
```
go test -bench=BenchmarkHead. -benchmem
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/chunkenc
BenchmarkHeadBlockIterator/Size_100000-8         	     486	   2430331 ns/op	 2400288 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_50000-8          	    1070	   1126875 ns/op	 1204256 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_15000-8          	    4156	    279365 ns/op	  360480 B/op	       2 allocs/op
BenchmarkHeadBlockIterator/Size_10000-8          	    6690	    177187 ns/op	  245792 B/op	       2 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/chunkenc	8.675s
```

**Special notes for your reviewer**:
Please review and discuss the guard code at the top of `Entry()` would we prefer a panic to returning dummy data here?

```
	if li.cur < 0 || li.cur >= len(li.entries) {
		return logproto.Entry{}
	}
```

**Checklist**
- [ ] Documentation added
- [x] Tests updated

