### PR TITLE
fix promtail/templates/NOTES.txt to show correctly port-forward command

### DIFF
--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.18.1
+version: 0.18.2
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/NOTES.txt
+++ b/production/helm/promtail/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Verify the application is working by running these commands:
-  kubectl --namespace {{ .Release.Namespace }} port-forward daemonset/{{ include "promtail.fullname" . }} {{ .Values.port }}
-  curl http://127.0.0.1:{{ .Values.port }}/metrics
+  kubectl --namespace {{ .Release.Namespace }} port-forward daemonset/{{ include "promtail.fullname" . }} {{ .Values.config.server.http_listen_port }}
+  curl http://127.0.0.1:{{ .Values.config.server.http_listen_port }}/metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When loki/promtail is installed, it shows invalid notes.
2 commands (kubectl, curl) are missing a port.

**Which issue(s) this PR fixes**:
Fixes #1696

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

