### PR TITLE
Add extraOutputs variable to support multiple outputs for fluent-bit

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.1.1
+version: 0.1.2
 appVersion: v1.4.1
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/README.md
+++ b/production/helm/fluent-bit/README.md
@@ -84,6 +84,7 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `config.labels`          | A set of labels to send for every log                                                              | `'{job="fluent-bit"}'`           |
 | `config.labelMap`        | Mapping of labels from a record. See [Fluent Bit documentation](../../../cmd/fluent-bit/README.md) |                                  |
 | `config.parsers`         | Definition of extras fluent bit parsers. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/filter/parser). The format is a sequence of mappings where each key is the same as the one in the [PARSER] section of parsers.conf file       | `[]`                            |
+| `config.extraOutputs`    | Definition of extras fluent bit outputs. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/outputs/). The format is a sequence of mappings where each key is the same as the one in the [OUTPUT]                                | `[]`                            |
 | `affinity`               | [affinity][affinity] settings for pod assignment                                                   | `{}`                             |
 | `annotations`            | Annotations to add to Kubernetes resources.                                                        | `{}`                             |
 | `deploymentStrategy`     | The deployment strategy to use with the daemonset                                                  | `RollingUpdate`                  |

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -44,7 +44,12 @@ data:
         LabelMapPath /fluent-bit/etc/labelmap.json
         LineFormat {{ .Values.config.lineFormat }}
         LogLevel {{ .Values.config.loglevel }}
-
+    {{- range $extraOutput := .Values.config.extraOutputs }}
+    [OUTPUT]
+    {{- range $key,$value := $extraOutput }}
+        {{ $key }} {{ $value }}
+    {{- end }}
+    {{- end }}
   parsers.conf: |-
     [PARSER]
         Name        docker

--- a/production/helm/fluent-bit/values.yaml
+++ b/production/helm/fluent-bit/values.yaml
@@ -31,6 +31,10 @@ config:
   #    Time_Key: time
   #    Time_Format: "%d/%b/%Y:%H:%M:%S %z"
 
+  # extraOutputs: # Allow to define extra outputs in addition to the one automatically created
+  #   - Name: stdout
+  #     Format: json
+  #     json_date_format: time
 
 affinity: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds extra outputs feature for fluent-bit helm chart

**Which issue(s) this PR fixes**:
Fixes #2039

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added

