### PR TITLE
Loki: Adds an `interval` paramater to query_range queries allowing a sampling of events to be returned based on the provided interval

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -229,7 +229,8 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 		cmd.Flag("since", "Lookback window.").Default("1h").DurationVar(&since)
 		cmd.Flag("from", "Start looking for logs at this absolute time (inclusive)").StringVar(&from)
 		cmd.Flag("to", "Stop looking for logs at this absolute time (exclusive)").StringVar(&to)
-		cmd.Flag("step", "Query resolution step width").DurationVar(&q.Step)
+		cmd.Flag("step", "Query resolution step width, for metric queries. Evaluate the query at the specified step over the time range.").DurationVar(&q.Step)
+		cmd.Flag("interval", "Query interval, for log queries. Return entries at the specified interval, ignoring those between.").DurationVar(&q.Interval)
 	}
 
 	cmd.Flag("forward", "Scan forwards through logs.").Default("false").BoolVar(&q.Forward)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -230,7 +230,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 		cmd.Flag("from", "Start looking for logs at this absolute time (inclusive)").StringVar(&from)
 		cmd.Flag("to", "Stop looking for logs at this absolute time (exclusive)").StringVar(&to)
 		cmd.Flag("step", "Query resolution step width, for metric queries. Evaluate the query at the specified step over the time range.").DurationVar(&q.Step)
-		cmd.Flag("interval", "Query interval, for log queries. Return entries at the specified interval, ignoring those between.").DurationVar(&q.Interval)
+		cmd.Flag("interval", "Query interval, for log queries. Return entries at the specified interval, ignoring those between. **This parameter is experimental, please see Issue 1779**").DurationVar(&q.Interval)
 	}
 
 	cmd.Flag("forward", "Scan forwards through logs.").Default("false").BoolVar(&q.Forward)

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,7 +218,7 @@ accepts the following query parameters in the URL:
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
 - `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.  Only applies to query types which produce a matrix response.
-- `interval`: Only return entries aligned with the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
+- `interval`: **Experimental, See Below** Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
 In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and the frontend.
@@ -227,9 +227,9 @@ In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and 
 
 Use the `step` parameter when making metric queries to Loki, or queries which return a matrix response.  It is evaluated in exactly the same way Prometheus evaluates `step`.  First the query will be evaluated at `start` and then evaluated again at `start + step` and again at `start + step + step` until `end` is reached.  The result will be a matrix of the query result evaluated at each step.
 
-Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached.
+Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached.  It does not fill missing entries.
 
-
+**Note about the experimental nature of interval** This flag may be removed in the future in favor of a LogQL expression to perform similar behavior.
 
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -217,15 +217,21 @@ accepts the following query parameters in the URL:
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.
+- `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.  Only applies to query types which produce a matrix response.
+- `interval`: Only return entries aligned with the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
-Requests against this endpoint require Loki to query the index store in order to
-find log streams for particular labels. Because the index store is spread out by
-time, the time span covered by `start` and `end`, if large, may cause additional
-load against the index server and result in a slow query.
-
 In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and the frontend.
+
+##### Step vs Interval
+
+Use the `step` parameter when making metric queries to Loki, or queries which return a matrix response.  It is evaluated in exactly the same way Prometheus evaluates `step`.  First the query will be evaluated at `start` and then evaluated again at `start + step` and again at `start + step + step` until `end` is reached.  The result will be a matrix of the query result evaluated at each step.
+
+Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached.
+
+
+
+
 
 Response:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -229,7 +229,7 @@ Use the `step` parameter when making metric queries to Loki, or queries which re
 
 Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached.  It does not fill missing entries.
 
-**Note about the experimental nature of interval** This flag may be removed in the future in favor of a LogQL expression to perform similar behavior.
+**Note about the experimental nature of interval** This flag may be removed in the future, if so it will likely be in favor of a LogQL expression to perform similar behavior, however that is uncertain at this time.  [Issue 1779](https://github.com/grafana/loki/issues/1779) was created to track the discussion, if you are using `interval` please go add your use case and thoughts to that issue.
 
 
 

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -54,7 +54,7 @@ func (c *Client) Query(queryStr string, limit int, time time.Time, direction log
 // QueryRange uses the /api/v1/query_range endpoint to execute a range query
 // excluding interfacer b/c it suggests taking the interface promql.Node instead of logproto.Direction b/c it happens to have a String() method
 // nolint:interfacer
-func (c *Client) QueryRange(queryStr string, limit int, from, through time.Time, direction logproto.Direction, step time.Duration, quiet bool) (*loghttp.QueryResponse, error) {
+func (c *Client) QueryRange(queryStr string, limit int, from, through time.Time, direction logproto.Direction, step, interval time.Duration, quiet bool) (*loghttp.QueryResponse, error) {
 	params := util.NewQueryStringBuilder()
 	params.SetString("query", queryStr)
 	params.SetInt32("limit", limit)
@@ -66,6 +66,10 @@ func (c *Client) QueryRange(queryStr string, limit int, from, through time.Time,
 	// otherwise we do leverage on the API defaults
 	if step != 0 {
 		params.SetInt("step", int64(step.Seconds()))
+	}
+
+	if interval != 0 {
+		params.SetInt("interval", int64(interval.Seconds()))
 	}
 
 	return c.doQuery(params.EncodeWithPath(queryRangePath), quiet)

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -43,6 +43,7 @@ type Query struct {
 	Limit           int
 	Forward         bool
 	Step            time.Duration
+	Interval        time.Duration
 	Quiet           bool
 	NoLabels        bool
 	IgnoreLabelsKey []string
@@ -70,7 +71,7 @@ func (q *Query) DoQuery(c *client.Client, out output.LogOutput, statistics bool)
 	if q.isInstant() {
 		resp, err = c.Query(q.QueryString, q.Limit, q.Start, d, q.Quiet)
 	} else {
-		resp, err = c.QueryRange(q.QueryString, q.Limit, q.Start, q.End, d, q.Step, q.Quiet)
+		resp, err = c.QueryRange(q.QueryString, q.Limit, q.Start, q.End, d, q.Step, q.Interval, q.Quiet)
 	}
 
 	if err != nil {
@@ -121,7 +122,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 	if q.isInstant() {
 		query = eng.NewInstantQuery(q.QueryString, q.Start, q.resultsDirection(), uint32(q.Limit))
 	} else {
-		query = eng.NewRangeQuery(q.QueryString, q.Start, q.End, q.Step, q.resultsDirection(), uint32(q.Limit))
+		query = eng.NewRangeQuery(q.QueryString, q.Start, q.End, q.Step, q.Interval, q.resultsDirection(), uint32(q.Limit))
 	}
 
 	// execute the query

--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -76,6 +76,26 @@ func step(r *http.Request, start, end time.Time) (time.Duration, error) {
 	return 0, errors.Errorf("cannot parse %q to a valid duration", value)
 }
 
+func interval(r *http.Request) (time.Duration, error) {
+	value := r.Form.Get("interval")
+	if value == "" {
+		return 0, nil
+	}
+	// Allow passing as no unit seconds
+	if d, err := strconv.ParseFloat(value, 64); err == nil {
+		ts := d * float64(time.Second)
+		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
+			return 0, errors.Errorf("cannot parse %q to a valid duration. It overflows int64", value)
+		}
+		return time.Duration(ts), nil
+	}
+	// Or parse as a duration
+	if d, err := model.ParseDuration(value); err == nil {
+		return time.Duration(d), nil
+	}
+	return 0, errors.Errorf("cannot parse %q to a valid duration", value)
+}
+
 // Match extracts and parses multiple matcher groups from a slice of strings
 func Match(xs []string) ([][]*labels.Matcher, error) {
 	if len(xs) == 0 {

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -1,7 +1,6 @@
 package loghttp
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
@@ -139,9 +138,6 @@ func TestHttp_ParseRangeQuery_Step(t *testing.T) {
 }
 
 func Test_interval(t *testing.T) {
-	type args struct {
-		r *http.Request
-	}
 	tests := []struct {
 		name     string
 		reqPath  string

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	errEndBeforeStart = errors.New("end timestamp must not be before or equal to start time")
-	errNegativeStep   = errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
-	errStepTooSmall   = errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
+	errEndBeforeStart   = errors.New("end timestamp must not be before or equal to start time")
+	errNegativeStep     = errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
+	errStepTooSmall     = errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
+	errNegativeInterval = errors.New("interval must be >= 0")
 )
 
 // QueryStatus holds the status of a query
@@ -239,6 +240,7 @@ type RangeQuery struct {
 	Start     time.Time
 	End       time.Time
 	Step      time.Duration
+	Interval  time.Duration
 	Query     string
 	Direction logproto.Direction
 	Limit     uint32
@@ -282,6 +284,15 @@ func ParseRangeQuery(r *http.Request) (*RangeQuery, error) {
 	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
 	if (result.End.Sub(result.Start) / result.Step) > 11000 {
 		return nil, errStepTooSmall
+	}
+
+	result.Interval, err = interval(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Interval < 0 {
+		return nil, errNegativeInterval
 	}
 
 	return &result, nil

--- a/pkg/loghttp/query_test.go
+++ b/pkg/loghttp/query_test.go
@@ -42,6 +42,10 @@ func TestParseRangeQuery(t *testing.T) {
 			&http.Request{
 				URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=100&direction=BACKWARD&step=1`),
 			}, nil, true},
+		{"negative interval",
+			&http.Request{
+				URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=100&direction=BACKWARD&step=1,interval=-1`),
+			}, nil, true},
 		{"good",
 			&http.Request{
 				URL: mustParseURL(`?query={foo="bar"}&start=2017-06-10T21:42:24.760738998Z&end=2017-07-10T21:42:24.760738998Z&limit=1000&direction=BACKWARD&step=3600`),

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -26,6 +26,7 @@ var (
 		Help:      "LogQL query timings",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"query_type"})
+	lastEntryMinTime = time.Unix(-100, 0)
 )
 
 // ValueTypeStreams promql.ValueType for log streams
@@ -304,7 +305,7 @@ func readStreams(i iter.EntryIterator, size uint32, dir logproto.Direction, inte
 	respSize := uint32(0)
 	// lastEntry should be a really old time so that the first comparison is always true, we use a negative
 	// value here because many unit tests start at time.Unix(0,0)
-	lastEntry := time.Unix(-100, 0)
+	lastEntry := lastEntryMinTime
 	for respSize < size && i.Next() {
 		labels, entry := i.Labels(), i.Entry()
 		forwardShouldOutput := dir == logproto.FORWARD &&

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -342,6 +342,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		start     time.Time
 		end       time.Time
 		step      time.Duration
+		interval  time.Duration
 		direction logproto.Direction
 		limit     uint32
 
@@ -353,7 +354,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		expected promql.Value
 	}{
 		{
-			`{app="foo"}`, time.Unix(0, 0), time.Unix(30, 0), time.Second, logproto.FORWARD, 10,
+			`{app="foo"}`, time.Unix(0, 0), time.Unix(30, 0), time.Second, 0, logproto.FORWARD, 10,
 			[][]*logproto.Stream{
 				{newStream(testSize, identity, `{app="foo"}`)},
 			},
@@ -363,7 +364,27 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			Streams([]*logproto.Stream{newStream(10, identity, `{app="foo"}`)}),
 		},
 		{
-			`{app="bar"} |= "foo" |~ ".+bar"`, time.Unix(0, 0), time.Unix(30, 0), time.Second, logproto.BACKWARD, 30,
+			`{app="food"}`, time.Unix(0, 0), time.Unix(30, 0), 0, 2 * time.Second, logproto.FORWARD, 10,
+			[][]*logproto.Stream{
+				{newStream(testSize, identity, `{app="food"}`)},
+			},
+			[]SelectParams{
+				{&logproto.QueryRequest{Direction: logproto.FORWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="food"}`}},
+			},
+			Streams([]*logproto.Stream{newIntervalStream(10, 2*time.Second, identity, `{app="food"}`)}),
+		},
+		{
+			`{app="fed"}`, time.Unix(0, 0), time.Unix(30, 0), 0, 2 * time.Second, logproto.BACKWARD, 10,
+			[][]*logproto.Stream{
+				{newBackwardStream(testSize, identity, `{app="fed"}`)},
+			},
+			[]SelectParams{
+				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 10, Selector: `{app="fed"}`}},
+			},
+			Streams([]*logproto.Stream{newBackwardIntervalStream(testSize, 10, 2*time.Second, identity, `{app="fed"}`)}),
+		},
+		{
+			`{app="bar"} |= "foo" |~ ".+bar"`, time.Unix(0, 0), time.Unix(30, 0), time.Second, 0, logproto.BACKWARD, 30,
 			[][]*logproto.Stream{
 				{newStream(testSize, identity, `{app="bar"}`)},
 			},
@@ -373,7 +394,17 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			Streams([]*logproto.Stream{newStream(30, identity, `{app="bar"}`)}),
 		},
 		{
-			`rate({app="foo"} |~".+bar" [1m])`, time.Unix(60, 0), time.Unix(120, 0), time.Minute, logproto.BACKWARD, 10,
+			`{app="barf"} |= "foo" |~ ".+bar"`, time.Unix(0, 0), time.Unix(30, 0), 0, 3 * time.Second, logproto.BACKWARD, 30,
+			[][]*logproto.Stream{
+				{newBackwardStream(testSize, identity, `{app="barf"}`)},
+			},
+			[]SelectParams{
+				{&logproto.QueryRequest{Direction: logproto.BACKWARD, Start: time.Unix(0, 0), End: time.Unix(30, 0), Limit: 30, Selector: `{app="barf"}|="foo"|~".+bar"`}},
+			},
+			Streams([]*logproto.Stream{newBackwardIntervalStream(testSize, 30, 3*time.Second, identity, `{app="barf"}`)}),
+		},
+		{
+			`rate({app="foo"} |~".+bar" [1m])`, time.Unix(60, 0), time.Unix(120, 0), time.Minute, 0, logproto.BACKWARD, 10,
 			[][]*logproto.Stream{
 				{newStream(testSize, identity, `{app="foo"}`)},
 			},
@@ -388,7 +419,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`rate({app="foo"}[30s])`, time.Unix(60, 0), time.Unix(120, 0), 15 * time.Second, logproto.FORWARD, 10,
+			`rate({app="foo"}[30s])`, time.Unix(60, 0), time.Unix(120, 0), 15 * time.Second, 0, logproto.FORWARD, 10,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(2, identity), `{app="foo"}`)},
 			},
@@ -403,7 +434,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`count_over_time({app="foo"} |~".+bar" [1m])`, time.Unix(60, 0), time.Unix(120, 0), 30 * time.Second, logproto.BACKWARD, 10,
+			`count_over_time({app="foo"} |~".+bar" [1m])`, time.Unix(60, 0), time.Unix(120, 0), 30 * time.Second, 0, logproto.BACKWARD, 10,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`)}, // 10 , 20 , 30 .. 60 = 6 total
 			},
@@ -418,7 +449,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`count_over_time(({app="foo"} |~".+bar")[5m])`, time.Unix(5*60, 0), time.Unix(5*120, 0), 30 * time.Second, logproto.BACKWARD, 10,
+			`count_over_time(({app="foo"} |~".+bar")[5m])`, time.Unix(5*60, 0), time.Unix(5*120, 0), 30 * time.Second, 0, logproto.BACKWARD, 10,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`)}, // 10 , 20 , 30 .. 300 = 30 total
 			},
@@ -445,7 +476,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`avg(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`avg(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(10, identity), `{app="bar"}`)},
 			},
@@ -460,7 +491,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`min(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`min(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(10, identity), `{app="bar"}`)},
 			},
@@ -475,7 +506,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`max by (app) (rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`max by (app) (rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -494,7 +525,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`max(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`max(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -509,7 +540,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`sum(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`sum(rate({app=~"foo|bar"} |~".+bar" [1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(5, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -524,7 +555,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -543,7 +574,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`count(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`count(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(10, identity), `{app="bar"}`)},
 			},
@@ -558,7 +589,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`stdvar without (app) (count_over_time(({app=~"foo|bar"} |~".+bar")[1m])) `, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`stdvar without (app) (count_over_time(({app=~"foo|bar"} |~".+bar")[1m])) `, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -573,7 +604,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`stddev(count_over_time(({app=~"foo|bar"} |~".+bar")[1m])) `, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`stddev(count_over_time(({app=~"foo|bar"} |~".+bar")[1m])) `, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(2, identity), `{app="bar"}`)},
 			},
@@ -588,7 +619,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`rate(({app=~"foo|bar"} |~".+bar")[1m])`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`rate(({app=~"foo|bar"} |~".+bar")[1m])`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -607,7 +638,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`topk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`topk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`), newStream(testSize, factor(15, identity), `{app="boo"}`)},
 			},
@@ -626,7 +657,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(5, identity), `{app="bar"}`)},
 			},
@@ -641,7 +672,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(15, identity), `{app="fuzz"}`),
 					newStream(testSize, factor(5, identity), `{app="fuzz"}`), newStream(testSize, identity, `{app="buzz"}`)},
@@ -665,7 +696,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`bottomk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`bottomk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{newStream(testSize, factor(10, identity), `{app="foo"}`), newStream(testSize, factor(20, identity), `{app="bar"}`),
 					newStream(testSize, factor(5, identity), `{app="fuzz"}`), newStream(testSize, identity, `{app="buzz"}`)},
@@ -685,7 +716,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			},
 		},
 		{
-			`bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			`bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app)`, time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(10, identity), `{app="foo"}`),
@@ -715,7 +746,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		// binops
 		{
 			`rate({app="foo"}[1m]) or rate({app="bar"}[1m])`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -744,7 +775,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 			rate({app=~"foo|bar"}[1m]) and
 			rate({app="bar"}[1m])
 			`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -770,7 +801,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		rate({app=~"foo|bar"}[1m]) unless
 		rate({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -796,7 +827,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		rate({app=~"foo|bar"}[1m]) +
 		rate({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -822,7 +853,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		rate({app=~"foo|bar"}[1m]) -
 		rate({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -848,7 +879,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		count_over_time({app=~"foo|bar"}[1m]) *
 		count_over_time({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -874,7 +905,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		count_over_time({app=~"foo|bar"}[1m]) *
 		count_over_time({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -900,7 +931,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		count_over_time({app=~"foo|bar"}[1m]) /
 		count_over_time({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -926,7 +957,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		count_over_time({app=~"foo|bar"}[1m]) %
 		count_over_time({app="bar"}[1m])
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -954,7 +985,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		sum by (app) (rate({app=~"foo|bar"} |~".+bar" [1m])) /
 		sum by (app) (rate({app=~"foo|bar"} |~".+bar" [1m]))
 		`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="foo"}`),
@@ -977,7 +1008,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`1+1--1`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{},
 			[]SelectParams{},
 			promql.Matrix{
@@ -988,7 +1019,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`rate({app="bar"}[1m]) - 1`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="bar"}`),
@@ -1006,7 +1037,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`1 - rate({app="bar"}[1m])`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="bar"}`),
@@ -1024,7 +1055,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`rate({app="bar"}[1m]) - 1 / 2`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="bar"}`),
@@ -1042,7 +1073,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`count_over_time({app="bar"}[1m]) ^ count_over_time({app="bar"}[1m])`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{
 				{
 					newStream(testSize, factor(5, identity), `{app="bar"}`),
@@ -1060,7 +1091,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 		},
 		{
 			`2`,
-			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, logproto.FORWARD, 100,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			[][]*logproto.Stream{},
 			[]SelectParams{},
 			promql.Matrix{
@@ -1076,7 +1107,7 @@ func TestEngine_NewRangeQuery(t *testing.T) {
 
 			eng := NewEngine(EngineOpts{}, newQuerierRecorder(test.streams, test.params))
 
-			q := eng.NewRangeQuery(test.qs, test.start, test.end, test.step, test.direction, test.limit)
+			q := eng.NewRangeQuery(test.qs, test.start, test.end, test.step, test.interval, test.direction, test.limit)
 			res, err := q.Exec(context.Background())
 			if err != nil {
 				t.Fatal(err)
@@ -1148,7 +1179,7 @@ func benchmarkRangeQuery(testsize int64, b *testing.B) {
 			{`bottomk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))`, logproto.FORWARD},
 			{`bottomk(3,rate(({app=~"foo|bar"} |~".+bar")[1m])) without (app)`, logproto.FORWARD},
 		} {
-			q := eng.NewRangeQuery(test.qs, start, end, 60*time.Second, test.direction, 1000)
+			q := eng.NewRangeQuery(test.qs, start, end, 60*time.Second, 0, test.direction, 1000)
 			res, err := q.Exec(context.Background())
 			if err != nil {
 				b.Fatal(err)
@@ -1223,6 +1254,47 @@ func newStream(n int64, f generator, labels string) *logproto.Stream {
 	entries := []logproto.Entry{}
 	for i := int64(0); i < n; i++ {
 		entries = append(entries, f(i))
+	}
+	return &logproto.Stream{
+		Entries: entries,
+		Labels:  labels,
+	}
+}
+
+func newIntervalStream(n int64, step time.Duration, f generator, labels string) *logproto.Stream {
+	entries := []logproto.Entry{}
+	lastEntry := int64(-100) // Start with a really small value (negative) so we always output the first item
+	for i := int64(0); int64(len(entries)) < n; i++ {
+		if float64(lastEntry)+step.Seconds() <= float64(i) {
+			entries = append(entries, f(i))
+			lastEntry = i
+		}
+	}
+	return &logproto.Stream{
+		Entries: entries,
+		Labels:  labels,
+	}
+}
+
+func newBackwardStream(n int64, f generator, labels string) *logproto.Stream {
+	entries := []logproto.Entry{}
+	for i := n - 1; i > 0; i-- {
+		entries = append(entries, f(i))
+	}
+	return &logproto.Stream{
+		Entries: entries,
+		Labels:  labels,
+	}
+}
+
+func newBackwardIntervalStream(n, expectedResults int64, step time.Duration, f generator, labels string) *logproto.Stream {
+	entries := []logproto.Entry{}
+	lastEntry := int64(100000) //Start with some really big value so that we always output the first item
+	for i := n - 1; int64(len(entries)) < expectedResults; i-- {
+		if float64(lastEntry)-step.Seconds() >= float64(i) {
+			entries = append(entries, f(i))
+			lastEntry = i
+		}
 	}
 	return &logproto.Stream{
 		Entries: entries,

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -37,6 +37,7 @@ type LiteralParams struct {
 	qs         string
 	start, end time.Time
 	step       time.Duration
+	interval   time.Duration
 	direction  logproto.Direction
 	limit      uint32
 }

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -50,7 +50,7 @@ func (q *Querier) RangeQueryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
+	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Interval, request.Direction, request.Limit)
 	result, err := query.Exec(ctx)
 	if err != nil {
 		writeError(err, w)
@@ -127,7 +127,7 @@ func (q *Querier) LogQueryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Direction, request.Limit)
+	query := q.engine.NewRangeQuery(request.Query, request.Start, request.End, request.Step, request.Interval, request.Direction, request.Limit)
 	result, err := query.Exec(ctx)
 	if err != nil {
 		writeError(err, w)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This is a possible solution #1779 which creates a new query parameter for range_queries called interval.  It is being marked **experimental** in the docs as it's very possible we will remove this flag one day in favor of a LogQL based solution.

Signed-off-by: Ed Welch <edward.welch@grafana.com>



**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

