### PR TITLE
Move ReservedLabelTenantID out from a dedicated file

### DIFF
--- a/pkg/logentry/stages/tenant.go
+++ b/pkg/logentry/stages/tenant.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/promtail/constants"
+	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -75,7 +75,7 @@ func (s *tenantStage) Process(labels model.LabelSet, extracted map[string]interf
 		return
 	}
 
-	labels[constants.ReservedLabelTenantID] = model.LabelValue(tenantID)
+	labels[client.ReservedLabelTenantID] = model.LabelValue(tenantID)
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/tenant_test.go
+++ b/pkg/logentry/stages/tenant_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/grafana/loki/pkg/promtail/constants"
+	"github.com/grafana/loki/pkg/promtail/client"
 	lokiutil "github.com/grafana/loki/pkg/util"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -90,7 +90,7 @@ func TestTenantStage_Process(t *testing.T) {
 		},
 		"should not override the tenant if the source field is not defined in the extracted map": {
 			config:         &TenantConfig{Source: "tenant_id"},
-			inputLabels:    model.LabelSet{constants.ReservedLabelTenantID: "foo"},
+			inputLabels:    model.LabelSet{client.ReservedLabelTenantID: "foo"},
 			inputExtracted: map[string]interface{}{},
 			expectedTenant: lokiutil.StringRef("foo"),
 		},
@@ -102,7 +102,7 @@ func TestTenantStage_Process(t *testing.T) {
 		},
 		"should override the tenant if the source field is defined in the extracted map": {
 			config:         &TenantConfig{Source: "tenant_id"},
-			inputLabels:    model.LabelSet{constants.ReservedLabelTenantID: "foo"},
+			inputLabels:    model.LabelSet{client.ReservedLabelTenantID: "foo"},
 			inputExtracted: map[string]interface{}{"tenant_id": "bar"},
 			expectedTenant: lokiutil.StringRef("bar"),
 		},
@@ -120,7 +120,7 @@ func TestTenantStage_Process(t *testing.T) {
 		},
 		"should override the tenant with the configured static value": {
 			config:         &TenantConfig{Value: "bar"},
-			inputLabels:    model.LabelSet{constants.ReservedLabelTenantID: "foo"},
+			inputLabels:    model.LabelSet{client.ReservedLabelTenantID: "foo"},
 			inputExtracted: map[string]interface{}{},
 			expectedTenant: lokiutil.StringRef("bar"),
 		},
@@ -145,7 +145,7 @@ func TestTenantStage_Process(t *testing.T) {
 			assert.Equal(t, time.Unix(1, 1), timestamp)
 			assert.Equal(t, "hello world", entry)
 
-			actualTenant, ok := labels[constants.ReservedLabelTenantID]
+			actualTenant, ok := labels[client.ReservedLabelTenantID]
 			if testData.expectedTenant == nil {
 				assert.False(t, ok)
 			} else {

--- a/pkg/promtail/constants/labels.go
+++ b/pkg/promtail/constants/labels.go
@@ -1,7 +1,0 @@
-package constants
-
-const (
-	// Label reserved to override the tenant ID while processing
-	// pipeline stages
-	ReservedLabelTenantID = "__tenant_id__"
-)


### PR DESCRIPTION
**What this PR does / why we need it**:

In PR #1135 I've received a last minute comment about the dedicated file for `ReservedLabelTenantID`. In this PR I'm fixing it, removing the dedicated file and moving the constant to promtail client.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

