### PR TITLE
BatchIter edge cases

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -532,7 +532,7 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 	blocks := make([]Block, 0, len(c.blocks))
 
 	for _, b := range c.blocks {
-		if maxt > b.mint && b.maxt > mint {
+		if maxt >= b.mint && b.maxt >= mint {
 			blocks = append(blocks, b)
 		}
 	}

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -37,6 +37,18 @@ var (
 	testTargetSize = 1500 * 1024
 )
 
+func TestBlocksInclusive(t *testing.T) {
+	chk := NewMemChunk(EncNone, testBlockSize, testTargetSize)
+	err := chk.Append(logprotoEntry(1, "1"))
+	require.Nil(t, err)
+	err = chk.cut()
+	require.Nil(t, err)
+
+	blocks := chk.Blocks(time.Unix(0, 1), time.Unix(0, 1))
+	require.Equal(t, 1, len(blocks))
+	require.Equal(t, 1, blocks[0].Entries())
+}
+
 func TestBlock(t *testing.T) {
 	for _, enc := range testEncoding {
 		t.Run(enc.String(), func(t *testing.T) {

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -143,8 +143,6 @@ func (it *batchChunkIterator) nextBatch() (genericIterator, error) {
 	var includesOverlap bool
 
 	for it.chunks.Len() > 0 {
-		// reset nextChunk on each loop to prevent it from pointing to previous chunks
-		nextChunk = nil
 
 		// pop the next batch of chunks and append/prepend previous overlapping chunks
 		// so we can merge/de-dupe overlapping entries.

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -129,7 +129,7 @@ func (c *LazyChunk) SampleIterator(
 			continue
 		}
 		if nextChunk != nil {
-			delete(c.overlappingBlocks, b.Offset())
+			delete(c.overlappingSampleBlocks, b.Offset())
 		}
 		// non-overlapping block with the next chunk are not cached.
 		its = append(its, b.SampleIterator(ctx, filter, extractor))

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -54,6 +54,36 @@ func TestLazyChunkIterator(t *testing.T) {
 	}
 }
 
+func TestLazyChunksPop(t *testing.T) {
+	for i, tc := range []struct {
+		initial    int
+		n          int
+		expectedLn int
+		rem        int
+	}{
+		{1, 1, 1, 0},
+		{2, 1, 1, 1},
+		{3, 4, 3, 0},
+	} {
+
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			lc := &lazyChunks{}
+			for i := 0; i < tc.initial; i++ {
+				lc.chunks = append(lc.chunks, &LazyChunk{})
+			}
+			out := lc.pop(tc.n)
+
+			for i := 0; i < tc.expectedLn; i++ {
+				require.NotNil(t, out[i])
+			}
+
+			for i := 0; i < tc.rem; i++ {
+				require.NotNil(t, lc.chunks[i])
+			}
+		})
+	}
+}
+
 func TestIsOverlapping(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
-var fooLabelsWithName = "{foo=\"bar\", __name__=\"log\"}"
+var fooLabelsWithName = "{foo=\"bar\", __name__=\"logs\"}"
 var fooLabels = "{foo=\"bar\"}"
 
 var from = time.Unix(0, time.Millisecond.Nanoseconds())


### PR DESCRIPTION
This fixes a few issues in the batch iterator code, including:

1) Ensure calls to `MemChunk.Blocks` are inclusive. This is particularly helpful when they contain a single entry which has been requested in the batching code. At this point it's unknown whether the call is looking for `[start,end)` or `(start,end]`, dependent on `logproto.Direction`. This is handled at a higher layer via the `TimeBoundedIter`, so we should handle these requests inclusively for now. I found it stripping logs when `start=end` was requested.

2) Only include previously overlapping chunks one time per batch. In rare cases, it could previously add these repeatedly on a loop, effectively duplicating references to the same chunks within a single batch.

3) Fixes sample iterator from deleting a regular iterator in the memchunk cache map.

4) Fixes metric name in a test utility.

5) Thanks to the wondrous @rfratto for spotting the embedded field race condition.