### PR TITLE
positions.ignore-corruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master / unreleased
+
+* [FEATURE] promtail positions file corruptions can be ignored with the `positions.ignore-corruptions` flag. In the case the positions yaml is corrupted an empty positions config will be used and should later overwrite the malformed yaml.
+
 # 1.2.0 (2019-12-09)
 
 One week has passed since the last Loki release, and it's time for a new one!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master / unreleased
 
-* [FEATURE] promtail positions file corruptions can be ignored with the `positions.ignore-corruptions` flag. In the case the positions yaml is corrupted an empty positions config will be used and should later overwrite the malformed yaml.
+* [FEATURE] promtail positions file corruptions can be ignored with the `positions.ignore-invalid-yaml` flag. In the case the positions yaml is corrupted an empty positions config will be used and should later overwrite the malformed yaml.
 
 # 1.2.0 (2019-12-09)
 

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -226,6 +226,9 @@ is restarted to allow it to continue from where it left off.
 
 # How often to update the positions file
 [sync_period: <duration> | default = 10s]
+
+# Whether to ignore & later overwrite positions files that are corrupted
+[ignore_corruptions: <boolean> | default = false]
 ```
 
 ## scrape_config

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -228,7 +228,7 @@ is restarted to allow it to continue from where it left off.
 [sync_period: <duration> | default = 10s]
 
 # Whether to ignore & later overwrite positions files that are corrupted
-[ignore_corruptions: <boolean> | default = false]
+[ignore_invalid_yaml: <boolean> | default = false]
 ```
 
 ## scrape_config

--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -199,7 +199,7 @@ func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error)
 	if err != nil {
 		// return empty if cfg option enabled
 		if cfg.IgnoreInvalidYaml {
-			level.Debug(logger).Log("msg", "ignoring corrupted positions file", "file", cleanfn, "error", err)
+			level.Debug(logger).Log("msg", "ignoring invalid positions file", "file", cleanfn, "error", err)
 			return map[string]string{}, nil
 		}
 

--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -22,14 +22,14 @@ const positionFileMode = 0600
 type Config struct {
 	SyncPeriod        time.Duration `yaml:"sync_period"`
 	PositionsFile     string        `yaml:"filename"`
-	IgnoreCorruptions bool          `yaml:"ignore_corruptions"`
+	IgnoreInvalidYaml bool          `yaml:"ignore_invalid_yaml"`
 }
 
 // RegisterFlags register flags.
 func (cfg *Config) RegisterFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&cfg.SyncPeriod, "positions.sync-period", 10*time.Second, "Period with this to sync the position file.")
 	flag.StringVar(&cfg.PositionsFile, "positions.file", "/var/log/positions.yaml", "Location to read/write positions from.")
-	flag.BoolVar(&cfg.IgnoreCorruptions, "positions.ignore-corruptions", false, "whether to ignore & later overwrite positions files that are corrupted")
+	flag.BoolVar(&cfg.IgnoreInvalidYaml, "positions.ignore-invalid-yaml", false, "whether to ignore & later overwrite positions files that are corrupted")
 }
 
 // Positions tracks how far through each file we've read.
@@ -198,7 +198,7 @@ func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error)
 	err = yaml.UnmarshalStrict(buf, &p)
 	if err != nil {
 		// return empty if cfg option enabled
-		if cfg.IgnoreCorruptions {
+		if cfg.IgnoreInvalidYaml {
 			level.Debug(logger).Log("msg", "ignoring corrupted positions file", "file", cleanfn, "error", err)
 			return map[string]string{}, nil
 		}

--- a/pkg/promtail/positions/positions_test.go
+++ b/pkg/promtail/positions/positions_test.go
@@ -110,7 +110,7 @@ func TestReadPositionsFromBadYamlIgnoreCorruption(t *testing.T) {
 
 	out, err := readPositionsFile(Config{
 		PositionsFile:     temp,
-		IgnoreCorruptions: true,
+		IgnoreInvalidYaml: true,
 	}, log.NewNopLogger())
 
 	require.NoError(t, err)


### PR DESCRIPTION
Adds a new config, `positions.ignore-corruptions` which allows ignoring corrupted yaml in the positions files. I believe this is already largely mitigated by the introduction of atomic file updates to the positions file.

This flag will not affect existing deployments, which error upon startup when finding malformed positions yaml.

closes https://github.com/grafana/loki/issues/1460
