### PR TITLE
Fix fluent-bit metrics

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.1.0
+version: 0.1.1
 appVersion: v1.4.1
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
 data:
   fluent-bit.conf: |-
     [SERVICE]
+        HTTP_Server    On
+        HTTP_Listen    0.0.0.0
+        HTTP_PORT      {{ .Values.config.port }}
         Flush          1
         Daemon         Off
         Log_Level      {{ .Values.config.loglevel }}

--- a/production/helm/fluent-bit/templates/servicemonitor.yaml
+++ b/production/helm/fluent-bit/templates/servicemonitor.yaml
@@ -21,6 +21,7 @@ spec:
       - {{ .Release.Namespace | quote }}
   endpoints:
   - port: http-metrics
+    path: /api/v1/metrics/prometheus
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Metrics are not actually able to be scraped because the http server is not enabled. Once it is, you still need to change the path as default /metrics is incorrect

**Which issue(s) this PR fixes**:
NA
**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

