### PR TITLE
[WIP] Change default schema version to v11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           name: Run Chart Tests
           command: |
             ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-            ct install --helm-extra-args="--set loki.image.tag=latest,promtail.image.tag=latest" --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
+            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
 
   publish-helm:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           name: Run Chart Tests
           command: |
             ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
+            ct install --helm-extra-args="--set loki.image.tag=latest,promtail.image.tag=latest" --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
 
   publish-helm:
     <<: *defaults

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -24,6 +24,13 @@ schema_config:
     index:
       prefix: index_
       period: 168h
+  - from: 2019-11-14
+    store: boltdb
+    object_store: filesystem
+    schema: v11
+    index:
+      prefix: index_v11_
+      period: 168h
 
 storage_config:
   boltdb:
@@ -53,4 +60,3 @@ table_manager:
     provisioned_write_throughput: 0
   retention_deletes_enabled: false
   retention_period: 0
-

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -628,7 +628,9 @@ store: <string>
 # cassandra. If omitted, defaults to same value as store.
 [object_store: <string>]
 
-# The schema to use. Set to v9 or v10.
+# The schema to use. Set to v9 or v11.
+# v11 also indexes all label names per unique series which improve labels queries latency.
+# v11 is the current recommended version.
 schema: <string>
 
 # Configures how the index is updated and stored.

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -29,7 +29,7 @@ schema_config:
   - from: 2018-04-15
     store: boltdb
     object_store: filesystem
-    schema: v9
+    schema: v11
     index:
       prefix: index_
       period: 168h
@@ -73,11 +73,11 @@ stores, respectively.
 schema_config:
   configs:
   - from: 2018-04-15
-    store: bigtable
-    object_store: gcs
-    schema: v9
+    store: boltdb
+    object_store: filesystem
+    schema: v11
     index:
-      prefix: loki_index_
+      prefix: index_
       period: 168h
 
 storage_config:
@@ -99,7 +99,7 @@ schema_config:
   - from: 2018-04-15
     store: cassandra
     object_store: filesystem
-    schema: v9
+    schema: v11
     index:
       prefix: cassandra_table
       period: 168h
@@ -127,7 +127,7 @@ schema_config:
     - from: 2018-04-15
       store: dynamo
       object_store: s3
-      schema: v9
+      schema: v11
       index:
         prefix: dynamodb_table_name
         period: 0

--- a/docs/operations/storage/retention.md
+++ b/docs/operations/storage/retention.md
@@ -45,7 +45,7 @@ schema_config:
   - from: 2018-04-15
     store: bigtable
     object_store: gcs
-    schema: v9
+    schema: v11
     index:
       prefix: loki_index_
       period: 168h

--- a/docs/operations/storage/table-manager.md
+++ b/docs/operations/storage/table-manager.md
@@ -66,11 +66,11 @@ for the query time range.
 ### Schema config example
 
 For example, the following `schema_config` defines two configurations: the first
-one using the schema `v8` and the current one using the `v9`.
+one using the schema `v9` and the current one using the `v11`.
 
 The first config stores data between `2019-01-01` and `2019-04-14` (included),
-then a new config has been added - to upgrade the schema version to `v9` -
-storing data using the `v9` schema from `2019-04-15` on.
+then a new config has been added - to upgrade the schema version to `v11` -
+storing data using the `v11` schema from `2019-04-15` on.
 
 For each config, multiple tables are created, each one storing data for
 `period` time (168 hours = 7 days).
@@ -80,13 +80,13 @@ schema_config:
   configs:
     - from:   2019-01-01
       store:  dynamo
-      schema: v8
+      schema: v9
       index:
         prefix: loki_
         period: 168h
     - from:   2019-04-15
       store:  dynamo
-      schema: v9
+      schema: v11
       index:
         prefix: loki_
         period: 168h

--- a/pkg/storage/hack/main.go
+++ b/pkg/storage/hack/main.go
@@ -55,7 +55,7 @@ func getStore() (lstore.Store, error) {
 					From:       chunk.DayTime{Time: start},
 					IndexType:  "boltdb",
 					ObjectType: "filesystem",
-					Schema:     "v9",
+					Schema:     "v11",
 					IndexTables: chunk.PeriodicTableConfig{
 						Prefix: "index_",
 						Period: time.Hour * 168,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -151,7 +151,7 @@ func getLocalStore() Store {
 				From:       chunk.DayTime{Time: start},
 				IndexType:  "boltdb",
 				ObjectType: "filesystem",
-				Schema:     "v9",
+				Schema:     "v11",
 				IndexTables: chunk.PeriodicTableConfig{
 					Prefix: "index_",
 					Period: time.Hour * 168,

--- a/production/helm/loki-stack/ci/latest-values.yaml
+++ b/production/helm/loki-stack/ci/latest-values.yaml
@@ -1,0 +1,6 @@
+promtail:
+  image:
+    tag: latest
+loki:
+  image:
+    tag: latest

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -52,6 +52,13 @@ config:
       index:
         prefix: index_
         period: 168h
+    - from: 2019-11-14
+      store: boltdb
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_v11_
+        period: 168h
   server:
     http_listen_port: 3100
   storage_config:

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -135,34 +135,34 @@
       },
 
       storage_config: {
-        index_queries_cache_config: {
-          memcached: {
-            batch_size: 100,
-            parallelism: 100,
-          },
+                        index_queries_cache_config: {
+                          memcached: {
+                            batch_size: 100,
+                            parallelism: 100,
+                          },
 
-          memcached_client: {
-            host: 'memcached-index-queries.%s.svc.cluster.local' % $._config.namespace,
-            service: 'memcached-client',
-            consistent_hash: true,
-          },
-        },
-      } +
-      (if std.count($._config.enabledBackends, 'gcs') > 0 then {
-        gcs: $._config.client_configs.gcs,
-       } else {}) +
-      (if std.count($._config.enabledBackends, 's3') > 0 then {
-        aws+: $._config.client_configs.s3
-       } else {}) +
-      (if std.count($._config.enabledBackends, 'bigtable') > 0 then {
-        bigtable: $._config.client_configs.gcp,
-       } else {}) +
-      (if std.count($._config.enabledBackends, 'cassandra') > 0 then {
-        cassandra: $._config.client_configs.cassandra,
-       } else {}) +
-      (if std.count($._config.enabledBackends, 'dynamodb') > 0 then {
-        aws+: $._config.client_configs.dynamo
-       } else {}),
+                          memcached_client: {
+                            host: 'memcached-index-queries.%s.svc.cluster.local' % $._config.namespace,
+                            service: 'memcached-client',
+                            consistent_hash: true,
+                          },
+                        },
+                      } +
+                      (if std.count($._config.enabledBackends, 'gcs') > 0 then {
+                         gcs: $._config.client_configs.gcs,
+                       } else {}) +
+                      (if std.count($._config.enabledBackends, 's3') > 0 then {
+                         aws+: $._config.client_configs.s3,
+                       } else {}) +
+                      (if std.count($._config.enabledBackends, 'bigtable') > 0 then {
+                         bigtable: $._config.client_configs.gcp,
+                       } else {}) +
+                      (if std.count($._config.enabledBackends, 'cassandra') > 0 then {
+                         cassandra: $._config.client_configs.cassandra,
+                       } else {}) +
+                      (if std.count($._config.enabledBackends, 'dynamodb') > 0 then {
+                         aws+: $._config.client_configs.dynamo,
+                       } else {}),
 
       chunk_store_config: {
         chunk_cache_config: {
@@ -195,16 +195,28 @@
 
       // Default schema config is bigtable/gcs, this will need to be overriden for other stores
       schema_config: {
-        configs: [{
-          from: '2018-04-15',
-          store: 'bigtable',
-          object_store: 'gcs',
-          schema: 'v9',
-          index: {
-            prefix: '%s_index_' % $._config.table_prefix,
-            period: '%dh' % $._config.index_period_hours,
+        configs: [
+          {
+            from: '2018-04-15',
+            store: 'bigtable',
+            object_store: 'gcs',
+            schema: 'v9',
+            index: {
+              prefix: '%s_index_' % $._config.table_prefix,
+              period: '%dh' % $._config.index_period_hours,
+            },
           },
-        }],
+          {
+            from: '2019-11-14',
+            store: 'bigtable',
+            object_store: 'gcs',
+            schema: 'v11',
+            index: {
+              prefix: '%s_index_v11_' % $._config.table_prefix,
+              period: '%dh' % $._config.index_period_hours,
+            },
+          },
+        ],
       },
 
       table_manager: {


### PR DESCRIPTION
This changes the default schema to v11. The v11 build on top of the v10 and indexes  series with label names.  v11 schema has been tested for more than a week in our environment. 

> We should merge this after #1264 