### PR TITLE
Move default port for Loki to 3100 everywhere.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -17,6 +17,6 @@ RUN addgroup -g 1000 -S loki && \
 RUN mkdir -p /loki && \
     chown -R loki:loki /etc/loki /loki
 USER loki
-EXPOSE 8080
+EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
 COPY       --from=build /go/bin/dlv /usr/bin/dlv
 COPY       cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE     8080
+EXPOSE     3100
 
 # Expose 40000 for delve
 EXPOSE 40000

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -1,7 +1,7 @@
 auth_enabled: false
 
 server:
-  http_listen_port: 8080
+  http_listen_port: 3100
 
 ingester:
   lifecycler:

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.32.1
+version: 0.32.2
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.25.2
+version: 0.25.3
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -89,7 +89,7 @@ config:
     max_look_back_period: 0
   table_manager:
     retention_deletes_enabled: false
-    retention_period: 0
+    retention_period: 0s
 
 ## Additional Loki container arguments, e.g. log level (debug, info, warn, error)
 extraArgs: {}

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -2,7 +2,7 @@
   _config+: {
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
-    http_listen_port: 8080,
+    http_listen_port: 3100,
 
     replication_factor: 3,
     memcached_replicas: 3,


### PR DESCRIPTION
Also fixes default value for the table manager that doesn't support 0 anymore on master.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

I've tested helm to ensure we can also write to disk with the new rootless image. And everything looks good.

```
❯ k exec -it loki-stack-0 -- /bin/sh
/ $ ls /data/loki
chunks  index
/ $ ls /data/loki/chunks
ZmFrZS80YzQ3OWEyNTMzMDhjZDlhOjE3MTA3Yjc1ZDAyOjE3MTA3Yjc1ZGQ5OmQ1ZTJjM2Jm
ZmFrZS80ZmM4ODEwNWFiODE1YmVmOjE3MTA3Yjc1NjVmOjE3MTA3Yjc1NzAxOmQ2M2Q4NWQ5
ZmFrZS81ZTAwMTM2OTkxNzVmN2E4OjE3MTA3YjdkODRmOjE3MTA3YjdkODUwOjk1NjBiMjY2
ZmFrZS81ZTAwMTM2OTkxNzVmN2E4OjE3MTA3YmRkYTE5OjE3MTA3YmRkYTFhOjk0MDUyNTJm
ZmFrZS9hYTRhMzMwZWNiN2FkMzNkOjE3MTA3YmU0MGNiOjE3MTA3YmY0ODkzOjVhMTlkYmNm
ZmFrZS9mN2IzZDI2YzJkY2NiNGQ5OjE3MTA3YjdlYzMzOjE3MTA3YzNhNjk1OjU0YmRjMg==
ZmFrZS9mN2IzZDI2YzJkY2NiNGQ5OjE3MTA3YzZjODdlOjE3MTA3YzZjODgxOjg4NGRlNTlm
```

Fixes #1832