### PR TITLE
Update loki helm chart to support service account annotations

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.20.1
+version: 0.21.0
 appVersion: v1.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.20.0
+version: 0.20.1
 appVersion: v1.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.18.0
+version: 0.18.1
 appVersion: v1.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.18.1
+version: 0.19.0
 appVersion: v1.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/serviceaccount.yaml
+++ b/production/helm/loki/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   name: {{ template "loki.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/production/helm/loki/templates/serviceaccount.yaml
+++ b/production/helm/loki/templates/serviceaccount.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ template "loki.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
   name: {{ template "loki.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -153,6 +153,7 @@ service:
 serviceAccount:
   create: true
   name:
+  annotations: {}
 
 terminationGracePeriodSeconds: 4800
 


### PR DESCRIPTION
This PR will enable annotating the Loki service account in order to user IAM roles for service account in EKS.

Fixes #1337 

