### PR TITLE
Add headers for WebSocket

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -43,7 +43,6 @@
             listen               80;
             auth_basic           “Prometheus”;
             auth_basic_user_file /etc/nginx/secrets/.htpasswd;
-            proxy_set_header     X-Scope-OrgID 1;
 
             location = /api/prom/push {
               proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;
@@ -51,7 +50,6 @@
 
             location = /api/prom/tail {
               proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
-              proxy_set_header X-Scope-OrgID 1;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }
@@ -66,7 +64,6 @@
 
             location = /loki/api/v1/tail {
               proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
-              proxy_set_header X-Scope-OrgID 1;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -46,19 +46,33 @@
             proxy_set_header     X-Scope-OrgID 1;
 
             location = /api/prom/push {
-              proxy_pass      http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_set_header X-Scope-OrgID 1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
             }
 
             location ~ /api/prom/.* {
-              proxy_pass      http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
             }
 
             location = /loki/api/v1/push {
-              proxy_pass      http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+            }
+
+            location = /loki/api/v1/tail {
+              proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_set_header X-Scope-OrgID 1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
             }
 
             location ~ /loki/api/.* {
-              proxy_pass      http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
             }
           }
         }

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -43,6 +43,7 @@
             listen               80;
             auth_basic           “Prometheus”;
             auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+            proxy_set_header     X-Scope-OrgID 1;
 
             location = /api/prom/push {
               proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;


### PR DESCRIPTION
When Loki Canary connects to a [gateway](https://github.com/grafana/loki/blob/master/production/ksonnet/loki/gateway.libsonnet ), the following error occurred.
```
failed to connect to ws://xxxx/api/prom/tail?query=%7Bstream%3D%22stdout%22%2Cname%3D%22loki-canary%22%7D with err websocket: bad handshake
```

Loki Canary opens a WebSocket connection to Loki, so the gateway needs to send a request including the ```Upgrade``` and ```Connection``` headers.
http://nginx.org/en/docs/http/websocket.html

And, since ```/loki/api/v1/tail``` and ```/api/prom/tail``` are handled in ```Querier``` module instead of ```QueryFrontend``` module, the gateway needs to send a request to ```Querier```.