### PR TITLE
Change `/loki/api/v1/label` to `loki/api/v1/labels`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ The HTTP API includes the following endpoints:
 
 - [`GET /loki/api/v1/query`](#get-lokiapiv1query)
 - [`GET /loki/api/v1/query_range`](#get-lokiapiv1query_range)
-- [`GET /loki/api/v1/label`](#get-lokiapiv1label)
+- [`GET /loki/api/v1/labels`](#get-lokiapiv1labels)
 - [`GET /loki/api/v1/label/<name>/values`](#get-lokiapiv1labelnamevalues)
 - [`GET /loki/api/v1/tail`](#get-lokiapiv1tail)
 - [`POST /loki/api/v1/push`](#post-lokiapiv1push)
@@ -35,7 +35,7 @@ These endpoints are exposed by just the querier:
 
 - [`GET /loki/api/v1/query`](#get-lokiapiv1query)
 - [`GET /loki/api/v1/query_range`](#get-lokiapiv1query_range)
-- [`GET /loki/api/v1/label`](#get-lokiapiv1label)
+- [`GET /loki/api/v1/labels`](#get-lokiapiv1labels)
 - [`GET /loki/api/v1/label/<name>/values`](#get-lokiapiv1labelnamevalues)
 - [`GET /loki/api/v1/tail`](#get-lokiapiv1tail)
 - [`GET /api/prom/tail`](#get-lokiapipromtail)
@@ -338,15 +338,15 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode '
 }
 ```
 
-## `GET /loki/api/v1/label`
+## `GET /loki/api/v1/labels`
 
-`/loki/api/v1/label` retrieves the list of known labels within a given time span. It
+`/loki/api/v1/labels` retrieves the list of known labels within a given time span. It
 accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
 
-In microservices mode, `/loki/api/v1/label` is exposed by the querier.
+In microservices mode, `/loki/api/v1/labels` is exposed by the querier.
 
 Response:
 
@@ -363,7 +363,7 @@ Response:
 ### Examples
 
 ```bash
-$ curl -G -s  "http://localhost:3100/loki/api/v1/label" | jq
+$ curl -G -s  "http://localhost:3100/loki/api/v1/labels" | jq
 {
   "status": "success",
   "data": [

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -21,7 +21,7 @@ import (
 const (
 	queryPath       = "/loki/api/v1/query?query=%s&limit=%d&time=%d&direction=%s"
 	queryRangePath  = "/loki/api/v1/query_range"
-	labelsPath      = "/loki/api/v1/label"
+	labelsPath      = "/loki/api/v1/labels"
 	labelValuesPath = "/loki/api/v1/label/%s/values"
 	tailPath        = "/loki/api/v1/tail?query=%s&delay_for=%d&limit=%d&start=%d"
 )

--- a/pkg/loghttp/versions_test.go
+++ b/pkg/loghttp/versions_test.go
@@ -9,7 +9,7 @@ import (
 func Test_GetVersion(t *testing.T) {
 	require.Equal(t, GetVersion("/loki/api/v1/query_range"), VersionV1)
 	require.Equal(t, GetVersion("/loki/api/v1/query"), VersionV1)
-	require.Equal(t, GetVersion("/loki/api/v1/label"), VersionV1)
+	require.Equal(t, GetVersion("/loki/api/v1/labels"), VersionV1)
 	require.Equal(t, GetVersion("/loki/api/v1/label/{name}/values"), VersionV1)
 	require.Equal(t, GetVersion("/loki/api/v1/tail"), VersionV1)
 
@@ -20,7 +20,7 @@ func Test_GetVersion(t *testing.T) {
 
 	require.Equal(t, GetVersion("/LOKI/api/v1/query_range"), VersionV1)
 	require.Equal(t, GetVersion("/LOKI/api/v1/query"), VersionV1)
-	require.Equal(t, GetVersion("/LOKI/api/v1/label"), VersionV1)
+	require.Equal(t, GetVersion("/LOKI/api/v1/labels"), VersionV1)
 	require.Equal(t, GetVersion("/LOKI/api/v1/label/{name}/values"), VersionV1)
 	require.Equal(t, GetVersion("/LOKI/api/v1/tail"), VersionV1)
 

--- a/pkg/logql/marshal/marshal_test.go
+++ b/pkg/logql/marshal/marshal_test.go
@@ -197,7 +197,7 @@ var queryTests = []struct {
 	},
 }
 
-// covers responses from /loki/api/v1/label and /loki/api/v1/label/{name}/values
+// covers responses from /loki/api/v1/labels and /loki/api/v1/label/{name}/values
 var labelTests = []struct {
 	actual   logproto.LabelResponse
 	expected string

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -164,7 +164,10 @@ func (t *Loki) initQuerier() (err error) {
 
 	t.server.HTTP.Handle("/loki/api/v1/query_range", httpMiddleware.Wrap(http.HandlerFunc(t.querier.RangeQueryHandler)))
 	t.server.HTTP.Handle("/loki/api/v1/query", httpMiddleware.Wrap(http.HandlerFunc(t.querier.InstantQueryHandler)))
+	// Prometheus compatibility requires `loki/api/v1/labels` however we already released `loki/api/v1/label`
+	// which is a little more consistent with `/loki/api/v1/label/{name}/values` so we are going to handle both paths.
 	t.server.HTTP.Handle("/loki/api/v1/label", httpMiddleware.Wrap(http.HandlerFunc(t.querier.LabelHandler)))
+	t.server.HTTP.Handle("/loki/api/v1/labels", httpMiddleware.Wrap(http.HandlerFunc(t.querier.LabelHandler)))
 	t.server.HTTP.Handle("/loki/api/v1/label/{name}/values", httpMiddleware.Wrap(http.HandlerFunc(t.querier.LabelHandler)))
 	t.server.HTTP.Handle("/loki/api/v1/tail", httpMiddleware.Wrap(http.HandlerFunc(t.querier.TailHandler)))
 


### PR DESCRIPTION
Fixes #1367 

To be Prometheus compatible, this endpoint should be `loki/api/v1/labels`