### PR TITLE
adds stringer methods for all ast expr types

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -370,7 +370,7 @@ func (e *vectorAggregationExpr) String() string {
 	return formatOperation(e.operation, e.grouping, params...)
 }
 
-// helepr used to impl Stringer for vector and range aggregations
+// helper used to impl Stringer for vector and range aggregations
 func formatOperation(op string, grouping *grouping, params ...string) string {
 	nonEmptyParams := make([]string, 0, len(params))
 	for _, p := range params {


### PR DESCRIPTION
Continuing some AST refactoring, this ensures all expressions impl `fmt.Stringer` in order to be able to move between an in memory AST and its string representation.