### PR TITLE
Helm: Fix regression in chart name

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.38.2
+version: 0.38.3
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/requirements.yaml
+++ b/production/helm/loki-stack/requirements.yaml
@@ -2,15 +2,15 @@ dependencies:
 - name: "loki"
   condition: loki.enabled
   repository: "file://../loki"
-  version: "^0.6.0"
+  version: "^0.30.0"
 - name: "promtail"
   condition: promtail.enabled
   repository: "file://../promtail"
-  version: "^0.6.0"
+  version: "^0.23.0"
 - name: "fluent-bit"
   condition: fluent-bit.enabled
   repository: "file://../fluent-bit"
-  version: "^0.0.1"
+  version: "^0.1.0"
 - name: "grafana"
   condition: grafana.enabled
   version: "~3.8.15"

--- a/production/helm/loki-stack/values.yaml
+++ b/production/helm/loki-stack/values.yaml
@@ -1,11 +1,8 @@
 loki:
-  fullnameOverride: loki
   enabled: true
 
 promtail:
   enabled: true
-  loki:
-    serviceName: loki
 
 fluent-bit:
   enabled: false
@@ -41,7 +38,6 @@ filebeat:
 
 logstash:
   enabled: false
-  fullnameOverride: logstash-loki
   image:
     repository: grafana/logstash-output-loki
     tag: 1.0.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a regression caused by the Logstash PR #1822. That PR populated the `fullnameOverride` for sub-charts, breaking existing deployments and external resources depending upon the release-prefixed service name. `fullnameOverride` is an optional field for users to override the name, it shouldn't be set by charts. Helm best practice is that workload names contain the release name so that you can deploy the same chart multiple times to the same namespace.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

