### PR TITLE
Allows to change the log driver mode and buffer size.

### DIFF
--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -113,6 +113,8 @@ func validateDriverOpt(loggerInfo logger.Info) error {
 		case "env-regex":
 		case "max-size":
 		case "max-file":
+		case "mode":
+		case "max-buffer-size":
 		default:
 			return fmt.Errorf("%s: wrong log-opt: '%s' - %s", driverName, opt, loggerInfo.ContainerID)
 		}


### PR DESCRIPTION
Before those configs where not allowed, but docker can use them to have a different log delivery behaviour.

see https://docs.docker.com/config/containers/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver

Potentially fixes #2017

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>