### PR TITLE
Clarified that the api push path needs to be specified.

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -143,7 +143,8 @@ Loki:
 ```yaml
 # The URL where Loki is listening, denoted in Loki as http_listen_address and
 # http_listen_port. If Loki is running in microservices mode, this is the HTTP
-# URL for the Distributor.
+# URL for the Distributor. Path to the push API needs to be included. 
+# Example: http://example.com:3100/loki/api/v1/push
 url: <string>
 
 # The tenant ID used by default to push logs to Loki. If omitted or empty


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarified that the api push path needs to be specified in client.url property. Otherwise folks will run into this message:

level=error ts=2020-04-09T15:08:53.408999Z caller=client.go:247 component=client host=example.com:3100 msg="final error sending batch" status=404 error="server returned HTTP status 404 Not Found (404): 404 page not found"


