### PR TITLE
Helm/loki-stack: refresh default grafana.image.tag to 6.6.0

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.27.1
+version: 0.28.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/values.yaml
+++ b/production/helm/loki-stack/values.yaml
@@ -13,7 +13,7 @@ grafana:
     datasources:
       enabled: true
   image:
-    tag: 6.4.1
+    tag: 6.6.0
 
 prometheus:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refreshes the default parameter of grafana.image.tag in loki-stack' helm chart.
grafana.image.tag will be changed from 6.4.1 to 6.6.0.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

