### PR TITLE
Fluentd: guard against nil values when sanitizing labels

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.4'
+  spec.version = '1.2.5'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com' , 'cyril.tovena@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -195,7 +195,7 @@ module Fluent
         data_labels = {} if data_labels.nil?
         data_labels = data_labels.merge(@extra_labels)
         # sanitize label values
-        data_labels.each { |k, v| formatted_labels[k] = v.gsub('"', '\\"') }
+        data_labels.each { |k, v| formatted_labels[k] = v.gsub('"', '\\"') if v }
         formatted_labels
       end
 


### PR DESCRIPTION
I tried updating to 1.2.4 and got these errors:

```
2019-12-05 22:16:01 +0200 [warn]: #1 got unrecoverable error in primary and no secondary error_class=NoMethodError error="undefined method `gsub' for nil:NilClass"
```

It seems that a guard condition for nil label values was omitted in https://github.com/grafana/loki/commit/2b7f375a21457c5f412f1b13e571a3e3968146cb.

