### PR TITLE
[promtail helm chart] - Expand promtail syslog svc to support values

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.32.0
+version: 0.32.1
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.19.1
+version: 0.19.2
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/service-syslog.yaml
+++ b/production/helm/promtail/templates/service-syslog.yaml
@@ -15,13 +15,10 @@ metadata:
   annotations:
     {{- toYaml .Values.syslogService.annotations | nindent 4 }}
 spec:
-{{- if (or (eq .Values.syslogService.type "ClusterIP") (empty .Values.syslogService.type)) }}
-  type: ClusterIP
+  type: {{ .Values.syslogService.type }}
   {{- if .Values.syslogService.clusterIP }}
   clusterIP: {{ .Values.syslogService.clusterIP }}
   {{end}}
-{{- else if eq .Values.syslogService.type "LoadBalancer" }}
-  type: {{ .Values.syslogService.type }}
   {{- if .Values.syslogService.loadBalancerIP }}
   loadBalancerIP: {{ .Values.syslogService.loadBalancerIP }}
   {{- end }}
@@ -29,9 +26,6 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml .Values.syslogService.loadBalancerSourceRanges | indent 4 }}
   {{- end -}}
-{{- else }}
-  type: {{ .Values.syslogService.type }}
-{{- end }}
   {{- if .Values.syslogService.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.syslogService.externalTrafficPolicy }}
   {{- end }}

--- a/production/helm/promtail/templates/service-syslog.yaml
+++ b/production/helm/promtail/templates/service-syslog.yaml
@@ -15,16 +15,26 @@ metadata:
   annotations:
     {{- toYaml .Values.syslogService.annotations | nindent 4 }}
 spec:
-  type: {{ .Values.syslogService.type }}
-{{- if (and (eq .Values.syslogService.type "ClusterIP") (not (empty .Values.syslogService.clusterIP))) }}
+{{- if (or (eq .Values.syslogService.type "ClusterIP") (empty .Values.syslogService.type)) }}
+  type: ClusterIP
+  {{- if .Values.syslogService.clusterIP }}
   clusterIP: {{ .Values.syslogService.clusterIP }}
-{{- end }}
-{{- if .Values.syslogService.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.syslogService.loadBalancerSourceRanges }}
-    - {{ $cidr }}
+  {{end}}
+{{- else if eq .Values.syslogService.type "LoadBalancer" }}
+  type: {{ .Values.syslogService.type }}
+  {{- if .Values.syslogService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.syslogService.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.syslogService.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.syslogService.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.syslogService.type }}
 {{- end }}
+  {{- if .Values.syslogService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.syslogService.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.syslogService.port }}
       protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:

The promtail helm chart syslog service configuration in the values.yaml
supports elements not accounted-for in the actual syslog service
template.

This change modifies the promtail syslog service to account for those
missing elements.

**Special notes for your reviewer**:

This fixes items missed in #1617 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

