### PR TITLE
Break out of the loop when an interrupt signal is received.

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -76,6 +76,7 @@ func main() {
 			w.Stop()
 			r.Stop()
 			c.Stop()
+			return
 		case <-terminate:
 			_, _ = fmt.Fprintf(os.Stderr, "shutting down\n")
 			w.Stop()


### PR DESCRIPTION
Loki Canary does not terminate when Ctrl+C is pressed.