### PR TITLE
fluent-plugin-grafana-loki: Add `fluentd_thread` label when `flush_thread_count' > 1

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/README.md
+++ b/fluentd/fluent-plugin-grafana-loki/README.md
@@ -110,6 +110,14 @@ For example, using [fluent-plugin-record-modifier](https://github.com/repeatedly
 </match>
 ```
 
+### Using multiple buffer flush threads
+
+Similarly, when using `flush_thread_count` > 1 in the [`buffer`](https://docs.fluentd.org/configuration/buffer-section#flushing-parameters)
+section, a thread identifier must be added as a label to ensure that log chunks flushed in parallel to loki by fluentd always have increasing
+times for their unique label sets.
+
+This plugin automatically adds a `fluentd_thread` label with the name of the buffer flush thread when `flush_thread_count` > 1.
+
 ## Docker Image
 
 There is a Docker image `grafana/fluent-plugin-grafana-loki:master` which contains default configuration files to git log information

--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.6'
+  spec.version = '1.2.7'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -267,6 +267,15 @@ module Fluent
           line = record.to_s
         end
 
+        # add buffer flush thread title as a label if there are multiple flush threads
+        # this prevents "entry out of order" errors in loki by making the label constellation
+        # unique per flush thread
+        # note that flush thread != fluentd worker. if you use multiple workers you still need to
+        # add the worker id as a label
+        if @buffer_config.flush_thread_count > 1
+          chunk_labels['fluentd_thread'] = Thread.current[:_fluentd_plugin_helper_thread_title].to_s
+        end
+
         # return both the line content plus the labels found in the record
         {
           line: line,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently fluent-plugin-grafana-loki can't be used with multiple buffer flush threads (`num_threads` or `flush_thread_count` > 1) because logs with the same label sets are flushed in parallel, resulting in `entry out of order for stream` errors in Loki.

This PR changes `fluent-plugin-grafana-loki` to automatically add a 'fluentd_thread` log label when the fluentd loki output is configured with `flush_thread_count` > 1, which allows logs flushed in parallel to have unique label sets and avoid out-of-order errors.

In our deployment (~300 fluentd agents forwarding to a single loki), using this change and setting `flush_thread_count` to 4 has allowed us to achieve sub-500ms log latecy times (measured with loki-canary). Previously we were seeing 32s latency, even when using multi-worker fluentd configs.

**Which issue(s) this PR fixes**:
No issue currently, should I create one?

**Special notes for your reviewer**:
Thanks for reviewing!

**Checklist**
- [x] Documentation added
- [ ] Tests updated

