### PR TITLE
loki: Allow setting a 'step' when querying logs.

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -57,10 +57,10 @@ func bounds(r *http.Request) (time.Time, time.Time, error) {
 	return start, end, nil
 }
 
-func step(r *http.Request, start, end time.Time) (time.Duration, error) {
+func step(r *http.Request) (time.Duration, error) {
 	value := r.Form.Get("step")
 	if value == "" {
-		return time.Duration(defaultQueryRangeStep(start, end)) * time.Second, nil
+		return 0, nil
 	}
 
 	if d, err := strconv.ParseFloat(value, 64); err == nil {

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -54,10 +54,10 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 		reqPath  string
 		expected *RangeQuery
 	}{
-		"should set the default step based on the input time range if the step parameter is not provided": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000",
+		"should set the default step based on the input time range if the step parameter is not provided on metric query": {
+			reqPath: "/loki/api/v1/query_range?query=rate({job=\"boring\"}[5m])&start=0&end=3600000000000",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "rate({job=\"boring\"}[5m])",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      14 * time.Second,
@@ -65,10 +65,21 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 				Direction: logproto.BACKWARD,
 			},
 		},
-		"should use the input step parameter if provided as an integer": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5",
+		"should leave the step at 0 if step is not provided on a log query": {
+			reqPath: "/loki/api/v1/query_range?query={job=\"boring\"}&start=0&end=3600000000000",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "{job=\"boring\"}",
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(3600, 0),
+				Step:      0,
+				Limit:     100,
+				Direction: logproto.BACKWARD,
+			},
+		},
+		"should use the input step parameter if provided as an integer": {
+			reqPath: "/loki/api/v1/query_range?query={job=\"sleeping\"}&start=0&end=3600000000000&step=5",
+			expected: &RangeQuery{
+				Query:     "{job=\"sleeping\"}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5 * time.Second,
@@ -77,9 +88,9 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 			},
 		},
 		"should use the input step parameter if provided as a float without decimals": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5.000",
+			reqPath: "/loki/api/v1/query_range?query={state=\"broken\"}&start=0&end=3600000000000&step=5.000",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "{state=\"broken\"}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5 * time.Second,
@@ -88,9 +99,9 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 			},
 		},
 		"should use the input step parameter if provided as a float with decimals": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5.500",
+			reqPath: "/loki/api/v1/query_range?query={stop=\"start\"}&start=0&end=3600000000000&step=5.500",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "{stop=\"start\"}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5.5 * 1e9,
@@ -99,9 +110,9 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 			},
 		},
 		"should use the input step parameter if provided as a duration in seconds": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5s",
+			reqPath: "/loki/api/v1/query_range?query={query=\"query\"}&start=0&end=3600000000000&step=5s",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "{query=\"query\"}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5 * time.Second,
@@ -110,9 +121,9 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 			},
 		},
 		"should use the input step parameter if provided as a duration in days": {
-			reqPath: "/loki/api/v1/query_range?query={}&start=0&end=3600000000000&step=5d",
+			reqPath: "/loki/api/v1/query_range?query={foo!=\"foo\"}&start=0&end=3600000000000&step=5d",
 			expected: &RangeQuery{
-				Query:     "{}",
+				Query:     "{foo!=\"foo\"}",
 				Start:     time.Unix(0, 0),
 				End:       time.Unix(3600, 0),
 				Step:      5 * 24 * 3600 * time.Second,

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -12,12 +12,13 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logql/stats"
 )
 
 var (
 	errEndBeforeStart = errors.New("end timestamp must not be before or equal to start time")
-	errNegativeStep   = errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
+	errNegativeStep   = errors.New("negative query resolution step widths are not accepted. Try a positive integer")
 	errStepTooSmall   = errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
 )
 
@@ -269,19 +270,31 @@ func ParseRangeQuery(r *http.Request) (*RangeQuery, error) {
 		return nil, err
 	}
 
-	result.Step, err = step(r, result.Start, result.End)
+	result.Step, err = step(r)
 	if err != nil {
 		return nil, err
 	}
-
-	if result.Step <= 0 {
+	if result.Step < 0 {
 		return nil, errNegativeStep
 	}
 
-	// For safety, limit the number of returned points per timeseries.
-	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
-	if (result.End.Sub(result.Start) / result.Step) > 11000 {
-		return nil, errStepTooSmall
+	// Additional rules are required for the step on metric queries,
+	// so we need to parse the expression now to see what type it is.
+	expr, err := logql.ParseExpr(result.Query)
+	if err != nil {
+		return nil, err
+	}
+	switch expr.(type) {
+	case logql.SampleExpr:
+		if result.Step == 0 {
+			result.Step = time.Duration(defaultQueryRangeStep(result.Start, result.End)) * time.Second
+		}
+
+		// For safety, limit the number of returned points per timeseries.
+		// This is sufficient for 60s resolution for a week or 1h resolution for a year.
+		if (result.End.Sub(result.Start) / result.Step) > 11000 {
+			return nil, errStepTooSmall
+		}
 	}
 
 	return &result, nil

--- a/pkg/loghttp/query_test.go
+++ b/pkg/loghttp/query_test.go
@@ -40,7 +40,7 @@ func TestParseRangeQuery(t *testing.T) {
 			}, nil, true},
 		{"too small step",
 			&http.Request{
-				URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=100&direction=BACKWARD&step=1`),
+				URL: mustParseURL(`?query=rate({foo="bar"}[5m])&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=100&direction=BACKWARD&step=1`),
 			}, nil, true},
 		{"good",
 			&http.Request{

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -61,7 +61,7 @@ func (p LiteralParams) Direction() logproto.Direction { return p.direction }
 
 // GetRangeType returns whether a query is an instant query or range query
 func GetRangeType(q Params) QueryRangeType {
-	if q.Start() == q.End() && q.Step() == 0 {
+	if q.Start() == q.End() {
 		return InstantType
 	}
 	return RangeType


### PR DESCRIPTION
If you've ever wanted to query your logs and return a subset based on a step interval like you can with metrics and Prometheus, then this PR is for you.

There aren't a ton of use cases for this, but it just so happens I have one so here we are.

The idea is you can query your logs with say `step=10s` and get back a stream with a log entry every 10s (entries between the step will be ignored)

The skipped entries do not count towards the limit.