### PR TITLE
download boltdb files parallelly during reads

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -19,7 +19,10 @@ import (
 )
 
 // timeout for downloading initial files for a table to avoid leaking resources by allowing it to take all the time.
-const downloadTimeout = 5 * time.Minute
+const (
+	downloadTimeout     = 5 * time.Minute
+	downloadParallelism = 50
+)
 
 type BoltDBIndexClient interface {
 	QueryDB(ctx context.Context, db *bbolt.DB, query chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error
@@ -118,11 +121,18 @@ func (t *Table) init(ctx context.Context) (err error) {
 
 	level.Debug(util.Logger).Log("msg", fmt.Sprintf("list of files to download for period %s: %s", t.name, objects))
 
+	// download the dbs parallelly
+	err = t.doParallelDownload(ctx, objects)
+	if err != nil {
+		return err
+	}
+
 	folderPath, err := t.folderPathForTable(true)
 	if err != nil {
 		return
 	}
 
+	// open all the downloaded dbs
 	for _, object := range objects {
 		dbName, err := getDBNameFromObjectKey(object.Key)
 		if err != nil {
@@ -131,11 +141,6 @@ func (t *Table) init(ctx context.Context) (err error) {
 
 		filePath := path.Join(folderPath, dbName)
 		df := downloadedFile{}
-
-		err = t.getFileFromStorage(ctx, object.Key, filePath)
-		if err != nil {
-			return err
-		}
 
 		df.mtime = object.ModifiedAt
 		df.boltdb, err = local.OpenBoltdbFile(filePath)
@@ -412,4 +417,74 @@ func getDBNameFromObjectKey(objectKey string) (string, error) {
 		return "", fmt.Errorf("empty db name, object key: %v", objectKey)
 	}
 	return ss[1], nil
+}
+
+// doParallelDownload downloads objects(dbs) parallelly. It is upto the caller to open the dbs after the download finishes successfully.
+func (t *Table) doParallelDownload(ctx context.Context, objects []chunk.StorageObject) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	folderPath, err := t.folderPathForTable(true)
+	if err != nil {
+		return err
+	}
+
+	queue := make(chan chunk.StorageObject)
+	n := util.Min(len(objects), downloadParallelism)
+	incomingErrors := make(chan error, n)
+
+	// Run n parallel goroutines fetching objects to download from the queue
+	for i := 0; i < n; i++ {
+		go func() {
+			// when there is an error, break the loop and send the error to the channel to stop the operation.
+			var err error
+			for {
+				object, ok := <-queue
+				if !ok {
+					break
+				}
+
+				var dbName string
+				dbName, err = getDBNameFromObjectKey(object.Key)
+				if err != nil {
+					break
+				}
+
+				filePath := path.Join(folderPath, dbName)
+				err = t.getFileFromStorage(ctx, object.Key, filePath)
+				if err != nil {
+					break
+				}
+			}
+
+			incomingErrors <- err
+			return
+		}()
+	}
+
+	// Send all the objects to download into the queue
+	go func() {
+		for _, object := range objects {
+			select {
+			case queue <- object:
+			case <-ctx.Done():
+				break
+			}
+
+		}
+		close(queue)
+	}()
+
+	// receive all the errors which also lets us make sure all the goroutines have stopped.
+	var firstErr error
+	for i := 0; i < n; i++ {
+		err := <-incomingErrors
+		if err != nil && firstErr == nil {
+			// cancel the download operation in case of error.
+			cancel()
+			firstErr = err
+		}
+	}
+
+	return firstErr
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When downloading files initially for reads we download them 1 at a time which is quite slow since we are now creating `96` per ingester per day. This PR changes the code to download up to 50 files at a time.


**Checklist**
- [x] Tests updated

