### PR TITLE
docs: Fix missing quotes

### DIFF
--- a/docs/logql.md
+++ b/docs/logql.md
@@ -69,7 +69,7 @@ After writing the log stream selector, the resulting set of logs can be further 
 - `{job="mysql"} |= "error"`
 - `{name="kafka"} |~ "tsdb-ops.*io:2003"`
 - `` {name="cassandra"} |~  `error=\w+` ``
-- `{instance=~"kafka-[23]",name="kafka"} != kafka.server:type=ReplicaManager`
+- `{instance=~"kafka-[23]",name="kafka"} != "kafka.server:type=ReplicaManager"`
 
 In the previous examples, `|=`, `|~`, and `!=` act as **filter operators** and
 the following filter operators are supported:


### PR DESCRIPTION
**What this PR does / why we need it**:
Missing quotes in the logql docs
