### PR TITLE
loki-docker-driver: Change "ignoring empty line" to debug logging

### DIFF
--- a/cmd/docker-driver/loki.go
+++ b/cmd/docker-driver/loki.go
@@ -53,7 +53,7 @@ func New(logCtx logger.Info, logger log.Logger) (logger.Logger, error) {
 // Log implements `logger.Logger`
 func (l *loki) Log(m *logger.Message) error {
 	if len(bytes.Fields(m.Line)) == 0 {
-		level.Info(l.logger).Log("msg", "ignoring empty line", "line", string(m.Line))
+		level.Debug(l.logger).Log("msg", "ignoring empty line", "line", string(m.Line))
 		return nil
 	}
 	lbs := l.labels.Clone()


### PR DESCRIPTION
Signed-off-by: Johnathan Falk <johnathan.falk@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR changes the error message "ignoring empty line" to be a debug not info message so it doesn't clutter and destroy logs.

**Which issue(s) this PR fixes**:
Fixes #2342

**Special notes for your reviewer**:
One misbehaving docker container can spam millions of messages in day by having this as default info. Yes you should fix the container, but this also shouldn't fill my log drive with useless messages.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

