### PR TITLE
[helm loki/promtail] make UpdateStrategy configurable

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.34.0
+version: 0.34.1
 appVersion: v1.4.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.20.0
+version: 0.20.1
 appVersion: v1.4.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/daemonset.yaml
+++ b/production/helm/promtail/templates/daemonset.yaml
@@ -16,10 +16,7 @@ spec:
       app: {{ template "promtail.name" . }}
       release: {{ .Release.Name }}
   updateStrategy:
-    type: {{ .Values.deploymentStrategy }}
-  {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
-    rollingUpdate: null
-  {{- end }}
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -4,7 +4,12 @@ affinity: {}
 
 annotations: {}
 
-deploymentStrategy: RollingUpdate
+# The update strategy to apply to the DaemonSet
+##
+deploymentStrategy: {}
+#  rollingUpdate:
+#    maxUnavailable: 1
+#  type: RollingUpdate
 
 initContainer:
   enabled: false


### PR DESCRIPTION
This commit makes UpdateStrategy of the promtail daemonset configurable.
On large installations, you may want to increase the value of maxUnavailable.

This fixes https://github.com/grafana/loki/issues/1878

**What this PR does / why we need it**:

See #1897 


**Which issue(s) this PR fixes**:
Fixes #1897 

**Special notes for your reviewer**:

I've reused the existing variable. This may break when you have this configured to the non-default value. Please advice if I shall add another variable or something else.

The codeis inspired by https://github.com/helm/charts/blob/master/stable/nginx-ingress/values.yaml#L139 and https://github.com/helm/charts/blob/master/stable/nginx-ingress/templates/controller-daemonset.yaml#L25

**Checklist**
- [X] Documentation added
- [X] Tests updated

