### PR TITLE
BugFix: Fix logcli --quiet parameter parsing issue

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -148,7 +148,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 			query.Start = mustParse(from, defaultStart)
 			query.End = mustParse(to, defaultEnd)
 		}
-
+		query.Quiet = *quiet
 		return nil
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix logcli `--quiet` parameter parsing issue

**Which issue(s) this PR fixes**:
Fixes #1676 

