### PR TITLE
Update release instructions and release script

### DIFF
--- a/docs/maintaining/release.md
+++ b/docs/maintaining/release.md
@@ -1,5 +1,8 @@
 # Releasing Loki
 
+This document is a series of instructions for core Loki maintainers to be able
+to publish a new Loki release.
+
 ## Prerequisites
 
 Each maintainer performing a release should perform the following steps once

--- a/docs/maintaining/release.md
+++ b/docs/maintaining/release.md
@@ -1,34 +1,95 @@
 # Releasing Loki
 
-## How To Perform a Release
+## Prerequisites
 
-* Create a new branch for updating changelog and version numbers
-    * In the changelog, set the version number and release date, create the next release as (unreleased) as a placeholder for people to add notes to the changelog
-    * List all the merged PR's since the last release, this command is helpful for generating the output: `curl https://api.github.com/search/issues?q=repo:grafana/loki+is:pr+"merged:>=2019-08-02" | jq -r ' .items[] | "* [" + (.number|tostring) + "](" + .html_url + ") **" + .user.login + "**: " + .title'`
-* Go through the `docs/` and update references to the previous release version to the new one.
+Each maintainer performing a release should perform the following steps once
+before releasing Loki.
 
-> Until [852](https://github.com/grafana/loki/issues/852) is fixed, updating the Helm and Ksonnet configs has to wait until after the release tag is pushed so that the Helm tests will pass.
+### Signing Tags and Commits
 
-* Merge the changelog PR
-* Run:
+#### Add Existing GPG Key to GitHub
 
-    **Note: This step creates the tag and therefore the release, this will trigger CI to build release artifacts (binaries and images) as well as publish them.  As soon as this tag is pushed when CI finishes the new release artifacts will be available to the public**
+First, Navigate to your user's [SSH and GPG keys settings
+page](https://github.com/settings/keys). If the GPG key for the email address
+used to commit with Loki is not present, follow these instructions to add it:
 
-```https://github.com/grafana/loki/releases
-git pull
-git tag -s v0.2.0 -m "tagging release v0.2.0"
-git push origin v0.2.0
+1. Run `gpg --armor --export <your email address>`
+2. Copy the output.
+3. In the settings page linked above, click "New GPG Key".
+4. Copy and paste the PGP public key block.
+
+#### Signing Commits and Tags by Default
+
+To avoid accidentally publishing a tag or commit without signing it, you can run
+the following to ensure all commits and tags are signed:
+
+```bash
+git config --global commit.gpgSign true
+git config --global tag.gpgSign true
 ```
 
-* After the builds finish, run:
+##### macOS Signing Errors
+
+If you are on macOS and using an encrypted GPG key, the `gpg-agent` may be
+unable to prompt you for your private key passphrase. This will be denoted by an
+error when creating a commit or tag. To circumvent the error, add the following
+into your `~/.bash_profile` or `~/.zshrc`, depending on which shell you are
+using:
 
 ```
-make release-prepare
+export GPG_TTY=$(tty)
 ```
 
-* Set the release version and in most cases the auto selected helm version numbers should be fine.
-* Commit to another branch, make a PR and get merge it.
-* Go to GitHub and finish manually editing the auto generated release template and publish it!
+## Performing the Release
 
+1. Create a new branch to update `CHANGELOG.md` and references to version
+   numbers.
+2. Modify `CHANGELOG.md` with the new version number and its release date.
+3. List all the merged PRs since the previous release. This command is helpful
+   for generating the list (modifying the date to the date of the previous release): `curl https://api.github.com/search/issues?q=repo:grafana/loki+is:pr+"merged:>=2019-08-02" | jq -r ' .items[] | "* [" + (.number|tostring) + "](" + .html_url + ") **" + .user.login + "**: " + .title'`
+4. Go through `docs/` and find references to the previous release version and
+   update them to reference the new version.
+5. *Without creating a tag*, create a commit based on your changes and open a PR
+   for updating the release notes.
+   1. Until [852](https://github.com/grafana/loki/issues/852) is fixed, updating
+      Helm and Ksonnet configs needs to be done in a separate commit following
+      the release tag so that Helm tests pass.
+6. Merge the changelog PR.
+7. Create a new tag for the release.
+    1. Once this step is done, the CI will be triggered to create release
+       artifacts and publish them to a draft release. The tag will be made
+       publicly available immediately.
+    2. Run the following to create the tag:
 
+       ```bash
+       RELEASE=v1.2.3 # UPDATE ME to reference new release
+       git checkout master # If not already on master
+       git pull
+       git tag -s $RELEASE -m "tagging release $RELEASE"
+       git push origin $RELEASE
+       ```
+8. Watch CircleCI and wait for all the jobs to finish running.
 
+## Updating Helm and Ksonnet configs
+
+These steps should be executed after the previous section, once CircleCI has
+finished running all the release jobs.
+
+1. Run `bash ./tools/release_prepare.sh`
+2. When prompted for the release version, enter the latest tag.
+3. When prompted for new Helm version numbers, the defaults should suffice (a
+   minor version bump).
+4. Commit the changes to a new branch, push, make a PR, and get it merged.
+
+## Publishing the Release Draft
+
+Once the previous two steps are completed, you can publish your draft!
+
+1. Go to the [GitHub releases page](https://github.com/grafana/loki/releases)
+   and find the drafted release.
+2. Edit the drafted release, copying and pasting *notable changes* from the
+   CHANGELOG. Add a link to the CHANGELOG, noting that the full list of changes
+   can be found there. Refer to other releases for help with formatting this.
+3. Optionally, have other team members review the release draft so you feel
+   comfortable with it.
+4. Publish the release!

--- a/tools/release_prepare.sh
+++ b/tools/release_prepare.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# sed-wrap runs the appropriate sed command based on the
+# underlying value of $OSTYPE
+sed-wrap() {
+  if [[ "$OSTYPE" == "linux"* ]]; then
+    # Linux
+    sed -i "$1" $2
+  else
+    # macOS, BSD
+    sed -i '' "$1" $2
+  fi
+}
+
 echo
 echo "Last 5 tags:"
 git tag --sort=-taggerdate | head -n 5
@@ -49,20 +61,20 @@ if [[ "${CONTINUE}" != "y" ]]; then
 fi
 
 echo "Updating helm and ksonnet image versions"
-sed -i '' "s/.*promtail:.*/    promtail: 'grafana\/promtail:${VERSION}',/" production/ksonnet/promtail/config.libsonnet
-sed -i '' "s/.*loki_canary:.*/    loki_canary: 'grafana\/loki-canary:${VERSION}',/" production/ksonnet/loki-canary/config.libsonnet
-sed -i '' "s/.*loki:.*/    loki: 'grafana\/loki:${VERSION}',/" production/ksonnet/loki/images.libsonnet
-sed -i '' "s/.*tag:.*/  tag: ${VERSION}/" production/helm/loki/values.yaml
-sed -i '' "s/.*tag:.*/  tag: ${VERSION}/" production/helm/promtail/values.yaml
+sed-wrap "s/.*promtail:.*/    promtail: 'grafana\/promtail:${VERSION}',/" production/ksonnet/promtail/config.libsonnet
+sed-wrap "s/.*loki_canary:.*/    loki_canary: 'grafana\/loki-canary:${VERSION}',/" production/ksonnet/loki-canary/config.libsonnet
+sed-wrap "s/.*loki:.*/    loki: 'grafana\/loki:${VERSION}',/" production/ksonnet/loki/images.libsonnet
+sed-wrap "s/.*tag:.*/  tag: ${VERSION}/" production/helm/loki/values.yaml
+sed-wrap "s/.*tag:.*/  tag: ${VERSION}/" production/helm/promtail/values.yaml
 
 echo "Updating helm charts"
-sed -i '' "s/^version:.*/version: ${LOKI_VERSION}/" production/helm/loki/Chart.yaml
-sed -i '' "s/^version:.*/version: ${PROMTAIL_VERSION}/" production/helm/promtail/Chart.yaml
-sed -i '' "s/^version:.*/version: ${LOKI_STACK_VERSION}/" production/helm/loki-stack/Chart.yaml
+sed-wrap "s/^version:.*/version: ${LOKI_VERSION}/" production/helm/loki/Chart.yaml
+sed-wrap "s/^version:.*/version: ${PROMTAIL_VERSION}/" production/helm/promtail/Chart.yaml
+sed-wrap "s/^version:.*/version: ${LOKI_STACK_VERSION}/" production/helm/loki-stack/Chart.yaml
 
-sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki/Chart.yaml
-sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/promtail/Chart.yaml
-sed -i '' "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki-stack/Chart.yaml
+sed-wrap "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki/Chart.yaml
+sed-wrap "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/promtail/Chart.yaml
+sed-wrap "s/^appVersion:.*/appVersion: ${VERSION}/" production/helm/loki-stack/Chart.yaml
 
 echo
 echo "######################################################################################################"


### PR DESCRIPTION
Doing some post-release cleanup: 

1. The `sed` command in the `release_prepare` script didn't work on Linux. I added a wrapper function to use the right arguments. 
2. I tweaked the release documentation with all prereqs and a more detailed workflow on getting the release done. 