### PR TITLE
Use the build image for docker builds

### DIFF
--- a/cmd/fluent-bit/Dockerfile
+++ b/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13 as build
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
+FROM $BUILD_IMAGE as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13 as build
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
+FROM $BUILD_IMAGE as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-canary

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13 as build
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
+FROM $BUILD_IMAGE as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13 as build
+ARG BUILD_IMAGE=grafana/loki-build-image:0.9.0
+FROM $BUILD_IMAGE as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev


### PR DESCRIPTION
this is required to be able to compile protobufs which we do with each build now, 

I'm actually not quite sure how this is working in drone to be honest....

/cc @sh0rez 
