### PR TITLE
Added basic multiline support based on stage-chains idea

### DIFF
--- a/pkg/logentry/stages/extensions.go
+++ b/pkg/logentry/stages/extensions.go
@@ -8,7 +8,7 @@ import (
 const RFC3339Nano = "RFC3339Nano"
 
 // NewDocker creates a Docker json log format specific pipeline stage.
-func NewDocker(logger log.Logger, registerer prometheus.Registerer) (Stage, error) {
+func NewDocker(logger log.Logger, registerer prometheus.Registerer) (*Pipeline, error) {
 	stages := PipelineStages{
 		PipelineStage{
 			StageTypeJSON: JSONConfig{
@@ -36,7 +36,7 @@ func NewDocker(logger log.Logger, registerer prometheus.Registerer) (Stage, erro
 }
 
 // NewCRI creates a CRI format specific pipeline stage
-func NewCRI(logger log.Logger, registerer prometheus.Registerer) (Stage, error) {
+func NewCRI(logger log.Logger, registerer prometheus.Registerer) (*Pipeline, error) {
 	stages := PipelineStages{
 		PipelineStage{
 			StageTypeRegex: RegexConfig{

--- a/pkg/logentry/stages/extensions_test.go
+++ b/pkg/logentry/stages/extensions_test.go
@@ -71,11 +71,12 @@ func TestNewDocker(t *testing.T) {
 			}
 			lbs := toLabelSet(tt.labels)
 			extr := map[string]interface{}{}
-			p.Process(lbs, extr, &tt.t, &tt.entry)
+			result := &resultChain{}
+			p.Process(lbs, extr, tt.t, tt.entry, result)
 
-			assertLabels(t, tt.expectedLabels, lbs)
-			assert.Equal(t, tt.expectedEntry, tt.entry, "did not receive expected log entry")
-			if tt.t.Unix() != tt.expectedT.Unix() {
+			assertLabels(t, tt.expectedLabels, result.labels)
+			assert.Equal(t, tt.expectedEntry, result.entry, "did not receive expected log entry")
+			if result.time.Unix() != tt.expectedT.Unix() {
 				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
 			}
 		})
@@ -147,11 +148,12 @@ func TestNewCri(t *testing.T) {
 			}
 			lbs := toLabelSet(tt.labels)
 			extr := map[string]interface{}{}
-			p.Process(lbs, extr, &tt.t, &tt.entry)
+			result := &resultChain{}
+			p.Process(lbs, extr, tt.t, tt.entry, result)
 
-			assertLabels(t, tt.expectedLabels, lbs)
-			assert.Equal(t, tt.expectedEntry, tt.entry, "did not receive expected log entry")
-			if tt.t.Unix() != tt.expectedT.Unix() {
+			assertLabels(t, tt.expectedLabels, result.labels)
+			assert.Equal(t, tt.expectedEntry, result.entry, "did not receive expected log entry")
+			if result.time.Unix() != tt.expectedT.Unix() {
 				t.Fatalf("mismatch ts want: %s got:%s", tt.expectedT, tt.t)
 			}
 		})

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -91,8 +91,9 @@ func TestPipeline_JSON(t *testing.T) {
 			ts := time.Now()
 			entry := testData.entry
 			extracted := map[string]interface{}{}
-			pl.Process(lbls, extracted, &ts, &entry)
-			assert.Equal(t, testData.expectedExtract, extracted)
+			result := &resultChain{}
+			pl.Process(lbls, extracted, ts, entry, result)
+			assert.Equal(t, testData.expectedExtract, result.extracted)
 		})
 	}
 }
@@ -351,10 +352,10 @@ func TestJSONParser_Parse(t *testing.T) {
 			}
 			lbs := model.LabelSet{}
 			extr := tt.extracted
-			ts := time.Now()
-			p.Process(lbs, extr, &ts, &tt.entry)
+			result := &resultChain{}
+			p.Process(lbs, extr, time.Now(), tt.entry, result)
 
-			assert.Equal(t, tt.expectedExtract, extr)
+			assert.Equal(t, tt.expectedExtract, result.extracted)
 		})
 	}
 }

--- a/pkg/logentry/stages/labels.go
+++ b/pkg/logentry/stages/labels.go
@@ -62,7 +62,7 @@ type labelStage struct {
 }
 
 // Process implements Stage
-func (l *labelStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (l *labelStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
 	for lName, lSrc := range l.cfgs {
 		if lValue, ok := extracted[*lSrc]; ok {
 			s, err := getString(lValue)
@@ -82,6 +82,8 @@ func (l *labelStage) Process(labels model.LabelSet, extracted map[string]interfa
 			labels[model.LabelName(lName)] = labelValue
 		}
 	}
+
+	chain.NextStage(labels, extracted, time, entry)
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/labels_test.go
+++ b/pkg/logentry/stages/labels_test.go
@@ -42,11 +42,10 @@ func TestLabelsPipeline_Labels(t *testing.T) {
 		"level": "WARN",
 		"app":   "loki",
 	}
-	ts := time.Now()
-	entry := testLabelsLogLine
 	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
-	assert.Equal(t, expectedLbls, lbls)
+	result := &resultChain{}
+	pl.Process(lbls, extracted, time.Now(), testLabelsLogLine, result)
+	assert.Equal(t, expectedLbls, result.labels)
 }
 
 var (
@@ -157,8 +156,11 @@ func TestLabelStage_Process(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			st.Process(test.inputLabels, test.extractedData, nil, nil)
-			assert.Equal(t, test.expectedLabels, test.inputLabels)
+
+			result := &resultChain{}
+
+			st.Process(test.inputLabels, test.extractedData, time.Now(), "", result)
+			assert.Equal(t, test.expectedLabels, result.labels)
 		})
 	}
 }

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -111,7 +111,7 @@ func newMatcherStage(logger log.Logger, jobName *string, config interface{}, reg
 type matcherStage struct {
 	matchers []*labels.Matcher
 	filter   logql.Filter
-	pipeline Stage
+	pipeline *Pipeline
 	action   string
 }
 

--- a/pkg/logentry/stages/metrics.go
+++ b/pkg/logentry/stages/metrics.go
@@ -115,7 +115,7 @@ type metricStage struct {
 }
 
 // Process implements Stage
-func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
 	for name, collector := range m.metrics {
 		if v, ok := extracted[*m.cfg[name].Source]; ok {
 			switch vec := collector.(type) {
@@ -128,6 +128,8 @@ func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interf
 			}
 		}
 	}
+
+	chain.NextStage(labels, extracted, time, entry)
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -84,12 +84,9 @@ func TestMetricsPipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 	lbls := model.LabelSet{}
-	ts := time.Now()
 	extracted := map[string]interface{}{}
-	entry := testMetricLogLine1
-	pl.Process(lbls, extracted, &ts, &entry)
-	entry = testMetricLogLine2
-	pl.Process(lbls, extracted, &ts, &entry)
+	pl.Process(lbls, extracted, time.Now(), testMetricLogLine1, &resultChain{})
+	pl.Process(lbls, extracted, time.Now(), testMetricLogLine2, &resultChain{})
 
 	if err := testutil.GatherAndCompare(registry,
 		strings.NewReader(expectedMetrics)); err != nil {
@@ -244,14 +241,14 @@ func TestMetricStage_Process(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create stage with metrics: %v", err)
 	}
-	var ts = time.Now()
-	var entry = logFixture
+
 	extr := map[string]interface{}{}
-	jsonStage.Process(labelFoo, extr, &ts, &entry)
-	regexStage.Process(labelFoo, extr, &ts, &regexLogFixture)
-	metricStage.Process(labelFoo, extr, &ts, &entry)
+
+	jsonStage.Process(labelFoo, extr, time.Now(), logFixture, &resultChain{})
+	regexStage.Process(labelFoo, extr, time.Now(), regexLogFixture, &resultChain{})
+	metricStage.Process(labelFoo, extr, time.Now(), logFixture, &resultChain{})
 	// Process the same extracted values again with different labels so we can verify proper metric/label assignments
-	metricStage.Process(labelFu, extr, &ts, &entry)
+	metricStage.Process(labelFu, extr, time.Now(), logFixture, &resultChain{})
 
 	names := metricNames(metricsConfig)
 	if err := testutil.GatherAndCompare(registry,

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -1,0 +1,100 @@
+package stages
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	ErrEmptyMultilineStageConfig = "multiline stage config cannot be empty"
+	ErrMultilineNameRequired     = "multiline stage pipeline name can be omitted but cannot be an empty string"
+	ErrFirstLineRequired         = "firstLine regular expression required"
+)
+
+// MatcherConfig contains the configuration for a matcherStage
+type MultilineConfig struct {
+	PipelineName    *string `mapstructure:"pipeline_name"`
+	FirstLineRegexp string  `mapstructure:"firstline"`
+}
+
+func validateMultilineConfig(cfg *MultilineConfig) (*regexp.Regexp, error) {
+	if cfg == nil {
+		return nil, errors.New(ErrEmptyMultilineStageConfig)
+	}
+	if cfg.PipelineName != nil && *cfg.PipelineName == "" {
+		return nil, errors.New(ErrMultilineNameRequired)
+	}
+	if cfg.FirstLineRegexp == "" {
+		return nil, errors.New(ErrFirstLineRequired)
+	}
+
+	re, err := regexp.Compile(cfg.FirstLineRegexp)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse firstline regex")
+	}
+
+	return re, nil
+}
+
+// newMatcherStage creates a new matcherStage from config
+func newMultilineStage(logger log.Logger, config interface{}) (*multilineStage, error) {
+	cfg := &MultilineConfig{}
+	err := mapstructure.Decode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	re, err := validateMultilineConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &multilineStage{
+		firstLine:  re,
+		multilines: map[string][]string{},
+	}, nil
+}
+
+type multilineStage struct {
+	firstLine *regexp.Regexp
+
+	mapMu      sync.Mutex
+	multilines map[string][]string
+}
+
+func (m *multilineStage) Name() string {
+	return "multiline"
+}
+
+// Process implements Stage
+func (m *multilineStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
+	isFirstLine := m.firstLine.MatchString(entry)
+	key := labels.String()
+
+	m.mapMu.Lock()
+	previous := m.multilines[key]
+
+	if isFirstLine {
+		// flush previous entry, if there is any, and store new one
+		if previous != nil {
+			delete(m.multilines, key)
+			m.mapMu.Unlock()
+
+			chain.NextStage(labels, extracted, time, strings.Join(previous, "\n"))
+
+			m.mapMu.Lock()
+		}
+
+		m.multilines[key] = []string{entry} // start new multiline entry
+	} else {
+		// buffer current entry, add it to previous (if any), and wait for more lines.
+		m.multilines[key] = append(previous, entry)
+	}
+	m.mapMu.Unlock()
+}

--- a/pkg/logentry/stages/output.go
+++ b/pkg/logentry/stages/output.go
@@ -57,8 +57,9 @@ type outputStage struct {
 }
 
 // Process implements Stage
-func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
 	if o.cfgs == nil {
+		chain.NextStage(labels, extracted, time, entry)
 		return
 	}
 	if v, ok := extracted[o.cfgs.Source]; ok {
@@ -69,12 +70,14 @@ func (o *outputStage) Process(labels model.LabelSet, extracted map[string]interf
 			}
 			return
 		}
-		*entry = s
+		entry = s
 	} else {
 		if Debug {
 			level.Debug(o.logger).Log("msg", "extracted data did not contain output source")
 		}
 	}
+
+	chain.NextStage(labels, extracted, time, entry)
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/output_test.go
+++ b/pkg/logentry/stages/output_test.go
@@ -37,11 +37,10 @@ func TestPipeline_Output(t *testing.T) {
 		t.Fatal(err)
 	}
 	lbls := model.LabelSet{}
-	ts := time.Now()
-	entry := testOutputLogLine
 	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
-	assert.Equal(t, "this is a log line", entry)
+	result := &resultChain{}
+	pl.Process(lbls, extracted, time.Now(), testOutputLogLine, result)
+	assert.Equal(t, "this is a log line", result.entry)
 }
 
 func TestOutputValidation(t *testing.T) {
@@ -103,9 +102,9 @@ func TestOutputStage_Process(t *testing.T) {
 				t.Fatal(err)
 			}
 			lbls := model.LabelSet{}
-			entry := "replaceme"
-			st.Process(lbls, test.extracted, nil, &entry)
-			assert.Equal(t, test.expectedOutput, entry)
+			result := &resultChain{}
+			st.Process(lbls, test.extracted, time.Now(), "replaceme", result)
+			assert.Equal(t, test.expectedOutput, result.entry)
 		})
 	}
 }

--- a/pkg/logentry/stages/pipeline_test.go
+++ b/pkg/logentry/stages/pipeline_test.go
@@ -225,10 +225,11 @@ func BenchmarkPipeline(b *testing.B) {
 			}
 			lb := model.LabelSet{}
 			ts := time.Now()
+			r := &resultChain{}
 			for i := 0; i < b.N; i++ {
 				extracted := map[string]interface{}{}
 
-				pl.Process(lb, extracted, ts, bm.entry, &resultChain{})
+				pl.Process(lb, extracted, ts, bm.entry, r)
 			}
 		})
 	}

--- a/pkg/logentry/stages/regex_test.go
+++ b/pkg/logentry/stages/regex_test.go
@@ -87,11 +87,10 @@ func TestPipeline_Regex(t *testing.T) {
 			}
 
 			lbls := model.LabelSet{}
-			ts := time.Now()
-			entry := testData.entry
 			extracted := map[string]interface{}{}
-			pl.Process(lbls, extracted, &ts, &entry)
-			assert.Equal(t, testData.expectedExtract, extracted)
+			result := &resultChain{}
+			pl.Process(lbls, extracted, time.Now(), testData.entry, result)
+			assert.Equal(t, testData.expectedExtract, result.extracted)
 		})
 	}
 }
@@ -294,10 +293,9 @@ func TestRegexParser_Parse(t *testing.T) {
 				t.Fatalf("failed to create regex parser: %s", err)
 			}
 			lbs := model.LabelSet{}
-			extr := tt.extracted
-			ts := time.Now()
-			p.Process(lbs, extr, &ts, &tt.entry)
-			assert.Equal(t, tt.expectedExtract, extr)
+			result := &resultChain{}
+			p.Process(lbs, tt.extracted, time.Now(), tt.entry, result)
+			assert.Equal(t, tt.expectedExtract, result.extracted)
 
 		})
 	}
@@ -339,8 +337,7 @@ func BenchmarkRegexStage(b *testing.B) {
 			ts := time.Now()
 			extr := map[string]interface{}{}
 			for i := 0; i < b.N; i++ {
-				entry := bm.entry
-				stage.Process(labels, extr, &ts, &entry)
+				stage.Process(labels, extr, ts, bm.entry, &resultChain{})
 			}
 		})
 	}

--- a/pkg/logentry/stages/regex_test.go
+++ b/pkg/logentry/stages/regex_test.go
@@ -336,8 +336,9 @@ func BenchmarkRegexStage(b *testing.B) {
 			labels := model.LabelSet{}
 			ts := time.Now()
 			extr := map[string]interface{}{}
+			r := &resultChain{}
 			for i := 0; i < b.N; i++ {
-				stage.Process(labels, extr, ts, bm.entry, &resultChain{})
+				stage.Process(labels, extr, ts, bm.entry, r)
 			}
 		})
 	}

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -38,6 +38,18 @@ type Stage interface {
 	Name() string
 }
 
+// FlushableStage is a stage that can be flushed.
+type FlushableStage interface {
+	Stage
+	Flush(chain RepeatableStageChain)
+}
+
+// RepeatableStageChain is a chain, that can be cloned and run again later.
+type RepeatableStageChain interface {
+	StageChain
+	Clone() RepeatableStageChain
+}
+
 // StageFunc is modelled on http.HandlerFunc.
 type StageFunc func(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain)
 

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -22,6 +22,7 @@ const (
 	StageTypeTemplate  = "template"
 	StageTypePipeline  = "pipeline"
 	StageTypeTenant    = "tenant"
+	StageTypeMultiline = "multiline"
 )
 
 // StageChain is supplied to the Stage, and gives stage an option to continue with the next stage (if it so decides)
@@ -102,6 +103,11 @@ func New(logger log.Logger, jobName *string, stageType string, cfg interface{}, 
 		}
 	case StageTypeTenant:
 		s, err = newTenantStage(logger, cfg)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeMultiline:
+		s, err = newMultilineStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -83,7 +83,9 @@ type templateStage struct {
 }
 
 // Process implements Stage
-func (o *templateStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (o *templateStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
+	defer chain.NextStage(labels, extracted, time, entry) // we can use defer, because this stage doesn't modify time or entry
+
 	if o.cfgs == nil {
 		return
 	}

--- a/pkg/logentry/stages/template_test.go
+++ b/pkg/logentry/stages/template_test.go
@@ -48,17 +48,15 @@ func TestPipeline_Template(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lbls := model.LabelSet{}
 	expectedLbls := model.LabelSet{
 		"app":   "LOKI doki",
 		"level": "OK",
 		"type":  "TEST",
 	}
-	ts := time.Now()
-	entry := testTemplateLogLine
-	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
-	assert.Equal(t, expectedLbls, lbls)
+
+	result := &resultChain{}
+	pl.Process(model.LabelSet{}, map[string]interface{}{}, time.Now(), testTemplateLogLine, result)
+	assert.Equal(t, expectedLbls, result.labels)
 }
 
 func TestTemplateValidation(t *testing.T) {
@@ -197,9 +195,9 @@ func TestTemplateStage_Process(t *testing.T) {
 				t.Fatal(err)
 			}
 			lbls := model.LabelSet{}
-			entry := "not important for this test"
-			st.Process(lbls, test.extracted, nil, &entry)
-			assert.Equal(t, test.expectedExtracted, test.extracted)
+			result := &resultChain{}
+			st.Process(lbls, test.extracted, time.Now(), "not important for this test", result)
+			assert.Equal(t, test.expectedExtracted, result.extracted)
 		})
 	}
 }

--- a/pkg/logentry/stages/tenant.go
+++ b/pkg/logentry/stages/tenant.go
@@ -60,7 +60,7 @@ func newTenantStage(logger log.Logger, configs interface{}) (*tenantStage, error
 }
 
 // Process implements Stage
-func (s *tenantStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+func (s *tenantStage) Process(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string, chain StageChain) {
 	var tenantID string
 
 	// Get tenant ID from source or configured value
@@ -71,11 +71,11 @@ func (s *tenantStage) Process(labels model.LabelSet, extracted map[string]interf
 	}
 
 	// Skip an empty tenant ID (ie. failed to get the tenant from the source)
-	if tenantID == "" {
-		return
+	if tenantID != "" {
+		labels[client.ReservedLabelTenantID] = model.LabelValue(tenantID)
 	}
 
-	labels[client.ReservedLabelTenantID] = model.LabelValue(tenantID)
+	chain.NextStage(labels, extracted, time, entry)
 }
 
 // Name implements Stage

--- a/pkg/logentry/stages/tenant_test.go
+++ b/pkg/logentry/stages/tenant_test.go
@@ -135,17 +135,16 @@ func TestTenantStage_Process(t *testing.T) {
 
 			// Process and dummy line and ensure nothing has changed except
 			// the tenant reserved label
-			timestamp := time.Unix(1, 1)
-			entry := "hello world"
 			labels := testData.inputLabels.Clone()
 			extracted := testData.inputExtracted
 
-			stage.Process(labels, extracted, &timestamp, &entry)
+			result := &resultChain{}
+			stage.Process(labels, extracted, time.Unix(1, 1), "hello world", result)
 
-			assert.Equal(t, time.Unix(1, 1), timestamp)
-			assert.Equal(t, "hello world", entry)
+			assert.Equal(t, time.Unix(1, 1), result.time)
+			assert.Equal(t, "hello world", result.entry)
 
-			actualTenant, ok := labels[client.ReservedLabelTenantID]
+			actualTenant, ok := result.labels[client.ReservedLabelTenantID]
 			if testData.expectedTenant == nil {
 				assert.False(t, ok)
 			} else {

--- a/pkg/logentry/stages/timestamp_test.go
+++ b/pkg/logentry/stages/timestamp_test.go
@@ -40,11 +40,10 @@ func TestTimestampPipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 	lbls := model.LabelSet{}
-	ts := time.Now()
-	entry := testTimestampLogLine
 	extracted := map[string]interface{}{}
-	pl.Process(lbls, extracted, &ts, &entry)
-	assert.Equal(t, time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)).Unix(), ts.Unix())
+	result := &resultChain{}
+	pl.Process(lbls, extracted, time.Now(), testTimestampLogLine, result)
+	assert.Equal(t, time.Date(2012, 11, 01, 22, 8, 41, 0, time.FixedZone("", -4*60*60)).Unix(), result.time.Unix())
 }
 
 var (
@@ -235,10 +234,10 @@ func TestTimestampStage_Process(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ts := time.Now()
 			lbls := model.LabelSet{}
-			st.Process(lbls, test.extracted, &ts, nil)
-			assert.Equal(t, test.expected.UnixNano(), ts.UnixNano())
+			result := &resultChain{}
+			st.Process(lbls, test.extracted, time.Now(), "", result)
+			assert.Equal(t, test.expected.UnixNano(), result.time.UnixNano())
 		})
 	}
 }
@@ -378,12 +377,10 @@ func TestTimestampStage_ProcessActionOnFailure(t *testing.T) {
 			require.NoError(t, err)
 
 			for i, inputEntry := range testData.inputEntries {
-				extracted := inputEntry.extracted
-				timestamp := inputEntry.timestamp
-				entry := ""
+				result := &resultChain{}
 
-				s.Process(inputEntry.labels, extracted, &timestamp, &entry)
-				assert.Equal(t, testData.expectedTimestamps[i], timestamp, "entry: %d", i)
+				s.Process(inputEntry.labels, inputEntry.extracted, inputEntry.timestamp, "", result)
+				assert.Equal(t, testData.expectedTimestamps[i], result.time, "entry: %d", i)
 			}
 		})
 	}

--- a/pkg/logentry/stages/util_test.go
+++ b/pkg/logentry/stages/util_test.go
@@ -39,6 +39,20 @@ func assertLabels(t *testing.T, expect map[string]string, got model.LabelSet) {
 	}
 }
 
+type resultChain struct {
+	labels    model.LabelSet
+	extracted map[string]interface{}
+	time      time.Time
+	entry     string
+}
+
+func (rc *resultChain) NextStage(labels model.LabelSet, extracted map[string]interface{}, time time.Time, entry string) {
+	rc.labels = labels
+	rc.extracted = extracted
+	rc.time = time
+	rc.entry = entry
+}
+
 // Verify the formatting of float conversion to make sure there are not any trailing zeros,
 // and also make sure unix timestamps are converted properly
 func TestGetString(t *testing.T) {


### PR DESCRIPTION
Added basic support for multiline stage.

It's configuration looks like this:

```yaml
  pipeline_stages:
    - multiline:
        firstline: '^START'
        max_wait_time: 1s
```

If line matches first line, then it is buffered and multiline stage waits for additional line until next 'firstline' or max wait time is elapsed.

This PR builds on PR #1375. PoC, don't merge.