### PR TITLE
DOCS: clarified globbing behaviour of __path__ of the doublestar library

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -51,7 +51,7 @@ There are different types of labels present in Promtail:
   for the full list of Kubernetes meta labels.
 
 * The `__path__` label is a special label which Promtail uses after discovery to
-  figure out where the file to read is located. Wildcards are allowed.
+  figure out where the file to read is located. Wildcards are allowed, for example `/var/log/*.log` to get all files with a `log` extension in the specified directory, and `/var/log/**/*.log` for matching files and directories recursively.
 
 * The label `filename` is added for every file found in `__path__` to ensure the
   uniqueness of the streams. It is set to the absolute path of the file the line

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -51,7 +51,7 @@ There are different types of labels present in Promtail:
   for the full list of Kubernetes meta labels.
 
 * The `__path__` label is a special label which Promtail uses after discovery to
-  figure out where the file to read is located. Wildcards are allowed, for example `/var/log/*.log` to get all files with a `log` extension in the specified directory, and `/var/log/**/*.log` for matching files and directories recursively.
+  figure out where the file to read is located. Wildcards are allowed, for example `/var/log/*.log` to get all files with a `log` extension in the specified directory, and `/var/log/**/*.log` for matching files and directories recursively. For a full list of options check out the [docs for the library promtail uses.](https://github.com/bmatcuk/doublestar)
 
 * The label `filename` is added for every file found in `__path__` to ensure the
   uniqueness of the streams. It is set to the absolute path of the file the line


### PR DESCRIPTION
clarified globbing behaviour of __path__ of the doublestar library

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [ ] Tests updated

