### PR TITLE
Promtail: support unix timestamps with fractional seconds

### DIFF
--- a/docs/clients/promtail/stages/timestamp.md
+++ b/docs/clients/promtail/stages/timestamp.md
@@ -44,7 +44,7 @@ of pre-defined formats to represent common forms:
 Additionally, support for common Unix timestamps is supported with the following
 `format` values:
 
-- `Unix`: `1562708916`
+- `Unix`: `1562708916` or with fractions `1562708916.000000123`
 - `UnixMs`: `1562708916414`
 - `UnixUs`: `1562708916414123`
 - `UnixNs`: `1562708916000000123`

--- a/pkg/logentry/stages/timestamp_test.go
+++ b/pkg/logentry/stages/timestamp_test.go
@@ -223,6 +223,28 @@ func TestTimestampStage_Process(t *testing.T) {
 			},
 			time.Date(2019, 7, 9, 21, 48, 36, 0, time.UTC),
 		},
+		"unix fractions ms success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "Unix",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916.414123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 414123*1000, time.UTC),
+		},
+		"unix fractions ns success": {
+			TimestampConfig{
+				Source: "ts",
+				Format: "Unix",
+			},
+			map[string]interface{}{
+				"somethigelse": "notimportant",
+				"ts":           "1562708916.000000123",
+			},
+			time.Date(2019, 7, 9, 21, 48, 36, 123, time.UTC),
+		},
 		"unix millisecond success": {
 			TimestampConfig{
 				Source: "ts",

--- a/pkg/logentry/stages/util.go
+++ b/pkg/logentry/stages/util.go
@@ -67,6 +67,9 @@ func convertDateLayout(predef string, location *time.Location) parser {
 		return func(t string) (time.Time, error) {
 			if strings.Count(t, ".") == 1 {
 				split := strings.Split(t, ".")
+				if len(split) != 2 {
+					return time.Time{}, fmt.Errorf("Can't split %v into two parts", t)
+				}
 				sec, err := strconv.ParseInt(split[0], 10, 64)
 				if err != nil {
 					return time.Time{}, err

--- a/pkg/logentry/stages/util.go
+++ b/pkg/logentry/stages/util.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -64,6 +65,19 @@ func convertDateLayout(predef string, location *time.Location) parser {
 		}
 	case "Unix":
 		return func(t string) (time.Time, error) {
+			if strings.Count(t, ".") == 1 {
+				split := strings.Split(t, ".")
+				sec, err := strconv.ParseInt(split[0], 10, 64)
+				if err != nil {
+					return time.Time{}, err
+				}
+				frac, err := strconv.ParseInt(split[1], 10, 64)
+				if err != nil {
+					return time.Time{}, err
+				}
+				nsec := int64(float64(frac) * math.Pow(10, float64(9-len(split[1]))))
+				return time.Unix(sec, nsec), nil
+			}
 			i, err := strconv.ParseInt(t, 10, 64)
 			if err != nil {
 				return time.Time{}, err

--- a/pkg/logentry/stages/util.go
+++ b/pkg/logentry/stages/util.go
@@ -68,7 +68,7 @@ func convertDateLayout(predef string, location *time.Location) parser {
 			if strings.Count(t, ".") == 1 {
 				split := strings.Split(t, ".")
 				if len(split) != 2 {
-					return time.Time{}, fmt.Errorf("Can't split %v into two parts", t)
+					return time.Time{}, fmt.Errorf("can't split %v into two parts", t)
 				}
 				sec, err := strconv.ParseInt(split[0], 10, 64)
 				if err != nil {


### PR DESCRIPTION
If the timestamp contains a `.`, parse the fractions into nanoseconds.

**What this PR does / why we need it**:
See #2193

**Which issue(s) this PR fixes**:
Fixes #2193

**Special notes for your reviewer**:
There might be a nicer way, but I'm a Go newbie...

**Checklist**
- [x] Documentation added
- [x] Tests updated

