### PR TITLE
proof of concept: use UPX to compress binaries in docker images

### DIFF
--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.13 as build
+RUN apt-get update && apt-get install -qy upx && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki-canary
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki-canary && \
+    upx /src/loki/cmd/loki-canary/loki-canary
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.13 as build
+RUN apt-get update && apt-get install -qy upx && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki && \
+    upx /src/loki/cmd/loki/loki
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates

--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:1.13 as build
+RUN apt-get update && apt-get install -qy upx && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
 RUN apt-get update && apt-get install -qy libsystemd-dev
-RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false promtail
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false promtail && \
+    upx /src/loki/cmd/promtail/promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:stretch-slim


### PR DESCRIPTION
This draft PR acts as a proof of concept to demonstrate that we can get some quick wins for reducing the Docker image sizes. 

Before and after comparisons of the final image size:

- `grafana/loki: 47.6MB -> 19.4MB` 
- `grafana/promtail: 135MB -> 92.1MB`
- `grafana/loki-canary: 19.6MB -> 11MB` 

If consensus can be reached about this being a good idea, a better approach to this PR would be to handle this in the Makefile and have the Dockerfiles use the build image with `upx` added in; that way both the containers and the published release binaries would be compressed.