### PR TITLE
Supports same duration format in LogQL as Prometheus

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -176,7 +176,7 @@ type logRange struct {
 	interval time.Duration
 }
 
-func mustNewRange(left LogSelectorExpr, interval time.Duration) *logRange {
+func newLogRange(left LogSelectorExpr, interval time.Duration) *logRange {
 	return &logRange{
 		left:     left,
 		interval: interval,

--- a/pkg/logql/expr.y
+++ b/pkg/logql/expr.y
@@ -66,7 +66,7 @@ logExpr:
     ;
 
 
-logRangeExpr: logExpr DURATION { $$ = mustNewRange($1, $2) };
+logRangeExpr: logExpr DURATION { $$ = newLogRange($1, $2) };
 
 
 rangeAggregationExpr: rangeOp OPEN_PARENTHESIS logRangeExpr CLOSE_PARENTHESIS { $$ = newRangeAggregationExpr($3,$1) };

--- a/pkg/logql/expr.y.go
+++ b/pkg/logql/expr.y.go
@@ -582,7 +582,7 @@ exprdefault:
 	case 10:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
 		{
-			exprVAL.LogRangeExpr = mustNewRange(exprDollar[1].LogExpr, exprDollar[2].duration)
+			exprVAL.LogRangeExpr = newLogRange(exprDollar[1].LogExpr, exprDollar[2].duration)
 		}
 	case 11:
 		exprDollar = exprS[exprpt-4 : exprpt+1]

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"text/scanner"
 	"time"
+
+	"github.com/prometheus/common/model"
 )
 
 var tokens = map[string]int{
@@ -64,12 +66,12 @@ func (l *lexer) Lex(lval *exprSymType) int {
 		d := ""
 		for r := l.Next(); r != scanner.EOF; r = l.Next() {
 			if string(r) == "]" {
-				i, err := time.ParseDuration(d)
+				i, err := model.ParseDuration(d)
 				if err != nil {
 					l.Error(err.Error())
 					return 0
 				}
-				lval.duration = i
+				lval.duration = time.Duration(i)
 				return DURATION
 			}
 			d += string(r)


### PR DESCRIPTION
I realized reviewing https://github.com/grafana/loki/pull/1355 that Prometheus has its own way to parse duration.

This PR brings the same idea to Loki LogQL range duration.

/cc @slim-bean 
