### PR TITLE
helm: support adding init containers to the loki pod

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.23.0
+version: 0.24.0
 appVersion: v1.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.21.0
+version: 0.22.0
 appVersion: v1.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -41,6 +41,8 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -176,6 +176,12 @@ serviceMonitor:
   additionalLabels: {}
   # scrapeTimeout: 10s
 
+initContainers: []
+## Init containers to be added to the loki pod.
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
+
 extraContainers: []
 ## Additional containers to be added to the loki pod.
 # - name: reverse-proxy


### PR DESCRIPTION
Add support for adding init containers the same way you can add extra containers to the loki pod.

