### PR TITLE
sum the bad words by name and level 

### DIFF
--- a/production/loki-mixin/dashboard-loki-operational.libsonnet
+++ b/production/loki-mixin/dashboard-loki-operational.libsonnet
@@ -315,11 +315,11 @@
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
-                "expr": "topk(5, rate(promtail_custom_bad_words_total{cluster=\"$cluster\", exported_namespace=\"$namespace\"}[5m]) - \nrate(promtail_custom_bad_words_total{cluster=\"$cluster\", exported_namespace=\"$namespace\"}[5m] offset 1h))",
-                "legendFormat": "{{exported_instance}}-{{level}}",
+              {
+                "expr": "topk(5, sum by (name,level) (rate(promtail_custom_bad_words_total{cluster=\"$cluster\", exported_namespace=\"$namespace\"}[$__interval])) - \nsum by (name,level) (rate(promtail_custom_bad_words_total{cluster=\"$cluster\", exported_namespace=\"$namespace\"}[$__interval] offset 1h)))",
+                "legendFormat": "{{name}}-{{level}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,


### PR DESCRIPTION
such that there isn't a spike during rollouts (previously summing by instance meant a new instance had no old metrics to compare to causing a spike in the output)

