### PR TITLE
pkg/promtail/client: missing URL in client returns error

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,6 +104,10 @@ type entry struct {
 
 // New makes a new Client.
 func New(cfg Config, logger log.Logger) (Client, error) {
+	if cfg.URL.URL == nil {
+		return nil, errors.New("client needs target URL")
+	}
+
 	c := &client{
 		logger:  log.With(logger, "component", "client", "host", cfg.URL.Host),
 		cfg:     cfg,


### PR DESCRIPTION
**What this PR does / why we need it**:
If client has no URL, don't panic but return error.

**Which issue(s) this PR fixes**:
Fixes #1404 
