### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Documentation owner: Diana Payton
+# Diana does not own the content, but assists with editing and updates
+/docs/ @oddlittlebird


### PR DESCRIPTION
Makes me a codeowner of the Loki docs folder so that I have more visibility of what is going on with Loki docs and can assist with editing and advice.

This change only adds me as a reviewer to PRs that touch the docs folder. It does not require my approval for merging content into the docs folder, so it will not block any work.