### PR TITLE
authentication.md: replace "user" with "tenant"

### DIFF
--- a/docs/operations/authentication.md
+++ b/docs/operations/authentication.md
@@ -5,7 +5,7 @@ expected to run an authenticating reverse proxy in front of your services, such
 as NGINX using basic auth or an OAuth2 proxy.
 
 Note that when using Loki in multi-tenant mode, Loki requires the HTTP header
-`X-Scope-OrgID` to be set to a string identifying the user; the responsibility
+`X-Scope-OrgID` to be set to a string identifying the tenant; the responsibility
 of populating this value should be handled by the authenticating reverse proxy.
 For more information on multi-tenancy please read its
 [documentation](multi-tenancy.md).


### PR DESCRIPTION
In the context of the multi-tenant mode the concept of "user" is confusing. I think this sentence is clearer with the patch. Let me know what you think.