### PR TITLE
updating typo for end time parameter in api docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -216,7 +216,7 @@ accepts the following query parameters in the URL:
 - `query`: The [LogQL](./logql.md) query to perform
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 - `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
@@ -366,7 +366,7 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode '
 accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 
 In microservices mode, `/loki/api/v1/labels` is exposed by the querier.
 
@@ -403,7 +403,7 @@ label within a given time span. It accepts the following query parameters in
 the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 
 In microservices mode, `/loki/api/v1/label/<name>/values` is exposed by the querier.
 
@@ -578,7 +578,7 @@ support the following values:
 - `query`: The [LogQL](./logql.md) query to perform
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 - `regexp`: a regex to filter the returned results
 
@@ -644,7 +644,7 @@ $ curl -G -s  "http://localhost:3100/api/prom/query" --data-urlencode '{foo="bar
 accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 
 In microservices mode, `/api/prom/label` is exposed by the querier.
 
@@ -681,7 +681,7 @@ label within a given time span. It accepts the following query parameters in
 the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The start time for the query as a nanosecond Unix epoch. Defaults to now.
+- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 
 In microservices mode, `/api/prom/label/<name>/values` is exposed by the querier.
 


### PR DESCRIPTION
there are typos in end time parameter description which needs to be corrected.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

