### PR TITLE
fluentd plugin: support placeholders in tenant field

### DIFF
--- a/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.11'
+  spec.version = '1.2.12'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/docs/clients/fluentd/README.md
+++ b/docs/clients/fluentd/README.md
@@ -173,7 +173,23 @@ Specify a username and password if the Loki server requires authentication.
 If using the GrafanaLab's hosted Loki, the username needs to be set to your instanceId and the password should be a Grafana.com api key.
 
 ### tenant
-Loki is a multi-tenant log storage platform and all requests sent must include a tenant.  For some installations the tenant will be set automatically by an authenticating proxy.  Otherwise you can define a tenant to be passed through.  The tenant can be any string value.
+Loki is a multi-tenant log storage platform and all requests sent must include a tenant.  For some installations the tenant will be set automatically by an authenticating proxy.  Otherwise you can define a tenant to be passed through.
+The tenant can be any string value. 
+
+The tenant field also supports placeholders, so it can dynamically change based on tag and record fields. Each placeholder must be added as a buffer chunk key. The following is an example of setting the tenant based on a k8s pod label:
+
+```
+<match **>
+  @type loki
+  url "https://logs-us-west1.grafana.net"
+  tenant ${$.kubernetes.labels.tenant}
+  # ...
+  <buffer $.kubernetes.labels.tenant>
+    @type memory
+    flush_interval 5s
+  </buffer>
+</match>
+```
 
 ### client certificate verification
 Specify a pair of client certificate and private key with `cert` and `key` if a reverse proxy with client certificate verification is configured in front of Loki. `ca_cert` can also be specified if the server uses custom certificate authority.


### PR DESCRIPTION
**What this PR does / why we need it**:

When running in a multi-tenant environment with a single fluentd and loki in multi-tenant mode, it's currently impossible to use a single loki output `match` because the tenant field is static. You basically need to have a separate `match` for every tenant and handle the routing yourself.

This PR adds placeholder support to the tenant field, so each chunk can be sent to the right tenant based on tag or record values while still using a single loki output `match`.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

