### PR TITLE
Add /ready endpoint to table-manager

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -305,7 +305,21 @@ func (t *Loki) initTableManager() error {
 	if err != nil {
 		return err
 	}
-	return services.StartAndAwaitRunning(context.Background(), t.tableManager)
+
+	if err := services.StartAndAwaitRunning(context.Background(), t.tableManager); err != nil {
+		return err
+	}
+
+	// Once the execution reaches this point, synchronous table initialization has been
+	// done and the table-manager is ready to serve, so we're just returning a 200.
+	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("Ready")); err != nil {
+			level.Error(util.Logger).Log("msg", "error writing success message", "error", err)
+		}
+	}))
+
+	return nil
 }
 
 func (t *Loki) stopTableManager() error {

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -10,6 +10,10 @@
     container.new('table-manager', $._images.tableManager) +
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.table_manager_args)) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.withInitialDelaySeconds(15) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('100m', '100Mi') +
     $.util.resourcesLimits('200m', '200Mi'),
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `/ready` endpoint to table-manager and query-frontend

**Which issue(s) this PR fixes**:
Fixes #1722 

