### PR TITLE
series endpoint uses normal splits

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -262,8 +262,8 @@ func NewSeriesTripperware(
 	if cfg.SplitQueriesByInterval != 0 {
 		queryRangeMiddleware = append(queryRangeMiddleware,
 			queryrange.InstrumentMiddleware("split_by_interval", instrumentMetrics),
-			// Force a 24 hours split by for series API, this will be more efficient with our static daily bucket storage.
-			SplitByIntervalMiddleware(WithSplitByLimits(limits, 24*time.Hour), codec, splitByMetrics),
+			// The Series API needs to pull one chunk per series to extract the label set, which is much cheaper than iterating through all matching chunks.
+			SplitByIntervalMiddleware(WithSplitByLimits(limits, cfg.SplitQueriesByInterval), codec, splitByMetrics),
 		)
 	}
 	if cfg.MaxRetries > 0 {
@@ -288,8 +288,25 @@ func NewLabelsTripperware(
 	retryMiddlewareMetrics *queryrange.RetryMiddlewareMetrics,
 	splitByMetrics *SplitByMetrics,
 ) (frontend.Tripperware, error) {
-	// for now we'll use the same config as for the Series API.
-	return NewSeriesTripperware(cfg, log, limits, codec, instrumentMetrics, retryMiddlewareMetrics, splitByMetrics)
+	queryRangeMiddleware := []queryrange.Middleware{}
+	if cfg.SplitQueriesByInterval != 0 {
+		queryRangeMiddleware = append(queryRangeMiddleware,
+			queryrange.InstrumentMiddleware("split_by_interval", instrumentMetrics),
+			// Force a 24 hours split by for labels API, this will be more efficient with our static daily bucket storage.
+			// This is because the labels API is an index-only operation.
+			SplitByIntervalMiddleware(WithSplitByLimits(limits, 24*time.Hour), codec, splitByMetrics),
+		)
+	}
+	if cfg.MaxRetries > 0 {
+		queryRangeMiddleware = append(queryRangeMiddleware, queryrange.InstrumentMiddleware("retry", instrumentMetrics), queryrange.NewRetryMiddleware(log, cfg.MaxRetries, retryMiddlewareMetrics))
+	}
+
+	return func(next http.RoundTripper) http.RoundTripper {
+		if len(queryRangeMiddleware) > 0 {
+			return queryrange.NewRoundTripper(next, codec, queryRangeMiddleware...)
+		}
+		return next
+	}, nil
 }
 
 // NewMetricTripperware creates a new frontend tripperware responsible for handling metric queries

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -216,7 +216,7 @@ func TestSeriesTripperware(t *testing.T) {
 
 	lreq := &LokiSeriesRequest{
 		Match:   []string{`{job="varlogs"}`},
-		StartTs: testTime.Add(-25 * time.Hour), // bigger than the limit
+		StartTs: testTime.Add(-5 * time.Hour), // bigger than the limit
 		EndTs:   testTime,
 		Path:    "/loki/api/v1/series",
 	}


### PR DESCRIPTION
We hardcoded series splitby to 24h recently to align with the 24h index buckets
https://github.com/grafana/loki/blob/master/pkg/querier/queryrange/roundtrip.go#L265-L266

We can see that the index time is pretty short, but we’re fetching too many chunks.
Also there’s no guarantee and in fact it’s incredibly unlikely that a 24h split will align with 1 daily bucket (it’s much more likely that the start/end of the split is between bucket bounds, which would spill into another bucket).
I think we can decrease the splitby for these reasons.

