### PR TITLE
docs: fix syntax error in pipeline example

### DIFF
--- a/docs/clients/promtail/pipelines.md
+++ b/docs/clients/promtail/pipelines.md
@@ -140,7 +140,7 @@ scrape_configs:
       # which Promtail exposes. The counter is only incremented when panic
       # was extracted from the regex stage.
       - metrics:
-        - panic_total:
+          panic_total:
             type: Counter
             description: "total count of panic"
             source: panic


### PR DESCRIPTION
the contents of metrics stages should be a map of string to metric, not a slice. See https://github.com/grafana/loki/blob/master/docs/clients/promtail/stages/metrics.md