### PR TITLE
helm: Add loadBalancerIP option to loki chart

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.37.4
+version: 0.38.0
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.29.1
+version: 0.30.0
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/service.yaml
+++ b/production/helm/loki/templates/service.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if (and (eq .Values.service.type "ClusterIP") (not (empty .Values.service.clusterIP))) }}
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}
+{{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
 {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- range $cidr := .Values.service.loadBalancerSourceRanges }}


### PR DESCRIPTION
**Add loadBalancerIP to loki**
The chart's service already has *annotation* options enabled 
https://github.com/grafana/loki/blob/master/production/helm/loki/templates/service.yaml#L15

One of the usages of the annotation is to add an internal load balancer and some cloud providers allow you to select a static IP like:

```yaml
  service:
    annotations:
      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
    type: LoadBalancer
    loadBalancerIP: 10.2.17.3
```

**Test**
```shell
$ helm3 upgrade --install loki ./loki-stack-0.38.0.tgz -f values/staging/loki.yaml --namespace infra  
Release "loki" has been upgraded. Happy Helming!
NAME: loki
LAST DEPLOYED: Thu Jun 18 16:43:03 2020
NAMESPACE: infra
STATUS: deployed
REVISION: 2
NOTES:
The Loki stack has been deployed to your cluster. Loki can now be added as a datasource in Grafana.

See http://docs.grafana.org/features/datasources/loki/ for more detail.
$ kubectl -n infra get svc
NAME                            TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
loki                            LoadBalancer   10.0.124.174   10.2.17.3     3100:30990/TCP   61m
loki-headless                   ClusterIP      None           <none>        3100/TCP         61m
prometheus-kube-state-metrics   ClusterIP      10.0.199.224   <none>        8080/TCP         6d5h
prometheus-node-exporter        ClusterIP      None           <none>        9100/TCP         6d5h
prometheus-server               LoadBalancer   10.0.137.207   10.2.17.2     80:31265/TCP     6d5h
```

