### PR TITLE
Targets not required in promtail config

### DIFF
--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -799,7 +799,8 @@ configuration.
 
 ```yaml
 # Configures the discovery to look on the current machine. Must be either
-# localhost or the hostname of the current computer.
+# localhost or the hostname of the current computer. This is not a mandatory config
+# and this can skipped.
 targets:
   - localhost
 
@@ -1073,6 +1074,31 @@ scrape_configs:
    - targets:
       - localhost
      labels:
+      job: varlogs  # A `job` label is fairly standard in prometheus and useful for linking metrics and logs.
+      host: yourhost # A `host` label will help identify logs from this machine vs others
+      __path__: /var/log/*.log  # The path matching uses a third party library: https://github.com/bmatcuk/doublestar
+```
+
+## Example Static Config without targets
+
+While promtail may have been named for the prometheus service discovery code, that same code works very well for tailing logs without containers or container environments directly on virtual machines or bare metal.
+
+```yaml
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /var/log/positions.yaml # This location needs to be writeable by promtail.
+
+client:
+  url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
+
+scrape_configs:
+ - job_name: system
+   pipeline_stages:
+   static_configs:
+   - labels:
       job: varlogs  # A `job` label is fairly standard in prometheus and useful for linking metrics and logs.
       host: yourhost # A `host` label will help identify logs from this machine vs others
       __path__: /var/log/*.log  # The path matching uses a third party library: https://github.com/bmatcuk/doublestar

--- a/docs/clients/promtail/configuration.md
+++ b/docs/clients/promtail/configuration.md
@@ -798,9 +798,11 @@ for them.  It is the canonical way to specify static targets in a scrape
 configuration.
 
 ```yaml
-# Configures the discovery to look on the current machine. Must be either
-# localhost or the hostname of the current computer. This is not a mandatory config
-# and this can skipped.
+# Configures the discovery to look on the current machine. 
+# This is required by the prometheus service discovery code but doesn't
+# really apply to Promtail which can ONLY look at files on the local machine
+# As such it should only have the value of localhost, OR it can be excluded
+# entirely and a default value of localhost will be applied by Promtail.
 targets:
   - localhost
 

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -109,13 +109,14 @@ func NewFileTargetManager(
 		}
 
 		// Add Source value to the static config target groups for unique identification
-		// within scrape pool. Also, set dummy target if target is not defined in promtail config.
+		// within scrape pool. Also, default target label to localhost if target is not
+		// defined in promtail config.
 		// Just to make sure prometheus target group sync works fine.
 		for i, tg := range cfg.ServiceDiscoveryConfig.StaticConfigs {
 			tg.Source = fmt.Sprintf("%d", i)
 			if len(tg.Targets) == 0 {
 				tg.Targets = []model.LabelSet{
-					{model.AddressLabel: "dummy"},
+					{model.AddressLabel: "localhost"},
 				}
 			}
 		}

--- a/pkg/promtail/targets/filetargetmanager.go
+++ b/pkg/promtail/targets/filetargetmanager.go
@@ -109,9 +109,15 @@ func NewFileTargetManager(
 		}
 
 		// Add Source value to the static config target groups for unique identification
-		// within scrape pool.
+		// within scrape pool. Also, set dummy target if target is not defined in promtail config.
+		// Just to make sure prometheus target group sync works fine.
 		for i, tg := range cfg.ServiceDiscoveryConfig.StaticConfigs {
 			tg.Source = fmt.Sprintf("%d", i)
+			if len(tg.Targets) == 0 {
+				tg.Targets = []model.LabelSet{
+					{model.AddressLabel: "dummy"},
+				}
+			}
 		}
 
 		s := &targetSyncer{


### PR DESCRIPTION
**What this PR does / why we need it**:
Targets are not required in promtail config. If defined in config we will just use that otherwise we will just add `dummy` host.

**Which issue(s) this PR fixes**:
Fixes #1929 

**Checklist**
- [x] Documentation added
- [ ] Tests updated

