### PR TITLE
pkg/chunkenc: ignore duplicate lines pushed to a stream

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -131,7 +131,7 @@ func (s *stream) Push(_ context.Context, entries []logproto.Entry, synchronizePe
 		// This check is done at the stream level so it persists across cut and
 		// flushed chunks.
 		//
-		// N.B.: it's still possible for duplicates to be appended if a stream is
+		// NOTE: it's still possible for duplicates to be appended if a stream is
 		// deleted from inactivity.
 		if entries[i].Timestamp.Equal(s.lastLine.ts) && entries[i].Line == s.lastLine.content {
 			continue


### PR DESCRIPTION
This commit changes the behavior of appending to a stream to ignore an incoming line if its timestamp and contents match the previous line received. This should reduce the chances of ingesters storing duplicate log lines when clients retry push requests whenever a 500 is returned.

Fixes #1517.