### PR TITLE
Accept match[] in series API

### DIFF
--- a/pkg/loghttp/series.go
+++ b/pkg/loghttp/series.go
@@ -18,6 +18,7 @@ func ParseSeriesQuery(r *http.Request) (*logproto.SeriesRequest, error) {
 	}
 
 	xs := r.Form["match"]
+	xs = append(xs, r.Form["match[]"]...)
 
 	// ensure matchers are valid before fanning out to ingesters/store as well as returning valuable parsing errors
 	// instead of 500s

--- a/pkg/loghttp/series_test.go
+++ b/pkg/loghttp/series_test.go
@@ -41,6 +41,17 @@ func TestParseSeriesQuery(t *testing.T) {
 			false,
 			mkSeriesRequest(t, "1000", "2000", []string{`{a="1"}`, `{b="2", c=~"3", d!="4"}`}),
 		},
+		{
+			"accept match[]",
+			withForm(url.Values{
+				"start":   []string{"1000"},
+				"end":     []string{"2000"},
+				"match":   []string{`{a="1"}`},
+				"match[]": []string{`{b="2", c=~"3", d!="4"}`},
+			}),
+			false,
+			mkSeriesRequest(t, "1000", "2000", []string{`{a="1"}`, `{b="2", c=~"3", d!="4"}`}),
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			out, err := ParseSeriesQuery(tc.input)


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

With this `match[]` support, now we can query the series directly via `promtool`

```
➜  promtool query series --match='{job="varlogs"}' 'http://127.0.0.1:3100/loki'   
{filename="/var/log/syslog", job="varlogs"}
{filename="/var/log/Xorg.1.log", job="varlogs"}
{filename="/var/log/parallels.log", job="varlogs"}
```

**Which issue(s) this PR fixes**:
Fixes #1842 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

