### PR TITLE
Rollback google.golang.org/api to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
 	golang.org/x/tools v0.0.0-20190925134113-a044388aa56f // indirect
-	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/appengine v1.6.3 // indirect
 	google.golang.org/genproto v0.0.0-20190916214212-f660b8655731 // indirect
 	google.golang.org/grpc v1.23.1

--- a/go.sum
+++ b/go.sum
@@ -716,9 +716,8 @@ google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.0.0-20180921000521-920bb1beccf7/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
+google.golang.org/api v0.8.0 h1:VGGbLNyPF7dvYHhcUGYBBGCRDDK0RRJAI6KCvo0CL+E=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
-google.golang.org/api v0.10.0 h1:7tmAxx3oKE98VMZ+SBZzvYYWRQ9HODBxmC8mXUsraSQ=
-google.golang.org/api v0.10.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-api.json
+++ b/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-api.json
@@ -1170,7 +1170,7 @@
       }
     }
   },
-  "revision": "20190807",
+  "revision": "20190708",
   "rootUrl": "https://cloudresourcemanager.googleapis.com/",
   "schemas": {
     "Ancestor": {
@@ -1488,7 +1488,7 @@
       "id": "GetPolicyOptions",
       "properties": {
         "requestedPolicyVersion": {
-          "description": "Optional. The policy format version to be returned.\nAcceptable values are 0, 1, and 3.\nIf the value is 0, or the field is omitted, policy format version 1 will be\nreturned.",
+          "description": "Optional. The policy format version to be returned.\nAcceptable values are 0 and 1.\nIf the value is 0, or the field is omitted, policy format version 1 will be\nreturned.",
           "format": "int32",
           "type": "integer"
         }

--- a/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-gen.go
+++ b/vendor/google.golang.org/api/cloudresourcemanager/v1/cloudresourcemanager-gen.go
@@ -975,7 +975,7 @@ func (s *GetOrgPolicyRequest) MarshalJSON() ([]byte, error) {
 type GetPolicyOptions struct {
 	// RequestedPolicyVersion: Optional. The policy format version to be
 	// returned.
-	// Acceptable values are 0, 1, and 3.
+	// Acceptable values are 0 and 1.
 	// If the value is 0, or the field is omitted, policy format version 1
 	// will be
 	// returned.

--- a/vendor/google.golang.org/api/compute/v1/compute-api.json
+++ b/vendor/google.golang.org/api/compute/v1/compute-api.json
@@ -24,12 +24,12 @@
     }
   },
   "basePath": "/compute/v1/projects/",
-  "baseUrl": "https://compute.googleapis.com/compute/v1/projects/",
+  "baseUrl": "https://www.googleapis.com/compute/v1/projects/",
   "batchPath": "batch/compute/v1",
   "description": "Creates and runs virtual machines on Google Cloud Platform.",
   "discoveryVersion": "v1",
   "documentationLink": "https://developers.google.com/compute/docs/reference/latest/",
-  "etag": "\"9eZ1uxVRThTDhLJCZHhqs3eQWz4/DncSnvGqwaU1HaysGzrVActiBqE\"",
+  "etag": "\"9eZ1uxVRThTDhLJCZHhqs3eQWz4/wnMyqmR3tmklkU9hLzfbwTAQ-KE\"",
   "icons": {
     "x16": "https://www.google.com/images/icons/product/compute_engine-16.png",
     "x32": "https://www.google.com/images/icons/product/compute_engine-32.png"
@@ -19353,7 +19353,7 @@
     }
   },
   "revision": "20190624",
-  "rootUrl": "https://compute.googleapis.com/",
+  "rootUrl": "https://www.googleapis.com/",
   "schemas": {
     "AcceleratorConfig": {
       "description": "A specification of the type and number of accelerator cards attached to the instance.",

--- a/vendor/google.golang.org/api/gensupport/resumable.go
+++ b/vendor/google.golang.org/api/gensupport/resumable.go
@@ -22,13 +22,10 @@ type Backoff interface {
 	Pause() time.Duration
 }
 
-// These are declared as global variables so that tests can overwrite them.
-var (
-	retryDeadline = 32 * time.Second
-	backoff       = func() Backoff {
-		return &gax.Backoff{Initial: 100 * time.Millisecond}
-	}
-)
+// This is declared as a global variable so that tests can overwrite it.
+var backoff = func() Backoff {
+	return &gax.Backoff{Initial: 100 * time.Millisecond}
+}
 
 const (
 	// statusTooManyRequests is returned by the storage API if the
@@ -151,6 +148,15 @@ func (rx *ResumableUpload) transferChunk(ctx context.Context) (*http.Response, e
 	return res, nil
 }
 
+func contextDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
 // Upload starts the process of a resumable upload with a cancellable context.
 // It retries using the provided back off strategy until cancelled or the
 // strategy indicates to stop retrying.
@@ -160,6 +166,8 @@ func (rx *ResumableUpload) transferChunk(ctx context.Context) (*http.Response, e
 // rx is private to the auto-generated API code.
 // Exactly one of resp or err will be nil.  If resp is non-nil, the caller must call resp.Body.Close.
 func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err error) {
+	var pause time.Duration
+
 	var shouldRetry = func(status int, err error) bool {
 		if 500 <= status && status <= 599 {
 			return true
@@ -176,66 +184,53 @@ func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err
 		return false
 	}
 
-	// There are a couple of cases where it's possible for err and resp to both
-	// be non-nil. However, we expose a simpler contract to our callers: exactly
-	// one of resp and err will be non-nil. This means that any response body
-	// must be closed here before returning a non-nil error.
-	var prepareReturn = func(resp *http.Response, err error) (*http.Response, error) {
+	bo := backoff()
+
+	for {
+		// Ensure that we return in the case of cancelled context, even if pause is 0.
+		if contextDone(ctx) {
+			return nil, ctx.Err()
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pause):
+		}
+
+		resp, err = rx.transferChunk(ctx)
+
+		var status int
+		if resp != nil {
+			status = resp.StatusCode
+		}
+
+		// Check if we should retry the request.
+		if shouldRetry(status, err) {
+			pause = bo.Pause()
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+			continue
+		}
+
+		// If the chunk was uploaded successfully, but there's still
+		// more to go, upload the next chunk without any delay.
+		if statusResumeIncomplete(resp) {
+			pause = 0
+			resp.Body.Close()
+			continue
+		}
+
+		// It's possible for err and resp to both be non-nil here, but we expose a simpler
+		// contract to our callers: exactly one of resp and err will be non-nil.  This means
+		// that any response body must be closed here before returning a non-nil error.
 		if err != nil {
 			if resp != nil && resp.Body != nil {
 				resp.Body.Close()
 			}
 			return nil, err
 		}
+
 		return resp, nil
-	}
-
-	// Send all chunks.
-	for {
-		var pause time.Duration
-
-		// Each chunk gets its own initialized-at-zero retry.
-		bo := backoff()
-		quitAfter := time.After(retryDeadline)
-
-		// Retry loop for a single chunk.
-		for {
-			select {
-			case <-ctx.Done():
-				if err == nil {
-					err = ctx.Err()
-				}
-				return prepareReturn(resp, err)
-			case <-time.After(pause):
-			case <-quitAfter:
-				return prepareReturn(resp, err)
-			}
-
-			resp, err = rx.transferChunk(ctx)
-
-			var status int
-			if resp != nil {
-				status = resp.StatusCode
-			}
-
-			// Check if we should retry the request.
-			if !shouldRetry(status, err) {
-				break
-			}
-
-			pause = bo.Pause()
-			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
-			}
-		}
-
-		// If the chunk was uploaded successfully, but there's still
-		// more to go, upload the next chunk without any delay.
-		if statusResumeIncomplete(resp) {
-			resp.Body.Close()
-			continue
-		}
-
-		return prepareReturn(resp, err)
 	}
 }

--- a/vendor/google.golang.org/api/storage/v1/storage-api.json
+++ b/vendor/google.golang.org/api/storage/v1/storage-api.json
@@ -26,7 +26,7 @@
   "description": "Stores and retrieves potentially large, immutable data objects.",
   "discoveryVersion": "v1",
   "documentationLink": "https://developers.google.com/storage/docs/json_api/",
-  "etag": "\"9eZ1uxVRThTDhLJCZHhqs3eQWz4/9Oh4KBZowCPgFtht1bjglfUQ9l0\"",
+  "etag": "\"9eZ1uxVRThTDhLJCZHhqs3eQWz4/m18VxIxuaQHJN-C1B3-yQYvta24\"",
   "icons": {
     "x16": "https://www.google.com/images/icons/product/cloud_storage-16.png",
     "x32": "https://www.google.com/images/icons/product/cloud_storage-32.png"
@@ -449,13 +449,6 @@
               "location": "path",
               "required": true,
               "type": "string"
-            },
-            "optionsRequestedPolicyVersion": {
-              "description": "The IAM policy format version to be returned. If the optionsRequestedPolicyVersion is for an older version that doesn't support part of the requested IAM policy, the request fails.",
-              "format": "int32",
-              "location": "query",
-              "minimum": "1",
-              "type": "integer"
             },
             "provisionalUserProject": {
               "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",
@@ -3203,7 +3196,7 @@
       }
     }
   },
-  "revision": "20190812",
+  "revision": "20190624",
   "rootUrl": "https://www.googleapis.com/",
   "schemas": {
     "Bucket": {
@@ -3319,6 +3312,7 @@
                 },
                 "lockedTime": {
                   "description": "The deadline for changing iamConfiguration.uniformBucketLevelAccess.enabled from true to false in RFC 3339  format. iamConfiguration.uniformBucketLevelAccess.enabled may be changed from true to false until the locked time, after which the field is immutable.",
+                  "format": "date-time",
                   "type": "string"
                 }
               },
@@ -4311,11 +4305,6 @@
         "resourceId": {
           "description": "The ID of the resource to which this policy belongs. Will be of the form projects/_/buckets/bucket for buckets, and projects/_/buckets/bucket/objects/object for objects. A specific generation may be specified by appending #generationNumber to the end of the object name, e.g. projects/_/buckets/my-bucket/objects/data.txt#17. The current generation can be denoted with #0. This field is ignored on input.",
           "type": "string"
-        },
-        "version": {
-          "description": "The IAM policy format version.",
-          "format": "int32",
-          "type": "integer"
         }
       },
       "type": "object"

--- a/vendor/google.golang.org/api/storage/v1/storage-gen.go
+++ b/vendor/google.golang.org/api/storage/v1/storage-gen.go
@@ -2068,9 +2068,6 @@ type Policy struct {
 	// generation can be denoted with #0. This field is ignored on input.
 	ResourceId string `json:"resourceId,omitempty"`
 
-	// Version: The IAM policy format version.
-	Version int64 `json:"version,omitempty"`
-
 	// ServerResponse contains the HTTP response code and headers from the
 	// server.
 	googleapi.ServerResponse `json:"-"`
@@ -3724,16 +3721,6 @@ func (r *BucketsService) GetIamPolicy(bucket string) *BucketsGetIamPolicyCall {
 	return c
 }
 
-// OptionsRequestedPolicyVersion sets the optional parameter
-// "optionsRequestedPolicyVersion": The IAM policy format version to be
-// returned. If the optionsRequestedPolicyVersion is for an older
-// version that doesn't support part of the requested IAM policy, the
-// request fails.
-func (c *BucketsGetIamPolicyCall) OptionsRequestedPolicyVersion(optionsRequestedPolicyVersion int64) *BucketsGetIamPolicyCall {
-	c.urlParams_.Set("optionsRequestedPolicyVersion", fmt.Sprint(optionsRequestedPolicyVersion))
-	return c
-}
-
 // ProvisionalUserProject sets the optional parameter
 // "provisionalUserProject": The project to be billed for this request
 // if the target bucket is requester-pays bucket.
@@ -3860,13 +3847,6 @@ func (c *BucketsGetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, err
 	//       "location": "path",
 	//       "required": true,
 	//       "type": "string"
-	//     },
-	//     "optionsRequestedPolicyVersion": {
-	//       "description": "The IAM policy format version to be returned. If the optionsRequestedPolicyVersion is for an older version that doesn't support part of the requested IAM policy, the request fails.",
-	//       "format": "int32",
-	//       "location": "query",
-	//       "minimum": "1",
-	//       "type": "integer"
 	//     },
 	//     "provisionalUserProject": {
 	//       "description": "The project to be billed for this request if the target bucket is requester-pays bucket.",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -649,7 +649,7 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
 golang.org/x/time/rate
-# google.golang.org/api v0.10.0
+# google.golang.org/api v0.8.0
 google.golang.org/api/cloudresourcemanager/v1
 google.golang.org/api/compute/v1
 google.golang.org/api/gensupport


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki ingesters are suffering from a slow goroutine leak most likely due to:

https://github.com/googleapis/google-cloud-go/issues/1380

This issue is not seen in other applications using 0.8.0.  Hail marying a rollback to see if it fixes the issue.