### PR TITLE
Convert second(Integer class) to nanosecond precision

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.8'
+  spec.version = '1.2.9'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -218,7 +218,13 @@ module Fluent
       end
 
       def to_nano(time)
-        time.to_i * (10**9) + time.nsec
+        # time is a Fluent::EventTime object, or an Integer which represents unix timestamp (seconds from Epoch)
+        # https://docs.fluentd.org/plugin-development/api-plugin-output#chunk-each-and-block
+        if time.is_a?(Fluent::EventTime)
+          time.to_i * (10**9) + time.nsec
+        else
+          time.to_i * (10**9)
+        end
       end
 
       def record_to_line(record)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

[The commits to convert second precision to nanosecond prevision](https://github.com/grafana/loki/pull/1363/commits/3ee3309007cdc4a6f83708cd858721526ba35296#diff-d8326ce3cc517867cfd0fd30850e45d7R218) should be considered not only `Fluent::EventTime` object but `Integer` object. Otherwise, this causes the following error.

```
td-agent.log:482992:2020-01-30 03:40:48 +0000 [warn]: #0 [forward_to_loki] got unrecoverable error in primary and no secondary error_class=NoMethodError error="undefined method `nsec' for 1580355636:Integer\nDid you mean?  inspect"
td-agent.log:482994:2020-01-30 03:40:48 +0000 [warn]: #0 [forward_to_loki] bad chunk is moved to /tmp/fluent/backup/worker0/forward_to_loki/59d53385f435fa0b70e60a0101e7091d.log
```

This is because `Integer` does not have `nsec` method

```
irb(main):001:0> 1.class
=> Integer
irb(main):002:0> 1.nsec
Traceback (most recent call last):
        4: from /Users/takayuki-watanabe/.rbenv/versions/2.6/bin/irb:23:in `<main>'
        3: from /Users/takayuki-watanabe/.rbenv/versions/2.6/bin/irb:23:in `load'
        2: from /Users/takayuki-watanabe/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/irb-1.2.0/exe/irb:11:in `<top (required)>'
        1: from (irb):2
NoMethodError (undefined method `nsec' for 1:Integer)
```


**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This PR should be merged after I add some specs but it will take time since the current specs are broken.  https://github.com/grafana/loki/issues/1645

**Checklist**

- [ ] Tests updated: Not yet

