### PR TITLE
Add cap_net_bind_service linux capabilities to Loki.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -6,14 +6,18 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcap2-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN setcap cap_net_bind_service=+ep /src/loki/cmd/loki/loki
+
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates libcap \
+RUN apk add --update --no-cache ca-certificates \
     && rm -rf /var/cache/apk/*
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-
-RUN setcap cap_net_bind_service=+ep /usr/bin/loki
 
 RUN addgroup -g 1000 -S loki && \
     adduser -u 1000 -S loki -G loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -7,10 +7,13 @@ WORKDIR /src/loki
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates libcap \
+    && rm -rf /var/cache/apk/*
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+
+RUN setcap cap_net_bind_service=+ep /usr/bin/loki
 
 RUN addgroup -g 1000 -S loki && \
     adduser -u 1000 -S loki -G loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -6,23 +6,22 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcap2-bin \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN setcap cap_net_bind_service=+ep /src/loki/cmd/loki/loki
-
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates \
+RUN apk add --update --no-cache ca-certificates libcap \
     && rm -rf /var/cache/apk/*
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
+RUN setcap cap_net_bind_service=+ep /usr/bin/loki
+
+RUN apk del --no-cache libcap && rm -rf /var/cache/apk/*
+
 RUN addgroup -g 1000 -S loki && \
     adduser -u 1000 -S loki -G loki
 RUN mkdir -p /loki && \
     chown -R loki:loki /etc/loki /loki
+
 USER loki
 EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -2,7 +2,7 @@
   _config+: {
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
-    http_listen_port: 80,
+    http_listen_port: 3100,
 
     replication_factor: 3,
     memcached_replicas: 3,

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -2,7 +2,7 @@
   _config+: {
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
-    http_listen_port: 3100,
+    http_listen_port: 80,
 
     replication_factor: 3,
     memcached_replicas: 3,


### PR DESCRIPTION
This allow Loki to bind to port below port 1024 without being a root user.
Also update tanka to use 80 as default port since this is more intuitive to remember.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>