### PR TITLE
Allow extra command line args for external labels like hostname

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.25.0
+version: 0.25.1
 appVersion: v1.2.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.16.1
+version: 0.16.2
 appVersion: v1.2.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -51,6 +51,11 @@ spec:
             - "-client.url={{ .Values.loki.serviceScheme }}://{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}/loki/api/v1/push"
             {{- end }}
             {{- end }}
+            {{- if .Values.extraCommandlineArgs }}
+            {{- range .Values.extraCommandlineArgs }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/promtail


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Promtail Helm chart to allow extra command line args. So we that can pass follow command line argument to Promtail.

```
-client.external-labels=hostname=$(HOSTNAME)
```

**Which issue(s) this PR related**:
https://github.com/grafana/loki/issues/636


