### PR TITLE
Replace __host__ with __address__

### DIFF
--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	pathLabel = "__path__"
-	hostLabel = "__host__"
+	hostLabel = "__address__"
 )
 
 var (
@@ -230,7 +230,7 @@ func (s *targetSyncer) sync(groups []*targetgroup.Group) {
 			}
 
 			host, ok := labels[hostLabel]
-			if ok && string(host) != s.hostname {
+			if ok && string(host) != s.hostname && string(host) != "localhost" {
 				dropped = append(dropped, newDroppedTarget(fmt.Sprintf("ignoring target, wrong host (labels:%s hostname:%s)", labels.String(), s.hostname), discoveredLabels))
 				level.Debug(s.log).Log("msg", "ignoring target, wrong host", "labels", labels.String(), "hostname", s.hostname)
 				failedTargets.WithLabelValues("wrong_host").Inc()


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace `__host__` with `__address__`. Discovered label is `__address__`. So, this part of the code is not getting executed as expected since we have `__host__` https://github.com/grafana/loki/blob/master/pkg/promtail/targets/filetargetmanager.go#L232

**Which issue(s) this PR fixes**:
Fixes #1831 
