### PR TITLE
Fix typo in changelog for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [1572](https://github.com/grafana/loki/pull/1572) **owen-d**: Introduces the `querier.query-ingesters-within` flag and associated yaml config. When enabled, queries for a time range that do not overlap this lookback interval will not be sent to the ingesters.
 * [1558](https://github.com/grafana/loki/pull/1558) **owen-d**: Introduces `ingester.max-chunk-age` which specifies the maximum chunk age before it's cut.
 
-## 1.3.0 (2019-01-16)
+## 1.3.0 (2020-01-16)
 
 ### What's New?? ###
 


### PR DESCRIPTION
The last release was in December 2019.
1.3.0 was released in January 2020, not 2019.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

To avoid confusion, and creating time paradoxes. 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I may be wrong?

**Checklist**
- [x] Documentation added
- [ ] Tests updated

