### PR TITLE
RangeQuery benchmark optimizations

### DIFF
--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -79,10 +79,18 @@ type iteratorMinHeap struct {
 
 func (h iteratorMinHeap) Less(i, j int) bool {
 	t1, t2 := h.iteratorHeap[i].Entry().Timestamp, h.iteratorHeap[j].Entry().Timestamp
-	if !t1.Equal(t2) {
-		return t1.Before(t2)
+
+	un1 := t1.UnixNano()
+	un2 := t2.UnixNano()
+
+	switch {
+	case un1 < un2:
+		return true
+	case un1 > un2:
+		return false
+	default: // un1 == un2:
+		return h.iteratorHeap[i].Labels() < h.iteratorHeap[j].Labels()
 	}
-	return h.iteratorHeap[i].Labels() < h.iteratorHeap[j].Labels()
 }
 
 type iteratorMaxHeap struct {
@@ -91,10 +99,18 @@ type iteratorMaxHeap struct {
 
 func (h iteratorMaxHeap) Less(i, j int) bool {
 	t1, t2 := h.iteratorHeap[i].Entry().Timestamp, h.iteratorHeap[j].Entry().Timestamp
-	if !t1.Equal(t2) {
-		return t1.After(t2)
+
+	un1 := t1.UnixNano()
+	un2 := t2.UnixNano()
+
+	switch {
+	case un1 < un2:
+		return false
+	case un1 > un2:
+		return true
+	default: // un1 == un2
+		return h.iteratorHeap[i].Labels() > h.iteratorHeap[j].Labels()
 	}
-	return h.iteratorHeap[i].Labels() > h.iteratorHeap[j].Labels()
 }
 
 // HeapIterator iterates over a heap of iterators with ability to push new iterators and get some properties like time of entry at peek and len

--- a/pkg/iter/iterator_test.go
+++ b/pkg/iter/iterator_test.go
@@ -2,7 +2,6 @@ package iter
 
 import (
 	"fmt"
-	"math/rand"
 	"sort"
 	"testing"
 	"time"

--- a/pkg/iter/iterator_test.go
+++ b/pkg/iter/iterator_test.go
@@ -2,6 +2,8 @@ package iter
 
 import (
 	"fmt"
+	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -241,16 +243,37 @@ func TestMostCommon(t *testing.T) {
 	}
 	require.Equal(t, "a", mostCommon(tuples).Entry.Line)
 
-	// Last is most common
 	tuples = []tuple{
 		{Entry: logproto.Entry{Line: "a"}},
 		{Entry: logproto.Entry{Line: "b"}},
-		{Entry: logproto.Entry{Line: "c"}},
 		{Entry: logproto.Entry{Line: "b"}},
 		{Entry: logproto.Entry{Line: "c"}},
 		{Entry: logproto.Entry{Line: "c"}},
+		{Entry: logproto.Entry{Line: "c"}},
+		{Entry: logproto.Entry{Line: "d"}},
 	}
 	require.Equal(t, "c", mostCommon(tuples).Entry.Line)
+}
+
+func TestInsert(t *testing.T) {
+	toInsert := []tuple{
+		{Entry: logproto.Entry{Line: "a"}},
+		{Entry: logproto.Entry{Line: "e"}},
+		{Entry: logproto.Entry{Line: "c"}},
+		{Entry: logproto.Entry{Line: "b"}},
+		{Entry: logproto.Entry{Line: "d"}},
+		{Entry: logproto.Entry{Line: "a"}},
+		{Entry: logproto.Entry{Line: "c"}},
+	}
+
+	var ts []tuple
+	for _, e := range toInsert {
+		ts = insert(ts, e)
+	}
+
+	require.True(t, sort.SliceIsSorted(ts, func(i, j int) bool {
+		return ts[i].Line < ts[j].Line
+	}))
 }
 
 func TestEntryIteratorForward(t *testing.T) {

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -764,6 +764,11 @@ func getLocalQuerier(size int64) Querier {
 		iter.NewStreamIterator(newStream(size, identity, `{app="bar",bar="foo"}`)),
 		iter.NewStreamIterator(newStream(size, identity, `{app="bar",bar="bazz"}`)),
 		iter.NewStreamIterator(newStream(size, identity, `{app="bar",bar="fuzz"}`)),
+		// some duplicates
+		iter.NewStreamIterator(newStream(size, identity, `{app="foo"}`)),
+		iter.NewStreamIterator(newStream(size, identity, `{app="bar"}`)),
+		iter.NewStreamIterator(newStream(size, identity, `{app="bar",bar="bazz"}`)),
+		iter.NewStreamIterator(newStream(size, identity, `{app="bar"}`)),
 	}
 	return QuerierFunc(func(ctx context.Context, p SelectParams) (iter.EntryIterator, error) {
 		return iter.NewHeapIterator(iters, p.Direction), nil


### PR DESCRIPTION
Couple of small optimizations for RangeQuery benchmark.

```
$ benchstat orig.txt new.txt 
name                 old time/op    new time/op    delta
RangeQuery100000-4     2.53ms ± 8%    2.28ms ± 4%  -10.00%  (p=0.000 n=10+9)
RangeQuery200000-4     7.23ms ± 8%    5.80ms ± 3%  -19.82%  (p=0.000 n=10+9)
RangeQuery500000-4      2.78s ± 2%     2.29s ± 3%  -17.61%  (p=0.000 n=9+10)
RangeQuery1000000-4     5.54s ± 3%     4.54s ± 3%  -18.07%  (p=0.000 n=10+9)

name                 old alloc/op   new alloc/op   delta
RangeQuery100000-4      290kB ± 3%     254kB ± 1%  -12.53%  (p=0.000 n=9+9)
RangeQuery200000-4      586kB ± 7%     368kB ± 1%  -37.22%  (p=0.000 n=10+9)
RangeQuery500000-4      263MB ± 0%     135MB ± 0%  -48.68%  (p=0.000 n=10+10)
RangeQuery1000000-4     527MB ± 0%     271MB ± 0%  -48.62%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
RangeQuery100000-4      2.95k ± 5%     1.97k ± 0%  -33.07%  (p=0.000 n=9+9)
RangeQuery200000-4      7.64k ± 9%     2.09k ± 0%  -72.65%  (p=0.000 n=10+9)
RangeQuery500000-4      4.14M ± 0%     0.14M ± 0%  -96.72%  (p=0.000 n=10+10)
RangeQuery1000000-4     8.27M ± 0%     0.27M ± 0%  -96.75%  (p=0.000 n=10+10)
```

Benchmark is also updated to have some duplicate streams, as it didn't have any before.
