### PR TITLE
Feature/query ingesters within

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+* [1572](https://github.com/grafana/loki/pull/1572) **owen-d**: Introduces the `querier.query-ingesters-within` flag and associated yaml config. When enabled, queries for a time range that do not overlap this lookback interval will not be sent to the ingesters.
 * [1558](https://github.com/grafana/loki/pull/1558) **owen-d**: Introduces `ingester.max-chunk-age` which specifies the maximum chunk age before it's cut.
 
 ## 1.3.0 (2019-01-16)

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -166,6 +166,10 @@ The `querier_config` block configures the Loki Querier.
 # requests.
 [extra_query_delay: <duration> | default = 0s]
 
+# Maximum lookback beyond which queries are not sent to ingester.
+# 0 means all queries are sent to ingester.
+[query_ingesters_within: <duration> | default = 0s]
+
 # Configuration options for the LogQL engine.
 engine:
   # Timeout for query execution

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -103,8 +103,7 @@ func (c *queryClientMock) Recv() (*logproto.QueryResponse, error) {
 	if res == nil {
 		return (*logproto.QueryResponse)(nil), args.Error(1)
 	}
-	return args.Get(0).(*logproto.QueryResponse), args.Error(1)
-
+	return res.(*logproto.QueryResponse), args.Error(1)
 }
 
 func (c *queryClientMock) Header() (grpc_metadata.MD, error) {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -99,7 +99,12 @@ func newQueryClientMock() *queryClientMock {
 
 func (c *queryClientMock) Recv() (*logproto.QueryResponse, error) {
 	args := c.Called()
+	res := args.Get(0)
+	if res == nil {
+		return (*logproto.QueryResponse)(nil), args.Error(1)
+	}
 	return args.Get(0).(*logproto.QueryResponse), args.Error(1)
+
 }
 
 func (c *queryClientMock) Header() (grpc_metadata.MD, error) {


### PR DESCRIPTION
This adds the `querier.query-ingesters-within` flag and associated yaml config. When enabled, queries for a time range that do not overlap this lookback interval will not be sent to the ingesters. This allows many expensive larger queries which often utilize query splitting to avoid unnecessarily burdening the ingesters.