### PR TITLE
Update build image with missing deps and a fix or two

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 .defaults: &defaults
   docker:
-    - image: grafana/loki-build-image:0.8.0
+    - image: grafana/loki-build-image:0.9.0
   working_directory: /src/loki
 
 jobs:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -12,28 +12,28 @@ workspace:
 
 steps:
 - name: test
-  image: grafana/loki-build-image:0.8.0
+  image: grafana/loki-build-image:0.9.0
   commands:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
 
 - name: lint
-  image: grafana/loki-build-image:0.8.0
+  image: grafana/loki-build-image:0.9.0
   commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
 
 - name: check-generated-files
-  image: grafana/loki-build-image:0.8.0
+  image: grafana/loki-build-image:0.9.0
   commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
 
 - name: check-mod
-  image: grafana/loki-build-image:0.8.0
+  image: grafana/loki-build-image:0.9.0
   commands:
   - make BUILD_IN_CONTAINER=false check-mod
   depends_on:
@@ -526,7 +526,7 @@ platform:
 
 steps:
 - name: trigger
-  image: grafana/loki-build-image:0.8.0
+  image: grafana/loki-build-image:0.9.0
   commands:
   - ./tools/deploy.sh
   environment:

--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/promtail/Dockerfile.cross
+++ b/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.8.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intented to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/docs/maintaining/release-loki-build-image.md
+++ b/docs/maintaining/release-loki-build-image.md
@@ -5,4 +5,9 @@ The [`loki-build-image`](../../loki-build-image/) is the Docker image used to ru
 ## How To Perform a Release
 
 1. Update `BUILD_IMAGE_VERSION` in the `Makefile`
+1. Update the image version in all the other places it exists
+    1. Dockerfiles in `cmd` directory
+    1. .circlie/config.yml
+1. Run `make drone` to rebuild the drone yml file with the new image version (the image version in the Makefile is used)
+1. Commit your changes (else you will get a WIP tag)
 2. Run `make build-image-push`

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -14,11 +14,17 @@ RUN apk add --no-cache curl && \
 FROM alpine:edge as docker
 RUN apk add --no-cache docker-cli
 
+# TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
+# however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
+# Read the comment below regarding GO111MODULE=on and why it is necessary
+FROM golang:1.13.4 as drone
+RUN GO111MODULE=on go get github.com/drone/drone-cli/drone@1fad337d74ca0ecf420993d9d2d7229a1c99f054
+
 FROM golang:1.13.4-stretch
 RUN apt-get update && \
     apt-get install -qy \
       musl \
-      file unzip jq gettext\
+      file zip unzip jq gettext\
       protobuf-compiler libprotobuf-dev \
       libsystemd-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -26,10 +32,14 @@ RUN apt-get update && \
 COPY --from=docker /usr/bin/docker /usr/bin/docker
 COPY --from=helm /usr/bin/helm /usr/bin/helm
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
+COPY --from=drone /go/bin/drone /usr/bin/drone
 
-# Enable go 1.11 modules to be able to install pinned version of dependencies
-# even if we're installing them in the GOPATH
-RUN go get \
+# Install some necessary dependencies.
+# Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.
+# If we don't force this, Go is going to default to GOPATH mode as we do not have an active project or go.mod
+# file for it to detect and switch to Go Modules automatically.
+# It's possible this can be revisited in newer versions of Go if the behavior around GOPATH vs GO111MODULES changes
+RUN GO111MODULE=on go get \
     github.com/golang/protobuf/protoc-gen-go@v1.3.0 \
     github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 \
     github.com/gogo/protobuf/gogoproto@v1.3.0 \


### PR DESCRIPTION
#1160 changed how we compress release binaries from gzip to zip, however our build image did not have zip installed.  This PR fixes that.

#1303 Erroneously removed the required `GO111MODULES=on` from the build image, I updated the comment in the image as to why this is required.

I also fixed #1323 because I needed to rebuild drone with the latest build image and didn't have the drone-cli installed so figured this was as good a time as any to add it to the build image