### PR TITLE
fixes problematic helm image, uses k13

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: grafana/loki
-  tag: keepalive-master-6d5408c
+  tag: k13-e9789f7
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -17,7 +17,7 @@ initContainer:
 
 image:
   repository: grafana/promtail
-  tag: keepalive-master-6d5408c
+  tag: k13-e9789f7
   pullPolicy: IfNotPresent
 
 livenessProbe: {}


### PR DESCRIPTION
## What
The current helm image causes panics as described in https://github.com/grafana/loki/pull/1939
This changes the associated image as a stopgap
