### PR TITLE
Add flag to disable tracing activation

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -58,19 +58,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-	trace, err := tracing.NewFromEnv(fmt.Sprintf("loki-%s", config.Target))
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error in initializing tracing. tracing will not be enabled", "err", err)
-	}
-	defer func() {
-		if trace != nil {
-			if err := trace.Close(); err != nil {
-				level.Error(util.Logger).Log("msg", "error closing tracing", "err", err)
-			}
+	if config.Tracing.Enabled {
+		// Setting the environment variable JAEGER_AGENT_HOST enables tracing
+		trace, err := tracing.NewFromEnv(fmt.Sprintf("loki-%s", config.Target))
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "error in initializing tracing. tracing will not be enabled", "err", err)
 		}
+		defer func() {
+			if trace != nil {
+				if err := trace.Close(); err != nil {
+					level.Error(util.Logger).Log("msg", "error closing tracing", "err", err)
+				}
+			}
 
-	}()
+		}()
+	}
 
 	// Start Loki
 	t, err := loki.New(config)

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -25,7 +25,9 @@ Configuration examples can be found in the [Configuration Examples](examples.md)
 * [table_manager_config](#table_manager_config)
   * [provision_config](#provision_config)
     * [auto_scaling_config](#auto_scaling_config)
+* [tracing_config](#tracing_config)
 * [Runtime Configuration file](#runtime-configuration-file)
+
 
 ## Configuration File Reference
 
@@ -97,6 +99,9 @@ Supported contents and default values of `loki.yaml`:
 
 # Configuration for "runtime config" module, responsible for reloading runtime configuration file.
 [runtime_config: <runtime_config>]
+
+#Configuration for tracing
+[tracing: <tracing_config>]
 ```
 
 ## server_config
@@ -1042,6 +1047,15 @@ The `auto_scaling_config` block configures autoscaling for DynamoDB.
 
 # DynamoDB target ratio of consumed capacity to provisioned capacity.
 [target: <float> | default = 80]
+```
+
+## tracing_config
+
+The `tracing_config` block configures tracing for Jaeger. Currently limited to disable auto-configuration per [environment variables](https://www.jaegertracing.io/docs/1.16/client-features/) only.
+
+```yaml
+# Whether or not tracing should be enabled.
+[enabled: <boolean>: default = true]
 ```
 
 ## Runtime Configuration file

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/loki/pkg/querier"
 	"github.com/grafana/loki/pkg/querier/queryrange"
 	"github.com/grafana/loki/pkg/storage"
+	"github.com/grafana/loki/pkg/tracing"
 	serverutil "github.com/grafana/loki/pkg/util/server"
 	"github.com/grafana/loki/pkg/util/validation"
 )
@@ -57,6 +58,7 @@ type Config struct {
 	QueryRange       queryrange.Config           `yaml:"query_range,omitempty"`
 	RuntimeConfig    runtimeconfig.ManagerConfig `yaml:"runtime_config,omitempty"`
 	MemberlistKV     memberlist.KVConfig         `yaml:"memberlist"`
+	Tracing          tracing.Config              `yaml:"tracing"`
 }
 
 // RegisterFlags registers flag.
@@ -81,6 +83,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Worker.RegisterFlags(f)
 	c.QueryRange.RegisterFlags(f)
 	c.RuntimeConfig.RegisterFlags(f)
+	c.Tracing.RegisterFlags(f)
 }
 
 // Validate the config and returns an error if the validation

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -1,0 +1,13 @@
+package tracing
+
+import (
+	"flag"
+)
+
+type Config struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "tracing.enabled", true, "Set to false to disable tracing.")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses the capability to disable tracing per configuration flag in enviroments where the Jaeger env variables are in place and thus auto-activate tracing. The config flag comes in hand as an user provided override to disable tracing if required.

**Which issue(s) this PR fixes**:
Fixes #2183

**Checklist**
- [x] Documentation added

