### PR TITLE
Increased production distributors memory request and limit

### DIFF
--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -15,8 +15,8 @@
     container.mixin.readinessProbe.httpGet.withPort(80) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
-    $.util.resourcesRequests('500m', '100Mi') +
-    $.util.resourcesLimits('1', '200Mi'),
+    $.util.resourcesRequests('500m', '500Mi') +
+    $.util.resourcesLimits('1', '1Gi'),
 
   local deployment = $.apps.v1.deployment,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today we found out the current distributors memory request and limit is pretty low and distributors can easily be `OOMKilled`. In this PR I'm proposing to raise the default vaules.

_I've also checked the helm chart but, to my understanding, we're not setting CPU and memory resources for Loki (I assume they're set by the final user). Please let me know if I misunderstood it._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

