### PR TITLE
Fixes config change in the result cache

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -117,7 +117,6 @@
         cache_results: true,
         max_retries: 5,
         results_cache: {
-          cache_split_interval: '30m',
           max_freshness: '10m',
           cache: {
             memcached_client: {


### PR DESCRIPTION
Since https://github.com/grafana/loki/pull/1612 we don't need the cache_split_interval anymore.
