### PR TITLE
Enable global limits by default in production mixin

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -91,10 +91,6 @@
       'limits.per-user-override-config': '/etc/loki/overrides/overrides.yaml',
     },
 
-    // Global limits are currently opt-in only.
-    max_streams_global_limit_enabled: false,
-    ingestion_rate_global_limit_enabled: false,
-
     loki: {
       server: {
         graceful_shutdown_timeout: '5s',
@@ -141,10 +137,8 @@
         reject_old_samples: true,
         reject_old_samples_max_age: '168h',
         max_query_length: '12000h',  // 500 days
-      } + if !$._config.max_streams_global_limit_enabled then {} else {
-        max_streams_per_user: 0,
+        max_streams_per_user: 0, // Disabled in favor of the global limit
         max_global_streams_per_user: 10000,  // 10k
-      } + if !$._config.ingestion_rate_global_limit_enabled then {} else {
         ingestion_rate_strategy: 'global',
         ingestion_rate_mb: 10,
         ingestion_burst_size_mb: 20,
@@ -274,7 +268,6 @@
         },
       },
 
-    } + if !$._config.ingestion_rate_global_limit_enabled then {} else {
       distributor: {
         // Creates a ring between distributors, required by the ingestion rate global limit.
         ring: {


### PR DESCRIPTION
**What this PR does / why we need it**:
We're running global limits since a while at Grafana. In this PR I'm proposing to switch the production mixin to global limits and remove the feature flag (it's always possible to override the config to disable them).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

