### PR TITLE
build: tagged release docker images no longer start with 'v'

### DIFF
--- a/.drone/docker-manifest.tmpl
+++ b/.drone/docker-manifest.tmpl
@@ -1,4 +1,4 @@
-image: grafana/{{config.target}}:{{#if build.tag}}{{build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}
+image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}
 tags:
   - latest
   - master
@@ -8,16 +8,16 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: grafana/{{config.target}}:{{#if build.tag}}{{build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-amd64
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: grafana/{{config.target}}:{{#if build.tag}}{{build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm64
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm64
     platform:
       architecture: arm64
       os: linux
       variant: v8
-  - image: grafana/{{config.target}}:{{#if build.tag}}{{build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm
     platform:
       architecture: arm
       os: linux

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -113,7 +113,7 @@ local manifest(apps) = pipeline('manifest') {
   steps: std.foldl(
     function(acc, app) acc + [{
       name: 'manifest-' + app,
-      image: 'plugins/manifest:1.2.3',
+      image: 'plugins/manifest',
       settings: {
         // the target parameter is abused for the app's name,
         // as it is unused in spec mode. See docker-manifest.tmpl

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -504,7 +504,7 @@ platform:
 
 steps:
 - name: manifest-promtail
-  image: plugins/manifest:1.2.3
+  image: plugins/manifest
   settings:
     password:
       from_secret: docker_password
@@ -516,7 +516,7 @@ steps:
   - clone
 
 - name: manifest-loki
-  image: plugins/manifest:1.2.3
+  image: plugins/manifest
   settings:
     password:
       from_secret: docker_password
@@ -529,7 +529,7 @@ steps:
   - manifest-promtail
 
 - name: manifest-loki-canary
-  image: plugins/manifest:1.2.3
+  image: plugins/manifest
   settings:
     password:
       from_secret: docker_password

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -10,6 +10,12 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's#/#-#g')
 # We are forcing to 7 here, as we are doing for grafana/grafana as well.
 SHA=$(git rev-parse --short=7 HEAD | head -c7)
 
-# If this is a tag, use it,                      otherwise branch-hash
-TAG=$(git describe --exact-match 2> /dev/null || echo "${BRANCH}-${SHA}")
-echo ${TAG}${WIP}
+# If not a tag, use branch-hash else use tag
+TAG=$((git describe --exact-match 2> /dev/null || echo "") | sed 's/v//g')
+
+if [ -z "$TAG" ]
+then
+      echo ${BRANCH}-${SHA}${WIP}
+else
+      echo ${TAG}
+fi


### PR DESCRIPTION
Previously we used the repo tag `v1.3.0` as the docker image tag as well: `grafana/loki:v1.3.0`

This prevents some nice behaviors of docker such as `grafana/loki:1.3` to get patch fixes, etc.

This PR will change how tagged images are tagged, stripping the v prefix

This partially addresses #1401 

Signed-off-by: Edward Welch <edward.welch@grafana.com>