### PR TITLE
upload boltdb files from shipper only when they are not expected to be modified or during shutdown

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table.go
+++ b/pkg/storage/stores/shipper/uploads/table.go
@@ -200,8 +200,11 @@ func (lt *Table) Upload(ctx context.Context, force bool) error {
 	// To avoid uploading it, excluding previous active shard as well if it has been not more than a minute since it became inactive.
 	uploadShardsBefore := fmt.Sprint(time.Now().Add(-time.Minute).Truncate(shardDBsByDuration).Unix())
 
-	// Adding check for considering only files which are shared and have just an epoch in their name.
-	// We can remove this check after a release or two when we will have only files with epoch in their name.
+	// Adding check for considering only files which are sharded and have just an epoch in their name.
+	// Before introducing sharding we had a single file per table which were were moved inside the folder per table as part of migration.
+	// The files were named with <table_prefix><period>.
+	// Since sharding was introduced we have a new file every 15 mins and their names just include an epoch timestamp, for e.g `1597927538`.
+	// We can remove this check after we no longer support upgrading from 1.5.0.
 	filenameWithEpochRe, err := regexp.Compile(`^[0-9]{10}$`)
 	if err != nil {
 		return err

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -400,4 +400,18 @@ func TestTable_ImmutableUploads(t *testing.T) {
 	for _, expectedDB := range expectedDBsToUpload {
 		require.FileExists(t, filepath.Join(objectStorageDir, table.buildObjectKey(fmt.Sprint(expectedDB))))
 	}
+
+	// delete everything uploaded
+	dir, err := ioutil.ReadDir(filepath.Join(objectStorageDir, table.name))
+	for _, d := range dir {
+		os.RemoveAll(filepath.Join(objectStorageDir, table.name, d.Name()))
+	}
+
+	// force upload of dbs
+	require.NoError(t, table.Upload(context.Background(), true))
+
+	// make sure nothing was re-uploaded
+	for _, expectedDB := range expectedDBsToUpload {
+		require.NoFileExists(t, filepath.Join(objectStorageDir, table.buildObjectKey(fmt.Sprint(expectedDB))))
+	}
 }

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -101,22 +101,46 @@ func TestTable_Write(t *testing.T) {
 	}()
 
 	now := time.Now()
+
+	// allow modifying last 5 shards
+	table.modifyShardsSince = now.Add(-5 * shardDBsByDuration).Unix()
+
 	// a couple of times for which we want to do writes to make the table create different shards
-	writeTimes := []time.Time{now, now.Add(-(shardDBsByDuration + 5*time.Minute)), now.Add(-(shardDBsByDuration*3 + 3*time.Minute))}
+	testCases := []struct {
+		writeTime time.Time
+		dbName    string // set only when it is supposed to be written to a different name than usual
+	}{
+		{
+			writeTime: now,
+		},
+		{
+			writeTime: now.Add(-(shardDBsByDuration + 5*time.Minute)),
+		},
+		{
+			writeTime: now.Add(-(shardDBsByDuration*3 + 3*time.Minute)),
+		},
+		{
+			writeTime: now.Add(-6 * shardDBsByDuration), // write with time older than table.modifyShardsSince
+			dbName:    fmt.Sprint(table.modifyShardsSince),
+		},
+	}
 
 	numFiles := 0
 
 	// performing writes and checking whether the index gets written to right shard
-	for i, tm := range writeTimes {
+	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			batch := boltIndexClient.NewWriteBatch()
 			testutil.AddRecordsToBatch(batch, "test", i*10, 10)
-			require.NoError(t, table.write(context.Background(), tm, batch.(*local.BoltWriteBatch).Writes["test"]))
+			require.NoError(t, table.write(context.Background(), tc.writeTime, batch.(*local.BoltWriteBatch).Writes["test"]))
 
 			numFiles++
 			require.Equal(t, numFiles, len(table.dbs))
 
-			expectedDBName := fmt.Sprint(tm.Truncate(shardDBsByDuration).Unix())
+			expectedDBName := tc.dbName
+			if expectedDBName == "" {
+				expectedDBName = fmt.Sprint(tc.writeTime.Truncate(shardDBsByDuration).Unix())
+			}
 			db, ok := table.dbs[expectedDBName]
 			require.True(t, ok)
 
@@ -147,7 +171,7 @@ func TestTable_Upload(t *testing.T) {
 	require.NoError(t, table.write(context.Background(), now, batch.(*local.BoltWriteBatch).Writes["test"]))
 
 	// upload the table
-	require.NoError(t, table.Upload(context.Background()))
+	require.NoError(t, table.Upload(context.Background(), true))
 	require.Len(t, table.dbs, 1)
 
 	// compare the local dbs for the table with the dbs in remote storage after upload to ensure they have same data
@@ -168,7 +192,7 @@ func TestTable_Upload(t *testing.T) {
 	require.NoError(t, table.write(context.Background(), now.Add(shardDBsByDuration), batch.(*local.BoltWriteBatch).Writes["test"]))
 
 	// upload the dbs to storage
-	require.NoError(t, table.Upload(context.Background()))
+	require.NoError(t, table.Upload(context.Background(), true))
 	require.Len(t, table.dbs, 2)
 
 	// check local dbs with remote dbs to ensure they have same data
@@ -226,7 +250,7 @@ func TestTable_Cleanup(t *testing.T) {
 	}()
 
 	// upload all the existing dbs
-	require.NoError(t, table.Upload(context.Background()))
+	require.NoError(t, table.Upload(context.Background(), true))
 	require.Len(t, table.uploadedDBsMtime, 3)
 
 	// change the mtime of outsideRetentionButModified db after the upload
@@ -303,5 +327,77 @@ func Test_LoadBoltDBsFromDir(t *testing.T) {
 	// close all the open dbs
 	for _, boltdb := range dbs {
 		require.NoError(t, boltdb.Close())
+	}
+}
+
+func TestTable_ImmutableUploads(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "table-writes")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	boltDBIndexClient, storageClient := buildTestClients(t, tempDir)
+	indexPath := filepath.Join(tempDir, indexDirName)
+
+	defer func() {
+		boltDBIndexClient.Stop()
+	}()
+
+	activeShard := time.Now().Truncate(shardDBsByDuration)
+
+	// some dbs to setup
+	dbNames := []int64{
+		activeShard.Add(-shardDBsByDuration).Unix(), // inactive shard, should upload
+		activeShard.Add(-2 * time.Minute).Unix(),    // 2 minutes before active shard, should upload
+		activeShard.Unix(),                          // active shard, should not upload
+	}
+
+	dbs := map[string]testutil.DBRecords{}
+	for _, dbName := range dbNames {
+		dbs[fmt.Sprint(dbName)] = testutil.DBRecords{
+			NumRecords: 10,
+		}
+	}
+
+	// setup some dbs for a table at a path.
+	tablePath := testutil.SetupDBTablesAtPath(t, "test-table", indexPath, dbs)
+
+	table, err := LoadTable(tablePath, "test", storageClient, boltDBIndexClient)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	defer func() {
+		table.Stop()
+	}()
+
+	// db expected to be uploaded without forcing the upload
+	expectedDBsToUpload := []int64{dbNames[0], dbNames[1]}
+
+	// upload dbs without forcing the upload which should not upload active shard or shard which has been active upto a minute back.
+	require.NoError(t, table.Upload(context.Background(), false))
+
+	// verify that only expected dbs are uploaded
+	objectStorageDir := filepath.Join(tempDir, objectsStorageDirName)
+	uploadedDBs, err := ioutil.ReadDir(filepath.Join(objectStorageDir, table.name))
+	require.NoError(t, err)
+
+	require.Len(t, uploadedDBs, len(expectedDBsToUpload))
+	for _, expectedDB := range expectedDBsToUpload {
+		require.FileExists(t, filepath.Join(objectStorageDir, table.buildObjectKey(fmt.Sprint(expectedDB))))
+	}
+
+	// force upload of dbs
+	require.NoError(t, table.Upload(context.Background(), true))
+	expectedDBsToUpload = dbNames
+
+	// verify that all the dbs are uploaded
+	uploadedDBs, err = ioutil.ReadDir(filepath.Join(objectStorageDir, table.name))
+	require.NoError(t, err)
+
+	require.Len(t, uploadedDBs, len(expectedDBsToUpload))
+	for _, expectedDB := range expectedDBsToUpload {
+		require.FileExists(t, filepath.Join(objectStorageDir, table.buildObjectKey(fmt.Sprint(expectedDB))))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We want to avoid modifying files once they are uploaded to the store by `boltdb-shipper`.
This PR takes care of it by avoiding uploading active shard or shard which was active up to a minute back.
It also avoids modifying files created and uploaded by previous restart by considering init time of the Table.

This PR would help build a compactor easily which is much needed since an ingester is now creating `96` files per day which is slowing down the queries.

**Checklist**
- [x] Tests updated

