### PR TITLE
Use 8080 for Loki http port  binding in tanka.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -13,6 +13,6 @@ RUN addgroup -g 1000 -S loki && \
 USER loki
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
 COPY       --from=build /go/bin/dlv /usr/bin/dlv
 COPY       cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE     80
+EXPOSE     8080
 
 # Expose 40000 for delve
 EXPOSE 40000

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -1,7 +1,7 @@
 auth_enabled: false
 
 server:
-  http_listen_port: 3100
+  http_listen_port: 8080
 
 ingester:
   lifecycler:
@@ -17,13 +17,13 @@ ingester:
 
 schema_config:
   configs:
-  - from: 2018-04-15
-    store: boltdb
-    object_store: filesystem
-    schema: v11
-    index:
-      prefix: index_
-      period: 168h
+    - from: 2018-04-15
+      store: boltdb
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 168h
 
 storage_config:
   boltdb:
@@ -53,4 +53,3 @@ table_manager:
     provisioned_write_throughput: 0
   retention_deletes_enabled: false
   retention_period: 0s
-

--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -7,7 +7,7 @@
 
     defaultPorts::
       [
-        containerPort.new(name='http-metrics', port=80),
+        containerPort.new(name='http-metrics', port=$._config.http_listen_port),
         containerPort.new(name='grpc', port=9095),
       ],
   },

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -2,6 +2,7 @@
   _config+: {
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
+    http_listen_port: 8080,
 
     replication_factor: 3,
     memcached_replicas: 3,
@@ -99,6 +100,7 @@
         grpc_server_max_send_msg_size: $._config.grpc_server_max_msg_size,
         grpc_server_max_concurrent_streams: 1000,
         http_server_write_timeout: '1m',
+        http_listen_port: $._config.http_listen_port,
       },
       frontend: {
         compress_responses: true,

--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -12,7 +12,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.distributor_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('500m', '500Mi') +

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -46,31 +46,31 @@
             proxy_set_header     X-Scope-OrgID 1;
 
             location = /api/prom/push {
-              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
             }
 
             location = /api/prom/tail {
-              proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://querier.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }
 
             location ~ /api/prom/.* {
-              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
             }
 
             location = /loki/api/v1/push {
-              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://distributor.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
             }
 
             location = /loki/api/v1/tail {
-              proxy_pass       http://querier.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://querier.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }
 
             location ~ /loki/api/.* {
-              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local$request_uri;
+              proxy_pass       http://query-frontend.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;
             }
           }
         }

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -11,7 +11,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.ingester_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('1', '5Gi') +

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -11,7 +11,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.querier_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1),
 

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -11,7 +11,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.table_manager_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('100m', '100Mi') +


### PR DESCRIPTION
Previously we were using 80 but now that we run a rootless Loki for security reason.
 We can't bind below 1000.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


PS: tested in dev.