### PR TITLE
Improve promtail configuration docs

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -277,7 +277,7 @@ kubernetes_sd_configs:
 ### pipeline_stages
 
 The [pipeline](./pipelines.md) stages (`pipeline_stages`) is used to transform
-log entries and their labels after discovery and consists of a list of any of the items listed below
+log entries and their labels after discovery and consists of a list of any of the items listed below.
 
 Stages serve several purposes, more detail can be found [here](./pipelines.md), however generally you extract data with `regex` or `json` stages into a temporary map which can then be use as `labels` or `output` or any of the other stages aside from `docker` and `cri` which are explained in more detail below.
 

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -1048,10 +1048,10 @@ scrape_configs:
       host: yourhost ③  
       __path__: /var/log/*.log  ④
 ```
-① This location needs to be writeable by promtail.
-② A `job` label is fairly standard in prometheus and useful for linking metrics and logs. 
-③ A `host` label will help identify logs from this machine vs others.
-④ The path matching uses [@bmatcuk's glob library](https://github.com/bmatcuk/doublestar)
+① This location needs to be writeable by promtail.  
+② A `job` label is fairly standard in prometheus and useful for linking metrics and logs.   
+③ A `host` label will help identify logs from this machine vs others.  
+④ The path matching uses [@bmatcuk's glob library](https://github.com/bmatcuk/doublestar)  
 
 
 ## Example Journal Config

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -1017,7 +1017,7 @@ sync_period: "10s"
 
 ## Example Docker Config
 
-It's fairly difficult to tail docker files on a standalone machine because they are in different locations for every OS.  We recommend the [docker logging driver](../../../cmd/docker-driver/README.md) for local docker installs or docker-compose.
+It's fairly difficult to tail Docker files on a standalone machine because they are in different locations for every OS.  We recommend the [Docker logging driver](../../../cmd/docker-driver/README.md) for local Docker installs or Docker Compose.
 
 If running in a kubernetes environment, you should look at the defined configs which are in [helm](../../../production/helm/promtail/templates/configmap.yaml) and [jsonnet](../../../production/ksonnet/promtail/scrape_config.libsonnet), these leverage the prometheus service discovery libraries (and give promtail it's name) for automatically finding and tailing pods.  The jsonnet config explains with comments what each section is for.
 


### PR DESCRIPTION
Fixes #1593 (or at least improves) 

The promtail configs were missing the `docker` and `cri` stages as well as had potentially confusing names in the docs vs the actual stage names.

Also the docker example was difficult to follow because every OS logs docker logs to a different location.




Signed-off-by: Edward Welch <edward.welch@grafana.com>