### PR TITLE
Helm chart: Prevent prometheus to scrape both services

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.25.1
+version: 0.25.2
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/service-headless.yaml
+++ b/production/helm/loki/templates/service-headless.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ template "loki.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    variant: headless
 spec:
   clusterIP: None
   ports:

--- a/production/helm/loki/templates/servicemonitor.yaml
+++ b/production/helm/loki/templates/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       app: {{ template "loki.name" . }}
       release: {{ .Release.Name | quote }}
+      variant: headless
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}


### PR DESCRIPTION
Loki metrics port is exposed through 2 different services.

`ServiceMonitor` label selector match both services. Prometheus scrape both services. But this is useless... as it's the same metrics.

This PR add an extra label to the headless and switch the SM to force prometheus to scrap the headless service only