### PR TITLE
change the chunk size histogram to allow for bigger buckets

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -42,7 +42,7 @@ var (
 		Namespace: "loki",
 		Name:      "ingester_chunk_size_bytes",
 		Help:      "Distribution of stored chunk sizes (when stored).",
-		Buckets:   prometheus.ExponentialBuckets(10000, 2, 7), // biggest bucket is 10000*2^(7-1) = 640000 (~640KB)
+		Buckets:   prometheus.ExponentialBuckets(50000, 2, 10), // biggest bucket is 50000*2^(10-1) = 25,600,000 (~25.6MB)
 	})
 	chunkCompressionRatio = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "loki",

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -42,7 +42,7 @@ var (
 		Namespace: "loki",
 		Name:      "ingester_chunk_size_bytes",
 		Help:      "Distribution of stored chunk sizes (when stored).",
-		Buckets:   prometheus.ExponentialBuckets(50000, 2, 10), // biggest bucket is 50000*2^(10-1) = 25,600,000 (~25.6MB)
+		Buckets:   prometheus.ExponentialBuckets(20000, 2, 10), // biggest bucket is 20000*2^(10-1) = 10,240,000 (~10.2MB)
 	})
 	chunkCompressionRatio = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "loki",


### PR DESCRIPTION
Previous histogram topped out at around 640kB buckets, this moves it up to about 10.24MB

Signed-off-by: Edward Welch <edward.welch@grafana.com>
