### PR TITLE
helm: update default terminationGracePeriodSeconds to 4800

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.19.0
+version: 0.19.1
 appVersion: v0.4.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.17.1
+version: 0.17.2
 appVersion: v0.4.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -154,7 +154,7 @@ serviceAccount:
   create: true
   name:
 
-terminationGracePeriodSeconds: 30
+terminationGracePeriodSeconds: 4800
 
 ## Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
Users that run Loki using the Helm chart may not modify the value for terminationGracePeriodSeconds to allow Loki enough time to flush all of its data. If Loki is forcefully terminated by Kubernetes during a flush, missing data or an unhealthy ingester in the ring in microservices mode can occur.

This commit changes the grace period to 4800 seconds, the value used in the Jsonnet code.

I've never updated the Helm charts before so I'm not sure if I need to update the versions or do anything else (do I need to run a script somewhere?).

/cc @slim-bean 
