### PR TITLE
documentation: iam requirement for autoscaling

### DIFF
--- a/docs/operations/storage/README.md
+++ b/docs/operations/storage/README.md
@@ -83,7 +83,9 @@ Resources: `arn:aws:dynamodb:<aws_region>:<aws_account_id>:table/<prefix>*`
 * `application-autoscaling:DescribeScalableTargets`
 * `application-autoscaling:DescribeScalingPolicies`
 * `application-autoscaling:RegisterScalableTarget`
+* `application-autoscaling:DeregisterScalableTarget`
 * `application-autoscaling:PutScalingPolicy`
+* `application-autoscaling:DeleteScalingPolicy`
 
 Resources: `*`
 


### PR DESCRIPTION
**What this PR does / why we need it**: improve documentation by adding IAM requirement for AutoScaling and DynamoDB

These permissions are required when table go from 'active' to 'inactive' and you use on-demand mode for inactive table. I missed it this the first time

**Special notes for your reviewer**: me again 😁 

**Checklist**
- [X] Documentation added

