### PR TITLE
This logs queries with latency tag when  recording stats.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/stretchr/testify v1.4.0
 	github.com/tonistiigi/fifo v0.0.0-20190226154929-a9fb20d87448
+	github.com/uber/jaeger-client-go v2.20.1+incompatible
 	github.com/ugorji/go v1.1.7 // indirect
 	github.com/weaveworks/common v0.0.0-20200201141823-27e183090ab1
 	go.etcd.io/etcd v0.0.0-20190815204525-8f85f0dc2607 // indirect

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -133,7 +133,7 @@ func (q *query) Exec(ctx context.Context) (Result, error) {
 			status = "400"
 		}
 	}
-	RecordMetrics(status, q.String(), rangeType, statResult)
+	RecordMetrics(ctx, q, status, statResult)
 
 	return Result{
 		Data:       data,
@@ -181,7 +181,7 @@ func (ng *engine) exec(ctx context.Context, q *query) (promql.Value, error) {
 	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
 	defer cancel()
 
-	qs := q.String()
+	qs := q.Query()
 
 	expr, err := ParseExpr(qs)
 	if err != nil {

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -24,7 +24,7 @@ var (
 
 // Params details the parameters associated with a loki request
 type Params interface {
-	String() string
+	Query() string
 	Start() time.Time
 	End() time.Time
 	Step() time.Duration
@@ -42,7 +42,7 @@ type LiteralParams struct {
 }
 
 // String impls Params
-func (p LiteralParams) String() string { return p.qs }
+func (p LiteralParams) Query() string { return p.qs }
 
 // Start impls Params
 func (p LiteralParams) Start() time.Time { return p.start }

--- a/pkg/logql/stats/stats.pb.go
+++ b/pkg/logql/stats/stats.pb.go
@@ -95,7 +95,7 @@ type Summary struct {
 	TotalBytesProcessed int64 `protobuf:"varint,3,opt,name=totalBytesProcessed,proto3" json:"totalBytesProcessed"`
 	// Total lines processed.
 	TotalLinesProcessed int64 `protobuf:"varint,4,opt,name=totalLinesProcessed,proto3" json:"totalLinesProcessed"`
-	// Execution time in nanoseconds.
+	// Execution time in seconds.
 	ExecTime float64 `protobuf:"fixed64,5,opt,name=execTime,proto3" json:"execTime"`
 }
 

--- a/pkg/logql/stats/stats.proto
+++ b/pkg/logql/stats/stats.proto
@@ -26,7 +26,7 @@ message Summary {
   int64 totalBytesProcessed = 3 [(gogoproto.jsontag) = "totalBytesProcessed"];
   // Total lines processed.
   int64 totalLinesProcessed = 4 [(gogoproto.jsontag) = "totalLinesProcessed"];
-  // Execution time in nanoseconds.
+  // Execution time in seconds.
   double execTime = 5 [(gogoproto.jsontag) = "execTime"];
 }
 

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -379,8 +379,8 @@ func paramsFromRequest(req queryrange.Request) *paramsWrapper {
 	}
 }
 
-func (p paramsWrapper) String() string {
-	return p.Query
+func (p paramsWrapper) Query() string {
+	return p.LokiRequest.Query
 }
 func (p paramsWrapper) Start() time.Time {
 	return p.StartTs


### PR DESCRIPTION
Useful for building a dashboard of slow queries.

I plan in the long term to add a dashboard using this in our mixin.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>