### PR TITLE
HTTP API: Support duration and float formats for step parameter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -204,7 +204,7 @@ accepts the following query parameters in the URL:
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
-- `step`: Query resolution step width in duration format or seconds. Defaults to a dynamic value based on `start` and `end`.
+- `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
 Requests against this endpoint require Loki to query the index store in order to

--- a/docs/api.md
+++ b/docs/api.md
@@ -204,7 +204,7 @@ accepts the following query parameters in the URL:
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
-- `step`: Query resolution step width in seconds. Defaults to a dynamic value based on `start` and `end`.
+- `step`: Query resolution step width in duration format or seconds. Defaults to a dynamic value based on `start` and `end`.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
 Requests against this endpoint require Loki to query the index store in order to

--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -50,11 +50,20 @@ func bounds(r *http.Request) (time.Time, time.Time, error) {
 }
 
 func step(r *http.Request, start, end time.Time) (time.Duration, error) {
-	s, err := parseInt(r.URL.Query().Get("step"), defaultQueryRangeStep(start, end))
-	if err != nil {
-		return 0, err
+	value := r.URL.Query().Get("step")
+	if value == "" {
+		return time.Duration(defaultQueryRangeStep(start, end)) * time.Second, nil
 	}
-	return time.Duration(s) * time.Second, nil
+
+	d, err := time.ParseDuration(value)
+	if err == nil {
+		return d, nil
+	}
+	f, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		return time.Duration(f) * time.Second, nil
+	}
+	return 0, err
 }
 
 // defaultQueryRangeStep returns the default step used in the query range API,

--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -2,13 +2,14 @@ package loghttp
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
 	"math"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
 )

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -63,8 +63,30 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 				Direction: logproto.BACKWARD,
 			},
 		},
-		"should use the input step parameter if provided": {
+		"should use the input step parameter if provided as an integer": {
 			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5",
+			expected: &RangeQuery{
+				Query:     "{}",
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(3600, 0),
+				Step:      5 * time.Second,
+				Limit:     100,
+				Direction: logproto.BACKWARD,
+			},
+		},
+		"should use the input step parameter if provided as a float": {
+			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5.000",
+			expected: &RangeQuery{
+				Query:     "{}",
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(3600, 0),
+				Step:      5 * time.Second,
+				Limit:     100,
+				Direction: logproto.BACKWARD,
+			},
+		},
+		"should use the input step parameter if provided as a duration": {
+			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5s",
 			expected: &RangeQuery{
 				Query:     "{}",
 				Start:     time.Unix(0, 0),

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -74,7 +74,7 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 				Direction: logproto.BACKWARD,
 			},
 		},
-		"should use the input step parameter if provided as a float": {
+		"should use the input step parameter if provided as a float without decimals": {
 			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5.000",
 			expected: &RangeQuery{
 				Query:     "{}",
@@ -85,13 +85,35 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 				Direction: logproto.BACKWARD,
 			},
 		},
-		"should use the input step parameter if provided as a duration": {
+		"should use the input step parameter if provided as a float with decimals": {
+			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5.500",
+			expected: &RangeQuery{
+				Query:     "{}",
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(3600, 0),
+				Step:      5.5 * 1e9,
+				Limit:     100,
+				Direction: logproto.BACKWARD,
+			},
+		},
+		"should use the input step parameter if provided as a duration in seconds": {
 			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5s",
 			expected: &RangeQuery{
 				Query:     "{}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5 * time.Second,
+				Limit:     100,
+				Direction: logproto.BACKWARD,
+			},
+		},
+		"should use the input step parameter if provided as a duration in days": {
+			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5d",
+			expected: &RangeQuery{
+				Query:     "{}",
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(3600, 0),
+				Step:      5 * 24 * 3600 * time.Second,
 				Limit:     100,
 				Direction: logproto.BACKWARD,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
To have an http interface more compliant with Prometheus specification we should support both duration and float formats for the step parameter. See https://prometheus.io/docs/prometheus/latest/querying/api/

**Which issue(s) this PR fixes**:
Fixes #1209

**Special notes for your reviewer**:
I don't code in Go frequently, so please let me know if I can improve this PR. 
Although it's not necessary I kept a test for integer format to support backwards compatibility.

**Checklist**
- [x] Documentation added
- [x] Tests updated

