### PR TITLE
fix broken store GetChunks and PutChunks methods

### DIFF
--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -72,6 +72,10 @@ func (f Facade) Utilization() float64 {
 	return f.c.Utilization()
 }
 
+func (f Facade) Size() int {
+	return f.c.UncompressedSize()
+}
+
 // LokiChunk returns the chunkenc.Chunk.
 func (f Facade) LokiChunk() Chunk {
 	return f.c


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We recently revendored cortex which started using [`Size` method in `Chunk` interface](https://github.com/cortexproject/cortex/blob/14e68bc6d5132255ac84c4b5d11f2ddc27c526e5/pkg/chunk/encoding/chunk.go#L62) to export some metrics during `PutChunks` and `GetChunks` operation [here](https://github.com/cortexproject/cortex/blob/1638c365085ba79c61405266b52e372fb4eb31a1/pkg/chunk/storage/metrics.go#L95). Now in Loki we do not have this method defined and we satisfy the `Chunk` interface by just embedding the interface in the [`Facade`](https://github.com/grafana/loki/blob/master/pkg/chunkenc/facade.go#L30) struct.

Since Loki uses same `PutChunks` and `GetChunks` methods from Cortex for reads and writes, it is panicking while doing those operations. This PR fixes the issue by adding `Size` method to `Facade` struct.

