### PR TITLE
Validates limit parameter.

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -26,6 +26,9 @@ func limit(r *http.Request) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
+	if l <= 0 {
+		return 0, errors.New("limit must be a positive value")
+	}
 	return uint32(l), nil
 }
 


### PR DESCRIPTION
This was missing, we don't support 0 or negative limit. Currently it will have an unwanted behaviour because of how we reduce result using the limit here https://github.com/grafana/loki/blob/master/pkg/logql/engine.go#L286

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

