### PR TITLE
pkg/promtail: Initialize counters to 0 when creating client

### DIFF
--- a/pkg/promtail/client/client_test.go
+++ b/pkg/promtail/client/client_test.go
@@ -70,6 +70,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
 				# TYPE promtail_sent_entries_total counter
 				promtail_sent_entries_total{host="__HOST__"} 3.0
+				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE promtail_dropped_entries_total counter
+				promtail_dropped_entries_total{host="__HOST__"} 0
 			`,
 		},
 		"batch log entries together until the batch wait time is reached": {
@@ -93,6 +96,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
 				# TYPE promtail_sent_entries_total counter
 				promtail_sent_entries_total{host="__HOST__"} 2.0
+				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE promtail_dropped_entries_total counter
+				promtail_dropped_entries_total{host="__HOST__"} 0
 			`,
 		},
 		"retry send a batch up to backoff's max retries in case the server responds with a 5xx": {
@@ -119,6 +125,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
 				# TYPE promtail_dropped_entries_total counter
 				promtail_dropped_entries_total{host="__HOST__"} 1.0
+				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE promtail_sent_entries_total counter
+				promtail_sent_entries_total{host="__HOST__"} 0
 			`,
 		},
 		"do not retry send a batch in case the server responds with a 4xx": {
@@ -137,6 +146,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
 				# TYPE promtail_dropped_entries_total counter
 				promtail_dropped_entries_total{host="__HOST__"} 1.0
+				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE promtail_sent_entries_total counter
+				promtail_sent_entries_total{host="__HOST__"} 0
 			`,
 		},
 		"batch log entries together honoring the client tenant ID": {
@@ -156,6 +168,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
 				# TYPE promtail_sent_entries_total counter
 				promtail_sent_entries_total{host="__HOST__"} 2.0
+				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE promtail_dropped_entries_total counter
+				promtail_dropped_entries_total{host="__HOST__"} 0
 			`,
 		},
 		"batch log entries together honoring the tenant ID overridden while processing the pipeline stages": {
@@ -183,6 +198,9 @@ func TestClient_Handle(t *testing.T) {
 				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
 				# TYPE promtail_sent_entries_total counter
 				promtail_sent_entries_total{host="__HOST__"} 4.0
+				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE promtail_dropped_entries_total counter
+				promtail_dropped_entries_total{host="__HOST__"} 0
 			`,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This ensures metrics are not missing before they're incremented the first
time, as recommended by the upstream Prometheus instrumentation guidelines:
https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics.

Currently, in the case of dropped_entries_total and dropped_bytes_total,
the metric is simply missing until the first occurrence of an entry
being dropped.

**Checklist**
- [ ] Documentation added
- [x] Tests updated