### PR TITLE
fluent-bit-plugin: Auto add Kubernetes labels to Loki labels

### DIFF
--- a/cmd/fluent-bit/README.md
+++ b/cmd/fluent-bit/README.md
@@ -18,7 +18,7 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 | LogLevel      | LogLevel for plugin logger.                    | "info"                              |
 | RemoveKeys    | Specify removing keys.                         | none                                |
 | LabelKeys     | Comma separated list of keys to use as stream labels. All other keys will be placed into the log line. LabelKeys is deactivated when using `LabelMapPath` label mapping configuration. | none |
-| LineFormat    | Format to use when flattening the record to a log line. Valid values are "json" or "key_value". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format <key>=<value>. | json |
+| LineFormat    | Format to use when flattening the record to a log line. Valid values are "json", "key_value" or "kubernetes". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format <key>=<value>. if set to "kubernetes", the log line will auto parse kubernetes metadata into Labels. | json |
 | DropSingleKey | If set to true and after extracting label_keys a record only has a single key remaining, the log line sent to Loki will just be the value of the record key.| true |
 | LabelMapPath | Path to a json file defining how to transform nested records. | none
 

--- a/cmd/fluent-bit/README.md
+++ b/cmd/fluent-bit/README.md
@@ -17,7 +17,7 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 | Labels        | labels for API requests.                       | {job="fluent-bit"}                    |
 | LogLevel      | LogLevel for plugin logger.                    | "info"                              |
 | RemoveKeys    | Specify removing keys.                         | none                                |
-| AutoKubernetesLabels | If set to ture, it will auto parse kubernetes metadata into labels | false    |
+| AutoKubernetesLabels | If set to true, it will add all Kubernetes labels to Loki labels | false    |
 | LabelKeys     | Comma separated list of keys to use as stream labels. All other keys will be placed into the log line. LabelKeys is deactivated when using `LabelMapPath` label mapping configuration. | none |
 | LineFormat    | Format to use when flattening the record to a log line. Valid values are "json" or "key_value". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format <key>=<value>. | json |
 | DropSingleKey | If set to true and after extracting label_keys a record only has a single key remaining, the log line sent to Loki will just be the value of the record key.| true |
@@ -31,7 +31,7 @@ You can use `Labels`, `RemoveKeys` , `LabelKeys` and `LabelMapPath` to how the o
 
 ### AutoKubernetesLabels
 
-If set to ture, it will parser kubernetes metadata into labels automatically and ignore the paramater `LabelKeys`, LabelMapPath.
+If set to true, it will add all Kubernetes labels to Loki labels automatically and ignore paramaters `LabelKeys`, LabelMapPath.
 
 ### LabelMapPath
 

--- a/cmd/fluent-bit/README.md
+++ b/cmd/fluent-bit/README.md
@@ -17,8 +17,9 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 | Labels        | labels for API requests.                       | {job="fluent-bit"}                    |
 | LogLevel      | LogLevel for plugin logger.                    | "info"                              |
 | RemoveKeys    | Specify removing keys.                         | none                                |
+| AutoKubernetesLabels | If set to ture, it will auto parse kubernetes metadata into labels | false    |
 | LabelKeys     | Comma separated list of keys to use as stream labels. All other keys will be placed into the log line. LabelKeys is deactivated when using `LabelMapPath` label mapping configuration. | none |
-| LineFormat    | Format to use when flattening the record to a log line. Valid values are "json", "key_value" or "kubernetes". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format <key>=<value>. if set to "kubernetes", the log line will auto parse kubernetes metadata into Labels. | json |
+| LineFormat    | Format to use when flattening the record to a log line. Valid values are "json" or "key_value". If set to "json" the log line sent to Loki will be the fluentd record (excluding any keys extracted out as labels) dumped as json. If set to "key_value", the log line will be each item in the record concatenated together (separated by a single space) in the format <key>=<value>. | json |
 | DropSingleKey | If set to true and after extracting label_keys a record only has a single key remaining, the log line sent to Loki will just be the value of the record key.| true |
 | LabelMapPath | Path to a json file defining how to transform nested records. | none
 
@@ -27,6 +28,10 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 Labels are used to [query logs](../../docs/logql.md) `{container_name="nginx", cluster="us-west1"}`, they are usually metadata about the workload producing the log stream (`instance`, `container_name`, `region`, `cluster`, `level`).  In Loki labels are indexed consequently you should be cautious when choosing them (high cardinality label values can have performance drastic impact).
 
 You can use `Labels`, `RemoveKeys` , `LabelKeys` and `LabelMapPath` to how the output plugin will perform labels extraction.
+
+### AutoKubernetesLabels
+
+If set to ture, it will parser kubernetes metadata into labels automatically and ignore the paramater `LabelKeys`, LabelMapPath.
 
 ### LabelMapPath
 
@@ -89,6 +94,16 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     LineFormat key_value
 ```
 
+```properties
+[Output]
+    Name loki
+    Match *
+    Url http://localhost:3100/loki/api/v1/push
+    BatchWait 1 # (1sec)
+    BatchSize 30720 # (30KiB)
+    AutoKubernetesLabels true
+    RemoveKeys key1,key2
+```
 A full [example configuration file](fluent-bit.conf) is also available in this repository.
 
 ## Building

--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -36,14 +36,14 @@ const (
 )
 
 type config struct {
-	clientConfig  client.Config
-	logLevel      logging.Level
+	clientConfig         client.Config
+	logLevel             logging.Level
 	autoKubernetesLabels bool
-	removeKeys    []string
-	labelKeys     []string
-	lineFormat    format
-	dropSingleKey bool
-	labelMap      map[string]interface{}
+	removeKeys           []string
+	labelKeys            []string
+	lineFormat           format
+	dropSingleKey        bool
+	labelMap             map[string]interface{}
 }
 
 func parseConfig(cfg ConfigGetter) (*config, error) {

--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -33,7 +33,7 @@ type format int
 const (
 	jsonFormat format = iota
 	kvPairFormat
-  kubernetesFormat
+	kubernetesFormat
 )
 
 type config struct {

--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -33,6 +33,7 @@ type format int
 const (
 	jsonFormat format = iota
 	kvPairFormat
+  kubernetesFormat
 )
 
 type config struct {
@@ -132,6 +133,8 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		res.lineFormat = jsonFormat
 	case "key_value":
 		res.lineFormat = kvPairFormat
+	case "kubernetes":
+		res.lineFormat = kubernetesFormat
 	default:
 		return nil, fmt.Errorf("invalid format: %s", lineFormat)
 	}

--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -33,12 +33,12 @@ type format int
 const (
 	jsonFormat format = iota
 	kvPairFormat
-	kubernetesFormat
 )
 
 type config struct {
 	clientConfig  client.Config
 	logLevel      logging.Level
+	autoKubernetesLabels bool
 	removeKeys    []string
 	labelKeys     []string
 	lineFormat    format
@@ -107,6 +107,16 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	}
 	res.logLevel = level
 
+	autoKubernetesLabels := cfg.Get("AutoKubernetesLabels")
+	switch autoKubernetesLabels {
+	case "false", "":
+		res.autoKubernetesLabels = false
+	case "true":
+		res.autoKubernetesLabels = true
+	default:
+		return nil, fmt.Errorf("invalid boolean AutoKubernetesLabels: %v", autoKubernetesLabels)
+	}
+
 	removeKey := cfg.Get("RemoveKeys")
 	if removeKey != "" {
 		res.removeKeys = strings.Split(removeKey, ",")
@@ -133,8 +143,6 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		res.lineFormat = jsonFormat
 	case "key_value":
 		res.lineFormat = kvPairFormat
-	case "kubernetes":
-		res.lineFormat = kubernetesFormat
 	default:
 		return nil, fmt.Errorf("invalid format: %s", lineFormat)
 	}

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -88,23 +88,25 @@ func autoLabels(records map[string]interface{}) model.LabelSet {
 	kuberneteslbs := model.LabelSet{}
 	replacer := strings.NewReplacer("/", "_", ".", "_", "-", "_")
 	for k, v := range records["kubernetes"].(map[interface{}]interface{}) {
-		if k.(string) == "labels" {
+		switch key := k.(string); {
+		case "labels":
 			for m, n := range v.(map[interface{}]interface{}) {
 				switch t := n.(type) {
 				case []byte:
 					kuberneteslbs[model.LabelName(replacer.Replace(m.(string)))] = model.LabelValue(string(t))
 				default:
-					kuberneteslbs[model.LabelName(replacer.Replace(m.(string)))] = model.LabelValue(fmt.Sprintf("%v",n))
+					kuberneteslbs[model.LabelName(replacer.Replace(m.(string)))] = model.LabelValue(fmt.Sprintf("%v", n))
 				}
 			}
-		} else if k.(string) == "docker_id" || k.(string) == "pod_id" || k.(string) == "annotations" {
+		case "docker_id", "pod_id", "annotations":
 			// do nothing
-		} else {
+			continue
+		default:
 			switch t := v.(type) {
 			case []byte:
 				kuberneteslbs[model.LabelName(k.(string))] = model.LabelValue(string(t))
 			default:
-				kuberneteslbs[model.LabelName(k.(string))] = model.LabelValue(fmt.Sprintf("%v",v))
+				kuberneteslbs[model.LabelName(k.(string))] = model.LabelValue(fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -88,7 +88,7 @@ func autoLabels(records map[string]interface{}) model.LabelSet {
 	kuberneteslbs := model.LabelSet{}
 	replacer := strings.NewReplacer("/", "_", ".", "_", "-", "_")
 	for k, v := range records["kubernetes"].(map[interface{}]interface{}) {
-		switch key := k.(string); {
+		switch key := k.(string); key {
 		case "labels":
 			for m, n := range v.(map[interface{}]interface{}) {
 				switch t := n.(type) {

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -130,7 +130,7 @@ func Test_createLine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got, err := createLine(tt.records, tt.f)
+			got, err := createLine(tt.records, tt.f)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createLine() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -130,7 +130,7 @@ func Test_createLine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createLine(tt.records, tt.f)
+			_, got, err := createLine(tt.records, tt.f)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createLine() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/fluent-bit/out_loki.go
+++ b/cmd/fluent-bit/out_loki.go
@@ -53,6 +53,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(logger).Log("[flb-go]", "provided parameter", "BatchSize", conf.clientConfig.BatchSize)
 	level.Info(logger).Log("[flb-go]", "provided parameter", "Labels", conf.clientConfig.ExternalLabels)
 	level.Info(logger).Log("[flb-go]", "provided parameter", "LogLevel", conf.logLevel)
+	level.Info(logger).Log("[flb-go]", "provided parameter", "AutoKubernetesLabels", conf.autoKubernetesLabels)
 	level.Info(logger).Log("[flb-go]", "provided parameter", "RemoveKeys", fmt.Sprintf("%+v", conf.removeKeys))
 	level.Info(logger).Log("[flb-go]", "provided parameter", "LabelKeys", fmt.Sprintf("%+v", conf.labelKeys))
 	level.Info(logger).Log("[flb-go]", "provided parameter", "LineFormat", conf.lineFormat)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
It is too complex to change LabelMap every time when we deploy appliction in new labels. If you install 3rd add-on, you even don't know what the labels are.  This PR provides a way to automatic parse the metadata when you set lineformat with "kubernetes".

**Checklist**
- [x] Documentation added
- [ ] Tests updated

