### PR TITLE
Fileglob parsing fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/bmatcuk/doublestar v1.1.1
+	github.com/bmatcuk/doublestar v1.2.2
 	github.com/containerd/containerd v1.3.2 // indirect
 	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
@@ -46,7 +46,7 @@ require (
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/stretchr/testify v1.4.0
 	github.com/tonistiigi/fifo v0.0.0-20190226154929-a9fb20d87448
-	github.com/ugorji/go v1.1.7 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
 	github.com/weaveworks/common v0.0.0-20191103151037-0e7cefadc44f
 	go.etcd.io/etcd v0.0.0-20190815204525-8f85f0dc2607 // indirect
 	go.opencensus.io v0.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCS
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
-github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bmatcuk/doublestar v1.2.2 h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=
+github.com/bmatcuk/doublestar v1.2.2/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668 h1:U/lr3Dgy4WK+hNk4tyD+nuGjpVLPEHuJSFXMw11/HPA=

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -195,16 +195,21 @@ func (t *FileTarget) run() {
 
 func (t *FileTarget) sync() error {
 
-	// Find list of directories to add to watcher.
-	path, err := filepath.Abs(t.path)
-	if err != nil {
-		return errors.Wrap(err, "filetarget.sync.filepath.Abs")
-	}
-
 	// Gets current list of files to tail.
-	matches, err := doublestar.Glob(path)
+	matches, err := doublestar.Glob(t.path)
 	if err != nil {
 		return errors.Wrap(err, "filetarget.sync.filepath.Glob")
+	}
+
+	// Gets absolute path for each pattern.
+	for i := 0; i < len(matches); i++ {
+		if ! filepath.IsAbs(matches[i]) {
+			path, err := filepath.Abs(matches[i])
+			if err != nil {
+				return errors.Wrap(err, "filetarget.sync.filepath.Abs")
+			}
+			matches[i] = path
+		}
 	}
 
 	// Record the size of all the files matched by the Glob pattern.

--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -203,7 +203,7 @@ func (t *FileTarget) sync() error {
 
 	// Gets absolute path for each pattern.
 	for i := 0; i < len(matches); i++ {
-		if ! filepath.IsAbs(matches[i]) {
+		if !filepath.IsAbs(matches[i]) {
 			path, err := filepath.Abs(matches[i])
 			if err != nil {
 				return errors.Wrap(err, "filetarget.sync.filepath.Abs")

--- a/vendor/github.com/bmatcuk/doublestar/doublestar.go
+++ b/vendor/github.com/bmatcuk/doublestar/doublestar.go
@@ -9,35 +9,49 @@ import (
 	"unicode/utf8"
 )
 
+// ErrBadPattern indicates a pattern was malformed.
 var ErrBadPattern = path.ErrBadPattern
 
 // Split a path on the given separator, respecting escaping.
-func splitPathOnSeparator(path string, separator rune) []string {
-	// if the separator is '\\', then we can just split...
+func splitPathOnSeparator(path string, separator rune) (ret []string) {
+	idx := 0
 	if separator == '\\' {
-		return strings.Split(path, string(separator))
+		// if the separator is '\\', then we can just split...
+		ret = strings.Split(path, string(separator))
+		idx = len(ret)
+	} else {
+		// otherwise, we need to be careful of situations where the separator was escaped
+		cnt := strings.Count(path, string(separator))
+		if cnt == 0 {
+			return []string{path}
+		}
+
+		ret = make([]string, cnt+1)
+		pathlen := len(path)
+		separatorLen := utf8.RuneLen(separator)
+		emptyEnd := false
+		for start := 0; start < pathlen; {
+			end := indexRuneWithEscaping(path[start:], separator)
+			if end == -1 {
+				emptyEnd = false
+				end = pathlen
+			} else {
+				emptyEnd = true
+				end += start
+			}
+			ret[idx] = path[start:end]
+			start = end + separatorLen
+			idx++
+		}
+
+		// If the last rune is a path separator, we need to append an empty string to
+		// represent the last, empty path component. By default, the strings from
+		// make([]string, ...) will be empty, so we just need to icrement the count
+		if emptyEnd {
+			idx++
+		}
 	}
 
-	// otherwise, we need to be careful of situations where the separator was escaped
-	cnt := strings.Count(path, string(separator))
-	if cnt == 0 {
-		return []string{path}
-	}
-	ret := make([]string, cnt+1)
-	pathlen := len(path)
-	separatorLen := utf8.RuneLen(separator)
-	idx := 0
-	for start := 0; start < pathlen; {
-		end := indexRuneWithEscaping(path[start:], separator)
-		if end == -1 {
-			end = pathlen
-		} else {
-			end += start
-		}
-		ret[idx] = path[start:end]
-		start = end + separatorLen
-		idx++
-	}
 	return ret[:idx]
 }
 
@@ -58,6 +72,101 @@ func indexRuneWithEscaping(s string, r rune) int {
 	return end
 }
 
+// Find the last index of a rune in a string,
+// ignoring any times the rune is escaped using "\".
+func lastIndexRuneWithEscaping(s string, r rune) int {
+	end := strings.LastIndex(s, string(r))
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		end = lastIndexRuneWithEscaping(s[:end-1], r)
+	}
+	return end
+}
+
+// Find the index of the first instance of one of the unicode characters in
+// chars, ignoring any times those characters are escaped using "\".
+func indexAnyWithEscaping(s, chars string) int {
+	end := strings.IndexAny(s, chars)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		_, adj := utf8.DecodeRuneInString(s[end:])
+		start := end + adj
+		end = indexAnyWithEscaping(s[start:], chars)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
+}
+
+// Split a set of alternatives such as {alt1,alt2,...} and returns the index of
+// the rune after the closing curly brace. Respects nested alternatives and
+// escaped runes.
+func splitAlternatives(s string) (ret []string, idx int) {
+	ret = make([]string, 0, 2)
+	idx = 0
+	slen := len(s)
+	braceCnt := 1
+	esc := false
+	start := 0
+	for braceCnt > 0 {
+		if idx >= slen {
+			return nil, -1
+		}
+
+		sRune, adj := utf8.DecodeRuneInString(s[idx:])
+		if esc {
+			esc = false
+		} else if sRune == '\\' {
+			esc = true
+		} else if sRune == '{' {
+			braceCnt++
+		} else if sRune == '}' {
+			braceCnt--
+		} else if sRune == ',' && braceCnt == 1 {
+			ret = append(ret, s[start:idx])
+			start = idx + adj
+		}
+
+		idx += adj
+	}
+	ret = append(ret, s[start:idx-1])
+	return
+}
+
+// Returns true if the pattern is "zero length", meaning
+// it could match zero or more characters.
+func isZeroLengthPattern(pattern string) (ret bool, err error) {
+	// * can match zero
+	if pattern == "" || pattern == "*" || pattern == "**" {
+		return true, nil
+	}
+
+	// an alternative with zero length can match zero, for example {,x} - the
+	// first alternative has zero length
+	r, adj := utf8.DecodeRuneInString(pattern)
+	if r == '{' {
+		options, endOptions := splitAlternatives(pattern[adj:])
+		if endOptions == -1 {
+			return false, ErrBadPattern
+		}
+		if ret, err = isZeroLengthPattern(pattern[adj+endOptions:]); !ret || err != nil {
+			return
+		}
+		for _, o := range options {
+			if ret, err = isZeroLengthPattern(o); ret || err != nil {
+				return
+			}
+		}
+	}
+
+	return false, nil
+}
+
 // Match returns true if name matches the shell file name pattern.
 // The pattern syntax is:
 //
@@ -65,8 +174,8 @@ func indexRuneWithEscaping(s string, r rune) int {
 //    { term }
 //  term:
 //    '*'         matches any sequence of non-path-separators
-//              '**'        matches any sequence of characters, including
-//                          path separators.
+//    '**'        matches any sequence of characters, including
+//                path separators.
 //    '?'         matches any single non-path-separator character
 //    '[' [ '^' ] { character-range } ']'
 //          character class (must be non-empty)
@@ -100,6 +209,7 @@ func Match(pattern, name string) (bool, error) {
 // Note: this is meant as a drop-in replacement for filepath.Match().
 //
 func PathMatch(pattern, name string) (bool, error) {
+	pattern = filepath.ToSlash(pattern)
 	return matchWithSeparator(pattern, name, os.PathSeparator)
 }
 
@@ -129,14 +239,13 @@ func PathMatch(pattern, name string) (bool, error) {
 // is malformed.
 //
 func matchWithSeparator(pattern, name string, separator rune) (bool, error) {
-	patternComponents := splitPathOnSeparator(pattern, separator)
 	nameComponents := splitPathOnSeparator(name, separator)
-	return doMatching(patternComponents, nameComponents)
+	return doMatching(pattern, nameComponents)
 }
 
-func doMatching(patternComponents, nameComponents []string) (matched bool, err error) {
+func doMatching(pattern string, nameComponents []string) (matched bool, err error) {
 	// check for some base-cases
-	patternLen, nameLen := len(patternComponents), len(nameComponents)
+	patternLen, nameLen := len(pattern), len(nameComponents)
 	if patternLen == 0 && nameLen == 0 {
 		return true, nil
 	}
@@ -144,33 +253,46 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 		return false, nil
 	}
 
-	patIdx, nameIdx := 0, 0
-	for patIdx < patternLen && nameIdx < nameLen {
-		if patternComponents[patIdx] == "**" {
-			// if our last pattern component is a doublestar, we're done -
-			// doublestar will match any remaining name components, if any.
-			if patIdx++; patIdx >= patternLen {
+	slashIdx := indexRuneWithEscaping(pattern, '/')
+	lastComponent := slashIdx == -1
+	if lastComponent {
+		slashIdx = len(pattern)
+	}
+	if pattern[:slashIdx] == "**" {
+		// if our last pattern component is a doublestar, we're done -
+		// doublestar will match any remaining name components, if any.
+		if lastComponent {
+			return true, nil
+		}
+
+		// otherwise, try matching remaining components
+		for nameIdx := 0; nameIdx < nameLen; nameIdx++ {
+			if m, _ := doMatching(pattern[slashIdx+1:], nameComponents[nameIdx:]); m {
 				return true, nil
 			}
+		}
+		return false, nil
+	}
 
-			// otherwise, try matching remaining components
-			for ; nameIdx < nameLen; nameIdx++ {
-				if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
-					return true, nil
-				}
-			}
-			return false, nil
-		} else {
-			// try matching components
-			matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
-			if !matched || err != nil {
+	var matches []string
+	matches, err = matchComponent(pattern, nameComponents[0])
+	if matches == nil || err != nil {
+		return
+	}
+	if len(matches) == 0 && nameLen == 1 {
+		return true, nil
+	}
+
+	if nameLen > 1 {
+		for _, alt := range matches {
+			matched, err = doMatching(alt, nameComponents[1:])
+			if matched || err != nil {
 				return
 			}
 		}
-		patIdx++
-		nameIdx++
 	}
-	return patIdx >= patternLen && nameIdx >= nameLen, nil
+
+	return false, nil
 }
 
 // Glob returns the names of all files matching pattern or nil
@@ -189,42 +311,60 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // Note: this is meant as a drop-in replacement for filepath.Glob().
 //
 func Glob(pattern string) (matches []string, err error) {
-	patternComponents := splitPathOnSeparator(filepath.ToSlash(pattern), '/')
-	if len(patternComponents) == 0 {
+	if len(pattern) == 0 {
 		return nil, nil
 	}
 
-	// On Windows systems, this will return the drive name ('C:'), on others,
-	// it will return an empty string.
-	volumeName := filepath.VolumeName(pattern)
+	// if the pattern starts with alternatives, we need to handle that here - the
+	// alternatives may be a mix of relative and absolute
+	if pattern[0] == '{' {
+		options, endOptions := splitAlternatives(pattern[1:])
+		if endOptions == -1 {
+			return nil, ErrBadPattern
+		}
+		for _, o := range options {
+			m, e := Glob(o + pattern[endOptions+1:])
+			if e != nil {
+				return nil, e
+			}
+			matches = append(matches, m...)
+		}
+		return matches, nil
+	}
 
-	// If the first pattern component is equal to the volume name, then the
-	// pattern is an absolute path.
-	if patternComponents[0] == volumeName {
-		return doGlob(fmt.Sprintf("%s%s", volumeName, string(os.PathSeparator)), patternComponents[1:], matches)
+	// If the pattern is relative or absolute and we're on a non-Windows machine,
+	// volumeName will be an empty string. If it is absolute and we're on a
+	// Windows machine, volumeName will be a drive letter ("C:") for filesystem
+	// paths or \\<server>\<share> for UNC paths.
+	isAbs := filepath.IsAbs(pattern) || pattern[0] == '\\' || pattern[0] == '/'
+	volumeName := filepath.VolumeName(pattern)
+	isWindowsUNC := strings.HasPrefix(volumeName, `\\`)
+	if isWindowsUNC || isAbs {
+		startIdx := len(volumeName) + 1
+		return doGlob(fmt.Sprintf("%s%s", volumeName, string(os.PathSeparator)), filepath.ToSlash(pattern[startIdx:]), matches)
 	}
 
 	// otherwise, it's a relative pattern
-	return doGlob(".", patternComponents, matches)
+	return doGlob(".", filepath.ToSlash(pattern), matches)
 }
 
 // Perform a glob
-func doGlob(basedir string, components, matches []string) (m []string, e error) {
+func doGlob(basedir, pattern string, matches []string) (m []string, e error) {
 	m = matches
 	e = nil
 
-	// figure out how many components we don't need to glob because they're
-	// just names without patterns - we'll use os.Lstat below to check if that
-	// path actually exists
-	patLen := len(components)
-	patIdx := 0
-	for ; patIdx < patLen; patIdx++ {
-		if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 {
-			break
-		}
+	// if the pattern starts with any path components that aren't globbed (ie,
+	// `path/to/glob*`), we can skip over the un-globbed components (`path/to` in
+	// our example).
+	globIdx := indexAnyWithEscaping(pattern, "*?[{\\")
+	if globIdx > 0 {
+		globIdx = lastIndexRuneWithEscaping(pattern[:globIdx], '/')
+	} else if globIdx == -1 {
+		globIdx = lastIndexRuneWithEscaping(pattern, '/')
 	}
-	if patIdx > 0 {
-		basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
+	if globIdx > 0 {
+		basedir = filepath.Join(basedir, pattern[:globIdx])
+		pattern = pattern[globIdx+1:]
 	}
 
 	// Lstat will return an error if the file/directory doesn't exist
@@ -233,8 +373,8 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
 		return
 	}
 
-	// if there are no more components, we've found a match
-	if patIdx >= patLen {
+	// if the pattern is empty, we've found a match
+	if len(pattern) == 0 {
 		m = append(m, basedir)
 		return
 	}
@@ -261,8 +401,12 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
 	defer dir.Close()
 
 	files, _ := dir.Readdir(-1)
-	lastComponent := (patIdx + 1) >= patLen
-	if components[patIdx] == "**" {
+	slashIdx := indexRuneWithEscaping(pattern, '/')
+	lastComponent := slashIdx == -1
+	if lastComponent {
+		slashIdx = len(pattern)
+	}
+	if pattern[:slashIdx] == "**" {
 		// if the current component is a doublestar, we'll try depth-first
 		for _, file := range files {
 			// if symlink, we may want to follow
@@ -278,7 +422,7 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
 				if lastComponent {
 					m = append(m, filepath.Join(basedir, file.Name()))
 				}
-				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
+				m, e = doGlob(filepath.Join(basedir, file.Name()), pattern, m)
 			} else if lastComponent {
 				// if the pattern's last component is a doublestar, we match filenames, too
 				m = append(m, filepath.Join(basedir, file.Name()))
@@ -287,80 +431,81 @@ func doGlob(basedir string, components, matches []string) (m []string, e error) 
 		if lastComponent {
 			return // we're done
 		}
-		patIdx++
-		lastComponent = (patIdx + 1) >= patLen
+
+		pattern = pattern[slashIdx+1:]
 	}
 
 	// check items in current directory and recurse
-	var match bool
+	var match []string
 	for _, file := range files {
-		match, e = matchComponent(components[patIdx], file.Name())
+		match, e = matchComponent(pattern, file.Name())
 		if e != nil {
 			return
 		}
-		if match {
-			if lastComponent {
+		if match != nil {
+			if len(match) == 0 {
 				m = append(m, filepath.Join(basedir, file.Name()))
 			} else {
-				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx+1:], m)
+				for _, alt := range match {
+					m, e = doGlob(filepath.Join(basedir, file.Name()), alt, m)
+				}
 			}
 		}
 	}
 	return
 }
 
-// Attempt to match a single pattern component with a path component
-func matchComponent(pattern, name string) (bool, error) {
-	// check some base cases
-	patternLen, nameLen := len(pattern), len(name)
-	if patternLen == 0 && nameLen == 0 {
-		return true, nil
-	}
-	if patternLen == 0 {
-		return false, nil
-	}
-	if nameLen == 0 && pattern != "*" {
-		return false, nil
-	}
-
+// Attempt to match a single path component with a pattern. Note that the
+// pattern may include multiple components but that the "name" is just a single
+// path component. The return value is a slice of patterns that should be
+// checked against subsequent path components or nil, indicating that the
+// pattern does not match this path. It is assumed that pattern components are
+// separated by '/'
+func matchComponent(pattern, name string) ([]string, error) {
 	// check for matches one rune at a time
+	patternLen, nameLen := len(pattern), len(name)
 	patIdx, nameIdx := 0, 0
 	for patIdx < patternLen && nameIdx < nameLen {
 		patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
 		nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
-		if patRune == '\\' {
-			// handle escaped runes
+		if patRune == '/' {
+			patIdx++
+			break
+		} else if patRune == '\\' {
+			// handle escaped runes, only if separator isn't '\\'
 			patIdx += patAdj
 			patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
 			if patRune == utf8.RuneError {
-				return false, ErrBadPattern
+				return nil, ErrBadPattern
 			} else if patRune == nameRune {
 				patIdx += patAdj
 				nameIdx += nameAdj
 			} else {
-				return false, nil
+				return nil, nil
 			}
 		} else if patRune == '*' {
-			// handle stars
+			// handle stars - a star at the end of the pattern or before a separator
+			// will always match the rest of the path component
 			if patIdx += patAdj; patIdx >= patternLen {
-				// a star at the end of a pattern will always
-				// match the rest of the path
-				return true, nil
+				return []string{}, nil
+			}
+			if patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:]); patRune == '/' {
+				return []string{pattern[patIdx+patAdj:]}, nil
 			}
 
 			// check if we can make any matches
 			for ; nameIdx < nameLen; nameIdx += nameAdj {
-				if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
-					return true, nil
+				if m, e := matchComponent(pattern[patIdx:], name[nameIdx:]); m != nil || e != nil {
+					return m, e
 				}
 			}
-			return false, nil
+			return nil, nil
 		} else if patRune == '[' {
 			// handle character sets
 			patIdx += patAdj
 			endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
 			if endClass == -1 {
-				return false, ErrBadPattern
+				return nil, ErrBadPattern
 			}
 			endClass += patIdx
 			classRunes := []rune(pattern[patIdx:endClass])
@@ -374,7 +519,7 @@ func matchComponent(pattern, name string) (bool, error) {
 				for classIdx < classRunesLen {
 					low := classRunes[classIdx]
 					if low == '-' {
-						return false, ErrBadPattern
+						return nil, ErrBadPattern
 					}
 					classIdx++
 					if low == '\\' {
@@ -382,18 +527,18 @@ func matchComponent(pattern, name string) (bool, error) {
 							low = classRunes[classIdx]
 							classIdx++
 						} else {
-							return false, ErrBadPattern
+							return nil, ErrBadPattern
 						}
 					}
 					high := low
 					if classIdx < classRunesLen && classRunes[classIdx] == '-' {
 						// we have a range of runes
 						if classIdx++; classIdx >= classRunesLen {
-							return false, ErrBadPattern
+							return nil, ErrBadPattern
 						}
 						high = classRunes[classIdx]
 						if high == '-' {
-							return false, ErrBadPattern
+							return nil, ErrBadPattern
 						}
 						classIdx++
 						if high == '\\' {
@@ -401,7 +546,7 @@ func matchComponent(pattern, name string) (bool, error) {
 								high = classRunes[classIdx]
 								classIdx++
 							} else {
-								return false, ErrBadPattern
+								return nil, ErrBadPattern
 							}
 						}
 					}
@@ -410,46 +555,74 @@ func matchComponent(pattern, name string) (bool, error) {
 					}
 				}
 				if matchClass == (classRunes[0] == '^') {
-					return false, nil
+					return nil, nil
 				}
 			} else {
-				return false, ErrBadPattern
+				return nil, ErrBadPattern
 			}
 			patIdx = endClass + 1
 			nameIdx += nameAdj
 		} else if patRune == '{' {
 			// handle alternatives such as {alt1,alt2,...}
 			patIdx += patAdj
-			endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
+			options, endOptions := splitAlternatives(pattern[patIdx:])
 			if endOptions == -1 {
-				return false, ErrBadPattern
+				return nil, ErrBadPattern
 			}
-			endOptions += patIdx
-			options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
-			patIdx = endOptions + 1
+			patIdx += endOptions
+
+			results := make([][]string, 0, len(options))
+			totalResults := 0
 			for _, o := range options {
 				m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
 				if e != nil {
-					return false, e
+					return nil, e
 				}
-				if m {
-					return true, nil
+				if m != nil {
+					results = append(results, m)
+					totalResults += len(m)
 				}
 			}
-			return false, nil
+			if len(results) > 0 {
+				lst := make([]string, 0, totalResults)
+				for _, m := range results {
+					lst = append(lst, m...)
+				}
+				return lst, nil
+			}
+
+			return nil, nil
 		} else if patRune == '?' || patRune == nameRune {
 			// handle single-rune wildcard
 			patIdx += patAdj
 			nameIdx += nameAdj
 		} else {
-			return false, nil
+			return nil, nil
 		}
 	}
-	if patIdx >= patternLen && nameIdx >= nameLen {
-		return true, nil
+	if nameIdx >= nameLen {
+		if patIdx >= patternLen {
+			return []string{}, nil
+		}
+
+		pattern = pattern[patIdx:]
+		slashIdx := indexRuneWithEscaping(pattern, '/')
+		testPattern := pattern
+		if slashIdx >= 0 {
+			testPattern = pattern[:slashIdx]
+		}
+
+		zeroLength, err := isZeroLengthPattern(testPattern)
+		if err != nil {
+			return nil, err
+		}
+		if zeroLength {
+			if slashIdx == -1 {
+				return []string{}, nil
+			} else {
+				return []string{pattern[slashIdx+1:]}, nil
+			}
+		}
 	}
-	if nameIdx >= nameLen && pattern[patIdx:] == "*" || pattern[patIdx:] == "**" {
-		return true, nil
-	}
-	return false, nil
+	return nil, nil
 }

--- a/vendor/github.com/bmatcuk/doublestar/go.mod
+++ b/vendor/github.com/bmatcuk/doublestar/go.mod
@@ -1,1 +1,3 @@
 module github.com/bmatcuk/doublestar
+
+go 1.12


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Updated doulbestar module to version 1.2.2 which contains fix for Glob parsing, please see this issue for details: https://github.com/bmatcuk/doublestar/issues/25

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/1314

**Special notes for your reviewer**:
I've also rewritten how absolute path is set in `filetarget.go` as it was not expecting that more than one path can be specified.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

