### PR TITLE
Fixes buffered iterator skipping very long lines.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -699,7 +699,7 @@ func (si *bufferedIterator) moveNext() (int64, []byte, bool) {
 	}
 	for n < lineSize {
 		r, err := si.bufReader.Read(si.buf[n:lineSize])
-		if err != nil {
+		if err != nil && err != io.EOF {
 			si.err = err
 			return 0, nil, false
 		}


### PR DESCRIPTION
Funny enough this was triggered only with gzip and only with a certain size. But thanks for investigation here #2272 I was able to reproduce this with a test and indeed this was incorrect.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

Fixes #2272

Thanks @quchenyuan for your tenacity !