### PR TITLE
Fix rubocop violation for fluentd/fluent-plugin-loki

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/bin/setup
+++ b/fluentd/fluent-plugin-grafana-loki/bin/setup
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-sudo gem install bundle
+gem install bundler
 bundle install

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -69,7 +69,7 @@ module Fluent
         config_set_default :chunk_keys, []
       end
 
-      def configure(conf)
+      def configure(conf) # rubocop:disable Metrics/CyclomaticComplexity
         compat_parameters_convert(conf, :buffer)
         super
         @uri = URI.parse(@url + '/loki/api/v1/push')

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -73,7 +73,7 @@ module Fluent
         compat_parameters_convert(conf, :buffer)
         super
         @uri = URI.parse(@url + '/loki/api/v1/push')
-        unless @uri.kind_of?(URI::HTTP) or @uri.kind_of?(URI::HTTPS)
+        unless @uri.is_a?(URI::HTTP) or @uri.is_a?(URI::HTTPS)
           raise Fluent::ConfigError, "url parameter must be valid HTTP"
         end
         @record_accessors = {}

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -74,7 +74,7 @@ module Fluent
         super
         @uri = URI.parse(@url + '/loki/api/v1/push')
         unless @uri.is_a?(URI::HTTP) || @uri.is_a?(URI::HTTPS)
-          raise Fluent::ConfigError, "url parameter must be valid HTTP"
+          raise Fluent::ConfigError, 'url parameter must be valid HTTP'
         end
 
         @record_accessors = {}

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -73,7 +73,7 @@ module Fluent
         compat_parameters_convert(conf, :buffer)
         super
         @uri = URI.parse(@url + '/loki/api/v1/push')
-        unless @uri.is_a?(URI::HTTP) or @uri.is_a?(URI::HTTPS)
+        unless @uri.is_a?(URI::HTTP) || @uri.is_a?(URI::HTTPS)
           raise Fluent::ConfigError, "url parameter must be valid HTTP"
         end
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -76,6 +76,7 @@ module Fluent
         unless @uri.is_a?(URI::HTTP) or @uri.is_a?(URI::HTTPS)
           raise Fluent::ConfigError, "url parameter must be valid HTTP"
         end
+
         @record_accessors = {}
         conf.elements.select { |element| element.name == 'label' }.each do |element|
           element.each_pair do |k, v|


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

For the maintainability of fluentd output plugin

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/1645

**Special notes for your reviewer**:

I want to refactor fluentd plugin code through https://github.com/grafana/loki/issues/1645 but it may take time and many contexts. For the first step, I want to fix rubocop violation during `rake spec`

