### PR TITLE
Convert string to bytes once only when doing string filtering.

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -138,13 +138,15 @@ func (e *filterExpr) Filter() (Filter, error) {
 		}
 
 	case labels.MatchEqual:
+		mb := []byte(e.match)
 		f = func(line []byte) bool {
-			return bytes.Contains(line, []byte(e.match))
+			return bytes.Contains(line, mb)
 		}
 
 	case labels.MatchNotEqual:
+		mb := []byte(e.match)
 		f = func(line []byte) bool {
-			return !bytes.Contains(line, []byte(e.match))
+			return !bytes.Contains(line, mb)
 		}
 
 	default:

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -111,3 +111,25 @@ func Test_FilterMatcher(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkContainsFilter(b *testing.B) {
+	expr, err := ParseLogSelector(`{app="foo"} |= "foo"`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	f, err := expr.Filter()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	line := []byte("hello world foo bar")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if !f(line) {
+			b.Fatal("doesn't match")
+		}
+	}
+}


### PR DESCRIPTION
This is trivial change that moves conversion out of returned function. This makes it slightly faster:
```
name              old time/op    new time/op    delta
ContainsFilter-4    18.2ns ± 2%     9.8ns ± 1%  -46.20%  (p=0.000 n=10+8)

name              old alloc/op   new alloc/op   delta
ContainsFilter-4     0.00B          0.00B          ~     (all equal)

name              old allocs/op  new allocs/op  delta
ContainsFilter-4      0.00           0.00          ~     (all equal)
```