### PR TITLE
Loki: allow no encoding/compression on chunks

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -40,6 +40,7 @@ const (
 )
 
 var supportedEncoding = []Encoding{
+	EncNone,
 	EncGZIP,
 	EncLZ4_64k,
 	EncSnappy,


### PR DESCRIPTION
We didn't export this originally, I found a use case for it, I suspect others might too so I'm exporting it.
Signed-off-by: Ed Welch <edward.welch@grafana.com>