### PR TITLE
TOUCH_PROTOS build arg for dockerfile

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -237,7 +237,7 @@ steps:
   settings:
     dockerfile: cmd/loki/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -182,6 +182,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+    - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -200,6 +202,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+    - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -218,6 +222,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+    - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -254,6 +260,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+    - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -270,6 +278,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+    - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/promtail

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -236,6 +236,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ endif
 
 protos: $(PROTO_GOS)
 
+# use with care. This signals to make that the proto definitions don't need recompiling.
 touch-protos:
 	for proto in $(PROTO_GOS); do [ -f "./$${proto}" ] && touch "$${proto}" && echo "touched $${proto}"; done
 

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.13 as build
+# TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
+# This is helpful when file system timestamps can't be trusted with make
+ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki-canary
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,7 +4,6 @@ FROM golang:1.13 as build
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN echo touch protos "${TOUCH_PROTOS}"
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.13 as build
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN echo touch protos "{$TOUCH_PROTOS}"
+RUN echo touch protos "${TOUCH_PROTOS}"
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.13 as build
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
+RUN echo touch protos "{$TOUCH_PROTOS}"
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.13 as build
+# TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
+# This is helpful when file system timestamps can't be trusted with make
+ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.13 as build
+# TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
+# This is helpful when file system timestamps can't be trusted with make
+ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev
-RUN make clean && make BUILD_IN_CONTAINER=false promtail
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:stretch-slim


### PR DESCRIPTION
This allows us an escape hatch to avoid recompiling protos when building a docker image. Use with care!

closes https://github.com/grafana/loki/issues/1477

