### PR TITLE
Non-root user docker image for Loki.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -8,6 +8,9 @@ RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates
+RUN addgroup -g 1000 -S loki && \
+    adduser -u 1000 -S loki -G loki
+USER loki
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 EXPOSE 80


### PR DESCRIPTION
For best pratices. Fixes #1244 since the other CVE seems to be clear out now.

However promtail has couple of high and critical CVE  when scanning using trivy but none
of them seems actionable as debian doesn't seems to want to fix them or include upstream fixes.