### PR TITLE
Loki: Improve logging and add metrics to streams dropped by stream limit

### DIFF
--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 
-	"github.com/grafana/loki/pkg/util"
-
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logproto"
 
@@ -124,15 +122,12 @@ func TestSyncPeriod(t *testing.T) {
 		result = append(result, logproto.Entry{Timestamp: tt, Line: fmt.Sprintf("hello %d", i)})
 		tt = tt.Add(time.Duration(1 + rand.Int63n(randomStep.Nanoseconds())))
 	}
-
-	err = inst.Push(context.Background(), &logproto.PushRequest{Streams: []*logproto.Stream{{Labels: lbls, Entries: result}}})
+	pr := &logproto.PushRequest{Streams: []*logproto.Stream{{Labels: lbls, Entries: result}}}
+	err = inst.Push(context.Background(), pr)
 	require.NoError(t, err)
 
-	// let's verify results.
-	ls, err := util.ToClientLabels(lbls)
-	require.NoError(t, err)
-
-	s, err := inst.getOrCreateStream(ls)
+	// let's verify results
+	s, err := inst.getOrCreateStream(pr.Streams[0])
 	require.NoError(t, err)
 
 	// make sure each chunk spans max 'sync period' time

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	errMaxStreamsPerUserLimitExceeded = "per-user streams limit (local: %d global: %d actual local: %d) exceeded"
+	errMaxStreamsPerUserLimitExceeded = "tenant '%v' per-user streams limit exceeded, streams: %d exceeds calculated limit: %d (local limit: %d, global limit: %d, global/ingesters: %d)"
 )
 
 // RingCount is the interface exposed by a ring implementation which allows
@@ -37,32 +37,28 @@ func NewLimiter(limits *validation.Overrides, ring RingCount, replicationFactor 
 // AssertMaxStreamsPerUser ensures limit has not been reached compared to the current
 // number of streams in input and returns an error if so.
 func (l *Limiter) AssertMaxStreamsPerUser(userID string, streams int) error {
-	actualLimit := l.maxStreamsPerUser(userID)
-	if streams < actualLimit {
-		return nil
-	}
-
-	localLimit := l.limits.MaxLocalStreamsPerUser(userID)
-	globalLimit := l.limits.MaxGlobalStreamsPerUser(userID)
-
-	return fmt.Errorf(errMaxStreamsPerUserLimitExceeded, localLimit, globalLimit, actualLimit)
-}
-
-func (l *Limiter) maxStreamsPerUser(userID string) int {
+	//Start by setting the local limit either from override or default
 	localLimit := l.limits.MaxLocalStreamsPerUser(userID)
 
 	// We can assume that streams are evenly distributed across ingesters
 	// so we do convert the global limit into a local limit
 	globalLimit := l.limits.MaxGlobalStreamsPerUser(userID)
-	localLimit = l.minNonZero(localLimit, l.convertGlobalToLocalLimit(globalLimit))
+	adjustedGlobalLimit := l.convertGlobalToLocalLimit(globalLimit)
+
+	// Set the calculated limit to the lessor of the local limit or the new adjusted global limit
+	calculatedLimit := l.minNonZero(localLimit, adjustedGlobalLimit)
 
 	// If both the local and global limits are disabled, we just
 	// use the largest int value
-	if localLimit == 0 {
-		localLimit = math.MaxInt32
+	if calculatedLimit == 0 {
+		calculatedLimit = math.MaxInt32
 	}
 
-	return localLimit
+	if streams < calculatedLimit {
+		return nil
+	}
+
+	return fmt.Errorf(errMaxStreamsPerUserLimitExceeded, userID, streams, calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit)
 }
 
 func (l *Limiter) convertGlobalToLocalLimit(globalLimit int) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -37,7 +37,7 @@ func NewLimiter(limits *validation.Overrides, ring RingCount, replicationFactor 
 // AssertMaxStreamsPerUser ensures limit has not been reached compared to the current
 // number of streams in input and returns an error if so.
 func (l *Limiter) AssertMaxStreamsPerUser(userID string, streams int) error {
-	//Start by setting the local limit either from override or default
+	// Start by setting the local limit either from override or default
 	localLimit := l.limits.MaxLocalStreamsPerUser(userID)
 
 	// We can assume that streams are evenly distributed across ingesters
@@ -45,7 +45,7 @@ func (l *Limiter) AssertMaxStreamsPerUser(userID string, streams int) error {
 	globalLimit := l.limits.MaxGlobalStreamsPerUser(userID)
 	adjustedGlobalLimit := l.convertGlobalToLocalLimit(globalLimit)
 
-	// Set the calculated limit to the lessor of the local limit or the new adjusted global limit
+	// Set the calculated limit to the lesser of the local limit or the new calculated global limit
 	calculatedLimit := l.minNonZero(localLimit, adjustedGlobalLimit)
 
 	// If both the local and global limits are disabled, we just

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -10,7 +10,8 @@ const (
 	RateLimited = "rate_limited"
 	// LineTooLong is a reason for discarding too long log lines.
 	LineTooLong = "line_too_long"
-	// StreamLimit is a reason for discarding lines when we can't create any new streams
+	// StreamLimit is a reason for discarding lines when we can't create a new stream
+	// because the limit of active streams has been reached.
 	StreamLimit = "stream_limit"
 )
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -10,6 +10,8 @@ const (
 	RateLimited = "rate_limited"
 	// LineTooLong is a reason for discarding too long log lines.
 	LineTooLong = "line_too_long"
+	// StreamLimit is a reason for discarding lines when we can't create any new streams
+	StreamLimit = "stream_limit"
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.


### PR DESCRIPTION
I combined the two unit tests for the limiter into one and used the new more verbose error message to assert the output of the previous helper function.

Signed-off-by: Ed Welch <edward.welch@grafana.com>