### PR TITLE
incorporate some better defaults into table-manager configs

### DIFF
--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -41,15 +41,5 @@ chunk_store_config:
   max_look_back_period: 0s
 
 table_manager:
-  chunk_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
-  index_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
   retention_deletes_enabled: false
   retention_period: 0s

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -41,15 +41,5 @@ chunk_store_config:
   max_look_back_period: 0s
 
 table_manager:
-  chunk_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
-  index_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
   retention_deletes_enabled: false
   retention_period: 0s

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -257,18 +257,6 @@
         retention_deletes_enabled: false,
         poll_interval: '10m',
         creation_grace_period: '3h',
-        index_tables_provisioning: {
-          inactive_read_throughput: 0,
-          inactive_write_throughput: 0,
-          provisioned_read_throughput: 0,
-          provisioned_write_throughput: 0,
-        },
-        chunk_tables_provisioning: {
-          inactive_read_throughput: 0,
-          inactive_write_throughput: 0,
-          provisioned_read_throughput: 0,
-          provisioned_write_throughput: 0,
-        },
       },
 
       distributor: {

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -255,6 +255,8 @@
       table_manager: {
         retention_period: 0,
         retention_deletes_enabled: false,
+        poll_interval: '10m',
+        creation_grace_period: '3h',
         index_tables_provisioning: {
           inactive_read_throughput: 0,
           inactive_write_throughput: 0,

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -4,6 +4,15 @@
   table_manager_args::
     $._config.commonArgs {
       target: 'table-manager',
+
+      // Rate limit Bigtable Admin calls.  Google seem to limit to ~100QPS,
+      // and given 2yrs worth of tables (~100) a sync will table 20s.  This
+      // allows you to run upto 20 independant Cortex clusters on the same
+      // Google project before running into issues.
+      'bigtable.grpc-client-rate-limit': 5.0,
+      'bigtable.grpc-client-rate-limit-burst': 5,
+      'bigtable.backoff-on-ratelimits': true,
+      'bigtable.table-cache.enabled': true,
     },
 
   table_manager_container::


### PR DESCRIPTION
Removing the force to 0 for the dynamo-db provisioning in the table-manager configs, instead let this fall to defaults.
This cleans up some config and hopefully reduces confusion for people who use dynamo and get errors using these 0 values.
Also in the ksonnet I rolled in some performance tweeks we had in our environments in local overrides.