### PR TITLE
docs: Fix grpc_listen_host and http_listen_host.

### DIFF
--- a/docs/clients/promtail/README.md
+++ b/docs/clients/promtail/README.md
@@ -78,6 +78,6 @@ The web server exposed by Promtail can be configured in the Promtail `.yaml` con
 
 ```yaml
 server:
-  http_listen_host: 127.0.0.1
+  http_listen_address: 127.0.0.1
   http_listen_port: 9080
 ```

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -82,13 +82,13 @@ The `server_config` block configures Promtail's behavior as an HTTP server:
 
 ```yaml
 # HTTP server listen host
-[http_listen_host: <string>]
+[http_listen_address: <string>]
 
 # HTTP server listen port
 [http_listen_port: <int> | default = 80]
 
 # gRPC server listen host
-[grpc_listen_host: <string>]
+[grpc_listen_address: <string>]
 
 # gRPC server listen port
 [grpc_listen_port: <int> | default = 9095]
@@ -131,7 +131,7 @@ The `client_config` block configures how Promtail connects to an instance of
 Loki:
 
 ```yaml
-# The URL where Loki is listening, denoted in Loki as http_listen_host and
+# The URL where Loki is listening, denoted in Loki as http_listen_address and
 # http_listen_port. If Loki is running in microservices mode, this is the HTTP
 # URL for the Distributor.
 url: <string>

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -96,13 +96,13 @@ The `server_config` block configures Promtail's behavior as an HTTP server:
 
 ```yaml
 # HTTP server listen host
-[http_listen_host: <string>]
+[http_listen_address: <string>]
 
 # HTTP server listen port
 [http_listen_port: <int> | default = 80]
 
 # gRPC server listen host
-[grpc_listen_host: <string>]
+[grpc_listen_address: <string>]
 
 # gRPC server listen port
 [grpc_listen_port: <int> | default = 9095]


### PR DESCRIPTION
Both should be grpc_listen_address and http_listen_address respectively.

See https://github.com/weaveworks/common/blob/02b9c3fc5b90b294b61e167321cfbc64c5d57b9a/server/server.go#L30

Fixes #1344 
