### PR TITLE
Using strict parsing for yaml configs

### DIFF
--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -41,3 +41,25 @@ tls:
 		},
 	}, data)
 }
+
+func TestParseWithInvalidYAML(t *testing.T) {
+	yamlSource := dYAML([]byte(`
+servers:
+  ports: 2000
+  timeoutz: 60h
+tls:
+  keey: YAML
+`))
+
+	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+	flagSource := dFlags(fs, []string{"-verbose", "-server.port=21"})
+
+	data := Data{}
+	err := dParse(&data,
+		dDefaults(fs),
+		yamlSource,
+		flagSource,
+	)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "yaml: unmarshal errors:\n  line 2: field servers not found in type cfg.Data\n  line 6: field keey not found in type cfg.TLS")
+}

--- a/pkg/cfg/files.go
+++ b/pkg/cfg/files.go
@@ -55,7 +55,7 @@ func YAML(f *string) Source {
 // dYAML returns a YAML source and allows dependency injection
 func dYAML(y []byte) Source {
 	return func(dst interface{}) error {
-		return yaml.Unmarshal(y, dst)
+		return yaml.UnmarshalStrict(y, dst)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Helps developers find mistakes with config sooner. 

**Which issue(s) this PR fixes**:
Fixes #1289 

**Special notes for your reviewer**:
I didn't add docs but could. Wasn't sure if it really mattered to call out that if you mistype or enter a completely invalid config into the yaml file that you will be presented with an error. This change since it was at the YAML config level goes for both **loki** and **promtail**. 

Original bug report was just **promtail** but should be no reason we can't have this feature for both. 

**Checklist**
- [ ] Documentation added
- [x] Tests updated

