### PR TITLE
Split the Series API by 24h.

### DIFF
--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -216,7 +216,7 @@ func TestSeriesTripperware(t *testing.T) {
 
 	lreq := &LokiSeriesRequest{
 		Match:   []string{`{job="varlogs"}`},
-		StartTs: testTime.Add(-6 * time.Hour), // bigger than the limit
+		StartTs: testTime.Add(-48 * time.Hour), // bigger than the limit
 		EndTs:   testTime,
 		Path:    "/loki/api/v1/series",
 	}


### PR DESCRIPTION
We currently split too much by using the same split duration for query range.
Let's start with 24h, just tested in ops-tools and it works better.
We could later introduce a config.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>



