### PR TITLE
Support custom prefix name in metrics stage

### DIFF
--- a/docs/clients/promtail/stages/metrics.md
+++ b/docs/clients/promtail/stages/metrics.md
@@ -26,6 +26,9 @@ type: Counter
 # Describes the metric.
 [description: <string>]
 
+# Defines custom prefix name for the metric. If undefined, default name "promtail_custom_" will be prefixed.
+[prefix: <string>]
+
 # Key from the extracted data map to use for the mtric,
 # defaulting to the metric's name if not present.
 [source: <string>]
@@ -55,6 +58,9 @@ type: Gauge
 # Describes the metric.
 [description: <string>]
 
+# Defines custom prefix name for the metric. If undefined, default name "promtail_custom_" will be prefixed.
+[prefix: <string>]
+
 # Key from the extracted data map to use for the mtric,
 # defaulting to the metric's name if not present.
 [source: <string>]
@@ -82,6 +88,9 @@ type: Histogram
 
 # Describes the metric.
 [description: <string>]
+
+# Defines custom prefix name for the metric. If undefined, default name "promtail_custom_" will be prefixed.
+[prefix: <string>]
 
 # Key from the extracted data map to use for the mtric,
 # defaulting to the metric's name if not present.
@@ -114,6 +123,7 @@ config:
     log_lines_total:
       type: Counter
       description: "total number of log lines"
+      prefix: my_promtail_custom_
       source: time
       config:
         action: inc

--- a/pkg/logentry/stages/metrics.go
+++ b/pkg/logentry/stages/metrics.go
@@ -18,8 +18,6 @@ import (
 	"github.com/grafana/loki/pkg/logentry/metric"
 )
 
-const customPrefix = "promtail_custom_"
-
 const (
 	MetricTypeCounter   = "counter"
 	MetricTypeGauge     = "gauge"
@@ -34,6 +32,7 @@ type MetricConfig struct {
 	MetricType  string      `mapstructure:"type"`
 	Description string      `mapstructure:"description"`
 	Source      *string     `mapstructure:"source"`
+	Prefix      string      `mapstructure:"prefix"`
 	Config      interface{} `mapstructure:"config"`
 }
 
@@ -77,6 +76,13 @@ func newMetricStage(logger log.Logger, config interface{}, registry prometheus.R
 	metrics := map[string]prometheus.Collector{}
 	for name, cfg := range *cfgs {
 		var collector prometheus.Collector
+
+		customPrefix := ""
+		if cfg.Prefix != "" {
+			customPrefix = cfg.Prefix
+		} else {
+			customPrefix = "promtail_custom_"
+		}
 
 		switch strings.ToLower(cfg.MetricType) {
 		case MetricTypeCounter:

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -24,6 +24,7 @@ pipeline_stages:
     loki_count:
       type: Counter
       description: uhhhhhhh
+      prefix: my_promtail_custom_
       source: app
       config:
         value: loki
@@ -65,9 +66,9 @@ var testMetricLogLine2 = `
 const expectedMetrics = `# HELP promtail_custom_bloki_count blerrrgh
 # TYPE promtail_custom_bloki_count gauge
 promtail_custom_bloki_count -1.0
-# HELP promtail_custom_loki_count uhhhhhhh
-# TYPE promtail_custom_loki_count counter
-promtail_custom_loki_count 1.0
+# HELP my_promtail_custom_loki_count uhhhhhhh
+# TYPE my_promtail_custom_loki_count counter
+my_promtail_custom_loki_count 1.0
 # HELP promtail_custom_payload_size_bytes grrrragh
 # TYPE promtail_custom_payload_size_bytes histogram
 promtail_custom_payload_size_bytes_bucket{le="10.0"} 1.0
@@ -262,7 +263,13 @@ func TestMetricStage_Process(t *testing.T) {
 
 func metricNames(cfg MetricsConfig) []string {
 	result := make([]string, 0, len(cfg))
-	for name := range cfg {
+	for name, config := range cfg {
+		customPrefix := ""
+		if config.Prefix != "" {
+			customPrefix = config.Prefix
+		} else {
+			customPrefix = "promtail_custom_"
+		}
 		result = append(result, customPrefix+name)
 	}
 	return result


### PR DESCRIPTION
**What this PR does / why we need it**:
Supports providing custom prefix name to metrics defined in `metrics_stage`

**Which issue(s) this PR fixes**:
Fixes #1583 

**Checklist**
- [x] Documentation added
- [x] Tests updated

