### PR TITLE
Addition of a `/suspend` endpoint to Loki Canary

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -93,14 +93,11 @@ func main() {
 		}
 	}()
 
-	interrupt := make(chan os.Signal, 1)
 	terminate := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-	signal.Notify(terminate, syscall.SIGTERM)
+	signal.Notify(terminate, syscall.SIGTERM, os.Interrupt)
 
 	for {
 		select {
-		case <-interrupt:
 		case <-terminate:
 			_, _ = fmt.Fprintf(os.Stderr, "shutting down\n")
 			c.stop()

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -96,13 +96,10 @@ func main() {
 	terminate := make(chan os.Signal, 1)
 	signal.Notify(terminate, syscall.SIGTERM, os.Interrupt)
 
-	for {
-		select {
-		case <-terminate:
-			_, _ = fmt.Fprintf(os.Stderr, "shutting down\n")
-			c.stop()
-			return
-		}
+	for range terminate {
+		_, _ = fmt.Fprintf(os.Stderr, "shutting down\n")
+		c.stop()
+		return
 	}
 }
 

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -57,6 +57,7 @@ func main() {
 	c := comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *buckets, sentChan, receivedChan, r, true)
 
 	http.HandleFunc("/suspend", func(_ http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(os.Stderr, "suspending indefinitely\n")
 		stopCanary(w, r, c)
 	})
 	http.Handle("/metrics", promhttp.Handler())

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -62,7 +62,7 @@ func main() {
 	receivedChan := make(chan time.Time)
 
 	c := &canary{}
-	startCanary := func() *canary {
+	startCanary := func() {
 		c.stop()
 
 		c.lock.Lock()
@@ -71,8 +71,6 @@ func main() {
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
 		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *lName, *lVal)
 		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *buckets, sentChan, receivedChan, c.reader, true)
-
-		return c
 	}
 
 	startCanary()

--- a/docs/operations/loki-canary.md
+++ b/docs/operations/loki-canary.md
@@ -47,6 +47,13 @@ determine if they are truly missing or only missing from the WebSocket. If
 missing entries are not found in the direct query, the `missing_entries` counter
 is incremented.
 
+### Control
+
+Loki Canary responds to two endpoints to allow dynamic suspending/resuming of the 
+canary process.  This can be useful if you'd like to quickly disable or reenable the 
+canary.  To stop or start the canary issue an HTTP GET request against the `/suspend` or
+`/resume` endpoints.
+
 ## Installation
 
 ### Binary

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -86,12 +86,14 @@ func NewComparator(writer io.Writer, maxWait time.Duration, pruneInterval time.D
 		done:          make(chan struct{}),
 	}
 
-	responseLatency = promauto.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "loki_canary",
-		Name:      "response_latency",
-		Help:      "is how long it takes for log lines to be returned from Loki in seconds.",
-		Buckets:   prometheus.ExponentialBuckets(0.5, 2, buckets),
-	})
+	if responseLatency == nil {
+		responseLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_canary",
+			Name:      "response_latency",
+			Help:      "is how long it takes for log lines to be returned from Loki in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.5, 2, buckets),
+		})
+	}
 
 	go c.run()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a suspend endpoint to accomodate a way to permanently stop a canary without killing the process.  Canary now honors SIGINT as expected.

**Which issue(s) this PR fixes**:
Fixes #1700

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

