### PR TITLE
Add a test for duplicates count in the heap iterator and fixes it.

### DIFF
--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -259,7 +259,7 @@ func (i *heapIterator) Next() bool {
 			i.requeue(i.tuples[j].EntryIterator, true)
 			continue
 		}
-		// we count as duplicates only if the tuple if not the one (t) used to fill the current entry
+		// we count as duplicates only if the tuple is not the one (t) used to fill the current entry
 		if i.tuples[j] != t {
 			i.stats.TotalDuplicates++
 		}

--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -238,6 +238,15 @@ func (i *heapIterator) Next() bool {
 		})
 	}
 
+	// shortcut if we have a single tuple.
+	if len(i.tuples) == 1 {
+		i.currEntry = i.tuples[0].Entry
+		i.currLabels = i.tuples[0].Labels()
+		i.requeue(i.tuples[0].EntryIterator, false)
+		i.tuples = i.tuples[:0]
+		return true
+	}
+
 	// Find in tuples which entry occurs most often which, due to quorum based
 	// replication, is guaranteed to be the correct next entry.
 	t := mostCommon(i.tuples)
@@ -250,7 +259,10 @@ func (i *heapIterator) Next() bool {
 			i.requeue(i.tuples[j].EntryIterator, true)
 			continue
 		}
-		i.stats.TotalDuplicates++
+		// we count as duplicates only if the tuple if not the one (t) used to fill the current entry
+		if i.tuples[j] != t {
+			i.stats.TotalDuplicates++
+		}
 		i.requeue(i.tuples[j].EntryIterator, false)
 	}
 	i.tuples = i.tuples[:0]


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


Turned out I wasn't counting duplicates properly. Now that should be correct, I have added tests to ensure this is correct.

I've also added a shortcut for when there is a single tuple.

