### PR TITLE
Fix 32-bit Promtail ARM docker builds from Drone

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -160,11 +160,11 @@ local manifest(apps) = pipeline('manifest') {
     //
     // This is really really hacky and a better more permanent solution will be to use
     // buildkit.
-    if arch != 'arm' then {}
-    else {
+    if arch == 'arm'
+    then {
       steps: [
         step + (
-          if step.settings.dockerfile == "cmd/promtail/Dockerfile"
+          if std.objectHas(step, 'settings') && step.settings.dockerfile == 'cmd/promtail/Dockerfile'
           then {
             settings+: {
               dockerfile: 'cmd/promtail/Dockerfile.arm32',
@@ -175,6 +175,7 @@ local manifest(apps) = pipeline('manifest') {
         for step in super.steps
       ],
     }
+    else {}
   )
   for arch in archs
 ] + [

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -164,7 +164,7 @@ local manifest(apps) = pipeline('manifest') {
     else {
       steps: [
         step + (
-          if step.name == 'build-promtail-image' || step.name == 'publish-promtail-image'
+          if step.settings.dockerfile == "cmd/promtail/Dockerfile"
           then {
             settings+: {
               dockerfile: 'cmd/promtail/Dockerfile.arm32',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -368,7 +368,7 @@ steps:
   settings:
     build_args:
     - TOUCH_PROTOS=1
-    dockerfile: cmd/promtail/Dockerfile
+    dockerfile: cmd/promtail/Dockerfile.arm32
     dry_run: true
     password:
       from_secret: docker_password
@@ -424,7 +424,7 @@ steps:
   settings:
     build_args:
     - TOUCH_PROTOS=1
-    dockerfile: cmd/promtail/Dockerfile
+    dockerfile: cmd/promtail/Dockerfile.arm32
     password:
       from_secret: docker_password
     repo: grafana/promtail

--- a/cmd/promtail/Dockerfile.arm32
+++ b/cmd/promtail/Dockerfile.arm32
@@ -1,0 +1,30 @@
+FROM golang:1.13 as build
+# TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
+# This is helpful when file system timestamps can't be trusted with make
+ARG TOUCH_PROTOS
+COPY . /src/loki
+WORKDIR /src/loki
+RUN apt-get update && apt-get install -qy libsystemd-dev
+RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false promtail
+
+# Promtail requires debian as the base image to support systemd journal reading
+FROM debian:stretch-slim
+# tzdata required for the timestamp stage to work
+RUN apt-get update && \
+  apt-get install -qy \
+  tzdata ca-certificates libsystemd-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
+COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+
+# Drone CI builds arm32 images using armv8l rather than armv7l. Something in
+# our build process above causes ldconfig to be rerun and removes the armhf
+# library that debian:stretch-slim on ARM comes with. Symbolically linking to
+# ld-linux.so.3 fixes the problem and allows Promtail to start.
+#
+# This process isn't necessary when building on armv7l so we only do it if the
+# library was removed.
+RUN sh -c '[ ! -f /lib/ld-linux-armhf.so.3 ] && echo RE-LINKING LD-LINUX-ARMHF.SO.3 && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3'
+
+ENTRYPOINT ["/usr/bin/promtail"]


### PR DESCRIPTION
Drone's non-64 bit ARM builds run on armv8l rather than the armv7l on 32-bit Raspberry Pis. When the Docker image is built, the `apt-get` commands cause `ldconfig` to be rerun and removes armv7l-specific shared libraries, causing Promtail to not work on these platforms.

Note that this problem is only seen in Promtail because it needs to be built without static linking for scraping from the Journal to work. This issue was introduced by #1469, as Promtail was built with static linking prior to that PR. 

The workaround mentioned in #1575 (symbolically linking the existing shared library to the one with the expected name) is used by this PR as a _temporary_ solution to allow the next release to work on 32-bit ARM platforms. A more proper solution with Buildkit and a cross-compiler should be implemented in the future.

/cc @slim-bean 