### PR TITLE
table client for boltdb shipper to enforce retention

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -126,6 +126,7 @@ func New(cfg Config) (*Loki, error) {
 	}
 
 	loki.setupAuthMiddleware()
+	storage.RegisterCustomIndexClients(cfg.StorageConfig)
 
 	serviceMap, err := loki.initModuleServices(cfg.Target)
 	if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -235,7 +235,7 @@ func (t *Loki) initTableManager() (services.Service, error) {
 		os.Exit(1)
 	}
 
-	tableClient, err := loki_storage.NewTableClient(lastConfig.IndexType, t.cfg.StorageConfig)
+	tableClient, err := storage.NewTableClient(lastConfig.IndexType, t.cfg.StorageConfig.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -453,12 +453,16 @@ func TestStore_MultipleBoltDBShippersInConfig(t *testing.T) {
 	firstStoreDate := parseDate("2019-01-01")
 	secondStoreDate := parseDate("2019-01-02")
 
-	store, err := NewStore(Config{
+	config := Config{
 		Config: storage.Config{
 			FSConfig: cortex_local.FSConfig{Directory: path.Join(tempDir, "chunks")},
 		},
 		BoltDBShipperConfig: boltdbShipperConfig,
-	}, chunk.StoreConfig{}, chunk.SchemaConfig{
+	}
+
+	RegisterCustomIndexClients(config)
+
+	store, err := NewStore(config, chunk.StoreConfig{}, chunk.SchemaConfig{
 		Configs: []chunk.PeriodConfig{
 			{
 				From:       chunk.DayTime{Time: timeToModelTime(firstStoreDate)},

--- a/pkg/storage/stores/local/boltdb_shipper_table_client.go
+++ b/pkg/storage/stores/local/boltdb_shipper_table_client.go
@@ -60,7 +60,9 @@ func (b *boltDBShipperTableClient) DeleteTable(ctx context.Context, name string)
 }
 
 func (b *boltDBShipperTableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {
-	return
+	return chunk.TableDesc{
+		Name: name,
+	}, true, nil
 }
 
 func (b *boltDBShipperTableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {

--- a/pkg/storage/stores/local/boltdb_shipper_table_client.go
+++ b/pkg/storage/stores/local/boltdb_shipper_table_client.go
@@ -1,0 +1,68 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	cortex_util "github.com/cortexproject/cortex/pkg/util"
+
+	"github.com/grafana/loki/pkg/storage/stores/util"
+)
+
+type boltDBShipperTableClient struct {
+	objectClient chunk.ObjectClient
+}
+
+func NewBoltDBShipperTableClient(objectClient chunk.ObjectClient) chunk.TableClient {
+	return &boltDBShipperTableClient{util.NewPrefixedObjectClient(objectClient, storageKeyPrefix)}
+}
+
+func (b *boltDBShipperTableClient) ListTables(ctx context.Context) ([]string, error) {
+	_, dirs, err := b.objectClient.List(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	tables := make([]string, len(dirs))
+	for i, dir := range dirs {
+		tables[i] = strings.TrimSuffix(string(dir), "/")
+	}
+
+	return tables, nil
+}
+
+func (b *boltDBShipperTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
+	return nil
+}
+
+func (b *boltDBShipperTableClient) DeleteTable(ctx context.Context, name string) error {
+	objects, dirs, err := b.objectClient.List(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if len(dirs) != 0 {
+		level.Error(cortex_util.Logger).Log("msg", fmt.Sprintf("unexpected directories in %s folder, not touching them", name), "directories", fmt.Sprint(dirs))
+	}
+
+	for _, object := range objects {
+		err := b.objectClient.DeleteObject(ctx, object.Key)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *boltDBShipperTableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {
+	return
+}
+
+func (b *boltDBShipperTableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {
+	return nil
+}

--- a/pkg/storage/stores/local/boltdb_shipper_table_client_test.go
+++ b/pkg/storage/stores/local/boltdb_shipper_table_client_test.go
@@ -1,0 +1,83 @@
+package local
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+
+	"github.com/cortexproject/cortex/pkg/chunk/local"
+	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/util"
+)
+
+func TestBoltDBShipperTableClient(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "boltdb-shipper")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	objectClient, err := storage.NewObjectClient("filesystem", storage.Config{FSConfig: local.FSConfig{Directory: tempDir}})
+	require.NoError(t, err)
+
+	// create a couple of folders with files
+	foldersWithFiles := map[string][]string{
+		"table1": {"file1", "file2", "file3"},
+		"table2": {"file3", "file4"},
+		"table3": {"file5", "file6"},
+	}
+
+	// we need to use prefixed object client while creating files/folder
+	prefixedObjectClient := util.NewPrefixedObjectClient(objectClient, storageKeyPrefix)
+
+	for folder, files := range foldersWithFiles {
+		for _, fileName := range files {
+			err := prefixedObjectClient.PutObject(context.Background(), path.Join(folder, fileName), bytes.NewReader([]byte{}))
+			require.NoError(t, err)
+		}
+	}
+
+	tableClient := NewBoltDBShipperTableClient(objectClient)
+
+	// check list of tables returns all the folders/tables created above
+	checkExpectedTables(t, tableClient, foldersWithFiles)
+
+	// let us delete table1 and see if it goes away from the list of tables
+	err = tableClient.DeleteTable(context.Background(), "table1")
+	require.NoError(t, err)
+
+	// cortex does not omit empty directories from the list
+	// ToDo: change the code in cortex to remove empty directories from the list
+	ensureEmptyAndRemoveDirectory(t, path.Join(tempDir, storageKeyPrefix, "table1"))
+
+	delete(foldersWithFiles, "table1")
+	checkExpectedTables(t, tableClient, foldersWithFiles)
+}
+
+func checkExpectedTables(t *testing.T, tableClient chunk.TableClient, expectedTables map[string][]string) {
+	actualTables, err := tableClient.ListTables(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, actualTables, len(expectedTables))
+
+	for _, table := range actualTables {
+		_, ok := expectedTables[table]
+		require.True(t, ok)
+	}
+}
+
+func ensureEmptyAndRemoveDirectory(t *testing.T, directory string) {
+	filesInfo, err := ioutil.ReadDir(directory)
+	require.NoError(t, err)
+	require.Len(t, filesInfo, 0)
+
+	require.NoError(t, os.Remove(directory))
+}

--- a/pkg/storage/stores/util/object_client.go
+++ b/pkg/storage/stores/util/object_client.go
@@ -31,6 +31,10 @@ func (p PrefixedObjectClient) List(ctx context.Context, prefix string) ([]chunk.
 		objects[i].Key = strings.TrimPrefix(objects[i].Key, p.prefix)
 	}
 
+	for i := range commonPrefixes {
+		commonPrefixes[i] = chunk.StorageCommonPrefix(strings.TrimPrefix(string(commonPrefixes[i]), p.prefix))
+	}
+
 	return objects, commonPrefixes, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds table client for BoltDB Shipper for enforcing retention.

**Checklist**
- [x] Tests updated

