### PR TITLE
Regexp simplification

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -68,7 +68,7 @@ func (c *dumbChunk) Utilization() float64 {
 
 // Returns an iterator that goes from _most_ recent to _least_ recent (ie,
 // backwards).
-func (c *dumbChunk) Iterator(_ context.Context, from, through time.Time, direction logproto.Direction, _ logql.Filter) (iter.EntryIterator, error) {
+func (c *dumbChunk) Iterator(_ context.Context, from, through time.Time, direction logproto.Direction, _ logql.LineFilter) (iter.EntryIterator, error) {
 	i := sort.Search(len(c.entries), func(i int) bool {
 		return !from.After(c.entries[i].Timestamp)
 	})

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -96,7 +96,7 @@ type Chunk interface {
 	Bounds() (time.Time, time.Time)
 	SpaceFor(*logproto.Entry) bool
 	Append(*logproto.Entry) error
-	Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.Filter) (iter.EntryIterator, error)
+	Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.LineFilter) (iter.EntryIterator, error)
 	Size() int
 	Bytes() ([]byte, error)
 	Blocks() int

--- a/pkg/chunkenc/lazy_chunk.go
+++ b/pkg/chunkenc/lazy_chunk.go
@@ -19,7 +19,7 @@ type LazyChunk struct {
 }
 
 // Iterator returns an entry iterator.
-func (c *LazyChunk) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.Filter) (iter.EntryIterator, error) {
+func (c *LazyChunk) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.LineFilter) (iter.EntryIterator, error) {
 	// If the chunk is already loaded, then use that.
 	if c.Chunk.Data != nil {
 		lokiChunk := c.Chunk.Data.(*Facade).LokiChunk()

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc/testdata"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
 )
 
 var testEncoding = []Encoding{
@@ -504,9 +505,9 @@ func TestGenerateDataSize(t *testing.T) {
 			bytesRead := uint64(0)
 			for _, c := range chunks {
 				// use forward iterator for benchmark -- backward iterator does extra allocations by keeping entries in memory
-				iterator, err := c.Iterator(context.TODO(), time.Unix(0, 0), time.Now(), logproto.FORWARD, func(line []byte) bool {
+				iterator, err := c.Iterator(context.TODO(), time.Unix(0, 0), time.Now(), logproto.FORWARD, logql.LineFilterFunc(func(line []byte) bool {
 					return true // return all
-				})
+				}))
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -251,7 +251,7 @@ func (s *stream) cutChunkForSynchronization(entryTimestamp, prevEntryTimestamp t
 }
 
 // Returns an iterator.
-func (s *stream) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.Filter) (iter.EntryIterator, error) {
+func (s *stream) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, filter logql.LineFilter) (iter.EntryIterator, error) {
 	iterators := make([]iter.EntryIterator, 0, len(s.chunks))
 	for _, c := range s.chunks {
 		itr, err := c.chunk.Iterator(ctx, from, through, direction, filter)

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -22,7 +22,7 @@ type tailer struct {
 	id       uint32
 	orgID    string
 	matchers []*labels.Matcher
-	filter   logql.Filter
+	filter   logql.LineFilter
 	expr     logql.Expr
 
 	sendChan chan *logproto.Stream
@@ -139,7 +139,7 @@ func (t *tailer) filterEntriesInStream(stream *logproto.Stream) {
 
 	var filteredEntries []logproto.Entry
 	for _, e := range stream.Entries {
-		if t.filter([]byte(e.Line)) {
+		if t.filter.Filter([]byte(e.Line)) {
 			filteredEntries = append(filteredEntries, e)
 		}
 	}

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
 )
 
 func TestTransferOut(t *testing.T) {
@@ -90,7 +91,7 @@ func TestTransferOut(t *testing.T) {
 				time.Unix(0, 0),
 				time.Unix(10, 0),
 				logproto.FORWARD,
-				func([]byte) bool { return true },
+				logql.LineFilterFunc(func([]byte) bool { return true }),
 			)
 			if !assert.NoError(t, err) {
 				continue

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -110,7 +110,7 @@ func newMatcherStage(logger log.Logger, jobName *string, config interface{}, reg
 // matcherStage applies Label matchers to determine if the include stages should be run
 type matcherStage struct {
 	matchers []*labels.Matcher
-	filter   logql.Filter
+	filter   logql.LineFilter
 	pipeline Stage
 	action   string
 }
@@ -122,7 +122,7 @@ func (m *matcherStage) Process(labels model.LabelSet, extracted map[string]inter
 			return
 		}
 	}
-	if m.filter == nil || m.filter([]byte(*entry)) {
+	if m.filter == nil || m.filter.Filter([]byte(*entry)) {
 		switch m.action {
 		case MatchActionDrop:
 			// Adds the drop label to not be sent by the api.EntryHandler

--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -131,10 +131,7 @@ func (e *filterExpr) Filter() (LineFilter, error) {
 		if err != nil {
 			return nil, err
 		}
-		return andFilter{
-			left:  nextFilter,
-			right: f,
-		}, nil
+		return newAndFilter(nextFilter, f), nil
 	}
 	return f, nil
 }

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -122,6 +122,13 @@ func Test_FilterMatcher(t *testing.T) {
 			},
 			[]linecheck{{"foo", false}, {"bar", false}, {"foobar", true}},
 		},
+		{
+			`{app="foo"} |~ "foo"`,
+			[]*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+			[]linecheck{{"foo", true}, {"bar", false}, {"foobar", true}},
+		},
 	} {
 		tt := tt
 		t.Run(tt.q, func(t *testing.T) {
@@ -135,7 +142,7 @@ func Test_FilterMatcher(t *testing.T) {
 				assert.Nil(t, f)
 			} else {
 				for _, lc := range tt.lines {
-					assert.Equal(t, lc.e, f([]byte(lc.l)))
+					assert.Equal(t, lc.e, f.Filter([]byte(lc.l)))
 				}
 			}
 		})
@@ -158,7 +165,7 @@ func BenchmarkContainsFilter(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if !f(line) {
+		if !f.Filter(line) {
 			b.Fatal("doesn't match")
 		}
 	}

--- a/pkg/logql/filter.go
+++ b/pkg/logql/filter.go
@@ -1,0 +1,106 @@
+package logql
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"regexp/syntax"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Filter is a function to filter logs.
+type LineFilter interface {
+	Filter(line []byte) bool
+}
+
+type negativeFilter struct {
+	LineFilter
+}
+
+type andFilter struct {
+	left  LineFilter
+	right LineFilter
+}
+
+func (a andFilter) Filter(line []byte) bool {
+	return a.left.Filter(line) && a.right.Filter(line)
+}
+
+func (n negativeFilter) Filter(line []byte) bool {
+	return !n.LineFilter.Filter(line)
+}
+
+type regexpFilter struct {
+	*regexp.Regexp
+}
+
+func (r regexpFilter) Filter(line []byte) bool {
+	return r.Match(line)
+}
+
+type literalFilter []byte
+
+func (l literalFilter) Filter(line []byte) bool {
+	return bytes.Contains(line, l)
+}
+
+func newFilter(match string, mt labels.MatchType) (LineFilter, error) {
+	switch mt {
+	case labels.MatchRegexp:
+		return ParseRegex(match, true)
+	case labels.MatchNotRegexp:
+		return ParseRegex(match, false)
+	case labels.MatchEqual:
+		return literalFilter(match), nil
+	case labels.MatchNotEqual:
+		return negativeFilter{literalFilter(match)}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown matcher: %v", match)
+	}
+}
+
+func ParseRegex(re string, match bool) (LineFilter, error) {
+	reg, err := syntax.Parse(re, syntax.Perl)
+	if err != nil {
+		return nil, err
+	}
+	reg = reg.Simplify()
+
+	if f, ok := simplify(reg); ok {
+		return f, nil
+	}
+	// if reg.Op == syntax.OpAlternate || reg.Op == syntax.OpCapture {
+	// 	for _, sub := range reg.Sub {
+	// 		fmt.Println(sub)
+	// 	}
+	// }
+	// attempt to improve regex with tricks
+
+	return defaultRegex(re, match)
+}
+
+func simplify(reg *syntax.Regexp) (LineFilter, bool) {
+	switch reg.Op {
+	case syntax.OpAlternate:
+	case syntax.OpCapture:
+	case syntax.OpConcat:
+		return nil, false
+	case syntax.OpLiteral:
+		return literalFilter([]byte(string(reg.Rune))), true
+	}
+	return nil, false
+}
+
+func defaultRegex(re string, match bool) (LineFilter, error) {
+	reg, err := regexp.Compile(re)
+	if err != nil {
+		return nil, err
+	}
+	f := regexpFilter{reg}
+	if match {
+		return f, nil
+	}
+	return negativeFilter{LineFilter: f}, nil
+}

--- a/pkg/logql/filter.go
+++ b/pkg/logql/filter.go
@@ -9,9 +9,16 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-// LineFilter is a function to filter logs.
+// LineFilter is a interface to filter log lines.
 type LineFilter interface {
 	Filter(line []byte) bool
+}
+
+// LineFilterFunc is a syntax sugar for creating line filter from a function
+type LineFilterFunc func(line []byte) bool
+
+func (f LineFilterFunc) Filter(line []byte) bool {
+	return f(line)
 }
 
 type notFilter struct {
@@ -54,7 +61,7 @@ type orFilter struct {
 	right LineFilter
 }
 
-// newOrFilter creates a new filter which matches only if left and right matches.
+// newOrFilter creates a new filter which matches only if left or right matches.
 func newOrFilter(left LineFilter, right LineFilter) LineFilter {
 	return orFilter{
 		left:  left,

--- a/pkg/logql/filter.go
+++ b/pkg/logql/filter.go
@@ -218,9 +218,10 @@ func simplifyConcat(reg *syntax.Regexp, baseLiteral []byte) (LineFilter, bool) {
 			}
 			continue
 		}
-		if sub.Op != syntax.OpStar && sub.Sub[0].Op != syntax.OpAnyCharNotNL {
-			return nil, false
+		if sub.Op == syntax.OpStar && sub.Sub[0].Op == syntax.OpAnyCharNotNL {
+			continue
 		}
+		return nil, false
 	}
 
 	// we can simplify only if we found a literal.

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -17,41 +17,53 @@ func Test_SimplifiedRegex(t *testing.T) {
 		expected   LineFilter
 		match      bool
 	}{
-		// // regex we intend to support.
-		// {"foo", true, literalFilter([]byte("foo")), true},
-		// {"not", true, newNotFilter(literalFilter([]byte("not"))), false},
-		// {"(foo)", true, literalFilter([]byte("foo")), true},
-		// {"(foo|ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		// {"(foo|ba|ar)", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), literalFilter([]byte("ar"))), true},
-		// {"(foo|(ba|ar))", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("ba")), literalFilter([]byte("ar")))), true},
-		// {"foo.*", true, literalFilter([]byte("foo")), true},
-		// {".*foo", true, newNotFilter(literalFilter([]byte("foo"))), false},
-		// {".*foo.*", true, literalFilter([]byte("foo")), true},
-		// {"(.*)(foo).*", true, literalFilter([]byte("foo")), true},
-		// {"(foo.*|.*ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		// {"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		// {".*foo.*|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		// {".*foo|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		// // This construct is similar to (...), but won't create a capture group.
-		// {"(?:.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
-		// // named capture group
-		// {"(?P<foo>.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
-		// // parsed as (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
-		// {".*foo.*|bar|buzz", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("buzz")))), true},
-		// // parsed as (?-s:.)*foo(?-s:.)*|bar|uzz
-		// {".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), literalFilter([]byte("uzz"))), true},
-		// // parsed as foo|b(?:ar|(?:)|uzz)|zz
-		// {"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), newOrFilter(newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("b"))), literalFilter([]byte("buzz")))), literalFilter([]byte("zz"))), true},
-		// // parsed as f(?:(?:)|oo(?:(?:)|bar))
-		// {"f|foo|foobar", true, newOrFilter(literalFilter([]byte("f")), newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("foobar")))), true},
-		// // parsed as f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
-		// {"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
-		// // parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
-		// {"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		// regex we intend to support.
+		{"foo", true, literalFilter([]byte("foo")), true},
+		{"not", true, newNotFilter(literalFilter([]byte("not"))), false},
+		{"(foo)", true, literalFilter([]byte("foo")), true},
+		{"(foo|ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
+		{"(foo|ba|ar)", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), literalFilter([]byte("ar"))), true},
+		{"(foo|(ba|ar))", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("ba")), literalFilter([]byte("ar")))), true},
+		{"foo.*", true, literalFilter([]byte("foo")), true},
+		{".*foo", true, newNotFilter(literalFilter([]byte("foo"))), false},
+		{".*foo.*", true, literalFilter([]byte("foo")), true},
+		{"(.*)(foo).*", true, literalFilter([]byte("foo")), true},
+		{"(foo.*|.*ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
+		{"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		{".*foo.*|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		{".*foo|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		// This construct is similar to (...), but won't create a capture group.
+		{"(?:.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		// named capture group
+		{"(?P<foo>.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		// parsed as (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
+		{".*foo.*|bar|buzz", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("buzz")))), true},
+		// parsed as (?-s:.)*foo(?-s:.)*|bar|uzz
+		{".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), literalFilter([]byte("uzz"))), true},
+		// parsed as foo|b(?:ar|(?:)|uzz)|zz
+		{"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), newOrFilter(newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("b"))), literalFilter([]byte("buzz")))), literalFilter([]byte("zz"))), true},
+		// parsed as f(?:(?:)|oo(?:(?:)|bar))
+		{"f|foo|foobar", true, newOrFilter(literalFilter([]byte("f")), newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("foobar")))), true},
+		// parsed as f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
+		{"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		// parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
+		{"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
 
-		// regex we should not support.
+		// regex we are not supporting.
 		{"[a-z]+foo", false, nil, false},
 		{".+foo", false, nil, false},
+		{".*fo.*o", false, nil, false},
+		{".*", false, nil, false},
+		{`\d`, false, nil, false},
+		{`\sfoo`, false, nil, false},
+		{`foo?`, false, nil, false},
+		{`foo{1,2}bar{2,3}`, false, nil, false},
+		{`foo|\d*bar`, false, nil, false},
+		{`foo|fo{1,2}`, false, nil, false},
+		{`foo|fo\d*`, false, nil, false},
+		{`foo|fo\d+`, false, nil, false},
+		{`(\w\d+)`, false, nil, false},
+		{`.*f.*oo|fo{1,2}`, false, nil, false},
 	} {
 		t.Run(test.re, func(t *testing.T) {
 			d, err := newRegexpFilter(test.re, test.match)

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -89,7 +89,7 @@ func Test_SimplifiedRegex(t *testing.T) {
 	}
 }
 
-func Benchmark_RegexpSimplified(b *testing.B) {
+func Benchmark_LineFilter(b *testing.B) {
 	b.ReportAllocs()
 	logline := `level=bar ts=2020-02-22T14:57:59.398312973Z caller=logging.go:44 traceID=2107b6b551458908 msg="GET /buzz (200) 4.599635ms`
 	for _, test := range []struct {

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -25,6 +25,8 @@ func Test_SimplifiedRegex(t *testing.T) {
 		{".*foo.*", "foobar"},
 		{"(.*)(foo).*", "foobar"},
 		{".*foo.*|bar", "buzz"},
+		{"(?:.*foo.*|bar)", "buzz"},      // This construct is similar to (...), but won't create a capture group.
+		{"(?P<foo>.*foo.*|bar)", "buzz"}, // named capture group
 		{".*foo|bar", "foo,bar"},
 		{".*foo.*|bar|buzz", "buzz"},     // (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
 		{".*foo.*|bar|uzz", "buzz"},      // (?-s:.)*foo(?-s:.)*|bar|uzz

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -1,0 +1,55 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseRegex(t *testing.T) {
+	f, err := ParseRegex("foo", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := defaultRegex("foo", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := []byte("foobar")
+	require.Equal(t, f2.Filter(line), f.Filter(line))
+
+}
+
+func Benchmark_Regex(b *testing.B) {
+	b.ReportAllocs()
+
+	for _, test := range []struct {
+		re      string
+		match   bool
+		logline []byte
+	}{
+		{"foo|bar", true, []byte(`level=debug ts=2020-02-22T14:57:59.398312973Z caller=logging.go:44 traceID=2107b6b551458908 msg="GET /metrics (200) 4.599635ms`)},
+	} {
+		f, err := defaultRegex("foo|bar", true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run("default_"+test.re, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = f.Filter(logLine)
+			}
+		})
+		f, err = ParseRegex("foo|bar", true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run("simplified_"+test.re, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = f.Filter(logLine)
+			}
+		})
+	}
+
+}
+
+var logLine = []byte(`level=debug ts=2020-02-22T14:57:59.398312973Z caller=logging.go:44 traceID=2107b6b551458908 msg="GET /metrics (200) 4.599635ms`)

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -13,22 +13,25 @@ func Test_SimplifiedRegex(t *testing.T) {
 		re   string
 		line string
 	}{
-		// {"foo", "foo"}, // add expected filter.
-		// {"(foo)", "foobar"},
-		// {"(foo|ba)", "foobar"},
-		// {"(foo.*|.*ba)", "foobar"},
-		// {"(foo.*|.*ba)", "fo"},
-		// {"(foo|ba|ar)", "bar"},
-		// {"(foo|(ba|ar))", "bar"},
-		// {"foo.*", "foobar"},
-		// {".*foo", "foobar"},
-		// {".*foo.*", "foobar"},
-		// {"(.*)(foo).*", "foobar"},
-		// {".*foo.*|bar", "buzz"},
-		// {".*foo.*|bar", "foo,bar"},
-		{".*foo.*|bar|buzz", "buzz"},  // (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
-		{".*foo.*|bar|uzz", "buzz"},   // (?-s:.)*foo(?-s:.)*|bar|uzz
-		{"foo|bar|b|buzz|zz", "buzz"}, // foo|b(?:ar|(?:)|uzz)|zz
+		{"foo", "foo"}, // todo add expected filter.
+		{"(foo)", "foobar"},
+		{"(foo|ba)", "foobar"},
+		{"(foo.*|.*ba)", "foobar"},
+		{"(foo.*|.*ba)", "fo"},
+		{"(foo|ba|ar)", "bar"},
+		{"(foo|(ba|ar))", "bar"},
+		{"foo.*", "foobar"},
+		{".*foo", "foobar"},
+		{".*foo.*", "foobar"},
+		{"(.*)(foo).*", "foobar"},
+		{".*foo.*|bar", "buzz"},
+		{".*foo|bar", "foo,bar"},
+		{".*foo.*|bar|buzz", "buzz"},     // (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
+		{".*foo.*|bar|uzz", "buzz"},      // (?-s:.)*foo(?-s:.)*|bar|uzz
+		{"foo|bar|b|buzz|zz", "buzz"},    // foo|b(?:ar|(?:)|uzz)|zz
+		{"f|foo|foobar", "f"},            // f(?:(?:)|oo(?:(?:)|bar))
+		{"f.*|foobar.*|.*buzz", "bf"},    // f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
+		{"((f.*)|foobar.*)|.*buzz", "f"}, // ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
 	} {
 		t.Run(test.re, func(t *testing.T) {
 			assertRegex(t, test.re, test.line, true)

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -18,36 +18,36 @@ func Test_SimplifiedRegex(t *testing.T) {
 		match      bool
 	}{
 		// regex we intend to support.
-		{"foo", true, literalFilter([]byte("foo")), true},
-		{"not", true, newNotFilter(literalFilter([]byte("not"))), false},
-		{"(foo)", true, literalFilter([]byte("foo")), true},
-		{"(foo|ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		{"(foo|ba|ar)", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), literalFilter([]byte("ar"))), true},
-		{"(foo|(ba|ar))", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("ba")), literalFilter([]byte("ar")))), true},
-		{"foo.*", true, literalFilter([]byte("foo")), true},
-		{".*foo", true, newNotFilter(literalFilter([]byte("foo"))), false},
-		{".*foo.*", true, literalFilter([]byte("foo")), true},
-		{"(.*)(foo).*", true, literalFilter([]byte("foo")), true},
-		{"(foo.*|.*ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		{"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		{".*foo.*|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		{".*foo|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		{"foo", true, containsFilter("foo"), true},
+		{"not", true, newNotFilter(containsFilter("not")), false},
+		{"(foo)", true, containsFilter("foo"), true},
+		{"(foo|ba)", true, newOrFilter(containsFilter("foo"), containsFilter("ba")), true},
+		{"(foo|ba|ar)", true, newOrFilter(newOrFilter(containsFilter("foo"), containsFilter("ba")), containsFilter("ar")), true},
+		{"(foo|(ba|ar))", true, newOrFilter(containsFilter("foo"), newOrFilter(containsFilter("ba"), containsFilter("ar"))), true},
+		{"foo.*", true, containsFilter("foo"), true},
+		{".*foo", true, newNotFilter(containsFilter("foo")), false},
+		{".*foo.*", true, containsFilter("foo"), true},
+		{"(.*)(foo).*", true, containsFilter("foo"), true},
+		{"(foo.*|.*ba)", true, newOrFilter(containsFilter("foo"), containsFilter("ba")), true},
+		{"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(containsFilter("foo"), containsFilter("bar"))), false},
+		{".*foo.*|bar", true, newNotFilter(newOrFilter(containsFilter("foo"), containsFilter("bar"))), false},
+		{".*foo|bar", true, newNotFilter(newOrFilter(containsFilter("foo"), containsFilter("bar"))), false},
 		// This construct is similar to (...), but won't create a capture group.
-		{"(?:.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		{"(?:.*foo.*|bar)", true, newOrFilter(containsFilter("foo"), containsFilter("bar")), true},
 		// named capture group
-		{"(?P<foo>.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		{"(?P<foo>.*foo.*|bar)", true, newOrFilter(containsFilter("foo"), containsFilter("bar")), true},
 		// parsed as (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
-		{".*foo.*|bar|buzz", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("buzz")))), true},
+		{".*foo.*|bar|buzz", true, newOrFilter(containsFilter("foo"), newOrFilter(containsFilter("bar"), containsFilter("buzz"))), true},
 		// parsed as (?-s:.)*foo(?-s:.)*|bar|uzz
-		{".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), literalFilter([]byte("uzz"))), true},
+		{".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(containsFilter("foo"), containsFilter("bar")), containsFilter("uzz")), true},
 		// parsed as foo|b(?:ar|(?:)|uzz)|zz
-		{"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), newOrFilter(newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("b"))), literalFilter([]byte("buzz")))), literalFilter([]byte("zz"))), true},
+		{"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(containsFilter("foo"), newOrFilter(newOrFilter(containsFilter("bar"), containsFilter("b")), containsFilter("buzz"))), containsFilter("zz")), true},
 		// parsed as f(?:(?:)|oo(?:(?:)|bar))
-		{"f|foo|foobar", true, newOrFilter(literalFilter([]byte("f")), newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("foobar")))), true},
+		{"f|foo|foobar", true, newOrFilter(containsFilter("f"), newOrFilter(containsFilter("foo"), containsFilter("foobar"))), true},
 		// parsed as f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
-		{"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		{"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(containsFilter("f"), containsFilter("foobar")), containsFilter("buzz")), true},
 		// parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
-		{"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		{"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(containsFilter("f"), containsFilter("foobar")), containsFilter("buzz")), true},
 
 		// regex we are not supporting.
 		{"[a-z]+foo", false, nil, false},

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -89,9 +89,9 @@ func Test_SimplifiedRegex(t *testing.T) {
 	}
 }
 
-func Benchmark_Regex(b *testing.B) {
+func Benchmark_RegexpSimplified(b *testing.B) {
 	b.ReportAllocs()
-	logline := `level=bar ts=2020-02-22T14:57:59.398312973Z caller=logging.go:44 traceID=2107b6b551458908 msg="GET /foo (200) 4.599635ms`
+	logline := `level=bar ts=2020-02-22T14:57:59.398312973Z caller=logging.go:44 traceID=2107b6b551458908 msg="GET /buzz (200) 4.599635ms`
 	for _, test := range []struct {
 		re string
 	}{
@@ -104,6 +104,7 @@ func Benchmark_Regex(b *testing.B) {
 		{"foo|bar.*|buzz"},
 		{".*foo.*|bar|uzz"},
 		{"((f.*)|foobar.*)|.*buzz"},
+		{"(?P<foo>.*foo.*|bar)"},
 	} {
 		benchmarkRegex(b, test.re, logline, true)
 		benchmarkRegex(b, test.re, logline, false)

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -111,7 +111,12 @@ func Benchmark_LineFilter(b *testing.B) {
 	}
 }
 
+// see https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go
+// A note on compiler optimisations
+var res bool
+
 func benchmarkRegex(b *testing.B, re, line string, match bool) {
+	var m bool
 	l := []byte(line)
 	d, err := newRegexpFilter(re, match)
 	if err != nil {
@@ -124,12 +129,13 @@ func benchmarkRegex(b *testing.B, re, line string, match bool) {
 	b.ResetTimer()
 	b.Run(fmt.Sprintf("default_%v_%s", match, re), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = d.Filter(l)
+			m = d.Filter(l)
 		}
 	})
 	b.Run(fmt.Sprintf("simplified_%v_%s", match, re), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = s.Filter(l)
+			m = s.Filter(l)
 		}
 	})
+	res = m
 }

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -17,36 +17,41 @@ func Test_SimplifiedRegex(t *testing.T) {
 		expected   LineFilter
 		match      bool
 	}{
-		{"foo", true, literalFilter([]byte("foo")), true},
-		{"not", true, newNotFilter(literalFilter([]byte("not"))), false},
-		{"(foo)", true, literalFilter([]byte("foo")), true},
-		{"(foo|ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		{"(foo|ba|ar)", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), literalFilter([]byte("ar"))), true},
-		{"(foo|(ba|ar))", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("ba")), literalFilter([]byte("ar")))), true},
-		{"foo.*", true, literalFilter([]byte("foo")), true},
-		{".*foo", true, newNotFilter(literalFilter([]byte("foo"))), false},
-		{".*foo.*", true, literalFilter([]byte("foo")), true},
-		{"(.*)(foo).*", true, literalFilter([]byte("foo")), true},
-		{"(foo.*|.*ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
-		{"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		{".*foo.*|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		{".*foo|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
-		// This construct is similar to (...), but won't create a capture group.
-		{"(?:.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
-		// named capture group
-		{"(?P<foo>.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
-		// parsed as (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
-		{".*foo.*|bar|buzz", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("buzz")))), true},
-		// parsed as (?-s:.)*foo(?-s:.)*|bar|uzz
-		{".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), literalFilter([]byte("uzz"))), true},
-		// parsed as foo|b(?:ar|(?:)|uzz)|zz
-		{"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), newOrFilter(newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("b"))), literalFilter([]byte("buzz")))), literalFilter([]byte("zz"))), true},
-		// parsed as f(?:(?:)|oo(?:(?:)|bar))
-		{"f|foo|foobar", true, newOrFilter(literalFilter([]byte("f")), newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("foobar")))), true},
-		// parsed as f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
-		{"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
-		// parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
-		{"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		// // regex we intend to support.
+		// {"foo", true, literalFilter([]byte("foo")), true},
+		// {"not", true, newNotFilter(literalFilter([]byte("not"))), false},
+		// {"(foo)", true, literalFilter([]byte("foo")), true},
+		// {"(foo|ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
+		// {"(foo|ba|ar)", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), literalFilter([]byte("ar"))), true},
+		// {"(foo|(ba|ar))", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("ba")), literalFilter([]byte("ar")))), true},
+		// {"foo.*", true, literalFilter([]byte("foo")), true},
+		// {".*foo", true, newNotFilter(literalFilter([]byte("foo"))), false},
+		// {".*foo.*", true, literalFilter([]byte("foo")), true},
+		// {"(.*)(foo).*", true, literalFilter([]byte("foo")), true},
+		// {"(foo.*|.*ba)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("ba"))), true},
+		// {"(foo.*|.*bar.*)", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		// {".*foo.*|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		// {".*foo|bar", true, newNotFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar")))), false},
+		// // This construct is similar to (...), but won't create a capture group.
+		// {"(?:.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		// // named capture group
+		// {"(?P<foo>.*foo.*|bar)", true, newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), true},
+		// // parsed as (?-s:.)*foo(?-s:.)*|b(?:ar|uzz)
+		// {".*foo.*|bar|buzz", true, newOrFilter(literalFilter([]byte("foo")), newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("buzz")))), true},
+		// // parsed as (?-s:.)*foo(?-s:.)*|bar|uzz
+		// {".*foo.*|bar|uzz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("bar"))), literalFilter([]byte("uzz"))), true},
+		// // parsed as foo|b(?:ar|(?:)|uzz)|zz
+		// {"foo|bar|b|buzz|zz", true, newOrFilter(newOrFilter(literalFilter([]byte("foo")), newOrFilter(newOrFilter(literalFilter([]byte("bar")), literalFilter([]byte("b"))), literalFilter([]byte("buzz")))), literalFilter([]byte("zz"))), true},
+		// // parsed as f(?:(?:)|oo(?:(?:)|bar))
+		// {"f|foo|foobar", true, newOrFilter(literalFilter([]byte("f")), newOrFilter(literalFilter([]byte("foo")), literalFilter([]byte("foobar")))), true},
+		// // parsed as f(?:(?-s:.)*|oobar(?-s:.)*)|(?-s:.)*buzz
+		// {"f.*|foobar.*|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+		// // parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
+		// {"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(literalFilter([]byte("f")), literalFilter([]byte("foobar"))), literalFilter([]byte("buzz"))), true},
+
+		// regex we should not support.
+		{"[a-z]+foo", false, nil, false},
+		{".+foo", false, nil, false},
 	} {
 		t.Run(test.re, func(t *testing.T) {
 			d, err := newRegexpFilter(test.re, test.match)

--- a/pkg/storage/iterator.go
+++ b/pkg/storage/iterator.go
@@ -75,7 +75,7 @@ type batchChunkIterator struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 	matchers []*labels.Matcher
-	filter   logql.Filter
+	filter   logql.LineFilter
 	req      *logproto.QueryRequest
 	next     chan *struct {
 		iter iter.EntryIterator
@@ -84,7 +84,7 @@ type batchChunkIterator struct {
 }
 
 // newBatchChunkIterator creates a new batch iterator with the given batchSize.
-func newBatchChunkIterator(ctx context.Context, chunks []*chunkenc.LazyChunk, batchSize int, matchers []*labels.Matcher, filter logql.Filter, req *logproto.QueryRequest) *batchChunkIterator {
+func newBatchChunkIterator(ctx context.Context, chunks []*chunkenc.LazyChunk, batchSize int, matchers []*labels.Matcher, filter logql.LineFilter, req *logproto.QueryRequest) *batchChunkIterator {
 	// __name__ is not something we filter by because it's a constant in loki and only used for upstream compatibility.
 	// Therefore remove it
 	for i := range matchers {
@@ -277,7 +277,7 @@ func (it *batchChunkIterator) Close() error {
 }
 
 // newChunksIterator creates an iterator over a set of lazychunks.
-func newChunksIterator(ctx context.Context, chunks []*chunkenc.LazyChunk, matchers []*labels.Matcher, filter logql.Filter, direction logproto.Direction, from, through time.Time) (iter.EntryIterator, error) {
+func newChunksIterator(ctx context.Context, chunks []*chunkenc.LazyChunk, matchers []*labels.Matcher, filter logql.LineFilter, direction logproto.Direction, from, through time.Time) (iter.EntryIterator, error) {
 	chksBySeries := partitionBySeriesChunks(chunks)
 
 	// Make sure the initial chunks are loaded. This is not one chunk
@@ -310,7 +310,7 @@ func newChunksIterator(ctx context.Context, chunks []*chunkenc.LazyChunk, matche
 	return iter.NewHeapIterator(ctx, iters, direction), nil
 }
 
-func buildIterators(ctx context.Context, chks map[model.Fingerprint][][]*chunkenc.LazyChunk, filter logql.Filter, direction logproto.Direction, from, through time.Time) ([]iter.EntryIterator, error) {
+func buildIterators(ctx context.Context, chks map[model.Fingerprint][][]*chunkenc.LazyChunk, filter logql.LineFilter, direction logproto.Direction, from, through time.Time) ([]iter.EntryIterator, error) {
 	result := make([]iter.EntryIterator, 0, len(chks))
 	for _, chunks := range chks {
 		iterator, err := buildHeapIterator(ctx, chunks, filter, direction, from, through)
@@ -323,7 +323,7 @@ func buildIterators(ctx context.Context, chks map[model.Fingerprint][][]*chunken
 	return result, nil
 }
 
-func buildHeapIterator(ctx context.Context, chks [][]*chunkenc.LazyChunk, filter logql.Filter, direction logproto.Direction, from, through time.Time) (iter.EntryIterator, error) {
+func buildHeapIterator(ctx context.Context, chks [][]*chunkenc.LazyChunk, filter logql.LineFilter, direction logproto.Direction, from, through time.Time) (iter.EntryIterator, error) {
 	result := make([]iter.EntryIterator, 0, len(chks))
 
 	// __name__ is only used for upstream compatibility and is hardcoded within loki. Strip it from the return label set.


### PR DESCRIPTION
This PRs introduces simplification of regexp filter by parsing regexp and replacing them with combination of `bytes.Contains` aka literal filter.

The reasoning behind is that many regexp can be simplified to execute faster than actual regexp that requires [backtracking](https://riptutorial.com/regex/example/3179/what-causes-backtracking-) and string capturing. 

Currently we only support recursively those regexp operations:
- literal (foo)
- alternate (foo|bar)
- concat (foo.*) and (f(oo|bar))
- capture of any above.

Obviously we can support more (I have a lot of ideas) but I wanted to started with this for now and focus on what is next based on usage.

Now regarding benchmark I'm really impressed see below:

```
goos: darwin
goarch: amd64
pkg: github.com/grafana/loki/pkg/logql
Benchmark_LineFilter/default_true_foo.*-4         	21158535	        52.0 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_foo.*-4      	85218762	        14.0 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_foo.*-4        	22269228	        54.7 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_foo.*-4     	70311904	        17.3 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_.*foo.*-4       	  266133	      4547 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_.*foo.*-4    	86887345	        13.9 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_.*foo.*-4      	  265743	      4561 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_.*foo.*-4   	70870168	        17.4 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_.*foo-4         	  264886	      4608 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_.*foo-4      	86199532	        14.5 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_.*foo-4        	  214016	      5971 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_.*foo-4     	70008873	        18.9 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_foo|bar-4       	 3362852	       337 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_foo|bar-4    	26095603	        53.2 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_foo|bar-4      	 3665444	       381 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_foo|bar-4   	26247618	        43.2 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_foo|bar|buzz-4  	 3709946	       322 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_foo|bar|buzz-4         	29003151	        41.9 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_foo|bar|buzz-4           	 3651050	       323 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_foo|bar|buzz-4        	24917181	        53.7 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_foo|(bar|buzz)-4          	 2345220	       544 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_foo|(bar|buzz)-4       	28986980	        43.1 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_foo|(bar|buzz)-4         	 3044107	       402 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_foo|(bar|buzz)-4      	24970191	        49.1 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_foo|bar.*|buzz-4          	  568879	      2115 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_foo|bar.*|buzz-4       	29001889	        42.7 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_foo|bar.*|buzz-4         	  561146	      2210 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_foo|bar.*|buzz-4      	24876418	        48.2 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_.*foo.*|bar|uzz-4         	  320361	      3819 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_.*foo.*|bar|uzz-4      	26418298	        43.5 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_.*foo.*|bar|uzz-4        	  319743	      3692 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_.*foo.*|bar|uzz-4     	24772117	        48.1 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_((f.*)|foobar.*)|.*buzz-4 	  513464	      2356 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_((f.*)|foobar.*)|.*buzz-4         	14787681	        84.6 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_((f.*)|foobar.*)|.*buzz-4           	  385447	      2688 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_((f.*)|foobar.*)|.*buzz-4        	12987230	        96.2 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_true_(?P<foo>.*foo.*|bar)-4               	  323151	      5924 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_true_(?P<foo>.*foo.*|bar)-4            	27697644	        39.8 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/default_false_(?P<foo>.*foo.*|bar)-4              	  263703	      3805 ns/op	       0 B/op	       0 allocs/op
Benchmark_LineFilter/simplified_false_(?P<foo>.*foo.*|bar)-4           	27809758	        46.5 ns/op	       0 B/op	       0 allocs/op
```
Basically the smallest improvement is 5x and the biggest one is 333x 😮 !

Fixes #1542 and more !
