### PR TITLE
Set user agent on outgoing http requests

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/grafana/loki/pkg/build"
 	loghttp "github.com/grafana/loki/pkg/loghttp/legacy"
 	"github.com/grafana/loki/pkg/logproto"
 )
@@ -28,6 +29,7 @@ var (
 		Name:      "ws_reconnects",
 		Help:      "counts every time the websocket connection has to reconnect",
 	})
+	userAgent = fmt.Sprintf("loki-canary/%s", build.Version)
 )
 
 type LokiReader interface {
@@ -115,6 +117,7 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	}
 
 	req.SetBasicAuth(r.user, r.pass)
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -15,6 +15,7 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/prometheus/common/config"
 
+	"github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/util"
@@ -27,6 +28,10 @@ const (
 	labelValuesPath = "/loki/api/v1/label/%s/values"
 	seriesPath      = "/loki/api/v1/series"
 	tailPath        = "/loki/api/v1/tail"
+)
+
+var (
+	userAgent = fmt.Sprintf("loki-logcli/%s", build.Version)
 )
 
 // Client contains fields necessary to query a Loki instance
@@ -141,6 +146,7 @@ func (c *Client) doRequest(path, query string, quiet bool, out interface{}) erro
 	}
 
 	req.SetBasicAuth(c.Username, c.Password)
+	req.Header.Set("User-Agent", userAgent)
 
 	if c.OrgID != "" {
 		req.Header.Set("X-Scope-OrgID", c.OrgID)

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/logproto"
 )
@@ -70,6 +71,8 @@ var (
 	countersWithHost = []*prometheus.CounterVec{
 		encodedBytes, sentBytes, droppedBytes, sentEntries, droppedEntries,
 	}
+
+	userAgent = fmt.Sprintf("promtail/%s", build.Version)
 )
 
 func init() {
@@ -259,6 +262,7 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", userAgent)
 
 	// If the tenant ID is not empty promtail is running in multi-tenant mode, so
 	// we should send it to Loki


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR adds a User-Agent header on outgoing HTTP requests, so it is eg `promtail/v1.5.0` or `loki-logcli/v1.5.0` rather than `Go-http-client/1.1`.

**Special notes for your reviewer**:
First change in this repo, so might be missing other places where it is needed. 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

