### PR TITLE
Reuse slice for the range vector allocations.

### DIFF
--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -26,6 +26,7 @@ type rangeVectorIterator struct {
 	selRange, step, end, current int64
 	window                       map[string]*promql.Series
 	metrics                      map[string]labels.Labels
+	at                           []promql.Sample
 }
 
 func newRangeVectorIterator(
@@ -130,11 +131,14 @@ func (r *rangeVectorIterator) load(start, end int64) {
 }
 
 func (r *rangeVectorIterator) At(aggregator RangeVectorAggregator) (int64, promql.Vector) {
-	result := make([]promql.Sample, 0, len(r.window))
+	if r.at == nil {
+		r.at = make([]promql.Sample, 0, len(r.window))
+	}
+	r.at = r.at[:0]
 	// convert ts from nano to milli seconds as the iterator work with nanoseconds
 	ts := r.current / 1e+6
 	for _, series := range r.window {
-		result = append(result, promql.Sample{
+		r.at = append(r.at, promql.Sample{
 			Point: promql.Point{
 				V: aggregator(series.Points),
 				T: ts,
@@ -142,7 +146,7 @@ func (r *rangeVectorIterator) At(aggregator RangeVectorAggregator) (int64, promq
 			Metric: series.Metric,
 		})
 	}
-	return ts, result
+	return ts, r.at
 }
 
 var seriesPool sync.Pool


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
```
❯ benchcmp old.txt new.txt
benchmark                         old ns/op      new ns/op      delta
BenchmarkRangeQuery100000-16      3356959        3097925        -7.72%
BenchmarkRangeQuery200000-16      15821777       14543104       -8.08%
BenchmarkRangeQuery500000-16      2107956639     1992137391     -5.49%
BenchmarkRangeQuery1000000-16     4051613799     4041557363     -0.25%

benchmark                         old allocs     new allocs     delta
BenchmarkRangeQuery100000-16      5241           5235           -0.11%
BenchmarkRangeQuery200000-16      5993           5835           -2.64%
BenchmarkRangeQuery500000-16      138631         130304         -6.01%
BenchmarkRangeQuery1000000-16     272021         255363         -6.12%

benchmark                         old bytes     new bytes     delta
BenchmarkRangeQuery100000-16      716984        714652        -0.33%
BenchmarkRangeQuery200000-16      1464403       1338725       -8.58%
BenchmarkRangeQuery500000-16      135321968     132657776     -1.97%
BenchmarkRangeQuery1000000-16     270999096     265668520     -1.97%
```