### PR TITLE
documentation: using parsable value in example

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -707,7 +707,7 @@ logs in Loki.
 [enforce_metric_name: <boolean> | default = true]
 
 # Maximum number of active streams per user.
-[max_streams_per_user: <int> | default = 10e3]
+[max_streams_per_user: <int> | default = 10000]
 
 # Maximum number of chunks that can be fetched by a single query.
 [max_chunks_per_query: <int> | default = 2000000]


### PR DESCRIPTION
**What this PR does**: using value that actually parsable by loki

**Special notes for your reviewer**: Actually if you create a fully configuration file with the default values, for `max_streams_per_user` you got `failed parsing config: sourcing: yaml: unmarshal errors: line 321: cannot unmarshal !!str '10e3' into int`

Furthermore, other value doesn't use this syntax

**Checklist**
- [X] Documentation added

