### PR TITLE
Promtail: log at debug level when nothing matches the specified path for a file target

### DIFF
--- a/pkg/promtail/targets/filetarget.go
+++ b/pkg/promtail/targets/filetarget.go
@@ -203,6 +203,10 @@ func (t *FileTarget) sync() error {
 		return errors.Wrap(err, "filetarget.sync.filepath.Glob")
 	}
 
+	if len(matches) == 0 {
+		level.Debug(t.logger).Log("msg", "no files matched requested path, nothing will be tailed", "path", t.path)
+	}
+
 	// Gets absolute path for each pattern.
 	for i := 0; i < len(matches); i++ {
 		if !filepath.IsAbs(matches[i]) {


### PR DESCRIPTION
Signed-off-by: Ed Welch <edward.welch@grafana.com>