### PR TITLE
Codecov: Update config to add informational flag

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,11 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    project:
+      default:
+        informational: true
+
 
 parsers:
   gcov:


### PR DESCRIPTION
Setting the `informational` flag for the project so that we don't mark the checks as failed if the patch percentage is 0. See https://github.com/grafana/loki/pull/1612/commits for an example of a failure when it should really just tell us the information.