### PR TITLE
Let Loki start when using the debug image.

### DIFF
--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -24,5 +24,5 @@ RUN apk add --no-cache libc6-compat
 # Run delve, ending with -- because we pass params via kubernetes, per the docs:
 #   Pass flags to the program you are debugging using --, for example:`
 #   dlv exec ./hello -- server --config conf/config.toml`
-ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/usr/bin/loki-debug", "--"]
+ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--log", "--continue" , "--api-version=2", "exec", "/usr/bin/loki-debug", "--"]
 CMD        ["-config.file=/etc/loki/local-config.yaml"]


### PR DESCRIPTION
The current debug image is waiting for the debugger to attach before starting Loki.
I don't think it makes sense to wait for the debugger for a service. I've also added `--log` to output logs of dlv.