### PR TITLE
Loki-Canary: Add query spot checking and metric count checking

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -48,7 +48,8 @@ func main() {
 		"also the frequency which queries for missing logs will be dispatched to loki, and the frequency spot check queries are run")
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
-	//countOverTimeQueryDuration := flag.Duration("count-over-time-duration", 24*time.Hour, "The range value [4h] used in the count_over_time instant-query")
+	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
+	metrictTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query")
 
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
@@ -80,7 +81,7 @@ func main() {
 
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
 		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *queryTimeout, *lName, *lVal, *sName, *sValue)
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *buckets, sentChan, receivedChan, c.reader, true)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *metricTestInterval, *metrictTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -55,6 +55,7 @@ func main() {
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
 	spotCheckMax := flag.Duration("spot-check-max", 4*time.Hour, "How far back to check a spot check entry before dropping it")
+	spotCheckQueryRate := flag.Duration("spot-check-query-rate", 1*time.Minute, "Interval that the canary will query Loki for the current list of all spot check entries")
 
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 
@@ -82,7 +83,7 @@ func main() {
 
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
 		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *queryTimeout, *lName, *lVal, *sName, *sValue)
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -49,7 +49,8 @@ func main() {
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
 	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
-	metricTestQueryRange := flag.String("metric-test-range", "24h", "The range value [24h] used in the metric test instant-query")
+	metricTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query."+
+		" Note: this value is truncated to the running time of the canary until this value is reached")
 
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
@@ -58,12 +59,6 @@ func main() {
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 
 	flag.Parse()
-
-	_, err := time.ParseDuration(*metricTestQueryRange)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to parse metric-test-range as a duration string: %v", err.Error())
-		os.Exit(1)
-	}
 
 	if *printVersion {
 		fmt.Println(version.Print("loki-canary"))

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -39,12 +39,20 @@ func main() {
 	tls := flag.Bool("tls", false, "Does the loki connection use TLS?")
 	user := flag.String("user", "", "Loki username")
 	pass := flag.String("pass", "", "Loki password")
+	queryTimeout := flag.Duration("query-timeout", 10*time.Second, "How long to wait for a query response from Loki")
 
 	interval := flag.Duration("interval", 1000*time.Millisecond, "Duration between log entries")
 	size := flag.Int("size", 100, "Size in bytes of each log line")
 	wait := flag.Duration("wait", 60*time.Second, "Duration to wait for log entries before reporting them lost")
-	pruneInterval := flag.Duration("pruneinterval", 60*time.Second, "Frequency to check sent vs received logs, also the frequency which queries for missing logs will be dispatched to loki")
+	pruneInterval := flag.Duration("pruneinterval", 60*time.Second, "Frequency to check sent vs received logs, "+
+		"also the frequency which queries for missing logs will be dispatched to loki, and the frequency spot check queries are run")
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
+
+	//countOverTimeQueryDuration := flag.Duration("count-over-time-duration", 24*time.Hour, "The range value [4h] used in the count_over_time instant-query")
+
+	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
+		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
+	spotCheckMax := flag.Duration("spot-check-max", 4*time.Hour, "How far back to check a spot check entry before dropping it")
 
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 
@@ -71,8 +79,8 @@ func main() {
 		defer c.lock.Unlock()
 
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
-		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *lName, *lVal, *sName, *sValue)
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *buckets, sentChan, receivedChan, c.reader, true)
+		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *queryTimeout, *lName, *lVal, *sName, *sValue)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -49,7 +49,7 @@ func main() {
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
 	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
-	metrictTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query")
+	metricTestQueryRange := flag.String("metric-test-range", "24h", "The range value [24h] used in the metric test instant-query")
 
 	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
 		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
@@ -58,6 +58,12 @@ func main() {
 	printVersion := flag.Bool("version", false, "Print this builds version information")
 
 	flag.Parse()
+
+	_, err := time.ParseDuration(*metricTestQueryRange)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse metric-test-range as a duration string: %v", err.Error())
+		os.Exit(1)
+	}
 
 	if *printVersion {
 		fmt.Println(version.Print("loki-canary"))
@@ -81,7 +87,7 @@ func main() {
 
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
 		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *queryTimeout, *lName, *lVal, *sName, *sValue)
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *metricTestInterval, *metrictTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/pkg/canary/comparator/comparator.go
+++ b/pkg/canary/comparator/comparator.go
@@ -26,37 +26,37 @@ const (
 var (
 	totalEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "total_entries",
+		Name:      "entries_total",
 		Help:      "counts log entries written to the file",
 	})
 	outOfOrderEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "out_of_order_entries",
+		Name:      "out_of_order_entries_total",
 		Help:      "counts log entries received with a timestamp more recent than the others in the queue",
 	})
 	wsMissingEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "websocket_missing_entries",
+		Name:      "websocket_missing_entries_total",
 		Help:      "counts log entries not received within the maxWait duration via the websocket connection",
 	})
 	missingEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "missing_entries",
+		Name:      "missing_entries_total",
 		Help:      "counts log entries not received within the maxWait duration via both websocket and direct query",
 	})
 	spotCheckMissing = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "spot_check_missing_entries",
+		Name:      "spot_check_missing_entries_total",
 		Help:      "counts log entries not received when directly queried as part of spot checking",
 	})
 	unexpectedEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "unexpected_entries",
+		Name:      "unexpected_entries_total",
 		Help:      "counts a log entry received which was not expected (e.g. received after reported missing)",
 	})
 	duplicateEntries = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "loki_canary",
-		Name:      "duplicate_entries",
+		Name:      "duplicate_entries_total",
 		Help:      "counts a log entry received more than one time",
 	})
 	metricTestDeviation = promauto.NewGauge(prometheus.GaugeOpts{

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -19,7 +19,7 @@ func TestComparatorEntryReceivedOutOfOrder(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -60,7 +60,7 @@ func TestComparatorEntryReceivedNotExpected(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -101,7 +101,7 @@ func TestComparatorEntryReceivedDuplicate(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -158,7 +158,7 @@ func TestEntryNeverReceived(t *testing.T) {
 	mr := &mockReader{found}
 	maxWait := 50 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	c.entrySent(t1)
 	c.entrySent(t2)
@@ -216,7 +216,7 @@ func TestPruneAckdEntires(t *testing.T) {
 	actual := &bytes.Buffer{}
 	maxWait := 30 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Millisecond)
@@ -274,7 +274,7 @@ func TestSpotCheck(t *testing.T) {
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 10 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, spotCheck, spotCheckMax, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, spotCheck, spotCheckMax, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	// Send all the entries
 	for i := range entries {
@@ -336,4 +336,8 @@ type mockReader struct {
 
 func (r *mockReader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	return r.resp, nil
+}
+
+func (r *mockReader) QueryCountOverTime(queryRange time.Duration) (float64, error) {
+	return 0, nil
 }

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -155,7 +155,7 @@ func TestEntryNeverReceived(t *testing.T) {
 
 	found := []time.Time{t1, t3, t4, t5}
 
-	mr := &mockReader{found}
+	mr := &mockReader{resp: found}
 	maxWait := 50 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
 	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
@@ -270,7 +270,7 @@ func TestSpotCheck(t *testing.T) {
 		}
 	}
 
-	mr := &mockReader{found}
+	mr := &mockReader{resp: found}
 	maxWait := 50 * time.Millisecond
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 10 * time.Millisecond
@@ -306,6 +306,48 @@ func TestSpotCheck(t *testing.T) {
 	prometheus.Unregister(responseLatency)
 }
 
+func TestMetricTest(t *testing.T) {
+	metricTestDeviation = &mockGauge{}
+
+	actual := &bytes.Buffer{}
+
+	writeInterval := 500 * time.Millisecond
+
+	mr := &mockReader{}
+	maxWait := 50 * time.Millisecond
+	metricTestRange := 30 * time.Second
+	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
+	c := NewComparator(actual, maxWait, 50*time.Hour, 0, 0, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	// Force the start time to a known value
+	c.startTime = time.Unix(10, 0)
+
+	// Run test at time 20s which is 10s after start
+	mr.countOverTime = float64((10 * time.Second).Milliseconds()) / float64(writeInterval.Milliseconds())
+	c.metricTest(time.Unix(0, 20*time.Second.Nanoseconds()))
+	// We want to look back 30s but have only been running from time 10s to time 20s so the query range should be adjusted to 10s
+	assert.Equal(t, "10s", mr.queryRange)
+	// Should be no deviation we set countOverTime to the runtime/writeinterval which should be what metrictTest expected
+	assert.Equal(t, float64(0), metricTestDeviation.(*mockGauge).val)
+
+	// Run test at time 30s which is 20s after start
+	mr.countOverTime = float64((20 * time.Second).Milliseconds()) / float64(writeInterval.Milliseconds())
+	c.metricTest(time.Unix(0, 30*time.Second.Nanoseconds()))
+	// We want to look back 30s but have only been running from time 10s to time 20s so the query range should be adjusted to 10s
+	assert.Equal(t, "20s", mr.queryRange)
+	// Gauge should be equal to the countOverTime value
+	assert.Equal(t, float64(0), metricTestDeviation.(*mockGauge).val)
+
+	// Run test 60s after start, we should now be capping the query range to 30s and expecting only 30s of counts
+	mr.countOverTime = float64((30 * time.Second).Milliseconds()) / float64(writeInterval.Milliseconds())
+	c.metricTest(time.Unix(0, 60*time.Second.Nanoseconds()))
+	// We want to look back 30s but have only been running from time 10s to time 20s so the query range should be adjusted to 10s
+	assert.Equal(t, "30s", mr.queryRange)
+	// Gauge should be equal to the countOverTime value
+	assert.Equal(t, float64(0), metricTestDeviation.(*mockGauge).val)
+
+	prometheus.Unregister(responseLatency)
+}
+
 type mockCounter struct {
 	cLck  sync.Mutex
 	count int
@@ -337,8 +379,57 @@ func (m *mockCounter) Inc() {
 	m.count++
 }
 
+type mockGauge struct {
+	cLck sync.Mutex
+	val  float64
+}
+
+func (m *mockGauge) Desc() *prometheus.Desc {
+	panic("implement me")
+}
+
+func (m *mockGauge) Write(*io_prometheus_client.Metric) error {
+	panic("implement me")
+}
+
+func (m *mockGauge) Describe(chan<- *prometheus.Desc) {
+	panic("implement me")
+}
+
+func (m *mockGauge) Collect(chan<- prometheus.Metric) {
+	panic("implement me")
+}
+
+func (m *mockGauge) Set(v float64) {
+	m.cLck.Lock()
+	m.val = v
+	m.cLck.Unlock()
+}
+
+func (m *mockGauge) Inc() {
+	panic("implement me")
+}
+
+func (m *mockGauge) Dec() {
+	panic("implement me")
+}
+
+func (m *mockGauge) Add(float64) {
+	panic("implement me")
+}
+
+func (m *mockGauge) Sub(float64) {
+	panic("implement me")
+}
+
+func (m *mockGauge) SetToCurrentTime() {
+	panic("implement me")
+}
+
 type mockReader struct {
-	resp []time.Time
+	resp          []time.Time
+	countOverTime float64
+	queryRange    string
 }
 
 func (r *mockReader) Query(start time.Time, end time.Time) ([]time.Time, error) {
@@ -346,5 +437,6 @@ func (r *mockReader) Query(start time.Time, end time.Time) ([]time.Time, error) 
 }
 
 func (r *mockReader) QueryCountOverTime(queryRange string) (float64, error) {
-	return 0, nil
+	r.queryRange = queryRange
+	return r.countOverTime, nil
 }

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -338,6 +338,6 @@ func (r *mockReader) Query(start time.Time, end time.Time) ([]time.Time, error) 
 	return r.resp, nil
 }
 
-func (r *mockReader) QueryCountOverTime(queryRange time.Duration) (float64, error) {
+func (r *mockReader) QueryCountOverTime(queryRange string) (float64, error) {
 	return 0, nil
 }

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -19,7 +19,7 @@ func TestComparatorEntryReceivedOutOfOrder(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -60,7 +60,7 @@ func TestComparatorEntryReceivedNotExpected(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -101,7 +101,7 @@ func TestComparatorEntryReceivedDuplicate(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -158,7 +158,7 @@ func TestEntryNeverReceived(t *testing.T) {
 	mr := &mockReader{resp: found}
 	maxWait := 50 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	c.entrySent(t1)
 	c.entrySent(t2)
@@ -216,7 +216,7 @@ func TestPruneAckdEntires(t *testing.T) {
 	actual := &bytes.Buffer{}
 	maxWait := 30 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Millisecond)
@@ -275,7 +275,7 @@ func TestSpotCheck(t *testing.T) {
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 10 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, spotCheck, spotCheckMax, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	// Send all the entries
 	for i := range entries {
@@ -317,7 +317,7 @@ func TestMetricTest(t *testing.T) {
 	maxWait := 50 * time.Millisecond
 	metricTestRange := 30 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 0, 0, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, maxWait, 50*time.Hour, 0, 0, 4*time.Hour, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -293,6 +293,11 @@ func TestSpotCheck(t *testing.T) {
 	expected := fmt.Sprintf(ErrSpotCheckEntryNotReceived, // List entry not received from Loki
 		entries[20].UnixNano(), "-9ms")
 
+	// We didn't send the last entry and our initial counter did not start at 0 so we should get back entries 1-19
+	for i := 1; i < 20; i++ {
+		expected = expected + fmt.Sprintf(DebugQueryResult, entries[i].UnixNano())
+	}
+
 	assert.Equal(t, expected, actual.String())
 
 	assert.Equal(t, 2, spotCheckEntries.(*mockCounter).count)

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -253,6 +253,7 @@ func TestPruneAckdEntires(t *testing.T) {
 
 func TestSpotCheck(t *testing.T) {
 	spotCheckMissing = &mockCounter{}
+	spotCheckEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
 
@@ -290,10 +291,11 @@ func TestSpotCheck(t *testing.T) {
 	assert.Equal(t, 2, len(c.spotCheck))
 
 	expected := fmt.Sprintf(ErrSpotCheckEntryNotReceived, // List entry not received from Loki
-		entries[20], "9ms")
+		entries[20].UnixNano(), "-9ms")
 
 	assert.Equal(t, expected, actual.String())
 
+	assert.Equal(t, 2, spotCheckEntries.(*mockCounter).count)
 	assert.Equal(t, 1, spotCheckMissing.(*mockCounter).count)
 
 	prometheus.Unregister(responseLatency)

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -126,7 +126,7 @@ func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
 		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s])", r.sName, r.sValue, r.lName, r.lVal, queryRange)) +
 			"&limit=1000",
 	}
-	fmt.Fprintf(r.w, "Querying loki for missing values with query: %v\n", u.String())
+	fmt.Fprintf(r.w, "Querying loki for metric count with query: %v\n", u.String())
 
 	ctx, cancel := context.WithTimeout(context.Background(), r.queryTimeout)
 	defer cancel()
@@ -191,7 +191,7 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 			"&query=" + url.QueryEscape(fmt.Sprintf("{%v=\"%v\",%v=\"%v\"}", r.sName, r.sValue, r.lName, r.lVal)) +
 			"&limit=1000",
 	}
-	fmt.Fprintf(r.w, "Querying loki for missing values with query: %v\n", u.String())
+	fmt.Fprintf(r.w, "Querying loki for logs with query: %v\n", u.String())
 
 	ctx, cancel := context.WithTimeout(context.Background(), r.queryTimeout)
 	defer cancel()


### PR DESCRIPTION
The current canary implementation has been expanded to take a sample of entries created and query for them over time at a regular interval.

This should better exercise querying data as it moves from inmemory in ingesters to chunk storage to make sure data is consistently returned.

Additionally a metric query is run to count the logs over a period of time, this is helpful to exercise the Loki metrics query path as well as another sanity check that log data is being stored and retrieved properly.