### PR TITLE
logcli: Remove single newline from the raw line before printing.

### DIFF
--- a/pkg/logcli/output/raw.go
+++ b/pkg/logcli/output/raw.go
@@ -13,5 +13,8 @@ type RawOutput struct {
 
 // Format a log entry as is
 func (o *RawOutput) Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) string {
+	if len(line) > 0 && line[len(line)-1] == '\n' {
+		line = line[:len(line)-1]
+	}
 	return line
 }

--- a/pkg/logcli/output/raw_test.go
+++ b/pkg/logcli/output/raw_test.go
@@ -41,6 +41,22 @@ func TestRawOutput_Format(t *testing.T) {
 			"Hello world",
 			"Hello world",
 		},
+		"line with single newline at the end": {
+			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
+			timestamp,
+			someLabels,
+			0,
+			"Hello world\n",
+			"Hello world",
+		},
+		"line with multiple newlines at the end": {
+			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
+			timestamp,
+			someLabels,
+			0,
+			"Hello world\n\n\n",
+			"Hello world\n\n",
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes single newline at the end of raw log line. Lines are printed with Println, so this avoids having extra empty line between printed log lines.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

