### PR TITLE
Remove NET_BIND_SERVICE capability requirement.

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -13,8 +13,6 @@ RUN apk add --no-cache ca-certificates libcap
 COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
 COPY cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml
 
-RUN setcap cap_net_bind_service=+ep /usr/bin/loki
-
 RUN addgroup -g 10001 -S loki && \
     adduser -u 10001 -S loki -G loki
 RUN mkdir -p /loki && \

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -2,7 +2,7 @@
   _config+: {
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
-    http_listen_port: 80,
+    http_listen_port: 3100,
 
     replication_factor: 3,
     memcached_replicas: 3,


### PR DESCRIPTION
Mistakes were made. I think it's better to deal with not being able to bind to 80 than making the trouble for people running in restricted environment.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

Fixes #2115 
Fixes #2192