### PR TITLE
jsonnet: fix common/defaultPorts parameters

### DIFF
--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -7,8 +7,8 @@
 
     defaultPorts::
       [
-        containerPort.newNamed('http-metrics', 80),
-        containerPort.newNamed('grpc', 9095),
+        containerPort.newNamed(name='http-metrics', containerPort=80),
+        containerPort.newNamed(name='grpc', containerPort=9095),
       ],
   },
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

In `loki/common.libsonnet` , `defaultPorts` parameter order doesn't match with ksonnet.beta.4 containerPorts. 


```
// ksonnet.beta.4
newNamed(containerPort='', name=''):: 
    self.withContainerPort(containerPort).withName(name),
```



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

