### PR TITLE
disable index dedupe when rf > 1 and current or upcoming index type is boltdb-shipper

### DIFF
--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -86,5 +86,14 @@ Frequency for checking updates can be configured with `resync_interval` config.
 To avoid keeping downloaded index files forever there is a ttl for them which defaults to 24 hours, which means if index files for a period are not used for 24 hours they would be removed from cache location.
 ttl can be configured using `cache_ttl` config.
 
+### Write Deduplication disabled
+
+Loki does write deduplication of chunks and index using Chunks and WriteDedupe cache respectively, configured with [ChunkStoreConfig](../../configuration/README.md#chunk_store_config).
+The problem with write deduplication when using `boltdb-shipper` though is ingesters only keep uploading boltdb files periodically to make them available to all the other services which means there would be a brief period where some of the services would not have received updated index yet.
+The problem due to that is if an ingester which first wrote the chunks and index goes down and all the other ingesters which were part of replication scheme skipped writing those chunks and index due to deduplication, we would end up missing those logs from query responses since only the ingester which had the index went down.
+This problem would be faced even during rollouts which is quite common.
+
+To avoid this, Loki disables WriteDedupe and uses Chunks cache only for improving read performance when the replication factor is greater than 1 and `boltdb-shipper` is an active or upcoming index type.
+While Chunks cache would still be useful to have when using `boltdb-shipper` for read performance, please avoid configuring WriteDedupe cache since it would not be used anyways.
 
 

--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -93,7 +93,7 @@ The problem with write deduplication when using `boltdb-shipper` though is inges
 The problem due to that is if an ingester which first wrote the chunks and index goes down and all the other ingesters which were part of replication scheme skipped writing those chunks and index due to deduplication, we would end up missing those logs from query responses since only the ingester which had the index went down.
 This problem would be faced even during rollouts which is quite common.
 
-To avoid this, Loki disables WriteDedupe and uses Chunks cache only for improving read performance when the replication factor is greater than 1 and `boltdb-shipper` is an active or upcoming index type.
-While Chunks cache would still be useful to have when using `boltdb-shipper` for read performance, please avoid configuring WriteDedupe cache since it would not be used anyways.
+To avoid this, Loki disables deduplication of index when the replication factor is greater than 1 and `boltdb-shipper` is an active or upcoming index type.
+While using `boltdb-shipper` please avoid configuring WriteDedupe cache since it is used purely for the index deduplication, so it would not be used anyways.
 
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -255,7 +255,7 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 		}
 	}
 
-	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable both chunks dedupe and write dedupe cache.
+	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable index dedupe and write dedupe cache.
 	// This is to ensure that index entries are replicated to all the boltdb files in ingesters flushing replicated data.
 	if t.cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor > 1 && usingBoltdbShipper(t.cfg.SchemaConfig) {
 		t.cfg.ChunkStoreConfig.DisableIndexDeduplication = true
@@ -337,7 +337,7 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	return t.memberlistKV, nil
 }
 
-// activePeriodConfig type returns index of active PeriodicConfig which would be applicable to logs that would be pushed starting now.
+// activePeriodConfig returns index of active PeriodicConfig which would be applicable to logs that would be pushed starting now.
 // Note: Another PeriodicConfig might be applicable for future logs which can change index type.
 func activePeriodConfig(cfg chunk.SchemaConfig) int {
 	now := model.Now()

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -258,7 +258,7 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable both chunks dedupe and write dedupe cache.
 	// This is to ensure that index entries are replicated to all the boltdb files in ingesters flushing replicated data.
 	if t.cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor > 1 && usingBoltdbShipper(t.cfg.SchemaConfig) {
-		t.cfg.ChunkStoreConfig.DisableChunksDeduplication = true
+		t.cfg.ChunkStoreConfig.DisableIndexDeduplication = true
 		t.cfg.ChunkStoreConfig.WriteDedupeCacheConfig = cache.Config{}
 	}
 

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -18,22 +18,43 @@ func TestActiveIndexType(t *testing.T) {
 		IndexType: "first",
 	}}
 
-	assert.Equal(t, cfg.Configs[0], activePeriodConfig(cfg))
+	assert.Equal(t, 0, activePeriodConfig(cfg))
 
 	// add a newer PeriodConfig in the past which should be considered
 	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
 		From:      chunk.DayTime{Time: model.Now().Add(-12 * time.Hour)},
 		IndexType: "second",
 	})
-	assert.Equal(t, cfg.Configs[1], activePeriodConfig(cfg))
+	assert.Equal(t, 1, activePeriodConfig(cfg))
 
 	// add a newer PeriodConfig in the future which should not be considered
 	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
 		From:      chunk.DayTime{Time: model.Now().Add(time.Hour)},
 		IndexType: "third",
 	})
-	assert.Equal(t, cfg.Configs[1], activePeriodConfig(cfg))
+	assert.Equal(t, 1, activePeriodConfig(cfg))
+}
 
+func TestUsingBoltdbShipper(t *testing.T) {
+	var cfg chunk.SchemaConfig
+
+	// just one PeriodConfig in the past using boltdb-shipper
+	cfg.Configs = []chunk.PeriodConfig{{
+		From:      chunk.DayTime{Time: model.Now().Add(-24 * time.Hour)},
+		IndexType: "boltdb-shipper",
+	}}
+	assert.Equal(t, true, usingBoltdbShipper(cfg))
+
+	// just one PeriodConfig in the past not using boltdb-shipper
+	cfg.Configs[0].IndexType = "boltdb"
+	assert.Equal(t, false, usingBoltdbShipper(cfg))
+
+	// add a newer PeriodConfig in the future using boltdb-shipper
+	cfg.Configs = append(cfg.Configs, chunk.PeriodConfig{
+		From:      chunk.DayTime{Time: model.Now().Add(time.Hour)},
+		IndexType: "boltdb-shipper",
+	})
+	assert.Equal(t, true, usingBoltdbShipper(cfg))
 }
 
 func Test_calculateMaxLookBack(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We use dedupe caches for chunks and seriesIDs to determine whether we already have written a chunk or a seriesID already to the store. Since `boltdb-shipper` only uploads boltdb files periodically to make the index available to all the other services, an ingester which first wrote a chunk or seriesID goes down and other ingesters didn't write them due to deduplication, we would be missing some logs in query responses until that ingester is down. This would be a problem even during rollouts.

This PR disables index deduplication and avoid using write dedupe cache(which dedupes seriesIDs) when replication factor > 1 and current or upcoming index type is `boltdb-shipper`.

**Checklist**
- [x] Documentation added
- [x] Tests updated

