### PR TITLE
helm/fluent-bit: Add optional secret to pull Docker image in fluent-bit chart

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.1.5
+version: 0.2.0
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/daemonset.yaml
+++ b/production/helm/fluent-bit/templates/daemonset.yaml
@@ -35,9 +35,15 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "fluent-bit-loki.serviceAccountName" . }}
-    {{- if .Values.priorityClassName }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: fluent-bit-loki
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/production/helm/fluent-bit/values.yaml
+++ b/production/helm/fluent-bit/values.yaml
@@ -50,6 +50,11 @@ image:
   repository: grafana/fluent-bit-plugin-loki
   tag: 1.5.0-amd64
   pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be present in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # pullSecrets:
+  #   - myRegistrKeySecretName
 
 nameOverride: fluent-bit-loki
 

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.38.4
+version: 0.39.0
 appVersion: v1.5.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."


### PR DESCRIPTION
**What this PR does / why we need it**:
In fluent-bit Helm chart, add an optional value to define a secret used to pull Docker image (when hosted on a private repository).

**Which issue(s) this PR fixes**:
Fixes #2488 

**Special notes for your reviewer**:
I upgraded major digit for version of charts (fluent-bit and loki-stack).
