### PR TITLE
only fetches one chunk per series in /series

### DIFF
--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -1,0 +1,12 @@
+package logproto
+
+import "github.com/prometheus/prometheus/pkg/labels"
+
+type SeriesIdentifiers []SeriesIdentifier
+
+func (ids SeriesIdentifiers) Len() int      { return len(ids) }
+func (ids SeriesIdentifiers) Swap(i, j int) { ids[i], ids[j] = ids[j], ids[i] }
+func (ids SeriesIdentifiers) Less(i, j int) bool {
+	a, b := labels.FromMap(ids[i].Labels), labels.FromMap(ids[j].Labels)
+	return labels.Compare(a, b) <= 0
+}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
-	"github.com/grafana/loki/pkg/logql/marshal"
 	"github.com/grafana/loki/pkg/logql/stats"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/util/validation"
@@ -484,12 +483,9 @@ func (q *Querier) seriesForMatchers(
 	groups []string,
 ) ([]logproto.SeriesIdentifier, error) {
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	var results []logproto.SeriesIdentifier
 	for _, group := range groups {
-		iter, err := q.store.LazyQuery(ctx, logql.SelectParams{
+		ids, err := q.store.GetSeries(ctx, logql.SelectParams{
 			QueryRequest: &logproto.QueryRequest{
 				Selector:  group,
 				Limit:     1,
@@ -502,19 +498,10 @@ func (q *Querier) seriesForMatchers(
 			return nil, err
 		}
 
-		for iter.Next() {
-			ls, err := marshal.NewLabelSet(iter.Labels())
-			if err != nil {
-				return nil, err
-			}
+		results = append(results, ids...)
 
-			results = append(results, logproto.SeriesIdentifier{
-				Labels: ls.Map(),
-			})
-		}
 	}
 	return results, nil
-
 }
 
 func (q *Querier) validateQueryRequest(ctx context.Context, req *logproto.QueryRequest) error {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -243,6 +243,15 @@ func (s *storeMock) DeleteSeriesIDs(ctx context.Context, from, through model.Tim
 	panic("don't call me please")
 }
 
+func (s *storeMock) GetSeries(ctx context.Context, req logql.SelectParams) ([]logproto.SeriesIdentifier, error) {
+	args := s.Called(ctx, req)
+	res := args.Get(0)
+	if res == nil {
+		return []logproto.SeriesIdentifier(nil), args.Error(1)
+	}
+	return res.([]logproto.SeriesIdentifier), args.Error(1)
+}
+
 func (s *storeMock) Stop() {
 
 }
@@ -312,15 +321,6 @@ func mockIngesterDesc(addr string, state ring.IngesterState) ring.IngesterDesc {
 // starting at from
 func mockStreamIterator(from int, quantity int) iter.EntryIterator {
 	return iter.NewStreamIterator(mockStream(from, quantity))
-}
-
-func mockStreamIterFromLabelSets(from, quantity int, sets []string) iter.EntryIterator {
-	var streams []*logproto.Stream
-	for _, s := range sets {
-		streams = append(streams, mockStreamWithLabels(from, quantity, s))
-	}
-
-	return iter.NewStreamsIterator(context.Background(), streams, logproto.FORWARD)
 }
 
 // mockStream return a stream with quantity entries, where entries timestamp and

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -329,7 +329,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 			func(store *storeMock, querier *queryClientMock, ingester *querierClientMock, limits validation.Limits, req *logproto.SeriesRequest) {
 				ingester.On("Series", mock.Anything, req, mock.Anything).Return(nil, errors.New("tst-err"))
 
-				store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(0, 0), nil)
+				store.On("GetSeries", mock.Anything, mock.Anything).Return(nil, nil)
 			},
 			func(t *testing.T, q *Querier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -345,7 +345,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1"},
 				}), nil)
 
-				store.On("LazyQuery", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+				store.On("GetSeries", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
 			},
 			func(t *testing.T, q *Querier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -358,9 +358,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 			mkReq([]string{`{a="1"}`}),
 			func(store *storeMock, querier *queryClientMock, ingester *querierClientMock, limits validation.Limits, req *logproto.SeriesRequest) {
 				ingester.On("Series", mock.Anything, req, mock.Anything).Return(mockSeriesResponse(nil), nil)
-
-				store.On("LazyQuery", mock.Anything, mock.Anything).
-					Return(mockStreamIterator(0, 0), nil)
+				store.On("GetSeries", mock.Anything, mock.Anything).Return(nil, nil)
 			},
 			func(t *testing.T, q *Querier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -378,11 +376,10 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1", "b": "3"},
 				}), nil)
 
-				store.On("LazyQuery", mock.Anything, mock.Anything).
-					Return(mockStreamIterFromLabelSets(0, 10, []string{
-						`{a="1",b="4"}`,
-						`{a="1",b="5"}`,
-					}), nil)
+				store.On("GetSeries", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
+					{Labels: map[string]string{"a": "1", "b": "4"}},
+					{Labels: map[string]string{"a": "1", "b": "5"}},
+				}, nil)
 			},
 			func(t *testing.T, q *Querier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -404,11 +401,11 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1", "b": "2"},
 				}), nil)
 
-				store.On("LazyQuery", mock.Anything, mock.Anything).
-					Return(mockStreamIterFromLabelSets(0, 10, []string{
-						`{a="1",b="2"}`,
-						`{a="1",b="3"}`,
-					}), nil)
+				store.On("GetSeries", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
+					{Labels: map[string]string{"a": "1", "b": "2"}},
+					{Labels: map[string]string{"a": "1", "b": "3"}},
+				}, nil)
+
 			},
 			func(t *testing.T, q *Querier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -78,6 +78,7 @@ func decodeReq(req logql.SelectParams) ([]*labels.Matcher, logql.LineFilter, mod
 	return matchers, filter, from, through, nil
 }
 
+// lazyChunks is an internal function used to resolve a set of lazy chunks from the store without actually loading them. It's used internally by `LazyQuery` and `GetSeries`
 func (s *store) lazyChunks(ctx context.Context, matchers []*labels.Matcher, from, through model.Time) ([]*chunkenc.LazyChunk, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -120,12 +120,12 @@ func (s *store) GetSeries(ctx context.Context, req logql.SelectParams) ([]logpro
 	}
 
 	// group chunks by series
-	m := partitionBySeriesChunks(lazyChunks)
+	chunksBySeries := partitionBySeriesChunks(lazyChunks)
 
-	firstChunksPerSeries := make([]*chunkenc.LazyChunk, 0, len(m))
+	firstChunksPerSeries := make([]*chunkenc.LazyChunk, 0, len(chunksBySeries))
 
 	// discard all but one chunk per series
-	for _, chks := range m {
+	for _, chks := range chunksBySeries {
 		firstChunksPerSeries = append(firstChunksPerSeries, chks[0][0])
 	}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"flag"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -129,7 +130,7 @@ func (s *store) GetSeries(ctx context.Context, req logql.SelectParams) ([]logpro
 		firstChunksPerSeries = append(firstChunksPerSeries, chks[0][0])
 	}
 
-	results := make([]logproto.SeriesIdentifier, 0, len(firstChunksPerSeries))
+	results := make(logproto.SeriesIdentifiers, 0, len(firstChunksPerSeries))
 
 	// bound concurrency
 	groups := make([][]*chunkenc.LazyChunk, 0, len(firstChunksPerSeries)/s.cfg.MaxChunkBatchSize+1)
@@ -168,6 +169,7 @@ func (s *store) GetSeries(ctx context.Context, req logql.SelectParams) ([]logpro
 			})
 		}
 	}
+	sort.Sort(results)
 	return results, nil
 
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/marshal"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
@@ -354,4 +356,63 @@ func Test_store_LazyQuery(t *testing.T) {
 			assertStream(t, tt.expected, streams.Streams)
 		})
 	}
+}
+
+func Test_store_GetSeries(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		req      *logproto.QueryRequest
+		expected []logproto.SeriesIdentifier
+	}{
+		{
+			"all",
+			newQuery("{foo=~\"ba.*\"}", from, from.Add(6*time.Millisecond), logproto.FORWARD),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+				{Labels: mustParseLabels("{foo=\"bazz\"}")},
+			},
+		},
+		{
+			"regexp filter (post chunk fetching)",
+			newQuery("{foo=~\"bar.*\"}", from, from.Add(6*time.Millisecond), logproto.FORWARD),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+			},
+		},
+		{
+			"filter matcher",
+			newQuery("{foo=\"bar\"}", from, from.Add(6*time.Millisecond), logproto.FORWARD),
+			[]logproto.SeriesIdentifier{
+				{Labels: mustParseLabels("{foo=\"bar\"}")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &store{
+				Store: storeFixture,
+				cfg: Config{
+					MaxChunkBatchSize: 1,
+				},
+			}
+			ctx = user.InjectOrgID(context.Background(), "test-user")
+			out, err := s.GetSeries(ctx, logql.SelectParams{QueryRequest: tt.req})
+			if err != nil {
+				t.Errorf("store.GetSeries() error = %v", err)
+				return
+			}
+			require.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func mustParseLabels(s string) map[string]string {
+	l, err := marshal.NewLabelSet(s)
+
+	if err != nil {
+		log.Fatalf("Failed to parse %s", s)
+	}
+
+	return l
 }


### PR DESCRIPTION
## What
Improves `/series` API by fetching a single chunk for each series and then appying matchers one time per series.

## Why
Previously we used used the same functions and associated `EntryIterator` ifc as the traditional query path, fetching all logs in a time range then calculating labels per entry, only deduping them at the end. This was wildly inefficient and would oom queriers.

## Proof

Tested locally w/ v9 schema
```
$ ls -lh /var/log/*.log | grep -v ' 0B ' | wc -l
       9
$ logcli series --match='{filename=~".*log$"}' | wc -l
http://localhost:3100/loki/api/v1/series?end=1586288927776455000&match=%7Bfilename%3D~%22.%2Alog%24%22%7D&start=1586285327776455000
       9
```

/cc @cyriltovena 