### PR TITLE
fluent-plugin: Improve escaping in key_value format

### DIFF
--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -259,7 +259,13 @@ module Fluent
           when :key_value
             formatted_labels = []
             record.each do |k, v|
-              formatted_labels.push(%(#{k}="#{v}"))
+              # Escape double quotes and backslashes by prefixing them with a backslash
+              v = v.to_s.gsub(%r{(["\\])}, '\\\\\1')
+              if v.include?(' ') || v.include?('=')
+                formatted_labels.push(%(#{k}="#{v}"))
+              else
+                formatted_labels.push(%(#{k}=#{v}))
+              end
             end
             line = formatted_labels.join(' ')
           end


### PR DESCRIPTION
The `key_value` format does not seem to be well specified.
This change assumes "logfmt" as the format and escapes values accordingly.  
The code itself is lifted from here:
https://github.com/csquared/node-logfmt/blob/e279d43cde019acfcca0abe99ea6b7ce8327e1f7/lib/stringify.js

Grafana seems to handle values escaped in this manner much better than before.
e.g.: `query="{program="loki"}")` was shown as (IIRC) `query="{program=` and is now displayed correctly.

As an added bonus only values that require quoting will actually be quoted, improving readability and derived field regexes.