### PR TITLE
[Loki]: Cleanup dockerfile

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -20,6 +20,9 @@ RUN addgroup -g 10001 -S loki && \
     mkdir -p /data && \
     chown -R loki:loki /etc/loki /data
 
+# See https://github.com/grafana/loki/issues/1928
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 USER loki
 EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -8,16 +8,18 @@ RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make
 
 FROM alpine:3.9
 
+RUN apk add --no-cache ca-certificates
+
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
-RUN apk add --no-cache ca-certificates libcap && \
+RUN apk add --no-cache libcap && \
     setcap cap_net_bind_service=+ep /usr/bin/loki && \
     apk del --no-cache libcap
 
 RUN addgroup -g 10001 -S loki && \
-    adduser -u 10001 -S loki -G loki && \
-    mkdir -p /data && \
+    adduser -u 10001 -S loki -G loki
+RUN mkdir -p /data && \
     chown -R loki:loki /etc/loki /data
 
 # See https://github.com/grafana/loki/issues/1928

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -7,15 +7,13 @@ WORKDIR /src/loki
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates libcap \
-    && rm -rf /var/cache/apk/*
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
-RUN setcap cap_net_bind_service=+ep /usr/bin/loki
-
-RUN apk del --no-cache libcap && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates libcap && \
+    setcap cap_net_bind_service=+ep /usr/bin/loki && \
+    apk del --no-cache libcap
 
 RUN addgroup -g 1000 -S loki && \
     adduser -u 1000 -S loki -G loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -8,14 +8,12 @@ RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make
 
 FROM alpine:3.9
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libcap
 
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
-RUN apk add --no-cache libcap && \
-    setcap cap_net_bind_service=+ep /usr/bin/loki && \
-    apk del --no-cache libcap
+RUN setcap cap_net_bind_service=+ep /usr/bin/loki
 
 RUN addgroup -g 10001 -S loki && \
     adduser -u 10001 -S loki -G loki

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -17,8 +17,8 @@ RUN setcap cap_net_bind_service=+ep /usr/bin/loki
 
 RUN addgroup -g 10001 -S loki && \
     adduser -u 10001 -S loki -G loki
-RUN mkdir -p /data && \
-    chown -R loki:loki /etc/loki /data
+RUN mkdir -p /loki && \
+    chown -R loki:loki /etc/loki /loki
 
 # See https://github.com/grafana/loki/issues/1928
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -15,10 +15,10 @@ RUN apk add --no-cache ca-certificates libcap && \
     setcap cap_net_bind_service=+ep /usr/bin/loki && \
     apk del --no-cache libcap
 
-RUN addgroup -g 1000 -S loki && \
-    adduser -u 1000 -S loki -G loki
-RUN mkdir -p /loki && \
-    chown -R loki:loki /etc/loki /loki
+RUN addgroup -g 10001 -S loki && \
+    adduser -u 10001 -S loki -G loki && \
+    mkdir -p /data && \
+    chown -R loki:loki /etc/loki /data
 
 USER loki
 EXPOSE 3100

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -21,8 +21,8 @@ COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
 RUN addgroup -g 10001 -S loki && \
     adduser -u 10001 -S loki -G loki
-RUN mkdir -p /data && \
-    chown -R loki:loki /etc/loki /data
+RUN mkdir -p /loki && \
+    chown -R loki:loki /etc/loki /loki
 
 # See https://github.com/grafana/loki/issues/1928
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -13,9 +13,21 @@ WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.9
-RUN apk add --update --no-cache ca-certificates
+
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE 80
+
+RUN apk add --no-cache ca-certificates
+
+RUN addgroup -g 10001 -S loki && \
+    adduser -u 10001 -S loki -G loki && \
+    mkdir -p /data && \
+    chown -R loki:loki /etc/loki /data
+
+# See https://github.com/grafana/loki/issues/1928
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+USER loki
+EXPOSE 3100
 ENTRYPOINT [ "/usr/bin/loki" ]
 CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -14,14 +14,14 @@ RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAI
 
 FROM alpine:3.9
 
+RUN apk add --no-cache ca-certificates
+
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
 
-RUN apk add --no-cache ca-certificates
-
 RUN addgroup -g 10001 -S loki && \
-    adduser -u 10001 -S loki -G loki && \
-    mkdir -p /data && \
+    adduser -u 10001 -S loki -G loki
+RUN mkdir -p /data && \
     chown -R loki:loki /etc/loki /data
 
 # See https://github.com/grafana/loki/issues/1928

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -27,10 +27,10 @@ schema_config:
 
 storage_config:
   boltdb:
-    directory: /loki/index
+    directory: /data/loki/index
 
   filesystem:
-    directory: /loki/chunks
+    directory: /data/loki/chunks
 
 limits_config:
   enforce_metric_name: false

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -27,10 +27,10 @@ schema_config:
 
 storage_config:
   boltdb:
-    directory: /data/loki/index
+    directory: /loki/index
 
   filesystem:
-    directory: /data/loki/chunks
+    directory: /loki/chunks
 
 limits_config:
   enforce_metric_name: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
- It reduces the amount of layers in the docker file. Installing libcap in an earlier layer and then deleting it in a later layer doesn't remove the earlier data
- It changes the user/group ID to match what the default is in the Helm chart currently
- It changes the data directory to match what the default is in the Helm chart currently
- Adds an nsswitch.conf to stop localhost DNS lookups
- Updates `Dockerfile.cross` to match the plain `Dockerfile` except `setep` as I'm not sure the amd64 binary will work on cross-compiled binaries

**Which issue(s) this PR fixes**:
Fixes #1928

**Special notes for your reviewer**:
The PRs that changed the user/group ID and data directory haven't made it into a release yet so this should be safe to change.

I couldn't test this as GolangCI shutdown yesterday.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

