### PR TITLE
pkg/ingester: check that ingester is in LEAVING state when transferring chunks and claiming tokens. Required when using memberlist client.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/util"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
 	"github.com/cortexproject/cortex/pkg/ring"
@@ -120,6 +122,7 @@ func (t *Loki) initRing() (err error) {
 	if err != nil {
 		return
 	}
+	prometheus.MustRegister(t.ring)
 	t.server.HTTP.Handle("/ring", t.ring)
 	return
 }


### PR DESCRIPTION
In order to work with gossiped ring correctly, ingester that is going to claim tokens from a different ingester needs to make sure that leaving ingester is indeed in the LEAVING state. Otherwise claiming tokens will fail. This change implements the check.

(Plus it also adds ring to prometheus metrics in distributor)