### PR TITLE
Improve point allocations for each steps in the logql engine.

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -3,6 +3,7 @@ package logql
 import (
 	"context"
 	"errors"
+	"math"
 	"sort"
 	"time"
 
@@ -197,6 +198,11 @@ func (q *query) evalSample(ctx context.Context, expr SampleExpr) (parser.Value, 
 		return vec, nil
 	}
 
+	stepCount := int(math.Ceil(float64(q.params.End().Sub(q.params.Start()).Nanoseconds()) / float64(q.params.Step().Nanoseconds())))
+	if stepCount <= 0 {
+		stepCount = 1
+	}
+
 	for next {
 
 		for _, p := range vec {
@@ -210,6 +216,7 @@ func (q *query) evalSample(ctx context.Context, expr SampleExpr) (parser.Value, 
 			if !ok {
 				series = &promql.Series{
 					Metric: p.Metric,
+					Points: make([]promql.Point, 0, stepCount),
 				}
 				seriesIndex[hash] = series
 			}


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
```
❯ benchcmp old.txt new.txt
benchmark                         old ns/op      new ns/op      delta
BenchmarkRangeQuery100000-16      3177521        2690188        -15.34%
BenchmarkRangeQuery200000-16      13285761       11949290       -10.06%
BenchmarkRangeQuery500000-16      1925487305     1930636271     +0.27%
BenchmarkRangeQuery1000000-16     4044356716     3919126192     -3.10%

benchmark                         old allocs     new allocs     delta
BenchmarkRangeQuery100000-16      5239           5221           -0.34%
BenchmarkRangeQuery200000-16      5861           5793           -1.16%
BenchmarkRangeQuery500000-16      138631         138487         -0.10%
BenchmarkRangeQuery1000000-16     272012         271842         -0.06%

benchmark                         old bytes     new bytes     delta
BenchmarkRangeQuery100000-16      715357        696538        -2.63%
BenchmarkRangeQuery200000-16      1334607       1257068       -5.81%
BenchmarkRangeQuery500000-16      135321968     131401184     -2.90%
BenchmarkRangeQuery1000000-16     270956344     262054664     -3.29%

```

/cc @slim-bean 