### PR TITLE
Loki: refactor validation and improve error messages

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -28,10 +28,6 @@ import (
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
-const (
-	metricName = "logs"
-)
-
 var (
 	ingesterAppends = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -240,7 +240,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		// Return a 429 to indicate to the client they are being rate limited
 		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamplesCount))
 		validation.DiscardedBytes.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamplesSize))
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, int(d.ingestionRateLimiter.Limit(now, userID)), validatedSamplesCount, validatedSamplesSize)
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(int(d.ingestionRateLimiter.Limit(now, userID)), validatedSamplesCount, validatedSamplesSize))
 	}
 
 	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -63,7 +63,7 @@ func TestDistributor(t *testing.T) {
 			lines:            100,
 			maxLineSize:      1,
 			expectedResponse: success,
-			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg, 1, "{foo=\"bar\"}", 10),
+			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg(1, 10, "{foo=\"bar\"}")),
 		},
 		{
 			lines:            100,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -57,13 +57,13 @@ func TestDistributor(t *testing.T) {
 		},
 		{
 			lines:         100,
-			expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (100 bytes) exceeded while adding 100 lines for a total size of 1000 bytes"),
+			expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 100, 100, 1000),
 		},
 		{
 			lines:            100,
 			maxLineSize:      1,
 			expectedResponse: success,
-			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, "max line size (1B) exceeded while adding (10B) size line"),
+			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg, 1, "{foo=\"bar\"}", 10),
 		},
 		{
 			lines:            100,
@@ -116,9 +116,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  10 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 5, expectedError: nil},
-				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (10 bytes) exceeded while adding 1 lines for a total size of 6 bytes")},
+				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 10, 1, 6)},
 				{bytes: 5, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (10 bytes) exceeded while adding 1 lines for a total size of 1 bytes")},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 10, 1, 1)},
 			},
 		},
 		"global strategy: limit should be evenly shared across distributors": {
@@ -128,9 +128,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  5 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 3, expectedError: nil},
-				{bytes: 3, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (5 bytes) exceeded while adding 1 lines for a total size of 3 bytes")},
+				{bytes: 3, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 3)},
 				{bytes: 2, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (5 bytes) exceeded while adding 1 lines for a total size of 1 bytes")},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 1)},
 			},
 		},
 		"global strategy: burst should set to each distributor": {
@@ -140,9 +140,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  20 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 15, expectedError: nil},
-				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (5 bytes) exceeded while adding 1 lines for a total size of 6 bytes")},
+				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 6)},
 				{bytes: 5, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (5 bytes) exceeded while adding 1 lines for a total size of 1 bytes")},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 1)},
 			},
 		},
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -57,7 +57,7 @@ func TestDistributor(t *testing.T) {
 		},
 		{
 			lines:         100,
-			expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 100, 100, 1000),
+			expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(100, 100, 1000)),
 		},
 		{
 			lines:            100,
@@ -116,9 +116,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  10 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 5, expectedError: nil},
-				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 10, 1, 6)},
+				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(10, 1, 6))},
 				{bytes: 5, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 10, 1, 1)},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(10, 1, 1))},
 			},
 		},
 		"global strategy: limit should be evenly shared across distributors": {
@@ -128,9 +128,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  5 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 3, expectedError: nil},
-				{bytes: 3, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 3)},
+				{bytes: 3, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(5, 1, 3))},
 				{bytes: 2, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 1)},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(5, 1, 1))},
 			},
 		},
 		"global strategy: burst should set to each distributor": {
@@ -140,9 +140,9 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			ingestionBurstSizeMB:  20 * (1.0 / float64(bytesInMB)),
 			pushes: []testPush{
 				{bytes: 15, expectedError: nil},
-				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 6)},
+				{bytes: 6, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(5, 1, 6))},
 				{bytes: 5, expectedError: nil},
-				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitErrorMsg, 5, 1, 1)},
+				{bytes: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, validation.RateLimitedErrorMsg(5, 1, 1))},
 			},
 		},
 	}

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -29,13 +29,13 @@ func (v Validator) ValidateEntry(userID string, labels string, entry logproto.En
 	if v.RejectOldSamples(userID) && entry.Timestamp.UnixNano() < time.Now().Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano() {
 		validation.DiscardedSamples.WithLabelValues(validation.GreaterThanMaxSampleAge, userID).Inc()
 		validation.DiscardedBytes.WithLabelValues(validation.GreaterThanMaxSampleAge, userID).Add(float64(len(entry.Line)))
-		return httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg, labels, entry.Timestamp)
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg(labels, entry.Timestamp))
 	}
 
 	if entry.Timestamp.UnixNano() > time.Now().Add(v.CreationGracePeriod(userID)).UnixNano() {
 		validation.DiscardedSamples.WithLabelValues(validation.TooFarInFuture, userID).Inc()
 		validation.DiscardedBytes.WithLabelValues(validation.TooFarInFuture, userID).Add(float64(len(entry.Line)))
-		return httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg, labels, entry.Timestamp)
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg(labels, entry.Timestamp))
 	}
 
 	if maxSize := v.MaxLineSize(userID); maxSize != 0 && len(entry.Line) > maxSize {
@@ -45,13 +45,7 @@ func (v Validator) ValidateEntry(userID string, labels string, entry logproto.En
 		// for parity.
 		validation.DiscardedSamples.WithLabelValues(validation.LineTooLong, userID).Inc()
 		validation.DiscardedBytes.WithLabelValues(validation.LineTooLong, userID).Add(float64(len(entry.Line)))
-		return httpgrpc.Errorf(
-			http.StatusBadRequest,
-			validation.LineTooLongErrorMsg,
-			maxSize,
-			labels,
-			len(entry.Line),
-		)
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg(maxSize, len(entry.Line), labels))
 	}
 
 	return nil
@@ -76,39 +70,33 @@ func (v Validator) ValidateLabels(userID string, stream *logproto.Stream) error 
 			bytes += len(e.Line)
 		}
 		validation.DiscardedBytes.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Add(float64(bytes))
-		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg, cortex_client.FromLabelAdaptersToMetric(ls).String(), numLabelNames, v.MaxLabelNamesPerSeries(userID))
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg(cortex_client.FromLabelAdaptersToMetric(ls).String(), numLabelNames, v.MaxLabelNamesPerSeries(userID)))
 	}
 
 	maxLabelNameLength := v.MaxLabelNameLength(userID)
 	maxLabelValueLength := v.MaxLabelValueLength(userID)
 	lastLabelName := ""
 	for _, l := range ls {
-		var errTemplate string
-		var reason string
-		var cause string
 		if len(l.Name) > maxLabelNameLength {
-			reason = validation.LabelNameTooLong
-			errTemplate = validation.LabelNameTooLongErrorMsg
-			cause = l.Name
+			updateMetrics(validation.LabelNameTooLong, userID, stream)
+			return httpgrpc.Errorf(http.StatusBadRequest, validation.LabelNameTooLongErrorMsg(stream.Labels, l.Name))
 		} else if len(l.Value) > maxLabelValueLength {
-			reason = validation.LabelValueTooLong
-			errTemplate = validation.LabelValueTooLongErrorMsg
-			cause = l.Value
+			updateMetrics(validation.LabelValueTooLong, userID, stream)
+			return httpgrpc.Errorf(http.StatusBadRequest, validation.LabelValueTooLongErrorMsg(stream.Labels, l.Value))
 		} else if cmp := strings.Compare(lastLabelName, l.Name); cmp == 0 {
-			reason = validation.DuplicateLabelNames
-			errTemplate = validation.DuplicateLabelNamesErrorMsg
-			cause = l.Name
-		}
-		if errTemplate != "" {
-			validation.DiscardedSamples.WithLabelValues(reason, userID).Inc()
-			bytes := 0
-			for _, e := range stream.Entries {
-				bytes += len(e.Line)
-			}
-			validation.DiscardedBytes.WithLabelValues(reason, userID).Add(float64(bytes))
-			return httpgrpc.Errorf(http.StatusBadRequest, errTemplate, stream.Labels, cause)
+			updateMetrics(validation.DuplicateLabelNames, userID, stream)
+			return httpgrpc.Errorf(http.StatusBadRequest, validation.DuplicateLabelNamesErrorMsg(stream.Labels, l.Name))
 		}
 		lastLabelName = l.Name
 	}
 	return nil
+}
+
+func updateMetrics(reason, userID string, stream *logproto.Stream) {
+	validation.DiscardedSamples.WithLabelValues(reason, userID).Inc()
+	bytes := 0
+	for _, e := range stream.Entries {
+		bytes += len(e.Line)
+	}
+	validation.DiscardedBytes.WithLabelValues(reason, userID).Add(float64(bytes))
 }

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -85,7 +85,7 @@ func (v Validator) ValidateLabels(userID string, stream *logproto.Stream) error 
 	for _, l := range ls {
 		var errTemplate string
 		var reason string
-		var cause interface{}
+		var cause string
 		if len(l.Name) > maxLabelNameLength {
 			reason = validation.LabelNameTooLong
 			errTemplate = validation.LabelNameTooLongErrorMsg

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -39,14 +39,14 @@ func TestValidator_ValidateEntry(t *testing.T) {
 				}
 			},
 			logproto.Entry{Timestamp: testTime.Add(-time.Hour * 5), Line: "test"},
-			httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg, testStreamLabels, testTime.Add(-time.Hour*5)),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg(testStreamLabels, testTime.Add(-time.Hour*5))),
 		},
 		{
 			"test too new",
 			"test",
 			nil,
 			logproto.Entry{Timestamp: testTime.Add(time.Hour * 5), Line: "test"},
-			httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg, testStreamLabels, testTime.Add(time.Hour*5)),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg(testStreamLabels, testTime.Add(time.Hour*5))),
 		},
 		{
 			"line too long",
@@ -57,7 +57,7 @@ func TestValidator_ValidateEntry(t *testing.T) {
 				}
 			},
 			logproto.Entry{Timestamp: testTime, Line: "12345678901"},
-			httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg, 10, testStreamLabels, 11),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg(10, 11, testStreamLabels)),
 		},
 	}
 	for _, tt := range tests {
@@ -97,7 +97,7 @@ func TestValidator_ValidateLabels(t *testing.T) {
 				return &validation.Limits{MaxLabelNamesPerSeries: 2}
 			},
 			"{foo=\"bar\",food=\"bars\",fed=\"bears\"}",
-			httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg, "{fed=\"bears\", foo=\"bar\", food=\"bars\"}", 3, 2),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg("{fed=\"bears\", foo=\"bar\", food=\"bars\"}", 3, 2)),
 		},
 		{
 			"label name too long",
@@ -109,10 +109,10 @@ func TestValidator_ValidateLabels(t *testing.T) {
 				}
 			},
 			"{fooooo=\"bar\"}",
-			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelNameTooLongErrorMsg, "{fooooo=\"bar\"}", "fooooo"),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelNameTooLongErrorMsg("{fooooo=\"bar\"}", "fooooo")),
 		},
 		{
-			"label name too long",
+			"label value too long",
 			"test",
 			func(userID string) *validation.Limits {
 				return &validation.Limits{
@@ -122,7 +122,7 @@ func TestValidator_ValidateLabels(t *testing.T) {
 				}
 			},
 			"{foo=\"barrrrrr\"}",
-			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelValueTooLongErrorMsg, "{foo=\"barrrrrr\"}", "barrrrrr"),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelValueTooLongErrorMsg("{foo=\"barrrrrr\"}", "barrrrrr")),
 		},
 		{
 			"duplicate label",
@@ -135,7 +135,7 @@ func TestValidator_ValidateLabels(t *testing.T) {
 				}
 			},
 			"{foo=\"bar\", foo=\"barf\"}",
-			httpgrpc.Errorf(http.StatusBadRequest, validation.DuplicateLabelNamesErrorMsg, "{foo=\"bar\", foo=\"barf\"}", "foo"),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.DuplicateLabelNamesErrorMsg("{foo=\"bar\", foo=\"barf\"}", "foo")),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -1,0 +1,154 @@
+package distributor
+
+import (
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/util/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/httpgrpc"
+	"net/http"
+	"testing"
+	"time"
+)
+
+var testStreamLabels = "FIXME"
+var testTime = time.Now()
+
+func TestValidator_ValidateEntry(t *testing.T) {
+	tests := []struct {
+		name      string
+		userID    string
+		overrides validation.TenantLimits
+		entry     logproto.Entry
+		expected  error
+	}{
+		{
+			"test valid",
+			"test",
+			nil,
+			logproto.Entry{Timestamp: testTime, Line: "test"},
+			nil,
+		},
+		{
+			"test too old",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{
+					RejectOldSamples:       true,
+					RejectOldSamplesMaxAge: 1 * time.Hour,
+				}
+			},
+			logproto.Entry{Timestamp: testTime.Add(-time.Hour * 5), Line: "test"},
+			httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg, testStreamLabels, testTime.Add(-time.Hour*5)),
+		},
+		{
+			"test too new",
+			"test",
+			nil,
+			logproto.Entry{Timestamp: testTime.Add(time.Hour * 5), Line: "test"},
+			httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg, testStreamLabels, testTime.Add(time.Hour*5)),
+		},
+		{
+			"line too long",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{
+					MaxLineSize: 10,
+				}
+			},
+			logproto.Entry{Timestamp: testTime, Line: "12345678901"},
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg, 10, testStreamLabels, 11),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &validation.Limits{}
+			flagext.DefaultValues(l)
+			o, err := validation.NewOverrides(*l, tt.overrides)
+			assert.NoError(t, err)
+			v, err := NewValidator(o)
+			assert.NoError(t, err)
+
+			err = v.ValidateEntry(tt.userID, testStreamLabels, tt.entry)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
+func TestValidator_ValidateLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		userID    string
+		overrides validation.TenantLimits
+		labels    string
+		expected  error
+	}{
+		{
+			"test valid",
+			"test",
+			nil,
+			"{foo=\"bar\"}",
+			nil,
+		},
+		{
+			"test too many labels",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{MaxLabelNamesPerSeries: 2}
+			},
+			"{foo=\"bar\",food=\"bars\",fed=\"bears\"}",
+			httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg, "{fed=\"bears\", foo=\"bar\", food=\"bars\"}", 3, 2),
+		},
+		{
+			"label name too long",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{
+					MaxLabelNamesPerSeries: 2,
+					MaxLabelNameLength:     5,
+				}
+			},
+			"{fooooo=\"bar\"}",
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelNameTooLongErrorMsg, "{fooooo=\"bar\"}", "fooooo"),
+		},
+		{
+			"label name too long",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{
+					MaxLabelNamesPerSeries: 2,
+					MaxLabelNameLength:     5,
+					MaxLabelValueLength:    5,
+				}
+			},
+			"{foo=\"barrrrrr\"}",
+			httpgrpc.Errorf(http.StatusBadRequest, validation.LabelValueTooLongErrorMsg, "{foo=\"barrrrrr\"}", "barrrrrr"),
+		},
+		{
+			"duplicate label",
+			"test",
+			func(userID string) *validation.Limits {
+				return &validation.Limits{
+					MaxLabelNamesPerSeries: 2,
+					MaxLabelNameLength:     5,
+					MaxLabelValueLength:    5,
+				}
+			},
+			"{foo=\"bar\", foo=\"barf\"}",
+			httpgrpc.Errorf(http.StatusBadRequest, validation.DuplicateLabelNamesErrorMsg, "{foo=\"bar\", foo=\"barf\"}", "foo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &validation.Limits{}
+			flagext.DefaultValues(l)
+			o, err := validation.NewOverrides(*l, tt.overrides)
+			assert.NoError(t, err)
+			v, err := NewValidator(o)
+			assert.NoError(t, err)
+
+			err = v.ValidateLabels(tt.userID, &logproto.Stream{Labels: tt.labels})
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"context"
+	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/util/validation"
 	"net/http"
 	"sync"
@@ -170,7 +171,8 @@ func (i *instance) getOrCreateStream(pushReqStream *logproto.Stream) (*stream, e
 			bytes += len(e.Line)
 		}
 		validation.DiscardedBytes.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(bytes))
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, err.Error())
+		level.Warn(cutil.Logger).Log("message", "could not create new stream for tenant", "error", err)
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg)
 	}
 
 	sortedLabels := i.index.Add(labels, fp)

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -172,7 +172,7 @@ func (i *instance) getOrCreateStream(pushReqStream *logproto.Stream) (*stream, e
 		}
 		validation.DiscardedBytes.WithLabelValues(validation.StreamLimit, i.instanceID).Add(float64(bytes))
 		level.Warn(cutil.Logger).Log("message", "could not create new stream for tenant", "error", err)
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg)
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, validation.StreamLimitErrorMsg())
 	}
 
 	sortedLabels := i.index.Add(labels, fp)

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -1,6 +1,8 @@
 package validation
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	discardReasonLabel = "reason"
@@ -8,11 +10,33 @@ const (
 	// RateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
 	RateLimited = "rate_limited"
+	RateLimitErrorMsg = "Ingestion rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased"
 	// LineTooLong is a reason for discarding too long log lines.
 	LineTooLong = "line_too_long"
+	LineTooLongErrorMsg = "Max entry size '%d' exceeded for stream '%s' while adding an entry with length '%d'"
 	// StreamLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
 	StreamLimit = "stream_limit"
+	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
+	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
+	GreaterThanMaxSampleAge = "greater_than_max_sample_age"
+	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"
+	// TooFarInFuture is a reason for discarding log lines which are newer than the current time + `creation_grace_period`
+	TooFarInFuture          = "too_far_in_future"
+	TooFarInFutureErrorMsg = "entry for stream '%s' has timestamp too new: %v"
+	// MaxLabelNamesPerSeries is a reason for discarding a log line which has too many label names
+	MaxLabelNamesPerSeries  = "max_label_names_per_series"
+	MaxLabelNamesPerSeriesErrorMsg = "entry for stream '%s' has %d label names; limit %d"
+	// LabelNameTooLong is a reason for discarding a log line which has a label name too long
+	LabelNameTooLong        = "label_name_too_long"
+	LabelNameTooLongErrorMsg = "stream '%s' has label name too long: '%s'"
+	// LabelValueTooLong is a reason for discarding a log line which has a lable value too long
+	LabelValueTooLong       = "label_value_too_long"
+	LabelValueTooLongErrorMsg = "stream '%s' has label value too long: '%s'"
+	// DuplicateLabelNames is a reason for discarding a log line which has duplicate label names
+	DuplicateLabelNames     = "duplicate_label_names"
+	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
+
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -9,34 +9,33 @@ const (
 
 	// RateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
-	RateLimited = "rate_limited"
+	RateLimited       = "rate_limited"
 	RateLimitErrorMsg = "Ingestion rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased"
 	// LineTooLong is a reason for discarding too long log lines.
-	LineTooLong = "line_too_long"
-	LineTooLongErrorMsg = "Max entry size '%d' exceeded for stream '%s' while adding an entry with length '%d'"
+	LineTooLong         = "line_too_long"
+	LineTooLongErrorMsg = "Max entry size '%d' bytes exceeded for stream '%s' while adding an entry with length '%d' bytes"
 	// StreamLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
-	StreamLimit = "stream_limit"
+	StreamLimit         = "stream_limit"
 	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
-	GreaterThanMaxSampleAge = "greater_than_max_sample_age"
+	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
 	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"
 	// TooFarInFuture is a reason for discarding log lines which are newer than the current time + `creation_grace_period`
-	TooFarInFuture          = "too_far_in_future"
+	TooFarInFuture         = "too_far_in_future"
 	TooFarInFutureErrorMsg = "entry for stream '%s' has timestamp too new: %v"
 	// MaxLabelNamesPerSeries is a reason for discarding a log line which has too many label names
-	MaxLabelNamesPerSeries  = "max_label_names_per_series"
+	MaxLabelNamesPerSeries         = "max_label_names_per_series"
 	MaxLabelNamesPerSeriesErrorMsg = "entry for stream '%s' has %d label names; limit %d"
 	// LabelNameTooLong is a reason for discarding a log line which has a label name too long
-	LabelNameTooLong        = "label_name_too_long"
+	LabelNameTooLong         = "label_name_too_long"
 	LabelNameTooLongErrorMsg = "stream '%s' has label name too long: '%s'"
 	// LabelValueTooLong is a reason for discarding a log line which has a lable value too long
-	LabelValueTooLong       = "label_value_too_long"
+	LabelValueTooLong         = "label_value_too_long"
 	LabelValueTooLongErrorMsg = "stream '%s' has label value too long: '%s'"
 	// DuplicateLabelNames is a reason for discarding a log line which has duplicate label names
-	DuplicateLabelNames     = "duplicate_label_names"
+	DuplicateLabelNames         = "duplicate_label_names"
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
-
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
+	"time"
 )
 
 const (
@@ -14,35 +15,30 @@ const (
 	rateLimitErrorMsg = "Ingestion rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased"
 	// LineTooLong is a reason for discarding too long log lines.
 	LineTooLong         = "line_too_long"
-	LineTooLongErrorMsg = "Max entry size '%d' bytes exceeded for stream '%s' while adding an entry with length '%d' bytes"
+	lineTooLongErrorMsg = "Max entry size '%d' bytes exceeded for stream '%s' while adding an entry with length '%d' bytes"
 	// StreamLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
 	StreamLimit         = "stream_limit"
-	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
+	streamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
 	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
-	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"
+	greaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"
 	// TooFarInFuture is a reason for discarding log lines which are newer than the current time + `creation_grace_period`
 	TooFarInFuture         = "too_far_in_future"
-	TooFarInFutureErrorMsg = "entry for stream '%s' has timestamp too new: %v"
+	tooFarInFutureErrorMsg = "entry for stream '%s' has timestamp too new: %v"
 	// MaxLabelNamesPerSeries is a reason for discarding a log line which has too many label names
 	MaxLabelNamesPerSeries         = "max_label_names_per_series"
-	MaxLabelNamesPerSeriesErrorMsg = "entry for stream '%s' has %d label names; limit %d"
+	maxLabelNamesPerSeriesErrorMsg = "entry for stream '%s' has %d label names; limit %d"
 	// LabelNameTooLong is a reason for discarding a log line which has a label name too long
-	LabelNameTooLong = "label_name_too_long"
-	LabelNameTooLongErrd
-	rorMsg = "stream '%s' has label name too long: '%s'"
+	LabelNameTooLong         = "label_name_too_long"
+	labelNameTooLongErrorMsg = "stream '%s' has label name too long: '%s'"
 	// LabelValueTooLong is a reason for discarding a log line which has a lable value too long
 	LabelValueTooLong         = "label_value_too_long"
-	LabelValueTooLongErrorMsg = "stream '%s' has label value too long: '%s'"
+	labelValueTooLongErrorMsg = "stream '%s' has label value too long: '%s'"
 	// DuplicateLabelNames is a reason for discarding a log line which has duplicate label names
 	DuplicateLabelNames         = "duplicate_label_names"
-	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
+	duplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
-
-func RateLimitedErrorMsg(limit, lines, bytes int) string {
-	return fmt.Sprintf(rateLimitErrorMsg, limit, lines, bytes)
-}
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
 var DiscardedBytes = prometheus.NewCounterVec(
@@ -66,4 +62,49 @@ var DiscardedSamples = prometheus.NewCounterVec(
 
 func init() {
 	prometheus.MustRegister(DiscardedSamples, DiscardedBytes)
+}
+
+// RateLimitedErrorMsg returns an error string for rate limited requests
+func RateLimitedErrorMsg(limit, lines, bytes int) string {
+	return fmt.Sprintf(rateLimitErrorMsg, limit, lines, bytes)
+}
+
+// LineTooLongErrorMsg returns an error string for a line which is too long
+func LineTooLongErrorMsg(maxLength, entryLength int, stream string) string {
+	return fmt.Sprintf(lineTooLongErrorMsg, maxLength, stream, entryLength)
+}
+
+// StreamLimitErrorMsg returns an error string for requests refused for exceeding active stream limits
+func StreamLimitErrorMsg() string {
+	return fmt.Sprintf(streamLimitErrorMsg)
+}
+
+// GreaterThanMaxSampleAgeErrorMsg returns an error string for a line with a timestamp too old
+func GreaterThanMaxSampleAgeErrorMsg(stream string, timestamp time.Time) string {
+	return fmt.Sprintf(greaterThanMaxSampleAgeErrorMsg, stream, timestamp)
+}
+
+// TooFarInFutureErrorMsg returns an error string for a line with a timestamp too far in the future
+func TooFarInFutureErrorMsg(stream string, timestamp time.Time) string {
+	return fmt.Sprintf(tooFarInFutureErrorMsg, stream, timestamp)
+}
+
+// MaxLabelNamesPerSeriesErrorMsg returns an error string for a stream with too many labels
+func MaxLabelNamesPerSeriesErrorMsg(stream string, labelCount, labelLimit int) string {
+	return fmt.Sprintf(maxLabelNamesPerSeriesErrorMsg, stream, labelCount, labelLimit)
+}
+
+// LabelNameTooLongErrorMsg returns an error string for a stream with a label name too long
+func LabelNameTooLongErrorMsg(stream, label string) string {
+	return fmt.Sprintf(labelNameTooLongErrorMsg, stream, label)
+}
+
+// LabelValueTooLongErrorMsg returns an error string for a stream with a label value too long
+func LabelValueTooLongErrorMsg(stream, labelValue string) string {
+	return fmt.Sprintf(labelValueTooLongErrorMsg, stream, labelValue)
+}
+
+// DuplicateLabelNamesErrorMsg returns an error string for a stream which has duplicate labels
+func DuplicateLabelNamesErrorMsg(stream, label string) string {
+	return fmt.Sprintf(duplicateLabelNamesErrorMsg, stream, label)
 }

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -10,7 +11,7 @@ const (
 	// RateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
 	RateLimited       = "rate_limited"
-	RateLimitErrorMsg = "Ingestion rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased"
+	rateLimitErrorMsg = "Ingestion rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased"
 	// LineTooLong is a reason for discarding too long log lines.
 	LineTooLong         = "line_too_long"
 	LineTooLongErrorMsg = "Max entry size '%d' bytes exceeded for stream '%s' while adding an entry with length '%d' bytes"
@@ -28,8 +29,9 @@ const (
 	MaxLabelNamesPerSeries         = "max_label_names_per_series"
 	MaxLabelNamesPerSeriesErrorMsg = "entry for stream '%s' has %d label names; limit %d"
 	// LabelNameTooLong is a reason for discarding a log line which has a label name too long
-	LabelNameTooLong         = "label_name_too_long"
-	LabelNameTooLongErrorMsg = "stream '%s' has label name too long: '%s'"
+	LabelNameTooLong = "label_name_too_long"
+	LabelNameTooLongErrd
+	rorMsg = "stream '%s' has label name too long: '%s'"
 	// LabelValueTooLong is a reason for discarding a log line which has a lable value too long
 	LabelValueTooLong         = "label_value_too_long"
 	LabelValueTooLongErrorMsg = "stream '%s' has label value too long: '%s'"
@@ -37,6 +39,10 @@ const (
 	DuplicateLabelNames         = "duplicate_label_names"
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
+
+func RateLimitedErrorMsg(limit, lines, bytes int) string {
+	return fmt.Sprintf(rateLimitErrorMsg, limit, lines, bytes)
+}
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
 var DiscardedBytes = prometheus.NewCounterVec(


### PR DESCRIPTION
this copies some validation code from Cortex into Loki modifies it to be more appropriate for Loki, this gives us a single metric we can use for detecting validation errors (previously we had to check cortex_ and loki_ metrics) as well as lets us use error messages more appropriate for logs than metrics.

Signed-off-by: Ed Welch <edward.welch@grafana.com>


**Checklist**
- [ ] Documentation added
- [x] Tests updated

