### PR TITLE
helm chart: add missing line feed

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.28.0
+version: 0.28.1
 appVersion: v1.4.1
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -23,4 +23,4 @@ spec:
             release: {{ .Release.Name }}
     - ports:
       - port: {{ .Values.service.port }}
-{{- end -}}
+{{- end }}

--- a/production/helm/loki/templates/pdb.yaml
+++ b/production/helm/loki/templates/pdb.yaml
@@ -14,4 +14,4 @@ spec:
     matchLabels:
       app: {{ template "loki.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using `helm template` and concatenating the yaml-Files with `cat *`, there are missing line-feeds at the end of some files.
So I added the missing lines before EOF - like they are there in the other files.
