### PR TITLE
docs: Updated Kubernetes docs links in Helm charts

### DIFF
--- a/production/helm/fluent-bit/values.yaml
+++ b/production/helm/fluent-bit/values.yaml
@@ -39,7 +39,7 @@ image:
 nameOverride: fluent-bit-loki
 
 ## Node labels for pod assignment
-## ref: https://kubernetes.io/docs/user-guide/node-selection/
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 
 ## Pod Labels

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -80,7 +80,7 @@ livenessProbe:
     port: http-metrics
   initialDelaySeconds: 45
 
-## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
   enabled: false
 
@@ -88,10 +88,10 @@ networkPolicy:
 client: {}
   # name:
 
-## ref: https://kubernetes.io/docs/user-guide/node-selection/
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 ## If you set enabled as "True", you need :
 ## - create a pv which above 10Gi and has same namespace with loki
 ## - keep storageClassName same with below setting

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -23,7 +23,7 @@ loki:
 nameOverride: promtail
 
 ## Node labels for pod assignment
-## ref: https://kubernetes.io/docs/user-guide/node-selection/
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 
 pipelineStages:


### PR DESCRIPTION
**What this PR does / why we need it**:
When going though the values files I noticed that the links off to the documentation have moved and also that the wrong comment was added for the `networkPolicy` value.

**Special notes for your reviewer**:
I know its only a small change but it might save someone 2 minutes of confusion when using the `networkPolicy`.
