### PR TITLE
Loki/Change local storage directory to /loki/ and fix permissions (#1833)

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -8,11 +8,15 @@ RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make
 
 FROM alpine:3.9
 RUN apk add --update --no-cache ca-certificates
-RUN addgroup -g 1000 -S loki && \
-    adduser -u 1000 -S loki -G loki
-USER loki
+
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+
+RUN addgroup -g 1000 -S loki && \
+    adduser -u 1000 -S loki -G loki
+RUN mkdir -p /loki && \
+    chown -R loki:loki /etc/loki /loki
+USER loki
 EXPOSE 8080
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -27,10 +27,10 @@ schema_config:
 
 storage_config:
   boltdb:
-    directory: /tmp/loki/index
+    directory: /loki/index
 
   filesystem:
-    directory: /tmp/loki/chunks
+    directory: /loki/chunks
 
 limits_config:
   enforce_metric_name: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The default persistent directory `/tmp/loki/` in `local-config.yaml` cannot be a named docker volume because of permissions issues (see #1833)

Directory changed to `/loki/` and set permissions for `loki:loki`

**Which issue(s) this PR fixes**:
Fixes #1833 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

