### PR TITLE
fix labels path in logcli

### DIFF
--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -23,7 +23,7 @@ import (
 const (
 	queryPath       = "/loki/api/v1/query"
 	queryRangePath  = "/loki/api/v1/query_range"
-	labelsPath      = "/loki/api/v1/labels"
+	labelsPath      = "/loki/api/v1/label"
 	labelValuesPath = "/loki/api/v1/label/%s/values"
 	seriesPath      = "/loki/api/v1/series"
 	tailPath        = "/loki/api/v1/tail"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Labels path in logcli is incorrectly set to `/loki/api/v1/labels` instead of `/loki/api/v1/label` causing it to error out with 404. This PR fixes that.

