### PR TITLE
pkg/chunkenc: change default LZ4 buffer size to 64k.

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -24,17 +24,23 @@ var (
 type Encoding byte
 
 // The different available encodings.
+// Make sure to preserve the order, as these numeric values are written to the chunks!
 const (
 	EncNone Encoding = iota
 	EncGZIP
 	EncDumb
-	EncLZ4
+	EncLZ4_64k
 	EncSnappy
+
+	// Added for testing.
+	EncLZ4_256k
+	EncLZ4_1M
+	EncLZ4_4M
 )
 
 var supportedEncoding = []Encoding{
 	EncGZIP,
-	EncLZ4,
+	EncLZ4_64k,
 	EncSnappy,
 }
 
@@ -46,8 +52,14 @@ func (e Encoding) String() string {
 		return "none"
 	case EncDumb:
 		return "dumb"
-	case EncLZ4:
+	case EncLZ4_64k:
 		return "lz4"
+	case EncLZ4_256k:
+		return "lz4-256k"
+	case EncLZ4_1M:
+		return "lz4-1M"
+	case EncLZ4_4M:
+		return "lz4-4M"
 	case EncSnappy:
 		return "snappy"
 	default:

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -19,7 +19,10 @@ import (
 var testEncoding = []Encoding{
 	EncNone,
 	EncGZIP,
-	EncLZ4,
+	EncLZ4_64k,
+	EncLZ4_256k,
+	EncLZ4_1M,
+	EncLZ4_4M,
 	EncSnappy,
 }
 

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -27,12 +27,11 @@ type ReaderPool interface {
 
 var (
 	// Gzip is the gnu zip compression pool
-	Gzip = GzipPool{level: gzip.DefaultCompression}
-	// LZ4 is the l4z compression pool
-	Lz4_64k  = LZ4Pool{bufferSize: 1 << 16}
-	Lz4_256k = LZ4Pool{bufferSize: 1 << 18}
-	Lz4_1M   = LZ4Pool{bufferSize: 1 << 20}
-	Lz4_4M   = LZ4Pool{bufferSize: 1 << 22}
+	Gzip     = GzipPool{level: gzip.DefaultCompression}
+	Lz4_64k  = LZ4Pool{bufferSize: 1 << 16} // Lz4_64k is the l4z compression pool, with 64k buffer size
+	Lz4_256k = LZ4Pool{bufferSize: 1 << 18} // Lz4_256k uses 256k buffer
+	Lz4_1M   = LZ4Pool{bufferSize: 1 << 20} // Lz4_1M uses 1M buffer
+	Lz4_4M   = LZ4Pool{bufferSize: 1 << 22} // Lz4_4M uses 4M buffer
 
 	// Snappy is the snappy compression pool
 	Snappy SnappyPool

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -29,10 +29,10 @@ var (
 	// Gzip is the gnu zip compression pool
 	Gzip = GzipPool{level: gzip.DefaultCompression}
 	// LZ4 is the l4z compression pool
-	LZ4_64k  = LZ4Pool{bufferSize: 1 << 16}
-	LZ4_256k = LZ4Pool{bufferSize: 1 << 18}
-	LZ4_1M   = LZ4Pool{bufferSize: 1 << 20}
-	LZ4_4M   = LZ4Pool{bufferSize: 1 << 22}
+	Lz4_64k  = LZ4Pool{bufferSize: 1 << 16}
+	Lz4_256k = LZ4Pool{bufferSize: 1 << 18}
+	Lz4_1M   = LZ4Pool{bufferSize: 1 << 20}
+	Lz4_4M   = LZ4Pool{bufferSize: 1 << 22}
 
 	// Snappy is the snappy compression pool
 	Snappy SnappyPool
@@ -64,13 +64,13 @@ func getReaderPool(enc Encoding) ReaderPool {
 	case EncGZIP:
 		return &Gzip
 	case EncLZ4_64k:
-		return &LZ4_64k
+		return &Lz4_64k
 	case EncLZ4_256k:
-		return &LZ4_256k
+		return &Lz4_256k
 	case EncLZ4_1M:
-		return &LZ4_1M
+		return &Lz4_1M
 	case EncLZ4_4M:
-		return &LZ4_4M
+		return &Lz4_4M
 	case EncSnappy:
 		return &Snappy
 	case EncNone:

--- a/pkg/chunkenc/pool.go
+++ b/pkg/chunkenc/pool.go
@@ -178,8 +178,7 @@ func (pool *LZ4Pool) GetReader(src io.Reader) io.Reader {
 	}
 	// no need to set buffer size here. Reader uses buffer size based on
 	// LZ4 header that it is reading.
-	r := newLz4Reader(src)
-	return r
+	return newLz4Reader(src)
 }
 
 // PutReader places back in the pool a CompressionReader


### PR DESCRIPTION
Also added more LZ4 buffer size options for testing.

**What this PR does / why we need it**:
LZ4 uses 4M buffer size by default when compressing data. It actually uses twice as much memory for decompression. Even though we pool lz4 readers, it can be a lot of allocated and pooled memory, if there are many concurrent decompressions.

In addition to that, we avoid pooling readers that were used to read chunks compressed with higher block sizes. Reason is that such readers must have used twice as much memory, and we don't want to keep these big-allocations in the pool.

Using smaller buffer doesn't affect (de-)compression time, although it may slightly affect ratio.

Time:
```
Read/none-4      51.1ms ± 6%
Read/gzip-4       211ms ± 6%
Read/lz4-64k-4   81.7ms ± 4%
Read/lz4-256k-4  81.3ms ± 7%
Read/lz4-1M-4    83.8ms ± 6%
Read/lz4-4M-4    81.6ms ± 4%
Read/snappy-4    80.6ms ± 3%
```

Memory:
```
name             alloc/op
Read/none-4       176kB ± 0%
Read/gzip-4       189kB ± 0%
Read/lz4-64k-4    185kB ± 1%
Read/lz4-256k-4   213kB ± 2%
Read/lz4-1M-4     334kB ± 5%
Read/lz4-4M-4     800kB ± 9%
Read/snappy-4     187kB ± 0%
```

**Special notes for your reviewer**:
"lz4" now defaults to LZ4_64k. Other lz4 buffer sizes are not available for user, but used for testing only.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

