### PR TITLE
Promtail: Ignore dropped entries in subsequent metric-stages in pipelines.

### DIFF
--- a/docs/clients/promtail/stages/match.md
+++ b/docs/clients/promtail/stages/match.md
@@ -17,7 +17,8 @@ match:
   [pipeline_name: <string>]
 
   # Determines what action is taken when the selector matches the log 
-  # line. Defaults to keep. When set to drop, entries will be dropped. 
+  # line. Defaults to keep. When set to drop, entries will be dropped
+  # and no later metrics will be recorded.
   # Stages must be not defined when dropping entries. 
   [action: <string> | default = "keep"]
 

--- a/pkg/logentry/stages/metrics.go
+++ b/pkg/logentry/stages/metrics.go
@@ -144,6 +144,9 @@ type metricStage struct {
 
 // Process implements Stage
 func (m *metricStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	if _, ok := labels[dropLabel]; ok {
+		return
+	}
 	for name, collector := range m.metrics {
 		// There is a special case for counters where we count even if there is no match in the extracted map.
 		if c, ok := collector.(*metric.Counters); ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR makes the `metric` stage in Promtail ignore dropped entries. 

This allows users to define a pipeline like this:
```yaml
pipeline_stages:
      - match:
          selector: '{app="promtail"} |= "thing we don't want to log"'
          action: drop
      - metrics:
          log_lines_total:
            type: Counter
            description: "total number of logged lines"
            config:
              match_all: true
              action: inc
```

In general this also fixes the issue were the above config today would generate an error message like this: 
```log
missmatch metrics: gathering metrics failed: "__drop__" is not a valid label name for metric "promtail_custom_log_lines_total"
```
**Which issue(s) this PR fixes**:
Doesn't fix a GH-Issue 😢 

**Special notes for your reviewer**:
I also have a branch `feature/metrics-on-dropped` that solves this issue by removing labels with the prefix `__` instead. But I do believe that this PR solves the problem in a more predictable way.

**Checklist**
- [x] Documentation added
- [x] Tests updated