### PR TITLE
Update datasource path for loki

### DIFF
--- a/production/helm/loki-stack/templates/datasources.yaml
+++ b/production/helm/loki-stack/templates/datasources.yaml
@@ -18,7 +18,7 @@ data:
     - name: Loki
       type: loki
       access: proxy
-      url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
+      url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}/loki
       version: 1
 {{- end }}
 {{- if .Values.prometheus.enabled }}


### PR DESCRIPTION
`http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}` is for explore not for datasource.

Signed-off-by: Xiang Dai <764524258@qq.com>
