### PR TITLE
helm: Allow setting 'loadBalancerSourceRanges' for the loki service

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.26.0
+version: 0.27.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.23.0
+version: 0.24.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/service.yaml
+++ b/production/helm/loki/templates/service.yaml
@@ -18,6 +18,12 @@ spec:
 {{- if (and (eq .Values.service.type "ClusterIP") (not (empty .Values.service.clusterIP))) }}
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       protocol: TCP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This allows setting the `service.loadBalancerSourceRanges` Helm value which then in turn sets the `spec.loadBalancerSourceRanges` for the loki service. This is useful in situations where someone wants to set the `service.type` to LoadBalancer and restrict the source networks that can access the service.

**Which issue(s) this PR fixes**:
No issues created for this change.

**Special notes for your reviewer**:
I bumped the Helm Chart versions but I noticed there are other open PR's that also bumped. Let me know if I need to bump again.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

