### PR TITLE
helm/loki-stack: render loki datasource only if grafana is enabled

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.37.1
+version: 0.37.2
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/templates/datasources.yaml
+++ b/production/helm/loki-stack/templates/datasources.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.sidecar.datasources.enabled }}
+{{- if and .Values.grafana.enabled .Values.grafana.sidecar.datasources.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the grafana section in the default `values.yaml` of the `loki-stack` chart contains
```
grafana:
  enabled: false
  sidecar:
    datasources:
      enabled: true
```
which renders the loki datasource although grafana itself is disabled.
This PR changes this behaviour so the datasource is rendered only if grafana is enabled AND the datasources sidecar is enabled.