### PR TITLE
pkg/logentry: refactor stages to use channels

### DIFF
--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -352,7 +352,7 @@ func TestJSONParser_Parse(t *testing.T) {
 			lbs := model.LabelSet{}
 			extr := tt.extracted
 			ts := time.Now()
-			p.Process(lbs, extr, &ts, &tt.entry)
+			RunSync(p, lbs, extr, &ts, &tt.entry)
 
 			assert.Equal(t, tt.expectedExtract, extr)
 		})

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -247,11 +247,12 @@ func TestMetricStage_Process(t *testing.T) {
 	var ts = time.Now()
 	var entry = logFixture
 	extr := map[string]interface{}{}
-	jsonStage.Process(labelFoo, extr, &ts, &entry)
-	regexStage.Process(labelFoo, extr, &ts, &regexLogFixture)
-	metricStage.Process(labelFoo, extr, &ts, &entry)
+
+	RunSync(jsonStage, labelFoo, extr, &ts, &entry)
+	RunSync(regexStage, labelFoo, extr, &ts, &regexLogFixture)
+	RunSync(metricStage, labelFoo, extr, &ts, &entry)
 	// Process the same extracted values again with different labels so we can verify proper metric/label assignments
-	metricStage.Process(labelFu, extr, &ts, &entry)
+	RunSync(metricStage, labelFu, extr, &ts, &entry)
 
 	names := metricNames(metricsConfig)
 	if err := testutil.GatherAndCompare(registry,

--- a/pkg/logentry/stages/pipeline_test.go
+++ b/pkg/logentry/stages/pipeline_test.go
@@ -1,12 +1,17 @@
 package stages
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -233,6 +238,67 @@ func BenchmarkPipeline(b *testing.B) {
 	}
 }
 
+func BenchmarkPipeline_Concurrency(b *testing.B) {
+	tt := []struct {
+		concurrency int
+	}{
+		{concurrency: 1},
+		{concurrency: 10},
+		{concurrency: 100},
+		{concurrency: 1000},
+	}
+
+	for _, tc := range tt {
+		b.Run(fmt.Sprintf("%d clients", tc.concurrency), func(b *testing.B) {
+
+			pl, err := NewPipeline(infoLogger, loadConfig(testMultiStageYaml), nil, prometheus.DefaultRegisterer)
+			if err != nil {
+				panic(err)
+			}
+
+			ctx, quit := context.WithCancel(context.Background())
+			defer quit()
+			pl.Start(ctx)
+
+			var wg sync.WaitGroup
+
+			lines := make(chan string)
+			cli := pl.Wrap(api.EntryHandlerFunc(func(labels model.LabelSet, time time.Time, entry string) error {
+				lines <- entry
+				return nil
+			}))
+
+			go func() {
+				for range lines {
+					wg.Done()
+				}
+			}()
+
+			// Test time for concurrent clients to send many lines.
+			linesPerClient := 1000
+			numClients := tc.concurrency
+			for i := 0; i < numClients; i++ {
+				wg.Add(linesPerClient)
+
+				go func() {
+					for i := 0; i < linesPerClient; i++ {
+						lbs := map[model.LabelName]model.LabelValue{
+							"stream":      "stderr",
+							"action":      "GET",
+							"status_code": "200",
+						}
+
+						err := cli.Handle(lbs, time.Now(), rawTestLine)
+						assert.NoError(b, err)
+					}
+				}()
+			}
+
+			wg.Wait()
+		})
+	}
+}
+
 type stubHandler struct {
 	bool
 }
@@ -253,6 +319,10 @@ func TestPipeline_Wrap(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.Start(ctx)
 
 	tests := map[string]struct {
 		labels     model.LabelSet
@@ -280,7 +350,6 @@ func TestPipeline_Wrap(t *testing.T) {
 	for tName, tt := range tests {
 		tt := tt
 		t.Run(tName, func(t *testing.T) {
-			t.Parallel()
 			extracted := map[string]interface{}{}
 			p.Process(tt.labels, extracted, &now, &rawTestLine)
 			stub := &stubHandler{}
@@ -288,8 +357,10 @@ func TestPipeline_Wrap(t *testing.T) {
 			if err := handler.Handle(tt.labels, now, rawTestLine); err != nil {
 				t.Fatalf("failed to handle entry: %v", err)
 			}
-			assert.Equal(t, stub.bool, tt.shouldSend)
 
+			test.Poll(t, time.Millisecond*500, tt.shouldSend, func() interface{} {
+				return stub.bool
+			})
 		})
 	}
 }

--- a/pkg/logentry/stages/pipeline_test.go
+++ b/pkg/logentry/stages/pipeline_test.go
@@ -258,12 +258,11 @@ func BenchmarkPipeline_Concurrency(b *testing.B) {
 
 			ctx, quit := context.WithCancel(context.Background())
 			defer quit()
-			pl.Start(ctx)
 
 			var wg sync.WaitGroup
 
 			lines := make(chan string)
-			cli := pl.Wrap(api.EntryHandlerFunc(func(labels model.LabelSet, time time.Time, entry string) error {
+			cli := pl.Wrap(ctx, api.EntryHandlerFunc(func(labels model.LabelSet, time time.Time, entry string) error {
 				lines <- entry
 				return nil
 			}))
@@ -322,7 +321,6 @@ func TestPipeline_Wrap(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	p.Start(ctx)
 
 	tests := map[string]struct {
 		labels     model.LabelSet
@@ -353,7 +351,7 @@ func TestPipeline_Wrap(t *testing.T) {
 			extracted := map[string]interface{}{}
 			p.Process(tt.labels, extracted, &now, &rawTestLine)
 			stub := &stubHandler{}
-			handler := p.Wrap(stub)
+			handler := p.Wrap(ctx, stub)
 			if err := handler.Handle(tt.labels, now, rawTestLine); err != nil {
 				t.Fatalf("failed to handle entry: %v", err)
 			}

--- a/pkg/logentry/stages/regex_test.go
+++ b/pkg/logentry/stages/regex_test.go
@@ -296,7 +296,7 @@ func TestRegexParser_Parse(t *testing.T) {
 			lbs := model.LabelSet{}
 			extr := tt.extracted
 			ts := time.Now()
-			p.Process(lbs, extr, &ts, &tt.entry)
+			RunSync(p, lbs, extr, &ts, &tt.entry)
 			assert.Equal(t, tt.expectedExtract, extr)
 
 		})
@@ -340,7 +340,7 @@ func BenchmarkRegexStage(b *testing.B) {
 			extr := map[string]interface{}{}
 			for i := 0; i < b.N; i++ {
 				entry := bm.entry
-				stage.Process(labels, extr, &ts, &entry)
+				RunSync(stage, labels, extr, &ts, &entry)
 			}
 		})
 	}

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -39,11 +40,40 @@ func (s StageFunc) Process(labels model.LabelSet, extracted map[string]interface
 	s(labels, extracted, time, entry)
 }
 
-// New creates a new stage for the given type and configuration.
+func (s StageFunc) Name() string { return "function" }
+
+// AsyncStage is like Stage, but runs forever, or until the provided context is cancelled. Throughout
+// its execution, AsyncStage should read lines as input, modify them as needed, and pass through
+// zero or more output lines.
+type AsyncStage interface {
+	ProcessAsync(ctx context.Context, in <-chan StageData, out chan<- StageData)
+	Name() string
+}
+
+// StageData holds data that is passed through stages.
+type StageData struct {
+	// Labels is the set of labels associated with a log line.
+	Labels model.LabelSet
+
+	// Extracted is the extracted data map associated with a log line.
+	Extracted map[string]interface{}
+
+	// Time is the current timestamp associated with a log line.
+	Time time.Time
+
+	// Entry is the current log line's text value.
+	Entry string
+}
+
+// New creates a new AsyncStage for the given type and configuration.
 func New(logger log.Logger, jobName *string, stageType string,
-	cfg interface{}, registerer prometheus.Registerer) (Stage, error) {
-	var s Stage
-	var err error
+	cfg interface{}, registerer prometheus.Registerer) (AsyncStage, error) {
+	var (
+		s   Stage
+		as  AsyncStage
+		err error
+	)
+
 	switch stageType {
 	case StageTypeDocker:
 		s, err = NewDocker(logger, registerer)
@@ -103,5 +133,55 @@ func New(logger log.Logger, jobName *string, stageType string,
 	default:
 		return nil, errors.Errorf("Unknown stage type: %s", stageType)
 	}
-	return s, nil
+
+	if as == nil && s != nil {
+		as = MakeAsync(s)
+	}
+	return as, nil
+}
+
+// MakeAsync takes a synchronous stage and converts it into an AsyncStage.
+func MakeAsync(s Stage) AsyncStage {
+	return &asyncWrapper{s}
+}
+
+type asyncWrapper struct{ s Stage }
+
+func (w *asyncWrapper) ProcessAsync(ctx context.Context, in <-chan StageData, out chan<- StageData) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data := <-in:
+			w.s.Process(data.Labels, data.Extracted, &data.Time, &data.Entry)
+			out <- data
+		}
+	}
+}
+
+func (w *asyncWrapper) Name() string {
+	return w.s.Name()
+}
+
+func RunSync(s AsyncStage, labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	in := make(chan StageData)
+	out := make(chan StageData)
+
+	go func() {
+		s.ProcessAsync(ctx, in, out)
+	}()
+
+	in <- StageData{
+		Labels:    labels,
+		Extracted: extracted,
+		Time:      *t,
+		Entry:     *entry,
+	}
+
+	data := <-out
+	*t = data.Time
+	*entry = data.Entry
 }

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -108,6 +108,9 @@ func NewFileTargetManager(
 			}
 		}
 
+		// Run the pipeline
+		pipeline.Start(ctx)
+
 		s := &targetSyncer{
 			log:            logger,
 			positions:      positions,

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -108,9 +108,6 @@ func NewFileTargetManager(
 			}
 		}
 
-		// Run the pipeline
-		pipeline.Start(ctx)
-
 		s := &targetSyncer{
 			log:            logger,
 			positions:      positions,
@@ -118,7 +115,7 @@ func NewFileTargetManager(
 			targets:        map[string]*FileTarget{},
 			droppedTargets: []Target{},
 			hostname:       hostname,
-			entryHandler:   pipeline.Wrap(client),
+			entryHandler:   pipeline.Wrap(ctx, client),
 			targetConfig:   targetConfig,
 		}
 		tm.syncers[cfg.JobName] = s

--- a/pkg/promtail/targets/journaltargetmanager_linux.go
+++ b/pkg/promtail/targets/journaltargetmanager_linux.go
@@ -47,12 +47,9 @@ func NewJournalTargetManager(
 			return nil, err
 		}
 
-		// Run the pipeline
-		pipeline.Start(ctx)
-
 		t, err := NewJournalTarget(
 			logger,
-			pipeline.Wrap(client),
+			pipeline.Wrap(ctx, client),
 			positions,
 			cfg.JobName,
 			cfg.RelabelConfigs,

--- a/pkg/util/test/poll.go
+++ b/pkg/util/test/poll.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// Poll repeatedly evaluates condition until we either timeout, or it succeeds.
+func Poll(t *testing.T, d time.Duration, want interface{}, have func() interface{}) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for {
+		if time.Now().After(deadline) {
+			break
+		}
+		if reflect.DeepEqual(want, have()) {
+			return
+		}
+		time.Sleep(d / 10)
+	}
+	h := have()
+	if !reflect.DeepEqual(want, h) {
+		t.Fatalf("%v != %v", want, h)
+	}
+}


### PR DESCRIPTION
Proof of concept, do not merge!

This commit introduces an AsyncStage interface to run a Stage as an long-lasting process, manipulating log lines through channels. Existing stages have been wrapped as asynchronous stages.

An alternative solution using callbacks is in #1373.

/cc @slim-bean @cyriltovena 