### PR TITLE
Fix typo in promtail ClusterRole

### DIFF
--- a/docs/clients/promtail/installation.md
+++ b/docs/clients/promtail/installation.md
@@ -100,7 +100,7 @@ rules:
     resources:
     - nodes
     - services
-    - pod
+    - pods
     verbs:
     - get
     - watch


### PR DESCRIPTION
`pod` is not a valid resource in k8s, but `pods` is.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The existing ClusterRole won't work for pods, since `pod` is not a valid resource. `pods` is.
**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added (it is sort of a docs fix)
- [N/A] Tests updated (docs fix)

