### PR TITLE
pkg/loki: unmarshal module name from YAML

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	var config loki.Config
 	if err := cfg.Parse(&config); err != nil {
-		level.Error(util.Logger).Log("msg", "parsing config", "error", err)
+		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}
 	if *printVersion {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -42,6 +42,15 @@ const (
 	All
 )
 
+func (m *moduleName) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var val string
+	if err := unmarshal(&val); err != nil {
+		return err
+	}
+
+	return m.Set(val)
+}
+
 func (m moduleName) String() string {
 	switch m {
 	case Ring:


### PR DESCRIPTION
The module name field in the config could not be unmarshalled from a string, causing parsing the config to crash.

This commit also changes the error message when the config could not be parsed to print directly to stderr, as the logger won't be initialized at the point where parsing the config fails, leading to no output in the console.

Fixes #1259.
