### PR TITLE
Logql benchmark and performance improvement.

### DIFF
--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -602,26 +602,27 @@ type PeekingEntryIterator interface {
 func NewPeekingIterator(iter EntryIterator) PeekingEntryIterator {
 	// initialize the next entry so we can peek right from the start.
 	var cache *entryWithLabels
+	next := &entryWithLabels{}
 	if iter.Next() {
 		cache = &entryWithLabels{
 			entry:  iter.Entry(),
 			labels: iter.Labels(),
 		}
+		next.entry = cache.entry
+		next.labels = cache.labels
 	}
 	return &peekingEntryIterator{
 		iter:  iter,
 		cache: cache,
-		next:  cache,
+		next:  next,
 	}
 }
 
 // Next implements `EntryIterator`
 func (it *peekingEntryIterator) Next() bool {
 	if it.cache != nil {
-		it.next = &entryWithLabels{
-			entry:  it.cache.entry,
-			labels: it.cache.labels,
-		}
+		it.next.entry = it.cache.entry
+		it.next.labels = it.cache.labels
 		it.cacheNext()
 		return true
 	}
@@ -631,10 +632,8 @@ func (it *peekingEntryIterator) Next() bool {
 // cacheNext caches the next element if it exists.
 func (it *peekingEntryIterator) cacheNext() {
 	if it.iter.Next() {
-		it.cache = &entryWithLabels{
-			entry:  it.iter.Entry(),
-			labels: it.iter.Labels(),
-		}
+		it.cache.entry = it.iter.Entry()
+		it.cache.labels = it.iter.Labels()
 		return
 	}
 	// nothing left removes the cached entry

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -296,8 +296,9 @@ type groupedAggregation struct {
 // Evaluator implements `SampleExpr` for a vectorAggregationExpr
 // this is copied and adapted from Prometheus vector aggregation code.
 func (v *vectorAggregationExpr) Evaluator() StepEvaluator {
+	nextEvaluator := v.left.Evaluator()
 	return StepEvaluatorFn(func() (bool, int64, promql.Vector) {
-		next, ts, vec := v.left.Evaluator().Next()
+		next, ts, vec := nextEvaluator.Next()
 		if !next {
 			return false, 0, promql.Vector{}
 		}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -139,6 +139,12 @@ func printHeap(b *testing.B, show bool) {
 }
 
 func getLocalStore() Store {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxQueryLength: 6000 * time.Hour,
+	})
+	if err != nil {
+		panic(err)
+	}
 	store, err := NewStore(Config{
 		Config: storage.Config{
 			BoltDBConfig: local.BoltDBConfig{Directory: "/tmp/benchmark/index"},
@@ -158,7 +164,7 @@ func getLocalStore() Store {
 				},
 			},
 		},
-	}, &validation.Overrides{})
+	}, limits)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
@@ -120,7 +119,7 @@ func benchmarkStoreQuery(b *testing.B, query *logproto.QueryRequest) {
 		}
 		iter.Close()
 		printHeap(b, true)
-		log.Println("line fetched", len(res))
+		// log.Println("line fetched", len(res))
 	}
 	close(stop)
 }
@@ -128,14 +127,14 @@ func benchmarkStoreQuery(b *testing.B, query *logproto.QueryRequest) {
 var maxHeapInuse uint64
 
 func printHeap(b *testing.B, show bool) {
-	runtime.ReadMemStats(&m)
-	if m.HeapInuse > maxHeapInuse {
-		maxHeapInuse = m.HeapInuse
-	}
-	if show {
-		log.Printf("Benchmark %d maxHeapInuse: %d Mbytes\n", b.N, maxHeapInuse/1024/1024)
-		log.Printf("Benchmark %d currentHeapInuse: %d Mbytes\n", b.N, m.HeapInuse/1024/1024)
-	}
+	// runtime.ReadMemStats(&m)
+	// if m.HeapInuse > maxHeapInuse {
+	// 	maxHeapInuse = m.HeapInuse
+	// }
+	// if show {
+	// 	log.Printf("Benchmark %d maxHeapInuse: %d Mbytes\n", b.N, maxHeapInuse/1024/1024)
+	// 	log.Printf("Benchmark %d currentHeapInuse: %d Mbytes\n", b.N, m.HeapInuse/1024/1024)
+	// }
 }
 
 func getLocalStore() Store {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
@@ -119,7 +120,7 @@ func benchmarkStoreQuery(b *testing.B, query *logproto.QueryRequest) {
 		}
 		iter.Close()
 		printHeap(b, true)
-		// log.Println("line fetched", len(res))
+		log.Println("line fetched", len(res))
 	}
 	close(stop)
 }
@@ -127,14 +128,14 @@ func benchmarkStoreQuery(b *testing.B, query *logproto.QueryRequest) {
 var maxHeapInuse uint64
 
 func printHeap(b *testing.B, show bool) {
-	// runtime.ReadMemStats(&m)
-	// if m.HeapInuse > maxHeapInuse {
-	// 	maxHeapInuse = m.HeapInuse
-	// }
-	// if show {
-	// 	log.Printf("Benchmark %d maxHeapInuse: %d Mbytes\n", b.N, maxHeapInuse/1024/1024)
-	// 	log.Printf("Benchmark %d currentHeapInuse: %d Mbytes\n", b.N, m.HeapInuse/1024/1024)
-	// }
+	runtime.ReadMemStats(&m)
+	if m.HeapInuse > maxHeapInuse {
+		maxHeapInuse = m.HeapInuse
+	}
+	if show {
+		log.Printf("Benchmark %d maxHeapInuse: %d Mbytes\n", b.N, maxHeapInuse/1024/1024)
+		log.Printf("Benchmark %d currentHeapInuse: %d Mbytes\n", b.N, m.HeapInuse/1024/1024)
+	}
 }
 
 func getLocalStore() Store {


### PR DESCRIPTION
Hello !

This PR adds a benchmark for the LogQL engine and also improve allocations and therefore cpu usage when doing metrics queries. Improvement is around 40% in term of CPU and  80% for allocation/memory usage.

I can see there is still ways to improve metrics queries, but I didn't wanted to change the implementation too much, since we might add more to the language in the future.

Here is the result:

```
❯ benchcmp old.txt new.txt
benchmark                         old ns/op      new ns/op      delta
BenchmarkRangeQuery100000-16      3969200        1980841        -50.09%
BenchmarkRangeQuery200000-16      25067162       5204838        -79.24%
BenchmarkRangeQuery500000-16      2036930499     1394141266     -31.56%
BenchmarkRangeQuery1000000-16     3927444457     2844597499     -27.57%

benchmark                         old allocs     new allocs     delta
BenchmarkRangeQuery100000-16      49956          3518           -92.96%
BenchmarkRangeQuery200000-16      204431         9820           -95.20%
BenchmarkRangeQuery500000-16      13413890       4135290        -69.17%
BenchmarkRangeQuery1000000-16     26830056       8268585        -69.18%

benchmark                         old bytes      new bytes     delta
BenchmarkRangeQuery100000-16      1808878        321027        -82.25%
BenchmarkRangeQuery200000-16      9968806        719492        -92.78%
BenchmarkRangeQuery500000-16      822888736      262896816     -68.05%
BenchmarkRangeQuery1000000-16     1646616496     526540984     -68.02%
```

I'm also fixing the storage benchmark that is currently crashing because of a change in the limits.

