### PR TITLE
make `loki_ingester_memory_streams` Gauge per tenant.

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -302,7 +302,7 @@ func (i *Ingester) removeFlushedChunks(instance *instance, stream *stream) {
 		delete(instance.streams, stream.fp)
 		instance.index.Delete(stream.labels, stream.fp)
 		instance.streamsRemovedTotal.Inc()
-		memoryStreams.Dec()
+		memoryStreams.WithLabelValues(instance.instanceID).Dec()
 	}
 }
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -36,11 +36,11 @@ var (
 )
 
 var (
-	memoryStreams = promauto.NewGauge(prometheus.GaugeOpts{
+	memoryStreams = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "loki",
 		Name:      "ingester_memory_streams",
-		Help:      "The total number of streams in memory.",
-	})
+		Help:      "The total number of streams in memory per tenant.",
+	}, []string{"tenant"})
 	streamsCreatedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "ingester_streams_created_total",
@@ -112,7 +112,7 @@ func (i *instance) consumeChunk(ctx context.Context, labels []client.LabelAdapte
 		stream = newStream(i.cfg, fp, sortedLabels, i.factory)
 		i.streams[fp] = stream
 		i.streamsCreatedTotal.Inc()
-		memoryStreams.Inc()
+		memoryStreams.WithLabelValues(i.instanceID).Inc()
 		i.addTailersToNewStream(stream)
 	}
 
@@ -176,7 +176,7 @@ func (i *instance) getOrCreateStream(pushReqStream *logproto.Stream) (*stream, e
 	sortedLabels := i.index.Add(labels, fp)
 	stream = newStream(i.cfg, fp, sortedLabels, i.factory)
 	i.streams[fp] = stream
-	memoryStreams.Inc()
+	memoryStreams.WithLabelValues(i.instanceID).Inc()
 	i.streamsCreatedTotal.Inc()
 	i.addTailersToNewStream(stream)
 


### PR DESCRIPTION
We currently approximate this by subtracting `loki_ingester_streams_created_total-loki_ingester_streams_removed_total` (which have a tenanat label) however you can only do this if you don't use a rate, and if you don't use a rate you don't handle counter resets properly.
Separately the rate of streams created vs streams removed is useful to track churn per tenant, but it would be good to have a per tenant way of tracking active streams

Signed-off-by: Ed Welch <edward.welch@grafana.com>