### PR TITLE
Promtail Helm Chart: Add support for passing environment variables

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.30.0
+version: 0.31.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.18.0
+version: 0.18.1
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -76,10 +76,13 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           ports:
             - containerPort: {{ .Values.config.server.http_listen_port }}
               name: http-metrics

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -138,3 +138,6 @@ serviceMonitor:
   interval: ""
   additionalLabels: {}
   # scrapeTimeout: 10s
+
+# Extra env variables to pass to the promtail container
+env: []


### PR DESCRIPTION
* Make Promtail's Helm chart support passing extra env variables
* bump charts versions

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR enables developers to pass environment variables to the `promtail` containers via helm similarly to how it's done for [loki](https://github.com/grafana/loki/blob/master/production/helm/loki/values.yaml#L219)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

