### PR TITLE
refactor: use $.core.v1.envVar

### DIFF
--- a/production/ksonnet/loki-canary/loki-canary.libsonnet
+++ b/production/ksonnet/loki-canary/loki-canary.libsonnet
@@ -16,8 +16,8 @@ k + config {
     container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.loki_canary_args)) +
     container.withEnv([
-      container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-      container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+      $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+      $.core.v1.envVar.fromFieldPath('POD_NAME', 'metadata.name'),
     ]),
 
   local daemonSet = $.apps.v1.daemonSet,

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -49,7 +49,7 @@ k + config + scrape_config {
     container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.promtail_args)) +
     container.withEnv([
-      container.envType.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+      $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
     ]) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort(80) +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
`container.envType` comes from the deprecated ksonnet library, the newer and way better ;-) library refered to as
k8s-alpha promotes this to a first class citizen as `core.v1.envVar`.

This will drop support for the ksonnet library but allows us to remove some backwards compatibily support in k8s-alpha.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated