### PR TITLE
Docs: Fix Fluentd title (visible in menu)

### DIFF
--- a/docs/sources/clients/fluentd/_index.md
+++ b/docs/sources/clients/fluentd/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Fulentd
+title: Fluentd
 ---
 # Fluentd
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**: During our weekly [#everyonecancontribute Kaeffchen (German coffee chat)](https://everyonecancontribute.com/post/2020-07-22-kaeffchen-10/), we peeked into the Loki docs. There is a typo in the title which renders the menu title wrong. This PR fixes this, you likely need to sync it later reading the latest commits.

![Screenshot 2020-07-23 at 13 12 03](https://user-images.githubusercontent.com/382049/88280711-96a28880-cce6-11ea-89d6-06ecc2a5d88f.png)

<!--
**Which issue(s) this PR fixes**:
Fixes #<issue number>
-->

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

