### PR TITLE
Remove mount in the docker driver.

### DIFF
--- a/cmd/docker-driver/config.json
+++ b/cmd/docker-driver/config.json
@@ -17,15 +17,4 @@
             "settable": ["value"]
         }
     ],
-    "mounts": [
-        {
-            "name": "data",
-            "description": "Optional external pipeline files",
-            "source": "",
-            "destination": "/data",
-            "type": "none",
-            "options": ["bind", "ro"],
-            "settable": ["source", "destination"]
-        }
-    ]
 }

--- a/cmd/docker-driver/config.json
+++ b/cmd/docker-driver/config.json
@@ -1,12 +1,16 @@
 {
     "description": "Loki Logging Driver",
     "documentation": "https://github.com/grafana/loki",
-    "entrypoint": ["/bin/docker-driver"],
+    "entrypoint": [
+        "/bin/docker-driver"
+    ],
     "network": {
         "type": "host"
     },
     "interface": {
-        "types": ["docker.logdriver/1.0"],
+        "types": [
+            "docker.logdriver/1.0"
+        ],
         "socket": "loki.sock"
     },
     "env": [
@@ -14,7 +18,9 @@
             "name": "LOG_LEVEL",
             "description": "Set log level to output for plugin logs",
             "value": "info",
-            "settable": ["value"]
+            "settable": [
+                "value"
+            ]
         }
-    ],
+    ]
 }

--- a/docs/clients/docker-driver/configuration.md
+++ b/docs/clients/docker-driver/configuration.md
@@ -109,37 +109,6 @@ Custom labels can be added using the `loki-external-labels`,
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
 
-## Configure custom pipeline stage file
-
-You can also use custom pipeline stage files, with `loki-pipeline-stage-file` option,
-provided from outside of the Loki logging driver container by running Loki with a
-mounted volume. To do so, you'll need to disable the plugin, set a volume mount
-options and enable the plugin again:
-
-```bash
-docker plugin disable loki:latest
-docker plugin set loki:latest data.source=/etc/pipelines
-docker plugin enable loki:latest
-```
-
-In the example above the directory `/etc/pipelines` will be mounted as `/data`
-inside the Loki driver container and `loki-pipeline-stage-file` option can be
-passed with a custom pipeline configuration, provided there's a file
-`/etc/pipelines/mypipeline.yaml` on the host machine:
-
-```bash
-docker run --log-driver=loki \
-    --log-opt loki-url="https://<user_id>:<password>@logs-us-west1.grafana.net/loki/api/v1/push" \
-    --log-opt loki-pipeline-stage-file=/data/mypipeline.yaml \
-    grafana/grafana
-```
-
-Available options are:
-
-- `data.source`: the source directory the volume
-- `data.destination`: the path where the directory is mounted in the container,
-and is `/data` by default
-
 ## Supported log-opt options
 
 The following are all supported options that the Loki logging driver supports:


### PR DESCRIPTION
https://github.com/grafana/loki/pull/2054/ Introduced a way to mount file automatically in the docker driver. However we realized that for some operating systems if you don't have a data folder, installing the driver will fail.

Since we now have many other ways to pass pipeline stages I think we should remove this to make sure the driver onboarding experience is great.

Fixes #2269 
Fixes #2147

For those who still want to use this feature you can pull and install this version `grafana/loki-docker-driver:master-5e0fe09`.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>