### PR TITLE
Error handling: Show data stream at "debug" level, not "warn"

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
+++ b/fluentd/fluent-plugin-grafana-loki/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.9'
+  spec.version = '1.2.10'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
+++ b/fluentd/fluent-plugin-grafana-loki/lib/fluent/plugin/out_loki.rb
@@ -151,7 +151,7 @@ module Fluent
                           'res=nil'
                         end
           log.warn "failed to #{req.method} #{@uri} (#{res_summary})"
-          log.warn Yajl.dump(body)
+          log.debug Yajl.dump(body)
 
         end
       end


### PR DESCRIPTION
Humbly request to change the log level of the stream dump:

I feel that most people may want to see `log.warn "failed to #{req.method} #{@uri} (#{res_summary})"` however may not always need to see `Yajl.dump(body)`. So propose to move the later down to "debug" level.

This is especially relevant if fluent's input stream includes our own STDOUT/STDERR's output as is common when running in containers.

Many thanks for your time & consideration