### PR TITLE
pkg/promtail/positions: handle empty positions file

### DIFF
--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -206,6 +206,11 @@ func readPositionsFile(cfg Config, logger log.Logger) (map[string]string, error)
 		return nil, fmt.Errorf("invalid yaml positions file [%s]: %v", cleanfn, err)
 	}
 
+	// p.Positions will be nil if the file exists but is empty
+	if p.Positions == nil {
+		p.Positions = map[string]string{}
+	}
+
 	return p.Positions, nil
 }
 

--- a/pkg/promtail/positions/positions_test.go
+++ b/pkg/promtail/positions/positions_test.go
@@ -53,6 +53,26 @@ func TestReadPositionsOK(t *testing.T) {
 	require.Equal(t, "17623", pos["/tmp/random.log"])
 }
 
+func TestReadPositionsEmptyFile(t *testing.T) {
+	temp := tempFilename(t)
+	defer func() {
+		_ = os.Remove(temp)
+	}()
+
+	yaml := []byte(``)
+	err := ioutil.WriteFile(temp, yaml, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pos, err := readPositionsFile(Config{
+		PositionsFile: temp,
+	}, log.NewNopLogger())
+
+	require.NoError(t, err)
+	require.NotNil(t, pos)
+}
+
 func TestReadPositionsFromDir(t *testing.T) {
 	temp := tempFilename(t)
 	err := os.Mkdir(temp, 0644)


### PR DESCRIPTION
If the positions file is empty, unmarshaling it will lead to a nil map being created. This commit ensures that positions is always initialized to be non-nil.

Potentially handles #1659.
