### PR TITLE
docs: Replace `dyanmodb_url` with correct `dynamodb` key in docs and examples.

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -432,7 +432,7 @@ aws:
     # URL for DynamoDB with escaped Key and Secret encoded. If only region is specified as a
     # host, the proper endpoint will be deduced. Use inmemory:///<bucket-name> to
     # use a mock in-memory implementation.
-    dynamodb_url: <string>
+    dynamodb: <string>
 
     # DynamoDB table management requests per-second limit.
     [api_limit: <float> | default = 2.0]

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -119,7 +119,7 @@ storage_config:
   aws:
     s3: s3://access_key:secret_access_key@region/bucket_name
     dynamodb:
-      dynamodb_url: dynamodb://access_key:secret_access_key@region
+      dynamodb: dynamodb://access_key:secret_access_key@region
 ```
 
 If you don't wish to hard-code S3 credentials, you can also configure an EC2
@@ -130,7 +130,7 @@ storage_config:
   aws:
     s3: s3://region/bucket_name
     dynamodb:
-      dynamodb_url: dynamodb://region
+      dynamodb: dynamodb://region
 ```
 
 ### S3-compatible APIs


### PR DESCRIPTION
**What this PR does / why we need it**:
The location for a DynamoDB backend is set with a `dynamodb` location key and not `dynamodb_url`, the latter will result in a marshalling error when parsing the YAML.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

Signed-off-by: Heds Simons <heds@whaleway.net>



