### PR TITLE
Reversable iterators + more granular adapters

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -489,11 +489,15 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 		time.Unix(0, maxt),
 	)
 
+	if err := iterForward.Error(); err != nil {
+		return nil, err
+	}
+
 	if direction == logproto.FORWARD {
 		return iterForward, nil
 	}
 
-	return iter.NewReversedIter(iterForward, 0, false)
+	return iter.NewReversedIter(iterForward, 0, false), nil
 }
 
 func (b block) iterator(ctx context.Context, pool ReaderPool, filter logql.LineFilter) iter.EntryIterator {

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -497,7 +497,7 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 		return iterForward, nil
 	}
 
-	return iter.NewReversedIter(iterForward, 0, false), nil
+	return iter.NewReversedIter(iterForward), nil
 }
 
 func (b block) iterator(ctx context.Context, pool ReaderPool, filter logql.LineFilter) iter.EntryIterator {

--- a/pkg/iter/iterator.go
+++ b/pkg/iter/iterator.go
@@ -176,7 +176,7 @@ type heapIterator struct {
 }
 
 // NewHeapIterator returns a new iterator which uses a heap to merge together
-// entries for multiple interators.
+// entries for multiple interators. They must all be sorted in the same direction prior to construction.
 func NewHeapIterator(ctx context.Context, is []EntryIterator, direction logproto.Direction) HeapIterator {
 	result := &heapIterator{is: is, stats: stats.GetChunkData(ctx)}
 	switch direction {

--- a/pkg/iter/iterator_test.go
+++ b/pkg/iter/iterator_test.go
@@ -461,20 +461,20 @@ func TestReverseEntryIterator(t *testing.T) {
 	assert.NoError(t, reversedIter.Close())
 }
 
-func TestReverseEntryIteratorUnlimited(t *testing.T) {
-	itr1 := mkStreamIterator(offset(testSize, identity), defaultLabels)
-	itr2 := mkStreamIterator(offset(testSize, identity), "{foobar: \"bazbar\"}")
+func TestReverseEntryIteratorHeapIter(t *testing.T) {
+	itr1 := mkStreamIterator(identity, `{foo="bar"}`)
+	itr2 := mkStreamIterator(identity, `{foo="baz"}`)
 
-	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
+	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.FORWARD)
 	reversedIter := NewReversedIter(heapIterator, 0, false)
 
 	var ct int
-	expected := 2 * testSize
 
 	for reversedIter.Next() {
+		require.Equal(t, fmt.Sprintf("%d", (20-ct-1)/2), reversedIter.Entry().Line)
 		ct++
 	}
-	require.Equal(t, expected, ct)
+	require.Equal(t, false, reversedIter.Next())
 }
 
 func Test_PeekingIterator(t *testing.T) {

--- a/pkg/iter/iterator_test.go
+++ b/pkg/iter/iterator_test.go
@@ -371,7 +371,7 @@ func TestReversableEntryIterator(t *testing.T) {
 		{
 			name: "reversedIterator",
 			fn: func(stream *logproto.Stream) EntryIterator {
-				iter := NewReversedIter(NewStreamIterator(stream), 0, false)
+				iter := NewReversedIter(NewStreamIterator(stream))
 				iter.(ReversableIterator).Reverse()
 				return iter
 			},
@@ -431,7 +431,7 @@ func TestReversableNonOverlappingIter(t *testing.T) {
 	// test reverse
 	rev := NewNonOverlappingIterator([]EntryIterator{first(), second()}, `{foo="bar"}`)
 	rev.(ReversableIterator).Reverse()
-	equalIters(t, NewReversedIter(combined(), 0, false), rev)
+	equalIters(t, NewReversedIter(combined()), rev)
 
 	// test double reverse == identity
 	dbl := NewNonOverlappingIterator([]EntryIterator{first(), second()}, `{foo="bar"}`)
@@ -445,7 +445,8 @@ func TestReverseEntryIterator(t *testing.T) {
 	itr2 := mkStreamIterator(inverse(offset(testSize, identity)), "{foobar: \"bazbar\"}")
 
 	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
-	reversedIter := NewReversedIter(heapIterator, testSize, false)
+	limited := NewLimitedIterator(testSize, heapIterator)
+	reversedIter := NewReversedIter(limited)
 
 	for i := int64((testSize / 2) + 1); i <= testSize; i++ {
 		assert.Equal(t, true, reversedIter.Next())
@@ -466,7 +467,7 @@ func TestReverseEntryIteratorHeapIter(t *testing.T) {
 	itr2 := mkStreamIterator(identity, `{foo="baz"}`)
 
 	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.FORWARD)
-	reversedIter := NewReversedIter(heapIterator, 0, false)
+	reversedIter := NewReversedIter(heapIterator)
 
 	var ct int
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -308,10 +308,11 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer,
 		return nil, err
 	}
 
-	reversedIterator, err := iter.NewReversedIter(histIterators, req.Limit, true)
-	if err != nil {
+	if err := histIterators.Error(); err != nil {
 		return nil, err
 	}
+
+	reversedIterator := iter.NewReversedIter(histIterators, req.Limit, true)
 
 	return newTailer(
 		time.Duration(req.DelayFor)*time.Second,

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -312,7 +312,11 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer,
 		return nil, err
 	}
 
-	reversedIterator := iter.NewReversedIter(histIterators, req.Limit, true)
+	reversedIterator := iter.NewReversedIter(
+		iter.NewPrefetchedIterator(
+			iter.NewLimitedIter(req.Limit, histIterators),
+		),
+	)
 
 	return newTailer(
 		time.Duration(req.DelayFor)*time.Second,


### PR DESCRIPTION
## What
Looking for some feedback here. This defines a new interface extension,
```
type ReversableIterator interface {
	EntryIterator
	Reverse()
}
```
which allows reversing iterators in less than `O(n)` time/space if the underlying impl supports this optimization. 

As this PR stands, I doubt it will yield efficiency gains yet because we'd need to implement this interface for _every_ required iterator. i.e. embedding multiple adapters would require they all implement this in order for the resulting composite to implement it as well.

I've also included `limitedIterator` and `prefetchedIterator` adapters, rather than coupling this in the underlying `reversedIterator`.

