### PR TITLE
pkg/promtail/client: Handle fingerprint hash collisions

### DIFF
--- a/pkg/logentry/stages/timestamp.go
+++ b/pkg/logentry/stages/timestamp.go
@@ -145,7 +145,7 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]in
 	// The timestamp has been correctly parsed, so we should store it in the map
 	// containing the last known timestamp used by the "fudge" action on failure.
 	if *ts.cfg.ActionOnFailure == TimestampActionOnFailureFudge {
-		ts.lastKnownTimestamps.Add(labels.FastFingerprint(), *t)
+		ts.lastKnownTimestamps.Add(labels.String(), *t)
 	}
 }
 
@@ -193,8 +193,8 @@ func (ts *timestampStage) processActionOnFailure(labels model.LabelSet, t *time.
 }
 
 func (ts *timestampStage) processActionOnFailureFudge(labels model.LabelSet, t *time.Time) {
-	labelsFingerprint := labels.FastFingerprint()
-	lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsFingerprint)
+	labelsStr := labels.String()
+	lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr)
 
 	// If the last known timestamp is unknown (ie. has not been successfully parsed yet)
 	// there's nothing we can do, so we're going to keep the current timestamp
@@ -206,5 +206,5 @@ func (ts *timestampStage) processActionOnFailureFudge(labels model.LabelSet, t *
 	*t = lastTimestamp.(time.Time).Add(1 * time.Nanosecond)
 
 	// Store the fudged timestamp, so that a subsequent fudged timestamp will be 1ns after it
-	ts.lastKnownTimestamps.Add(labelsFingerprint, *t)
+	ts.lastKnownTimestamps.Add(labelsStr, *t)
 }

--- a/pkg/promtail/client/batch.go
+++ b/pkg/promtail/client/batch.go
@@ -15,6 +15,7 @@ import (
 // streams for each tenant are stored in a dedicated batch.
 type batch struct {
 	streams   map[model.Fingerprint]*logproto.Stream
+	mappings  map[model.Fingerprint]model.LabelSet // to handle hash collisions, we keep the real mapping here.
 	bytes     int
 	createdAt time.Time
 }
@@ -22,6 +23,7 @@ type batch struct {
 func newBatch(entries ...entry) *batch {
 	b := &batch{
 		streams:   map[model.Fingerprint]*logproto.Stream{},
+		mappings:  map[model.Fingerprint]model.LabelSet{},
 		bytes:     0,
 		createdAt: time.Now(),
 	}
@@ -39,7 +41,7 @@ func (b *batch) add(entry entry) {
 	b.bytes += len(entry.Line)
 
 	// Append the entry to an already existing stream (if any)
-	fp := entry.labels.FastFingerprint()
+	fp := b.uniqueFingerprint(entry.labels)
 	if stream, ok := b.streams[fp]; ok {
 		stream.Entries = append(stream.Entries, entry.Entry)
 		return
@@ -49,6 +51,27 @@ func (b *batch) add(entry entry) {
 	b.streams[fp] = &logproto.Stream{
 		Labels:  entry.labels.String(),
 		Entries: []logproto.Entry{entry.Entry},
+	}
+}
+
+func (b *batch) uniqueFingerprint(labels model.LabelSet) model.Fingerprint {
+	// fast fingerprint generates similar values for similar label sets.
+	// by using large prime, we get away from those close clusters quickly
+	const prime = 960119528882528219
+
+	fp := labels.FastFingerprint()
+	for {
+		if b.mappings[fp] == nil {
+			b.mappings[fp] = labels
+			return fp
+		}
+
+		if b.mappings[fp].Equal(labels) {
+			return fp
+		}
+
+		// otherwise, just try next one
+		fp += prime
 	}
 }
 
@@ -71,6 +94,17 @@ func (b *batch) age() time.Duration {
 // encode the batch as snappy-compressed push request, and returns
 // the encoded bytes and the number of encoded entries
 func (b *batch) encode() ([]byte, int, error) {
+	req, entriesCount := b.createPushRequest()
+	buf, err := proto.Marshal(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	buf = snappy.Encode(nil, buf)
+	return buf, entriesCount, nil
+}
+
+// creates push request and returns it, together with number of entries
+func (b *batch) createPushRequest() (*logproto.PushRequest, int) {
 	req := logproto.PushRequest{
 		Streams: make([]*logproto.Stream, 0, len(b.streams)),
 	}
@@ -80,11 +114,5 @@ func (b *batch) encode() ([]byte, int, error) {
 		req.Streams = append(req.Streams, stream)
 		entriesCount += len(stream.Entries)
 	}
-
-	buf, err := proto.Marshal(&req)
-	if err != nil {
-		return nil, 0, err
-	}
-	buf = snappy.Encode(nil, buf)
-	return buf, entriesCount, nil
+	return &req, entriesCount
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to fingerprint hash collisions, Promtail client can mix entries for different labels into the same stream. This can lead to having entries with incorrect labels, and possible out of order errors.

**Which issue(s) this PR fixes**:
Not sure if there is issue for this.

**Special notes for your reviewer**:
I've used large prime number to find next possible fingerprint value. Any prime (except 2) would work here, as would simple increment. I wanted to avoid using next fingerprint (+1), because fast fingerprint creates similar values for similar labels. 

**Checklist**
- [x] Documentation added (no extra documentation)
- [x] Tests updated

