### PR TITLE
ci: update triggers to use new deployment_tools location

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -3,4 +3,4 @@
 curl -s --header "Content-Type: application/json" \
   --data "{\"build_parameters\":{\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$(make print-images)\"}}" \
   --request POST \
-  https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
+  https://circleci.com/api/v1.1/project/github/grafana/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN


### PR DESCRIPTION
raintank/deployment_tools repo is being moved to grafana/deployment_tools

