### PR TITLE
promtail: metrics pipeline count all log lines

### DIFF
--- a/docs/clients/promtail/stages/metrics.md
+++ b/docs/clients/promtail/stages/metrics.md
@@ -29,11 +29,16 @@ type: Counter
 # Defines custom prefix name for the metric. If undefined, default name "promtail_custom_" will be prefixed.
 [prefix: <string>]
 
-# Key from the extracted data map to use for the mtric,
+# Key from the extracted data map to use for the metric,
 # defaulting to the metric's name if not present.
 [source: <string>]
 
 config:
+  # If present and true all log lines will be counted without
+  # attempting to match the source to the extract map.
+  # It is an error to specify `match_all: true` and also specify a `value`
+  [match_all: <bool>]
+  
   # Filters down source data and only changes the metric
   # if the targeted value exactly matches the provided string.
   # If not present, all data will match.

--- a/pkg/logentry/metric/counters.go
+++ b/pkg/logentry/metric/counters.go
@@ -13,13 +13,15 @@ const (
 	CounterInc = "inc"
 	CounterAdd = "add"
 
-	ErrCounterActionRequired = "counter action must be defined as either `inc` or `add`"
-	ErrCounterInvalidAction  = "action %s is not valid, action must be either `inc` or `add`"
+	ErrCounterActionRequired  = "counter action must be defined as either `inc` or `add`"
+	ErrCounterInvalidAction   = "action %s is not valid, action must be either `inc` or `add`"
+	ErrCounterInvalidMatchAll = "`match_all: true` cannot be combined with `value`, please remove `match_all` or `value`"
 )
 
 type CounterConfig struct {
-	Value  *string `mapstructure:"value"`
-	Action string  `mapstructure:"action"`
+	MatchAll *bool   `mapstructure:"match_all"`
+	Value    *string `mapstructure:"value"`
+	Action   string  `mapstructure:"action"`
 }
 
 func validateCounterConfig(config *CounterConfig) error {
@@ -29,6 +31,9 @@ func validateCounterConfig(config *CounterConfig) error {
 	config.Action = strings.ToLower(config.Action)
 	if config.Action != CounterInc && config.Action != CounterAdd {
 		return errors.Errorf(ErrCounterInvalidAction, config.Action)
+	}
+	if config.MatchAll != nil && *config.MatchAll && config.Value != nil {
+		return errors.Errorf(ErrCounterInvalidMatchAll)
 	}
 	return nil
 }

--- a/pkg/logentry/metric/counters_test.go
+++ b/pkg/logentry/metric/counters_test.go
@@ -1,0 +1,62 @@
+package metric
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	counterTestTrue  = true
+	counterTestFalse = false
+	counterTestVal   = "some val"
+)
+
+func Test_validateCounterConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config CounterConfig
+		err    error
+	}{
+		{"invalid action",
+			CounterConfig{
+				Action: "del",
+			},
+			errors.Errorf(ErrCounterInvalidAction, "del"),
+		},
+		{"invalid counter match all",
+			CounterConfig{
+				MatchAll: &counterTestTrue,
+				Value:    &counterTestVal,
+				Action:   "inc",
+			},
+			errors.New(ErrCounterInvalidMatchAll),
+		},
+		{"valid",
+			CounterConfig{
+				Value:  &counterTestVal,
+				Action: "inc",
+			},
+			nil,
+		},
+		{"valid match all is false",
+			CounterConfig{
+				MatchAll: &counterTestFalse,
+				Value:    &counterTestVal,
+				Action:   "inc",
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCounterConfig(&tt.config)
+			if ((err != nil) && (err.Error() != tt.err.Error())) || (err == nil && tt.err != nil) {
+				t.Errorf("Metrics stage validation error, expected error = %v, actual error = %v", tt.err, err)
+				return
+			}
+		})
+	}
+}

--- a/pkg/logentry/stages/metrics.go
+++ b/pkg/logentry/stages/metrics.go
@@ -123,6 +123,13 @@ type metricStage struct {
 // Process implements Stage
 func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
 	for name, collector := range m.metrics {
+		// There is a special case for counters where we count even if there is no match in the extracted map.
+		if c, ok := collector.(*metric.Counters); ok {
+			if c != nil && c.Cfg.MatchAll != nil && *c.Cfg.MatchAll {
+				m.recordCounter(name, c, labels, nil)
+				continue
+			}
+		}
 		if v, ok := extracted[*m.cfg[name].Source]; ok {
 			switch vec := collector.(type) {
 			case *metric.Counters:


### PR DESCRIPTION
It would be useful for the metrics stage to be able to count all log lines and output a metric for each combo of labels.

This adds a config option which enables this capability.


Signed-off-by: Edward Welch <edward.welch@grafana.com>