### PR TITLE
api support for scalars

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -65,6 +65,8 @@ func (q *Query) DoQuery(c *client.Client, out output.LogOutput, statistics bool)
 	case logql.ValueTypeStreams:
 		streams := resp.Data.Result.(loghttp.Streams)
 		q.printStream(streams, out)
+	case promql.ValueTypeScalar:
+		q.printScalar(resp.Data.Result.(loghttp.Scalar))
 	case promql.ValueTypeMatrix:
 		matrix := resp.Data.Result.(loghttp.Matrix)
 		q.printMatrix(matrix)
@@ -165,6 +167,16 @@ func (q *Query) printVector(vector loghttp.Vector) {
 
 	if err != nil {
 		log.Fatalf("Error marshalling vector: %v", err)
+	}
+
+	fmt.Print(string(bytes))
+}
+
+func (q *Query) printScalar(scalar loghttp.Scalar) {
+	bytes, err := json.MarshalIndent(scalar, "", "  ")
+
+	if err != nil {
+		log.Fatalf("Error marshalling scalar: %v", err)
 	}
 
 	fmt.Print(string(bytes))

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -182,6 +182,19 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 // Scalar is a single timestamp/float with no labels
 type Scalar model.Scalar
 
+func (s Scalar) MarshalJSON() ([]byte, error) {
+	return model.Scalar(s).MarshalJSON()
+}
+
+func (s *Scalar) UnmarshalJSON(b []byte) error {
+	var v model.Scalar
+	if err := v.UnmarshalJSON(b); err != nil {
+		return err
+	}
+	*s = Scalar(v)
+	return nil
+}
+
 // Vector is a slice of Samples
 type Vector []model.Sample
 

--- a/pkg/logql/marshal/query.go
+++ b/pkg/logql/marshal/query.go
@@ -29,6 +29,16 @@ func NewResultValue(v promql.Value) (loghttp.ResultValue, error) {
 		if err != nil {
 			return nil, err
 		}
+
+	case loghttp.ResultTypeScalar:
+		scalar, ok := v.(promql.Scalar)
+
+		if !ok {
+			return nil, fmt.Errorf("unexpected type %T for scalar", scalar)
+		}
+
+		value = NewScalar(scalar)
+
 	case loghttp.ResultTypeVector:
 		vector, ok := v.(promql.Vector)
 
@@ -93,6 +103,14 @@ func NewEntry(e logproto.Entry) loghttp.Entry {
 		Timestamp: e.Timestamp,
 		Line:      e.Line,
 	}
+}
+
+func NewScalar(s promql.Scalar) loghttp.Scalar {
+	return loghttp.Scalar{
+		Timestamp: model.Time(s.T),
+		Value:     model.SampleValue(s.V),
+	}
+
 }
 
 // NewVector constructs a Vector from a promql.Vector


### PR DESCRIPTION
## What
- logcli prints scalars
- loghttp types defer to prometheus model types for json marshaling

### loki response for instant query `1+1`:

```json
{
  "status": "success",
  "data": {
    "resultType": "scalar",
    "result": [
      1581712272.018,
      "2"
    ],
    "stats": {
      "summary": {
        "bytesProcessedPerSeconds": 0,
        "linesProcessedPerSeconds": 0,
        "totalBytesProcessed": 0,
        "totalLinesProcessed": 0,
        "execTime": 2.7652e-05
      },
      "store": {
        "totalChunksRef": 0,
        "totalChunksDownloaded": 0,
        "chunksDownloadTime": 0,
        "headChunkBytes": 0,
        "headChunkLines": 0,
        "decompressedBytes": 0,
        "decompressedLines": 0,
        "compressedBytes": 0,
        "totalDuplicates": 0
      },
      "ingester": {
        "totalReached": 0,
        "totalChunksMatched": 0,
        "totalBatches": 0,
        "totalLinesSent": 0,
        "headChunkBytes": 0,
        "headChunkLines": 0,
        "decompressedBytes": 0,
        "decompressedLines": 0,
        "compressedBytes": 0,
        "totalDuplicates": 0
      }
    }
  }
}
```

### Prometheus response for the same

```json
{
  "status": "success",
  "data": {
    "resultType": "scalar",
    "result": [
      1581711059,
      "2"
    ]
  }
}
```