### PR TITLE
Fix loki_discarded_samples_total metric

### DIFF
--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -10,6 +10,15 @@ const (
 	RateLimited = "rate_limited"
 )
 
+// DiscardedBytes is a metric of the total discarded bytes, by reason.
+var DiscardedBytes = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "loki_discarded_bytes_total",
+		Help: "The total number of bytes that were discarded.",
+	},
+	[]string{discardReasonLabel, "user"},
+)
+
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
 var DiscardedSamples = prometheus.NewCounterVec(
 	prometheus.CounterOpts{


### PR DESCRIPTION
`loki_discarded_samples_total` is supposed to be the count of samples that were discarded, but was instead being reported as the total bytes discarded. The metric has been fixed and a new metric, `loki_discarded_bytes_total`, has been added to report the total discarded bytes.

Fixes #1255.