### PR TITLE
Makefile: re-enable journal scraping on ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,9 @@ PROMTAIL_DEBUG_GO_FLAGS := $(DEBUG_GO_FLAGS)
 # Validate GOHOSTOS=linux && GOOS=linux to use CGO.
 ifeq ($(shell go env GOHOSTOS),linux)
 ifeq ($(shell go env GOOS),linux)
-ifeq ($(shell go env GOARCH),amd64)
 PROMTAIL_CGO = 1
 PROMTAIL_GO_FLAGS = $(DYN_GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS = $(DYN_DEBUG_GO_FLAGS)
-endif
 endif
 endif
 


### PR DESCRIPTION
My understanding is that we had to disable journal scraping on ARM builds because it wasn't easy to get it working in CircleCI. Now that we use Drone for the ARM builds, we should be able to re-enable it again.

Fixes #1459.