### PR TITLE
Docker logging driver: Add a keymod for the extra attributes from the Docker logging driver

### DIFF
--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -242,7 +242,7 @@ func parseConfig(logCtx logger.Info) (*config, error) {
 
 	// other labels coming from docker labels or env selected by user labels, labels-regex, env, env-regex config.
 	attrs, err := logCtx.ExtraAttributes(func(label string) string {
-                return strings.ReplaceAll(label, ".", "_")
+                return strings.ReplaceAll(strings.ReplaceAll(label, "-", "_"), ".", "_")
         })
 	if err != nil {
 		return nil, err

--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -241,7 +241,9 @@ func parseConfig(logCtx logger.Info) (*config, error) {
 	}
 
 	// other labels coming from docker labels or env selected by user labels, labels-regex, env, env-regex config.
-	attrs, err := logCtx.ExtraAttributes(nil)
+	attrs, err := logCtx.ExtraAttributes(func(label String) String {
+                return label.ReplaceAll(".", "_")
+        })
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -241,8 +241,8 @@ func parseConfig(logCtx logger.Info) (*config, error) {
 	}
 
 	// other labels coming from docker labels or env selected by user labels, labels-regex, env, env-regex config.
-	attrs, err := logCtx.ExtraAttributes(func(label String) String {
-                return label.ReplaceAll(".", "_")
+	attrs, err := logCtx.ExtraAttributes(func(label string) string {
+                return strings.ReplaceAll(label, ".", "_")
         })
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: Docker labelling best practices are to use labels with reverse DNS notation, but as Prometheus has a completely different view on this, it makes it very incompatible to collect custom labels which abide by Docker labelling practices, using the Docker logging driver.
Currently, the code has some special treatment for the Docker's labels, it should be possible to generalize this.

An easy way is to do a keymod when getting the extra attributes from Docker and replacing every `.` by `_`

**Which issue(s) this PR fixes**:
Fixes #2455 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

