### PR TITLE
Fixes possible panic in json pipeline stage.

### DIFF
--- a/pkg/logentry/stages/json.go
+++ b/pkg/logentry/stages/json.go
@@ -108,7 +108,7 @@ func (j *jsonStage) Process(labels model.LabelSet, extracted map[string]interfac
 		value, err := getString(extracted[*j.cfg.Source])
 		if err != nil {
 			if Debug {
-				level.Debug(j.logger).Log("msg", "failed to convert source value to string", "source", *j.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[*j.cfg.Source]).String())
+				level.Debug(j.logger).Log("msg", "failed to convert source value to string", "source", *j.cfg.Source, "err", err, "type", reflect.TypeOf(extracted[*j.cfg.Source]))
 			}
 			return
 		}

--- a/pkg/logentry/stages/json_test.go
+++ b/pkg/logentry/stages/json_test.go
@@ -233,7 +233,7 @@ var logFixture = `
 
 func TestJSONParser_Parse(t *testing.T) {
 	t.Parallel()
-
+	Debug = true
 	tests := map[string]struct {
 		config          interface{}
 		extracted       map[string]interface{}
@@ -338,6 +338,21 @@ func TestJSONParser_Parse(t *testing.T) {
 			logFixture,
 			map[string]interface{}{
 				"log": "not a json",
+			},
+		},
+		"nil source": {
+			map[string]interface{}{
+				"expressions": map[string]string{
+					"app": "",
+				},
+				"source": "log",
+			},
+			map[string]interface{}{
+				"log": nil,
+			},
+			logFixture,
+			map[string]interface{}{
+				"log": nil,
 			},
 		},
 	}


### PR DESCRIPTION
This was reported to me today and it happens because the previous source can be nil.
This was only happening when debug log was on. And the problem was only in the json because it was using .String on a nil value.

I've added a test and activate debug during tests to cover those path too.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
