### PR TITLE
Fixes the typo in the result cache config of the Loki ksonnet lib.

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -117,7 +117,7 @@
         cache_results: true,
         max_retries: 5,
         results_cache: {
-          split_interval: '30m',
+          cache_split_interval: '30m',
           max_freshness: '10m',
           cache: {
             memcached_client: {


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

PS: Mistakes were made.

