### PR TITLE
Fix a bug in range vector skipping data.

### DIFF
--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -70,14 +70,18 @@ func (r *rangeVectorIterator) popBack(newStart int64) {
 	// possible improvement: if there is no overlap we can just remove all.
 	for fp := range r.window {
 		lastPoint := 0
+		remove := false
 		for i, p := range r.window[fp].Points {
 			if p.T <= newStart {
 				lastPoint = i
+				remove = true
 				continue
 			}
 			break
 		}
-		r.window[fp].Points = r.window[fp].Points[lastPoint+1:]
+		if remove {
+			r.window[fp].Points = r.window[fp].Points[lastPoint+1:]
+		}
 		if len(r.window[fp].Points) == 0 {
 			s := r.window[fp]
 			delete(r.window, fp)

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -53,6 +53,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 		step            int64
 		expectedVectors []promql.Vector
 		expectedTs      []time.Time
+		start, end      time.Time
 	}{
 		{
 			(5 * time.Second).Nanoseconds(), // no overlap
@@ -73,6 +74,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 				},
 			},
 			[]time.Time{time.Unix(10, 0), time.Unix(40, 0), time.Unix(70, 0), time.Unix(100, 0)},
+			time.Unix(10, 0), time.Unix(100, 0),
 		},
 		{
 			(35 * time.Second).Nanoseconds(), // will overlap by 5 sec
@@ -96,6 +98,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 				},
 			},
 			[]time.Time{time.Unix(10, 0), time.Unix(40, 0), time.Unix(70, 0), time.Unix(100, 0)},
+			time.Unix(10, 0), time.Unix(100, 0),
 		},
 		{
 			(30 * time.Second).Nanoseconds(), // same range
@@ -116,6 +119,23 @@ func Test_RangeVectorIterator(t *testing.T) {
 				},
 			},
 			[]time.Time{time.Unix(10, 0), time.Unix(40, 0), time.Unix(70, 0), time.Unix(100, 0)},
+			time.Unix(10, 0), time.Unix(100, 0),
+		},
+		{
+			(50 * time.Second).Nanoseconds(), // all step are overlaping
+			(10 * time.Second).Nanoseconds(),
+			[]promql.Vector{
+				[]promql.Sample{
+					{Point: newPoint(time.Unix(110, 0), 2), Metric: labelBar},
+					{Point: newPoint(time.Unix(110, 0), 2), Metric: labelFoo},
+				},
+				[]promql.Sample{
+					{Point: newPoint(time.Unix(120, 0), 2), Metric: labelBar},
+					{Point: newPoint(time.Unix(120, 0), 2), Metric: labelFoo},
+				},
+			},
+			[]time.Time{time.Unix(110, 0), time.Unix(120, 0)},
+			time.Unix(110, 0), time.Unix(120, 0),
 		},
 	}
 
@@ -124,7 +144,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 			fmt.Sprintf("logs[%s] - step: %s", time.Duration(tt.selRange), time.Duration(tt.step)),
 			func(t *testing.T) {
 				it := newRangeVectorIterator(newEntryIterator(), tt.selRange,
-					tt.step, time.Unix(10, 0).UnixNano(), time.Unix(100, 0).UnixNano())
+					tt.step, tt.start.UnixNano(), tt.end.UnixNano())
 
 				i := 0
 				for it.Next() {


### PR DESCRIPTION
It seems that this bug was in there since day 1 of range vector aggregations. I found it while doing test for the new average in an experimental branch and with an average it shows more than with a count.

Basically the bug was removing one overlapping point in each step for all next steps. This would cause space in graph growing at the end.

I was staring at the code for a while until I realized, this portion of the code was always removing the first point whether or not there were overlapping point.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>