### PR TITLE
[helm loki/promtail] Add systemd-journald example with extraMount, extraVolumeMount

### DIFF
--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -149,6 +149,41 @@ syslogService:
   port: 1514
 ```
 
+## Run promtail with systemd-journal support
+
+In order to receive and process syslog message into promtail, the following changes will be necessary:
+
+* Review the [promtail systemd-journal configuration documentation](/docs/clients/promtail/scraping.md#journal-scraping-linux-only)
+
+* Configure the promtail helm chart with the systemd-journal configuration added to the `extraScrapeConfigs` section and volume mounts for the promtail pods to access the log files. For example:
+
+```yaml
+# Add additional scrape config
+extraScrapeConfigs:
+  - job_name: journal
+    journal:
+      path: /var/log/journal
+      max_age: 12h
+      labels:
+        job: systemd-journal
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'
+      - source_labels: ['__journal__hostname']
+        target_label: 'hostname'
+
+# Mount journal directory into promtail pods
+extraVolumes:
+  - name: journal
+    hostPath:
+      path: /var/log/journal
+
+extraVolumeMounts:
+  - name: journal
+    mountPath: /var/log/journal
+    readOnly: true
+```
+
 ## How to contribute
 
 After adding your new feature to the appropriate chart, you can build and deploy it locally to test:

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.33.0
+version: 0.33.1
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.19.2
+version: 0.19.3
 appVersion: v1.3.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -75,6 +75,9 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
@@ -116,5 +119,8 @@ spec:
           hostPath:
             path: /run/promtail
         {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -96,6 +96,9 @@ volumes:
   hostPath:
     path: /var/log/pods
 
+# Custom volumes together with the default ones
+extraVolumes: []
+
 volumeMounts:
 - name: docker
   mountPath: /var/lib/docker/containers
@@ -103,6 +106,9 @@ volumeMounts:
 - name: pods
   mountPath: /var/log/pods
   readOnly: true
+
+# Custom volumeMounts together with the default ones
+extraVolumeMounts: []
 
 config:
   client:


### PR DESCRIPTION
This commit adds the variables extraMount and extraVolumeMount to the
promtail helm chart.

It also adds an example on how to use the helm chart with
systemd-journal support.

**What this PR does / why we need it**:

This PR makes it easier to use the promtail helm chart with systemd-journal support.

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated

