### PR TITLE
[promtail helm chart] option to set fs.inotify.max_user_instances with init container

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.29.0
+version: 0.30.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.17.0
+version: 0.18.0
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -38,6 +38,17 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+    {{- if .Values.initContainer.enabled }}
+      initContainers:
+      - name: init
+        image: busybox
+        command:
+        - sh
+        - -c
+        - sysctl -w fs.inotify.max_user_instances={{ .Values.initContainer.fsInotifyMaxUserInstances }}
+        securityContext:
+          privileged: true
+    {{- end }}
       containers:
         - name: promtail
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -6,6 +6,10 @@ annotations: {}
 
 deploymentStrategy: RollingUpdate
 
+initContainer:
+  enabled: false
+  fsInotifyMaxUserInstances: 128
+
 image:
   repository: grafana/promtail
   tag: v1.3.0


### PR DESCRIPTION
**What this PR does / why we need it**:
We ran into an issue on our Kubernetes environment where Promtail was using 113 inotify watchers, with some other watchers it it the 128 limit on watchers which resulted in "too many open files" error on the Kubernetes nodes. 
Using an privileged init container to increase that limit fixed the issue for us, after the limit was raised the number of inotify watchers used by Promtail increased to about 175.

**Which issue(s) this PR fixes**:
Don't have a issue number for this.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

