### PR TITLE
Disable transfers in loki-local-config.yaml

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -13,7 +13,7 @@ ingester:
     final_sleep: 0s
   chunk_idle_period: 5m
   chunk_retain_period: 30s
-  max_transfer_retries: 1
+  max_transfer_retries: 0
 
 schema_config:
   configs:

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.26.0
+version: 0.27.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.23.0
+version: 0.24.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -24,6 +24,7 @@ config:
     chunk_idle_period: 3m
     chunk_block_size: 262144
     chunk_retain_period: 1m
+    max_transfer_retries: 0
     lifecycler:
       ring:
         kvstore:


### PR DESCRIPTION
#1425 added the ability to disable transfers by setting the max amount of retries to zero or lower. The PR, however, didn't change the default setting in loki-local-config.yaml. 

This commit changes the setting in loki-local-config.yaml to disable transfers since they would never succeed with the default settings of an inmemory ring anyway.