### PR TITLE
Add RegisterFlagsWithPrefix to config structs

### DIFF
--- a/pkg/promtail/config/config.go
+++ b/pkg/promtail/config/config.go
@@ -21,10 +21,16 @@ type Config struct {
 	TargetConfig    file.Config           `yaml:"target_config,omitempty"`
 }
 
+// RegisterFlags with prefix registers flags where every name is prefixed by
+// prefix. If prefix is a non-empty string, prefix should end with a period.
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	c.ServerConfig.RegisterFlagsWithPrefix(prefix, f)
+	c.ClientConfig.RegisterFlagsWithPrefix(prefix, f)
+	c.PositionsConfig.RegisterFlagsWithPrefix(prefix, f)
+	c.TargetConfig.RegisterFlagsWithPrefix(prefix, f)
+}
+
 // RegisterFlags registers flags.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	c.ServerConfig.RegisterFlags(f)
-	c.ClientConfig.RegisterFlags(f)
-	c.PositionsConfig.RegisterFlags(f)
-	c.TargetConfig.RegisterFlags(f)
+	c.RegisterFlagsWithPrefix("", f)
 }

--- a/pkg/promtail/positions/positions.go
+++ b/pkg/promtail/positions/positions.go
@@ -26,11 +26,17 @@ type Config struct {
 	ReadOnly          bool          `yaml:"-"`
 }
 
+// RegisterFlags with prefix registers flags where every name is prefixed by
+// prefix. If prefix is a non-empty string, prefix should end with a period.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.SyncPeriod, prefix+"positions.sync-period", 10*time.Second, "Period with this to sync the position file.")
+	f.StringVar(&cfg.PositionsFile, prefix+"positions.file", "/var/log/positions.yaml", "Location to read/write positions from.")
+	f.BoolVar(&cfg.IgnoreInvalidYaml, prefix+"positions.ignore-invalid-yaml", false, "whether to ignore & later overwrite positions files that are corrupted")
+}
+
 // RegisterFlags register flags.
 func (cfg *Config) RegisterFlags(flags *flag.FlagSet) {
-	flags.DurationVar(&cfg.SyncPeriod, "positions.sync-period", 10*time.Second, "Period with this to sync the position file.")
-	flag.StringVar(&cfg.PositionsFile, "positions.file", "/var/log/positions.yaml", "Location to read/write positions from.")
-	flag.BoolVar(&cfg.IgnoreInvalidYaml, "positions.ignore-invalid-yaml", false, "whether to ignore & later overwrite positions files that are corrupted")
+	cfg.RegisterFlagsWithPrefix("", flags)
 }
 
 // Positions tracks how far through each file we've read.

--- a/pkg/promtail/server/server.go
+++ b/pkg/promtail/server/server.go
@@ -50,10 +50,18 @@ type Config struct {
 	Disable           bool   `yaml:"disable"`
 }
 
+// RegisterFlags with prefix registers flags where every name is prefixed by
+// prefix. If prefix is a non-empty string, prefix should end with a period.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	// NOTE: weaveworks server's config can't be registered with a prefix.
+	cfg.Config.RegisterFlags(f)
+
+	f.BoolVar(&cfg.Disable, prefix+"server.disable", false, "Disable the http and grpc server.")
+}
+
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.Config.RegisterFlags(f)
-	f.BoolVar(&cfg.Disable, "server.disable", false, "Disable the http and grpc server.")
+	cfg.RegisterFlagsWithPrefix("", f)
 }
 
 // New makes a new Server

--- a/pkg/promtail/targets/file/filetarget.go
+++ b/pkg/promtail/targets/file/filetarget.go
@@ -60,10 +60,16 @@ type Config struct {
 	Stdin      bool          `yaml:"stdin"`
 }
 
+// RegisterFlags with prefix registers flags where every name is prefixed by
+// prefix. If prefix is a non-empty string, prefix should end with a period.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.SyncPeriod, prefix+"target.sync-period", 10*time.Second, "Period to resync directories being watched and files being tailed.")
+	f.BoolVar(&cfg.Stdin, prefix+"stdin", false, "Set to true to pipe logs to promtail.")
+}
+
 // RegisterFlags register flags.
 func (cfg *Config) RegisterFlags(flags *flag.FlagSet) {
-	flags.DurationVar(&cfg.SyncPeriod, "target.sync-period", 10*time.Second, "Period to resync directories being watched and files being tailed.")
-	flags.BoolVar(&cfg.Stdin, "stdin", false, "Set to true to pipe logs to promtail.")
+	cfg.RegisterFlagsWithPrefix("", flags)
 }
 
 // FileTarget describes a particular set of logs.


### PR DESCRIPTION
All config structs now have a `RegisterFlagsWithPrefix` function that allows specifying a prefixed string to append to all flag names. This may be used by clients to namespace support for Promtail in a larger application (e.g., `grafana/agent`).

One exception to this is the Weaveworks server which doesn't currently have a RegisterFlagsWithPrefix function. This might be a problem down the line, but it's not a problem for my particular use case (I expose a subset of the Promtail config which doesn't include the weaveworks server). 

I noticed a few config structs were incorrectly registering to the global FlagSet rather than the FlagSet passed to `RegisterFlags`. This PR also includes a fix for that.

Related to #2405.
