### PR TITLE
Use ingester client GRPC call options from config.

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -36,9 +36,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func New(cfg Config, addr string) (grpc_health_v1.HealthClient, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(
-			grpc.UseCompressor("gzip"),
-		),
+		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
 	}
 	opts = append(opts, cfg.GRPCClientConfig.DialOption(instrumentation())...)
 	conn, err := grpc.Dial(addr, opts...)


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

By default gzip was activated, not sure we want this anymore. The config still allows to activate it.
