### PR TITLE
helm : fix fluent-bit parser configuration syntax

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.0.1
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -51,7 +51,7 @@ data:
     {{- range $parser:= .Values.config.parsers }}
     [PARSER]
     {{- range $key,$value := $parser }}
-        {{ $key }} = {{ $value }}
+        {{ $key }} {{ $value }}
     {{- end }}
     {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The commit 0bd46200a0ea772ca1592fab974933c6f064caca add the ability to add custom parsers to fluent-bit configuration. But a syntax error was present in the config map which leads to custom parsers be ignored. This PR fix the syntax.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

