### PR TITLE
unifies reverse iterators

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -490,7 +490,7 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 		return iterForward, nil
 	}
 
-	return iter.NewEntryIteratorBackward(iterForward)
+	return iter.NewReversedIter(iterForward, 0, false)
 }
 
 func (b block) iterator(ctx context.Context, pool ReaderPool, filter logql.Filter) iter.EntryIterator {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -303,7 +303,7 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer,
 		return nil, err
 	}
 
-	reversedIterator, err := iter.NewEntryIteratorForward(histIterators, req.Limit, true)
+	reversedIterator, err := iter.NewReversedIter(histIterators, req.Limit, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This unifies two implementations which both reverse iterators in the `iter` pkg. The new unified impl should be clearer and handle all use cases.
