### PR TITLE
Close iterator properly and check nil before releasing buffers.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -695,16 +695,21 @@ func (si *bufferedIterator) close() {
 		current.BytesDecompressed += si.bytesDecompressed
 		current.BytesCompressed += int64(len(si.origBytes))
 	})
-	si.pool.PutReader(si.reader)
-	BufReaderPool.Put(si.bufReader)
+	if si.reader != nil {
+		si.pool.PutReader(si.reader)
+		si.reader = nil
+	}
+	if si.bufReader != nil {
+		BufReaderPool.Put(si.bufReader)
+		si.bufReader = nil
+	}
+
 	if si.buf != nil {
 		BytesBufferPool.Put(si.buf)
+		si.buf = nil
 	}
 	si.origBytes = nil
-	si.bufReader = nil
-	si.buf = nil
 	si.decBuf = nil
-	si.reader = nil
 }
 
 func (si *bufferedIterator) Labels() string { return "" }

--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -522,7 +522,12 @@ func (i *entryIteratorBackward) Entry() logproto.Entry {
 	return i.cur
 }
 
-func (i *entryIteratorBackward) Close() error { return nil }
+func (i *entryIteratorBackward) Close() error {
+	if !i.loaded {
+		return i.forwardIter.Close()
+	}
+	return nil
+}
 
 func (i *entryIteratorBackward) Error() error { return nil }
 
@@ -608,7 +613,12 @@ func (i *entryIteratorForward) Entry() logproto.Entry {
 	return i.cur.entry
 }
 
-func (i *entryIteratorForward) Close() error { return nil }
+func (i *entryIteratorForward) Close() error {
+	if !i.loaded {
+		return i.backwardIter.Close()
+	}
+	return nil
+}
 
 func (i *entryIteratorForward) Error() error { return nil }
 


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

Fixes a panic when close is called prior iterating on the chunks. I also realized that some iterator were never closing properly their inner iterator.