### PR TITLE
Logcli: automatically batch requests

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -273,6 +273,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 		cmd.Flag("to", "Stop looking for logs at this absolute time (exclusive)").StringVar(&to)
 		cmd.Flag("step", "Query resolution step width, for metric queries. Evaluate the query at the specified step over the time range.").DurationVar(&q.Step)
 		cmd.Flag("interval", "Query interval, for log queries. Return entries at the specified interval, ignoring those between. **This parameter is experimental, please see Issue 1779**").DurationVar(&q.Interval)
+		cmd.Flag("batch", "Query batch size to use until 'limit' is reached").Default("1000").IntVar(&q.BatchSize)
 	}
 
 	cmd.Flag("forward", "Scan forwards through logs.").Default("false").BoolVar(&q.Forward)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -158,8 +158,9 @@ func main() {
 	}
 }
 
-func newQueryClient(app *kingpin.Application) *client.Client {
-	client := &client.Client{
+func newQueryClient(app *kingpin.Application) client.Client {
+
+	client := &client.DefaultClient{
 		TLSConfig: config.TLSConfig{},
 	}
 

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -123,7 +123,7 @@ func main() {
 			ColoredOutput: rangeQuery.ColoredOutput,
 		}
 
-		out, err := output.NewLogOutput(*outputMode, outputOptions)
+		out, err := output.NewLogOutput(os.Stdout, *outputMode, outputOptions)
 		if err != nil {
 			log.Fatalf("Unable to create log output: %s", err)
 		}
@@ -145,7 +145,7 @@ func main() {
 			ColoredOutput: instantQuery.ColoredOutput,
 		}
 
-		out, err := output.NewLogOutput(*outputMode, outputOptions)
+		out, err := output.NewLogOutput(os.Stdout, *outputMode, outputOptions)
 		if err != nil {
 			log.Fatalf("Unable to create log output: %s", err)
 		}

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -69,7 +69,7 @@ Starting with Loki 1.6.0, `logcli` batches log queries to Loki.
 If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, then logcli automatically
 sends this request to Loki in batches.
 
-The default batch size is `1000`
+The default batch size is `1000`.
 
 Loki has a server side limit for the maximum lines returned in a query (default is 5000),
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -73,7 +73,7 @@ The default batch size is `1000`.
 
 Loki has a server-side limit for the maximum lines returned in a query (default is 5000).
 
-Batching allows for making larger requests than the server side limit so long as the `--batch` size is less than the server limit.
+Batching allows you to make larger requests than the server-side limit as long as the `--batch` size is less than the server limit.
 
 Please note that the query metadata is printed for each batch (it is printed on `stderr`), this can be removed with the `--quiet` flag.
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -67,7 +67,7 @@ $ logcli series -q --match='{namespace="loki",container_name="loki"}'
 Starting with Loki 1.6.0, `logcli` batches log queries to Loki.
 
 If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, then logcli automatically
-send this request to Loki in batches.
+sends this request to Loki in batches.
 
 The default batch size is `1000`
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -62,6 +62,21 @@ $ logcli series -q --match='{namespace="loki",container_name="loki"}'
 {app="loki", container_name="loki", controller_revision_hash="loki-57c9df47f4", filename="/var/log/pods/loki_loki-0_8ed03ded-bacb-4b13-a6fe-53a445a15887/loki/0.log", instance="loki-0", job="loki/loki", name="loki", namespace="loki", release="loki", statefulset_kubernetes_io_pod_name="loki-0", stream="stderr"}
 ```
 
+#### Batched Queries
+
+Starting with Loki 1.6.0, `logcli` will batch log queries to Loki.
+
+If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, logcli will automatically
+send this request to Loki in batches.
+
+The default batch size is `1000`
+
+Loki has a server side limit for the maximum lines returned in a query (default is 5000),
+
+Batching allows for making larger requests than the server side limit so long as the `--batch` size is less than the server limit.
+
+Please note that the query metadata is printed for each batch (it is printed on `stderr`), this can be removed with the `--quiet` flag.
+
 ### Configuration
 
 Configuration values are considered in the following order (lowest to highest):
@@ -188,6 +203,7 @@ Flags:
                            range.
       --interval=INTERVAL  Query interval, for log queries. Return entries at the specified interval, ignoring those between.
                            **This parameter is experimental, please see Issue 1779**.
+      --batch=1000         Query batch size to use until 'limit' is reached
       --forward            Scan forwards through logs.
       --no-labels          Do not print any labels.
       --exclude-label=EXCLUDE-LABEL ...

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -203,7 +203,7 @@ Flags:
                            range.
       --interval=INTERVAL  Query interval, for log queries. Return entries at the specified interval, ignoring those between.
                            **This parameter is experimental, please see Issue 1779**.
-      --batch=1000         Query batch size to use until 'limit' is reached
+      --batch=1000         Query batch size to use until 'limit' is reached.
       --forward            Scan forwards through logs.
       --no-labels          Do not print any labels.
       --exclude-label=EXCLUDE-LABEL ...

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -75,7 +75,7 @@ Loki has a server-side limit for the maximum lines returned in a query (default 
 
 Batching allows you to make larger requests than the server-side limit as long as the `--batch` size is less than the server limit.
 
-Please note that the query metadata is printed for each batch (it is printed on `stderr`), this can be removed with the `--quiet` flag.
+Please note that the query metadata is printed for each batch on `stderr`. Set the `--quiet` flag to stop this behavior.
 
 ### Configuration
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -64,7 +64,7 @@ $ logcli series -q --match='{namespace="loki",container_name="loki"}'
 
 #### Batched Queries
 
-Starting with Loki 1.6.0, `logcli` will batch log queries to Loki.
+Starting with Loki 1.6.0, `logcli` batches log queries to Loki.
 
 If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, logcli will automatically
 send this request to Loki in batches.

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -66,7 +66,7 @@ $ logcli series -q --match='{namespace="loki",container_name="loki"}'
 
 Starting with Loki 1.6.0, `logcli` batches log queries to Loki.
 
-If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, logcli will automatically
+If you set a `--limit` on a query (default is 30) to a large number, say `--limit=10000`, then logcli automatically
 send this request to Loki in batches.
 
 The default batch size is `1000`

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -71,7 +71,7 @@ sends this request to Loki in batches.
 
 The default batch size is `1000`.
 
-Loki has a server side limit for the maximum lines returned in a query (default is 5000),
+Loki has a server-side limit for the maximum lines returned in a query (default is 5000).
 
 Batching allows for making larger requests than the server side limit so long as the `--batch` size is less than the server limit.
 

--- a/pkg/logcli/labelquery/labels.go
+++ b/pkg/logcli/labelquery/labels.go
@@ -18,7 +18,7 @@ type LabelQuery struct {
 }
 
 // DoLabels prints out label results
-func (q *LabelQuery) DoLabels(c *client.Client) {
+func (q *LabelQuery) DoLabels(c client.Client) {
 	values := q.ListLabels(c)
 
 	for _, value := range values {
@@ -27,7 +27,7 @@ func (q *LabelQuery) DoLabels(c *client.Client) {
 }
 
 // ListLabels returns an array of label strings
-func (q *LabelQuery) ListLabels(c *client.Client) []string {
+func (q *LabelQuery) ListLabels(c client.Client) []string {
 	var labelResponse *loghttp.LabelResponse
 	var err error
 	if len(q.LabelName) > 0 {

--- a/pkg/logcli/output/default.go
+++ b/pkg/logcli/output/default.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -12,24 +13,26 @@ import (
 
 // DefaultOutput provides logs and metadata in human readable format
 type DefaultOutput struct {
+	w       io.Writer
 	options *LogOutputOptions
 }
 
 // Format a log entry in a human readable format
-func (o *DefaultOutput) Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) string {
+func (o *DefaultOutput) FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) {
 	timestamp := ts.In(o.options.Timezone).Format(time.RFC3339)
 	line = strings.TrimSpace(line)
 
 	if o.options.NoLabels {
-		return fmt.Sprintf("%s %s", color.BlueString(timestamp), line)
+		fmt.Fprintf(o.w, "%s %s\n", color.BlueString(timestamp), line)
+		return
 	}
-
 	if o.options.ColoredOutput {
 		labelsColor := getColor(lbls.String()).SprintFunc()
-		return fmt.Sprintf("%s %s %s", color.BlueString(timestamp), labelsColor(padLabel(lbls, maxLabelsLen)), line)
+		fmt.Fprintf(o.w, "%s %s %s\n", color.BlueString(timestamp), labelsColor(padLabel(lbls, maxLabelsLen)), line)
+	} else {
+		fmt.Fprintf(o.w, "%s %s %s\n", color.BlueString(timestamp), color.RedString(padLabel(lbls, maxLabelsLen)), line)
 	}
 
-	return fmt.Sprintf("%s %s %s", color.BlueString(timestamp), color.RedString(padLabel(lbls, maxLabelsLen)), line)
 }
 
 // add some padding after labels

--- a/pkg/logcli/output/default_test.go
+++ b/pkg/logcli/output/default_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			emptyLabels,
 			0,
 			"",
-			"2006-01-02T08:04:05Z {} ",
+			"2006-01-02T08:04:05Z {} \n",
 		},
 		"empty line with labels": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -41,7 +42,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			someLabels,
 			len(someLabels.String()),
 			"",
-			"2006-01-02T08:04:05Z {type=\"test\"} ",
+			"2006-01-02T08:04:05Z {type=\"test\"} \n",
 		},
 		"max labels length shorter than input labels": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -49,7 +50,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello",
-			"2006-01-02T08:04:05Z {type=\"test\"} Hello",
+			"2006-01-02T08:04:05Z {type=\"test\"} Hello\n",
 		},
 		"max labels length longer than input labels": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -57,7 +58,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			someLabels,
 			20,
 			"Hello",
-			"2006-01-02T08:04:05Z {type=\"test\"}        Hello",
+			"2006-01-02T08:04:05Z {type=\"test\"}        Hello\n",
 		},
 		"timezone option set to a Local one": {
 			&LogOutputOptions{Timezone: time.FixedZone("test", 2*60*60), NoLabels: false},
@@ -65,7 +66,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello",
-			"2006-01-02T10:04:05+02:00 {type=\"test\"} Hello",
+			"2006-01-02T10:04:05+02:00 {type=\"test\"} Hello\n",
 		},
 		"labels output disabled": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: true},
@@ -73,7 +74,7 @@ func TestDefaultOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello",
-			"2006-01-02T08:04:05Z Hello",
+			"2006-01-02T08:04:05Z Hello\n",
 		},
 	}
 
@@ -83,10 +84,11 @@ func TestDefaultOutput_Format(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			out := &DefaultOutput{testData.options}
-			actual := out.Format(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
+			writer := &bytes.Buffer{}
+			out := &DefaultOutput{writer,testData.options}
+			out.FormatAndPrintln(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
 
-			assert.Equal(t, testData.expected, actual)
+			assert.Equal(t, testData.expected, writer.String())
 		})
 	}
 }
@@ -111,16 +113,19 @@ func TestDefaultOutput_FormatLabelsPadding(t *testing.T) {
 	timestamp, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
 	maxLabelsLen := findMaxLabelsLength(labelsList)
 	options := &LogOutputOptions{Timezone: time.UTC, NoLabels: false}
-	out := &DefaultOutput{options}
+	writer := &bytes.Buffer{}
+	out := &DefaultOutput{writer,options}
 
 	// Format the same log line with different labels
 	formattedEntries := make([]string, 0, len(labelsList))
 	for _, lbls := range labelsList {
-		formattedEntries = append(formattedEntries, out.Format(timestamp, lbls, maxLabelsLen, "XXX"))
+		out.FormatAndPrintln(timestamp, lbls, maxLabelsLen, "XXX")
+		formattedEntries = append(formattedEntries, writer.String())
+		writer.Reset()
 	}
 
 	// Ensure the log line starts at the same position in each formatted output
-	assert.Equal(t, len(formattedEntries), len(labelsList))
+	assert.Equal(t, len(labelsList), len(formattedEntries))
 
 	expectedIndex := strings.Index(formattedEntries[0], "XXX")
 	if expectedIndex <= 0 {

--- a/pkg/logcli/output/jsonl.go
+++ b/pkg/logcli/output/jsonl.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"time"
 
@@ -10,11 +12,12 @@ import (
 
 // JSONLOutput prints logs and metadata as JSON Lines, suitable for scripts
 type JSONLOutput struct {
+	w       io.Writer
 	options *LogOutputOptions
 }
 
 // Format a log entry as json line
-func (o *JSONLOutput) Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) string {
+func (o *JSONLOutput) FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) {
 	entry := map[string]interface{}{
 		"timestamp": ts.In(o.options.Timezone),
 		"line":      line,
@@ -30,5 +33,5 @@ func (o *JSONLOutput) Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen i
 		log.Fatalf("error marshalling entry: %s", err)
 	}
 
-	return string(out)
+	fmt.Fprintln(o.w, string(out))
 }

--- a/pkg/logcli/output/jsonl_test.go
+++ b/pkg/logcli/output/jsonl_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestJSONLOutput_Format(t *testing.T) {
 			emptyLabels,
 			0,
 			"",
-			`{"labels":{},"line":"","timestamp":"2006-01-02T08:04:05Z"}`,
+			`{"labels":{},"line":"","timestamp":"2006-01-02T08:04:05Z"}` + "\n",
 		},
 		"empty line with labels": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -41,7 +42,7 @@ func TestJSONLOutput_Format(t *testing.T) {
 			someLabels,
 			len(someLabels.String()),
 			"",
-			`{"labels":{"type":"test"},"line":"","timestamp":"2006-01-02T08:04:05Z"}`,
+			`{"labels":{"type":"test"},"line":"","timestamp":"2006-01-02T08:04:05Z"}` + "\n",
 		},
 		"timezone option set to a Local one": {
 			&LogOutputOptions{Timezone: time.FixedZone("test", 2*60*60), NoLabels: false},
@@ -49,7 +50,7 @@ func TestJSONLOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello",
-			`{"labels":{"type":"test"},"line":"Hello","timestamp":"2006-01-02T10:04:05+02:00"}`,
+			`{"labels":{"type":"test"},"line":"Hello","timestamp":"2006-01-02T10:04:05+02:00"}` + "\n",
 		},
 		"labels output disabled": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: true},
@@ -57,7 +58,7 @@ func TestJSONLOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello",
-			`{"line":"Hello","timestamp":"2006-01-02T08:04:05Z"}`,
+			`{"line":"Hello","timestamp":"2006-01-02T08:04:05Z"}` + "\n",
 		},
 	}
 
@@ -66,10 +67,11 @@ func TestJSONLOutput_Format(t *testing.T) {
 
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
+			writer := &bytes.Buffer{}
+			out := &JSONLOutput{writer,testData.options}
+			out.FormatAndPrintln(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
 
-			out := &JSONLOutput{testData.options}
-			actual := out.Format(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
-
+			actual := writer.String()
 			assert.Equal(t, testData.expected, actual)
 			assert.NoError(t, isValidJSON(actual))
 		})

--- a/pkg/logcli/output/output.go
+++ b/pkg/logcli/output/output.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"hash/fnv"
+	"io"
 	"time"
 
 	"github.com/fatih/color"
@@ -27,7 +28,7 @@ var colorList = []*color.Color{
 
 // LogOutput is the interface any output mode must implement
 type LogOutput interface {
-	Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) string
+	FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string)
 }
 
 // LogOutputOptions defines options supported by LogOutput
@@ -38,7 +39,7 @@ type LogOutputOptions struct {
 }
 
 // NewLogOutput creates a log output based on the input mode and options
-func NewLogOutput(mode string, options *LogOutputOptions) (LogOutput, error) {
+func NewLogOutput(w io.Writer, mode string, options *LogOutputOptions) (LogOutput, error) {
 	if options.Timezone == nil {
 		options.Timezone = time.Local
 	}
@@ -46,14 +47,17 @@ func NewLogOutput(mode string, options *LogOutputOptions) (LogOutput, error) {
 	switch mode {
 	case "default":
 		return &DefaultOutput{
+			w:       w,
 			options: options,
 		}, nil
 	case "jsonl":
 		return &JSONLOutput{
+			w:       w,
 			options: options,
 		}, nil
 	case "raw":
 		return &RawOutput{
+			w:       w,
 			options: options,
 		}, nil
 	default:

--- a/pkg/logcli/output/output_test.go
+++ b/pkg/logcli/output/output_test.go
@@ -10,19 +10,19 @@ import (
 func TestNewLogOutput(t *testing.T) {
 	options := &LogOutputOptions{time.UTC, false, false}
 
-	out, err := NewLogOutput("default", options)
+	out, err := NewLogOutput(nil,"default", options)
 	assert.NoError(t, err)
-	assert.IsType(t, &DefaultOutput{options}, out)
+	assert.IsType(t, &DefaultOutput{nil,options}, out)
 
-	out, err = NewLogOutput("jsonl", options)
+	out, err = NewLogOutput(nil,"jsonl", options)
 	assert.NoError(t, err)
-	assert.IsType(t, &JSONLOutput{options}, out)
+	assert.IsType(t, &JSONLOutput{nil,options}, out)
 
-	out, err = NewLogOutput("raw", options)
+	out, err = NewLogOutput(nil,"raw", options)
 	assert.NoError(t, err)
-	assert.IsType(t, &RawOutput{options}, out)
+	assert.IsType(t, &RawOutput{nil,options}, out)
 
-	out, err = NewLogOutput("unknown", options)
+	out, err = NewLogOutput(nil,"unknown", options)
 	assert.Error(t, err)
 	assert.Nil(t, out)
 }

--- a/pkg/logcli/output/raw.go
+++ b/pkg/logcli/output/raw.go
@@ -14,6 +14,13 @@ type RawOutput struct {
 	options *LogOutputOptions
 }
 
+func NewRaw (writer io.Writer, options *LogOutputOptions) LogOutput {
+	return &RawOutput{
+		w: writer,
+		options: options,
+	}
+}
+
 // Format a log entry as is
 func (o *RawOutput) FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) {
 	if len(line) > 0 && line[len(line)-1] == '\n' {

--- a/pkg/logcli/output/raw.go
+++ b/pkg/logcli/output/raw.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/grafana/loki/pkg/loghttp"
@@ -8,13 +10,14 @@ import (
 
 // RawOutput prints logs in their original form, without any metadata
 type RawOutput struct {
+	w       io.Writer
 	options *LogOutputOptions
 }
 
 // Format a log entry as is
-func (o *RawOutput) Format(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) string {
+func (o *RawOutput) FormatAndPrintln(ts time.Time, lbls loghttp.LabelSet, maxLabelsLen int, line string) {
 	if len(line) > 0 && line[len(line)-1] == '\n' {
 		line = line[:len(line)-1]
 	}
-	return line
+	fmt.Fprintln(o.w, line)
 }

--- a/pkg/logcli/output/raw_test.go
+++ b/pkg/logcli/output/raw_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestRawOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"",
-			"",
+			"\n",
 		},
 		"non empty line": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -39,7 +40,7 @@ func TestRawOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello world",
-			"Hello world",
+			"Hello world\n",
 		},
 		"line with single newline at the end": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -47,7 +48,7 @@ func TestRawOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello world\n",
-			"Hello world",
+			"Hello world\n",
 		},
 		"line with multiple newlines at the end": {
 			&LogOutputOptions{Timezone: time.UTC, NoLabels: false},
@@ -55,7 +56,7 @@ func TestRawOutput_Format(t *testing.T) {
 			someLabels,
 			0,
 			"Hello world\n\n\n",
-			"Hello world\n\n",
+			"Hello world\n\n\n",
 		},
 	}
 
@@ -65,10 +66,11 @@ func TestRawOutput_Format(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			out := &RawOutput{testData.options}
-			actual := out.Format(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
+			writer := &bytes.Buffer{}
+			out := &RawOutput{writer,testData.options}
+			out.FormatAndPrintln(testData.timestamp, testData.lbls, testData.maxLabelsLen, testData.line)
 
-			assert.Equal(t, testData.expected, actual)
+			assert.Equal(t, testData.expected, writer.String())
 		})
 	}
 }

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -79,7 +79,7 @@ func (q *Query) DoQuery(c *client.Client, out output.LogOutput, statistics bool)
 		if statistics {
 			q.printStats(resp.Data.Statistics)
 		}
-		_, _ = q.printResult(resp.Data.Result, out)
+		_, _ = q.printResult(resp.Data.Result, out, nil)
 	} else {
 		if q.Limit < q.BatchSize {
 			q.BatchSize = q.Limit
@@ -197,7 +197,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 		return err
 	}
 
-	q.printResult(value, out)
+	q.printResult(value, out, nil)
 	return nil
 }
 

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -88,13 +88,16 @@ func (q *Query) DoQuery(c client.Client, out output.LogOutput, statistics bool) 
 		total := 0
 		start := q.Start
 		end := q.End
-		var lastEntry *loghttp.Entry
+		var lastEntry []*loghttp.Entry
 		for total < q.Limit {
 			bs := q.BatchSize
+			// We want to truncate the batch size if the remaining number
+			// of items needed to reach the limit is less than the batch size
 			if q.Limit-total < q.BatchSize {
-				// Have to add one because of the timestamp overlap described below, the first result
-				// will always be the last result of the last batch.
-				bs = q.Limit - total + 1
+				// Truncated batchsize is q.Limit - total, however we add to this
+				// the length of the overlap from the last query to make sure we get the
+				// correct amount of new logs knowing there will be some overlapping logs returned.
+				bs = q.Limit - total + len(lastEntry)
 			}
 			resp, err = c.QueryRange(q.QueryString, bs, start, end, d, q.Step, q.Interval, q.Quiet)
 			if err != nil {
@@ -111,13 +114,21 @@ func (q *Query) DoQuery(c client.Client, out output.LogOutput, statistics bool) 
 				break
 			}
 			// Also no result, wouldn't expect to hit this.
-			if lastEntry == nil {
+			if lastEntry == nil || len(lastEntry) == 0 {
 				break
 			}
 			// Can only happen if all the results return in one request
 			if resultLength == q.Limit {
 				break
 			}
+			if len(lastEntry) >= q.BatchSize {
+				log.Fatalf("Invalid batch size %v, the next query will have %v overlapping entries "+
+					"(there will always be 1 overlapping entry but Loki allows multiple entries to have "+
+					"the same timestamp, so when a batch ends in this scenario the next query will include "+
+					"all the overlapping entries again).  Please increase your batch size to at least %v to account "+
+					"for overlapping entryes\n", q.BatchSize, len(lastEntry), len(lastEntry)+1)
+			}
+
 			// Batching works by taking the timestamp of the last query and using it in the next query,
 			// because Loki supports multiple entries with the same timestamp it's possible for a batch to have
 			// fallen in the middle of a list of entries for the same time, so to make sure we get all entries
@@ -127,12 +138,13 @@ func (q *Query) DoQuery(c client.Client, out output.LogOutput, statistics bool) 
 			// to get the desired limit.
 			total += resultLength
 			// Based on the query direction we either set the start or end for the next query.
+			// If there are multiple entries in `lastEntry` they have to have the same timestamp so we can pick just the first
 			if q.Forward {
-				start = lastEntry.Timestamp
+				start = lastEntry[0].Timestamp
 			} else {
 				// The end timestamp is exclusive on a backward query, so to make sure we get back an overlapping result
 				// fudge the timestamp forward in time to make sure to get the last entry from this batch in the next query
-				end = lastEntry.Timestamp.Add(1 * time.Nanosecond)
+				end = lastEntry[0].Timestamp.Add(1 * time.Nanosecond)
 			}
 
 		}
@@ -140,9 +152,9 @@ func (q *Query) DoQuery(c client.Client, out output.LogOutput, statistics bool) 
 
 }
 
-func (q *Query) printResult(value loghttp.ResultValue, out output.LogOutput, lastEntry *loghttp.Entry) (int, *loghttp.Entry) {
+func (q *Query) printResult(value loghttp.ResultValue, out output.LogOutput, lastEntry []*loghttp.Entry) (int, []*loghttp.Entry) {
 	length := -1
-	var entry *loghttp.Entry
+	var entry []*loghttp.Entry
 	switch value.Type() {
 	case logql.ValueTypeStreams:
 		length, entry = q.printStream(value.(loghttp.Streams), out, lastEntry)
@@ -241,7 +253,7 @@ func (q *Query) isInstant() bool {
 	return q.Start == q.End
 }
 
-func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastEntry *loghttp.Entry) (int, *loghttp.Entry) {
+func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastEntry []*loghttp.Entry) (int, []*loghttp.Entry) {
 	common := commonLabels(streams)
 
 	// Remove the labels we want to show from common
@@ -304,14 +316,39 @@ func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastE
 	printed := 0
 	for _, e := range allEntries {
 		// Skip the last entry if it overlaps, this happens because batching includes the last entry from the last batch
-		if lastEntry != nil && e.entry.Timestamp == lastEntry.Timestamp && e.entry.Line == lastEntry.Line {
-			continue
+		if lastEntry != nil && len(lastEntry) > 0 && e.entry.Timestamp == lastEntry[0].Timestamp {
+			skip := false
+			// Because many logs can share a timestamp in the unlucky event a batch ends with a timestamp
+			// shared by multiple entries we have to check all that were stored to see if we've already
+			// printed them.
+			for _, le := range lastEntry {
+				if e.entry.Line == le.Line {
+					skip = true
+				}
+			}
+			if skip {
+				continue
+			}
 		}
 		out.FormatAndPrintln(e.entry.Timestamp, e.labels, maxLabelsLen, e.entry.Line)
 		printed++
 	}
 
-	return printed, &allEntries[len(allEntries)-1].entry
+	// Loki allows multiple entries at the same timestamp, this is a bit of a mess if a batch ends
+	// with an entry that shared multiple timestamps, so we need to keep a list of all these entries
+	// because the next query is going to contain them too and we want to not duplicate anything already
+	// printed.
+	lel := []*loghttp.Entry{}
+	// Start with the timestamp of the last entry
+	le := allEntries[len(allEntries)-1].entry
+	for i, e := range allEntries {
+		// Save any entry which has this timestamp (most of the time this will only be the single last entry)
+		if e.entry.Timestamp.Equal(le.Timestamp) {
+			lel = append(lel, &allEntries[i].entry)
+		}
+	}
+
+	return printed, lel
 }
 
 func (q *Query) printMatrix(matrix loghttp.Matrix) {

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -307,7 +307,7 @@ func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastE
 		if lastEntry != nil && e.entry.Timestamp == lastEntry.Timestamp && e.entry.Line == lastEntry.Line {
 			continue
 		}
-		fmt.Println(out.Format(e.entry.Timestamp, e.labels, maxLabelsLen, e.entry.Line))
+		out.FormatAndPrintln(e.entry.Timestamp, e.labels, maxLabelsLen, e.entry.Line)
 		printed++
 	}
 

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -140,6 +140,11 @@ func Test_subtract(t *testing.T) {
 	}
 }
 
+
+func Test_batch(t *testing.T) {
+
+}
+
 func mustParseLabels(s string) loghttp.LabelSet {
 	l, err := marshal.NewLabelSet(s)
 

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -1,11 +1,20 @@
 package query
 
 import (
+	"bytes"
+	"context"
 	"log"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/loghttp"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logql/marshal"
 )
 
@@ -140,9 +149,76 @@ func Test_subtract(t *testing.T) {
 	}
 }
 
-
 func Test_batch(t *testing.T) {
+	tests := []struct {
+		name         string
+		streams      []logproto.Stream
+		start, end   time.Time
+		limit, batch int
+		labelMatcher string
+		forward bool
+		expected     []string
+	}{
+		{
+			name: "super simple forward",
+			streams: []logproto.Stream{
+				logproto.Stream{
+					Labels:  "{test=\"simple\"}",
+					Entries: []logproto.Entry{
+						logproto.Entry{
+							Timestamp: time.Unix(1, 0),
+							Line:      "line1",
+						},
+						logproto.Entry{
+							Timestamp: time.Unix(2, 0),
+							Line:      "line2",
+						},
+						logproto.Entry{
+							Timestamp: time.Unix(3, 0),
+							Line:      "line3",
+						},
+					},
+				},
+			},
+			start: time.Unix(1, 0),
+			end: time.Unix(3, 0),
+			limit: 10,
+			batch: 10,
+			labelMatcher: "{test=\"simple\"}",
+			forward: true,
+			expected: []string{
+				"line1",
+				"line2",
+			},
 
+		},
+
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newTestQueryClient(tt.streams...)
+			writer := &bytes.Buffer{}
+			out := output.NewRaw(writer, nil)
+			q := Query{
+				QueryString:     tt.labelMatcher,
+				Start:           tt.start,
+				End:             tt.end,
+				Limit:           tt.limit,
+				BatchSize:       tt.batch,
+				Forward:         tt.forward,
+				Step:            0,
+				Interval:        0,
+				Quiet:           false,
+				NoLabels:        false,
+				IgnoreLabelsKey: nil,
+				ShowLabelsKey:   nil,
+				FixedLabelsLen:  0,
+				LocalConfig:     "",
+			}
+			q.DoQuery(tc, out, false)
+			assert.Equal(t, tt.expected, writer.String())
+		})
+	}
 }
 
 func mustParseLabels(s string) loghttp.LabelSet {
@@ -153,4 +229,64 @@ func mustParseLabels(s string) loghttp.LabelSet {
 	}
 
 	return l
+}
+
+type testQueryClient struct {
+	engine *logql.Engine
+}
+
+func newTestQueryClient(testStreams ...logproto.Stream) *testQueryClient {
+	q := logql.NewMockQuerier(0, testStreams)
+	e := logql.NewEngine(logql.EngineOpts{}, q)
+	return &testQueryClient{engine: e}
+}
+
+func (t *testQueryClient) Query(queryStr string, limit int, time time.Time, direction logproto.Direction, quiet bool) (*loghttp.QueryResponse, error) {
+	panic("implement me")
+}
+
+func (t *testQueryClient) QueryRange(queryStr string, limit int, from, through time.Time, direction logproto.Direction, step, interval time.Duration, quiet bool) (*loghttp.QueryResponse, error) {
+
+	params := logql.NewLiteralParams(queryStr, from, through, step, interval, direction, uint32(limit), nil)
+
+	v, err := t.engine.Query(params).Exec(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	value, err := marshal.NewResultValue(v.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	q := &loghttp.QueryResponse{
+		Status: "success",
+		Data: loghttp.QueryResponseData{
+			ResultType: value.Type(),
+			Result:     value,
+			Statistics: v.Statistics,
+		},
+	}
+
+	return q, nil
+}
+
+func (t *testQueryClient) ListLabelNames(quiet bool, from, through time.Time) (*loghttp.LabelResponse, error) {
+	panic("implement me")
+}
+
+func (t *testQueryClient) ListLabelValues(name string, quiet bool, from, through time.Time) (*loghttp.LabelResponse, error) {
+	panic("implement me")
+}
+
+func (t *testQueryClient) Series(matchers []string, from, through time.Time, quiet bool) (*loghttp.SeriesResponse, error) {
+	panic("implement me")
+}
+
+func (t *testQueryClient) LiveTailQueryConn(queryStr string, delayFor int, limit int, from int64, quiet bool) (*websocket.Conn, error) {
+	panic("implement me")
+}
+
+func (t *testQueryClient) GetOrgID() string {
+	panic("implement me")
 }

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -75,7 +74,7 @@ func (q *Query) TailQuery(delayFor int, c client.Client, out output.LogOutput) {
 			}
 
 			for _, entry := range stream.Entries {
-				fmt.Println(out.Format(entry.Timestamp, labels, 0, entry.Line))
+				out.FormatAndPrintln(entry.Timestamp, labels, 0, entry.Line)
 			}
 
 		}

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TailQuery connects to the Loki websocket endpoint and tails logs
-func (q *Query) TailQuery(delayFor int, c *client.Client, out output.LogOutput) {
+func (q *Query) TailQuery(delayFor int, c client.Client, out output.LogOutput) {
 	conn, err := c.LiveTailQueryConn(q.QueryString, delayFor, q.Limit, q.Start.UnixNano(), q.Quiet)
 	if err != nil {
 		log.Fatalf("Tailing logs failed: %+v", err)

--- a/pkg/logcli/seriesquery/series.go
+++ b/pkg/logcli/seriesquery/series.go
@@ -18,7 +18,7 @@ type SeriesQuery struct {
 }
 
 // DoSeries prints out series results
-func (q *SeriesQuery) DoSeries(c *client.Client) {
+func (q *SeriesQuery) DoSeries(c client.Client) {
 	values := q.GetSeries(c)
 
 	for _, value := range values {
@@ -27,7 +27,7 @@ func (q *SeriesQuery) DoSeries(c *client.Client) {
 }
 
 // GetSeries returns an array of label sets
-func (q *SeriesQuery) GetSeries(c *client.Client) []loghttp.LabelSet {
+func (q *SeriesQuery) GetSeries(c client.Client) []loghttp.LabelSet {
 	seriesResponse, err := c.Series(q.Matchers, q.Start, q.End, q.Quiet)
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)


### PR DESCRIPTION
Loki has a server side limit configured for the maximum number of log lines returned in a single query.

This can be cumbersome at the command line as often with logcli we pipe the output of the result into other tooling.

This PR adds automatic support for batching requests to Loki handled entirely on the client side.

You can now specify a `--limit` of any size and in the background logcli will make the request in batches sized on `--batch` which defaults at 1000.

Some notes:

Currently every request has separate information printed including stats, so you will see interruptions in the output on the console (these are sent to `stderr` however so they do not affect the output.

Use the `--quiet` flag to hide this information.

In the future we may want to consider handling this output differently, similarly `--stats` will be printed with each request.
