### PR TITLE
Pipe data to Promtail

### DIFF
--- a/cmd/promtail/main.go
+++ b/cmd/promtail/main.go
@@ -64,11 +64,10 @@ func main() {
 	}
 
 	level.Info(util.Logger).Log("msg", "Starting Promtail", "version", version.Info())
+	defer p.Shutdown()
 
 	if err := p.Run(); err != nil {
 		level.Error(util.Logger).Log("msg", "error starting promtail", "error", err)
 		os.Exit(1)
 	}
-
-	p.Shutdown()
 }

--- a/docs/clients/promtail/troubleshooting.md
+++ b/docs/clients/promtail/troubleshooting.md
@@ -25,7 +25,7 @@ only **the first scrape config is used**.
 
 [`static_configs:`](./configuration) can be used to provide static labels, although the targets property is ignored.
 
-If you don't provide any [`scrape_config:`](./configuration#scrape_config) a default one is used which will automatically adds the following default labels: `{job="stdin",hostname="Cyrils-iMac"}`.
+If you don't provide any [`scrape_config:`](./configuration#scrape_config) a default one is used which will automatically adds the following default labels: `{job="stdin",hostname="<detected_hostname>"}`.
 
 For example you could use this config below to parse and add the label `level` on all your piped logs:
 

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -56,6 +56,7 @@ func (p *Promtail) Run() error {
 	p.mtx.Lock()
 	// if we stopped promtail before the server even started we can return without starting.
 	if p.stopped {
+		p.mtx.Unlock()
 		return nil
 	}
 	p.mtx.Unlock() // unlock before blocking

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -1,11 +1,12 @@
 package promtail
 
 import (
+	"sync"
+
 	"github.com/cortexproject/cortex/pkg/util"
 
 	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/grafana/loki/pkg/promtail/config"
-	"github.com/grafana/loki/pkg/promtail/positions"
 	"github.com/grafana/loki/pkg/promtail/server"
 	"github.com/grafana/loki/pkg/promtail/targets"
 )
@@ -13,17 +14,15 @@ import (
 // Promtail is the root struct for Promtail...
 type Promtail struct {
 	client         client.Client
-	positions      *positions.Positions
 	targetManagers *targets.TargetManagers
 	server         *server.Server
+
+	stopped bool
+	mtx     sync.Mutex
 }
 
 // New makes a new Promtail.
 func New(cfg config.Config) (*Promtail, error) {
-	positions, err := positions.New(util.Logger, cfg.PositionsConfig)
-	if err != nil {
-		return nil, err
-	}
 
 	if cfg.ClientConfig.URL.URL != nil {
 		// if a single client config is used we add it to the multiple client config for backward compatibility
@@ -36,11 +35,10 @@ func New(cfg config.Config) (*Promtail, error) {
 	}
 
 	promtail := &Promtail{
-		client:    client,
-		positions: positions,
+		client: client,
 	}
 
-	tms, err := targets.NewTargetManagers(promtail, util.Logger, positions, client, cfg.ScrapeConfig, &cfg.TargetConfig)
+	tms, err := targets.NewTargetManagers(promtail, util.Logger, cfg.PositionsConfig, client, cfg.ScrapeConfig, &cfg.TargetConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -55,17 +53,25 @@ func New(cfg config.Config) (*Promtail, error) {
 
 // Run the promtail; will block until a signal is received.
 func (p *Promtail) Run() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	// if we stopped promtail before the server even started we can return without starting.
+	if p.stopped {
+		return nil
+	}
 	return p.server.Run()
 }
 
 // Shutdown the promtail.
 func (p *Promtail) Shutdown() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.stopped = true
 	if p.server != nil {
 		p.server.Shutdown()
 	}
 	if p.targetManagers != nil {
 		p.targetManagers.Stop()
 	}
-	p.positions.Stop()
 	p.client.Stop()
 }

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -54,11 +54,11 @@ func New(cfg config.Config) (*Promtail, error) {
 // Run the promtail; will block until a signal is received.
 func (p *Promtail) Run() error {
 	p.mtx.Lock()
-	defer p.mtx.Unlock()
 	// if we stopped promtail before the server even started we can return without starting.
 	if p.stopped {
 		return nil
 	}
+	p.mtx.Unlock() // unlock before blocking
 	return p.server.Run()
 }
 

--- a/pkg/promtail/targets/manager.go
+++ b/pkg/promtail/targets/manager.go
@@ -23,6 +23,7 @@ type TargetManagers struct {
 
 // NewTargetManagers makes a new TargetManagers
 func NewTargetManagers(
+	app Shutdownable,
 	logger log.Logger,
 	positions *positions.Positions,
 	client api.EntryHandler,
@@ -34,8 +35,12 @@ func NewTargetManagers(
 	var journalScrapeConfigs []scrape.Config
 	var syslogScrapeConfigs []scrape.Config
 
-	if IsPipe() {
-		//todo add the pipe target
+	if isPipe() {
+		stdin, err := newStdinTargetManager(app, client, scrapeConfigs)
+		if err != nil {
+			return nil, err
+		}
+		targetManagers = append(targetManagers, stdin)
 		return &TargetManagers{targetManagers: targetManagers}, nil
 	}
 

--- a/pkg/promtail/targets/manager.go
+++ b/pkg/promtail/targets/manager.go
@@ -34,6 +34,11 @@ func NewTargetManagers(
 	var journalScrapeConfigs []scrape.Config
 	var syslogScrapeConfigs []scrape.Config
 
+	if IsPipe() {
+		//todo add the pipe target
+		return &TargetManagers{targetManagers: targetManagers}, nil
+	}
+
 	for _, cfg := range scrapeConfigs {
 		if cfg.HasServiceDiscoveryConfig() {
 			fileScrapeConfigs = append(fileScrapeConfigs, cfg)

--- a/pkg/promtail/targets/manager.go
+++ b/pkg/promtail/targets/manager.go
@@ -35,7 +35,7 @@ func NewTargetManagers(
 	var journalScrapeConfigs []scrape.Config
 	var syslogScrapeConfigs []scrape.Config
 
-	if isPipe() {
+	if isStdinPipe() {
 		stdin, err := newStdinTargetManager(app, client, scrapeConfigs)
 		if err != nil {
 			return nil, err

--- a/pkg/promtail/targets/stdin_target_manager.go
+++ b/pkg/promtail/targets/stdin_target_manager.go
@@ -119,7 +119,7 @@ func newReaderTarget(in io.Reader, client api.EntryHandler, cfg scrape.Config) (
 	if err != nil {
 		return nil, err
 	}
-	var lbs model.LabelSet
+	lbs := model.LabelSet{}
 	for _, static := range cfg.ServiceDiscoveryConfig.StaticConfigs {
 		if static != nil && static.Labels != nil {
 			lbs = lbs.Merge(static.Labels)

--- a/pkg/promtail/targets/stdin_target_manager.go
+++ b/pkg/promtail/targets/stdin_target_manager.go
@@ -39,8 +39,8 @@ var (
 		JobName: "stdin",
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
 			StaticConfigs: []*targetgroup.Group{
-				&targetgroup.Group{Labels: model.LabelSet{"job": "stdin"}},
-				&targetgroup.Group{Labels: model.LabelSet{"hostname": model.LabelValue(hostName)}},
+				{Labels: model.LabelSet{"job": "stdin"}},
+				{Labels: model.LabelSet{"hostname": model.LabelValue(hostName)}},
 			},
 		},
 	}

--- a/pkg/promtail/targets/stdin_target_manager.go
+++ b/pkg/promtail/targets/stdin_target_manager.go
@@ -1,0 +1,109 @@
+package targets
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/logentry/stages"
+	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// bufferSize is the size of the buffer
+// if a line is bigger than that it will be ignore
+const bufferSize = 8096
+
+func IsPipe() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		level.Warn(util.Logger).Log("err", err)
+		return false
+	}
+	m := info.Mode()
+	if m&os.ModeCharDevice != 0 || info.Size() <= 0 {
+		return false
+	}
+	return true
+}
+
+type readerTarget struct {
+	in  *bufio.Reader
+	out api.EntryHandler
+
+	logger log.Logger
+
+	cancel context.CancelFunc
+	ctx    context.Context
+}
+
+func newReaderTarget(in io.Reader, client api.EntryHandler, cfg scrape.Config) (*readerTarget, error) {
+	if cfg.HasServiceDiscoveryConfig() {
+		return nil, errors.New("reader target does not support service discovery")
+	}
+	pipeline, err := stages.NewPipeline(log.With(util.Logger, "component", "pipeline"), cfg.PipelineStages, &cfg.JobName, prometheus.DefaultRegisterer)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t := &readerTarget{
+		in:     bufio.NewReaderSize(in, bufferSize),
+		out:    pipeline.Wrap(client),
+		cancel: cancel,
+		ctx:    ctx,
+		logger: log.With(util.Logger, "component", "reader"),
+	}
+	go t.process()
+
+	return t, nil
+}
+
+func (t *readerTarget) process() {
+	defer t.cancel()
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		default:
+			line, err := t.in.ReadString('\n')
+			if err != nil && err != io.EOF {
+				level.Warn(t.logger).Log("msg", "error reading buffer", "err", err)
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				if err == io.EOF {
+					return
+				}
+				continue
+			}
+			if err := t.out.Handle(nil, time.Now(), line); err != nil {
+				level.Error(t.logger).Log("msg", "error sending line", "err", err)
+			}
+			if err == io.EOF {
+				return
+			}
+		}
+	}
+}
+
+func (t *readerTarget) Ready() bool {
+	select {
+	case <-t.ctx.Done():
+		return false
+	default:
+		return true
+	}
+}
+func (t *readerTarget) Stop()                              { t.cancel() }
+func (t *readerTarget) ActiveTargets() map[string][]Target { return nil }
+func (t *readerTarget) AllTargets() map[string][]Target    { return nil }

--- a/pkg/promtail/targets/stdin_target_manager.go
+++ b/pkg/promtail/targets/stdin_target_manager.go
@@ -18,8 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// bufferSize is the size of the buffer
-// if a line is bigger than that it will be ignore
+// bufferSize is the size of the buffered reader
 const bufferSize = 8096
 
 func IsPipe() bool {
@@ -61,12 +60,12 @@ func newReaderTarget(in io.Reader, client api.EntryHandler, cfg scrape.Config) (
 		ctx:    ctx,
 		logger: log.With(util.Logger, "component", "reader"),
 	}
-	go t.process()
+	go t.read()
 
 	return t, nil
 }
 
-func (t *readerTarget) process() {
+func (t *readerTarget) read() {
 	defer t.cancel()
 
 	for {

--- a/pkg/promtail/targets/stdin_target_manager_test.go
+++ b/pkg/promtail/targets/stdin_target_manager_test.go
@@ -141,7 +141,7 @@ func Test_StdinConfigs(t *testing.T) {
 	// should take the first config
 	require.Equal(t, scrape.DefaultScrapeConfig, getStdinConfig([]scrape.Config{
 		scrape.DefaultScrapeConfig,
-		scrape.Config{},
+		{},
 	}))
 	// or use the default if none if provided
 	require.Equal(t, defaultStdInCfg, getStdinConfig([]scrape.Config{}))

--- a/pkg/promtail/targets/stdin_target_manager_test.go
+++ b/pkg/promtail/targets/stdin_target_manager_test.go
@@ -61,6 +61,16 @@ func Test_newReaderTarget(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"default config",
+			bytes.NewReader([]byte("\nfoo\r\nbar")),
+			defaultStdInCfg,
+			[]line{
+				{model.LabelSet{"job": "stdin", "hostname": model.LabelValue(hostName)}, "foo"},
+				{model.LabelSet{"job": "stdin", "hostname": model.LabelValue(hostName)}, "bar"},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,7 +114,7 @@ func Test_Shutdown(t *testing.T) {
 	stdIn = newFakeStin("line")
 	appMock := &mockShutdownable{called: make(chan bool, 1)}
 	recorder := &clientRecorder{}
-	manager, err := newStdinTargetManager(appMock, recorder, []scrape.Config{})
+	manager, err := newStdinTargetManager(appMock, recorder, []scrape.Config{{}})
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 	called := <-appMock.called
@@ -137,6 +147,6 @@ func Test_isPipe(t *testing.T) {
 	fake.FileInfo = &mockFileInfo{}
 	stdIn = fake
 	require.Equal(t, true, isStdinPipe())
-	stdIn = os.Stdout
+	stdIn = os.Stdin
 	require.Equal(t, false, isStdinPipe())
 }

--- a/pkg/promtail/targets/stdin_target_manager_test.go
+++ b/pkg/promtail/targets/stdin_target_manager_test.go
@@ -1,0 +1,89 @@
+package targets
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/promtail/scrape"
+	"github.com/prometheus/common/model"
+	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/stretchr/testify/require"
+)
+
+type line struct {
+	labels model.LabelSet
+	entry  string
+}
+
+type clientRecorder struct {
+	recorded []line
+}
+
+func (c *clientRecorder) Handle(labels model.LabelSet, time time.Time, entry string) error {
+	c.recorded = append(c.recorded, line{labels: labels, entry: entry})
+	return nil
+}
+
+func Test_newReaderTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      io.Reader
+		cfg     scrape.Config
+		want    []line
+		wantErr bool
+	}{
+		{
+			"bad config",
+			bytes.NewReader([]byte("")),
+			scrape.Config{ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{
+				StaticConfigs: []*targetgroup.Group{},
+			}},
+			nil,
+			true,
+		},
+		{
+			"no newlines",
+			bytes.NewReader([]byte("bar")),
+			scrape.Config{},
+			[]line{
+				{nil, "bar"},
+			},
+			false,
+		},
+		{
+			"empty",
+			bytes.NewReader([]byte("")),
+			scrape.Config{},
+			nil,
+			false,
+		},
+		{
+			"newlines",
+			bytes.NewReader([]byte("\nfoo\r\nbar")),
+			scrape.Config{},
+			[]line{
+				{nil, "foo"},
+				{nil, "bar"},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &clientRecorder{}
+			got, err := newReaderTarget(tt.in, recorder, tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newReaderTarget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			<-got.ctx.Done()
+			require.Equal(t, tt.want, recorder.recorded)
+		})
+	}
+}


### PR DESCRIPTION
Based on @slim-bean idea, this implements pipe support for promtail. I think this is a great way to quickly test Loki and Promtail.

Example:
```
cat my.log |  promtail --client.url http://127.0.0.1:3100/loki/api/v1/push --client.external-labels=k1=v1,k2=v2
```

See the doc for more informations.

I'm thinking about following this PR with another one to support `--dry-run` in promtail to prints streams instead of sending to Loki.

