### PR TITLE
Replace usage of sync/atomic with uber-go/atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ publish: dist
 
 lint:
 	GO111MODULE=on GOGC=10 golangci-lint run -v $(GOLANGCI_ARG)
+	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
 
 ########
 # Test #

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/ugorji/go v1.1.7 // indirect
 	github.com/weaveworks/common v0.0.0-20200625145055-4b1847531bc9
 	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50
+	go.uber.org/atomic v1.6.0
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	google.golang.org/grpc v1.29.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -20,6 +20,14 @@ RUN apk add --no-cache docker-cli
 FROM golang:1.14.2 as drone
 RUN GO111MODULE=on go get github.com/drone/drone-cli/drone@1fad337d74ca0ecf420993d9d2d7229a1c99f054
 
+# Install faillint used to lint go imports in CI.
+# This collisions with the version of go tools used in the base image, thus we install it in its own image and copy it over.
+# Error:
+#	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
+#   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
+FROM golang:1.14.2 as faillint
+RUN GO111MODULE=on go get github.com/fatih/faillint@v1.5.0
+
 FROM golang:1.14.2-stretch
 RUN apt-get update && \
     apt-get install -qy \
@@ -33,6 +41,7 @@ COPY --from=docker /usr/bin/docker /usr/bin/docker
 COPY --from=helm /usr/bin/helm /usr/bin/helm
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 COPY --from=drone /go/bin/drone /usr/bin/drone
+COPY --from=faillint /go/bin/faillint /usr/bin/faillint
 
 # Install some necessary dependencies.
 # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -984,6 +984,7 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.uber.org/atomic v1.6.0
+## explicit
 go.uber.org/atomic
 # go.uber.org/goleak v1.0.0
 go.uber.org/goleak


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**: Replaces all direct usages of `sync/atomic` with `go.uber.org/atomic`. That way we ensure that all access to variables that have atomic access is in fact always atomic.

**Which issue(s) this PR fixes**:
Partially addresses https://github.com/grafana/loki/issues/2448

**Special notes for your reviewer**: This only updates the code to use the alternative package. I haven't added any automation/linter to make sure that this is enforced.
For that, we could use [faillint](https://github.com/fatih/faillint), but I am not 100% sure of where this project is handling the installation of additional tools. Is that on `loki-build-image/Dockerfile`?

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

