### PR TITLE
Loki: runtime option overrides

### DIFF
--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 	"gopkg.in/yaml.v2"
 
+	"github.com/grafana/loki/pkg/util/runtime"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
@@ -14,7 +15,8 @@ import (
 // Reloading is done by runtimeconfig.Manager, which also keeps the currently loaded config.
 // These values are then pushed to the components that are interested in them.
 type runtimeConfigValues struct {
-	TenantLimits map[string]*validation.Limits `yaml:"overrides"`
+	TenantLimits         map[string]*validation.Limits `yaml:"overrides"`
+	TenantRuntimeOptions map[string]*runtime.Options   `yaml:"runtime_options"`
 
 	Multi kv.MultiRuntimeConfig `yaml:"multi_kv_config"`
 }
@@ -44,6 +46,17 @@ func tenantLimitsFromRuntimeConfig(c *runtimeconfig.Manager) validation.TenantLi
 		}
 
 		return cfg.TenantLimits[userID]
+	}
+}
+
+func tenantOptionsFromRuntimeConfig(c *runtimeconfig.Manager) runtime.TenantOptions {
+	return func(userID string) *runtime.Options {
+		cfg, ok := c.GetConfig().(*runtimeConfigValues)
+		if !ok || cfg == nil {
+			return nil
+		}
+
+		return cfg.TenantRuntimeOptions[userID]
 	}
 }
 

--- a/pkg/util/runtime/runtime.go
+++ b/pkg/util/runtime/runtime.go
@@ -1,0 +1,43 @@
+package runtime
+
+// TenantOptions is a function that returns options for given tenant, or
+// nil, if there are no tenant-specific options.
+type TenantOptions func(userID string) *Options
+
+// Options describe all the runtime options that can be configured
+type Options struct {
+	LogLimits bool `yaml:"log_limits"`
+}
+
+type RuntimeOptions struct {
+	defaultOptions *Options
+	tenantOptions  TenantOptions
+}
+
+// NewRuntimeOptions makes a new RuntimeOptions.
+func NewRuntimeOptions(tenantOptions TenantOptions) (*RuntimeOptions, error) {
+	return &RuntimeOptions{
+		// Different from limits, Options do not have defaults outside of code defaults
+		// i.e. their defaults are defined here. The only possibility with RuntimeOptions
+		// are to change the value away from the default via the runtime overrides mechanism
+		defaultOptions: &Options{
+			LogLimits: false,
+		},
+		tenantOptions: tenantOptions,
+	}, nil
+}
+
+// LogLimits returns if log messages should be displayed for the provided tenant when hitting limits
+func (o *RuntimeOptions) LogLimits(tenantID string) bool {
+	return o.getOverridesForUser(tenantID).LogLimits
+}
+
+func (o *RuntimeOptions) getOverridesForUser(tenantID string) *Options {
+	if o.tenantOptions != nil {
+		l := o.tenantOptions(tenantID)
+		if l != nil {
+			return l
+		}
+	}
+	return o.defaultOptions
+}


### PR DESCRIPTION
We already have a framework for loading limits and overrides at runtime, however there are non limit type options I would like to be able to toggle at runtime.

The first such use case of this would be to configure per-tenant logging of limits being hit, this can be way too noisy to have enabled all the time but invaluable for helping debug tenants.

Rather than overload the existing 'limits' overrides this introduces a new RuntimeOptions for changing configs at runtime.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

