### PR TITLE
Loki: Use a new context to update the ring state after a failed chunk transfer

### DIFF
--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -63,7 +63,7 @@ func (i *Ingester) TransferChunks(stream logproto.Ingester_TransferChunksServer)
 			// a failed transfer to try again.  If we fail to set the state back to PENDING then
 			// exit Loki as we will effectively be hung anyway stuck in a JOINING state and will
 			// never join.
-			ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			if err := i.lifecycler.ChangeState(ctx, ring.PENDING); err != nil {
 				level.Error(logger).Log("msg", "failed to update the ring state back to PENDING after "+
 					"a chunk transfer failure, there is nothing more Loki can do from this state "+

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -63,7 +63,6 @@ func (i *Ingester) TransferChunks(stream logproto.Ingester_TransferChunksServer)
 			// a failed transfer to try again.  If we fail to set the state back to PENDING then
 			// exit Loki as we will effectively be hung anyway stuck in a JOINING state and will
 			// never join.
-			ctx := context.Background()
 			ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 			if err := i.lifecycler.ChangeState(ctx, ring.PENDING); err != nil {
 				level.Error(logger).Log("msg", "failed to update the ring state back to PENDING after "+


### PR DESCRIPTION
Previously the GRPC stream context was used to update the ring state back to PENDING after a failed chunk transfer. 
However if the transfer failed because of a GRPC error this context would get canceled and this would prevent Loki from updating the ring state and it would force an os.Exit

This change uses a new context to update the ring state after a failed transfer to avoid this issue and also makes the error message more clear to explain why the loki process exits.