### PR TITLE
feat: tms readiness check bypass implementation

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -133,6 +133,9 @@ The `server_config` block configures Promtail's behavior as an HTTP server:
 
 # Base path to server all API routes from (e.g., /v1/).
 [http_path_prefix: <string>]
+
+# Target managers check flag for promtail readiness, if set to false the check is ignored
+[health_check_target: <bool> | default = true]
 ```
 
 ## client_config


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements tms readiness check bypass for /ready endpoint handler

**Which issue(s) this PR fixes**:
Fixes #1919

**Checklist**
- [ yes] Documentation added
- [ no] Tests updated

