### PR TITLE
Clearer error response from push endpoint when labels are malformed

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -67,7 +67,7 @@ func TestDistributor(t *testing.T) {
 			lines:            100,
 			mangleLabels:     true,
 			expectedResponse: success,
-			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, "parse error at line 1, col 4: literal not terminated"),
+			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, "error parsing labels: parse error at line 1, col 4: literal not terminated"),
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d](samples=%v)", i, tc.lines), func(t *testing.T) {

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -59,6 +60,7 @@ func (v Validator) ValidateLabels(userID string, labels string) error {
 		// an orthogonal concept (we need not use ValidateLabels in this context)
 		// but the upstream cortex_validation pkg uses it, so we keep this
 		// for parity.
+		err = fmt.Errorf("error parsing labels: %v", err)
 		return httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 	return cortex_validation.ValidateLabels(v, userID, ls)

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -2,7 +2,6 @@ package distributor
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -60,8 +59,7 @@ func (v Validator) ValidateLabels(userID string, labels string) error {
 		// an orthogonal concept (we need not use ValidateLabels in this context)
 		// but the upstream cortex_validation pkg uses it, so we keep this
 		// for parity.
-		err = fmt.Errorf("error parsing labels: %v", err)
-		return httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+		return httpgrpc.Errorf(http.StatusBadRequest, "error parsing labels: %v", err)
 	}
 	return cortex_validation.ValidateLabels(v, userID, ls)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when users use the `/loki/api/v1/push` with a malformed `labels`, they get an error response saying something along the lines of:
`parse error at line 1, col 4: literal not terminated`.

It isn't clear that the `labels` are the issue. This PR makes it clear.

**Which issue(s) this PR fixes**:
Fixes #1727 

**Checklist**
- [x] Documentation added
- [x] Tests updated

