### PR TITLE
Fix nil pointer dereference in ingester client

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -55,6 +55,7 @@ func New(cfg Config, addr string) (grpc_health_v1.HealthClient, error) {
 		PusherClient:   logproto.NewPusherClient(conn),
 		QuerierClient:  logproto.NewQuerierClient(conn),
 		IngesterClient: logproto.NewIngesterClient(conn),
+		HealthClient:   grpc_health_v1.NewHealthClient(conn),
 		Closer:         conn,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix nil pointer dereference in ingester client.
`HealthClient` was missing in ingester client setup which caused nil pointer dereference here in `client` https://github.com/cortexproject/cortex/blob/master/pkg/ingester/client/pool.go#L208

**Which issue(s) this PR fixes**:
Fixes #1679 

