### PR TITLE
Sets the chunk encoding correctly when creating chunk from bytes.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -188,6 +188,7 @@ func NewByteChunk(b []byte) (*MemChunk, error) {
 		if db.err() != nil {
 			return nil, errors.Wrap(db.err(), "verifying encoding")
 		}
+		bc.encoding = enc
 		bc.readers, bc.writers = getReaderPool(enc), getWriterPool(enc)
 	default:
 		return nil, errors.Errorf("invalid version %d", version)

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -148,6 +148,36 @@ func TestReadFormatV1(t *testing.T) {
 	}
 }
 
+func TestReadFormatV2(t *testing.T) {
+	c := NewMemChunk(EncLZ4)
+	fillChunk(c)
+
+	b, err := c.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewByteChunk(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, r.encoding, EncLZ4)
+
+	it, err := r.Iterator(time.Unix(0, 0), time.Unix(0, math.MaxInt64), logproto.FORWARD, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := int64(0)
+	for it.Next() {
+		require.Equal(t, i, it.Entry().Timestamp.UnixNano())
+		require.Equal(t, testdata.LogString(i), it.Entry().Line)
+
+		i++
+	}
+}
+
 func TestSerialization(t *testing.T) {
 	for _, enc := range testEncoding {
 		t.Run(enc.String(), func(t *testing.T) {

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -160,6 +160,7 @@ func TestRoundtripV2(t *testing.T) {
 			populated := fillChunk(c)
 
 			assertLines := func(c *MemChunk) {
+				require.Equal(t, enc, c.Encoding())
 				it, err := c.Iterator(time.Unix(0, 0), time.Unix(0, math.MaxInt64), logproto.FORWARD, nil)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
Previously only the reader and writer for the encoding was set, on subsequent serialization
the format would be missing, this only happens if the chunk is created from a chunk transfer.
Because it uses NewBytesChunk to load and also write.

I've also added a regression tests.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>