### PR TITLE
Loki: Allow configuring query_store_max_look_back_period when running a filesystem store and boltdb-shipper

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -317,6 +317,13 @@ The `ingester_config` block configures Ingesters.
 # The maximum duration of a timeseries chunk in memory. If a timeseries runs for longer than this the current chunk will be flushed to the store and a new chunk created.
 [max_chunk_age: <duration> | default = 1h]
 
+# How far in the past an ingester is allowed to query the store for data.  
+# This is only useful for running multiple loki binaries with a shared ring with a `filesystem` store which is NOT shared between the binaries
+# When using any "shared" object store like S3 or GCS this value must always be left as 0
+# It is an error to configure this to a non-zero value when using any object store other than `filesystem`
+# Use a value of -1 to allow the ingester to query the store infinitely far back in time.
+[query_store_max_look_back_period: <duration> | default = 0]
+
 ```
 
 ### lifecycler_config

--- a/docs/operations/storage/README.md
+++ b/docs/operations/storage/README.md
@@ -26,6 +26,7 @@ The following are supported for the index:
 * [Google Bigtable](https://cloud.google.com/bigtable)
 * [Apache Cassandra](https://cassandra.apache.org)
 * [BoltDB](https://github.com/boltdb/bolt) (doesn't work when clustering Loki)
+* [Boltb-Shipper](boltdb-shipper.md) EXPERIMENTAL index store which stores boltdb index files in the object store 
 
 The following are supported for the chunks:
 
@@ -34,7 +35,7 @@ The following are supported for the chunks:
 * [Apache Cassandra](https://cassandra.apache.org)
 * [Amazon S3](https://aws.amazon.com/s3)
 * [Google Cloud Storage](https://cloud.google.com/storage/)
-* Filesystem (doesn't work when clustering Loki)
+* [Filesystem](filesystem.md) (please read more about the filesystem to understand the pros/cons before using with production data)
 
 ## Cloud Storage Permissions
 

--- a/docs/operations/storage/boltdb-shipper.md
+++ b/docs/operations/storage/boltdb-shipper.md
@@ -83,21 +83,5 @@ Frequency for checking updates can be configured with `resync_interval` config.
 To avoid keeping downloaded index files forever there is a ttl for them which defaults to 24 hours, which means if index files for a period are not used for 24 hours they would be removed from cache location.
 ttl can be configured using `cache_ttl` config.
 
-## Horizontal scaling of non-shared filesystem stores
-
-Using the boltdb-shipper also allows running the single binary Loki (or really just the ingesters) with a `filesystem` object store also using a shared hash ring.
-
-If you configure a shared ring via etcd/consul/memberlist you can run multiple instances of Loki on separate machines with separate filesystems,
-this now works because the ingesters are able to query the store directly.
-
-To enable this configuration in the ingester config you must set `query_store_max_look_back_period` according to how far back you want to store data, or use a value of -1 for infinite.
-
-At query time, any Loki instance can field the query, the instance will then use the ring to ask every other Loki instance for relevant data, 
-and because the ingesters can each query their store as far back as `query_store_max_look_back_period` allows, the correct data can be returned.
-
-Scaling up is as easy as adding more loki instances and letting them talk to the same ring.
-
-Scaling down is possible but manual, you would need to shutdown the loki instance and then physically copy the chunks directory and its index files in their entirety to another Loki instance.
-You cannot move them in partial it must be all, this other Loki instance will then find the boltdb index files and serve the chunks copied.
 
 

--- a/docs/operations/storage/boltdb-shipper.md
+++ b/docs/operations/storage/boltdb-shipper.md
@@ -83,5 +83,22 @@ Frequency for checking updates can be configured with `resync_interval` config.
 To avoid keeping downloaded index files forever there is a ttl for them which defaults to 24 hours, which means if index files for a period are not used for 24 hours they would be removed from cache location.
 ttl can be configured using `cache_ttl` config.
 
+## Horizontal scaling of non-shared filesystem stores
+
+Using the boltdb-shipper also allows running the single binary Loki (or really just the ingesters) with a `filesystem` object store also using a shared hash ring.
+
+If you configure a shared ring via etcd/consul/memberlist you can run multiple instances of Loki on separate machines with separate filesystems,
+this now works because the ingesters are able to query the store directly.
+
+To enable this configuration in the ingester config you must set `query_store_max_look_back_period` according to how far back you want to store data, or use a value of -1 for infinite.
+
+At query time, any Loki instance can field the query, the instance will then use the ring to ask every other Loki instance for relevant data, 
+and because they ingesters can each query their store as far back as `query_store_max_look_back_period` allows, the correct data can be returned.
+
+Scaling up is as easy as adding more loki instances and letting them talk to the same ring.
+
+Scaling down is possible but manual, you would need to shutdown the loki instance and then physically copy the chunks directory and its index files in their entirety to another Loki instance.
+You cannot move them in partial it must be all, this other Loki instance will then find the boltdb index files and serve the chunks copied.
+
 
 

--- a/docs/operations/storage/boltdb-shipper.md
+++ b/docs/operations/storage/boltdb-shipper.md
@@ -93,12 +93,11 @@ this now works because the ingesters are able to query the store directly.
 To enable this configuration in the ingester config you must set `query_store_max_look_back_period` according to how far back you want to store data, or use a value of -1 for infinite.
 
 At query time, any Loki instance can field the query, the instance will then use the ring to ask every other Loki instance for relevant data, 
-and because they ingesters can each query their store as far back as `query_store_max_look_back_period` allows, the correct data can be returned.
+and because the ingesters can each query their store as far back as `query_store_max_look_back_period` allows, the correct data can be returned.
 
 Scaling up is as easy as adding more loki instances and letting them talk to the same ring.
 
 Scaling down is possible but manual, you would need to shutdown the loki instance and then physically copy the chunks directory and its index files in their entirety to another Loki instance.
 You cannot move them in partial it must be all, this other Loki instance will then find the boltdb index files and serve the chunks copied.
-
 
 

--- a/docs/operations/storage/filesystem.md
+++ b/docs/operations/storage/filesystem.md
@@ -1,0 +1,141 @@
+# Filesystem Object Store
+
+The filesystem object store is the easiest to get started with Loki but there are some pros/cons to this approach.
+
+Very simply it stores all the objects (chunks) in the specified directory:
+
+```yaml
+storage_config:
+  filesystem:
+    directory: /tmp/loki/
+```
+
+A folder is created for every tenant all the chunks for one tenant are stored in that directory.
+
+If loki is run in single-tenant mode, all the chunks are put in a folder named `fake` which is the synthesized tenant name used for single tenant mode.
+
+See [multi-tenancy](../multi-tenancy.md) for more information.
+
+## Pros
+
+Very simple, no additional software required to use Loki when paired with the BoltDB index store.
+
+Great for low volume applications, proof of concepts, and just playing around with Loki.
+
+## Cons
+
+### Scaling
+
+At some point there is a limit to how many chunks can be stored in a single directory, for example see [this issue](https://github.com/grafana/loki/issues/1502) which explains how a Loki user ran into a strange error with about **5.5 million chunk files** in their file store (and also a workaround for the problem).
+
+However, if you keep your streams low (remember loki writes a chunk per stream) and use configs like `chunk_target_size` (around 1MB), `max_chunk_age` (increase beyond 1h), `chunk_idle_period` (increase to match `max_chunk_age`) can be tweaked to reduce the number of chunks flushed (although they will trade for more memory consumption).
+
+It's still very possible to store terabytes of log data with the filestore, but realize there are limitations to how many files a filesystem will want to store in a single directory.
+
+### Durability
+
+The durability of the objects is at the mercy of the filesystem itself where other object stores like S3/GCS do a lot behind the scenes to offer extremely high durability to your data.
+
+### High Availability
+
+Running Loki clustered is not possible with the filesystem store unless the filesystem is shared in some fashion (NFS for example).  However using shared filesystems is likely going to be a bad experience with Loki just as it is for almost every other application.
+
+## New AND VERY EXPERIMENTAL in 1.5.0: Horizontal scaling of the filesystem store
+
+**WARNING** as the title suggests, this is very new and potentially buggy, and it is also very likely configs around this feature will change over time.
+
+With that warning out of the way, the addition of the [boltdb-shipper](boltdb-shipper.md) index store has added capabilities making it possible to overcome many of the limitations listed above using the filesystem store, specifically running Loki with the filesystem store on separate machines but still operate as a cluster supporting replication, and write distribution via the hash ring.
+
+As mentioned in the title, this is very alpha at this point but we would love for people to try this and help us flush out bugs.
+
+Here is an example config to run with Loki:
+
+Use this config on multiple computers (or containers), do not run it on the same computer as Loki uses the hostname as the ID in the ring.
+
+Do not use a shared fileystem such as NFS for this, each machine should have its own filesystem
+
+```yaml
+auth_enabled: false # single tenant mode
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  max_transfer_retries: 0 # Disable blocks transfers on ingesters shutdown or rollout.
+  chunk_idle_period: 2h # Let chunks sit idle for at least 2h before flushing, this helps to reduce total chunks in store
+  max_chunk_age: 2h  # Let chunks get at least 2h old before flushing due to age, this helps to reduce total chunks in store
+  chunk_target_size: 1048576 # Target chunks of 1MB, this helps to reduce total chunks in store
+  chunk_retain_period: 30s
+  
+  query_store_max_look_back_period: -1  # This will allow the ingesters to query the store for all data
+  lifecycler:
+    heartbeat_period: 5s
+    interface_names:
+      - eth0
+    join_after: 30s
+    num_tokens: 512
+    ring:
+      heartbeat_timeout: 1m
+      kvstore:
+        consul:
+          consistent_reads: true
+          host: localhost:8500
+          http_client_timeout: 20s
+        store: consul
+      replication_factor: 1 # This can be increased and probably should if you are running multiple machines!
+
+schema_config:
+  configs:
+    - from: 2018-04-15
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 168h
+
+storage_config:
+  boltdb_shipper:
+    shared_store: filesystem
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/boltdb-cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s  # No limit how far we can look back in the store
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s  # No deletions, infinite retention
+```
+
+It does require Consul to be running for the ring (any of the ring stores will work: consul, etcd, memberlist, Consul is used in this example)
+
+It is also required that Consul be available from each machine, this example only specifies `host: localhost:8500` you would likely need to change this to the correct hostname/ip and port of your consul server.
+
+**The config needs to be the same on every Loki instance!**
+
+The important piece of this config is `query_store_max_look_back_period: -1` this tells Loki to allow the ingesters to look in the store for all the data.
+
+Traffic can be sent to any of the Loki servers, it can be round-robin load balanced if desired.
+
+Each Loki instance will use Consul to properly route both read and write data to the correct Loki instance.
+
+Scaling up is as easy as adding more loki instances and letting them talk to the same ring.
+
+Scaling down is harder but possible.  You would need to shutdown a Loki server then take everything in:
+
+```yaml
+  filesystem:
+    directory: /tmp/loki/chunks
+```
+
+And copy it to the same directory on another Loki server, there is currently no way to split the chunks between servers you must move them all.  We expect to provide more options here in the future.
+
+

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -164,7 +164,9 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if t.cfg.Ingester.QueryStoreMaxLookBackPeriod != 0 {
+		t.cfg.Querier.IngesterQueryStoreMaxLookback = t.cfg.Ingester.QueryStoreMaxLookBackPeriod
+	}
 	t.querier, err = querier.New(t.cfg.Querier, t.cfg.IngesterClient, t.ring, t.store, t.overrides)
 	if err != nil {
 		return nil, err

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -504,7 +504,7 @@ func activePeriodConfig(cfg chunk.SchemaConfig) chunk.PeriodConfig {
 }
 
 func calculateMaxLookBack(pc chunk.PeriodConfig, maxLookBackConfig, maxChunkAge time.Duration) (time.Duration, error) {
-	if pc.ObjectType != local.FilesystemObjectStoreType && maxLookBackConfig.Milliseconds() != 0 {
+	if pc.ObjectType != local.FilesystemObjectStoreType && maxLookBackConfig.Nanoseconds() != 0 {
 		return 0, errors.New("it is an error to specify a non zero `query_store_max_look_back_period` value when using any object store other than `filesystem`")
 	}
 	// When using shipper, limit max look back for query to MaxChunkAge + upload interval by shipper + 15 mins to query only data whose index is not pushed yet

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -65,3 +65,78 @@ func TestActiveIndexType(t *testing.T) {
 	assert.Equal(t, cfg.Configs[1], activePeriodConfig(cfg))
 
 }
+
+func Test_calculateMaxLookBack(t *testing.T) {
+	type args struct {
+		pc                chunk.PeriodConfig
+		maxLookBackConfig time.Duration
+		maxChunkAge       time.Duration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name: "default",
+			args: args{
+				pc: chunk.PeriodConfig{
+					ObjectType: "filesystem",
+				},
+				maxLookBackConfig: 0,
+				maxChunkAge:       1 * time.Hour,
+			},
+			want:    90 * time.Minute,
+			wantErr: false,
+		},
+		{
+			name: "infinite",
+			args: args{
+				pc: chunk.PeriodConfig{
+					ObjectType: "filesystem",
+				},
+				maxLookBackConfig: -1,
+				maxChunkAge:       1 * time.Hour,
+			},
+			want:    -1,
+			wantErr: false,
+		},
+		{
+			name: "invalid store type",
+			args: args{
+				pc: chunk.PeriodConfig{
+					ObjectType: "gcs",
+				},
+				maxLookBackConfig: -1,
+				maxChunkAge:       1 * time.Hour,
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "less than default",
+			args: args{
+				pc: chunk.PeriodConfig{
+					ObjectType: "filesystem",
+				},
+				maxLookBackConfig: 1 * time.Hour,
+				maxChunkAge:       1 * time.Hour,
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := calculateMaxLookBack(tt.args.pc, tt.args.maxLookBackConfig, tt.args.maxChunkAge)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("calculateMaxLookBack() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("calculateMaxLookBack() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -48,20 +48,20 @@ func TestActiveIndexType(t *testing.T) {
 		IndexType: "first",
 	}}
 
-	assert.Equal(t, "first", activeIndexType(cfg))
+	assert.Equal(t, cfg.Configs[0], activePeriodConfig(cfg))
 
 	// add a newer PeriodConfig in the past which should be considered
 	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
 		From:      chunk.DayTime{Time: model.Now().Add(-12 * time.Hour)},
 		IndexType: "second",
 	})
-	assert.Equal(t, "second", activeIndexType(cfg))
+	assert.Equal(t, cfg.Configs[1], activePeriodConfig(cfg))
 
 	// add a newer PeriodConfig in the future which should not be considered
 	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
 		From:      chunk.DayTime{Time: model.Now().Add(time.Hour)},
 		IndexType: "third",
 	})
-	assert.Equal(t, "second", activeIndexType(cfg))
+	assert.Equal(t, cfg.Configs[1], activePeriodConfig(cfg))
 
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -496,7 +496,7 @@ func TestQuerier_IngesterMaxQueryLookback(t *testing.T) {
 			store.On("LazyQuery", mock.Anything, mock.Anything).Return(mockStreamIterator(0, 1), nil)
 
 			conf := mockQuerierConfig()
-			conf.IngesterMaxQueryLookback = tc.lookback
+			conf.QueryIngestersWithin = tc.lookback
 			q, err := newQuerier(
 				conf,
 				mockIngesterClientConfig(),

--- a/pkg/storage/stores/local/shipper.go
+++ b/pkg/storage/stores/local/shipper.go
@@ -34,6 +34,9 @@ const (
 	// BoltDBShipperType holds the index type for using boltdb with shipper which keeps flushing them to a shared storage
 	BoltDBShipperType = "boltdb-shipper"
 
+	// FilesystemObjectStoreType holds the periodic config type for the filesystem store
+	FilesystemObjectStoreType = "filesystem"
+
 	cacheCleanupInterval = 24 * time.Hour
 	storageKeyPrefix     = "index/"
 )

--- a/pkg/storage/stores/local/shipper.go
+++ b/pkg/storage/stores/local/shipper.go
@@ -131,7 +131,7 @@ func NewShipper(cfg ShipperConfig, storageClient chunk.ObjectClient, boltDBGette
 // avoid uploading same files again with different name. If the filed does not exist we would create one with uploader name set to
 // ingester name and startup timestamp so that we randomise the name and do not override files from other ingesters.
 func (s *Shipper) getUploaderName() (string, error) {
-	uploader := fmt.Sprintf("%s-%d", s.cfg.IngesterName, time.Now().Unix())
+	uploader := fmt.Sprintf("%s-%d", s.cfg.IngesterName, time.Now().UnixNano())
 
 	uploaderFilePath := path.Join(s.cfg.ActiveIndexDirectory, "uploader", "name")
 	if err := chunk_util.EnsureDirectory(path.Dir(uploaderFilePath)); err != nil {

--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -1,0 +1,40 @@
+package util
+
+func MergeStringLists(ss ...[]string) []string {
+	switch len(ss) {
+	case 0:
+		return nil
+	case 1:
+		return ss[0]
+	case 2:
+		return MergeStringPair(ss[0], ss[1])
+	default:
+		n := len(ss) / 2
+		return MergeStringPair(MergeStringLists(ss[:n]...), MergeStringLists(ss[n:]...))
+	}
+}
+
+func MergeStringPair(s1, s2 []string) []string {
+	i, j := 0, 0
+	result := make([]string, 0, len(s1)+len(s2))
+	for i < len(s1) && j < len(s2) {
+		if s1[i] < s2[j] {
+			result = append(result, s1[i])
+			i++
+		} else if s1[i] > s2[j] {
+			result = append(result, s2[j])
+			j++
+		} else {
+			result = append(result, s1[i])
+			i++
+			j++
+		}
+	}
+	for ; i < len(s1); i++ {
+		result = append(result, s1[i])
+	}
+	for ; j < len(s2); j++ {
+		result = append(result, s2[j])
+	}
+	return result
+}


### PR DESCRIPTION

This should allow horizontal scaling of a filesystem store on separate nodes as the ingesters can query the store

Signed-off-by: Ed Welch <edward.welch@grafana.com>