### PR TITLE
Loki stack helm chart can deploy datasources without Grafana

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.31.1
+version: 0.31.2
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/templates/datasources.yaml
+++ b/production/helm/loki-stack/templates/datasources.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.grafana.enabled .Values.grafana.sidecar.datasources.enabled }}
+{{- if .Values.grafana.sidecar.datasources.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Enables loki stack helm chart to install datasources in Grafana even if Grafana is not installed by this chart (but for example with `helm-operator` chart).

**Which issue(s) this PR fixes**:
Fixes #1624 

**Special notes for your reviewer**:
It will introduce a small breaking change as by default Grafana is disabled, and sidecar is enabled. With default configuration (`helm upgrade --install loki loki/loki-stack`), before the datasources are not installed, but after these changes they will be.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

