### PR TITLE
pkg/ingester: Added possibility to disable transfers.

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -244,7 +244,7 @@ The `ingester_config` block configures Ingesters.
 [lifecycler: <lifecycler_config>]
 
 # Number of times to try and transfer chunks when leaving before
-# falling back to flushing to the store.
+# falling back to flushing to the store. Zero = no transfers are done.
 [max_transfer_retries: <int> | default = 10]
 
 # How many flushes can happen concurrently from each stream.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -60,7 +60,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.LifecyclerConfig.RegisterFlags(f)
 
-	f.IntVar(&cfg.MaxTransferRetries, "ingester.max-transfer-retries", 10, "Number of times to try and transfer chunks before falling back to flushing.")
+	f.IntVar(&cfg.MaxTransferRetries, "ingester.max-transfer-retries", 10, "Number of times to try and transfer chunks before falling back to flushing. If set to 0 or negative value, transfers are disabled.")
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushed", 16, "")
 	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-check-period", 30*time.Second, "")
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 10*time.Second, "")

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -171,6 +171,10 @@ func (i *Ingester) StopIncomingRequests() {
 
 // TransferOut implements ring.Lifecycler.
 func (i *Ingester) TransferOut(ctx context.Context) error {
+	if i.cfg.MaxTransferRetries <= 0 {
+		return fmt.Errorf("transfers disabled")
+	}
+
 	backoff := util.NewBackoff(ctx, util.BackoffConfig{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 5 * time.Second,


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, with -ingester.max-transfer-retries set to zero, transfers would never stop. Now zero means don't transfer at all.

Note: this is in line with how Cortex works.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

