### PR TITLE
Documentation: Recommend using the latest schema version (v11)

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -20,7 +20,7 @@ schema_config:
   - from: 2018-04-15
     store: boltdb
     object_store: filesystem
-    schema: v9
+    schema: v11
     index:
       prefix: index_
       period: 168h

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -29,7 +29,7 @@ schema_config:
   - from: 2018-04-15
     store: boltdb
     object_store: filesystem
-    schema: v9
+    schema: v11
     index:
       prefix: index_
       period: 168h
@@ -75,7 +75,7 @@ schema_config:
   - from: 2018-04-15
     store: bigtable
     object_store: gcs
-    schema: v9
+    schema: v11
     index:
       prefix: loki_index_
       period: 168h
@@ -99,7 +99,7 @@ schema_config:
   - from: 2018-04-15
     store: cassandra
     object_store: filesystem
-    schema: v9
+    schema: v11
     index:
       prefix: cassandra_table
       period: 168h
@@ -127,7 +127,7 @@ schema_config:
     - from: 2018-04-15
       store: aws
       object_store: s3
-      schema: v9
+      schema: v11
       index:
         prefix: dynamodb_table_name
         period: 0

--- a/docs/operations/storage/retention.md
+++ b/docs/operations/storage/retention.md
@@ -49,7 +49,7 @@ schema_config:
   - from: 2018-04-15
     store: bigtable
     object_store: gcs
-    schema: v9
+    schema: v11
     index:
       prefix: loki_index_
       period: 168h

--- a/docs/operations/storage/table-manager.md
+++ b/docs/operations/storage/table-manager.md
@@ -66,11 +66,11 @@ for the query time range.
 ### Schema config example
 
 For example, the following `schema_config` defines two configurations: the first
-one using the schema `v8` and the current one using the `v9`.
+one using the schema `v10` and the current one using the `v11`.
 
 The first config stores data between `2019-01-01` and `2019-04-14` (included),
-then a new config has been added - to upgrade the schema version to `v9` -
-storing data using the `v9` schema from `2019-04-15` on.
+then a new config has been added - to upgrade the schema version to `v11` -
+storing data using the `v11` schema from `2019-04-15` on.
 
 For each config, multiple tables are created, each one storing data for
 `period` time (168 hours = 7 days).
@@ -80,13 +80,13 @@ schema_config:
   configs:
     - from:   2019-01-01
       store:  dynamo
-      schema: v8
+      schema: v10
       index:
         prefix: loki_
         period: 168h
     - from:   2019-04-15
       store:  dynamo
-      schema: v9
+      schema: v11
       index:
         prefix: loki_
         period: 168h

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -238,7 +238,7 @@
           from: '2018-04-15',
           store: 'bigtable',
           object_store: 'gcs',
-          schema: 'v9',
+          schema: 'v11',
           index: {
             prefix: '%s_index_' % $._config.table_prefix,
             period: '%dh' % $._config.index_period_hours,


### PR DESCRIPTION
**What this PR does / why we need it**:

According to the [architecture docs](https://github.com/grafana/loki/blob/master/docs/architecture.md), latest schema version is ~v10~ v11. However the documentation mentions only v9 in the examples.

This PR updates the docs and default values accordingly.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

