### PR TITLE
chore(ci): drone-cli

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -127,7 +127,7 @@ local manifest(apps) = pipeline('manifest') {
   ],
 };
 
-local drone = [
+[
   pipeline('check') {
     workspace: {
       base: '/src',
@@ -166,8 +166,4 @@ local drone = [
       },
     ],
   },
-];
-
-{
-  drone: std.manifestYamlStream(drone),
-}
+]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,500 +1,544 @@
+---
 kind: pipeline
 name: check
-steps:
-  - commands:
-      - make BUILD_IN_CONTAINER=false test
-    depends_on:
-      - clone
-    image: grafana/loki-build-image:0.7.4
-    name: test
-  - commands:
-      - make BUILD_IN_CONTAINER=false lint
-    depends_on:
-      - clone
-    image: grafana/loki-build-image:0.7.4
-    name: lint
-  - commands:
-      - make BUILD_IN_CONTAINER=false check-generated-files
-    depends_on:
-      - clone
-    image: grafana/loki-build-image:0.7.4
-    name: check-generated-files
-  - commands:
-      - make BUILD_IN_CONTAINER=false check-mod
-    depends_on:
-      - clone
-      - test
-      - lint
-    image: grafana/loki-build-image:0.7.4
-    name: check-mod
+
+platform:
+  os: linux
+  arch: amd64
+
 workspace:
   base: /src
   path: loki
+
+steps:
+- name: test
+  image: grafana/loki-build-image:0.7.4
+  commands:
+  - make BUILD_IN_CONTAINER=false test
+  depends_on:
+  - clone
+
+- name: lint
+  image: grafana/loki-build-image:0.7.4
+  commands:
+  - make BUILD_IN_CONTAINER=false lint
+  depends_on:
+  - clone
+
+- name: check-generated-files
+  image: grafana/loki-build-image:0.7.4
+  commands:
+  - make BUILD_IN_CONTAINER=false check-generated-files
+  depends_on:
+  - clone
+
+- name: check-mod
+  image: grafana/loki-build-image:0.7.4
+  commands:
+  - make BUILD_IN_CONTAINER=false check-mod
+  depends_on:
+  - clone
+  - test
+  - lint
+
 ---
-depends_on:
-  - check
 kind: pipeline
 name: docker-amd64
+
 platform:
-  arch: amd64
   os: linux
+  arch: amd64
+
 steps:
-  - commands:
-      - apk add --no-cache bash git
-      - git fetch origin --tags
-      - echo $(./tools/image-tag)-amd64 > .tags
-    image: alpine
-    name: image-tag
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
----
+- name: image-tag
+  image: alpine
+  commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  - echo $(./tools/image-tag)-amd64 > .tags
+
+- name: build-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
 depends_on:
-  - check
+- check
+
+---
 kind: pipeline
 name: docker-arm64
+
 platform:
-  arch: arm64
   os: linux
+  arch: arm64
+
 steps:
-  - commands:
-      - apk add --no-cache bash git
-      - git fetch origin --tags
-      - echo $(./tools/image-tag)-arm64 > .tags
-    image: alpine
-    name: image-tag
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
----
+- name: image-tag
+  image: alpine
+  commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  - echo $(./tools/image-tag)-arm64 > .tags
+
+- name: build-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
 depends_on:
-  - check
+- check
+
+---
 kind: pipeline
 name: docker-arm
+
 platform:
-  arch: arm
   os: linux
+  arch: arm
+
 steps:
-  - commands:
-      - apk add --no-cache bash git
-      - git fetch origin --tags
-      - echo $(./tools/image-tag)-arm > .tags
-    image: alpine
-    name: image-tag
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-image
-    settings:
-      dockerfile: cmd/loki/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-loki-canary-image
-    settings:
-      dockerfile: cmd/loki-canary/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/loki-canary
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-promtail-image
-    settings:
-      dockerfile: cmd/promtail/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/promtail
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
----
+- name: image-tag
+  image: alpine
+  commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  - echo $(./tools/image-tag)-arm > .tags
+
+- name: build-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: build-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-loki-canary-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/loki-canary/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/loki-canary
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-promtail-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/promtail/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/promtail
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
 depends_on:
-  - check
+- check
+
+---
 kind: pipeline
 name: fluent-bit-amd64
+
 platform:
-  arch: amd64
   os: linux
+  arch: amd64
+
 steps:
-  - commands:
-      - apk add --no-cache bash git
-      - git fetch origin --tags
-      - echo $(./tools/image-tag)-amd64 > .tags
-      - echo ",latest,master" >> .tags
-    image: alpine
-    name: image-tag
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: build-fluent-bit-image
-    settings:
-      dockerfile: cmd/fluent-bit/Dockerfile
-      dry_run: true
-      password:
-        from_secret: docker_password
-      repo: grafana/fluent-bit-plugin-loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        exclude:
-          - refs/heads/master
-          - refs/tags/v*
-  - depends_on:
-      - image-tag
-    image: plugins/docker
-    name: publish-fluent-bit-image
-    settings:
-      dockerfile: cmd/fluent-bit/Dockerfile
-      dry_run: false
-      password:
-        from_secret: docker_password
-      repo: grafana/fluent-bit-plugin-loki
-      username:
-        from_secret: docker_username
-    when:
-      ref:
-        include:
-          - refs/heads/master
-          - refs/tags/v*
----
+- name: image-tag
+  image: alpine
+  commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  - echo $(./tools/image-tag)-amd64 > .tags
+  - echo ",latest,master" >> .tags
+
+- name: build-fluent-bit-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/fluent-bit/Dockerfile
+    dry_run: true
+    password:
+      from_secret: docker_password
+    repo: grafana/fluent-bit-plugin-loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      exclude:
+      - refs/heads/master
+      - refs/tags/v*
+  depends_on:
+  - image-tag
+
+- name: publish-fluent-bit-image
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/fluent-bit/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: grafana/fluent-bit-plugin-loki
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/heads/master
+    - refs/tags/v*
+  depends_on:
+  - image-tag
+
 depends_on:
-  - docker-amd64
-  - docker-arm64
-  - docker-arm
+- check
+
+---
 kind: pipeline
 name: manifest
+
+platform:
+  os: linux
+  arch: amd64
+
 steps:
-  - depends_on:
-      - clone
-    image: plugins/manifest
-    name: manifest-promtail
-    settings:
-      ignore_missing: true
-      password:
-        from_secret: docker_password
-      spec: .drone/docker-manifest.tmpl
-      target: promtail
-      username:
-        from_secret: docker_username
-  - depends_on:
-      - clone
-    image: plugins/manifest
-    name: manifest-loki
-    settings:
-      ignore_missing: true
-      password:
-        from_secret: docker_password
-      spec: .drone/docker-manifest.tmpl
-      target: loki
-      username:
-        from_secret: docker_username
-  - depends_on:
-      - clone
-    image: plugins/manifest
-    name: manifest-loki-canary
-    settings:
-      ignore_missing: true
-      password:
-        from_secret: docker_password
-      spec: .drone/docker-manifest.tmpl
-      target: loki-canary
-      username:
-        from_secret: docker_username
+- name: manifest-promtail
+  image: plugins/manifest
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest.tmpl
+    target: promtail
+    username:
+      from_secret: docker_username
+  depends_on:
+  - clone
+
+- name: manifest-loki
+  image: plugins/manifest
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest.tmpl
+    target: loki
+    username:
+      from_secret: docker_username
+  depends_on:
+  - clone
+
+- name: manifest-loki-canary
+  image: plugins/manifest
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest.tmpl
+    target: loki-canary
+    username:
+      from_secret: docker_username
+  depends_on:
+  - clone
+
 trigger:
   ref:
-    include:
-      - refs/heads/master
-      - refs/tags/v*
----
+  - refs/heads/master
+  - refs/tags/v*
+
 depends_on:
-  - manifest
+- docker-amd64
+- docker-arm64
+- docker-arm
+
+---
 kind: pipeline
 name: deploy
+
+platform:
+  os: linux
+  arch: amd64
+
 steps:
-  - commands:
-      - ./tools/deploy.sh
-    environment:
-      CIRCLE_TOKEN:
-        from_secret: circle_token
-    image: grafana/loki-build-image:0.7.4
-    name: trigger
+- name: trigger
+  image: grafana/loki-build-image:0.7.4
+  commands:
+  - ./tools/deploy.sh
+  environment:
+    CIRCLE_TOKEN:
+      from_secret: circle_token
+
 trigger:
   ref:
-    include:
-      - refs/heads/master
-      - refs/tags/v*
+  - refs/heads/master
+  - refs/tags/v*
+
+depends_on:
+- manifest
+
+...

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ benchmark-store:
 
 # regenerate drone yaml
 drone:
-	jsonnet -V __build-image-version=$(BUILD_IMAGE_VERSION) .drone/drone.jsonnet | jq .drone -r | yq -y . > .drone/drone.yml
+	drone jsonnet --stream --format -V __build-image-version=$(BUILD_IMAGE_VERSION) --source .drone/drone.jsonnet --target .drone/drone.yml
 
 # support go modules
 check-mod:


### PR DESCRIPTION
Drone has a CLI (https://github.com/drone/drone-cli) that handles compiling the
Jsonnet to a valid `drone.yml`.

This is more elegant than our previous `jsonnet | yq` dance.

~~⚠️ **DO NOT MERGE** This depends on https://github.com/drone/drone-cli/pull/163 which is not yet merged ⚠️~~ PR merged