### PR TITLE
Fix error 'Field does not exist: jaeger_mixin' in tk show

### DIFF
--- a/production/ksonnet/loki/loki.libsonnet
+++ b/production/ksonnet/loki/loki.libsonnet
@@ -1,4 +1,5 @@
 (import 'ksonnet-util/kausal.libsonnet') +
+(import 'ksonnet-util/jaeger.libsonnet') +
 (import 'images.libsonnet') +
 (import 'common.libsonnet') +
 (import 'config.libsonnet') +


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin@yunify.com>

**What this PR does / why we need it**:
Got error like below when running tk show
```shell
tk show environments/loki/
evaluating jsonnet: RUNTIME ERROR: Field does not exist: jaeger_mixin
	/root/ben/loki/config/vendor/loki/query-frontend.libsonnet:16:5-19	object <anonymous>
	/root/ben/loki/config/vendor/loki/query-frontend.libsonnet:21:42-68	thunk from <thunk from <object <anonymous>>>
	<std>:237:55-61	thunk from <function <anonymous>>
	/root/ben/loki/config/vendor/ksonnet-util/kausal.libsonnet:317:27-28	function <addMount>
	<std>:237:50-62	function <anonymous>
		
	During manifestation	

```

