### PR TITLE
pkg/ingester: added sync period flags

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -284,6 +284,13 @@ The `ingester_config` block configures Ingesters.
 # - `lz4` fastest compression speed (188 kB per chunk)
 # - `snappy` fast and popular compression algorithm (272 kB per chunk)
 [chunk_encoding: <string> | default = gzip]
+
+# Parameters used to synchronize ingesters to cut chunks at the same moment.
+# Sync period is used to roll over incoming entry to a new chunk. If chunk's utilization
+# isn't high enough (eg. less than 50% when sync_min_utilization is set to 0.5), then
+# this chunk rollover doesn't happen.
+[sync_period: <duration> | default = 0]
+[sync_min_utilization: <float> | Default = 0]
 ```
 
 ### lifecycler_config


### PR DESCRIPTION
`-ingester.sync-period` can be used to tell ingesters to cut chunks early (before they are full) to synchronize ingesters so that they put the same data into the new chunks. If they do, they generate fully equal chunks and then they don't need to store them.

To avoid very small chunks, additional parameter is added: `-ingester.sync-min-utilization`. When set to eg. 0.5, chunk must be at least 50% full (utilization) in order to be cut early for sync purposes.

To avoid all chunks to be cut at the same time, series fingerprint is used as an offset to sync period. We need some value that all ingesters know about and can use, and although series fingerprints can be remapped on ingesters differently, they are good enough.

Based on [Bryan Boreham's work](https://www.weave.works/blog/how-i-halved-the-storage-of-cortex) in Cortex.

Signed-off-by: Peter Štibraný <peter.stibrany@grafana.com>

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

