### PR TITLE
cache key cant be reused when an interval changes

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -51,6 +51,9 @@ type cacheKeyLimits struct {
 // GenerateCacheKey will panic if it encounters a 0 split duration. We ensure against this by requiring
 // a nonzero split interval when caching is enabled
 func (l cacheKeyLimits) GenerateCacheKey(userID string, r queryrange.Request) string {
-	currentInterval := r.GetStart() / int64(l.QuerySplitDuration(userID)/time.Millisecond)
-	return fmt.Sprintf("%s:%s:%d:%d", userID, r.GetQuery(), r.GetStep(), currentInterval)
+	split := l.QuerySplitDuration(userID)
+	currentInterval := r.GetStart() / int64(split/time.Millisecond)
+	// include both the currentInterval and the split duration in key to ensure
+	// a cache key can't be reused when an interval changes
+	return fmt.Sprintf("%s:%s:%d:%d:%d", userID, r.GetQuery(), r.GetStep(), currentInterval, split)
 }

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -1,6 +1,7 @@
 package queryrange
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithDefaultLimits(t *testing.T) {
+func TestLimits(t *testing.T) {
 	l := fakeLimits{
 		splits: map[string]time.Duration{"a": time.Minute},
 	}
@@ -31,4 +32,15 @@ func TestWithDefaultLimits(t *testing.T) {
 	require.Equal(t, wrapped.QuerySplitDuration("a"), time.Minute)
 	require.Equal(t, wrapped.QuerySplitDuration("b"), time.Hour)
 
+	r := &LokiRequest{
+		Query:   "qry",
+		StartTs: time.Now(),
+		Step:    int64(time.Minute / time.Millisecond),
+	}
+
+	require.Equal(
+		t,
+		fmt.Sprintf("%s:%s:%d:%d:%d", "a", r.GetQuery(), r.GetStep(), r.GetStart()/int64(time.Minute/time.Millisecond), int64(time.Minute)),
+		cacheKeyLimits{wrapped}.GenerateCacheKey("a", r),
+	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a small (and probably unrealistic) loophole in the cache key generation code for the result cache. Including the interval used in a cache key will prevent us from ever reusing the same key across `querier.split-queries-by-interval` (and associated overrides) configuration changes.

For a hypothetical request start value 12 and split intervals 5 and 6, we'd generate the same cache keys because `12/5` == `12/6` in integer division. We now include the `5` and `6` respectively in our cache keys to prevent this collision.

**Checklist**
- [x] Tests updated

