### PR TITLE
Bump fluentd plugin to 1.2.6.

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.5'
+  spec.version = '1.2.6'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
This was omitted in the previous PR https://github.com/grafana/loki/pull/1475.
Unfortunately I need a new version to publish the new gem.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
