### PR TITLE
logcli: replaced GRAFANA_* with LOKI_* in logcli env vars, set default server url for logcli to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Notable Changes
 * [1486](https://github.com/grafana/loki/pull/1486) **pracucci**: Deprecated `-distributor.limiter-reload-period` flag / distributor's `limiter_reload_period` config option.
+* [1492](https://github.com/grafana/loki/pull/1492) **sandlis**: replaced GRAFANA_* with LOKI_* in logcli env vars, set default server url for logcli to http://localhost:3100.
 
 ### Features
 

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -109,13 +109,13 @@ func newQueryClient(app *kingpin.Application) *client.Client {
 		return nil
 	}
 
-	app.Flag("addr", "Server address. Can also be set using LOKI_ADDR ENV VAR.").Default("http://localhost:3100").Envar("LOKI_ADDR").Action(addressAction).StringVar(&client.Address)
-	app.Flag("username", "Username for HTTP basic auth. Can also be set using LOKI_USERNAME ENV VAR.").Default("").Envar("LOKI_USERNAME").StringVar(&client.Username)
-	app.Flag("password", "Password for HTTP basic auth. Can also be set using LOKI_PASSWORD ENV VAR.").Default("").Envar("LOKI_PASSWORD").StringVar(&client.Password)
-	app.Flag("ca-cert", "Path to the server Certificate Authority. Can also be set using LOKI_CA_CERT_PATH ENV VAR.").Default("").Envar("LOKI_CA_CERT_PATH").StringVar(&client.TLSConfig.CAFile)
+	app.Flag("addr", "Server address. Can also be set using LOKI_ADDR env var.").Default("http://localhost:3100").Envar("LOKI_ADDR").Action(addressAction).StringVar(&client.Address)
+	app.Flag("username", "Username for HTTP basic auth. Can also be set using LOKI_USERNAME env var.").Default("").Envar("LOKI_USERNAME").StringVar(&client.Username)
+	app.Flag("password", "Password for HTTP basic auth. Can also be set using LOKI_PASSWORD env var.").Default("").Envar("LOKI_PASSWORD").StringVar(&client.Password)
+	app.Flag("ca-cert", "Path to the server Certificate Authority. Can also be set using LOKI_CA_CERT_PATH env var.").Default("").Envar("LOKI_CA_CERT_PATH").StringVar(&client.TLSConfig.CAFile)
 	app.Flag("tls-skip-verify", "Server certificate TLS skip verify.").Default("false").BoolVar(&client.TLSConfig.InsecureSkipVerify)
-	app.Flag("cert", "Path to the client certificate. Can also be set using LOKI_CLIENT_CERT_PATH ENV VAR.").Default("").Envar("LOKI_CLIENT_CERT_PATH").StringVar(&client.TLSConfig.CertFile)
-	app.Flag("key", "Path to the client certificate key. Can also be set using LOKI_CLIENT_KEY_PATH ENV VAR.").Default("").Envar("LOKI_CLIENT_KEY_PATH").StringVar(&client.TLSConfig.KeyFile)
+	app.Flag("cert", "Path to the client certificate. Can also be set using LOKI_CLIENT_CERT_PATH env var.").Default("").Envar("LOKI_CLIENT_CERT_PATH").StringVar(&client.TLSConfig.CertFile)
+	app.Flag("key", "Path to the client certificate key. Can also be set using LOKI_CLIENT_KEY_PATH env var.").Default("").Envar("LOKI_CLIENT_KEY_PATH").StringVar(&client.TLSConfig.KeyFile)
 
 	return client
 }

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -109,9 +109,9 @@ func newQueryClient(app *kingpin.Application) *client.Client {
 		return nil
 	}
 
-	app.Flag("addr", "Server address.").Default("https://logs-us-west1.grafana.net").Envar("GRAFANA_ADDR").Action(addressAction).StringVar(&client.Address)
-	app.Flag("username", "Username for HTTP basic auth.").Default("").Envar("GRAFANA_USERNAME").StringVar(&client.Username)
-	app.Flag("password", "Password for HTTP basic auth.").Default("").Envar("GRAFANA_PASSWORD").StringVar(&client.Password)
+	app.Flag("addr", "Server address.").Default("http://localhost:3100").Envar("LOKI_ADDR").Action(addressAction).StringVar(&client.Address)
+	app.Flag("username", "Username for HTTP basic auth.").Default("").Envar("LOKI_USERNAME").StringVar(&client.Username)
+	app.Flag("password", "Password for HTTP basic auth.").Default("").Envar("LOKI_PASSWORD").StringVar(&client.Password)
 	app.Flag("ca-cert", "Path to the server Certificate Authority.").Default("").Envar("LOKI_CA_CERT_PATH").StringVar(&client.TLSConfig.CAFile)
 	app.Flag("tls-skip-verify", "Server certificate TLS skip verify.").Default("false").BoolVar(&client.TLSConfig.InsecureSkipVerify)
 	app.Flag("cert", "Path to the client certificate.").Default("").Envar("LOKI_CLIENT_CERT_PATH").StringVar(&client.TLSConfig.CertFile)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -109,13 +109,13 @@ func newQueryClient(app *kingpin.Application) *client.Client {
 		return nil
 	}
 
-	app.Flag("addr", "Server address.").Default("http://localhost:3100").Envar("LOKI_ADDR").Action(addressAction).StringVar(&client.Address)
-	app.Flag("username", "Username for HTTP basic auth.").Default("").Envar("LOKI_USERNAME").StringVar(&client.Username)
-	app.Flag("password", "Password for HTTP basic auth.").Default("").Envar("LOKI_PASSWORD").StringVar(&client.Password)
-	app.Flag("ca-cert", "Path to the server Certificate Authority.").Default("").Envar("LOKI_CA_CERT_PATH").StringVar(&client.TLSConfig.CAFile)
+	app.Flag("addr", "Server address. Can also be set using LOKI_ADDR ENV VAR.").Default("http://localhost:3100").Envar("LOKI_ADDR").Action(addressAction).StringVar(&client.Address)
+	app.Flag("username", "Username for HTTP basic auth. Can also be set using LOKI_USERNAME ENV VAR.").Default("").Envar("LOKI_USERNAME").StringVar(&client.Username)
+	app.Flag("password", "Password for HTTP basic auth. Can also be set using LOKI_PASSWORD ENV VAR.").Default("").Envar("LOKI_PASSWORD").StringVar(&client.Password)
+	app.Flag("ca-cert", "Path to the server Certificate Authority. Can also be set using LOKI_CA_CERT_PATH ENV VAR.").Default("").Envar("LOKI_CA_CERT_PATH").StringVar(&client.TLSConfig.CAFile)
 	app.Flag("tls-skip-verify", "Server certificate TLS skip verify.").Default("false").BoolVar(&client.TLSConfig.InsecureSkipVerify)
-	app.Flag("cert", "Path to the client certificate.").Default("").Envar("LOKI_CLIENT_CERT_PATH").StringVar(&client.TLSConfig.CertFile)
-	app.Flag("key", "Path to the client certificate key.").Default("").Envar("LOKI_CLIENT_KEY_PATH").StringVar(&client.TLSConfig.KeyFile)
+	app.Flag("cert", "Path to the client certificate. Can also be set using LOKI_CLIENT_CERT_PATH ENV VAR.").Default("").Envar("LOKI_CLIENT_CERT_PATH").StringVar(&client.TLSConfig.CertFile)
+	app.Flag("key", "Path to the client certificate key. Can also be set using LOKI_CLIENT_KEY_PATH ENV VAR.").Default("").Envar("LOKI_CLIENT_KEY_PATH").StringVar(&client.TLSConfig.KeyFile)
 
 	return client
 }

--- a/docs/getting-started/logcli.md
+++ b/docs/getting-started/logcli.md
@@ -25,21 +25,21 @@ $ go get github.com/grafana/loki/cmd/logcli
 If you are running on Grafana Cloud, use:
 
 ```bash
-$ export GRAFANA_ADDR=https://logs-us-west1.grafana.net
-$ export GRAFANA_USERNAME=<username>
-$ export GRAFANA_PASSWORD=<password>
+$ export LOKI_ADDR=https://logs-us-west1.grafana.net
+$ export LOKI_USERNAME=<username>
+$ export LOKI_PASSWORD=<password>
 ```
 
 Otherwise you can point LogCLI to a local instance directly
 without needing a username and password:
 
 ```bash
-$ export GRAFANA_ADDR=http://localhost:3100
+$ export LOKI_ADDR=http://localhost:3100
 ```
 
 > Note: If you are running Loki behind a proxy server and you have
-> authentication configured, you will also have to pass in GRAFANA_USERNAME
-> and GRAFANA_PASSWORD accordingly.
+> authentication configured, you will also have to pass in LOKI_USERNAME
+> and LOKI_PASSWORD accordingly.
 
 ```bash
 $ logcli labels job


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
1. Renamed logcli env vars:

- GRAFANA_ADDR -> LOKI_ADDR
- GRAFANA_USERNAME -> LOKI_USERNAME
- GRAFANA_PASSWORD -> LOKI_PASSWORD

2. Change the default value of LOKI_ADDR to http://localhost:3100

**Checklist**
- [x] Documentation updated
- [x] Changelog updated

