### PR TITLE
Recover from panic in http and grpc handlers.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0
 	github.com/gogo/protobuf v1.3.1 // remember to update loki-build-image/Dockerfile too
-	github.com/gogo/status v1.0.3 // indirect
 	github.com/golang/snappy v0.0.1
 	github.com/gorilla/mux v1.7.1
 	github.com/gorilla/websocket v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,11 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0
 	github.com/gogo/protobuf v1.3.1 // remember to update loki-build-image/Dockerfile too
+	github.com/gogo/status v1.0.3 // indirect
 	github.com/golang/snappy v0.0.1
 	github.com/gorilla/mux v1.7.1
 	github.com/gorilla/websocket v1.4.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/golang-lru v0.5.3

--- a/pkg/loki/fake_auth.go
+++ b/pkg/loki/fake_auth.go
@@ -19,7 +19,7 @@ var fakeHTTPAuthMiddleware = middleware.Func(func(next http.Handler) http.Handle
 	})
 })
 
-var fakeGRPCAuthUniaryMiddleware = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+var fakeGRPCAuthUnaryMiddleware = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	ctx = user.InjectOrgID(ctx, "fake")
 	return handler(ctx, req)
 }

--- a/pkg/util/server/error.go
+++ b/pkg/util/server/error.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/weaveworks/common/httpgrpc"
+
+	"github.com/grafana/loki/pkg/logql"
+)
+
+// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
+const StatusClientClosedRequest = 499
+
+// WriteError write a go error with the correct status code.
+func WriteError(err error, w http.ResponseWriter) {
+	switch {
+	case err == context.Canceled:
+		http.Error(w, err.Error(), StatusClientClosedRequest)
+	case err == context.DeadlineExceeded:
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+	case logql.IsParseError(err):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	default:
+		if grpcErr, ok := httpgrpc.HTTPResponseFromError(err); ok {
+			http.Error(w, string(grpcErr.Body), int(grpcErr.Code))
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/util/server/error_test.go
+++ b/pkg/util/server/error_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+
+	"github.com/grafana/loki/pkg/logql"
+)
+
+func Test_writeError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		err            error
+		msg            string
+		expectedStatus int
+	}{
+		{"cancelled", context.Canceled, context.Canceled.Error(), StatusClientClosedRequest},
+		{"deadline", context.DeadlineExceeded, context.DeadlineExceeded.Error(), http.StatusGatewayTimeout},
+		{"parse error", logql.ParseError{}, "parse error : ", http.StatusBadRequest},
+		{"httpgrpc", httpgrpc.Errorf(http.StatusBadRequest, errors.New("foo").Error()), "foo", http.StatusBadRequest},
+		{"internal", errors.New("foo"), "foo", http.StatusInternalServerError},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			WriteError(tt.err, rec)
+			require.Equal(t, tt.expectedStatus, rec.Result().StatusCode)
+			b, err := ioutil.ReadAll(rec.Result().Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.Equal(t, tt.msg, string(b[:len(b)-1]))
+		})
+	}
+}

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
+)
+
+// NewPrepopulateMiddleware creates a middleware which will parse incoming http forms.
+// This is important because some endpoints can POST x-www-form-urlencoded bodies instead of GET w/ query strings.
+func NewPrepopulateMiddleware() middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			err := req.ParseForm()
+			if err != nil {
+				WriteError(httpgrpc.Errorf(http.StatusBadRequest, err.Error()), w)
+				return
+
+			}
+			next.ServeHTTP(w, req)
+		})
+	})
+}

--- a/pkg/util/server/middleware_test.go
+++ b/pkg/util/server/middleware_test.go
@@ -1,20 +1,14 @@
-package querier
+package server
 
 import (
 	"bytes"
-	"context"
-	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/httpgrpc"
-
-	"github.com/grafana/loki/pkg/logql"
 )
 
 func TestPrepopulate(t *testing.T) {
@@ -107,33 +101,6 @@ func TestPrepopulate(t *testing.T) {
 				require.Equal(t, tc.expected, req.Form)
 			}
 
-		})
-	}
-}
-
-func Test_writeError(t *testing.T) {
-	for _, tt := range []struct {
-		name string
-
-		err            error
-		msg            string
-		expectedStatus int
-	}{
-		{"cancelled", context.Canceled, context.Canceled.Error(), StatusClientClosedRequest},
-		{"deadline", context.DeadlineExceeded, context.DeadlineExceeded.Error(), http.StatusGatewayTimeout},
-		{"parse error", logql.ParseError{}, "parse error : ", http.StatusBadRequest},
-		{"httpgrpc", httpgrpc.Errorf(http.StatusBadRequest, errors.New("foo").Error()), "foo", http.StatusBadRequest},
-		{"internal", errors.New("foo"), "foo", http.StatusInternalServerError},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			writeError(tt.err, rec)
-			require.Equal(t, tt.expectedStatus, rec.Result().StatusCode)
-			b, err := ioutil.ReadAll(rec.Result().Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			require.Equal(t, tt.msg, string(b[:len(b)-1]))
 		})
 	}
 }

--- a/pkg/util/server/recovery.go
+++ b/pkg/util/server/recovery.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
+)
+
+const maxStacksize = 8 * 1024
+
+var (
+	panicTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "panic_total",
+		Help:      "The total number of panic triggered",
+	})
+
+	RecoveryHTTPMiddleware = middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			defer func() {
+				if p := recover(); p != nil {
+					WriteError(onPanic(p), w)
+				}
+			}()
+			next.ServeHTTP(w, req)
+		})
+	})
+	RecoveryGRPCStreamInterceptor = grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandler(onPanic))
+	RecoveryGRPCUnaryInterceptor  = grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandler(onPanic))
+)
+
+func onPanic(p interface{}) error {
+	stack := make([]byte, maxStacksize)
+	stack = stack[:runtime.Stack(stack, true)]
+	// keep a multiline stack
+	fmt.Fprintf(os.Stderr, "panic: %v\n%s", p, stack)
+	panicTotal.Inc()
+	return httpgrpc.Errorf(http.StatusInternalServerError, "error while processing request: %v", p)
+}

--- a/pkg/util/server/recovery_test.go
+++ b/pkg/util/server/recovery_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func Test_onPanic(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	RecoveryHTTPMiddleware.
+		Wrap(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("foo bar")
+		})).
+		ServeHTTP(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	require.Error(t, RecoveryGRPCStreamInterceptor(nil, fakeStream{}, nil, grpc.StreamHandler(func(srv interface{}, stream grpc.ServerStream) error {
+		panic("foo")
+	})))
+
+	_, err = RecoveryGRPCUnaryInterceptor(context.Background(), nil, nil, grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
+		panic("foo")
+	}))
+	require.Error(t, err)
+}
+
+type fakeStream struct{}
+
+func (fakeStream) SetHeader(_ metadata.MD) error  { return nil }
+func (fakeStream) SendHeader(_ metadata.MD) error { return nil }
+func (fakeStream) SetTrailer(_ metadata.MD)       {}
+func (fakeStream) Context() context.Context       { return context.Background() }
+func (fakeStream) SendMsg(m interface{}) error    { return nil }
+func (fakeStream) RecvMsg(m interface{}) error    { return nil }

--- a/production/loki-mixin/alerts.libsonnet
+++ b/production/loki-mixin/alerts.libsonnet
@@ -23,6 +23,20 @@
             },
           },
           {
+            alert: 'LokiRequestPanics',
+            expr: |||
+              sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
+            |||,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: |||
+                {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% increase of panics.
+              |||,
+            },
+          },
+          {
             alert: 'LokiRequestLatency',
             expr: |||
               namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1

--- a/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/doc.go
+++ b/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+/*
+`grpc_recovery` are intereceptors that recover from gRPC handler panics.
+
+Server Side Recovery Middleware
+
+By default a panic will be converted into a gRPC error with `code.Internal`.
+
+Handling can be customised by providing an alternate recovery function.
+
+Please see examples for simple examples of use.
+*/
+package grpc_recovery

--- a/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/interceptors.go
+++ b/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/interceptors.go
@@ -1,0 +1,53 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_recovery
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// RecoveryHandlerFunc is a function that recovers from the panic `p` by returning an `error`.
+type RecoveryHandlerFunc func(p interface{}) (err error)
+
+// RecoveryHandlerFuncContext is a function that recovers from the panic `p` by returning an `error`.
+// The context can be used to extract request scoped metadata and context values.
+type RecoveryHandlerFuncContext func(ctx context.Context, p interface{}) (err error)
+
+// UnaryServerInterceptor returns a new unary server interceptor for panic recovery.
+func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+	o := evaluateOptions(opts)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = recoverFrom(ctx, r, o.recoveryHandlerFunc)
+			}
+		}()
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a new streaming server interceptor for panic recovery.
+func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+	o := evaluateOptions(opts)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = recoverFrom(stream.Context(), r, o.recoveryHandlerFunc)
+			}
+		}()
+
+		return handler(srv, stream)
+	}
+}
+
+func recoverFrom(ctx context.Context, p interface{}, r RecoveryHandlerFuncContext) error {
+	if r == nil {
+		return grpc.Errorf(codes.Internal, "%s", p)
+	}
+	return r(ctx, p)
+}

--- a/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/options.go
+++ b/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/options.go
@@ -1,0 +1,43 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_recovery
+
+import "context"
+
+var (
+	defaultOptions = &options{
+		recoveryHandlerFunc: nil,
+	}
+)
+
+type options struct {
+	recoveryHandlerFunc RecoveryHandlerFuncContext
+}
+
+func evaluateOptions(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+type Option func(*options)
+
+// WithRecoveryHandler customizes the function for recovering from a panic.
+func WithRecoveryHandler(f RecoveryHandlerFunc) Option {
+	return func(o *options) {
+		o.recoveryHandlerFunc = RecoveryHandlerFuncContext(func(ctx context.Context, p interface{}) error {
+			return f(p)
+		})
+	}
+}
+
+// WithRecoveryHandlerContext customizes the function for recovering from a panic.
+func WithRecoveryHandlerContext(f RecoveryHandlerFuncContext) Option {
+	return func(o *options) {
+		o.recoveryHandlerFunc = f
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -405,6 +405,7 @@ github.com/gorilla/mux
 github.com/gorilla/websocket
 # github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 github.com/grpc-ecosystem/go-grpc-middleware
+github.com/grpc-ecosystem/go-grpc-middleware/recovery
 github.com/grpc-ecosystem/go-grpc-middleware/tags
 github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing
 github.com/grpc-ecosystem/go-grpc-middleware/util/metautils


### PR DESCRIPTION
I don't see any good reason to crash any component during a bad request.

The stacktrace is still printed in multiline to stderr.
e.g

```
panic: foo
goroutine 50 [running]:
github.com/grafana/loki/pkg/util/server.onPanic(0x16c7720, 0x18af5e0, 0x4fd01d5aaf8, 0x3e7)
	/Users/ctovena/go/src/github.com/grafana/loki/pkg/util/server/recovery.go:41 +0x85
github.com/grpc-ecosystem/go-grpc-middleware/recovery.WithRecoveryHandler.func1.1(0x18d2140, 0xc000126008, 0x16c7720, 0x18af5e0, 0x1d81ca0, 0x1663693)
	/Users/ctovena/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/recovery/options.go:33 +0x39
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom(0x18d2140, 0xc000126008, 0x16c7720, 0x18af5e0, 0xc0002166c0, 0x1d5ed32, 0xd0)
	/Users/ctovena/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/recovery/interceptors.go:52 +0x5a
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1(0x18d2140, 0xc000126008, 0xc000204088, 0xc00026af28)
	/Users/ctovena/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/recovery/interceptors.go:26 +0x77
panic(0x16c7720, 0x18af5e0)
	/usr/local/Cellar/go/1.14.2_1/libexec/src/runtime/panic.go:969 +0x166
github.com/grafana/loki/pkg/util/server.Test_onPanic.func3(0x18d2140, 0xc000126008, 0x0, 0x0, 0xc00026aed8, 0x16642ab, 0x2575318, 0xc000263200)
	/Users/ctovena/go/src/github.com/grafana/loki/pkg/util/server/recovery_test.go:32 +0x39
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1(0x18d2140, 0xc000126008, 0x0, 0x0, 0x0, 0x18075d8, 0x0, 0x0, 0x0, 0x0)
	/Users/ctovena/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/recovery/interceptors.go:30 +0xbc
github.com/grafana/loki/pkg/util/server.Test_onPanic(0xc000263200)
	/Users/ctovena/go/src/github.com/grafana/loki/pkg/util/server/recovery_test.go:31 +0x2c9
testing.tRunner(0xc000263200, 0x18075e0)
	/usr/local/Cellar/go/1.14.2_1/libexec/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/Cellar/go/1.14.2_1/libexec/src/testing/testing.go:1042 +0x357
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>