### PR TITLE
ksonnet: fix replication always set to 3 in ksonnet

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -108,7 +108,7 @@
         lifecycler: {
           ring: {
             heartbeat_timeout: '1m',
-            replication_factor: 3,
+            replication_factor: $._config.replication_factor,
             kvstore: {
               store: 'consul',
               consul: {


### PR DESCRIPTION
**What this PR does / why we need it**:
`replication_factor` in `_config` was not being used while setting replication factor in ring. This should it.

