### PR TITLE
Support querying labels on time range in logcli

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -70,8 +70,8 @@ LogQL documentation:
 https://github.com/grafana/loki/blob/master/docs/logql.md`)
 	instantQuery = newQuery(true, instantQueryCmd)
 
-	labelsCmd = app.Command("labels", "Find values for a given label.")
-	labelName = labelsCmd.Arg("label", "The name of the label.").HintAction(hintActionLabelNames).String()
+	labelsCmd   = app.Command("labels", "Find values for a given label.")
+	labelsQuery = newLabelQuery(labelsCmd)
 
 	seriesCmd   = app.Command("series", "Run series query.")
 	seriesQuery = newSeriesQuery(seriesCmd)
@@ -122,18 +122,10 @@ func main() {
 
 		instantQuery.DoQuery(queryClient, out, *statistics)
 	case labelsCmd.FullCommand():
-		q := newLabelQuery(*labelName, *quiet)
-
-		q.DoLabels(queryClient)
+		labelsQuery.DoLabels(queryClient)
 	case seriesCmd.FullCommand():
 		seriesQuery.DoSeries(queryClient)
 	}
-}
-
-func hintActionLabelNames() []string {
-	q := newLabelQuery("", *quiet)
-
-	return q.ListLabels(queryClient)
 }
 
 func newQueryClient(app *kingpin.Application) *client.Client {
@@ -163,11 +155,31 @@ func newQueryClient(app *kingpin.Application) *client.Client {
 	return client
 }
 
-func newLabelQuery(labelName string, quiet bool) *labelquery.LabelQuery {
-	return &labelquery.LabelQuery{
-		LabelName: labelName,
-		Quiet:     quiet,
-	}
+func newLabelQuery(cmd *kingpin.CmdClause) *labelquery.LabelQuery {
+	var labelName, from, to string
+	var since time.Duration
+
+	q := &labelquery.LabelQuery{}
+
+	// executed after all command flags are parsed
+	cmd.Action(func(c *kingpin.ParseContext) error {
+
+		defaultEnd := time.Now()
+		defaultStart := defaultEnd.Add(-since)
+
+		q.Start = mustParse(from, defaultStart)
+		q.End = mustParse(to, defaultEnd)
+		q.LabelName = labelName
+		q.Quiet = *quiet
+		return nil
+	})
+
+	cmd.Arg("label", "The name of the label.").Default("").StringVar(&labelName)
+	cmd.Flag("since", "Lookback window.").Default("1h").DurationVar(&since)
+	cmd.Flag("from", "Start looking for labels at this absolute time (inclusive)").StringVar(&from)
+	cmd.Flag("to", "Stop looking for labels at this absolute time (exclusive)").StringVar(&to)
+
+	return q
 }
 
 func newSeriesQuery(cmd *kingpin.CmdClause) *seriesquery.SeriesQuery {

--- a/docs/getting-started/logcli.md
+++ b/docs/getting-started/logcli.md
@@ -169,7 +169,7 @@ Args:
   <query>  eg '{foo="bar",baz=~".*blip"} |~ ".*error.*"'
 
 $ logcli help labels
-usage: logcli labels [<label>]
+usage: logcli labels [<flags>] [<label>]
 
 Find values for a given label.
 
@@ -188,7 +188,11 @@ Flags:
       --tls-skip-verify  Server certificate TLS skip verify.
       --cert=""          Path to the client certificate. Can also be set using LOKI_CLIENT_CERT_PATH env var.
       --key=""           Path to the client certificate key. Can also be set using LOKI_CLIENT_KEY_PATH env var.
-      --org-id=ORG-ID    adds X-Scope-OrgID to API requests for representing tenant ID. Useful for requesting tenant data when bypassing an auth gateway.
+      --org-id=ORG-ID    adds X-Scope-OrgID to API requests for representing tenant ID. Useful for requesting 
+      tenant data when bypassing an auth gateway.
+      --since=1h         Lookback window.
+      --from=FROM        Start looking for labels at this absolute time (inclusive)
+      --to=TO            Stop looking for labels at this absolute time (exclusive)
 
 Args:
   [<label>]  The name of the label.

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -76,19 +76,26 @@ func (c *Client) QueryRange(queryStr string, limit int, from, through time.Time,
 }
 
 // ListLabelNames uses the /api/v1/label endpoint to list label names
-func (c *Client) ListLabelNames(quiet bool) (*loghttp.LabelResponse, error) {
+func (c *Client) ListLabelNames(quiet bool, from, through time.Time) (*loghttp.LabelResponse, error) {
 	var labelResponse loghttp.LabelResponse
-	if err := c.doRequest(labelsPath, "", quiet, &labelResponse); err != nil {
+	params := util.NewQueryStringBuilder()
+	params.SetInt("start", from.UnixNano())
+	params.SetInt("end", through.UnixNano())
+
+	if err := c.doRequest(labelsPath, params.Encode(), quiet, &labelResponse); err != nil {
 		return nil, err
 	}
 	return &labelResponse, nil
 }
 
 // ListLabelValues uses the /api/v1/label endpoint to list label values
-func (c *Client) ListLabelValues(name string, quiet bool) (*loghttp.LabelResponse, error) {
+func (c *Client) ListLabelValues(name string, quiet bool, from, through time.Time) (*loghttp.LabelResponse, error) {
 	path := fmt.Sprintf(labelValuesPath, url.PathEscape(name))
 	var labelResponse loghttp.LabelResponse
-	if err := c.doRequest(path, "", quiet, &labelResponse); err != nil {
+	params := util.NewQueryStringBuilder()
+	params.SetInt("start", from.UnixNano())
+	params.SetInt("end", through.UnixNano())
+	if err := c.doRequest(path, params.Encode(), quiet, &labelResponse); err != nil {
 		return nil, err
 	}
 	return &labelResponse, nil

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -3,6 +3,7 @@ package labelquery
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/loghttp"
@@ -12,6 +13,8 @@ import (
 type LabelQuery struct {
 	LabelName string
 	Quiet     bool
+	Start     time.Time
+	End       time.Time
 }
 
 // DoLabels prints out label results
@@ -28,9 +31,9 @@ func (q *LabelQuery) ListLabels(c *client.Client) []string {
 	var labelResponse *loghttp.LabelResponse
 	var err error
 	if len(q.LabelName) > 0 {
-		labelResponse, err = c.ListLabelValues(q.LabelName, q.Quiet)
+		labelResponse, err = c.ListLabelValues(q.LabelName, q.Quiet, q.Start, q.End)
 	} else {
-		labelResponse, err = c.ListLabelNames(q.Quiet)
+		labelResponse, err = c.ListLabelNames(q.Quiet, q.Start, q.End)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
logcli labels query was missing querying based on time range. This PR adds that support. 

**Checklist**
- [x] Documentation added

