### PR TITLE
Fixes path prefix in the querier.

### DIFF
--- a/pkg/loghttp/versions.go
+++ b/pkg/loghttp/versions.go
@@ -15,7 +15,7 @@ const (
 
 // GetVersion returns the loghttp version for a given path.
 func GetVersion(uri string) Version {
-	if strings.HasPrefix(strings.ToLower(uri), "/loki/api/v1") {
+	if strings.Contains(strings.ToLower(uri), "/loki/api/v1") {
 		return VersionV1
 	}
 


### PR DESCRIPTION
This solves the problem of path prefix in the querier only see #2176 

For the frontend we need to fix cortex first, then we can also fix it in Loki.

At least with this PR people using helm and the single binary won't have this issue.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
