### PR TITLE
promtail: write positions to new file first, move to target location afterwards

### DIFF
--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -205,5 +205,13 @@ func writePositionFile(filename string, positions map[string]string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Clean(filename), buf, os.FileMode(positionFileMode))
+	target := filepath.Clean(filename)
+	temp := target + "-new"
+
+	err = ioutil.WriteFile(temp, buf, os.FileMode(positionFileMode))
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(temp, target)
 }


### PR DESCRIPTION
promtail uses positions file to write positions in watched log files. It's doing so in an unsafe way, overwriting existing file. If error happens while writing to the file, file ends up being inconsistent. And old version is gone.

This PR changes positions writing, so that it's first written to new file, and only if that succeeds, is it move to target position. New file is file in the same directory, but with "-new" appended.

os.Rename guarantees that it replaces existing file, or it fails, but it cannot leave file inconsistent.
