### PR TITLE
s/dashboards/grafanaDashboards.

### DIFF
--- a/production/loki-mixin/dashboards.libsonnet
+++ b/production/loki-mixin/dashboards.libsonnet
@@ -2,7 +2,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
 {
-  dashboards+: {
+  grafanaDashboards+: {
     'loki-logs.json': import './dashboard-loki-logs.json',
     'loki-operational.json': import './dashboard-loki-operational.json',
     'loki-writes.json':

--- a/production/promtail-mixin/dashboards.libsonnet
+++ b/production/promtail-mixin/dashboards.libsonnet
@@ -2,7 +2,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
 {
-  dashboards+: {
+  grafanaDashboards+: {
     'promtail.json':
       g.dashboard('Loki / Promtail')
       .addTemplate('cluster', 'kube_pod_container_info{image=~".*promtail.*"}', 'cluster')


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom@grafana.com>

**What this PR does / why we need it**:

`dashboardz` field in mixins should be `grafanaDashboards`