### PR TITLE
make boltdb shipper singleton and some other minor refactoring

### DIFF
--- a/docs/operations/storage/boltdb-shipper.md
+++ b/docs/operations/storage/boltdb-shipper.md
@@ -26,8 +26,9 @@ storage_config:
   gcs:
     bucket_name: GCS_BUCKET_NAME
 
-  boltdb_shipper_config:
+  boltdb_shipper:
     active_index_directory: /loki/index
+    shared_store: gcs
     cache_location: /loki/boltdb-cache
 ``` 
 

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	json "github.com/json-iterator/go"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/weaveworks/common/user"
 
@@ -148,7 +149,7 @@ func localStore(conf loki.Config) (logql.Querier, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := storage.NewStore(conf.StorageConfig, conf.ChunkStoreConfig, conf.SchemaConfig, limits)
+	s, err := storage.NewStore(conf.StorageConfig, conf.ChunkStoreConfig, conf.SchemaConfig, limits, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -266,7 +266,7 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 		}
 	}
 
-	t.store, err = loki_storage.NewStore(t.cfg.StorageConfig, t.cfg.ChunkStoreConfig, t.cfg.SchemaConfig, t.overrides)
+	t.store, err = loki_storage.NewStore(t.cfg.StorageConfig, t.cfg.ChunkStoreConfig, t.cfg.SchemaConfig, t.overrides, prometheus.DefaultRegisterer)
 	if err != nil {
 		return
 	}

--- a/pkg/storage/hack/main.go
+++ b/pkg/storage/hack/main.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/user"
@@ -64,6 +65,7 @@ func getStore() (lstore.Store, error) {
 			},
 		},
 		&validation.Overrides{},
+		prometheus.DefaultRegisterer,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -26,7 +26,7 @@ import (
 type Config struct {
 	storage.Config      `yaml:",inline"`
 	MaxChunkBatchSize   int                 `yaml:"max_chunk_batch_size"`
-	BoltDBShipperConfig local.ShipperConfig `yaml:"boltdb_shipper_config"`
+	BoltDBShipperConfig local.ShipperConfig `yaml:"boltdb_shipper"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.
@@ -49,10 +49,10 @@ type store struct {
 }
 
 // NewStore creates a new Loki Store using configuration supplied.
-func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits storage.StoreLimits) (Store, error) {
-	registerCustomIndexClients(cfg, schemaCfg)
+func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits storage.StoreLimits, registerer prometheus.Registerer) (Store, error) {
+	registerCustomIndexClients(cfg)
 
-	s, err := storage.NewStore(cfg.Config, storeCfg, schemaCfg, limits, prometheus.DefaultRegisterer)
+	s, err := storage.NewStore(cfg.Config, storeCfg, schemaCfg, limits, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -218,35 +218,23 @@ func filterChunksByTime(from, through model.Time, chunks []chunk.Chunk) []chunk.
 	return filtered
 }
 
-func registerCustomIndexClients(cfg Config, schemaCfg chunk.SchemaConfig) {
-	boltdbShipperInstances := 0
-	storage.RegisterIndexStore(local.BoltDBShipperType, func() (chunk.IndexClient, error) {
-		// since we do not know which object client is being used for the period for which we are creating this index client,
-		// we need to iterate through all the periodic configs to find the right one.
-		// We maintain number of instances that we have already created in boltdbShipperInstances and then count the number of
-		// encounters of BoltDBShipperType until we find the right periodic config for getting the ObjectType.
-		// This is done assuming we are creating index client in the order of periodic configs.
-		// Note: We are assuming that user would never store chunks in table based store otherwise NewObjectClient would return an error.
+func registerCustomIndexClients(cfg Config) {
+	// BoltDB Shipper is supposed to be run as a singleton.
+	// This could also be done in NewBoltDBIndexClientWithShipper factory method but we are doing it here because that method is used
+	// in tests for creating multiple instances of it at a time.
+	var boltDBIndexClientWithShipper chunk.IndexClient
 
-		// ToDo: Try passing on ObjectType from Cortex to the callback for creating custom index client.
-		boltdbShipperEncounter := 0
-		objectStoreType := ""
-		for _, config := range schemaCfg.Configs {
-			if config.IndexType == local.BoltDBShipperType {
-				boltdbShipperEncounter++
-				if boltdbShipperEncounter > boltdbShipperInstances {
-					objectStoreType = config.ObjectType
-					break
-				}
-			}
+	storage.RegisterIndexStore(local.BoltDBShipperType, func() (chunk.IndexClient, error) {
+		if boltDBIndexClientWithShipper != nil {
+			return boltDBIndexClientWithShipper, nil
 		}
 
-		boltdbShipperInstances++
-		objectClient, err := storage.NewObjectClient(objectStoreType, cfg.Config)
+		objectClient, err := storage.NewObjectClient(cfg.BoltDBShipperConfig.SharedStoreType, cfg.Config)
 		if err != nil {
 			return nil, err
 		}
 
-		return local.NewBoltDBIndexClient(cortex_local.BoltDBConfig{Directory: cfg.BoltDBShipperConfig.ActiveIndexDirectory}, objectClient, cfg.BoltDBShipperConfig)
+		boltDBIndexClientWithShipper, err = local.NewBoltDBIndexClientWithShipper(cortex_local.BoltDBConfig{Directory: cfg.BoltDBShipperConfig.ActiveIndexDirectory}, objectClient, cfg.BoltDBShipperConfig)
+		return boltDBIndexClientWithShipper, err
 	}, nil)
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -557,7 +556,7 @@ func buildTestStreams(labels string, tr timeRange) logproto.Stream {
 	for from := tr.from; from.Before(tr.to); from = from.Add(time.Second) {
 		stream.Entries = append(stream.Entries, logproto.Entry{
 			Timestamp: from,
-			Line:      fmt.Sprintf("%s", from),
+			Line:      from.String(),
 		})
 	}
 

--- a/pkg/storage/stores/local/boltdb_index_client.go
+++ b/pkg/storage/stores/local/boltdb_index_client.go
@@ -14,8 +14,8 @@ type BoltdbIndexClientWithShipper struct {
 	shipper *Shipper
 }
 
-// NewBoltDBIndexClient creates a new IndexClient that used BoltDB.
-func NewBoltDBIndexClient(cfg local.BoltDBConfig, archiveStoreClient chunk.ObjectClient, archiverCfg ShipperConfig) (chunk.IndexClient, error) {
+// NewBoltDBIndexClientWithShipper creates a new IndexClient that used BoltDB.
+func NewBoltDBIndexClientWithShipper(cfg local.BoltDBConfig, archiveStoreClient chunk.ObjectClient, archiverCfg ShipperConfig) (chunk.IndexClient, error) {
 	boltDBIndexClient, err := local.NewBoltDBIndexClient(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/stores/local/shipper.go
+++ b/pkg/storage/stores/local/shipper.go
@@ -43,6 +43,7 @@ type BoltDBGetter interface {
 
 type ShipperConfig struct {
 	ActiveIndexDirectory string        `yaml:"active_index_directory"`
+	SharedStoreType      string        `yaml:"shared_store"`
 	CacheLocation        string        `yaml:"cache_location"`
 	CacheTTL             time.Duration `yaml:"cache_ttl"`
 	ResyncInterval       time.Duration `yaml:"resync_interval"`
@@ -53,6 +54,7 @@ type ShipperConfig struct {
 // RegisterFlags registers flags.
 func (cfg *ShipperConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ActiveIndexDirectory, "boltdb.shipper.active-index-directory", "", "Directory where ingesters would write boltdb files which would then be uploaded by shipper to configured storage")
+	f.StringVar(&cfg.SharedStoreType, "boltdb.shipper.shared-store", "", "Shared store for keeping boltdb files. Supported types: gcs, s3, azure, filesystem")
 	f.StringVar(&cfg.CacheLocation, "boltdb.shipper.cache-location", "", "Cache location for restoring boltDB files for queries")
 	f.DurationVar(&cfg.CacheTTL, "boltdb.shipper.cache-ttl", 24*time.Hour, "TTL for boltDB files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, "boltdb.shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")

--- a/pkg/storage/stores/local/uploads_test.go
+++ b/pkg/storage/stores/local/uploads_test.go
@@ -38,7 +38,7 @@ func createTestBoltDBWithShipper(t *testing.T, parentTempDir, ingesterName, loca
 	})
 	require.NoError(t, err)
 
-	boltdbIndexClientWithShipper, err := NewBoltDBIndexClient(local.BoltDBConfig{Directory: shipperConfig.ActiveIndexDirectory}, archiveStoreClient, shipperConfig)
+	boltdbIndexClientWithShipper, err := NewBoltDBIndexClientWithShipper(local.BoltDBConfig{Directory: shipperConfig.ActiveIndexDirectory}, archiveStoreClient, shipperConfig)
 	require.NoError(t, err)
 
 	return boltdbIndexClientWithShipper.(*BoltdbIndexClientWithShipper)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
To avoid various problems that we can run into by allowing to run multiple boltdb shipper instance we are making it singleton.
This PR also includes the following minor refactorings:
1. Renamed `NewBoltDBIndexClient` function to `NewBoltDBIndexClientWithShipper`.
2. Accepting `prometheus.Registerer` in `storage.NewStore` so that it can be set to nil during tests otherwise tests would fail if it is called multiple times.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

