### PR TITLE
Exempt proposals from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ daysUntilClose: 7
 # Labels that prevent issues from being marked as stale
 exemptLabels:
   - keepalive
+  - proposal
 
 # Label to use to identify a stale issue
 staleLabel: stale


### PR DESCRIPTION
I think proposals should be something we always take a look at and decide to close manually.