### PR TITLE
Ensure status codes are set correctly in the frontend.

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -47,11 +47,11 @@ func (r *LokiRequest) WithStartEnd(s int64, e int64) queryrange.Request {
 
 func (codec) DecodeRequest(_ context.Context, r *http.Request) (queryrange.Request, error) {
 	if err := r.ParseForm(); err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 	req, err := loghttp.ParseRangeQuery(r)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 	return &LokiRequest{
 		Query:     req.Query,
@@ -117,14 +117,11 @@ func (codec) DecodeResponse(ctx context.Context, r *http.Response, req queryrang
 	if err := json.Unmarshal(buf, &resp); err != nil {
 		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
 	}
-	if resp.Status != loghttp.QueryStatusSuccess {
-		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error executing request: %v", resp.Status)
-	}
 	switch string(resp.Data.ResultType) {
 	case loghttp.ResultTypeMatrix:
 		return &LokiPromResponse{
 			Response: &queryrange.PrometheusResponse{
-				Status: loghttp.QueryStatusSuccess,
+				Status: resp.Status,
 				Data: queryrange.PrometheusData{
 					ResultType: loghttp.ResultTypeMatrix,
 					Result:     toProto(resp.Data.Result.(loghttp.Matrix)),
@@ -134,7 +131,7 @@ func (codec) DecodeResponse(ctx context.Context, r *http.Response, req queryrang
 		}, nil
 	case loghttp.ResultTypeStream:
 		return &LokiResponse{
-			Status:     loghttp.QueryStatusSuccess,
+			Status:     resp.Status,
 			Direction:  req.(*LokiRequest).Direction,
 			Limit:      req.(*LokiRequest).Limit,
 			Version:    uint32(loghttp.GetVersion(req.(*LokiRequest).Path)),

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -2,12 +2,14 @@ package queryrange
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 )
 
@@ -135,7 +137,7 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrange.Request) (queryra
 
 	userid, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
 	interval := h.limits.QuerySplitDuration(userid)
@@ -169,7 +171,6 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrange.Request) (queryra
 	if err != nil {
 		return nil, err
 	}
-
 	return h.merger.MergeResponse(resps...)
 }
 


### PR DESCRIPTION
Previously we had cases where 400 would end up as 500.

We should use `httpgrpc.Errorf` when possible.


