### PR TITLE
Docker driver: Allow to provision external pipeline files to plugin

### DIFF
--- a/cmd/docker-driver/Dockerfile
+++ b/cmd/docker-driver/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false cmd/docker-driver/docker-driver
 
-FROM alpine:3.9
+FROM alpine:3.11
 RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/

--- a/cmd/docker-driver/config.json
+++ b/cmd/docker-driver/config.json
@@ -20,12 +20,12 @@
     "mounts": [
         {
             "name": "data",
-            "description": "Optional external pipelines files",
+            "description": "Optional external pipeline files",
             "source": "",
             "destination": "/data",
             "type": "none",
             "options": ["bind", "ro"],
-			"settable": ["source"]
+			"settable": ["source", "destination"]
         }
 	]
 }

--- a/cmd/docker-driver/config.json
+++ b/cmd/docker-driver/config.json
@@ -1,22 +1,22 @@
 {
-	"description": "Loki Logging Driver",
-	"documentation": "https://github.com/grafana/loki",
-	"entrypoint": ["/bin/docker-driver"],
-	"network": {
-		"type": "host"
-	},
-	"interface": {
-		"types": ["docker.logdriver/1.0"],
-		"socket": "loki.sock"
-	},
-	"env": [
-		{
-			"name": "LOG_LEVEL",
-			"description": "Set log level to output for plugin logs",
-			"value": "info",
-			"settable": ["value"]
-		}
-	],
+    "description": "Loki Logging Driver",
+    "documentation": "https://github.com/grafana/loki",
+    "entrypoint": ["/bin/docker-driver"],
+    "network": {
+        "type": "host"
+    },
+    "interface": {
+        "types": ["docker.logdriver/1.0"],
+        "socket": "loki.sock"
+    },
+    "env": [
+        {
+            "name": "LOG_LEVEL",
+            "description": "Set log level to output for plugin logs",
+            "value": "info",
+            "settable": ["value"]
+        }
+    ],
     "mounts": [
         {
             "name": "data",
@@ -25,7 +25,7 @@
             "destination": "/data",
             "type": "none",
             "options": ["bind", "ro"],
-			"settable": ["source", "destination"]
+            "settable": ["source", "destination"]
         }
-	]
+    ]
 }

--- a/cmd/docker-driver/config.json
+++ b/cmd/docker-driver/config.json
@@ -16,5 +16,16 @@
 			"value": "info",
 			"settable": ["value"]
 		}
+	],
+    "mounts": [
+        {
+            "name": "data",
+            "description": "Optional external pipelines files",
+            "source": "",
+            "destination": "/data",
+            "type": "none",
+            "options": ["bind", "ro"],
+			"settable": ["source"]
+        }
 	]
 }

--- a/docs/clients/docker-driver/configuration.md
+++ b/docs/clients/docker-driver/configuration.md
@@ -109,6 +109,37 @@ Custom labels can be added using the `loki-external-labels`,
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
 
+## Configure custom pipeline stage file
+
+You can also use custom pipeline stage files, with `loki-pipeline-stage-file` option,
+provided from outside of the Loki logging driver container by running Loki with a
+mounted volume. To do so, you'll need to disable the plugin, set a volume mount
+options and enable the plugin again:
+
+```bash
+docker plugin disable loki:latest
+docker plugin set loki:latest data.source=/etc/pipelines
+docker plugin enable loki:latest
+```
+
+In the example above the directory `/etc/pipelines` will be mounted as `/data`
+inside the Loki driver container and `loki-pipeline-stage-file` option can be
+passed with a custom pipeline configuration, provided there's a file
+`/etc/pipelines/mypipeline.yaml` on the host machine:
+
+```bash
+docker run --log-driver=loki \
+    --log-opt loki-url="https://<user_id>:<password>@logs-us-west1.grafana.net/loki/api/v1/push" \
+    --log-opt loki-pipeline-stage-file=/data/mypipeline.yaml \
+    grafana/grafana
+```
+
+Available options are:
+
+- `data.source`: the source directory the volume
+- `data.destination`: the path where the directory is mounted in the container,
+and is `/data` by default
+
 ## Supported log-opt options
 
 The following are all supported options that the Loki logging driver supports:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Add mounts section to docker plugin config.json.
This allow to make host directory with pipeline files accessable to docker driver plugin.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

