### PR TITLE
BugFix: Fix logcli client to use OrgID in LiveTail

### DIFF
--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -175,6 +175,10 @@ func (c *Client) wsConnect(path string, quiet bool) (*websocket.Conn, error) {
 
 	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(c.Username+":"+c.Password))}}
 
+	if c.OrgID != "" {
+		h.Set("X-Scope-OrgID", c.OrgID)
+	}
+
 	ws := websocket.Dialer{
 		TLSClientConfig: tlsConfig,
 	}


### PR DESCRIPTION
Signed-off-by: Schlotter, Christian <christi.schlotter@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

#1638 introduced `--org-id` for `logcli` as parameter but using it together with the flag `--tail` failed because the `--org-id` parameter did not get used in the client.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
