### PR TITLE
docs: observability.md: clarify lines vs. entries

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -15,12 +15,12 @@ All components of Loki expose the following metrics:
 
 The Loki Distributors expose the following metrics:
 
-| Metric Name                                       | Metric Type | Description                                                 |
-| ------------------------------------------------- | ----------- | ----------------------------------------------------------- |
-| `loki_distributor_ingester_appends_total`         | Counter     | The total number of batch appends sent to ingesters.        |
-| `loki_distributor_ingester_append_failures_total` | Counter     | The total number of failed batch appends sent to ingesters. |
-| `loki_distributor_bytes_received_total`           | Counter     | The total number of uncompressed bytes received per tenant. |
-| `loki_distributor_lines_received_total`           | Counter     | The total number of lines received per tenant.              |
+| Metric Name                                       | Metric Type | Description                                                                                                                          |
+| ------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `loki_distributor_ingester_appends_total`         | Counter     | The total number of batch appends sent to ingesters.                                                                                 |
+| `loki_distributor_ingester_append_failures_total` | Counter     | The total number of failed batch appends sent to ingesters.                                                                          |
+| `loki_distributor_bytes_received_total`           | Counter     | The total number of uncompressed bytes received per tenant.                                                                          |
+| `loki_distributor_lines_received_total`           | Counter     | The total number of log _entries_ received per tenant (not necessarily of _lines_, as an entry can have more than one line of text). |
 
 The Loki Ingesters expose the following metrics:
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -24,26 +24,26 @@ The Loki Distributors expose the following metrics:
 
 The Loki Ingesters expose the following metrics:
 
-| Metric Name                                  | Metric Type | Description                                                                                 |
-| -------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------- |
-| `cortex_ingester_flush_queue_length`         | Gauge       | The total number of series pending in the flush queue.                                      |
-| `cortex_chunk_store_index_entries_per_chunk` | Histogram   | Number of index entries written to storage per chunk.                                       |
-| `loki_ingester_memory_chunks`                | Gauge       | The total number of chunks in memory.                                                       |
-| `loki_ingester_memory_streams`               | Gauge       | The total number of streams in memory.                                                      |
-| `loki_ingester_chunk_age_seconds`            | Histogram   | Distribution of chunk ages when flushed.                                                    |
-| `loki_ingester_chunk_encode_time_seconds`    | Histogram   | Distribution of chunk encode times.                                                         |
-| `loki_ingester_chunk_entries`                | Histogram   | Distribution of lines per-chunk when flushed.                                               |
-| `loki_ingester_chunk_size_bytes`             | Histogram   | Distribution of chunk sizes when flushed.                                                   |
-| `loki_ingester_chunk_utilization`            | Histogram   | Distribution of chunk utilization (filled uncompressed bytes vs maximum uncompressed bytes) when flushed.                                             |
-| `loki_ingester_chunk_compression_ratio`      | Histogram   | Distribution of chunk compression ratio when flushed.                                       |
-| `loki_ingester_chunk_stored_bytes_total`     | Counter     | Total bytes stored in chunks per tenant.                                                    |
-| `loki_ingester_chunks_created_total`         | Counter     | The total number of chunks created in the ingester.                                         |
-| `loki_ingester_chunks_stored_total`          | Counter     | Total stored chunks per tenant.                                                             |
-| `loki_ingester_received_chunks`              | Counter     | The total number of chunks sent by this ingester whilst joining during the handoff process. |
-| `loki_ingester_samples_per_chunk`            | Histogram   | The number of samples in a chunk.                                                           |
-| `loki_ingester_sent_chunks`                  | Counter     | The total number of chunks sent by this ingester whilst leaving during the handoff process. |
-| `loki_ingester_streams_created_total`        | Counter     | The total number of streams created per tenant.                                             |
-| `loki_ingester_streams_removed_total`        | Counter     | The total number of streams removed per tenant.                                             |
+| Metric Name                                  | Metric Type | Description                                                                                               |
+| -------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------- |
+| `cortex_ingester_flush_queue_length`         | Gauge       | The total number of series pending in the flush queue.                                                    |
+| `cortex_chunk_store_index_entries_per_chunk` | Histogram   | Number of index entries written to storage per chunk.                                                     |
+| `loki_ingester_memory_chunks`                | Gauge       | The total number of chunks in memory.                                                                     |
+| `loki_ingester_memory_streams`               | Gauge       | The total number of streams in memory.                                                                    |
+| `loki_ingester_chunk_age_seconds`            | Histogram   | Distribution of chunk ages when flushed.                                                                  |
+| `loki_ingester_chunk_encode_time_seconds`    | Histogram   | Distribution of chunk encode times.                                                                       |
+| `loki_ingester_chunk_entries`                | Histogram   | Distribution of lines per-chunk when flushed.                                                             |
+| `loki_ingester_chunk_size_bytes`             | Histogram   | Distribution of chunk sizes when flushed.                                                                 |
+| `loki_ingester_chunk_utilization`            | Histogram   | Distribution of chunk utilization (filled uncompressed bytes vs maximum uncompressed bytes) when flushed. |
+| `loki_ingester_chunk_compression_ratio`      | Histogram   | Distribution of chunk compression ratio when flushed.                                                     |
+| `loki_ingester_chunk_stored_bytes_total`     | Counter     | Total bytes stored in chunks per tenant.                                                                  |
+| `loki_ingester_chunks_created_total`         | Counter     | The total number of chunks created in the ingester.                                                       |
+| `loki_ingester_chunks_stored_total`          | Counter     | Total stored chunks per tenant.                                                                           |
+| `loki_ingester_received_chunks`              | Counter     | The total number of chunks sent by this ingester whilst joining during the handoff process.               |
+| `loki_ingester_samples_per_chunk`            | Histogram   | The number of samples in a chunk.                                                                         |
+| `loki_ingester_sent_chunks`                  | Counter     | The total number of chunks sent by this ingester whilst leaving during the handoff process.               |
+| `loki_ingester_streams_created_total`        | Counter     | The total number of streams created per tenant.                                                           |
+| `loki_ingester_streams_removed_total`        | Counter     | The total number of streams removed per tenant.                                                           |
 
 Promtail exposes these metrics:
 
@@ -87,5 +87,3 @@ comprehensive package for monitoring Loki in production.
 
 For more information about mixins, take a look at the docs for the
 [monitoring-mixins project](https://github.com/monitoring-mixins/docs).
-
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

I was reading https://github.com/grafana/loki/blob/master/docs/operations/observability.md#observing-loki (much appreciated, thank you!) and came across the metric `loki_distributor_lines_received_total`. I know a little bit about the anatomy of the underlying protobuf structures where a log _entry_ can have more or less arbitrary text, including newline-separated _lines_ of text.

I wondered: does this metric count _entries_ or _lines_?

The [code](https://github.com/grafana/loki/blob/cdd60cdb79acd0d2283b22e24c1175b62860d5f7/pkg/distributor/distributor.go#L185) tells us that it is actually counting entries, not lines.

I understand that changing the metric name is not low-friction, but very much thought it's worth clarifying that in the docs so that we don't confuse readers that pay attention to this level of detail.

What do you think?

**Which issue(s) this PR fixes**:
no issue number

**Special notes for your reviewer**:
I have used VSCode to edit the Markdown here, and it is auto-formatting tables in quite a meaningful way. I'd understand though if that's not wanted. Let me know.


**Checklist**
- [ ] Documentation added
- [ ] Tests updated

