### PR TITLE
Fix docker latest and master tags

### DIFF
--- a/.drone/docker-manifest.tmpl
+++ b/.drone/docker-manifest.tmpl
@@ -1,6 +1,8 @@
 image: grafana/{{config.target}}:{{#if build.tag}}{{build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}
-{{#if build.tags}}
 tags:
+  - latest
+  - master
+{{#if build.tags}}
 {{#each build.tags}}
   - {{this}}
 {{/each}}

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -43,7 +43,7 @@ local docker(arch, app) = {
   },
 };
 
-local arch_image(arch) = {
+local arch_image(arch,tags='') = {
   platform: {
     os: 'linux',
     arch: arch,
@@ -55,11 +55,11 @@ local arch_image(arch) = {
       'apk add --no-cache bash git',
       'git fetch origin --tags',
       'echo $(./tools/image-tag)-%s > .tags' % arch,
-    ],
+    ] + if tags != '' then ['echo ",%s" >> .tags' % tags] else [],
   }],
 };
 
-local fluentbit() = pipeline('fluent-bit-amd64') + arch_image('amd64') {
+local fluentbit() = pipeline('fluent-bit-amd64') + arch_image('amd64','latest,master') {
  steps+: [
     // dry run for everything that is not tag or master
     docker('amd64', 'fluent-bit') {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -394,6 +394,7 @@ steps:
   - apk add --no-cache bash git
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
+  - echo ",latest,master" >> .tags
   image: alpine
   name: image-tag
 - depends_on:


### PR DESCRIPTION
Fixes #1087 

I couldn't just add the `latest` and `master` tags directly to the `.tags` file for multi-arch images because it resulted in drone/docker creating and pushing a `latest` and `master` for each architecture which then interferes with the manifest.

So instead I just added the `latest` and `master` tags to the template for the manifest generation.

FYI if anyone is curious how this drone manifest plugin actually works, it's just a thin wrapper around: https://github.com/estesp/manifest-tool, which is what the template file definition is based on.

For the fluent-bit image which is only built for amd64 and doesn't push a manifest file, I extended the jsonnet function which creates the `image-tag` step to accept an optional list of comma separated tags to put into the .tags file which is then used by the drone docker plugin to push images with those tags.

This allows pushing a `latest` and `master` tag for the fluent-bit image
