### PR TITLE
Promtail: Fail fast if promtail can't fail the file

### DIFF
--- a/pkg/promtail/targets/file/tailer.go
+++ b/pkg/promtail/targets/file/tailer.go
@@ -49,6 +49,7 @@ func newTailer(logger log.Logger, handler api.EntryHandler, positions positions.
 		Follow: true,
 		Poll:   true,
 		ReOpen: true,
+		MustExist: true,
 		Location: &tail.SeekInfo{
 			Offset: pos,
 			Whence: 0,


### PR DESCRIPTION
enable the MustExist flag when starting a tailer on a fail, this will cause the tail to fail fast and allow promtail to attempt to re-open the file.

Fixes #1325