### PR TITLE
Optimize empty filter queries.

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -131,7 +131,10 @@ func (e *filterExpr) Filter() (LineFilter, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newAndFilter(nextFilter, f), nil
+		f = newAndFilter(nextFilter, f)
+	}
+	if f == TrueFilter {
+		return nil, nil
 	}
 	return f, nil
 }

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -20,6 +20,11 @@ func Test_logSelectorExpr_String(t *testing.T) {
 		{`{foo="bar", bar!="baz"}`, false},
 		{`{foo="bar", bar!="baz"} != "bip" !~ ".+bop"`, true},
 		{`{foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap"`, true},
+		{`{foo="bar", bar!="baz"} |= ""`, false},
+		{`{foo="bar", bar!="baz"} |~ ""`, false},
+		{`{foo="bar", bar!="baz"} |~ ".*"`, false},
+		{`{foo="bar", bar!="baz"} |= "" |= ""`, false},
+		{`{foo="bar", bar!="baz"} |~ "" |= "" |~ ".*"`, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/logql/filter.go
+++ b/pkg/logql/filter.go
@@ -26,7 +26,7 @@ type trueFilter struct{}
 func (trueFilter) Filter(_ []byte) bool { return true }
 
 // TrueFilter is a filter that returns and matches all log lines whatever their content.
-var TrueFilter = &trueFilter{}
+var TrueFilter = trueFilter{}
 
 type notFilter struct {
 	LineFilter

--- a/pkg/logql/filter_test.go
+++ b/pkg/logql/filter_test.go
@@ -49,6 +49,8 @@ func Test_SimplifiedRegex(t *testing.T) {
 		// parsed as ((f(?-s:.)*)|foobar(?-s:.)*)|(?-s:.)*buzz
 		{"((f.*)|foobar.*)|.*buzz", true, newOrFilter(newOrFilter(containsFilter("f"), containsFilter("foobar")), containsFilter("buzz")), true},
 		{".*", true, TrueFilter, true},
+		{".*|.*", true, TrueFilter, true},
+		{".*||||", true, TrueFilter, true},
 		{"", true, TrueFilter, true},
 
 		// regex we are not supporting.


### PR DESCRIPTION
Optimize filter queries such as `{label="foo"} |~ "" |~ ".*" |= ""` doesn't contains a filter.

The query is not really rewritten and the stringer func still returns the correct original query.
However the `Filter` func of the `Expr` returns nil which what is being checked when splitting queries in the frontend and also what is being used in the memchunk.

see https://github.com/grafana/loki/blob/master/pkg/querier/queryrange/roundtrip.go#L81 and https://github.com/grafana/loki/blob/master/pkg/chunkenc/memchunk.go#L614

Fixes #1792

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>