### PR TITLE
Promtail: Bug: loki push api, clone labels before handling

### DIFF
--- a/pkg/promtail/targets/lokipush/pushtarget.go
+++ b/pkg/promtail/targets/lokipush/pushtarget.go
@@ -146,9 +146,9 @@ func (t *PushTarget) handle(w http.ResponseWriter, r *http.Request) {
 		for _, entry := range stream.Entries {
 			var err error
 			if t.config.KeepTimestamp {
-				err = t.handler.Handle(filtered, entry.Timestamp, entry.Line)
+				err = t.handler.Handle(filtered.Clone(), entry.Timestamp, entry.Line)
 			} else {
-				err = t.handler.Handle(filtered, time.Now(), entry.Line)
+				err = t.handler.Handle(filtered.Clone(), time.Now(), entry.Line)
 			}
 
 			if err != nil {


### PR DESCRIPTION
Make a clone of the LabelSet before handling, the handler contains a full pipeline and can modify the labels uniquely per each line which will lead to some concurrent map access panics if you don't pass a copy of the labels to each Handle invocation.

Fixes #2456