### PR TITLE
fluent-bit: sorted JSON and properly convert []byte to string

### DIFF
--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -42,7 +42,7 @@ type config struct {
 	labelKeys     []string
 	lineFormat    format
 	dropSingleKey bool
-	labeMap       map[string]interface{}
+	labelMap      map[string]interface{}
 }
 
 func parseConfig(cfg ConfigGetter) (*config, error) {
@@ -139,7 +139,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open LabelMap file: %s", err)
 		}
-		if err := json.Unmarshal(content, &res.labeMap); err != nil {
+		if err := json.Unmarshal(content, &res.labelMap); err != nil {
 			return nil, fmt.Errorf("failed to Unmarshal LabelMap file: %s", err)
 		}
 		res.labelKeys = nil

--- a/cmd/fluent-bit/config_test.go
+++ b/cmd/fluent-bit/config_test.go
@@ -97,7 +97,7 @@ func Test_parseConfig(t *testing.T) {
 				labelKeys:     nil,
 				removeKeys:    []string{"buzz", "fuzz"},
 				dropSingleKey: false,
-				labeMap: map[string]interface{}{
+				labelMap: map[string]interface{}{
 					"kubernetes": map[string]interface{}{
 						"container_name": "container",
 						"host":           "host",
@@ -160,8 +160,8 @@ func assertConfig(t *testing.T, expected, actual *config) {
 	if expected.logLevel.String() != actual.logLevel.String() {
 		t.Errorf("incorrect logLevel want:%v got:%v", expected.logLevel.String(), actual.logLevel.String())
 	}
-	if !reflect.DeepEqual(expected.labeMap, actual.labeMap) {
-		t.Errorf("incorrect labeMap want:%v got:%v", expected.labeMap, actual.labeMap)
+	if !reflect.DeepEqual(expected.labelMap, actual.labelMap) {
+		t.Errorf("incorrect labelMap want:%v got:%v", expected.labelMap, actual.labelMap)
 	}
 }
 

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -147,7 +147,7 @@ func removeKeys(records map[string]interface{}, keys []string) {
 func createLine(records map[string]interface{}, f format) (string, error) {
 	switch f {
 	case jsonFormat:
-		js, err := jsoniter.Marshal(records)
+		js, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(records)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -38,8 +38,8 @@ func (l *loki) sendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	records := toStringMap(r)
 	level.Debug(l.logger).Log("msg", "processing records", "records", fmt.Sprintf("%+v", records))
 	lbs := model.LabelSet{}
-	if l.cfg.labeMap != nil {
-		mapLabels(records, l.cfg.labeMap, lbs)
+	if l.cfg.labelMap != nil {
+		mapLabels(records, l.cfg.labelMap, lbs)
 	} else {
 		lbs = extractLabels(records, l.cfg.labelKeys)
 	}

--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -72,6 +72,8 @@ func toStringMap(record map[interface{}]interface{}) map[string]interface{} {
 		case []byte:
 			// prevent encoding to base64
 			m[key] = string(t)
+		case map[interface{}]interface{}:
+			m[key] = toStringMap(t)
 		default:
 			m[key] = v
 		}
@@ -106,10 +108,9 @@ func mapLabels(records map[string]interface{}, mapping map[string]interface{}, r
 		switch nextKey := v.(type) {
 		// if the next level is a map we are expecting we need to move deeper in the tree
 		case map[string]interface{}:
-			if nextValue, ok := records[k].(map[interface{}]interface{}); ok {
-				recordsMap := toStringMap(nextValue)
+			if nextValue, ok := records[k].(map[string]interface{}); ok {
 				// recursively search through the next level map.
-				mapLabels(recordsMap, nextKey, res)
+				mapLabels(nextValue, nextKey, res)
 			}
 		// we found a value in the mapping meaning we need to save the corresponding record value for the given key.
 		case string:

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -52,7 +52,7 @@ func Test_loki_sendRecord(t *testing.T) {
 		{"error", &config{labelKeys: []string{"fake"}, lineFormat: jsonFormat, removeKeys: []string{"foo"}}, nil},
 		{"key value", &config{labelKeys: []string{"fake"}, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, &entry{model.LabelSet{}, `bar=500`, now}},
 		{"single", &config{labelKeys: []string{"fake"}, dropSingleKey: true, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, &entry{model.LabelSet{}, `500`, now}},
-		{"labelmap", &config{labeMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, &entry{model.LabelSet{"other": "500"}, `{"foo":"bar"}`, now}},
+		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, &entry{model.LabelSet{"other": "500"}, `{"foo":"bar"}`, now}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -51,6 +51,25 @@ func Test_loki_sendRecord(t *testing.T) {
 		"G": "G",
 		"H": "H",
 	}
+	var byteArrayRecordFixture = map[interface{}]interface{}{
+		"label": "label",
+		"outer": []byte("foo"),
+		"map": map[interface{}]interface{}{
+			"inner": []byte("bar"),
+		},
+	}
+	var mixedTypesRecordFixture = map[interface{}]interface{}{
+		"label": "label",
+		"int":   42,
+		"float": 42.42,
+		"array": []interface{}{42, 42.42, "foo"},
+		"map": map[interface{}]interface{}{
+			"nested": map[interface{}]interface{}{
+				"foo":     "bar",
+				"invalid": []byte("a\xc5z"),
+			},
+		},
+	}
 
 	tests := []struct {
 		name   string
@@ -69,6 +88,8 @@ func Test_loki_sendRecord(t *testing.T) {
 		{"key value", &config{labelKeys: []string{"fake"}, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, &entry{model.LabelSet{}, `bar=500`, now}},
 		{"single", &config{labelKeys: []string{"fake"}, dropSingleKey: true, lineFormat: kvPairFormat, removeKeys: []string{"foo", "error", "fake"}}, simpleRecordFixture, &entry{model.LabelSet{}, `500`, now}},
 		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, &entry{model.LabelSet{"other": "500"}, `{"foo":"bar"}`, now}},
+		{"byte array", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, byteArrayRecordFixture, &entry{model.LabelSet{"label": "label"}, `{"map":{"inner":"bar"},"outer":"foo"}`, now}},
+		{"mixed types", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, mixedTypesRecordFixture, &entry{model.LabelSet{"label": "label"}, `{"array":[42,42.42,"foo"],"float":42.42,"int":42,"map":{"nested":{"foo":"bar","invalid":"a\ufffdz"}}}`, now}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -233,68 +254,23 @@ func Test_labelMapping(t *testing.T) {
 			model.LabelSet{},
 		},
 		{
-			"bytes string",
-			map[string]interface{}{
-				"kubernetes": map[interface{}]interface{}{
-					"foo": []byte("buzz"),
-				},
-				"stream": "stderr",
-			},
-			map[string]interface{}{
-				"kubernetes": map[string]interface{}{
-					"foo":         "test",
-					"nonexisting": "",
-				},
-				"stream": "output",
-				"nope":   "nope",
-			},
-			model.LabelSet{"test": "buzz", "output": "stderr"},
-		},
-		{
-			"numeric label",
-			map[string]interface{}{
-				"kubernetes": map[interface{}]interface{}{
-					"integer":        42,
-					"floating_point": 42.42,
-				},
-				"stream": "stderr",
-			},
-			map[string]interface{}{
-				"kubernetes": map[string]interface{}{
-					"integer":        "integer",
-					"floating_point": "floating_point",
-				},
-				"stream": "output",
-				"nope":   "nope",
-			},
-			model.LabelSet{"integer": "42", "floating_point": "42.42", "output": "stderr"},
-		},
-		{
-			"list label",
-			map[string]interface{}{
-				"kubernetes": map[interface{}]interface{}{
-					"integers": []int{42, 43},
-				},
-			},
-			map[string]interface{}{
-				"kubernetes": map[string]interface{}{
-					"integers": "integers",
-				},
-			},
-			model.LabelSet{"integers": "[42 43]"},
-		},
-		{
 			"deep string",
 			map[string]interface{}{
-				"kubernetes": map[interface{}]interface{}{
-					"label": map[interface{}]interface{}{
-						"component": map[interface{}]interface{}{
+				"int":   "42",
+				"float": "42.42",
+				"array": `[42,42.42,"foo"]`,
+				"kubernetes": map[string]interface{}{
+					"label": map[string]interface{}{
+						"component": map[string]interface{}{
 							"buzz": "value",
 						},
 					},
 				},
 			},
 			map[string]interface{}{
+				"int":   "int",
+				"float": "float",
+				"array": "array",
 				"kubernetes": map[string]interface{}{
 					"label": map[string]interface{}{
 						"component": map[string]interface{}{
@@ -305,34 +281,12 @@ func Test_labelMapping(t *testing.T) {
 				"stream": "output",
 				"nope":   "nope",
 			},
-			model.LabelSet{"label": "value"},
-		},
-		{
-			"skip invalid values",
-			map[string]interface{}{
-				"kubernetes": map[interface{}]interface{}{
-					"annotations": map[interface{}]interface{}{
-						"kubernetes.io/config.source": "cfg",
-						"kubernetes.io/config.hash":   []byte("a\xc5z"),
-					},
-					"container_name": "loki",
-					"namespace_name": "dev",
-					"pod_name":       "loki-asdwe",
-				},
+			model.LabelSet{
+				"int":   "42",
+				"float": "42.42",
+				"array": `[42,42.42,"foo"]`,
+				"label": "value",
 			},
-			map[string]interface{}{
-				"kubernetes": map[string]interface{}{
-					"annotations": map[string]interface{}{
-						"kubernetes.io/config.source": "source",
-						"kubernetes.io/config.hash":   "hash",
-					},
-					"container_name": "container",
-					"namespace_name": "namespace",
-					"pod_name":       "instance",
-				},
-				"stream": "output",
-			},
-			model.LabelSet{"container": "loki", "instance": "loki-asdwe", "namespace": "dev", "source": "cfg"},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/fluent-bit/out_loki.go
+++ b/cmd/fluent-bit/out_loki.go
@@ -56,7 +56,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(logger).Log("[flb-go]", "provided parameter", "LabelKeys", fmt.Sprintf("%+v", conf.labelKeys))
 	level.Info(logger).Log("[flb-go]", "provided parameter", "LineFormat", conf.lineFormat)
 	level.Info(logger).Log("[flb-go]", "provided parameter", "DropSingleKey", conf.dropSingleKey)
-	level.Info(logger).Log("[flb-go]", "provided parameter", "LabelMapPath", fmt.Sprintf("%+v", conf.labeMap))
+	level.Info(logger).Log("[flb-go]", "provided parameter", "LabelMapPath", fmt.Sprintf("%+v", conf.labelMap))
 
 	plugin, err = newPlugin(conf, logger)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm sorry for sneaking in two changes in a single PR, but I found one of the issues while fixing the other and the code is pretty much "just next line" in the tests. Chaining PRs would be a hassle... If there are any objections regarding a single commit, I'll happily rebase it to a separate PR.

*fluent-bit: fix variable spelling mistake*

I guess the changes are obvious and trivial, just fixing some variable misspelled all over the code base.

*fluent-bit: properly convert []byte to string*

Recently, a regression was introduced that no longer ran a deep
conversion of `[]byte` to `string` unless a label map was supplied. This
commit fixes this by running the string conversion recursively, also
removing the need of applying the conversion function again during label
map stage.

This change has two minor side effects:

- Some test cases had to be moved, as string conversion happens much
  earlier now.
- Invalid characters do not result in the whole label being ignored any
  more, but are replaced by the unicode placeholder character now. I'd
  consider this an improvement, making both debugging much easier ("why
  is that value suddenly missing?") and preserving as much information
  as possible.

*fluent-bit: sort JSON map*

While developing another fix, I stumbled upon #1309 as a newly written
unit test (with multiple key-value pairs in a map) was flaky.

While JSON does not [strictly define an order on records in a map][RFC8259],
but practical operations with a logging tool pretty much require it
(although of course grep for JSON is jq, not grep...). Also, the key
value output format is already sorted.

Switching to sorted output in jsoniter is pretty easy. As of today, it
still has a [bug] though, for which I already provided a [fix]. I
propose accepting that rare case where invalid types can occur from
msgpack output (can this even happen?) and re-enable the failing test
case as soon as the upstream PR is merged.

[RFC8259]: https://tools.ietf.org/html/rfc8259#section-4
[bug]:     json-iterator/go#388
[fix]:     json-iterator/go#422

**Which issue(s) this PR fixes**:

At least improves #1309. Whether this is a fix should be subject of discussion.

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated

