### PR TITLE
docs: version pin the docker image in docker-compose

### DIFF
--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:1.4.1
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:latest
+    image: grafana/promtail:1.4.1
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/docker-config.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
While the [documentation](https://github.com/grafana/loki/blob/master/docs/installation/docker.md) does version pin the links to specific versions of the docker-compose file, the file it docker-compose file does use the `latest` tag for loki.

For an example of issues this causes see #1941

**Which issue(s) this PR fixes**:

Fixes #1941

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

