### PR TITLE
Query range should not support date where start == end.

### DIFF
--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	errEndBeforeStart = errors.New("end timestamp must not be before start time")
+	errEndBeforeStart = errors.New("end timestamp must not be before or equal to start time")
 	errNegativeStep   = errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
 	errStepTooSmall   = errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
 )
@@ -255,7 +255,7 @@ func ParseRangeQuery(r *http.Request) (*RangeQuery, error) {
 		return nil, err
 	}
 
-	if result.End.Before(result.Start) {
+	if result.End.Before(result.Start) || result.Start.Equal(result.End) {
 		return nil, errEndBeforeStart
 	}
 

--- a/pkg/loghttp/query_test.go
+++ b/pkg/loghttp/query_test.go
@@ -24,6 +24,7 @@ func TestParseRangeQuery(t *testing.T) {
 		{"bad start", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=t`)}, nil, true},
 		{"bad end", &http.Request{URL: mustParseURL(`?query={foo="bar"}&end=t`)}, nil, true},
 		{"end before start", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2015-06-10T21:42:24.760738998Z`)}, nil, true},
+		{"end equal start", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2016-06-10T21:42:24.760738998Z`)}, nil, true},
 		{"bad limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=h`)}, nil, true},
 		{"bad direction",
 			&http.Request{

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -149,6 +149,11 @@ func (h *splitByInterval) Do(ctx context.Context, r queryrange.Request) (queryra
 
 	intervals := splitByTime(lokiRequest, interval)
 
+	// no interval should not be processed by the frontend.
+	if len(intervals) == 0 {
+		return h.next.Do(ctx, r)
+	}
+
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
 		sp.LogFields(otlog.Int("n_intervals", len(intervals)))
 


### PR DESCRIPTION
Since we are always checking against start inclusively and not end, this means this type of query
will always returns no result.

Fixes #1702, the frontend was not handling this type of query correctly.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
