### PR TITLE
Chore: Correct typo "per seconds"

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -888,7 +888,7 @@ The example belows show all possible statistics returned with their respective d
         "totalDuplicates": 0 // Total of duplicates removed from replication
       },
       "summary": {
-        "bytesProcessedPerSeconds": 0, // Total of bytes processed per seconds
+        "bytesProcessedPerSeconds": 0, // Total of bytes processed per second
         "execTime": 0, // Total execution time in seconds (float)
         "linesProcessedPerSeconds": 0, // Total lines processed per second
         "totalBytesProcessed":0, // Total amount of bytes processed overall for this request

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -27,7 +27,7 @@ var (
 	bytesPerSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "loki",
 		Name:      "logql_querystats_bytes_processed_per_seconds",
-		Help:      "Distribution of bytes processed per seconds for LogQL queries.",
+		Help:      "Distribution of bytes processed per second for LogQL queries.",
 		// 50MB 100MB 200MB 400MB 600MB 800MB 1GB 2GB 3GB 4GB 5GB 6GB 7GB 8GB 9GB 10GB 15GB 20GB
 		Buckets: []float64{50 * 1e6, 100 * 1e6, 400 * 1e6, 600 * 1e6, 800 * 1e6, 1 * 1e9, 2 * 1e9, 3 * 1e9, 4 * 1e9, 5 * 1e9, 6 * 1e9, 7 * 1e9, 8 * 1e9, 9 * 1e9, 10 * 1e9, 15 * 1e9, 20 * 1e9},
 	}, []string{"status_code", "type", "range", "latency_type"})

--- a/pkg/logql/stats/stats.pb.go
+++ b/pkg/logql/stats/stats.pb.go
@@ -87,9 +87,9 @@ func (m *Result) GetIngester() Ingester {
 
 // Summary is the summary of a query statistics.
 type Summary struct {
-	// Total bytes processed per seconds.
+	// Total bytes processed per second.
 	BytesProcessedPerSeconds int64 `protobuf:"varint,1,opt,name=bytesProcessedPerSeconds,proto3" json:"bytesProcessedPerSeconds"`
-	// Total lines processed per seconds.
+	// Total lines processed per second.
 	LinesProcessedPerSeconds int64 `protobuf:"varint,2,opt,name=linesProcessedPerSeconds,proto3" json:"linesProcessedPerSeconds"`
 	// Total bytes processed.
 	TotalBytesProcessed int64 `protobuf:"varint,3,opt,name=totalBytesProcessed,proto3" json:"totalBytesProcessed"`

--- a/pkg/logql/stats/stats.proto
+++ b/pkg/logql/stats/stats.proto
@@ -18,9 +18,9 @@ message Result {
 
 // Summary is the summary of a query statistics.
 message Summary {
-   // Total bytes processed per seconds.
+   // Total bytes processed per second.
   int64 bytesProcessedPerSeconds = 1 [(gogoproto.jsontag) = "bytesProcessedPerSeconds"];
-  // Total lines processed per seconds.
+  // Total lines processed per second.
   int64 linesProcessedPerSeconds = 2 [(gogoproto.jsontag) = "linesProcessedPerSeconds"];
   // Total bytes processed.
   int64 totalBytesProcessed = 3 [(gogoproto.jsontag) = "totalBytesProcessed"];


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed the typo "per seconds" when using the Loki data source in Grafana. Fixing it where I can find it.

Could we also safely fix it in the [protobuf schema](https://github.com/grafana/loki/blob/master/pkg/logql/stats/stats.proto#L22)?

