### PR TITLE
enforce requirment for periodic config for index tables to be 24h when using boltdb shipper

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -51,7 +51,7 @@ type Config struct {
 	Ingester         ingester.Config             `yaml:"ingester,omitempty"`
 	StorageConfig    storage.Config              `yaml:"storage_config,omitempty"`
 	ChunkStoreConfig chunk.StoreConfig           `yaml:"chunk_store_config,omitempty"`
-	SchemaConfig     chunk.SchemaConfig          `yaml:"schema_config,omitempty"`
+	SchemaConfig     storage.SchemaConfig        `yaml:"schema_config,omitempty"`
 	LimitsConfig     validation.Limits           `yaml:"limits_config,omitempty"`
 	TableManager     chunk.TableManagerConfig    `yaml:"table_manager,omitempty"`
 	Worker           frontend.WorkerConfig       `yaml:"frontend_worker,omitempty"`

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -25,7 +24,6 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
@@ -187,7 +185,7 @@ func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.cfg.Ingester.LifecyclerConfig.ListenPort = t.cfg.Server.GRPCListenPort
 
 	// We want ingester to also query the store when using boltdb-shipper
-	pc := t.cfg.SchemaConfig.Configs[activePeriodConfig(t.cfg.SchemaConfig)]
+	pc := t.cfg.SchemaConfig.Configs[loki_storage.ActivePeriodConfig(t.cfg.SchemaConfig)]
 	if pc.IndexType == shipper.BoltDBShipperType {
 		t.cfg.Ingester.QueryStore = true
 		mlb, err := calculateMaxLookBack(pc, t.cfg.Ingester.QueryStoreMaxLookBackPeriod, t.cfg.Ingester.MaxChunkAge)
@@ -240,7 +238,7 @@ func (t *Loki) initTableManager() (services.Service, error) {
 	bucketClient, err := storage.NewBucketClient(t.cfg.StorageConfig.Config)
 	util.CheckFatal("initializing bucket client", err)
 
-	t.tableManager, err = chunk.NewTableManager(t.cfg.TableManager, t.cfg.SchemaConfig, maxChunkAgeForTableManager, tableClient, bucketClient, nil, prometheus.DefaultRegisterer)
+	t.tableManager, err = chunk.NewTableManager(t.cfg.TableManager, t.cfg.SchemaConfig.SchemaConfig, maxChunkAgeForTableManager, tableClient, bucketClient, nil, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +247,7 @@ func (t *Loki) initTableManager() (services.Service, error) {
 }
 
 func (t *Loki) initStore() (_ services.Service, err error) {
-	if t.cfg.SchemaConfig.Configs[activePeriodConfig(t.cfg.SchemaConfig)].IndexType == shipper.BoltDBShipperType {
+	if t.cfg.SchemaConfig.Configs[loki_storage.ActivePeriodConfig(t.cfg.SchemaConfig)].IndexType == shipper.BoltDBShipperType {
 		t.cfg.StorageConfig.BoltDBShipperConfig.IngesterName = t.cfg.Ingester.LifecyclerConfig.ID
 		switch t.cfg.Target {
 		case Ingester:
@@ -265,7 +263,7 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 
 	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable index dedupe and write dedupe cache.
 	// This is to ensure that index entries are replicated to all the boltdb files in ingesters flushing replicated data.
-	if t.cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor > 1 && usingBoltdbShipper(t.cfg.SchemaConfig) {
+	if t.cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor > 1 && loki_storage.UsingBoltdbShipper(t.cfg.SchemaConfig) {
 		t.cfg.ChunkStoreConfig.DisableIndexDeduplication = true
 		t.cfg.ChunkStoreConfig.WriteDedupeCacheConfig = cache.Config{}
 	}
@@ -295,7 +293,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 		t.cfg.QueryRange,
 		util.Logger,
 		t.overrides,
-		t.cfg.SchemaConfig,
+		t.cfg.SchemaConfig.SchemaConfig,
 		t.cfg.Querier.QueryIngestersWithin,
 		prometheus.DefaultRegisterer,
 	)
@@ -358,30 +356,6 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 
 	t.memberlistKV = memberlist.NewKVInitService(&t.cfg.MemberlistKV)
 	return t.memberlistKV, nil
-}
-
-// activePeriodConfig returns index of active PeriodicConfig which would be applicable to logs that would be pushed starting now.
-// Note: Another PeriodicConfig might be applicable for future logs which can change index type.
-func activePeriodConfig(cfg chunk.SchemaConfig) int {
-	now := model.Now()
-	i := sort.Search(len(cfg.Configs), func(i int) bool {
-		return cfg.Configs[i].From.Time > now
-	})
-	if i > 0 {
-		i--
-	}
-	return i
-}
-
-// usingBoltdbShipper check whether current or the next index type is boltdb-shipper, returns true if yes.
-func usingBoltdbShipper(cfg chunk.SchemaConfig) bool {
-	activePCIndex := activePeriodConfig(cfg)
-	if cfg.Configs[activePCIndex].IndexType == shipper.BoltDBShipperType ||
-		(len(cfg.Configs)-1 > activePCIndex && cfg.Configs[activePCIndex+1].IndexType == shipper.BoltDBShipperType) {
-		return true
-	}
-
-	return false
 }
 
 func calculateMaxLookBack(pc chunk.PeriodConfig, maxLookBackConfig, maxChunkAge time.Duration) (time.Duration, error) {

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -5,57 +5,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 )
-
-func TestActiveIndexType(t *testing.T) {
-	var cfg chunk.SchemaConfig
-
-	// just one PeriodConfig in the past
-	cfg.Configs = []chunk.PeriodConfig{{
-		From:      chunk.DayTime{Time: model.Now().Add(-24 * time.Hour)},
-		IndexType: "first",
-	}}
-
-	assert.Equal(t, 0, activePeriodConfig(cfg))
-
-	// add a newer PeriodConfig in the past which should be considered
-	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
-		From:      chunk.DayTime{Time: model.Now().Add(-12 * time.Hour)},
-		IndexType: "second",
-	})
-	assert.Equal(t, 1, activePeriodConfig(cfg))
-
-	// add a newer PeriodConfig in the future which should not be considered
-	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
-		From:      chunk.DayTime{Time: model.Now().Add(time.Hour)},
-		IndexType: "third",
-	})
-	assert.Equal(t, 1, activePeriodConfig(cfg))
-}
-
-func TestUsingBoltdbShipper(t *testing.T) {
-	var cfg chunk.SchemaConfig
-
-	// just one PeriodConfig in the past using boltdb-shipper
-	cfg.Configs = []chunk.PeriodConfig{{
-		From:      chunk.DayTime{Time: model.Now().Add(-24 * time.Hour)},
-		IndexType: "boltdb-shipper",
-	}}
-	assert.Equal(t, true, usingBoltdbShipper(cfg))
-
-	// just one PeriodConfig in the past not using boltdb-shipper
-	cfg.Configs[0].IndexType = "boltdb"
-	assert.Equal(t, false, usingBoltdbShipper(cfg))
-
-	// add a newer PeriodConfig in the future using boltdb-shipper
-	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
-		From:      chunk.DayTime{Time: model.Now().Add(time.Hour)},
-		IndexType: "boltdb-shipper",
-	})
-	assert.Equal(t, true, usingBoltdbShipper(cfg))
-}
 
 func Test_calculateMaxLookBack(t *testing.T) {
 	type args struct {

--- a/pkg/storage/hack/main.go
+++ b/pkg/storage/hack/main.go
@@ -50,16 +50,18 @@ func getStore() (lstore.Store, error) {
 			},
 		},
 		chunk.StoreConfig{},
-		chunk.SchemaConfig{
-			Configs: []chunk.PeriodConfig{
-				{
-					From:       chunk.DayTime{Time: start},
-					IndexType:  "boltdb",
-					ObjectType: "filesystem",
-					Schema:     "v9",
-					IndexTables: chunk.PeriodicTableConfig{
-						Prefix: "index_",
-						Period: time.Hour * 168,
+		lstore.SchemaConfig{
+			SchemaConfig: chunk.SchemaConfig{
+				Configs: []chunk.PeriodConfig{
+					{
+						From:       chunk.DayTime{Time: start},
+						IndexType:  "boltdb",
+						ObjectType: "filesystem",
+						Schema:     "v9",
+						IndexTables: chunk.PeriodicTableConfig{
+							Prefix: "index_",
+							Period: time.Hour * 168,
+						},
 					},
 				},
 			},

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2,8 +2,10 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"sort"
+	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	cortex_local "github.com/cortexproject/cortex/pkg/chunk/local"
@@ -22,6 +24,11 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
+var (
+	currentBoltdbShipperNon24HoursErr  = errors.New("boltdb-shipper works best with 24h periodic index config. Either add a new config with future date set to 24h to retain the existing index or change the existing config to use 24h period")
+	upcomingBoltdbShipperNon24HoursErr = errors.New("boltdb-shipper with future date must always have periodic config for index set to 24h")
+)
+
 // Config is the loki storage configuration
 type Config struct {
 	storage.Config      `yaml:",inline"`
@@ -34,6 +41,28 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Config.RegisterFlags(f)
 	cfg.BoltDBShipperConfig.RegisterFlags(f)
 	f.IntVar(&cfg.MaxChunkBatchSize, "store.max-chunk-batch-size", 50, "The maximum number of chunks to fetch per batch.")
+}
+
+// SchemaConfig contains the config for our chunk index schemas
+type SchemaConfig struct {
+	chunk.SchemaConfig `yaml:",inline"`
+}
+
+// Validate the schema config and returns an error if the validation doesn't pass
+func (cfg *SchemaConfig) Validate() error {
+	activePCIndex := ActivePeriodConfig(*cfg)
+
+	// if current index type is boltdb-shipper and there are no upcoming index types then it should be set to 24 hours.
+	if cfg.Configs[activePCIndex].IndexType == local.BoltDBShipperType && cfg.Configs[activePCIndex].IndexTables.Period != 24*time.Hour && len(cfg.Configs)-1 == activePCIndex {
+		return currentBoltdbShipperNon24HoursErr
+	}
+
+	// if upcoming index type is boltdb-shipper, it should always be set to 24 hours.
+	if len(cfg.Configs)-1 > activePCIndex && (cfg.Configs[activePCIndex+1].IndexType == local.BoltDBShipperType && cfg.Configs[activePCIndex+1].IndexTables.Period != 24*time.Hour) {
+		return upcomingBoltdbShipperNon24HoursErr
+	}
+
+	return cfg.SchemaConfig.Validate()
 }
 
 // Store is the Loki chunk store to retrieve and save chunks.
@@ -50,8 +79,8 @@ type store struct {
 }
 
 // NewStore creates a new Loki Store using configuration supplied.
-func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits storage.StoreLimits, registerer prometheus.Registerer) (Store, error) {
-	s, err := storage.NewStore(cfg.Config, storeCfg, schemaCfg, limits, registerer, nil)
+func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg SchemaConfig, limits storage.StoreLimits, registerer prometheus.Registerer) (Store, error) {
+	s, err := storage.NewStore(cfg.Config, storeCfg, schemaCfg.SchemaConfig, limits, registerer, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -314,4 +343,28 @@ func RegisterCustomIndexClients(cfg *Config, registerer prometheus.Registerer) {
 
 		return shipper.NewBoltDBShipperTableClient(objectClient), nil
 	})
+}
+
+// ActivePeriodConfig returns index of active PeriodicConfig which would be applicable to logs that would be pushed starting now.
+// Note: Another PeriodicConfig might be applicable for future logs which can change index type.
+func ActivePeriodConfig(cfg SchemaConfig) int {
+	now := model.Now()
+	i := sort.Search(len(cfg.Configs), func(i int) bool {
+		return cfg.Configs[i].From.Time > now
+	})
+	if i > 0 {
+		i--
+	}
+	return i
+}
+
+// UsingBoltdbShipper checks whether current or the next index type is boltdb-shipper, returns true if yes.
+func UsingBoltdbShipper(cfg SchemaConfig) bool {
+	activePCIndex := ActivePeriodConfig(cfg)
+	if cfg.Configs[activePCIndex].IndexType == local.BoltDBShipperType ||
+		(len(cfg.Configs)-1 > activePCIndex && cfg.Configs[activePCIndex+1].IndexType == local.BoltDBShipperType) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -53,12 +53,12 @@ func (cfg *SchemaConfig) Validate() error {
 	activePCIndex := ActivePeriodConfig(*cfg)
 
 	// if current index type is boltdb-shipper and there are no upcoming index types then it should be set to 24 hours.
-	if cfg.Configs[activePCIndex].IndexType == local.BoltDBShipperType && cfg.Configs[activePCIndex].IndexTables.Period != 24*time.Hour && len(cfg.Configs)-1 == activePCIndex {
+	if cfg.Configs[activePCIndex].IndexType == shipper.BoltDBShipperType && cfg.Configs[activePCIndex].IndexTables.Period != 24*time.Hour && len(cfg.Configs)-1 == activePCIndex {
 		return currentBoltdbShipperNon24HoursErr
 	}
 
 	// if upcoming index type is boltdb-shipper, it should always be set to 24 hours.
-	if len(cfg.Configs)-1 > activePCIndex && (cfg.Configs[activePCIndex+1].IndexType == local.BoltDBShipperType && cfg.Configs[activePCIndex+1].IndexTables.Period != 24*time.Hour) {
+	if len(cfg.Configs)-1 > activePCIndex && (cfg.Configs[activePCIndex+1].IndexType == shipper.BoltDBShipperType && cfg.Configs[activePCIndex+1].IndexTables.Period != 24*time.Hour) {
 		return upcomingBoltdbShipperNon24HoursErr
 	}
 
@@ -361,8 +361,8 @@ func ActivePeriodConfig(cfg SchemaConfig) int {
 // UsingBoltdbShipper checks whether current or the next index type is boltdb-shipper, returns true if yes.
 func UsingBoltdbShipper(cfg SchemaConfig) bool {
 	activePCIndex := ActivePeriodConfig(cfg)
-	if cfg.Configs[activePCIndex].IndexType == local.BoltDBShipperType ||
-		(len(cfg.Configs)-1 > activePCIndex && cfg.Configs[activePCIndex+1].IndexType == local.BoltDBShipperType) {
+	if cfg.Configs[activePCIndex].IndexType == shipper.BoltDBShipperType ||
+		(len(cfg.Configs)-1 > activePCIndex && cfg.Configs[activePCIndex+1].IndexType == shipper.BoltDBShipperType) {
 		return true
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Boltdb shipper keeps uploading modified boltdb files by ingesters, which are by default created weekly. Queriers also downloads them during reads and keeps downloading the updated files. This means for a big cluster, files could grow a lot and ingesters have to upload bigger files even for minor updates and on the other side Queriers have to download them.

This PR enforces periodic config for index tables to be 24h when using boltdb shipper, which would help create smaller files. We anyways wanted to move towards that in future to help to add more components which can modify the index other than ingesters. The plan is to let only ingesters modify last 24 hours of the index and let other components to modify the rest of the index.

I think we should do it now while boltdb shipper is still in an experimental stage to avoid any problems in future and doing the provisioning in code for variable index file sizes.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Since this would not work with existing deployments which already used non-24h periodic duration, I am going to build a helper tool to rebuild boltdb files to make them have 24 hours worth of index.


**Checklist**
- [x] Documentation added

