### PR TITLE
boltdb shipper download failure handling and some refactorings

### DIFF
--- a/pkg/storage/stores/local/boltdb_index_client.go
+++ b/pkg/storage/stores/local/boltdb_index_client.go
@@ -58,7 +58,7 @@ func (b *BoltdbIndexClientWithShipper) query(ctx context.Context, query chunk.In
 	}
 
 	return instrument.CollectedRequest(ctx, "QUERY", instrument.NewHistogramCollector(b.shipper.metrics.requestDurationSeconds), instrument.ErrorCode, func(ctx context.Context) error {
-		return b.shipper.forEach(query.TableName, func(db *bbolt.DB) error {
+		return b.shipper.forEach(ctx, query.TableName, func(db *bbolt.DB) error {
 			return b.QueryDB(ctx, db, query, callback)
 		})
 	})

--- a/pkg/storage/stores/local/boltdb_index_client.go
+++ b/pkg/storage/stores/local/boltdb_index_client.go
@@ -58,7 +58,7 @@ func (b *BoltdbIndexClientWithShipper) query(ctx context.Context, query chunk.In
 	}
 
 	return instrument.CollectedRequest(ctx, "QUERY", instrument.NewHistogramCollector(b.shipper.metrics.requestDurationSeconds), instrument.ErrorCode, func(ctx context.Context) error {
-		return b.shipper.forEach(ctx, query.TableName, func(db *bbolt.DB) error {
+		return b.shipper.forEach(query.TableName, func(db *bbolt.DB) error {
 			return b.QueryDB(ctx, db, query, callback)
 		})
 	})

--- a/pkg/storage/stores/local/downloads.go
+++ b/pkg/storage/stores/local/downloads.go
@@ -17,43 +17,30 @@ import (
 )
 
 // checkStorageForUpdates compares files from cache with storage and builds the list of files to be downloaded from storage and to be deleted from cache
-func (s *Shipper) checkStorageForUpdates(ctx context.Context, period string, fc *filesCollection) (toDownload []chunk.StorageObject, toDelete []string, err error) {
-	if s.cfg.Mode == ShipperModeWriteOnly {
-		return
-	}
-
-	fc.RLock()
-	defer fc.RUnlock()
-
+func (fc *FilesCollection) checkStorageForUpdates(ctx context.Context) (toDownload []chunk.StorageObject, toDelete []string, err error) {
 	// listing tables from store
 	var objects []chunk.StorageObject
-	objects, _, err = s.storageClient.List(ctx, period+"/")
+	objects, _, err = fc.storageClient.List(ctx, fc.period+"/")
 	if err != nil {
 		return
 	}
 
 	listedUploaders := make(map[string]struct{}, len(objects))
 
+	fc.RLock()
 	for _, object := range objects {
 		uploader := strings.Split(object.Key, "/")[1]
-		// don't include the file which was uploaded by same ingester
-		if uploader == s.uploader {
-			continue
-		}
 		listedUploaders[uploader] = struct{}{}
 
 		// Checking whether file was updated in the store after we downloaded it, if not, no need to include it in updates
-		var df *downloadedFile
-		df, err = fc.getFile(uploader)
-		if err != nil {
-			return
-		}
-		if df == nil || df.mtime != object.ModifiedAt {
+		downloadedFileDetails, ok := fc.files[uploader]
+		if !ok || downloadedFileDetails.mtime != object.ModifiedAt {
 			toDownload = append(toDownload, object)
 		}
 	}
+	fc.RUnlock()
 
-	err = fc.iter(func(uploader string, df *downloadedFile) error {
+	err = fc.ForEach(func(uploader string, df *downloadedFile) error {
 		if _, isOK := listedUploaders[uploader]; !isOK {
 			toDelete = append(toDelete, uploader)
 		}
@@ -63,24 +50,27 @@ func (s *Shipper) checkStorageForUpdates(ctx context.Context, period string, fc 
 	return
 }
 
-// syncFilesForPeriod downloads updated and new files from for given period from all the uploaders and removes deleted ones
-func (s *Shipper) syncFilesForPeriod(ctx context.Context, period string, fc *filesCollection) error {
-	level.Debug(util.Logger).Log("msg", fmt.Sprintf("syncing files for period %s", period))
+// Sync downloads updated and new files from for given period from all the uploaders and removes deleted ones
+func (fc *FilesCollection) Sync(ctx context.Context) error {
+	level.Debug(util.Logger).Log("msg", fmt.Sprintf("syncing files for period %s", fc.period))
 
-	toDownload, toDelete, err := s.checkStorageForUpdates(ctx, period, fc)
+	toDownload, toDelete, err := fc.checkStorageForUpdates(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, storageObject := range toDownload {
-		err = s.downloadFile(ctx, period, storageObject, fc)
+		err = fc.downloadFile(ctx, storageObject)
 		if err != nil {
 			return err
 		}
 	}
 
+	fc.Lock()
+	defer fc.Unlock()
+
 	for _, uploader := range toDelete {
-		err := s.deleteFileFromCache(uploader, fc)
+		err := fc.cleanupFile(uploader)
 		if err != nil {
 			return err
 		}
@@ -90,15 +80,15 @@ func (s *Shipper) syncFilesForPeriod(ctx context.Context, period string, fc *fil
 }
 
 // It first downloads file to a temp location so that we close the existing file(if already exists), replace it with new one and then reopen it.
-func (s *Shipper) downloadFile(ctx context.Context, period string, storageObject chunk.StorageObject, fc *filesCollection) error {
+func (fc *FilesCollection) downloadFile(ctx context.Context, storageObject chunk.StorageObject) error {
 	uploader := strings.Split(storageObject.Key, "/")[1]
-	folderPath, _ := s.getFolderPathForPeriod(period, false)
+	folderPath, _ := fc.getFolderPathForPeriod(false)
 	filePath := path.Join(folderPath, uploader)
 
 	// download the file temporarily with some other name to allow boltdb client to close the existing file first if it exists
 	tempFilePath := path.Join(folderPath, fmt.Sprintf("%s.%s", uploader, "temp"))
 
-	err := s.getFileFromStorage(ctx, storageObject.Key, tempFilePath)
+	err := fc.getFileFromStorage(ctx, storageObject.Key, tempFilePath)
 	if err != nil {
 		return err
 	}
@@ -106,11 +96,8 @@ func (s *Shipper) downloadFile(ctx context.Context, period string, storageObject
 	fc.Lock()
 	defer fc.Unlock()
 
-	df, err := fc.getFile(uploader)
-	if err != nil {
-		return err
-	}
-	if df != nil {
+	df, ok := fc.files[uploader]
+	if ok {
 		if err := df.boltdb.Close(); err != nil {
 			return err
 		}
@@ -130,12 +117,14 @@ func (s *Shipper) downloadFile(ctx context.Context, period string, storageObject
 		return err
 	}
 
-	return fc.addFile(uploader, df)
+	fc.files[uploader] = df
+
+	return nil
 }
 
 // getFileFromStorage downloads a file from storage to given location.
-func (s *Shipper) getFileFromStorage(ctx context.Context, objectKey, destination string) error {
-	readCloser, err := s.storageClient.GetObject(ctx, objectKey)
+func (fc *FilesCollection) getFileFromStorage(ctx context.Context, objectKey, destination string) error {
+	readCloser, err := fc.storageClient.GetObject(ctx, objectKey)
 	if err != nil {
 		return err
 	}
@@ -161,12 +150,9 @@ func (s *Shipper) getFileFromStorage(ctx context.Context, objectKey, destination
 	return f.Sync()
 }
 
-// downloadFilesForPeriod should be called when files for a period does not exist i.e they were never downloaded or got cleaned up later on by TTL
-// While files are being downloaded it will block all reads/writes on filesCollection by taking an exclusive lock
-func (s *Shipper) downloadFilesForPeriod(ctx context.Context, period string, fc *filesCollection) (err error) {
-	fc.Lock()
-	defer fc.Unlock()
-
+// downloadAllFilesForPeriod should be called when files for a period does not exist i.e they were never downloaded or got cleaned up later on by TTL
+// While files are being downloaded it will block all reads/writes on FilesCollection by taking an exclusive lock
+func (fc *FilesCollection) downloadAllFilesForPeriod(ctx context.Context) (err error) {
 	defer func() {
 		status := statusSuccess
 		if err != nil {
@@ -174,38 +160,37 @@ func (s *Shipper) downloadFilesForPeriod(ctx context.Context, period string, fc 
 			fc.setErr(err)
 
 			// cleaning up files due to error to avoid returning invalid results.
-			if err := fc.cleanupAllFiles(); err != nil {
-				level.Error(util.Logger).Log("msg", "failed to cleanup partially downloaded files", "err", err)
+			for fileName := range fc.files {
+				if err := fc.cleanupFile(fileName); err != nil {
+					level.Error(util.Logger).Log("msg", "failed to cleanup partially downloaded file", "filename", fileName, "err", err)
+				}
 			}
 		}
-		s.metrics.filesDownloadOperationTotal.WithLabelValues(status).Inc()
+		fc.metrics.filesDownloadOperationTotal.WithLabelValues(status).Inc()
 	}()
 
 	startTime := time.Now()
 	totalFilesSize := int64(0)
 
-	objects, _, err := s.storageClient.List(ctx, period+"/")
+	objects, _, err := fc.storageClient.List(ctx, fc.period+"/")
 	if err != nil {
 		return
 	}
 
-	level.Debug(util.Logger).Log("msg", fmt.Sprintf("list of files to download for period %s: %s", period, objects))
+	level.Debug(util.Logger).Log("msg", fmt.Sprintf("list of files to download for period %s: %s", fc.period, objects))
 
-	folderPath, err := s.getFolderPathForPeriod(period, true)
+	folderPath, err := fc.getFolderPathForPeriod(true)
 	if err != nil {
 		return
 	}
 
 	for _, object := range objects {
 		uploader := getUploaderFromObjectKey(object.Key)
-		if uploader == s.uploader {
-			continue
-		}
 
 		filePath := path.Join(folderPath, uploader)
 		df := downloadedFile{}
 
-		err = s.getFileFromStorage(ctx, object.Key, filePath)
+		err = fc.getFileFromStorage(ctx, object.Key, filePath)
 		if err != nil {
 			return
 		}
@@ -224,21 +209,18 @@ func (s *Shipper) downloadFilesForPeriod(ctx context.Context, period string, fc 
 
 		totalFilesSize += stat.Size()
 
-		err = fc.addFile(uploader, &df)
-		if err != nil {
-			return
-		}
+		fc.files[uploader] = &df
 	}
 
 	duration := time.Since(startTime).Seconds()
-	s.metrics.filesDownloadDurationSeconds.add(period, duration)
-	s.metrics.filesDownloadSizeBytes.add(period, totalFilesSize)
+	fc.metrics.filesDownloadDurationSeconds.add(fc.period, duration)
+	fc.metrics.filesDownloadSizeBytes.add(fc.period, totalFilesSize)
 
 	return
 }
 
-func (s *Shipper) getFolderPathForPeriod(period string, ensureExists bool) (string, error) {
-	folderPath := path.Join(s.cfg.CacheLocation, period)
+func (fc *FilesCollection) getFolderPathForPeriod(ensureExists bool) (string, error) {
+	folderPath := path.Join(fc.cacheLocation, fc.period)
 
 	if ensureExists {
 		err := chunk_util.EnsureDirectory(folderPath)

--- a/pkg/storage/stores/local/filescollection.go
+++ b/pkg/storage/stores/local/filescollection.go
@@ -1,0 +1,97 @@
+package local
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+type downloadedFile struct {
+	mtime  time.Time
+	boltdb *bbolt.DB
+}
+
+// filesCollection holds info about shipped boltdb index files by other uploaders(ingesters).
+// It is used to hold boltdb files created by all the ingesters for same period i.e with same name.
+// In the object store files are uploaded as <boltdb-filename>/<uploader-id> to manage files with same name from different ingesters.
+// Note: filesCollection does not manage the locks on mutex to allow users of it to
+// do batch operations or single operation or operations requiring intermittent locking.
+// Note2: It has an err variable which is set when filesCollection is in invalid state due to some issue.
+// All operations which try to access/update the files except cleanup returns an error if set.
+type filesCollection struct {
+	sync.RWMutex
+	lastUsedAt time.Time
+	files      map[string]*downloadedFile
+	err        error
+}
+
+func newFilesCollection() *filesCollection {
+	return &filesCollection{files: map[string]*downloadedFile{}}
+}
+
+func (fc *filesCollection) addFile(fileName string, df *downloadedFile) error {
+	if fc.err != nil {
+		return fc.err
+	}
+
+	fc.files[fileName] = df
+	return nil
+}
+
+func (fc *filesCollection) getFile(fileName string) (*downloadedFile, error) {
+	if fc.err != nil {
+		return nil, fc.err
+	}
+
+	return fc.files[fileName], nil
+}
+
+func (fc *filesCollection) cleanupFile(fileName string) error {
+	boltdbFile := fc.files[fileName].boltdb
+	filePath := boltdbFile.Path()
+
+	if err := boltdbFile.Close(); err != nil {
+		return err
+	}
+
+	delete(fc.files, fileName)
+
+	return os.Remove(filePath)
+}
+
+func (fc *filesCollection) iter(callback func(uploader string, df *downloadedFile) error) error {
+	if fc.err != nil {
+		return fc.err
+	}
+
+	for uploader, df := range fc.files {
+		if err := callback(uploader, df); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fc *filesCollection) cleanupAllFiles() error {
+	for uploader, _ := range fc.files {
+		if err := fc.cleanupFile(uploader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fc *filesCollection) updateLastUsedAt() {
+	fc.lastUsedAt = time.Now()
+}
+
+func (fc *filesCollection) lastUsedTime() time.Time {
+	return fc.lastUsedAt
+}
+
+func (fc *filesCollection) setErr(err error) {
+	fc.err = err
+}

--- a/pkg/storage/stores/local/metrics.go
+++ b/pkg/storage/stores/local/metrics.go
@@ -51,45 +51,52 @@ func (m *downloadPeriodBytesMetric) add(period string, downloadedBytes int64) {
 	m.gauge.Set(float64(totalDownloadedBytes))
 }
 
-type boltDBShipperMetrics struct {
+type downloaderMetrics struct {
 	// metrics for measuring performance of downloading of files per period initially i.e for the first time
 	filesDownloadDurationSeconds *downloadPeriodDurationMetric
 	filesDownloadSizeBytes       *downloadPeriodBytesMetric
 
+	filesDownloadOperationTotal *prometheus.CounterVec
+}
+
+type boltDBShipperMetrics struct {
+	downloaderMetrics *downloaderMetrics
+
 	// duration in seconds spent in serving request on index managed by BoltDB Shipper
 	requestDurationSeconds *prometheus.HistogramVec
 
-	filesDownloadOperationTotal *prometheus.CounterVec
-	filesUploadOperationTotal   *prometheus.CounterVec
+	filesUploadOperationTotal *prometheus.CounterVec
 }
 
 func newBoltDBShipperMetrics(r prometheus.Registerer) *boltDBShipperMetrics {
 	m := &boltDBShipperMetrics{
-		filesDownloadDurationSeconds: &downloadPeriodDurationMetric{
-			periods: map[string]float64{},
-			gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		downloaderMetrics: &downloaderMetrics{
+			filesDownloadDurationSeconds: &downloadPeriodDurationMetric{
+				periods: map[string]float64{},
+				gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+					Namespace: "loki_boltdb_shipper",
+					Name:      "initial_files_download_duration_seconds",
+					Help:      "Time (in seconds) spent in downloading of files per period, initially i.e for the first time",
+				})},
+			filesDownloadSizeBytes: &downloadPeriodBytesMetric{
+				periods: map[string]int64{},
+				gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+					Namespace: "loki_boltdb_shipper",
+					Name:      "initial_files_download_size_bytes",
+					Help:      "Size of files (in bytes) downloaded per period, initially i.e for the first time",
+				})},
+			filesDownloadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 				Namespace: "loki_boltdb_shipper",
-				Name:      "initial_files_download_duration_seconds",
-				Help:      "Time (in seconds) spent in downloading of files per period, initially i.e for the first time",
-			})},
-		filesDownloadSizeBytes: &downloadPeriodBytesMetric{
-			periods: map[string]int64{},
-			gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-				Namespace: "loki_boltdb_shipper",
-				Name:      "initial_files_download_size_bytes",
-				Help:      "Size of files (in bytes) downloaded per period, initially i.e for the first time",
-			})},
+				Name:      "files_download_operation_total",
+				Help:      "Total number of download operations done by status",
+			}, []string{"status"}),
+		},
 		requestDurationSeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "request_duration_seconds",
 			Help:      "Time (in seconds) spent serving requests when using boltdb shipper",
 			Buckets:   instrument.DefBuckets,
 		}, []string{"operation", "status_code"}),
-		filesDownloadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki_boltdb_shipper",
-			Name:      "files_download_operation_total",
-			Help:      "Total number of download operations done by status",
-		}, []string{"status"}),
 		filesUploadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "files_upload_operation_total",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Previously boltdb shipper was using context from request for initial downloading of files which means if a request times out download operation would be cancelled as well and we will continue using whatever files were downloading until the context got cancelled. This would result in incorrect results until files get resynced. This PR takes care of it by passing the background context instead. This means files would continue to download even though request got timed out. We would anyways need those files for serving next requests.

This PR also does some code refactoring to make things clearer at some of the places and support the changes which handle the download failure issue.

