### PR TITLE
Loki Canary: One more round of improvements to query for missing websocket entries up to max-wait

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -43,9 +43,10 @@ func main() {
 
 	interval := flag.Duration("interval", 1000*time.Millisecond, "Duration between log entries")
 	size := flag.Int("size", 100, "Size in bytes of each log line")
-	wait := flag.Duration("wait", 60*time.Second, "Duration to wait for log entries before reporting them lost")
+	wait := flag.Duration("wait", 60*time.Second, "Duration to wait for log entries on websocket before querying loki for them")
+	maxWait := flag.Duration("max-wait", 5*time.Minute, "Duration to keep querying Loki for missing websocket entries before reporting them missing")
 	pruneInterval := flag.Duration("pruneinterval", 60*time.Second, "Frequency to check sent vs received logs, "+
-		"also the frequency which queries for missing logs will be dispatched to loki, and the frequency spot check queries are run")
+		"also the frequency which queries for missing logs will be dispatched to loki")
 	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
 	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
@@ -83,7 +84,7 @@ func main() {
 
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *size)
 		c.reader = reader.NewReader(os.Stderr, receivedChan, *tls, *addr, *user, *pass, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval)
-		c.comparator = comparator.NewComparator(os.Stderr, *wait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
+		c.comparator = comparator.NewComparator(os.Stderr, *wait, *maxWait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 
 	startCanary()

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -19,7 +19,7 @@ func TestComparatorEntryReceivedOutOfOrder(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -60,7 +60,7 @@ func TestComparatorEntryReceivedNotExpected(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
 	t1 := time.Now()
 	t2 := t1.Add(1 * time.Second)
@@ -101,9 +101,9 @@ func TestComparatorEntryReceivedDuplicate(t *testing.T) {
 	duplicateEntries = &mockCounter{}
 
 	actual := &bytes.Buffer{}
-	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 1*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
-	t1 := time.Now()
+	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Second)
 	t3 := t2.Add(1 * time.Second)
 	t4 := t3.Add(1 * time.Second)
@@ -147,18 +147,19 @@ func TestEntryNeverReceived(t *testing.T) {
 
 	actual := &bytes.Buffer{}
 
-	t1 := time.Now()
-	t2 := t1.Add(1 * time.Millisecond)
-	t3 := t2.Add(1 * time.Millisecond)
-	t4 := t3.Add(1 * time.Millisecond)
-	t5 := t4.Add(1 * time.Millisecond)
+	t1 := time.Unix(10, 0)
+	t2 := time.Unix(20, 0)
+	t3 := time.Unix(30, 0)
+	t4 := time.Unix(40, 0)
+	t5 := time.Unix(50, 0)
 
 	found := []time.Time{t1, t3, t4, t5}
 
 	mr := &mockReader{resp: found}
-	maxWait := 50 * time.Millisecond
+	wait := 60 * time.Second
+	maxWait := 300 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	c.entrySent(t1)
 	c.entrySent(t2)
@@ -174,27 +175,32 @@ func TestEntryNeverReceived(t *testing.T) {
 
 	assert.Equal(t, 2, c.Size())
 
-	//Wait a few maxWait intervals just to make sure all entries are expired
-	<-time.After(2 * maxWait)
+	//Set the time to 120s, this would be more than one wait (60s) and enough to go looking for the missing entries
+	c1Time := time.Unix(120, 0)
+	c.pruneEntries(c1Time)
+	assert.Equal(t, 1, len(c.missingEntries)) // One of the entries was found so only one should be missing
 
-	c.pruneEntries()
+	//Now set the time to 2x maxWait which should guarnatee we stopped looking for the other missing entry
+	c2Time := t1.Add(2 * maxWait)
+	c.pruneEntries(c2Time)
 
-	expected := fmt.Sprintf(ErrOutOfOrderEntry+ErrOutOfOrderEntry+ // Out of order because we missed entries
-		ErrEntryNotReceivedWs+ErrEntryNotReceivedWs+ // Complain about missed entries
-		DebugWebsocketMissingEntry+DebugWebsocketMissingEntry+ // List entries we are missing
-		DebugQueryResult+DebugQueryResult+DebugQueryResult+DebugQueryResult+ // List entries we got back from Loki
-		ErrEntryNotReceived, // List entry not received from Loki
-		t3, []time.Time{t2},
-		t5, []time.Time{t2, t4},
-		t2.UnixNano(), maxWait.Seconds(),
-		t4.UnixNano(), maxWait.Seconds(),
-		t2.UnixNano(),
-		t4.UnixNano(),
-		t1.UnixNano(),
-		t3.UnixNano(),
-		t4.UnixNano(),
-		t5.UnixNano(),
-		t2.UnixNano(), maxWait.Seconds())
+	expected := fmt.Sprintf(ErrOutOfOrderEntry+ErrOutOfOrderEntry+ // 1 Out of order because we missed entries
+		ErrEntryNotReceivedWs+ErrEntryNotReceivedWs+ // 2 Log that entries weren't received over websocket
+		DebugWebsocketMissingEntry+DebugWebsocketMissingEntry+ // 3 List entries we are missing
+		DebugQueryResult+DebugQueryResult+DebugQueryResult+DebugQueryResult+ // 4 List entries we got back from Loki
+		DebugEntryFound+ // 5 We log when t4 was found on followup query
+		DebugWebsocketMissingEntry+ // 6 Log missing entries on second run of pruneEntries
+		DebugQueryResult+DebugQueryResult+DebugQueryResult+DebugQueryResult+ // 7 Because we call pruneEntries twice we get the confirmation query results back twice
+		ErrEntryNotReceived, // 8 List entry we never received and is missing completely
+
+		t3, []time.Time{t2}, t5, []time.Time{t2, t4}, // 1 Out of order entry params
+		t2.UnixNano(), wait.Seconds(), t4.UnixNano(), wait.Seconds(), // 2 Entry not received over websocket params
+		t2.UnixNano(), t4.UnixNano(), // 3 Missing entries
+		t1.UnixNano(), t3.UnixNano(), t4.UnixNano(), t5.UnixNano(), // 4 Confirmation query results first run
+		t4.UnixNano(), c1Time.Sub(t4).Seconds(), // 5 t4 Entry found in follow up query
+		t2.UnixNano(),                                              // 6 Missing Entry
+		t1.UnixNano(), t3.UnixNano(), t4.UnixNano(), t5.UnixNano(), // 7 Confirmation query results second run
+		t2.UnixNano(), maxWait.Seconds()) // 8 Entry never found
 
 	assert.Equal(t, expected, actual.String())
 	assert.Equal(t, 0, c.Size())
@@ -214,11 +220,12 @@ func TestEntryNeverReceived(t *testing.T) {
 
 func TestPruneAckdEntires(t *testing.T) {
 	actual := &bytes.Buffer{}
+	wait := 30 * time.Millisecond
 	maxWait := 30 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call pruneEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
+	c := NewComparator(actual, wait, maxWait, 50*time.Hour, 15*time.Minute, 4*time.Hour, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), nil, false)
 
-	t1 := time.Now()
+	t1 := time.Unix(0, 0)
 	t2 := t1.Add(1 * time.Millisecond)
 	t3 := t2.Add(1 * time.Millisecond)
 	t4 := t3.Add(100 * time.Second)
@@ -242,9 +249,8 @@ func TestPruneAckdEntires(t *testing.T) {
 	assert.Equal(t, 4, len(c.ackdEntries))
 
 	// Wait a couple maxWaits to make sure the first 3 timestamps get pruned from the ackdEntries,
-	// the fourth should still remain because its much much newer and we only prune things older than maxWait
-	<-time.After(2 * maxWait)
-	c.pruneEntries()
+	// the fourth should still remain because its much much newer and we only prune things older than wait
+	c.pruneEntries(t1.Add(2 * maxWait))
 
 	assert.Equal(t, 1, len(c.ackdEntries))
 	assert.Equal(t, t4, *c.ackdEntries[0])
@@ -271,11 +277,10 @@ func TestSpotCheck(t *testing.T) {
 	}
 
 	mr := &mockReader{resp: found}
-	maxWait := 50 * time.Millisecond
 	spotCheck := 10 * time.Millisecond
 	spotCheckMax := 10 * time.Millisecond
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, spotCheck, spotCheckMax, 4*time.Hour, 1*time.Minute, 0, 0, 1, make(chan time.Time), make(chan time.Time), mr, false)
 
 	// Send all the entries
 	for i := range entries {
@@ -315,10 +320,9 @@ func TestMetricTest(t *testing.T) {
 	writeInterval := 500 * time.Millisecond
 
 	mr := &mockReader{}
-	maxWait := 50 * time.Millisecond
 	metricTestRange := 30 * time.Second
 	//We set the prune interval timer to a huge value here so that it never runs, instead we call spotCheckEntries manually below
-	c := NewComparator(actual, maxWait, 50*time.Hour, 0, 0, 4*time.Hour, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
+	c := NewComparator(actual, 1*time.Hour, 1*time.Hour, 50*time.Hour, 0, 0, 4*time.Hour, 10*time.Minute, metricTestRange, writeInterval, 1, make(chan time.Time), make(chan time.Time), mr, false)
 	// Force the start time to a known value
 	c.startTime = time.Unix(10, 0)
 
@@ -350,6 +354,26 @@ func TestMetricTest(t *testing.T) {
 	assert.Equal(t, float64(60), metricTestActual.(*mockGauge).val)
 
 	prometheus.Unregister(responseLatency)
+}
+
+func Test_pruneList(t *testing.T) {
+	t1 := time.Unix(0, 0)
+	t2 := time.Unix(1, 0)
+	t3 := time.Unix(2, 0)
+	t4 := time.Unix(3, 0)
+	t5 := time.Unix(4, 0)
+
+	list := []*time.Time{&t1, &t2, &t3, &t4, &t5}
+
+	outList := pruneList(list, func(_ int, ts *time.Time) bool {
+		// Sorry t2, nobody likes you
+		return ts.Equal(t2)
+	}, func(i int, ts *time.Time) {
+		assert.Equal(t, 1, i)
+		assert.Equal(t, t2, *ts)
+	})
+
+	assert.Equal(t, []*time.Time{&t1, &t3, &t4, &t5}, outList)
 }
 
 type mockCounter struct {


### PR DESCRIPTION
With `wait` set to only 1 min when we miss a websocket entry we check for it after 1 minute but only check one time.

If promtail was delayed or another hiccup existed somewhere the entry could still make it but later.

This PR introduces `max-wait` where the canary will continue to check for missing entries up to this time before officially marking them lost.

There was also a repeating pattern of removing elements from a slice which I extracted into a dedicated function for better reuse