### PR TITLE
adds config validation, similar to cortex

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -50,6 +50,14 @@ func main() {
 	}
 	util.InitLogger(&config.Server)
 
+	// Validate the config once both the config file has been loaded
+	// and CLI flags parsed.
+	err := config.Validate(util.Logger)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "validating config", "err", err.Error())
+		os.Exit(1)
+	}
+
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace, err := tracing.NewFromEnv(fmt.Sprintf("loki-%s", config.Target))
 	if err != nil {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/weaveworks/common/middleware"
@@ -71,6 +72,24 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Worker.RegisterFlags(f)
 	c.QueryRange.RegisterFlags(f)
 	c.RuntimeConfig.RegisterFlags(f)
+}
+
+// Validate the config and returns an error if the validation
+// doesn't pass
+func (c *Config) Validate(log log.Logger) error {
+	if err := c.SchemaConfig.Validate(); err != nil {
+		return errors.Wrap(err, "invalid schema config")
+	}
+	if err := c.StorageConfig.Validate(); err != nil {
+		return errors.Wrap(err, "invalid storage config")
+	}
+	if err := c.QueryRange.Validate(log); err != nil {
+		return errors.Wrap(err, "invalid queryrange config")
+	}
+	if err := c.TableManager.Validate(); err != nil {
+		return errors.Wrap(err, "invalid tablemanager config")
+	}
+	return nil
 }
 
 // Loki is the root datastructure for Loki.


### PR DESCRIPTION
### Background
After the 1.0 vendoring, we're exposed to some tricky configuration errors because we instantiate our configurations differently than cortex but use cortex's underlying configs. In this case, we loaded the schema's `PeriodConfig` blocks via yaml, causing subsequent calls to `Load` to no-op (this is intended to be an idempotent method). 

### What
This PR introduces a `Config.Validate` function and calls it in the loki execution path - it mainly calls cortex validation code similar to cortex: https://github.com/cortexproject/cortex/blob/master/cmd/cortex/main.go#L83-L89

Cortex `Load`: https://github.com/cortexproject/cortex/blob/master/pkg/chunk/schema_config.go#L228-L239

I've tested this fix on one of our clusters and confirmed we're no longer seeing panics due to `0` (default go value) shard factors in our configs. 