### PR TITLE
WIP: production/promtail-mixin: Make dashboard queries configurable

### DIFF
--- a/production/promtail-mixin/dashboards.libsonnet
+++ b/production/promtail-mixin/dashboards.libsonnet
@@ -3,24 +3,54 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 {
   grafanaDashboards+: {
+    local dashboards = self,
+
     'promtail.json':
+      {
+        local cfg = self,
+
+        showMultiCluster:: true,
+        clusterLabel:: 'cluster',
+        clusterMatchers:: if cfg.showMultiCluster then [utils.selector.eq(cfg.clusterLabel, '$cluster')] else [],
+
+        matchers:: [utils.selector.eq('job', '$namespace/$name')],
+        selector:: std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in (cfg.clusterMatchers + dashboards['promtail.json'].matchers)]),
+
+        templateLabels:: (
+          if cfg.showMultiCluster then [
+            {
+              variable:: 'cluster',
+              label:: cfg.clusterLabel,
+              query:: 'kube_pod_container_info{image=~".*promtail.*"}',
+            },
+          ] else []
+        ) + [
+          {
+            variable:: 'namespace',
+            label:: 'namespace',
+            query:: 'kube_pod_container_info{image=~".*promtail.*"}',
+          },
+          {
+            variable:: 'name',
+            label:: 'created_by_name',
+            query:: 'kube_pod_info{namespace="$namespace",pod=~"promtail.*"}',
+          },
+        ],
+      } +
       g.dashboard('Loki / Promtail')
-      .addTemplate('cluster', 'kube_pod_container_info{image=~".*promtail.*"}', 'cluster')
-      .addTemplate('namespace', 'kube_pod_container_info{image=~".*promtail.*"}', 'namespace')
-      .addTemplate('name', 'kube_pod_info{namespace="$namespace",pod=~"promtail.*"}', 'created_by_name')
       .addRow(
         g.row('Targets & Files')
         .addPanel(
           g.panel('Active Targets') +
           g.queryPanel(
-            'sum(promtail_targets_active_total{cluster="$cluster", job="$namespace/$name"})',
+            'sum(promtail_targets_active_total{%s})' % dashboards['promtail.json'].selector,
             'Active Targets',
           ),
         )
         .addPanel(
           g.panel('Active Files') +
           g.queryPanel(
-            'sum(promtail_files_active_total{cluster="$cluster", job="$namespace/$name"})',
+            'sum(promtail_files_active_total{%s})' % dashboards['promtail.json'].selector,
             'Active Targets',
           ),
         )
@@ -30,7 +60,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         .addPanel(
           g.panel('Bps') +
           g.queryPanel(
-            'sum(rate(promtail_read_bytes_total{cluster="$cluster", job="$namespace/$name"}[1m]))',
+            'sum(rate(promtail_read_bytes_total{%s}[1m]))' % dashboards['promtail.json'].selector,
             'logs read',
           ) +
           { yaxes: g.yaxes('Bps') },
@@ -38,7 +68,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         .addPanel(
           g.panel('Lines') +
           g.queryPanel(
-            'sum(rate(promtail_read_lines_total{cluster="$cluster", job="$namespace/$name"}[1m]))',
+            'sum(rate(promtail_read_lines_total{%s}[1m]))' % dashboards['promtail.json'].selector,
             'lines read',
           ),
         )
@@ -47,12 +77,45 @@ local utils = import 'mixin-utils/utils.libsonnet';
         g.row('Requests')
         .addPanel(
           g.panel('QPS') +
-          g.qpsPanel('promtail_request_duration_seconds_count{cluster="$cluster", job="$namespace/$name"}')
+          g.qpsPanel('promtail_request_duration_seconds_count{%s}' % dashboards['promtail.json'].selector),
         )
         .addPanel(
           g.panel('Latency') +
-          utils.latencyRecordingRulePanel('promtail_request_duration_seconds', [utils.selector.eq('job', '$namespace/$name')], extra_selectors=[utils.selector.eq('cluster', '$cluster')])
+          utils.latencyRecordingRulePanel('promtail_request_duration_seconds', dashboards['promtail.json'].matchers, extra_selectors=dashboards['promtail.json'].clusterMatchers)
         )
-      ),
+      ) {
+        templating+: {
+          list+: [
+            {
+              allValue: null,
+              current: {
+                text: 'prod',
+                value: 'prod',
+              },
+              datasource: '$datasource',
+              hide: 0,
+              includeAll: false,
+              label: l.variable,
+              multi: false,
+              name: l.variable,
+              options: [
+
+              ],
+              query: 'label_values(%s, %s)' % [l.query, l.label],
+              refresh: 1,
+              regex: '',
+              sort: 2,
+              tagValuesQuery: '',
+              tags: [
+
+              ],
+              tagsQuery: '',
+              type: 'query',
+              useTags: false,
+            }
+            for l in dashboards['promtail.json'].templateLabels
+          ],
+        },
+      },
   },
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Note I'm not entirely happy with _where_ configuration is, but this could potentially be a direction for resolving https://github.com/grafana/loki/issues/1830, making the mixin more configurable and not quite force specific relabeling rules for them to work.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/1830

**Special notes for your reviewer**:
Mainly looking for feedback at this point, before I put more work into doing this. One thing we could do is instead move the configuration to the root of the exported object, which would kind of force people to not use the global merge pattern that we sadly advocated for in the beginning of monitoring mixins (cc @sh0rez).
**Checklist**
- [ ] Documentation added
- [ ] Tests updated

@cyriltovena 