### PR TITLE
Push logs to Promtail over HTTP

### DIFF
--- a/cmd/promtail/promtail-local-config.yaml
+++ b/cmd/promtail/promtail-local-config.yaml
@@ -9,6 +9,8 @@ clients:
   - url: http://localhost:3100/loki/api/v1/push
 
 scrape_configs:
+- job_name: http
+  http: {}
 - job_name: system
   static_configs:
   - targets:

--- a/docs/clients/promtail/README.md
+++ b/docs/clients/promtail/README.md
@@ -11,7 +11,8 @@ It primarily:
 3. Pushes them to the Loki instance.
 
 Currently, Promtail can tail logs from two sources: local log files and the
-systemd journal (on AMD64 machines only).
+systemd journal (on AMD64 machines only). Promtail also supports receiving
+log lines over [HTTP](./scraping.md#http-target).
 
 ## Log File Discovery
 
@@ -71,6 +72,22 @@ This endpoint returns 200 when Promtail is up and running, and there's at least 
 This endpoint returns Promtail metrics for Prometheus. See
 "[Operations > Observability](../../operations/observability.md)" to get a list
 of exported metrics.
+
+### `POST /push/<label pairs>`
+
+When the [HTTP Target](./scraping.md#http-target) is being used, a `/push`
+endpoint is enabled that allows for writing logs:
+
+```
+curl -XPOST "http://promtail/push/label1/value1/label2/value2" -d 'hello, world!'
+```
+
+An RFC 3339 timestamp can also be provided in the URL through the `ts` query
+parameter:
+
+```
+curl -XPOST "http://promtail/push/label1/value1?ts=2009-11-10T23:00:00Z" -d 'hello, world!'
+```
 
 ### Promtail web server config
 

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -22,12 +22,14 @@ and how to scrape logs from files.
             * [metric_gauge](#metric_gauge)
             * [metric_histogram](#metric_histogram)
         * [tenant_stage](#tenant_stage)
+    * [http_config](#http_config)
     * [journal_config](#journal_config)
     * [relabel_config](#relabel_config)
     * [static_config](#static_config)
     * [file_sd_config](#file_sd_config)
     * [kubernetes_sd_config](#kubernetes_sd_config)
 * [target_config](#target_config)
+* [Example HTTP Config](#example-http-config)
 * [Example Docker Config](#example-docker-config)
 * [Example Journal Config](#example-journal-config)
 
@@ -240,6 +242,9 @@ job_name: <string>
 
 # Describes how to transform logs from targets.
 [pipeline_stages: <pipeline_stages>]
+
+# Describes how to receieve logs over HTTP.
+[http: <http_config>]
 
 # Describes how to scrape logs from the journal.
 [journal: <journal_config>]
@@ -558,6 +563,19 @@ tenant:
   # Value to use to set the tenant ID when this stage is executed. Useful
   # when this stage is included within a conditional pipeline with "match".
   [ value: <string> ]
+```
+
+### http_config
+
+The `http_config` block configures an endpoint on the Promtail server (`/push`)
+that allows users to push logs directly to Promtail.
+See the [push API](./README.md##post-pushlabel-pairs) docs for information on
+how to invoke the endpoint.
+
+```yaml
+# Label map to add to every log pushed to Promtail.
+labels:
+  [ <labelname>: <labelvalue> ... ]
 ```
 
 ### journal_config
@@ -908,6 +926,24 @@ targets.
 # Period to resync directories being watched and files being tailed to discover
 # new ones or stop watching removed ones.
 sync_period: "10s"
+```
+
+## Example HTTP Config
+
+```yaml
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
+
+scrape_configs:
+ - job_name: http
+   http: {}
 ```
 
 ## Example Docker Config

--- a/docs/clients/promtail/scraping.md
+++ b/docs/clients/promtail/scraping.md
@@ -75,6 +75,40 @@ relabel_configs:
 
 See [Relabeling](#relabeling) for more information.
 
+## HTTP Target
+
+Promtail supports a special type of target for shipping logs through Promtail
+rather than to Loki directly. Pushing data directly to Promtail is useful to
+take advantage of Promtail's log transformation capabilities.
+
+The `http` target enables a `/push` endpoint on the Promtail server, and is
+configured with the following stanza:
+
+```yaml
+scrape_configs:
+  - job_name: http_job
+    http:
+      labels:
+        job: http
+```
+
+Providing `labels` is optional and defines a static list of labels to append to
+every entry. If labels is omitted, define the `http` stanza simply as `http:
+{}`. `http` _must_ be present for the target to be enabled.
+
+When using the `http` target, `relabel_configs` and `pipeline_stages` will work
+as usual.
+
+### HTTP Target Limitations
+
+When using the HTTP target, note of the following limitations:
+
+1. Only one `scrape_config` entry can define `http`. If multiple `http` blocks
+   are found, all but the first will be ignored.
+2. For any given service, only ship logs to a single Promtail instance's HTTP
+   target. If logs are delivered to more than one instance, using the metrics
+   step in a pipeline will not work, and out of order errors may occur.
+
 ## Relabeling
 
 Each `scrape_configs` entry can contain a `relabel_configs` stanza.

--- a/pkg/promtail/scrape/scrape.go
+++ b/pkg/promtail/scrape/scrape.go
@@ -19,8 +19,15 @@ type Config struct {
 	EntryParser            api.EntryParser                  `yaml:"entry_parser"`
 	PipelineStages         stages.PipelineStages            `yaml:"pipeline_stages,omitempty"`
 	JournalConfig          *JournalTargetConfig             `yaml:"journal,omitempty"`
+	HTTPConfig             *HTTPTargetConfig                `yaml:"http,omitempty"`
 	RelabelConfigs         []*relabel.Config                `yaml:"relabel_configs,omitempty"`
 	ServiceDiscoveryConfig sd_config.ServiceDiscoveryConfig `yaml:",inline"`
+}
+
+// HTTPTargetConfig describes a scrape config that listens for requests over HTTP.
+type HTTPTargetConfig struct {
+	// Labels optionally holds labels to associate with each record read from HTTP.
+	Labels model.LabelSet `yaml:"labels"`
 }
 
 // JournalTargetConfig describes systemd journal records to scrape.

--- a/pkg/promtail/targets/httptarget.go
+++ b/pkg/promtail/targets/httptarget.go
@@ -1,0 +1,178 @@
+package targets
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/relabel"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	httpEntries = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "http_target_entries_total",
+		Help:      "Total number of successful entries sent to HTTP target",
+	})
+)
+
+// HTTPTarget listens to HTTP requests and handles them as if they were
+// tailed from a file.
+type HTTPTarget struct {
+	logger        log.Logger
+	handler       api.EntryHandler
+	relabelConfig []*relabel.Config
+	labels        model.LabelSet
+}
+
+// NewHTTPTarget configures a new HTTPTarget.
+func NewHTTPTarget(
+	logger log.Logger,
+	handler api.EntryHandler,
+	relabel []*relabel.Config,
+	config *scrape.HTTPTargetConfig,
+) (*HTTPTarget, error) {
+
+	return &HTTPTarget{
+		logger:        logger,
+		handler:       handler,
+		relabelConfig: relabel,
+		labels:        config.Labels,
+	}, nil
+}
+
+// ServeHTTP implements http.Handler, and is invoked by promtail's server
+// whenever a write request comes in, generating logs to eventually send
+// to Loki.
+//
+// Logs are expected to come in with the URL path of label pairs separated
+// by slashes: /label1/value1/label2/value2 (and so on). A RFC3339 or
+// RFC3339Nano timestamp can be also by provided by adding `?ts=<timestamp>`
+// as a query parameter.
+func (t *HTTPTarget) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	pathLabels, err := labelsFromPath(req.URL.Path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	lbls, err := t.transformLabels(pathLabels)
+	if err != nil {
+		level.Error(t.logger).Log("msg", "failed to get labels for message", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if len(lbls) == 0 {
+		// Drop entry, no labels.
+		w.WriteHeader(200)
+		return
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		level.Error(t.logger).Log("msg", "failed to read request body", "err", err)
+		http.Error(w, "could not read message body", http.StatusInternalServerError)
+		return
+	} else if len(body) == 0 {
+		http.Error(w, "no log message provided", http.StatusBadRequest)
+		return
+	}
+
+	messageTime := time.Now()
+	if ts := req.URL.Query().Get("ts"); ts != "" {
+		var err error
+		messageTime, err = time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("could not read log timestamp: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	t.handler.Handle(lbls, messageTime, string(body))
+	httpEntries.Inc()
+
+	w.WriteHeader(200)
+}
+
+func (t *HTTPTarget) transformLabels(lbls map[string]string) (model.LabelSet, error) {
+	// Add constant labels
+	for k, v := range t.labels {
+		lbls[string(k)] = string(v)
+	}
+
+	processed := relabel.Process(labels.FromMap(lbls), t.relabelConfig...).Map()
+
+	ret := make(model.LabelSet)
+	for k, v := range processed {
+		if k[0:2] == "__" {
+			continue
+		}
+		ret[model.LabelName(k)] = model.LabelValue(v)
+	}
+
+	return ret, nil
+}
+
+// Type returns HTTPTargetType.
+func (t *HTTPTarget) Type() TargetType {
+	return HTTPTargetType
+}
+
+// Ready indicates whether or not the journal is ready to be read from.
+func (t *HTTPTarget) Ready() bool {
+	return true
+}
+
+// DiscoveredLabels returns the set of labels discovered by the HTTPTarget, which
+// is always nil. Implements Target.
+func (t *HTTPTarget) DiscoveredLabels() model.LabelSet {
+	return nil
+}
+
+// Labels returns the set of labels that statically apply to all log entries
+// produced by the HTTPTarget.
+func (t *HTTPTarget) Labels() model.LabelSet {
+	return t.labels
+}
+
+// Details returns target-specific details.
+func (t *HTTPTarget) Details() interface{} {
+	return map[string]string{}
+}
+
+// Stop shuts down the HTTPTarget.
+func (t *HTTPTarget) Stop() error {
+	return nil
+}
+
+func labelsFromPath(path string) (map[string]string, error) {
+	var pairs []string
+	for _, part := range strings.Split(path, "/") {
+		if part == "" {
+			continue
+		}
+		pairs = append(pairs, strings.TrimSpace(part))
+	}
+
+	if len(pairs)%2 != 0 {
+		return nil, fmt.Errorf("missing label value in path for %s", pairs[len(pairs)-1])
+	}
+
+	ls := make(map[string]string)
+	for i := 0; i < len(pairs); i += 2 {
+		ls[pairs[i]] = pairs[i+1]
+	}
+
+	return ls, nil
+}

--- a/pkg/promtail/targets/httptarget_test.go
+++ b/pkg/promtail/targets/httptarget_test.go
@@ -1,0 +1,91 @@
+package targets
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+type ClientMessage struct {
+	Labels    model.LabelSet
+	Timestamp time.Time
+	Message   string
+}
+
+type TestLabeledClient struct {
+	log      log.Logger
+	messages []ClientMessage
+	sync.Mutex
+}
+
+func (c *TestLabeledClient) Handle(ls model.LabelSet, t time.Time, s string) error {
+	level.Debug(c.log).Log("msg", "received log", "log", s)
+
+	c.Lock()
+	defer c.Unlock()
+	c.messages = append(c.messages, ClientMessage{ls, t, s})
+	return nil
+}
+
+func TestHTTPTarget(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := &TestLabeledClient{log: logger}
+
+	tgt, err := NewHTTPTarget(logger, client, nil, &scrape.HTTPTargetConfig{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "label1/value1/label2/value2/", strings.NewReader("hello, world"))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	tgt.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, len(client.messages), 1)
+	require.Equal(t, model.LabelSet{
+		"label1": "value1",
+		"label2": "value2",
+	}, client.messages[0].Labels)
+	require.Equal(t, "hello, world", client.messages[0].Message)
+	require.NotZero(t, client.messages[0].Timestamp)
+}
+
+func TestHTTPTarget_Timestamp(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	client := &TestLabeledClient{log: logger}
+
+	tgt, err := NewHTTPTarget(logger, client, nil, &scrape.HTTPTargetConfig{})
+	require.NoError(t, err)
+
+	// Get a timestamp trimmed to precision defined by RFC3339Nano
+	ts := time.Now()
+	ts, _ = time.Parse(time.RFC3339Nano, ts.Format(time.RFC3339Nano))
+
+	path := fmt.Sprintf("label1/value1/label2/value2?ts=%s", ts.Format(time.RFC3339Nano))
+	req, err := http.NewRequest("GET", path, strings.NewReader("hello, world"))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	tgt.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, len(client.messages), 1)
+	require.Equal(t, ClientMessage{
+		Labels:    model.LabelSet{"label1": "value1", "label2": "value2"},
+		Timestamp: ts,
+		Message:   "hello, world",
+	}, client.messages[0])
+}

--- a/pkg/promtail/targets/httptargetmanager.go
+++ b/pkg/promtail/targets/httptargetmanager.go
@@ -1,0 +1,87 @@
+package targets
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/logentry/stages"
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HTTPTargetManager manages a series of HTTPTargets.
+type HTTPTargetManager struct {
+	logger  log.Logger
+	targets map[string]*HTTPTarget
+}
+
+// NewHTTPTargetManager creates a new HTTPTargetManager.
+func NewHTTPTargetManager(
+	logger log.Logger,
+	client api.EntryHandler,
+	scrapeConfigs []scrape.Config,
+) (*HTTPTargetManager, error) {
+
+	tm := &HTTPTargetManager{
+		logger:  logger,
+		targets: make(map[string]*HTTPTarget),
+	}
+
+	if len(scrapeConfigs) > 1 {
+		level.Warn(logger).Log("msg", "multiple http scrape_config sections found: only the first will be used")
+	}
+
+	for _, cfg := range scrapeConfigs {
+		registerer := prometheus.DefaultRegisterer
+		pipeline, err := stages.NewPipeline(log.With(logger, "component", "http_pipeline"), cfg.PipelineStages, &cfg.JobName, registerer)
+		if err != nil {
+			return nil, err
+		}
+
+		t, err := NewHTTPTarget(logger, pipeline.Wrap(client), cfg.RelabelConfigs, cfg.HTTPConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		tm.targets[cfg.JobName] = t
+		break
+	}
+
+	return tm, nil
+}
+
+// Ready returns true if at least one HTTPTarget is also ready.
+func (tm *HTTPTargetManager) Ready() bool {
+	for _, t := range tm.targets {
+		if t.Ready() {
+			return true
+		}
+	}
+	return false
+}
+
+// Stop stops the HTTPTargetManager and all of its HTTPTargets.
+func (tm *HTTPTargetManager) Stop() {
+	for _, t := range tm.targets {
+		if err := t.Stop(); err != nil {
+			level.Error(t.logger).Log("msg", "error stopping HTTPTarget", "err", err.Error())
+		}
+	}
+}
+
+// ActiveTargets returns the list of HTTPTargets where journal data
+// is being read. ActiveTargets is an alias to AllTargets as
+// HTTPTargets cannot be deactivated, only stopped.
+func (tm *HTTPTargetManager) ActiveTargets() map[string][]Target {
+	return tm.AllTargets()
+}
+
+// AllTargets returns the list of all targets where journal data
+// is currently being read.
+func (tm *HTTPTargetManager) AllTargets() map[string][]Target {
+	result := make(map[string][]Target, len(tm.targets))
+	for k, v := range tm.targets {
+		result[k] = []Target{v}
+	}
+	return result
+}

--- a/pkg/promtail/targets/target.go
+++ b/pkg/promtail/targets/target.go
@@ -14,6 +14,9 @@ const (
 	// JournalTargetType is a journalctl target
 	JournalTargetType = TargetType("Journal")
 
+	// HTTPTargetType is an HTTP target
+	HTTPTargetType = TargetType("HTTP")
+
 	// DroppedTargetType is a target that's been dropped.
 	DroppedTargetType = TargetType("dropped")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

External clients that wish to push data to Loki are unable to take advantage of Promtail's pipelines, metrics, and buffering capabilities. This PR adds an `http` target that adds an HTTP handler used 
by the Promtail server. 

Example usage: 

```bash
curl -XPOST "http://localhost:3080/push/foo/bar" -d 'hello, world!'
```

Creates a log line in Loki with the label set `{foo="bar"}`.

**Checklist**
- [x] Documentation added
- [x] Tests updated

