### PR TITLE
Adds tenant-id for docker driver.

### DIFF
--- a/cmd/docker-driver/README.md
+++ b/cmd/docker-driver/README.md
@@ -126,6 +126,7 @@ To specify additional logging driver options, you can use the --log-opt NAME=VAL
 | `loki-max-backoff`       | No        | `10s`                 | The maximum amount of time to wait before retrying a batch. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 | `loki-retries`           | No        | `10`            | The maximum amount of retries for a log batch.
 | `loki-pipeline-stage-file`     | No        |                  | The location of a pipeline stage configuration file ([example](./pipeline-example.yaml)). Pipeline stages allows to parse log lines to extract more labels. [see documentation](../../docs/logentry/processing-log-lines.md)
+| `loki-tenant-id`            | No        |                      | Set the tenant id (http header`X-Scope-OrgID`) when sending logs to Loki. It can be overrides by a pipeline stage.
 | `loki-tls-ca-file`            | No        |                      | Set the path to a custom certificate authority.
 | `loki-tls-cert-file` | No        |               | Set the path to a client certificate file.
 | `loki-tls-key-file`         | No        |                      | Set the path to a client key.

--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -38,6 +38,7 @@ const (
 	cfgMaxBackoffKey     = "loki-max-backoff"
 	cfgMaxRetriesKey     = "loki-retries"
 	cfgPipelineStagesKey = "loki-pipeline-stage-file"
+	cfgTenantIDKey       = "loki-tenant-id"
 
 	swarmServiceLabelKey = "com.docker.swarm.service.name"
 	swarmStackLabelKey   = "com.docker.stack.namespace"
@@ -98,6 +99,7 @@ func validateDriverOpt(loggerInfo logger.Info) error {
 		case cfgMaxBackoffKey:
 		case cfgMaxRetriesKey:
 		case cfgPipelineStagesKey:
+		case cfgTenantIDKey:
 		case "labels":
 		case "env":
 		case "env-regex":
@@ -187,6 +189,12 @@ func parseConfig(logCtx logger.Info) (*config, error) {
 			return nil, fmt.Errorf("%s: option %s is invalid %s", driverName, cfgProxyURLKey, err)
 		}
 		clientConfig.Client.ProxyURL.URL = proxyURL
+	}
+
+	// parse tenant id
+	tenantID, ok := logCtx.Config[cfgTenantIDKey]
+	if ok && tenantID != "" {
+		clientConfig.TenantID = tenantID
 	}
 
 	// parse external labels


### PR DESCRIPTION
As discussed since pipeline stages are not trivial to configure for docker (although I've discovered propagated mount that I need to try), this add an options to set the tenant id. (`--log-opt loki-tenant-id=51pastis`)

Fixes https://github.com/grafana/loki/issues/1374