### PR TITLE
Added a link to the replace parsing stage

### DIFF
--- a/docs/clients/promtail/stages/README.md
+++ b/docs/clients/promtail/stages/README.md
@@ -9,6 +9,7 @@ Parsing stages:
   * [cri](./cri.md): Extract data by parsing the log line using the standard CRI format.
   * [regex](./regex.md): Extract data using a regular expression.
   * [json](./json.md): Extract data by parsing the log line as JSON.
+  * [replace](./replace.md): Replace data using a regular expression.
 
 Transform stages:
 


### PR DESCRIPTION
Added a link to the `replace` parsing stage. This was missing from the README.md

**Checklist**
- [X] Documentation added
- [ ] Tests updated

