### PR TITLE
This improves the log ouput for statistics in the logcli.

### DIFF
--- a/pkg/logql/stats/context.go
+++ b/pkg/logql/stats/context.go
@@ -62,12 +62,17 @@ func (r Result) Log(log log.Logger) {
 		"Store.DecompressedLines", r.Store.DecompressedLines,
 		"Store.CompressedBytes", humanize.Bytes(uint64(r.Store.CompressedBytes)),
 		"Store.TotalDuplicates", r.Store.TotalDuplicates,
+	)
+	r.Summary.Log(log)
+}
 
-		"Summary.BytesProcessedPerSeconds", humanize.Bytes(uint64(r.Summary.BytesProcessedPerSeconds)),
-		"Summary.LinesProcessedPerSeconds", r.Summary.LinesProcessedPerSeconds,
-		"Summary.TotalBytesProcessed", humanize.Bytes(uint64(r.Summary.TotalBytesProcessed)),
-		"Summary.TotalLinesProcessed", r.Summary.TotalLinesProcessed,
-		"Summary.ExecTime", time.Duration(int64(r.Summary.ExecTime*float64(time.Second))),
+func (s Summary) Log(log log.Logger) {
+	log.Log(
+		"Summary.BytesProcessedPerSeconds", humanize.Bytes(uint64(s.BytesProcessedPerSeconds)),
+		"Summary.LinesProcessedPerSeconds", s.LinesProcessedPerSeconds,
+		"Summary.TotalBytesProcessed", humanize.Bytes(uint64(s.TotalBytesProcessed)),
+		"Summary.TotalLinesProcessed", s.TotalLinesProcessed,
+		"Summary.ExecTime", time.Duration(int64(s.ExecTime*float64(time.Second))),
 	)
 }
 

--- a/pkg/logql/stats/context.go
+++ b/pkg/logql/stats/context.go
@@ -67,7 +67,7 @@ func (r Result) Log(log log.Logger) {
 }
 
 func (s Summary) Log(log log.Logger) {
-	log.Log(
+	_ = log.Log(
 		"Summary.BytesProcessedPerSeconds", humanize.Bytes(uint64(s.BytesProcessedPerSeconds)),
 		"Summary.LinesProcessedPerSeconds", s.LinesProcessedPerSeconds,
 		"Summary.TotalBytesProcessed", humanize.Bytes(uint64(s.TotalBytesProcessed)),


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

I also only kept the summary as shown below : 

```
logcli query --stats '{cluster="us-central1",container_name="promtail"} |= "foawdsda"' --since=12h
https://logs-dev-ops-tools1.grafana.net/loki/api/v1/query_range?direction=BACKWARD&end=1580934143741999000&limit=30&query=%7Bcluster%3D%22us-central1%22%2Ccontainer_name%3D%22promtail%22%7D+%7C%3D+%22foawdsda%22&start=1580890943741999000
Summary.BytesProcessedPerSeconds 	 425 MB
Summary.LinesProcessedPerSeconds 	 1424677
Summary.TotalBytesProcessed 		 44 GB
Summary.TotalLinesProcessed 		 147727595
Summary.ExecTime 			 1m43.691954136s
```
