### PR TITLE
production/helm: Add projected and downwardAPI volume types to PodSecurityPolicy (#2355)

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.1.4
+version: 0.1.5
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/podsecuritypolicy.yaml
+++ b/production/helm/fluent-bit/templates/podsecuritypolicy.yaml
@@ -15,6 +15,8 @@ spec:
     - 'secret'
     - 'configMap'
     - 'hostPath'
+    - 'projected'
+    - 'downwardAPI'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.30.1
+version: 0.30.2
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/podsecuritypolicy.yaml
+++ b/production/helm/loki/templates/podsecuritypolicy.yaml
@@ -16,6 +16,8 @@ spec:
     - 'emptyDir'
     - 'persistentVolumeClaim'
     - 'secret'
+    - 'projected'
+    - 'downwardAPI'
   hostNetwork: false
   hostIPC: false
   hostPID: false
@@ -37,4 +39,3 @@ spec:
   requiredDropCapabilities:
     - ALL
 {{- end }}
-

--- a/production/helm/promtail/Chart.yaml
+++ b/production/helm/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.23.2
+version: 0.23.3
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Responsible for gathering logs and sending them to Loki"

--- a/production/helm/promtail/templates/podsecuritypolicy.yaml
+++ b/production/helm/promtail/templates/podsecuritypolicy.yaml
@@ -15,6 +15,8 @@ spec:
     - 'secret'
     - 'configMap'
     - 'hostPath'
+    - 'projected'
+    - 'downwardAPI'
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR adds the `projected` and `downwardAPI` volume types to the allowed list of volume types in the PodSecurityPolicy of the loki, promtail and fluent-bit Helm charts. See Issue #2355 for context.

**Which issue(s) this PR fixes**:
Fixes #2355 

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added **N/A**
- [ ] Tests updated **N/A**

