### PR TITLE
PeriodConfig documentation fix dynamodb -> aws-dynamo

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -690,7 +690,7 @@ for from specific time periods.
 # store and object_store below affect which <storage_config> key is
 # used.
 
-# Which store to use for the index. Either cassandra, bigtable, dynamodb, or
+# Which store to use for the index. Either cassandra, bigtable, aws-dynamo, or
 # boltdb
 store: <string>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Documentation fix.
Looking at cortex `NewIndexClient` [code](https://github.com/cortexproject/cortex/blob/2eea1787e7d6b351bdfea78022eb690b58cbacc0/pkg/chunk/storage/factory.go#L123), dynamodb is not an option. it should be `aws` or `aws-dynamo` 
