### PR TITLE
change slack url to slack.grafana.com and use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://cloud.drone.io/grafana/loki"><img src="https://cloud.drone.io/api/badges/grafana/loki/status.svg" alt="Drone CI" /></a>
 <a href="https://circleci.com/gh/grafana/loki/tree/master"><img src="https://circleci.com/gh/grafana/loki.svg?style=shield&circle-token=618193e5787b2951c1ea3352ad5f254f4f52313d" alt="CircleCI" /></a>
 <a href="https://goreportcard.com/report/github.com/grafana/loki"><img src="https://goreportcard.com/badge/github.com/grafana/loki" alt="Go Report Card" /></a>
-<a href="http://slack.raintank.io/"><img src="https://img.shields.io/badge/join%20slack-%23loki-brightgreen.svg" alt="Slack" /></a>
+<a href="https://slack.grafana.com/"><img src="https://img.shields.io/badge/join%20slack-%23loki-brightgreen.svg" alt="Slack" /></a>
 
 # Loki: like Prometheus, but for logs.
 
@@ -63,7 +63,7 @@ Some key documents to read:
 
 If you have any questions or feedback regarding Loki:
 
-- Ask a question on the Loki Slack channel. To invite yourself to the Grafana Slack, visit [http://slack.raintank.io/](http://slack.raintank.io/) and join the #loki channel.
+- Ask a question on the Loki Slack channel. To invite yourself to the Grafana Slack, visit [https://slack.grafana.com/](https://slack.grafana.com/) and join the #loki channel.
 - [File an issue](https://github.com/grafana/loki/issues/new) for bugs, issues and feature suggestions.
 - Send an email to [lokiproject@googlegroups.com](mailto:lokiproject@googlegroups.com), or use the [web interface](https://groups.google.com/forum/#!forum/lokiproject).
 - UI issues should be filed directly in [Grafana](https://github.com/grafana/grafana/issues/new).


### PR DESCRIPTION
Related to #1769, although the original link works again.