### PR TITLE
Update docker-driver Dockerfile: add tzdb

### DIFF
--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false cmd/docker-driver/docker-driver
 
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/
 ENTRYPOINT [ "/bin/docker-driver" ]


### PR DESCRIPTION
Fix error "_invalid timestamp stage config: invalid location specified: unknown time zone Europe/Moscow_" when specifying `location` in [timestamp stage](https://github.com/grafana/loki/blob/master/docs/clients/promtail/stages/timestamp.md)

**What this PR does / why we need it**: `tzdata` is required for `time.LoadLocation()` function.