### PR TITLE
production/helm: Support overriding full Loki configuration

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.21.0
+version: 0.22.0
 appVersion: v1.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -59,3 +59,27 @@ Create the app name of loki clients. Defaults to the same logic as "loki.fullnam
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get configuration as a string.
+.Values.config is undefined by default, meaning it is only ever defined by the user.
+If .Values.config is unspecified, we simply template and return .Values.configDefaults as a YAML string.
+Otherwise, we check the type of .Values.config, if it's a string, we template it and return it, otherwise we assume it is a map and merge it with the .Values.configDefaults, convert it from the merged map into a YAML string, and return that string templated.
+*/}}
+{{- define "loki.config" -}}
+{{- if .Values.config }}
+{{- if kindIs "string" .Values.config }}
+{{ tpl .Values.config . }}
+{{- else }}
+{{- $srcCopy := deepCopy .Values.configDefaults -}}
+{{- $destCopy := deepCopy .Values.config -}}
+{{- $newDict := mergeOverwrite $destCopy $srcCopy -}}
+{{ tpl (toYaml $newDict) . }}
+{{- end -}}{{/* end if kindIs string */}}
+{{- else }}{{/* else is when .Values.config is not truthy */}}
+{{ tpl (toYaml .Values.configDefaults) . }}
+{{- end -}}{{/* end if .Values.config */}}
+{{- end -}}{{/* end define */}}
+
+
+

--- a/production/helm/loki/templates/secret.yaml
+++ b/production/helm/loki/templates/secret.yaml
@@ -9,4 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- if .Values.configString }}
+  loki.yaml: {{ tpl .Values.configString . | b64enc}}
+{{- else }}
   loki.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
+{{- end }}

--- a/production/helm/loki/templates/secret.yaml
+++ b/production/helm/loki/templates/secret.yaml
@@ -9,8 +9,4 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{- if .Values.configString }}
-  loki.yaml: {{ tpl .Values.configString . | b64enc}}
-{{- else }}
-  loki.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
-{{- end }}
+  loki.yaml: {{ include "loki.config" . | b64enc}}

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -61,11 +61,7 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
           ports:
             - name: http-metrics
-{{- if .Values.configString }}
-              containerPort: {{ (.Values.configString | fromYaml ).server.http_listen_port }}
-{{- else }}
-              containerPort: {{ .Values.config.server.http_listen_port }}
-{{- end }}
+              containerPort: {{ (include "loki.config" . | fromYaml).server.http_listen_port }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -61,7 +61,11 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
           ports:
             - name: http-metrics
+{{- if .Values.configString }}
+              containerPort: {{ (.Values.configString | fromYaml ).server.http_listen_port }}
+{{- else }}
               containerPort: {{ .Values.config.server.http_listen_port }}
+{{- end }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -18,6 +18,7 @@ annotations: {}
 tracing:
   jaegerAgentHost:
 
+configString: ""
 config:
   auth_enabled: false
   ingester:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -18,8 +18,8 @@ annotations: {}
 tracing:
   jaegerAgentHost:
 
-configString: ""
-config:
+# config: null
+configDefaults:
   auth_enabled: false
   ingester:
     chunk_idle_period: 3m


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows helm based deployments to supply the full `loki.yaml` configuration,
rather than getting a mix of defaults from the helm chart as well as the user
supplied configuration.

I've broken up this change into 2 commits. The first is a simpler change which
adds an additional field to support this, and the 2nd is a bit more complex,
but handles this use-case without any new fields by using reflection to check
the type of value supplied by the user.

**Which issue(s) this PR fixes**:
Fixes #1392

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated