### PR TITLE
Removing old file needed for dep (no longer needed)

### DIFF
--- a/pkg/logproto/dep.go
+++ b/pkg/logproto/dep.go
@@ -1,7 +1,0 @@
-package logproto
-
-import (
-	// trick dep into including this, needed by the generated code.
-	_ "github.com/cortexproject/cortex/pkg/chunk/storage"
-	_ "github.com/gogo/protobuf/types"
-)


### PR DESCRIPTION
This should fix the anyone using the logproto.pb.go file from registering a bunch of cortex metrics (e.g. loki-canary).

