### PR TITLE
Fix vector-scalar comparisons

### DIFF
--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -1373,11 +1373,11 @@ func TestEngine_RangeQuery(t *testing.T) {
 				promql.Series{
 					Metric: labels.Labels{labels.Label{Name: "app", Value: "foo"}},
 					Points: []promql.Point{
-						promql.Point{T: 60000, V: 1},
-						promql.Point{T: 75000, V: 0},
-						promql.Point{T: 90000, V: 0},
-						promql.Point{T: 105000, V: 1},
-						promql.Point{T: 120000, V: 1},
+						{T: 60000, V: 1},
+						{T: 75000, V: 0},
+						{T: 90000, V: 0},
+						{T: 105000, V: 1},
+						{T: 120000, V: 1},
 					},
 				},
 			},

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -825,7 +825,7 @@ func literalStepEvaluator(
 					left,
 					right,
 					!returnBool,
-					false,
+					IsComparisonOperator(op),
 				); merged != nil {
 					results = append(results, *merged)
 				}

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -60,7 +60,7 @@ func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQue
 		req := ParamsToLokiRequest(qry.Params).WithShards(qry.Shards).WithQuery(qry.Expr.String()).(*LokiRequest)
 		logger, ctx := spanlogger.New(ctx, "DownstreamHandler.instance")
 		defer logger.Finish()
-		level.Debug(logger).Log("shards", req.Shards, "query", req.Query)
+		level.Debug(logger).Log("shards", fmt.Sprintf("%+v", req.Shards), "query", req.Query)
 
 		res, err := in.handler.Do(ctx, req)
 		if err != nil {


### PR DESCRIPTION
- formats shards in downstreamers for better logging
- Make vector-scalar comparisons filter by default, but not set the results to 0 or 1.

```
$ logcli query 'sum(rate({filename=~"/var/log/wifi.*"}[1m])) > 1'
http://localhost:3100/loki/api/v1/query_range?direction=BACKWARD&end=1591386888234918000&limit=30&query=sum%28rate%28%7Bfilename%3D~%22%2Fvar%2Flog%2Fwifi.%2A%22%7D%5B1m%5D%29%29+%3E+1&start=1591383288234918000
[
  {
    "metric": {

    },
    "values": [
      [
        1591384744.234,
        "1893.2666666666664"
      ],
      [
        1591384758.234,
        "1893.2666666666664"
      ],
      [
        1591384772.234,
        "1893.2666666666664"
      ],
      [
        1591384786.234,
        "1893.2666666666664"
      ],
      [
        1591384800.234,
        "1074.3166666666666"
      ]
    ]
  }
]
```
vs
```
$ logcli query 'sum(rate({filename=~"/var/log/wifi.*"}[1m])) > bool 1'
http://localhost:3100/loki/api/v1/query_range?direction=BACKWARD&end=1591386974813316000&limit=30&query=sum%28rate%28%7Bfilename%3D~%22%2Fvar%2Flog%2Fwifi.%2A%22%7D%5B1m%5D%29%29+%3E+bool+1&start=1591383374813316000
[
  {
    "metric": {

    },
    "values": [
      [
        1591384746.813,
        "1"
      ],
      [
        1591384760.813,
        "1"
      ],
      [
        1591384774.813,
        "1"
      ],
      [
        1591384788.813,
        "1"
      ]
    ]
  }
]
```