### PR TITLE
Remove rules that reference no longer existing metrics

### DIFF
--- a/production/loki-mixin/alerts.libsonnet
+++ b/production/loki-mixin/alerts.libsonnet
@@ -40,44 +40,6 @@
         ],
       },
       {
-        name: 'loki_frontend_alerts',
-        rules: [
-          {
-            alert: 'FrontendRequestErrors',
-            expr: |||
-              100 * sum(rate(cortex_gw_request_duration_seconds_count{status_code=~"5.."}[1m])) by (namespace, job, route)
-                /
-              sum(rate(cortex_gw_request_duration_seconds_count[1m])) by (namespace, job, route)
-                > 10
-            |||,
-            'for': '15m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: |||
-                {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.
-              |||,
-            },
-          },
-          {
-            alert: 'FrontendRequestLatency',
-            expr: |||
-              namespace_job_route:cortex_gw_request_duration_seconds:99quantile > 1
-            |||,
-            'for': '15m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: |||
-                {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-              |||,
-            },
-          },
-        ],
-      },
-      {
         name: 'promtail_alerts',
         rules: [
           {

--- a/production/loki-mixin/recording_rules.libsonnet
+++ b/production/loki-mixin/recording_rules.libsonnet
@@ -9,12 +9,6 @@ local utils = import "mixin-utils/utils.libsonnet";
         utils.histogramRules('loki_request_duration_seconds', ['job', 'route']) +
         utils.histogramRules('loki_request_duration_seconds', ['namespace', 'job', 'route']),
     }, {
-      name: 'loki_frontend_rules',
-      rules:
-        utils.histogramRules('cortex_gw_request_duration_seconds', ['job']) +
-        utils.histogramRules('cortex_gw_request_duration_seconds', ['job', 'route']) +
-        utils.histogramRules('cortex_gw_request_duration_seconds', ['namespace', 'job', 'route']),
-    }, {
       name: 'promtail_rules',
       rules:
         utils.histogramRules('promtail_request_duration_seconds', ['job']) +


### PR DESCRIPTION
Removes rules and alerts that reference metrics that no longer exist per @jtlisi 