### PR TITLE
Change the Grafana image to latest

### DIFF
--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - loki
 
   grafana:
-    image: grafana/grafana:master
+    image: grafana/grafana:latest
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
For a better first use experience, I would recommend changing the grafana image to `latest`. Grafana `master` is not guaranteed to be in a stable state. 


