### PR TITLE
fixes lambda-promtail relative doc link

### DIFF
--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -11,7 +11,7 @@ Loki supports the following official clients for sending logs:
 - [Fluentd](fluentd/)
 - [Fluent Bit](fluentbit/)
 - [Logstash](logstash/)
-- [Lambda Promtail](/lambda-promtail/)
+- [Lambda Promtail](lambda-promtail/)
 
 ## Picking a client
 


### PR DESCRIPTION
Should fix the 404 on the public docs site.