### PR TITLE
fix(ksonnet): named parameters for containerPort

### DIFF
--- a/production/ksonnet/loki-canary/loki-canary.libsonnet
+++ b/production/ksonnet/loki-canary/loki-canary.libsonnet
@@ -13,7 +13,7 @@ k + config {
   loki_canary_container::
     container.new('loki-canary', $._images.loki_canary) +
     $.util.resourcesRequests('10m', '20Mi') +
-    container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
+    container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.loki_canary_args)) +
     container.withEnv([
       container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),

--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -7,8 +7,8 @@
 
     defaultPorts::
       [
-        containerPort.newNamed(name='http-metrics', containerPort=80),
-        containerPort.newNamed(name='grpc', containerPort=9095),
+        containerPort.new(name='http-metrics', port=containerPort=80),
+        containerPort.new(name='grpc', port=containerPort=9095),
       ],
   },
 }

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -82,7 +82,7 @@
 
   gateway_container::
     container.new('nginx', $._images.nginx) +
-    container.withPorts($.core.v1.containerPort.new('http', 80)) +
+    container.withPorts($.core.v1.containerPort.new(name='http', port=80)) +
     $.util.resourcesRequests('50m', '100Mi'),
 
   local deployment = $.apps.v1.deployment,

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -46,7 +46,7 @@ k + config + scrape_config {
 
   promtail_container::
     container.new('promtail', $._images.promtail) +
-    container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
+    container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.promtail_args)) +
     container.withEnv([
       container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),


### PR DESCRIPTION
Because ksonnet-lib switched the order of the `containerPort.new()`
parameters from `ksonnet.beta.3` to `ksonnet.beta.4`, we have to use
named parameters to avoid invalid resources when using one of these versions.