### PR TITLE
bumps helm to keepalive-master after cortex vendoring

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.34.3
+version: 0.35.0
 appVersion: v1.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.34.2
-appVersion: v1.4.1
+version: 0.34.3
+appVersion: v1.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."
 home: https://grafana.com/loki

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: loki
-version: 0.26.1
-appVersion: v1.4.1
+version: 0.26.2
+appVersion: v1.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."
 home: https://grafana.com/loki

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.26.2
+version: 0.27.0
 appVersion: v1.4.2
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: grafana/loki
-  tag: 1.4.1
+  tag: keepalive-master-6d5408c
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 name: promtail
-version: 0.20.1
-appVersion: v1.4.1
+version: 0.21.0
+appVersion: v1.4.2
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"
 home: https://grafana.com/loki

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -17,7 +17,7 @@ initContainer:
 
 image:
   repository: grafana/promtail
-  tag: 1.4.1
+  tag: keepalive-master-6d5408c
   pullPolicy: IfNotPresent
 
 livenessProbe: {}


### PR DESCRIPTION
This bumps helm charts after the cortex 1.0 vendoring. The helm chart used some options which were changed in a backwards incompatible way, thus rendering the chart broken and failing all CI builds. This introduces a new tag, prefixed `keepalive` in order to not be pruned due to it's master prefix:

https://hub.docker.com/layers/grafana/loki/keepalive-master-6d5408c/images/sha256-16a50c98ae5a6e348323848411fbe4a9940b85ed745fe6733f0d587659e877ef?context=explore