### PR TITLE
promtail: add support for passing through journal entries as JSON

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -572,6 +572,12 @@ Promtail. Requires a build of Promtail that has journal support _enabled_. If
 using the AMD64 Docker image, this is enabled by default.
 
 ```yaml
+# When true, log messages from the journal are passed through the
+# pipeline as a JSON message with all of the journal entries' original
+# fields. When false, the log message is the text content of the MESSAGE
+# field from the journal entry.
+[json: <boolean> | default = false]
+
 # The oldest relative time from process start that will be read
 # and sent to Loki.
 [max_age: <duration> | default = 7h]

--- a/docs/clients/promtail/scraping.md
+++ b/docs/clients/promtail/scraping.md
@@ -85,6 +85,7 @@ defined in a `journal` stanza:
 scrape_configs:
   - job_name: journal
     journal:
+      json: false
       max_age: 12h
       path: /var/log/journal
       labels:
@@ -100,6 +101,11 @@ time specified will be sent to Loki; this circumvents "entry too old" errors.
 The `path` field tells Promtail where to read journal entries from. The labels
 map defines a constant list of labels to add to every journal entry that Promtail
 reads.
+
+When the `json` field is set to `true`, messages from the journal will be
+passed through the pipeline as JSON, keeping all of the original fields from the
+journal entry. This is useful when you don't want to index some fields but you
+still want to know what values they contained.
 
 By default, Promtail reads from the journal by looking in the `/var/log/journal`
 and `/run/log/journal` paths. If running Promtail inside of a Docker container,

--- a/pkg/promtail/scrape/scrape.go
+++ b/pkg/promtail/scrape/scrape.go
@@ -35,6 +35,11 @@ type JournalTargetConfig struct {
 	// if the cursor is older than the MaxAge value, it will not be used.
 	MaxAge string `yaml:"max_age"`
 
+	// JSON forces the output message of entries read from the journal to be
+	// JSON. The message will contain all original fields from the source
+	// journal entry.
+	JSON bool `yaml:"json"`
+
 	// Labels optionally holds labels to associate with each record coming out
 	// of the journal.
 	Labels model.LabelSet `yaml:"labels"`


### PR DESCRIPTION
This commit adds an extra configuration field (`json`) to the journal target configuration schema. When set to true, messages from the journal target will be passed through as JSON, containing all of the fields from the entry as keys and their values as the value.

For backwards compatibility, the value for `json` defaults to false.

Closes #1288.

/cc @roidelapluie