### PR TITLE
Helm/loki-stack: add template for the service name to connect to loki

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.27.0
+version: 0.27.1
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/templates/_helpers.tpl
+++ b/production/helm/loki-stack/templates/_helpers.tpl
@@ -38,3 +38,21 @@ Added as a fix for https://github.com/grafana/loki/issues/1169
 {{- define "prometheus.fullname" -}}
 {{- printf "%s-%s" .Release.Name "prometheus-server" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+The service name to connect to Loki. Defaults to the same logic as "loki.fullname"
+*/}}
+{{- define "loki.serviceName" -}}
+{{- if .Values.loki.serviceName -}}
+{{- .Values.loki.serviceName -}}
+{{- else if .Values.loki.fullnameOverride -}}
+{{- .Values.loki.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "loki" .Values.loki.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the template for the service name to connect to loki.
Helm chart for loki-stack requires template "loki.serviceName", but it doesn't exist.

**Which issue(s) this PR fixes**:
Fixes #1566

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

