### PR TITLE
Logcli remote storage.

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -169,7 +169,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&query.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&query.ShowLabelsKey)
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&query.FixedLabelsLen)
-	cmd.Flag("local-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&query.LocalConfig)
+	cmd.Flag("store-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&query.LocalConfig)
 
 	return query
 }

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -169,6 +169,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&query.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&query.ShowLabelsKey)
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&query.FixedLabelsLen)
+	cmd.Flag("local-config", "Execute the current query using a local store with the given Loki's configuration file.").Default("").StringVar(&query.LocalConfig)
 
 	return query
 }

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -169,7 +169,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 	cmd.Flag("exclude-label", "Exclude labels given the provided key during output.").StringsVar(&query.IgnoreLabelsKey)
 	cmd.Flag("include-label", "Include labels given the provided key during output.").StringsVar(&query.ShowLabelsKey)
 	cmd.Flag("labels-length", "Set a fixed padding to labels").Default("0").IntVar(&query.FixedLabelsLen)
-	cmd.Flag("local-config", "Execute the current query using a local store with the given Loki's configuration file.").Default("").StringVar(&query.LocalConfig)
+	cmd.Flag("local-config", "Execute the current query using a configured storage from a given Loki configuration file.").Default("").StringVar(&query.LocalConfig)
 
 	return query
 }

--- a/docs/getting-started/logcli.md
+++ b/docs/getting-started/logcli.md
@@ -82,6 +82,7 @@ Flags:
       --tls-skip-verify  Server certificate TLS skip verify.
       --cert=""          Path to the client certificate.
       --key=""           Path to the client certificate key.
+      --org-id=ORG-ID    org ID header to be substituted for auth
 
 Commands:
   help [<command>...]
@@ -115,6 +116,7 @@ Flags:
       --from=FROM        Start looking for logs at this absolute time (inclusive)
       --to=TO            Stop looking for logs at this absolute time (exclusive)
       --forward          Scan forwards through logs.
+      --local-config=""  Execute the current query using a configured storage from a given Loki configuration file.
   -t, --tail             Tail the logs
       --delay-for=0      Delay in tailing by number of seconds to accumulate logs for re-ordering
       --no-labels        Do not print any labels


### PR DESCRIPTION
This allows to query a remote storage (eg. bigtable/gcs) using the logcli. It requires to provide a loki configuration files.

example of usage:

```
logcli query --org-id=3927 --local-config=/Users/ctovena/local-gcs.yaml {container_name="ingress-nginx"}
```

Example of configuration:

```
chunk_store_config:
limits_config:
  enforce_metric_name: false
  ingestion_burst_size_mb: 20
  ingestion_rate_mb: 10
  ingestion_rate_strategy: global
  max_global_streams_per_user: 10000
  max_query_length: 12000h
  max_query_parallelism: 32
  max_streams_per_user: 0
  reject_old_samples: true
  reject_old_samples_max_age: 168h
schema_config:
  configs:
    - from: "2018-04-15"
      index:
        period: 168h
        prefix: loki_dev_index_
      object_store: gcs
      schema: v9
      store: bigtable
    - from: "2019-10-30"
      index:
        period: 168h
        prefix: loki_dev_index_
      object_store: gcs
      schema: v11
      store: bigtable
storage_config:
  bigtable:
    instance: dev-us-central1
    project: dev
  gcs:
    bucket_name:  dev
  max_chunk_batch_size: 50
```

This is very handy to debug store queries.