### PR TITLE
ci: make manifest publishing run in serial

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -506,7 +506,6 @@ steps:
 - name: manifest-promtail
   image: plugins/manifest
   settings:
-    ignore_missing: true
     password:
       from_secret: docker_password
     spec: .drone/docker-manifest.tmpl
@@ -519,7 +518,6 @@ steps:
 - name: manifest-loki
   image: plugins/manifest
   settings:
-    ignore_missing: true
     password:
       from_secret: docker_password
     spec: .drone/docker-manifest.tmpl
@@ -528,11 +526,11 @@ steps:
       from_secret: docker_username
   depends_on:
   - clone
+  - manifest-promtail
 
 - name: manifest-loki-canary
   image: plugins/manifest
   settings:
-    ignore_missing: true
     password:
       from_secret: docker_password
     spec: .drone/docker-manifest.tmpl
@@ -541,6 +539,7 @@ steps:
       from_secret: docker_username
   depends_on:
   - clone
+  - manifest-loki
 
 trigger:
   ref:


### PR DESCRIPTION
It looks like there's some issues with publishing the Docker manifest after a merge. This PR does two things:

1. Make the CI fail if not all images in the manifest get published. This will be annoying but leads to less confusion.
2. Runs the manifest steps serially. Running them in parallel might have been contributing to the manifest steps flaking before.