### PR TITLE
Pull in cortex changes to support IAM roles for EKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
-	github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d
+	github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.0.0-20190607191414-238f8eaa31aa

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d h1:b0rUibdDf+OVEdBvfUIptXR0Sqn3DUz3C0Ilm8d/yOg=
-github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d/go.mod h1:kxKBAZMqeLb5cr4YTxVFoquewYNStgqAfLvx9Y/Y08k=
 github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968 h1:cI97HPV3BMKCHmLNYAyIzbuFW3T7EOdDckvizPTGYtQ=
 github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968/go.mod h1:kxKBAZMqeLb5cr4YTxVFoquewYNStgqAfLvx9Y/Y08k=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbp
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d h1:b0rUibdDf+OVEdBvfUIptXR0Sqn3DUz3C0Ilm8d/yOg=
 github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d/go.mod h1:kxKBAZMqeLb5cr4YTxVFoquewYNStgqAfLvx9Y/Y08k=
+github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968 h1:cI97HPV3BMKCHmLNYAyIzbuFW3T7EOdDckvizPTGYtQ=
+github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968/go.mod h1:kxKBAZMqeLb5cr4YTxVFoquewYNStgqAfLvx9Y/Y08k=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cznic/b v0.0.0-20180115125044-35e9bbe41f07/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/cznic/fileutil v0.0.0-20180108211300-6a051e75936f/go.mod h1:8S58EK26zhXSxzv7NQFpnliaOQsmDUxvoQO3rt154Vg=

--- a/vendor/github.com/cortexproject/cortex/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/chunk/aws/dynamodb_storage_client.go
@@ -861,5 +861,5 @@ func awsSessionFromURL(awsURL *url.URL) (client.ConfigProvider, error) {
 		return nil, err
 	}
 	config = config.WithMaxRetries(0) // We do our own retries, so we can monitor them
-	return session.New(config), nil
+	return session.NewSession(config)
 }

--- a/vendor/github.com/cortexproject/cortex/pkg/chunk/aws/s3_storage_client.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/chunk/aws/s3_storage_client.go
@@ -51,7 +51,11 @@ func NewS3ObjectClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.O
 	s3Config = s3Config.WithS3ForcePathStyle(cfg.S3ForcePathStyle) // support for Path Style S3 url if has the flag
 
 	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them
-	s3Client := s3.New(session.New(s3Config))
+	sess, err := session.NewSession(s3Config)
+	if err != nil {
+		return nil, err
+	}
+	s3Client := s3.New(sess)
 	bucketNames := []string{strings.TrimPrefix(cfg.S3.URL.Path, "/")}
 	if cfg.BucketNames != "" {
 		bucketNames = strings.Split(cfg.BucketNames, ",") // comma separated list of bucket names

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -113,7 +113,7 @@ github.com/coreos/go-systemd/sdjournal
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/dlopen
-# github.com/cortexproject/cortex v0.3.1-0.20191117214907-06c4340e652d
+# github.com/cortexproject/cortex v0.3.1-0.20191122194007-ed7c302fd968
 github.com/cortexproject/cortex/pkg/chunk
 github.com/cortexproject/cortex/pkg/chunk/aws
 github.com/cortexproject/cortex/pkg/chunk/cache


### PR DESCRIPTION

This PR pulls in changes in cortex that will enable the use of IAM roles for service accounts in AWS EKS.

Fixes #1241 

