### PR TITLE
Fixed TOUCH_PROTOS in all DroneCI pipelines

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -89,7 +89,10 @@ local multiarch_image(arch) = pipeline('docker-' + arch) + arch_image(arch) {
     docker(arch, app) {
       depends_on: ['image-tag'],
       when: condition('exclude').tagMaster,
-      settings+: { dry_run: true },
+      settings+: {
+        dry_run: true,
+        build_args: [ 'TOUCH_PROTOS=1' ]
+      },
     }
     for app in apps
   ] + [
@@ -97,6 +100,9 @@ local multiarch_image(arch) = pipeline('docker-' + arch) + arch_image(arch) {
     docker(arch, app) {
       depends_on: ['image-tag'],
       when: condition('include').tagMaster,
+      settings+: {
+        build_args: [ 'TOUCH_PROTOS=1' ]
+      },
     }
     for app in apps
   ],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -60,9 +60,9 @@ steps:
 - name: build-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -80,9 +80,9 @@ steps:
 - name: build-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -100,9 +100,9 @@ steps:
 - name: build-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -120,9 +120,9 @@ steps:
 - name: publish-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki
@@ -138,9 +138,9 @@ steps:
 - name: publish-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -156,9 +156,9 @@ steps:
 - name: publish-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/promtail
@@ -193,9 +193,9 @@ steps:
 - name: build-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -213,9 +213,9 @@ steps:
 - name: build-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -233,9 +233,9 @@ steps:
 - name: build-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -253,9 +253,9 @@ steps:
 - name: publish-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki
@@ -271,9 +271,9 @@ steps:
 - name: publish-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -289,9 +289,9 @@ steps:
 - name: publish-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
     - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/promtail
@@ -326,9 +326,9 @@ steps:
 - name: build-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -346,9 +346,9 @@ steps:
 - name: build-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -366,9 +366,9 @@ steps:
 - name: build-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     dry_run: true
     password:
       from_secret: docker_password
@@ -386,9 +386,9 @@ steps:
 - name: publish-loki-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki
@@ -404,9 +404,9 @@ steps:
 - name: publish-loki-canary-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/loki-canary/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/loki-canary/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -422,9 +422,9 @@ steps:
 - name: publish-promtail-image
   image: plugins/docker
   settings:
-    dockerfile: cmd/promtail/Dockerfile
     build_args:
-      - TOUCH_PROTOS=1
+    - TOUCH_PROTOS=1
+    dockerfile: cmd/promtail/Dockerfile
     password:
       from_secret: docker_password
     repo: grafana/promtail

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -61,6 +61,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -79,6 +81,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -97,6 +101,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -115,6 +121,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki
@@ -131,6 +139,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -147,6 +157,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/promtail
@@ -315,6 +327,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -333,6 +347,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -351,6 +367,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     dry_run: true
     password:
       from_secret: docker_password
@@ -369,6 +387,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki
@@ -385,6 +405,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/loki-canary/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/loki-canary
@@ -401,6 +423,8 @@ steps:
   image: plugins/docker
   settings:
     dockerfile: cmd/promtail/Dockerfile
+    build_args:
+      - TOUCH_PROTOS=1
     password:
       from_secret: docker_password
     repo: grafana/promtail


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR https://github.com/grafana/loki/pull/1479 introduced `TOUCH_PROTOS` to avoid protos to be rebuilt on arm64 only, while we should do it for all DroneCI pipelines (amd64 and arm).

**Which issue(s) this PR fixes**:
Fixes #1477

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

