### PR TITLE
adds span metadata for split queries

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/weaveworks/common/user"
 )
 
@@ -98,6 +100,10 @@ func (h *splitByInterval) Process(
 func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult) {
 
 	for data := range ch {
+
+		_, ctx := opentracing.StartSpanFromContext(ctx, "interval")
+		queryrange.LogToSpan(ctx, data.req)
+
 		resp, err := h.next.Do(ctx, data.req)
 		if err != nil {
 			data.err <- err
@@ -116,6 +122,11 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrange.Request) (queryra
 	}
 
 	intervals := splitByTime(lokiRequest, h.interval)
+
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		sp.LogFields(otlog.Int("n_intervals", len(intervals)))
+
+	}
 
 	if lokiRequest.Direction == logproto.BACKWARD {
 		for i, j := 0, len(intervals)-1; i < j; i, j = i+1, j-1 {

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -101,7 +101,7 @@ func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult) {
 
 	for data := range ch {
 
-		_, ctx := opentracing.StartSpanFromContext(ctx, "interval")
+		sp, ctx := opentracing.StartSpanFromContext(ctx, "interval")
 		queryrange.LogToSpan(ctx, data.req)
 
 		resp, err := h.next.Do(ctx, data.req)
@@ -110,6 +110,7 @@ func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult) {
 		} else {
 			data.resp <- resp
 		}
+		sp.Finish()
 	}
 }
 


### PR DESCRIPTION
This PR adds a bit of instrumentation around the frontend interval splitting, namely:

- adds a field to the current span detailing the number of splits
- each split is now given it's own span with metadata like start & end times. This is very helpful when debugging so we don't have to pull parameters out of URIs and then calculate the timestamps from our numerical timestamps.
