### PR TITLE
Template: Added a sha256 template function for obfuscating / anonymize PII data in e.g. the replace stage

### DIFF
--- a/docs/sources/clients/promtail/stages/replace.md
+++ b/docs/sources/clients/promtail/stages/replace.md
@@ -125,6 +125,29 @@ The log line would become
 11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" HttpStatusOk 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"
 ```
 
+### With `replace` value in `template` format with hashing for obfuscating data
+
+To obfuscate sensitive data, you can combine the `replace` stage with the `Sha256` template method
+
+```yaml
+- replace:
+    # SSN
+    expression: '([0-9]{3}-[0-9]{2}-[0-9]{4})'
+    replace: '*SSN*{{ .Value | Sha256 "salt" }}*'
+- replace:
+    # IP4
+    expression: '(\d{1,3}[.]\d{1,3}[.]\d{1,3}[.]\d{1,3})'
+    replace: '*IP4*{{ .Value | Sha256 "salt" }}*'    
+- replace:
+    # email
+    expression: '([\w\.=-]+@[\w\.-]+\.[\w]{2,64})'
+    replace: '*email*{{ .Value | Sha256 "salt" }}*'  
+- replace:
+    # creditcard
+    expression: '((?:\d[ -]*?){13,16})'
+    replace: '*creditcard*{{ .Value | Sha256 "salt" }}*'  
+```
+
 ### `replace` with named captured group
 
 Given the pipeline:

--- a/docs/sources/clients/promtail/stages/template.md
+++ b/docs/sources/clients/promtail/stages/template.md
@@ -178,3 +178,13 @@ and trailing white space removed, as defined by Unicode.
     source: output
     template: '{{ regexReplaceAllLiteral "(ts=)" .Value "timestamp=" }}'
 ```
+
+### Sha256
+
+`Sha256` returns a Sha256 hash of the string, represented as a hexadecimal number of 64 digits. It can be used to obfuscate sensitive data / PII in the logs. It requires a (fixed) salt value, to add complexity to low input domains (e.g. all possible Social Security Numbers)
+
+```yaml
+- template:
+    source: output
+    template: '{{ Sha256 .Value "salt" }}'
+```

--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -35,9 +35,8 @@ var (
 		"TrimSuffix": strings.TrimSuffix,
 		"TrimSpace":  strings.TrimSpace,
 		"Sha256": func(salt string, s string) string {
-			hasher := sha256.New()
-			hasher.Write([]byte(salt + s))
-			return hex.EncodeToString(hasher.Sum(nil))
+			hash := sha256.Sum256([]byte(salt + s))
+			return hex.EncodeToString(hash[:])
 		},
 		"regexReplaceAll": func(regex string, s string, repl string) string {
 			r := regexp.MustCompile(regex)

--- a/pkg/logentry/stages/template.go
+++ b/pkg/logentry/stages/template.go
@@ -2,6 +2,8 @@ package stages
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"reflect"
 	"regexp"
@@ -32,6 +34,11 @@ var (
 		"TrimPrefix": strings.TrimPrefix,
 		"TrimSuffix": strings.TrimSuffix,
 		"TrimSpace":  strings.TrimSpace,
+		"Sha256": func(salt string, s string) string {
+			hasher := sha256.New()
+			hasher.Write([]byte(salt + s))
+			return hex.EncodeToString(hasher.Sum(nil))
+		},
 		"regexReplaceAll": func(regex string, s string, repl string) string {
 			r := regexp.MustCompile(regex)
 			return r.ReplaceAllString(s, repl)

--- a/pkg/logentry/stages/template_test.go
+++ b/pkg/logentry/stages/template_test.go
@@ -342,6 +342,18 @@ func TestTemplateStage_Process(t *testing.T) {
 			map[string]interface{}{},
 			map[string]interface{}{},
 		},
+		"Sha256": {
+			TemplateConfig{
+				Source:   "testval",
+				Template: "{{ Sha256 .Value \"salt\" }}",
+			},
+			map[string]interface{}{
+				"testval": "this is PII data",
+			},
+			map[string]interface{}{
+				"testval": "de33958efc1d63cd095a30e308a209d8b4e25cb281799494528505459ed6b2f2",
+			},
+		},
 	}
 	for name, test := range tests {
 		test := test

--- a/pkg/logentry/stages/template_test.go
+++ b/pkg/logentry/stages/template_test.go
@@ -351,7 +351,7 @@ func TestTemplateStage_Process(t *testing.T) {
 				"testval": "this is PII data",
 			},
 			map[string]interface{}{
-				"testval": "de33958efc1d63cd095a30e308a209d8b4e25cb281799494528505459ed6b2f2",
+				"testval": "5526fd6f8ad457279cf8ff06453c6cb61bf479fa826e3b099caa6c846f9376f2",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `replace` pipeline stage allows the replacement of PII values, but no obfuscating/anonymization like https://github.com/y-ken/fluent-plugin-anonymizer. By calculating the hash of a known value, you retain the possibility to query on the hashed value, so no data is lost.

See this example where typical PII data like email and SSN are replaced with a hashed value

<img width="741" alt="image" src="https://user-images.githubusercontent.com/35603/88474101-d0ac9e00-cf23-11ea-87f0-98aa844fb51d.png">

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated

