### PR TITLE
Promtail: force the log level on any Loki Push API target servers to match Promtail's log level.

### DIFF
--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -50,6 +50,14 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 		cfg.ClientConfigs = append(cfg.ClientConfigs, cfg.ClientConfig)
 	}
 
+	// This is a bit crude but if the Loki Push API target is specified,
+	// force the log level to match the promtail log level
+	for i := range cfg.ScrapeConfig {
+		if cfg.ScrapeConfig[i].PushConfig != nil {
+			cfg.ScrapeConfig[i].PushConfig.Server.LogLevel = cfg.ServerConfig.LogLevel
+		}
+	}
+
 	var err error
 	if dryRun {
 		promtail.client, err = client.NewLogger(promtail.logger, cfg.ClientConfigs...)

--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -55,6 +55,7 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 	for i := range cfg.ScrapeConfig {
 		if cfg.ScrapeConfig[i].PushConfig != nil {
 			cfg.ScrapeConfig[i].PushConfig.Server.LogLevel = cfg.ServerConfig.LogLevel
+			cfg.ScrapeConfig[i].PushConfig.Server.LogFormat = cfg.ServerConfig.LogFormat
 		}
 	}
 


### PR DESCRIPTION
I don't love this solution, but I also don't love passing the log level through all the constructors just for the push target.
This seemed a bit better?