### PR TITLE
Fix docker driver doc

### DIFF
--- a/docs/sources/clients/docker-driver/_index.md
+++ b/docs/sources/clients/docker-driver/_index.md
@@ -44,7 +44,7 @@ re-enabling:
 
 ```bash
 docker plugin disable loki
-docker plugin upgrade loki grafana/loki-docker-driver:master
+docker plugin upgrade loki grafana/loki-docker-driver:latest
 docker plugin enable loki
 ```
 


### PR DESCRIPTION
Had some trouble today understanding why loki driver stopped recognizing log-opts after upgrade. It was, until I figured out that `grafana/loki-docker-driver:master` image is actually 1 year old, and I should use `latest` instead.

This PR fixes Upgrading section by replacing incorrect tag in snippet.

By the way, consider the option of updating/deleting `master` tag in docker hub registry. It can eliminate this kind of problem. 