### PR TITLE
some metrics for measuring performance and failures in boltdb shipper

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/ring"
@@ -126,7 +128,7 @@ func New(cfg Config) (*Loki, error) {
 	}
 
 	loki.setupAuthMiddleware()
-	storage.RegisterCustomIndexClients(cfg.StorageConfig)
+	storage.RegisterCustomIndexClients(cfg.StorageConfig, prometheus.DefaultRegisterer)
 
 	serviceMap, err := loki.initModuleServices(cfg.Target)
 	if err != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -206,7 +206,7 @@ func filterChunksByTime(from, through model.Time, chunks []chunk.Chunk) []chunk.
 	return filtered
 }
 
-func RegisterCustomIndexClients(cfg Config) {
+func RegisterCustomIndexClients(cfg Config, registerer prometheus.Registerer) {
 	// BoltDB Shipper is supposed to be run as a singleton.
 	// This could also be done in NewBoltDBIndexClientWithShipper factory method but we are doing it here because that method is used
 	// in tests for creating multiple instances of it at a time.
@@ -222,7 +222,10 @@ func RegisterCustomIndexClients(cfg Config) {
 			return nil, err
 		}
 
-		boltDBIndexClientWithShipper, err = local.NewBoltDBIndexClientWithShipper(cortex_local.BoltDBConfig{Directory: cfg.BoltDBShipperConfig.ActiveIndexDirectory}, objectClient, cfg.BoltDBShipperConfig)
+		boltDBIndexClientWithShipper, err = local.NewBoltDBIndexClientWithShipper(
+			cortex_local.BoltDBConfig{Directory: cfg.BoltDBShipperConfig.ActiveIndexDirectory},
+			objectClient, cfg.BoltDBShipperConfig, registerer)
+
 		return boltDBIndexClientWithShipper, err
 	}, func() (client chunk.TableClient, e error) {
 		objectClient, err := storage.NewObjectClient(cfg.BoltDBShipperConfig.SharedStoreType, cfg.Config)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -460,7 +460,7 @@ func TestStore_MultipleBoltDBShippersInConfig(t *testing.T) {
 		BoltDBShipperConfig: boltdbShipperConfig,
 	}
 
-	RegisterCustomIndexClients(config)
+	RegisterCustomIndexClients(config, nil)
 
 	store, err := NewStore(config, chunk.StoreConfig{}, chunk.SchemaConfig{
 		Configs: []chunk.PeriodConfig{

--- a/pkg/storage/stores/local/boltdb_index_client.go
+++ b/pkg/storage/stores/local/boltdb_index_client.go
@@ -3,13 +3,11 @@ package local
 import (
 	"context"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/weaveworks/common/instrument"
-
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/local"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/instrument"
 	"go.etcd.io/bbolt"
 )
 

--- a/pkg/storage/stores/local/boltdb_index_client.go
+++ b/pkg/storage/stores/local/boltdb_index_client.go
@@ -3,6 +3,10 @@ package local
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/common/instrument"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/local"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
@@ -15,13 +19,13 @@ type BoltdbIndexClientWithShipper struct {
 }
 
 // NewBoltDBIndexClientWithShipper creates a new IndexClient that used BoltDB.
-func NewBoltDBIndexClientWithShipper(cfg local.BoltDBConfig, archiveStoreClient chunk.ObjectClient, archiverCfg ShipperConfig) (chunk.IndexClient, error) {
+func NewBoltDBIndexClientWithShipper(cfg local.BoltDBConfig, archiveStoreClient chunk.ObjectClient, archiverCfg ShipperConfig, registerer prometheus.Registerer) (chunk.IndexClient, error) {
 	boltDBIndexClient, err := local.NewBoltDBIndexClient(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	shipper, err := NewShipper(archiverCfg, archiveStoreClient, boltDBIndexClient)
+	shipper, err := NewShipper(archiverCfg, archiveStoreClient, boltDBIndexClient, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +59,9 @@ func (b *BoltdbIndexClientWithShipper) query(ctx context.Context, query chunk.In
 		}
 	}
 
-	return b.shipper.forEach(ctx, query.TableName, func(db *bbolt.DB) error {
-		return b.QueryDB(ctx, db, query, callback)
+	return instrument.CollectedRequest(ctx, "QUERY", instrument.NewHistogramCollector(b.shipper.metrics.requestDurationSeconds), instrument.ErrorCode, func(ctx context.Context) error {
+		return b.shipper.forEach(ctx, query.TableName, func(db *bbolt.DB) error {
+			return b.QueryDB(ctx, db, query, callback)
+		})
 	})
 }

--- a/pkg/storage/stores/local/metrics.go
+++ b/pkg/storage/stores/local/metrics.go
@@ -1,6 +1,8 @@
 package local
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/instrument"
@@ -11,10 +13,48 @@ const (
 	statusSuccess = "success"
 )
 
+type downloadPeriodDurationMetric struct {
+	sync.RWMutex
+	gauge   prometheus.Gauge
+	periods map[string]float64
+}
+
+func (m *downloadPeriodDurationMetric) add(period string, downloadDuration float64) {
+	m.Lock()
+	defer m.Unlock()
+	m.periods[period] = downloadDuration
+
+	totalDuration := float64(0)
+	for _, dur := range m.periods {
+		totalDuration += dur
+	}
+
+	m.gauge.Set(totalDuration)
+}
+
+type downloadPeriodBytesMetric struct {
+	sync.RWMutex
+	gauge   prometheus.Gauge
+	periods map[string]int64
+}
+
+func (m *downloadPeriodBytesMetric) add(period string, downloadedBytes int64) {
+	m.Lock()
+	defer m.Unlock()
+	m.periods[period] = downloadedBytes
+
+	totalDownloadedBytes := int64(0)
+	for _, downloadedBytes := range m.periods {
+		totalDownloadedBytes += downloadedBytes
+	}
+
+	m.gauge.Set(float64(totalDownloadedBytes))
+}
+
 type boltDBShipperMetrics struct {
 	// metrics for measuring performance of downloading of files per period initially i.e for the first time
-	initialFilesDownloadDurationSeconds *prometheus.GaugeVec
-	initialFilesDownloadSizeBytes       *prometheus.GaugeVec
+	filesDownloadDurationSeconds *downloadPeriodDurationMetric
+	filesDownloadSizeBytes       *downloadPeriodBytesMetric
 
 	// duration in seconds spent in serving request on index managed by BoltDB Shipper
 	requestDurationSeconds *prometheus.HistogramVec
@@ -25,16 +65,20 @@ type boltDBShipperMetrics struct {
 
 func newBoltDBShipperMetrics(r prometheus.Registerer) *boltDBShipperMetrics {
 	m := &boltDBShipperMetrics{
-		initialFilesDownloadDurationSeconds: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "loki_boltdb_shipper",
-			Name:      "initial_files_download_duration_seconds",
-			Help:      "Time (in seconds) spent in downloading of files per period, initially i.e for the first time",
-		}, []string{"period"}),
-		initialFilesDownloadSizeBytes: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "loki_boltdb_shipper",
-			Name:      "initial_files_download_size_bytes",
-			Help:      "Size of files (in bytes) downloaded per period, initially i.e for the first time",
-		}, []string{"period"}),
+		filesDownloadDurationSeconds: &downloadPeriodDurationMetric{
+			periods: map[string]float64{},
+			gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+				Namespace: "loki_boltdb_shipper",
+				Name:      "initial_files_download_duration_seconds",
+				Help:      "Time (in seconds) spent in downloading of files per period, initially i.e for the first time",
+			})},
+		filesDownloadSizeBytes: &downloadPeriodBytesMetric{
+			periods: map[string]int64{},
+			gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+				Namespace: "loki_boltdb_shipper",
+				Name:      "initial_files_download_size_bytes",
+				Help:      "Size of files (in bytes) downloaded per period, initially i.e for the first time",
+			})},
 		requestDurationSeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "request_duration_seconds",

--- a/pkg/storage/stores/local/metrics.go
+++ b/pkg/storage/stores/local/metrics.go
@@ -1,0 +1,52 @@
+package local
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/instrument"
+)
+
+type boltDBShipperMetrics struct {
+	// metrics for measuring performance of downloading of files per period initially i.e for the first time
+	initialFilesDownloadDurationSeconds *prometheus.GaugeVec
+	initialFilesDownloadSizeBytes       *prometheus.GaugeVec
+
+	// duration in seconds spent in serving request on index managed by BoltDB Shipper
+	requestDurationSeconds *prometheus.HistogramVec
+
+	filesDownloadFailures prometheus.Counter
+	filesUploadFailures   prometheus.Counter
+}
+
+func newBoltDBShipperMetrics(r prometheus.Registerer) *boltDBShipperMetrics {
+	m := &boltDBShipperMetrics{
+		initialFilesDownloadDurationSeconds: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "initial_files_download_duration_seconds",
+			Help:      "Time (in seconds) spent in downloading of files per period, initially i.e for the first time",
+		}, []string{"period"}),
+		initialFilesDownloadSizeBytes: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "initial_files_download_size_bytes",
+			Help:      "Size of files (in bytes) downloaded per period, initially i.e for the first time",
+		}, []string{"period"}),
+		requestDurationSeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "request_duration_seconds",
+			Help:      "Time (in seconds) spent serving requests when using boltdb shipper",
+			Buckets:   instrument.DefBuckets,
+		}, []string{"operation", "status_code"}),
+		filesDownloadFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "files_download_failures_total",
+			Help:      "Total number of failures in downloading of files",
+		}),
+		filesUploadFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "files_upload_failures_total",
+			Help:      "TTotal number of failures in downloading of files",
+		}),
+	}
+
+	return m
+}

--- a/pkg/storage/stores/local/metrics.go
+++ b/pkg/storage/stores/local/metrics.go
@@ -6,6 +6,11 @@ import (
 	"github.com/weaveworks/common/instrument"
 )
 
+const (
+	statusFailure = "failure"
+	statusSuccess = "success"
+)
+
 type boltDBShipperMetrics struct {
 	// metrics for measuring performance of downloading of files per period initially i.e for the first time
 	initialFilesDownloadDurationSeconds *prometheus.GaugeVec
@@ -14,8 +19,8 @@ type boltDBShipperMetrics struct {
 	// duration in seconds spent in serving request on index managed by BoltDB Shipper
 	requestDurationSeconds *prometheus.HistogramVec
 
-	filesDownloadFailures prometheus.Counter
-	filesUploadFailures   prometheus.Counter
+	filesDownloadOperationTotal *prometheus.CounterVec
+	filesUploadOperationTotal   *prometheus.CounterVec
 }
 
 func newBoltDBShipperMetrics(r prometheus.Registerer) *boltDBShipperMetrics {
@@ -36,16 +41,16 @@ func newBoltDBShipperMetrics(r prometheus.Registerer) *boltDBShipperMetrics {
 			Help:      "Time (in seconds) spent serving requests when using boltdb shipper",
 			Buckets:   instrument.DefBuckets,
 		}, []string{"operation", "status_code"}),
-		filesDownloadFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		filesDownloadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
-			Name:      "files_download_failures_total",
-			Help:      "Total number of failures in downloading of files",
-		}),
-		filesUploadFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name:      "files_download_operation_total",
+			Help:      "Total number of download operations done by status",
+		}, []string{"status"}),
+		filesUploadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
-			Name:      "files_upload_failures_total",
-			Help:      "TTotal number of failures in downloading of files",
-		}),
+			Name:      "files_upload_operation_total",
+			Help:      "Total number of upload operations done by status",
+		}, []string{"status"}),
 	}
 
 	return m

--- a/pkg/storage/stores/local/uploads_test.go
+++ b/pkg/storage/stores/local/uploads_test.go
@@ -38,7 +38,8 @@ func createTestBoltDBWithShipper(t *testing.T, parentTempDir, ingesterName, loca
 	})
 	require.NoError(t, err)
 
-	boltdbIndexClientWithShipper, err := NewBoltDBIndexClientWithShipper(local.BoltDBConfig{Directory: shipperConfig.ActiveIndexDirectory}, archiveStoreClient, shipperConfig)
+	boltdbIndexClientWithShipper, err := NewBoltDBIndexClientWithShipper(
+		local.BoltDBConfig{Directory: shipperConfig.ActiveIndexDirectory}, archiveStoreClient, shipperConfig, nil)
 	require.NoError(t, err)
 
 	return boltdbIndexClientWithShipper.(*BoltdbIndexClientWithShipper)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds following metrics for measuring performance and failures in boltdb shipper.
* `loki_boltdb_shipper_files_download_failures_total`: Total number of failures in downloading files from shared store.
* `loki_boltdb_shipper_files_upload_failures_total`: Total number of failures in uploading files from shared store.
* `loki_boltdb_shipper_initial_files_download_duration_seconds`: Measures download time per period only for initial download since that is what would impact query performance.
* `loki_boltdb_shipper_initial_files_download_size_bytes`: Measures total files size per period only for initial download since that is what would impact query performance.
* `loki_boltdb_shipper_request_duration_seconds`: Histogram measuring time(in seconds) spent in processing requests. We do only read requests for now.

