### PR TITLE
pkg/querier: don't query all ingesters

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -161,6 +161,10 @@ The `querier_config` block configures the Loki Querier.
 # served.
 [tail_max_duration: <duration> | default = 1h]
 
+# Time to wait before sending more than the minimum successful query
+# requests.
+[extra_query_delay: <duration> | default = 0s]
+
 # Configuration options for the LogQL engine.
 engine:
   # Timeout for query execution


### PR DESCRIPTION
This commit uses replicationSet.Do for communicating with the ingesters from the queriers. This mimicks the behavior of Cortex. An extra_query_delay flag has been added to match the flag present in Cortex's querier config.

Fixes #1447.