### PR TITLE
Pin helm version in circle-ci helm testing workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Install Helm
           command: |
-            curl -L https://git.io/get_helm.sh | bash
+            curl -L https://git.io/get_helm.sh | bash -s -- -v v2.16.3
             kubectl apply -f tools/helm.yaml
             helm init --service-account helm --wait
       - run:


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

A new version of helm 2.x is out and it doesn't create namespace by default anymore. Because of that `ct install` fails  and we can't really create the namespace in advance since its name is autogenerated.

Not sure how to solve this since ct is also part of helm tooling and so they broke their own tooling, for now I'll pin the helm version it was due anyway.