### PR TITLE
promtail: Add Entry variable to template

### DIFF
--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -97,6 +97,7 @@ func (o *templateStage) Process(labels model.LabelSet, extracted map[string]inte
 			td["Value"] = s
 		}
 	}
+	td["Entry"] = *entry
 
 	buf := &bytes.Buffer{}
 	err := o.template.Execute(buf, td)


### PR DESCRIPTION
The new Entry variable is the log message that could be needed in template.

**What this PR does / why we need it**:
It permits to access the log line (`entry`) from template pipelines using the `Entry` variable.

For exemple, to convert a log line to lowercase:
- template:
    source: message
    template: '{{ ToLower .Entry }}'
- output:
    source: message

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

