### PR TITLE
helm: add annotations to service monitor

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.1.3
+version: 0.1.4
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/servicemonitor.yaml
+++ b/production/helm/fluent-bit/templates/servicemonitor.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/production/helm/fluent-bit/values.yaml
+++ b/production/helm/fluent-bit/values.yaml
@@ -109,4 +109,5 @@ serviceMonitor:
   enabled: false
   interval: ""
   additionalLabels: {}
+  annotations: {}
   # scrapeTimeout: 10s

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.30.0
+version: 0.30.1
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/servicemonitor.yaml
+++ b/production/helm/loki/templates/servicemonitor.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -195,6 +195,7 @@ serviceMonitor:
   enabled: false
   interval: ""
   additionalLabels: {}
+  annotations: {}
   # scrapeTimeout: 10s
 
 initContainers: []

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.23.1
+version: 0.23.2
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/servicemonitor.yaml
+++ b/production/helm/promtail/templates/servicemonitor.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/production/helm/promtail/values.yaml
+++ b/production/helm/promtail/values.yaml
@@ -163,6 +163,7 @@ serviceMonitor:
   enabled: false
   interval: ""
   additionalLabels: {}
+  annotations: {}
   # scrapeTimeout: 10s
 
 # Extra env variables to pass to the promtail container


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to annotate serviceMonitors resources. As serviceMonitors are not native Kubernetes resources, people using ArgoCd may want to use specific argocd annotations in order to [order their deployment](https://argoproj.github.io/argo-cd/user-guide/sync-waves/) , or [skip dry run](https://argoproj.github.io/argo-cd/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types)

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

