### PR TITLE
promtail: remove the read lines counter when the log file stops being tailed

### DIFF
--- a/pkg/promtail/targets/tailer.go
+++ b/pkg/promtail/targets/tailer.go
@@ -147,6 +147,7 @@ func (t *tailer) stop() error {
 	<-t.done
 	filesActive.Add(-1.)
 	// When we stop tailing the file, also un-export metrics related to the file
+	readLines.DeleteLabelValues(t.path)
 	readBytes.DeleteLabelValues(t.path)
 	totalBytes.DeleteLabelValues(t.path)
 	logLengthHistogram.DeleteLabelValues(t.path)


### PR DESCRIPTION
We do this with all the other per file metrics but missed this one which causes some metrics to "leak" over time as files come and go

Signed-off-by: Edward Welch <edward.welch@grafana.com>