### PR TITLE
Fix wget syntax in documentation

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -20,6 +20,6 @@ $ docker run -v $(pwd):/mnt/config -v /var/log:/var/log grafana/promtail:latest 
 ## Install with Docker Compose
 
 ```bash
-$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/production/docker-compose.yaml -o docker-compose.yaml
+$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/production/docker-compose.yaml -O docker-compose.yaml
 $ docker-compose -f docker-compose.yaml up
 ```

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -11,9 +11,9 @@ For production, we recommend Tanka or Helm.
 ## Install with Docker
 
 ```bash
-$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/cmd/loki/loki-local-config.yaml -o loki-config.yaml
+$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
 $ docker run -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:v1.3.0 -config.file=/mnt/config/loki-config.yaml
-$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/cmd/promtail/promtail-docker-config.yaml -o promtail-config.yaml
+$ wget https://raw.githubusercontent.com/grafana/loki/v1.3.0/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
 $ docker run -v $(pwd):/mnt/config -v /var/log:/var/log grafana/promtail:latest -config.file=/mnt/config/promtail-config.yaml
 ```
 


### PR DESCRIPTION
The syntax was wrong and doesn't work as expected

```
       -O file
       --output-document=file
           The documents will not be written to the appropriate files, but all will be concatenated together and written to file.  If - is used as file, documents
           will be printed to standard output, disabling link conversion.  (Use ./- to print to a file literally named -.)


```

Capital "O" solves it.