### PR TITLE
fluentd-plugin: Handle non 503 http 400/500 codes as unrecoverable

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.7'
+  spec.version = '1.2.8'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
**What this PR does / why we need it**:

HTTP 400 is returned when data is sent out-of-order, and 500 is returned
when the response body is too large. Besides 503 which is usually
returned by load balancers/proxies, 400/500 aren't retryable. Throw a
Fluentd::UnrecoverableError so that these logs can be handled by
secondary outputs since it will not be possible to send to Loki.

The approach taken here is based on send_request in the http_output
plugin in https://github.com/fluent/fluentd/blob/3d96b15c21ba2b4e4eb2ff514b2a11e2ffafe36c/lib/fluent/plugin/out_http.rb#L203-L229

Additionally, I've added a `log_failed_streams` configuration option to
control logging the log stream contents. Since log streams can be fairly
large, logging the entire contents can be expensive and generally isn't
very useful by default. Loki errors do contain the log stream labels
when responding with an 'out of order' error, so identifying information
of what logs fail is still available.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated