### PR TITLE
Increasing the threshold for a file lag and reducing the severity to warning

### DIFF
--- a/production/promtail-mixin/alerts.libsonnet
+++ b/production/promtail-mixin/alerts.libsonnet
@@ -40,15 +40,15 @@
           {
             alert: 'PromtailFileLagging',
             expr: |||
-              abs(promtail_file_bytes_total - promtail_read_bytes_total) > 100000
+              abs(promtail_file_bytes_total - promtail_read_bytes_total) > 1e6
             |||,
             'for': '15m',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               message: |||
-                {{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} has been lagging by more than 100kb for more than 15m.
+                {{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} has been lagging by more than 1MB for more than 15m.
               |||,
             },
           },


### PR DESCRIPTION
After a year of playing with this alert and fixing race conditions, I think the races are fixed however the existing tolerance of 100kB is really much too small for busy promtail instances processing 5000lines/sec or more.  

The original intent of this alert was to look for complete failures to tail a file and bugs in tailing which have since been squashed, therefore I think it's appropriate to increasing the threshold a file can fall behind to 1MB.  This would still catch any new bugs in tailing or other issue but not be so flaky when log volume spikes on a promtail instance.

We also often find this alert is a red herring and sensitive to large bursts in log volume, and do not think it's appropriate to page someone when it fires.  However it's still useful to know if this is happening as if nothing else it's going to indicate some delay in getting your logs to Loki.

The other reason to change it to warning is that it's hard to define an action anyone can take in an immediate sense when it fires which is another bar we hold for critial alerts.

Other alerts will catch the cases where Loki is not receiving logs at all.

Signed-off-by: Edward Welch <edward.welch@grafana.com>