### PR TITLE
pkg/chunkenc: Fix BenchmarkRead to focus on reading chunks, not converting bytes to string

### DIFF
--- a/pkg/chunkenc/util_test.go
+++ b/pkg/chunkenc/util_test.go
@@ -14,13 +14,16 @@ func logprotoEntry(ts int64, line string) *logproto.Entry {
 	}
 }
 
-func generateData(enc Encoding) []Chunk {
+func generateData(enc Encoding) ([]Chunk, uint64) {
 	chunks := []Chunk{}
 	i := int64(0)
+	size := uint64(0)
+
 	for n := 0; n < 50; n++ {
 		entry := logprotoEntry(0, testdata.LogString(0))
 		c := NewMemChunk(enc)
 		for c.SpaceFor(entry) {
+			size += uint64(len(entry.Line))
 			_ = c.Append(entry)
 			i++
 			entry = logprotoEntry(i, testdata.LogString(i))
@@ -28,7 +31,7 @@ func generateData(enc Encoding) []Chunk {
 		c.Close()
 		chunks = append(chunks, c)
 	}
-	return chunks
+	return chunks, size
 }
 
 func fillChunk(c Chunk) int64 {


### PR DESCRIPTION
Previously BenchmarkRead asked for every single line from chunks to be returned. This causes a lot of unnnecessary allocations (due to `string([]byte)` conversion), which dominate the benchmark. Instead of counting bytes when reading, we now count size when generating data for logging speed.

Another test was added to show that these two approaches are comparable.

This change makes BenchmarkRead to report real time needed to decode chunks:

```
name           old time/op    new time/op    delta
Read/none-4      86.2ms ± 0%    33.2ms ± 0%   ~     (p=1.000 n=1+1)
Read/gzip-4       255ms ± 0%     194ms ± 0%   ~     (p=1.000 n=1+1)
Read/lz4-4        121ms ± 0%      64ms ± 0%   ~     (p=1.000 n=1+1)
Read/snappy-4     119ms ± 0%      67ms ± 0%   ~     (p=1.000 n=1+1)

name           old alloc/op   new alloc/op   delta
Read/none-4       134MB ± 0%       0MB ± 0%   ~     (p=1.000 n=1+1)
Read/gzip-4       135MB ± 0%       0MB ± 0%   ~     (p=1.000 n=1+1)
Read/lz4-4        136MB ± 0%       1MB ± 0%   ~     (p=1.000 n=1+1)
Read/snappy-4     135MB ± 0%       0MB ± 0%   ~     (p=1.000 n=1+1)

name           old allocs/op  new allocs/op  delta
Read/none-4        491k ± 0%        3k ± 0%   ~     (p=1.000 n=1+1)
Read/gzip-4        491k ± 0%        3k ± 0%   ~     (p=1.000 n=1+1)
Read/lz4-4         491k ± 0%        3k ± 0%   ~     (p=1.000 n=1+1)
Read/snappy-4      491k ± 0%        3k ± 0%   ~     (p=1.000 n=1+1)
```

Decompression speed is now also more correct (esp. None is much higher than LZ4/Snappy)

```
	Before (/s)		Now (/s)
None	1.1 GB (n=1)		4.0 GB (n=1)
None	1.5 GB (n=9)		3.8 GB (n=38)
None	1.6 GB (n=13)
Gzip	516 MB (n=1)		640 MB (n=1)
Gzip	509 MB (n=3)		664 MB (n=4)
Gzip	514 MB (n=4)		649 MB (n=6)
LZ4	1.1 GB (n=1)		1.7 GB (n=1)
LZ4	1.1 GB (n=9)		1.9 GB (n=15)
Snappy	1.1 GB (n=1)		2.0 GB (n=1)
Snappy	1.1 GB (n=9)		1.8 GB (n=16)
```
