### PR TITLE
Documentation: Fix example AWS storage configuration

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -125,7 +125,7 @@ index storage:
 schema_config:
   configs:
     - from: 2018-04-15
-      store: dynamo
+      store: aws
       object_store: s3
       schema: v9
       index:


### PR DESCRIPTION
`store` must be `aws`, not `dynamo`. 

Without this change, the previous example configuration causes Loki to error at startup:

```
level=error ts=2019-12-10T00:27:54.489032373Z caller=main.go:66 msg="error initialising loki" err="error initialising module: table-manager: Unrecognized storage client dynamo, choose one of: aws, cassandra, inmemory, gcp, bigtable, bigtable-hashed"
```