### PR TITLE
Decouple logql engine/AST from execution context

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -1,9 +1,7 @@
 package logql
 
 import (
-	"container/heap"
 	"context"
-	"math"
 	"sort"
 	"time"
 
@@ -12,7 +10,6 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/stats"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -75,9 +72,8 @@ type Engine interface {
 
 // engine is the LogQL engine.
 type engine struct {
-	timeout           time.Duration
-	maxLookBackPeriod time.Duration
-	querier           Querier
+	timeout   time.Duration
+	evaluator Evaluator
 }
 
 // NewEngine creates a new LogQL engine.
@@ -89,9 +85,11 @@ func NewEngine(opts EngineOpts, q Querier) Engine {
 	opts.applyDefault()
 
 	return &engine{
-		timeout:           opts.Timeout,
-		maxLookBackPeriod: opts.MaxLookBackPeriod,
-		querier:           q,
+		timeout: opts.Timeout,
+		evaluator: &defaultEvaluator{
+			querier:           q,
+			maxLookBackPeriod: opts.MaxLookBackPeriod,
+		},
 	}
 }
 
@@ -102,23 +100,16 @@ type Query interface {
 }
 
 type query struct {
-	qs         string
-	start, end time.Time
-	step       time.Duration
-	direction  logproto.Direction
-	limit      uint32
+	LiteralParams
 
 	ng *engine
-}
-
-func (q *query) isInstant() bool {
-	return q.start == q.end && q.step == 0
 }
 
 // Exec Implements `Query`
 func (q *query) Exec(ctx context.Context) (promql.Value, error) {
 	var queryType string
-	if q.isInstant() {
+
+	if IsInstant(q) {
 		queryType = "instant"
 	} else {
 		queryType = "range"
@@ -134,13 +125,15 @@ func (ng *engine) NewRangeQuery(
 	start, end time.Time, step time.Duration,
 	direction logproto.Direction, limit uint32) Query {
 	return &query{
-		qs:        qs,
-		start:     start,
-		end:       end,
-		step:      step,
-		direction: direction,
-		limit:     limit,
-		ng:        ng,
+		LiteralParams: LiteralParams{
+			qs:        qs,
+			start:     start,
+			end:       end,
+			step:      step,
+			direction: direction,
+			limit:     limit,
+		},
+		ng: ng,
 	}
 }
 
@@ -150,13 +143,15 @@ func (ng *engine) NewInstantQuery(
 	ts time.Time,
 	direction logproto.Direction, limit uint32) Query {
 	return &query{
-		qs:        qs,
-		start:     ts,
-		end:       ts,
-		step:      0,
-		direction: direction,
-		limit:     limit,
-		ng:        ng,
+		LiteralParams: LiteralParams{
+			qs:        qs,
+			start:     ts,
+			end:       ts,
+			step:      0,
+			direction: direction,
+			limit:     limit,
+		},
+		ng: ng,
 	}
 }
 
@@ -166,14 +161,15 @@ func (ng *engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
 	defer cancel()
 
-	if q.qs == "1+1" {
-		if q.isInstant() {
+	qs := q.String()
+	if qs == "1+1" {
+		if IsInstant(q) {
 			return promql.Vector{}, nil
 		}
 		return promql.Matrix{}, nil
 	}
 
-	expr, err := ParseExpr(q.qs)
+	expr, err := ParseExpr(qs)
 	if err != nil {
 		return nil, err
 	}
@@ -187,26 +183,10 @@ func (ng *engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 
 	switch e := expr.(type) {
 	case SampleExpr:
-		if err := ng.setupIterators(ctx, e, q); err != nil {
-			return nil, err
-		}
-		return ng.evalSample(e, q), nil
+		return ng.evalSample(ctx, e, q)
 
 	case LogSelectorExpr:
-		params := SelectParams{
-			QueryRequest: &logproto.QueryRequest{
-				Start:     q.start,
-				End:       q.end,
-				Limit:     q.limit,
-				Direction: q.direction,
-				Selector:  e.String(),
-			},
-		}
-		// instant query, we look back to find logs near the requested ts.
-		if q.isInstant() {
-			params.Start = params.Start.Add(-ng.maxLookBackPeriod)
-		}
-		iter, err := ng.querier.Select(ctx, params)
+		iter, err := ng.evaluator.Iterator(ctx, e, q)
 		if err != nil {
 			return nil, err
 		}
@@ -217,44 +197,20 @@ func (ng *engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 	return nil, nil
 }
 
-// setupIterators walk through the AST tree and build iterators required to eval samples.
-func (ng *engine) setupIterators(ctx context.Context, expr SampleExpr, q *query) error {
-	if expr == nil {
-		return nil
-	}
-	switch e := expr.(type) {
-	case *vectorAggregationExpr:
-		return ng.setupIterators(ctx, e.left, q)
-	case *rangeAggregationExpr:
-		iter, err := ng.querier.Select(ctx, SelectParams{
-			&logproto.QueryRequest{
-				Start:     q.start.Add(-e.left.interval),
-				End:       q.end,
-				Limit:     0,
-				Direction: logproto.FORWARD,
-				Selector:  e.Selector().String(),
-			},
-		})
-		if err != nil {
-			return err
-		}
-		e.iterator = newRangeVectorIterator(iter, e.left.interval.Nanoseconds(), q.step.Nanoseconds(),
-			q.start.UnixNano(), q.end.UnixNano())
-	}
-	return nil
-}
-
 // evalSample evaluate a sampleExpr
-func (ng *engine) evalSample(expr SampleExpr, q *query) promql.Value {
-	defer helpers.LogError("closing SampleExpr", expr.Close)
+func (ng *engine) evalSample(ctx context.Context, expr SampleExpr, q *query) (promql.Value, error) {
 
-	stepEvaluator := expr.Evaluator()
+	stepEvaluator, err := ng.evaluator.Evaluator(ctx, expr, q)
+	defer helpers.LogError("closing SampleExpr", stepEvaluator.Close)
+	if err != nil {
+		return nil, err
+	}
 	seriesIndex := map[uint64]*promql.Series{}
 
 	next, ts, vec := stepEvaluator.Next()
-	if q.isInstant() {
+	if IsInstant(q) {
 		sort.Slice(vec, func(i, j int) bool { return labels.Compare(vec[i].Metric, vec[j].Metric) < 0 })
-		return vec
+		return vec, nil
 	}
 	for next {
 		for _, p := range vec {
@@ -285,7 +241,7 @@ func (ng *engine) evalSample(expr SampleExpr, q *query) promql.Value {
 	}
 	result := promql.Matrix(series)
 	sort.Sort(result)
-	return result
+	return result, nil
 }
 
 func readStreams(i iter.EntryIterator, size uint32) (Streams, error) {
@@ -317,211 +273,6 @@ type groupedAggregation struct {
 	groupCount  int
 	heap        vectorByValueHeap
 	reverseHeap vectorByReverseValueHeap
-}
-
-// Evaluator implements `SampleExpr` for a vectorAggregationExpr
-// this is copied and adapted from Prometheus vector aggregation code.
-func (v *vectorAggregationExpr) Evaluator() StepEvaluator {
-	nextEvaluator := v.left.Evaluator()
-	return StepEvaluatorFn(func() (bool, int64, promql.Vector) {
-		next, ts, vec := nextEvaluator.Next()
-		if !next {
-			return false, 0, promql.Vector{}
-		}
-		result := map[uint64]*groupedAggregation{}
-		if v.operation == OpTypeTopK || v.operation == OpTypeBottomK {
-			if v.params < 1 {
-				return next, ts, promql.Vector{}
-			}
-
-		}
-		for _, s := range vec {
-			metric := s.Metric
-
-			var (
-				groupingKey uint64
-			)
-			if v.grouping.without {
-				groupingKey, _ = metric.HashWithoutLabels(make([]byte, 0, 1024), v.grouping.groups...)
-			} else {
-				groupingKey, _ = metric.HashForLabels(make([]byte, 0, 1024), v.grouping.groups...)
-			}
-			group, ok := result[groupingKey]
-			// Add a new group if it doesn't exist.
-			if !ok {
-				var m labels.Labels
-
-				if v.grouping.without {
-					lb := labels.NewBuilder(metric)
-					lb.Del(v.grouping.groups...)
-					lb.Del(labels.MetricName)
-					m = lb.Labels()
-				} else {
-					m = make(labels.Labels, 0, len(v.grouping.groups))
-					for _, l := range metric {
-						for _, n := range v.grouping.groups {
-							if l.Name == n {
-								m = append(m, l)
-								break
-							}
-						}
-					}
-					sort.Sort(m)
-				}
-				result[groupingKey] = &groupedAggregation{
-					labels:     m,
-					value:      s.V,
-					mean:       s.V,
-					groupCount: 1,
-				}
-
-				inputVecLen := len(vec)
-				resultSize := v.params
-				if v.params > inputVecLen {
-					resultSize = inputVecLen
-				}
-				if v.operation == OpTypeStdvar || v.operation == OpTypeStddev {
-					result[groupingKey].value = 0.0
-				} else if v.operation == OpTypeTopK {
-					result[groupingKey].heap = make(vectorByValueHeap, 0, resultSize)
-					heap.Push(&result[groupingKey].heap, &promql.Sample{
-						Point:  promql.Point{V: s.V},
-						Metric: s.Metric,
-					})
-				} else if v.operation == OpTypeBottomK {
-					result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 0, resultSize)
-					heap.Push(&result[groupingKey].reverseHeap, &promql.Sample{
-						Point:  promql.Point{V: s.V},
-						Metric: s.Metric,
-					})
-				}
-				continue
-			}
-			switch v.operation {
-			case OpTypeSum:
-				group.value += s.V
-
-			case OpTypeAvg:
-				group.groupCount++
-				group.mean += (s.V - group.mean) / float64(group.groupCount)
-
-			case OpTypeMax:
-				if group.value < s.V || math.IsNaN(group.value) {
-					group.value = s.V
-				}
-
-			case OpTypeMin:
-				if group.value > s.V || math.IsNaN(group.value) {
-					group.value = s.V
-				}
-
-			case OpTypeCount:
-				group.groupCount++
-
-			case OpTypeStddev, OpTypeStdvar:
-				group.groupCount++
-				delta := s.V - group.mean
-				group.mean += delta / float64(group.groupCount)
-				group.value += delta * (s.V - group.mean)
-
-			case OpTypeTopK:
-				if len(group.heap) < v.params || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
-					if len(group.heap) == v.params {
-						heap.Pop(&group.heap)
-					}
-					heap.Push(&group.heap, &promql.Sample{
-						Point:  promql.Point{V: s.V},
-						Metric: s.Metric,
-					})
-				}
-
-			case OpTypeBottomK:
-				if len(group.reverseHeap) < v.params || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
-					if len(group.reverseHeap) == v.params {
-						heap.Pop(&group.reverseHeap)
-					}
-					heap.Push(&group.reverseHeap, &promql.Sample{
-						Point:  promql.Point{V: s.V},
-						Metric: s.Metric,
-					})
-				}
-			default:
-				panic(errors.Errorf("expected aggregation operator but got %q", v.operation))
-			}
-		}
-		vec = vec[:0]
-		for _, aggr := range result {
-			switch v.operation {
-			case OpTypeAvg:
-				aggr.value = aggr.mean
-
-			case OpTypeCount:
-				aggr.value = float64(aggr.groupCount)
-
-			case OpTypeStddev:
-				aggr.value = math.Sqrt(aggr.value / float64(aggr.groupCount))
-
-			case OpTypeStdvar:
-				aggr.value = aggr.value / float64(aggr.groupCount)
-
-			case OpTypeTopK:
-				// The heap keeps the lowest value on top, so reverse it.
-				sort.Sort(sort.Reverse(aggr.heap))
-				for _, v := range aggr.heap {
-					vec = append(vec, promql.Sample{
-						Metric: v.Metric,
-						Point: promql.Point{
-							T: ts,
-							V: v.V,
-						},
-					})
-				}
-				continue // Bypass default append.
-
-			case OpTypeBottomK:
-				// The heap keeps the lowest value on top, so reverse it.
-				sort.Sort(sort.Reverse(aggr.reverseHeap))
-				for _, v := range aggr.reverseHeap {
-					vec = append(vec, promql.Sample{
-						Metric: v.Metric,
-						Point: promql.Point{
-							T: ts,
-							V: v.V,
-						},
-					})
-				}
-				continue // Bypass default append.
-			default:
-			}
-			vec = append(vec, promql.Sample{
-				Metric: aggr.labels,
-				Point: promql.Point{
-					T: ts,
-					V: aggr.value,
-				},
-			})
-		}
-		return next, ts, vec
-	})
-}
-
-// Evaluator implements `SampleExpr` for a rangeAggregationExpr
-func (e *rangeAggregationExpr) Evaluator() StepEvaluator {
-	var fn RangeVectorAggregator
-	switch e.operation {
-	case OpTypeRate:
-		fn = rate(e.left.interval)
-	case OpTypeCountOverTime:
-		fn = count
-	}
-	return StepEvaluatorFn(func() (bool, int64, promql.Vector) {
-		next := e.iterator.Next()
-		if !next {
-			return false, 0, promql.Vector{}
-		}
-		ts, vec := e.iterator.At(fn)
-		return true, ts, vec
-	})
 }
 
 // rate calculate the per-second rate of log lines.

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -57,14 +57,7 @@ func (opts *EngineOpts) applyDefault() {
 	}
 }
 
-/*
-Engine interface
-function/agg Nodes should have Associative method to allow ad-hoc parallelization?
-limit + filter (regexp) queries can be parallelized well
-non filtered queries can be executed in roughly 1/shard_factor time, but require 2x decode cost: sending all (unfiltered) data back to frontend
-
-custom downstream impl may require it's own endpoint (in order to pass shard info not encoded in labels)
-*/
+// Engine interface used to construct queries
 type Engine interface {
 	NewRangeQuery(qs string, start, end time.Time, step time.Duration, direction logproto.Direction, limit uint32) Query
 	NewInstantQuery(qs string, ts time.Time, direction logproto.Direction, limit uint32) Query
@@ -162,6 +155,7 @@ func (ng *engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 	defer cancel()
 
 	qs := q.String()
+	// This is a legacy query used for health checking. Not the best practice, but it works.
 	if qs == "1+1" {
 		if IsInstant(q) {
 			return promql.Vector{}, nil

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -1,0 +1,271 @@
+package logql
+
+import (
+	"container/heap"
+	"context"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+)
+
+type Qry interface {
+	String() string
+	Start() time.Time
+	End() time.Time
+	Step() time.Duration
+	Limit() uint32
+}
+
+func IsInstant(q Qry) bool {
+	return q.Start() == q.End() && q.Step() == 0
+}
+
+type Evaluator interface {
+	Evaluator(context.Context, SampleExpr, Qry) (StepEvaluator, error)
+	Iterator(context.Context, LogSelectorExpr, Qry) (iter.EntryIterator, error)
+}
+
+type defaultEvaluator struct {
+	querier Querier
+}
+
+func (ev *defaultEvaluator) Evaluator(ctx context.Context, expr SampleExpr, q Qry) (StepEvaluator, error) {
+	switch e := expr.(type) {
+	case *vectorAggregationExpr:
+		return ev.vectorAggEvaluator(ctx, e, q)
+	case *rangeAggregationExpr:
+		return ev.rangeAggEvaluator(ctx, e, q)
+
+	default:
+		return nil, errors.Errorf("unexpected type (%T): %v", e, e)
+	}
+}
+
+func (ev *defaultEvaluator) vectorAggEvaluator(ctx context.Context, expr *vectorAggregationExpr, q Qry) (StepEvaluator, error) {
+	nextEvaluator, err := ev.Evaluator(ctx, expr.left, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return StepEvaluatorFn(func() (bool, int64, promql.Vector) {
+		next, ts, vec := nextEvaluator.Next()
+		if !next {
+			return false, 0, promql.Vector{}
+		}
+		result := map[uint64]*groupedAggregation{}
+		if expr.operation == OpTypeTopK || expr.operation == OpTypeBottomK {
+			if expr.params < 1 {
+				return next, ts, promql.Vector{}
+			}
+
+		}
+		for _, s := range vec {
+			metric := s.Metric
+
+			var (
+				groupingKey uint64
+			)
+			if expr.grouping.without {
+				groupingKey, _ = metric.HashWithoutLabels(make([]byte, 0, 1024), expr.grouping.groups...)
+			} else {
+				groupingKey, _ = metric.HashForLabels(make([]byte, 0, 1024), expr.grouping.groups...)
+			}
+			group, ok := result[groupingKey]
+			// Add a new group if it doesn't exist.
+			if !ok {
+				var m labels.Labels
+
+				if expr.grouping.without {
+					lb := labels.NewBuilder(metric)
+					lb.Del(expr.grouping.groups...)
+					lb.Del(labels.MetricName)
+					m = lb.Labels()
+				} else {
+					m = make(labels.Labels, 0, len(expr.grouping.groups))
+					for _, l := range metric {
+						for _, n := range expr.grouping.groups {
+							if l.Name == n {
+								m = append(m, l)
+								break
+							}
+						}
+					}
+					sort.Sort(m)
+				}
+				result[groupingKey] = &groupedAggregation{
+					labels:     m,
+					value:      s.V,
+					mean:       s.V,
+					groupCount: 1,
+				}
+
+				inputVecLen := len(vec)
+				resultSize := expr.params
+				if expr.params > inputVecLen {
+					resultSize = inputVecLen
+				}
+				if expr.operation == OpTypeStdvar || expr.operation == OpTypeStddev {
+					result[groupingKey].value = 0.0
+				} else if expr.operation == OpTypeTopK {
+					result[groupingKey].heap = make(vectorByValueHeap, 0, resultSize)
+					heap.Push(&result[groupingKey].heap, &promql.Sample{
+						Point:  promql.Point{V: s.V},
+						Metric: s.Metric,
+					})
+				} else if expr.operation == OpTypeBottomK {
+					result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 0, resultSize)
+					heap.Push(&result[groupingKey].reverseHeap, &promql.Sample{
+						Point:  promql.Point{V: s.V},
+						Metric: s.Metric,
+					})
+				}
+				continue
+			}
+			switch expr.operation {
+			case OpTypeSum:
+				group.value += s.V
+
+			case OpTypeAvg:
+				group.groupCount++
+				group.mean += (s.V - group.mean) / float64(group.groupCount)
+
+			case OpTypeMax:
+				if group.value < s.V || math.IsNaN(group.value) {
+					group.value = s.V
+				}
+
+			case OpTypeMin:
+				if group.value > s.V || math.IsNaN(group.value) {
+					group.value = s.V
+				}
+
+			case OpTypeCount:
+				group.groupCount++
+
+			case OpTypeStddev, OpTypeStdvar:
+				group.groupCount++
+				delta := s.V - group.mean
+				group.mean += delta / float64(group.groupCount)
+				group.value += delta * (s.V - group.mean)
+
+			case OpTypeTopK:
+				if len(group.heap) < expr.params || group.heap[0].V < s.V || math.IsNaN(group.heap[0].V) {
+					if len(group.heap) == expr.params {
+						heap.Pop(&group.heap)
+					}
+					heap.Push(&group.heap, &promql.Sample{
+						Point:  promql.Point{V: s.V},
+						Metric: s.Metric,
+					})
+				}
+
+			case OpTypeBottomK:
+				if len(group.reverseHeap) < expr.params || group.reverseHeap[0].V > s.V || math.IsNaN(group.reverseHeap[0].V) {
+					if len(group.reverseHeap) == expr.params {
+						heap.Pop(&group.reverseHeap)
+					}
+					heap.Push(&group.reverseHeap, &promql.Sample{
+						Point:  promql.Point{V: s.V},
+						Metric: s.Metric,
+					})
+				}
+			default:
+				panic(errors.Errorf("expected aggregation operator but got %q", expr.operation))
+			}
+		}
+		vec = vec[:0]
+		for _, aggr := range result {
+			switch expr.operation {
+			case OpTypeAvg:
+				aggr.value = aggr.mean
+
+			case OpTypeCount:
+				aggr.value = float64(aggr.groupCount)
+
+			case OpTypeStddev:
+				aggr.value = math.Sqrt(aggr.value / float64(aggr.groupCount))
+
+			case OpTypeStdvar:
+				aggr.value = aggr.value / float64(aggr.groupCount)
+
+			case OpTypeTopK:
+				// The heap keeps the lowest value on top, so reverse it.
+				sort.Sort(sort.Reverse(aggr.heap))
+				for _, v := range aggr.heap {
+					vec = append(vec, promql.Sample{
+						Metric: v.Metric,
+						Point: promql.Point{
+							T: ts,
+							V: v.V,
+						},
+					})
+				}
+				continue // Bypass default append.
+
+			case OpTypeBottomK:
+				// The heap keeps the lowest value on top, so reverse it.
+				sort.Sort(sort.Reverse(aggr.reverseHeap))
+				for _, v := range aggr.reverseHeap {
+					vec = append(vec, promql.Sample{
+						Metric: v.Metric,
+						Point: promql.Point{
+							T: ts,
+							V: v.V,
+						},
+					})
+				}
+				continue // Bypass default append.
+			default:
+			}
+			vec = append(vec, promql.Sample{
+				Metric: aggr.labels,
+				Point: promql.Point{
+					T: ts,
+					V: aggr.value,
+				},
+			})
+		}
+		return next, ts, vec
+	}), nil
+}
+
+func (ev *defaultEvaluator) rangeAggEvaluator(ctx context.Context, expr *rangeAggregationExpr, q Qry) (StepEvaluator, error) {
+	entryIter, err := ev.querier.Select(ctx, SelectParams{
+		&logproto.QueryRequest{
+			Start:     q.Start().Add(-expr.left.interval),
+			End:       q.End(),
+			Limit:     0,
+			Direction: logproto.FORWARD,
+			Selector:  expr.Selector().String(),
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	vecIter := newRangeVectorIterator(entryIter, expr.left.interval.Nanoseconds(), q.Step().Nanoseconds(),
+		q.Start().UnixNano(), q.End().UnixNano())
+
+	var fn RangeVectorAggregator
+	switch expr.operation {
+	case OpTypeRate:
+		fn = rate(expr.left.interval)
+	case OpTypeCountOverTime:
+		fn = count
+	}
+	return StepEvaluatorFn(func() (bool, int64, promql.Vector) {
+		next := vecIter.Next()
+		if !next {
+			return false, 0, promql.Vector{}
+		}
+		ts, vec := vecIter.At(fn)
+		return true, ts, vec
+	}), nil
+}

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -41,7 +41,7 @@ func (q *Querier) RangeQueryHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, httpgrpc.Errorf(http.StatusBadRequest, err.Error()).Error(), http.StatusBadRequest)
 		return
 	}
-	query := q.engine.NewRangeQuery(q, request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
+	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
 	result, err := query.Exec(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -65,7 +65,7 @@ func (q *Querier) InstantQueryHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, httpgrpc.Errorf(http.StatusBadRequest, err.Error()).Error(), http.StatusBadRequest)
 		return
 	}
-	query := q.engine.NewInstantQuery(q, request.Query, request.Ts, request.Direction, request.Limit)
+	query := q.engine.NewInstantQuery(request.Query, request.Ts, request.Direction, request.Limit)
 	result, err := query.Exec(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -111,7 +111,7 @@ func (q *Querier) LogQueryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query := q.engine.NewRangeQuery(q, request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
+	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
 	result, err := query.Exec(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -60,7 +60,7 @@ type Querier struct {
 	ring   ring.ReadRing
 	pool   *cortex_client.Pool
 	store  storage.Store
-	engine *logql.Engine
+	engine logql.Engine
 	limits *validation.Overrides
 }
 
@@ -76,14 +76,16 @@ func New(cfg Config, clientCfg client.Config, ring ring.ReadRing, store storage.
 // newQuerier creates a new Querier and allows to pass a custom ingester client factory
 // used for testing purposes
 func newQuerier(cfg Config, clientCfg client.Config, clientFactory cortex_client.Factory, ring ring.ReadRing, store storage.Store, limits *validation.Overrides) (*Querier, error) {
-	return &Querier{
+	querier := Querier{
 		cfg:    cfg,
 		ring:   ring,
 		pool:   cortex_client.NewPool(clientCfg.PoolConfig, ring, clientFactory, util.Logger),
 		store:  store,
-		engine: logql.NewEngine(cfg.Engine),
 		limits: limits,
-	}, nil
+	}
+	querier.engine = logql.NewEngine(cfg.Engine, &querier)
+
+	return &querier, nil
 }
 
 type responseFromIngesters struct {


### PR DESCRIPTION
## What
This PR introduces a few changes/refactorings designed to decouple the LogQL engine and AST from its execution context. The idea is that an AST is just a stateless tree structure which can be processed by an evaluation engine. Separating the evaluation from AST will allow us to more easily build different evaluation contexts (sharding comes to mind).

- logql `Engine` is now an interface
- iterators and evaluators are no longer struct fields on AST nodes
- introduces an `Evaluator` interface
- evaluators can be combined with ast nodes in order to resolve the underlying queries.

## Why
Previously, evaluators and iterators were tied directly into the AST nodes themselves. This makes them difficult to extend/refactor/etc.


```
$ benchcmp /tmp/master.out /tmp/refactor.out
benchmark                        old ns/op      new ns/op      delta
BenchmarkContainsFilter-8        8.30           8.41           +1.33%
BenchmarkRangeQuery100000-8      2516982        2213231        -12.07%
BenchmarkRangeQuery200000-8      10473399       12376741       +18.17%
BenchmarkRangeQuery500000-8      1937572837     1888996274     -2.51%
BenchmarkRangeQuery1000000-8     4224820576     3931777379     -6.94%

benchmark                        old allocs     new allocs     delta
BenchmarkRangeQuery100000-8      2848           2907           +2.07%
BenchmarkRangeQuery200000-8      3333           3514           +5.43%
BenchmarkRangeQuery500000-8      136397         136449         +0.04%
BenchmarkRangeQuery1000000-8     269751         269815         +0.02%

benchmark                        old bytes     new bytes     delta
BenchmarkRangeQuery100000-8      412186        405320        -1.67%
BenchmarkRangeQuery200000-8      894959        1009403       +12.79%
BenchmarkRangeQuery500000-8      135070672     135033424     -0.03%
BenchmarkRangeQuery1000000-8     270658240     270658704     +0.00%
```