### PR TITLE
logcli: Query needs to be stored into url.RawQuery, and not url.Path

### DIFF
--- a/pkg/logcli/client/client_test.go
+++ b/pkg/logcli/client/client_test.go
@@ -5,17 +5,17 @@ import "testing"
 func Test_buildURL(t *testing.T) {
 	tests := []struct {
 		name    string
-		u, p    string
+		u, p, q string
 		want    string
 		wantErr bool
 	}{
-		{"err", "8://2", "/bar", "", true},
-		{"strip /", "http://localhost//", "//bar", "http://localhost/bar", false},
-		{"sub path", "https://localhost/loki/", "/bar/foo", "https://localhost/loki/bar/foo", false},
+		{"err", "8://2", "/bar", "", "", true},
+		{"strip /", "http://localhost//", "//bar", "a=b", "http://localhost/bar?a=b", false},
+		{"sub path", "https://localhost/loki/", "/bar/foo", "c=d&e=f", "https://localhost/loki/bar/foo?c=d&e=f", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildURL(tt.u, tt.p)
+			got, err := buildURL(tt.u, tt.p, tt.q)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildURL() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/util/query_string_builder.go
+++ b/pkg/util/query_string_builder.go
@@ -46,16 +46,3 @@ func (b *QueryStringBuilder) SetFloat32(name string, value float32) {
 func (b *QueryStringBuilder) Encode() string {
 	return b.values.Encode()
 }
-
-// Encode returns the URL-encoded query string, prefixing it with the
-// input URL path.
-func (b *QueryStringBuilder) EncodeWithPath(path string) string {
-	queryString := b.Encode()
-	if path == "" {
-		return queryString
-	} else if queryString == "" {
-		return path
-	}
-
-	return path + "?" + queryString
-}

--- a/pkg/util/query_string_builder_test.go
+++ b/pkg/util/query_string_builder_test.go
@@ -14,12 +14,10 @@ func TestQueryStringBuilder(t *testing.T) {
 	tests := map[string]struct {
 		input           map[string]interface{}
 		expectedEncoded string
-		expectedPath    string
 	}{
 		"should return an empty query string on no params": {
 			input:           map[string]interface{}{},
 			expectedEncoded: "",
-			expectedPath:    "/test",
 		},
 		"should return the URL encoded query string parameters": {
 			input: map[string]interface{}{
@@ -31,7 +29,6 @@ func TestQueryStringBuilder(t *testing.T) {
 				"string":     "foo",
 			},
 			expectedEncoded: "float32=123.456&float64=123.456&float64int=12345&int32=32&int64=64&string=foo",
-			expectedPath:    "/test?float32=123.456&float64=123.456&float64int=12345&int32=32&int64=64&string=foo",
 		},
 	}
 
@@ -59,7 +56,6 @@ func TestQueryStringBuilder(t *testing.T) {
 			}
 
 			assert.Equal(t, testData.expectedEncoded, params.Encode())
-			assert.Equal(t, testData.expectedPath, params.EncodeWithPath("/test"))
 		})
 	}
 }


### PR DESCRIPTION
Logcli put path + query string into `url.Path` field, which was then path-encoded into:

```https://logs-dev-ops-tools1.grafana.net/loki/api/v1/query_range%3Fdirection=BACKWARD&end=1588318369339918000&limit=30&query=%257Bnamespace%253D%2522loki-ops2%2522%257D&start=1588314769339918000```

which doesn't work.

Query needs to be stored into `RawQuery` field instead to be correctly encoded as a query string after `?`.

This PR also removes now unused `EncodeWithPath` method from QueryStringBuilder.

Related to #2000, which introduced `buildURL` function.