### PR TITLE
Attempting to add `informational` only feedback for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,9 @@ coverage:
     project:
       default:
         informational: true
-
+    patch:
+      default:
+        informational: true
 
 parsers:
   gcov:


### PR DESCRIPTION
An attempt to try to add the `informational` flag (to not fail build steps) for the `codecov/patch` portion of the build steps. This is _not_ in their documentation, but there are lots of other things not correct in their documentation as noted on their community site, so I'm going to try this. Otherwise, I will submit another PR to turn the codecov/patch off and we'll just have stats for the whole project.