### PR TITLE
documents frontend worker

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -21,6 +21,7 @@ Configuration examples can be found in the [Configuration Examples](examples.md)
 * [schema_config](#schema_config)
   * [period_config](#period_config)
 * [limits_config](#limits_config)
+* [frontend_worker_config](#frontend_worker_config)
 * [table_manager_config](#table_manager_config)
   * [provision_config](#provision_config)
     * [auto_scaling_config](#auto_scaling_config)
@@ -86,6 +87,10 @@ Supported contents and default values of `loki.yaml`:
 
 # Configures limits per-tenant or globally
 [limits_config: <limits_config>]
+
+# The frontend_worker_config configures the worker - running within the Loki
+# querier - picking up and executing queries enqueued by the query-frontend.
+[frontend_worker: <frontend_worker_config>]
 
 # Configures the table manager for retention
 [table_manager: <table_manager_config>]
@@ -819,6 +824,62 @@ logs in Loki.
 
 # Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.reload-period (runtime_config.period in YAML)
 [per_tenant_override_period: <duration> | default = 10s]
+```
+
+### `frontend_worker_config`
+
+The `frontend_worker_config` configures the worker - running within the Loki querier - picking up and executing queries enqueued by the query-frontend.
+
+```yaml
+# Address of query frontend service, in host:port format.
+# CLI flag: -querier.frontend-address
+[frontend_address: <string> | default = ""]
+
+# Number of simultaneous queries to process.
+# CLI flag: -querier.worker-parallelism
+[parallelism: <int> | default = 10]
+
+# How often to query DNS.
+# CLI flag: -querier.dns-lookup-period
+[dns_lookup_duration: <duration> | default = 10s]
+
+grpc_client_config:
+  # gRPC client max receive message size (bytes).
+  # CLI flag: -querier.frontend-client.grpc-max-recv-msg-size
+  [max_recv_msg_size: <int> | default = 104857600]
+
+  # gRPC client max send message size (bytes).
+  # CLI flag: -querier.frontend-client.grpc-max-send-msg-size
+  [max_send_msg_size: <int> | default = 16777216]
+
+  # Use compression when sending messages.
+  # CLI flag: -querier.frontend-client.grpc-use-gzip-compression
+  [use_gzip_compression: <boolean> | default = false]
+
+  # Rate limit for gRPC client; 0 means disabled.
+  # CLI flag: -querier.frontend-client.grpc-client-rate-limit
+  [rate_limit: <float> | default = 0]
+
+  # Rate limit burst for gRPC client.
+  # CLI flag: -querier.frontend-client.grpc-client-rate-limit-burst
+  [rate_limit_burst: <int> | default = 0]
+
+  # Enable backoff and retry when we hit ratelimits.
+  # CLI flag: -querier.frontend-client.backoff-on-ratelimits
+  [backoff_on_ratelimits: <boolean> | default = false]
+
+  backoff_config:
+    # Minimum delay when backing off.
+    # CLI flag: -querier.frontend-client.backoff-min-period
+    [min_period: <duration> | default = 100ms]
+
+    # Maximum delay when backing off.
+    # CLI flag: -querier.frontend-client.backoff-max-period
+    [max_period: <duration> | default = 10s]
+
+    # Number of times to backoff and retry before failing.
+    # CLI flag: -querier.frontend-client.backoff-retries
+    [max_retries: <int> | default = 10]
 ```
 
 ## table_manager_config

--- a/docs/configuration/query-frontend.md
+++ b/docs/configuration/query-frontend.md
@@ -135,3 +135,10 @@ spec:
 ### Grafana
 
 Once you've deployed these, you'll need your grafana datasource to point to the new frontend service, now available within the cluster at `http://query-frontend.<namespace>.svc.cluster.local:3100`.
+
+### GRPC Mode (Pull model)
+
+the query frontend operates in one of two fashions:
+
+1) with `--frontend.downstream-url` or its yaml equivalent `frontend.downstream`. This simply proxies requests over http to said url.
+2) without (1) it defaults to a pull service. In this form, the frontend instantiates per-tenant queues that downstream queriers pull queries from via grpc. When operating in this mode, queriers need to specify `-querier.frontend-address` or its yaml equivalent `frontend_worker.frontend_address`.


### PR DESCRIPTION
## What

Adds documentation regarding the frontend worker configuration and the pull model for grpc-enabled frontends.

Closes https://github.com/grafana/loki/issues/1867