### PR TITLE
chunk lifespan histogram

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -83,7 +83,7 @@ var (
 	}, []string{"reason"})
 	chunkLifespan = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "loki",
-		Name:      "ingester_chunk_lifespan_minutes",
+		Name:      "ingester_chunk_bounds_minutes",
 		Help:      "Distribution of chunk end-start durations.",
 		// 15m to 2h
 		Buckets: prometheus.LinearBuckets(15, 15, 8),


### PR DESCRIPTION
## What
Adds a histogram reporting the average chunk lifespan (end-start) minutes.
## Why
This allows us to track the bounds of flushed chunks. Currently we only track how long the reside in ingester memory. Understanding lifespans will help us parallelize more efficiently by reducing the likelihood of multiple queriers downloading the same chunks (with small interval configs). This should work very well with sharding, too.
## Issue
closes https://github.com/grafana/loki/issues/1902