### PR TITLE
fluentd: Suppress unread configuration warning

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.1'
+  spec.version = '1.2.2'
   spec.authors = %w[woodsaj briangann]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -86,11 +86,13 @@ module Fluent
           @remove_keys_accessors.push(record_accessor_create(key))
         end
 
-        @cert = OpenSSL::X509::Certificate.new(File.read(@cert)) if @cert
-        @key = OpenSSL::PKey.read(File.read(key)) if @key
+        if !@key.nil? && !@cert.nil?
+          @cert = OpenSSL::X509::Certificate.new(File.read(@cert)) if @cert
+          @key = OpenSSL::PKey.read(File.read(@key)) if @key
 
-        if !@key.is_a?(OpenSSL::PKey::RSA) && !@key.is_a?(OpenSSL::PKey::DSA)
-          raise "Unsupported private key type #{key.class}"
+          if !@key.is_a?(OpenSSL::PKey::RSA) && !@key.is_a?(OpenSSL::PKey::DSA)
+            raise "Unsupported private key type #{key.class}"
+          end
         end
 
         if !@ca_cert.nil? && !File.exist?(@ca_cert)

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -76,7 +76,7 @@ module Fluent
         @record_accessors = {}
         conf.elements.select { |element| element.name == 'label' }.each do |element|
           element.each_pair do |k, v|
-            element.key?(k) # to suppress unread configuration warning
+            element.has_key?(k) # rubocop:disable Style/PreferredHashMethods #to suppress unread configuration warning
             v = k if v.empty?
             @record_accessors[k] = record_accessor_create(v)
           end


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to resolve fluentd warning for `<label>` configuration.

```
2019-11-08 13:29:55 +0000 [warn]: section <label> is not used in <match **> of loki plugin
2019-11-08 13:29:55 +0000 [warn]: section <label> is not used in <match **> of loki plugin
2019-11-08 13:29:55 +0000 [warn]: section <label> is not used in <match **> of loki plugin
2019-11-08 13:29:55 +0000 [warn]: section <label> is not used in <match **> of loki plugin
```
With the fix it should disappear

**+1 Fix mandatory client cert configuration**

**Checklist**
- [x] Documentation added
- [x] Tests updated

