### PR TITLE
querier: fix panic in tailer when max tail duration exceeds

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -193,6 +193,11 @@ func (q *Querier) TailHandler(w http.ResponseWriter, r *http.Request) {
 					}
 					level.Error(util.Logger).Log("msg", "Error from client", "err", err)
 					break
+				} else if tailer.stopped {
+					return
+				} else {
+					level.Error(util.Logger).Log("msg", "Unexpected error from client", "err", err)
+					break
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When max tail duration reaches, server closes the connection. A goroutine which keeps checking for connection close message from client does not check for already closed connection. This PR takes care of it.

