### PR TITLE
fix(ksonnet): use apps/v1

### DIFF
--- a/production/ksonnet/loki-canary/loki-canary.libsonnet
+++ b/production/ksonnet/loki-canary/loki-canary.libsonnet
@@ -20,7 +20,7 @@ k + config {
       container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
     ]),
 
-  local daemonSet = $.extensions.v1beta1.daemonSet,
+  local daemonSet = $.apps.v1.daemonSet,
 
   loki_canary_daemonset:
     daemonSet.new('loki-canary', [$.loki_canary_container]),

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -273,7 +273,7 @@
       'config.yaml': $.util.manifestYaml($._config.loki),
     }),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   config_hash_mixin::
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({

--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -18,7 +18,7 @@
     $.util.resourcesRequests('500m', '100Mi') +
     $.util.resourcesLimits('1', '200Mi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container]) +

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -73,7 +73,7 @@
     container.withPorts($.core.v1.containerPort.new('http', 80)) +
     $.util.resourcesRequests('50m', '100Mi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   gateway_deployment:
     deployment.new('gateway', 3, [

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -17,7 +17,7 @@
     $.util.resourcesRequests('1', '5Gi') +
     $.util.resourcesLimits('2', '10Gi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   ingester_deployment:
     deployment.new('ingester', 3, [$.ingester_container]) +

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -15,7 +15,7 @@
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   querier_deployment:
     deployment.new('querier', 3, [$.querier_container]) +

--- a/production/ksonnet/loki/query-frontend.libsonnet
+++ b/production/ksonnet/loki/query-frontend.libsonnet
@@ -15,7 +15,7 @@
     $.util.resourcesLimits(null, '1200Mi') +
     $.jaeger_mixin,
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   query_frontend_deployment:
     deployment.new('query-frontend', 2, [$.query_frontend_container]) +

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -13,7 +13,7 @@
     $.util.resourcesRequests('100m', '100Mi') +
     $.util.resourcesLimits('200m', '200Mi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   table_manager_deployment:
     deployment.new('table-manager', 1, [$.table_manager_container]) +

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -58,7 +58,7 @@ k + config + scrape_config {
     container.mixin.securityContext.withPrivileged(true) +
     container.mixin.securityContext.withRunAsUser(0),
 
-  local daemonSet = $.extensions.v1beta1.daemonSet,
+  local daemonSet = $.apps.v1.daemonSet,
 
   promtail_daemonset:
     daemonSet.new($._config.promtail_pod_name, [$.promtail_container]) +


### PR DESCRIPTION
Required for more modern Kubernetes versions. Limits version support of our libs
to Kubernetes 1.9 to latest (1.17).

See https://github.com/grafana/jsonnet-libs/pull/201