### PR TITLE
Adds default -config.file for the promtail docker images.

### DIFF
--- a/cmd/promtail/Dockerfile
+++ b/cmd/promtail/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update && \
   tzdata ca-certificates libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
-COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
-COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 ENTRYPOINT ["/usr/bin/promtail"]
+CMD ["-config.file=/etc/promtail/config.yml"]

--- a/cmd/promtail/Dockerfile.arm32
+++ b/cmd/promtail/Dockerfile.arm32
@@ -16,7 +16,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
 COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
-COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 
 # Drone CI builds arm32 images using armv8l rather than armv7l. Something in
 # our build process above causes ldconfig to be rerun and removes the armhf
@@ -28,3 +28,4 @@ COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
 RUN sh -c '[ ! -f /lib/ld-linux-armhf.so.3 ] && echo RE-LINKING LD-LINUX-ARMHF.SO.3 && ln -s /lib/ld-linux.so.3 /lib/ld-linux-armhf.so.3'
 
 ENTRYPOINT ["/usr/bin/promtail"]
+CMD ["-config.file=/etc/promtail/config.yml"]

--- a/cmd/promtail/Dockerfile.cross
+++ b/cmd/promtail/Dockerfile.cross
@@ -4,7 +4,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.9.1
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
 FROM golang:1.11.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
-    go env GOARM > /goarm
+  go env GOARM > /goarm
 
 FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
@@ -16,10 +16,11 @@ RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAI
 FROM debian:stretch-slim
 # tzdata required for the timestamp stage to work
 RUN apt-get update && \
-    apt-get install -qy \
-      tzdata ca-certificates libsystemd-dev && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  apt-get install -qy \
+  tzdata ca-certificates libsystemd-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/cmd/promtail/promtail /usr/bin/promtail
 COPY cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
-COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+COPY cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 ENTRYPOINT ["/usr/bin/promtail"]
+CMD ["-config.file=/etc/promtail/config.yml"]

--- a/cmd/promtail/Dockerfile.debug
+++ b/cmd/promtail/Dockerfile.debug
@@ -14,7 +14,7 @@ RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/cmd/promtail/promtail-debug /usr/bin/promtail-debug
 COPY       --from=build /go/bin/dlv /usr/bin/dlv
 COPY       cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
-COPY       cmd/promtail/promtail-docker-config.yaml /etc/promtail/docker-config.yaml
+COPY       cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 
 # Expose 40000 for delve
 EXPOSE 40000
@@ -26,3 +26,4 @@ RUN apk add --no-cache libc6-compat
 #   Pass flags to the program you are debugging using --, for example:`
 #   dlv exec ./hello -- server --config conf/config.toml`
 ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/usr/bin/promtail-debug", "--"]
+CMD ["-config.file=/etc/promtail/config.yml"]


### PR DESCRIPTION
Closes #2194.

This is already the case for Loki. I think it's better to have this since most people would expect it as default at least for docker. (which was the case for #2194 )

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

