### PR TITLE
Fixes the fluentbit batchwait  backward compatiblity.

### DIFF
--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -75,11 +75,17 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 
 	batchWait := cfg.Get("BatchWait")
 	if batchWait != "" {
-		batchWaitValue, err := time.ParseDuration(batchWait)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse BatchWait: %s", batchWait)
+		// first try to parse as seconds format.
+		batchWaitSeconds, err := strconv.Atoi(batchWait)
+		if err == nil {
+			res.clientConfig.BatchWait = time.Duration(batchWaitSeconds) * time.Second
+		} else {
+			batchWaitValue, err := time.ParseDuration(batchWait)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse BatchWait: %s", batchWait)
+			}
+			res.clientConfig.BatchWait = batchWaitValue
 		}
-		res.clientConfig.BatchWait = batchWaitValue
 	}
 
 	batchSize := cfg.Get("BatchSize")

--- a/cmd/fluent-bit/config_test.go
+++ b/cmd/fluent-bit/config_test.go
@@ -58,7 +58,7 @@ func Test_parseConfig(t *testing.T) {
 				"LogLevel":      "warn",
 				"Labels":        `{app="foo"}`,
 				"BatchSize":     "100",
-				"BatchWait":     "30s",
+				"BatchWait":     "30",
 				"Timeout":       "1s",
 				"RemoveKeys":    "buzz,fuzz",
 				"LabelKeys":     "foo,bar",

--- a/cmd/fluent-bit/fluent-bit.conf
+++ b/cmd/fluent-bit/fluent-bit.conf
@@ -5,7 +5,7 @@
     Name loki
     Match *
     Url ${LOKI_URL}
-    BatchWait 1
+    BatchWait 1s
     BatchSize 1001024
     Labels {job="fluent-bit"}
     LineFormat json


### PR DESCRIPTION
We move from second `1` to duration `1s`, but we can keep that compatible.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

Fixes https://github.com/grafana/loki/issues/2372

