### PR TITLE
Update tanka.md so that promtail.yml is the correct format

### DIFF
--- a/docs/installation/tanka.md
+++ b/docs/installation/tanka.md
@@ -61,11 +61,11 @@ loki + promtail + gateway {
     
     promtail_config+: {
       clients: [{
-        scheme: 'http',
-        hostname: 'gateway.%(namespace)s.svc' % $._config,
-        username: 'loki',
-        password: 'password',
-        container_root_path: '/var/lib/docker',
+        scheme:: 'http',
+        hostname:: 'gateway.%(namespace)s.svc' % $._config,
+        username:: 'loki',
+        password:: 'password',
+        container_root_path:: '/var/lib/docker',
       }],
     },
 


### PR DESCRIPTION
Following https://github.com/grafana/loki/blob/master/docs/installation/tanka.md, I encountered the following error.
```
% kubectl logs promtail-pf4z7
Unable to parse config: /etc/promtail/promtail.yml: yaml: unmarshal errors:
  line 2: field container_root_path not found in type client.raw
  line 3: field hostname not found in type client.raw
  line 4: field password not found in type client.raw
  line 5: field scheme not found in type client.raw
  line 7: field username not found in type client.raw
```

The content of ```promtail.yml``` is the following.
```
% tk show environments/loki --dangerous-allow-redirect | grep -A8 'promtail.yml: |'
  promtail.yml: |
    clients:
    - container_root_path: /var/lib/docker
      hostname: gateway.loki.svc
      password: password
      scheme: http
      url: http://loki:password@gateway.loki.svc/loki/api/v1/push
      username: loki
    scrape_configs:
```

So, I use ```:: ``` so that each field doesn't appear in the JSON output.