### PR TITLE
compress boltdb files to gzip while uploading from shipper

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -76,7 +76,7 @@ func TestTableManager_QueryPages(t *testing.T) {
 	var queries []chunk.IndexQuery
 	for name, dbs := range tables {
 		queries = append(queries, chunk.IndexQuery{TableName: name})
-		testutil.SetupDBTablesAtPath(t, name, objectStoragePath, dbs)
+		testutil.SetupDBTablesAtPath(t, name, objectStoragePath, dbs, true)
 	}
 
 	tableManager, _, stopFunc := buildTestTableManager(t, tempDir)

--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -83,7 +83,7 @@ func TestTable_Query(t *testing.T) {
 		},
 	}
 
-	testutil.SetupDBTablesAtPath(t, "test", objectStoragePath, testDBs)
+	testutil.SetupDBTablesAtPath(t, "test", objectStoragePath, testDBs, true)
 
 	table, _, stopFunc := buildTestTable(t, "test", tempDir)
 	defer func() {
@@ -127,7 +127,7 @@ func TestTable_Sync(t *testing.T) {
 	}
 
 	// setup the table in storage with some records
-	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, testDBs)
+	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, testDBs, false)
 
 	// create table instance
 	table, boltdbClient, stopFunc := buildTestTable(t, "test", tempDir)
@@ -217,7 +217,7 @@ func TestTable_doParallelDownload(t *testing.T) {
 				}
 			}
 
-			testutil.SetupDBTablesAtPath(t, fmt.Sprint(tc), objectStoragePath, testDBs)
+			testutil.SetupDBTablesAtPath(t, fmt.Sprint(tc), objectStoragePath, testDBs, true)
 
 			table, _, stopFunc := buildTestTable(t, fmt.Sprint(tc), tempDir)
 			defer func() {

--- a/pkg/storage/stores/shipper/testutil/testutil.go
+++ b/pkg/storage/stores/shipper/testutil/testutil.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -145,11 +144,13 @@ func SetupDBTablesAtPath(t *testing.T, tableName, path string, dbs map[string]DB
 	tablePath := filepath.Join(path, tableName)
 	require.NoError(t, chunk_util.EnsureDirectory(tablePath))
 
+	var i int
 	for name, dbRecords := range dbs {
 		AddRecordsToDB(t, filepath.Join(tablePath, name), boltIndexClient, dbRecords.Start, dbRecords.NumRecords)
-		if compressRandomFiles && rand.Intn(2) == 0 {
+		if compressRandomFiles && i%2 == 0 {
 			compressFile(t, filepath.Join(tablePath, name))
 		}
+		i++
 	}
 
 	return tablePath

--- a/pkg/storage/stores/shipper/uploads/table.go
+++ b/pkg/storage/stores/shipper/uploads/table.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"go.etcd.io/bbolt"
+
+	"github.com/grafana/loki/pkg/chunkenc"
 )
 
 const (
@@ -235,9 +237,19 @@ func (lt *Table) uploadDB(ctx context.Context, name string, db *bbolt.DB) error 
 		}
 	}()
 
-	err = db.View(func(tx *bbolt.Tx) error {
-		_, err := tx.WriteTo(f)
-		return err
+	err = db.View(func(tx *bbolt.Tx) (err error) {
+		compressedWriter := chunkenc.Gzip.GetWriter(f)
+		defer chunkenc.Gzip.PutWriter(compressedWriter)
+
+		defer func() {
+			cerr := compressedWriter.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		_, err = tx.WriteTo(compressedWriter)
+		return
 	})
 	if err != nil {
 		return err
@@ -304,7 +316,7 @@ func (lt *Table) buildObjectKey(dbName string) string {
 		objectKey = fmt.Sprintf("%s/%s", lt.name, lt.uploader)
 	}
 
-	return objectKey
+	return fmt.Sprintf("%s.gz", objectKey)
 }
 
 func loadBoltDBsFromDir(dir string) (map[string]*bbolt.DB, error) {

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -2,7 +2,6 @@ package uploads
 
 import (
 	"context"
-	"github.com/cortexproject/cortex/pkg/chunk/local"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/local"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +27,7 @@ func buildTestTableManager(t *testing.T, testDir string) (*TableManager, *local.
 		IndexDir:       indexPath,
 		UploadInterval: time.Hour,
 	}
-	tm, err := NewTableManager(cfg, boltDBIndexClient, storageClient,  nil)
+	tm, err := NewTableManager(cfg, boltDBIndexClient, storageClient, nil)
 	require.NoError(t, err)
 
 	return tm, boltDBIndexClient, func() {
@@ -64,7 +64,7 @@ func TestLoadTables(t *testing.T) {
 			Start:      20,
 			NumRecords: 10,
 		},
-	})
+	}, false)
 
 	// table2 with 2 dbs
 	testutil.SetupDBTablesAtPath(t, "table2", indexPath, map[string]testutil.DBRecords{
@@ -76,7 +76,7 @@ func TestLoadTables(t *testing.T) {
 			Start:      40,
 			NumRecords: 10,
 		},
-	})
+	}, false)
 
 	expectedTables := map[string]struct {
 		start, numRecords int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds supports for compressing boltdb files before uploading which is expected to reduce file sizes by 1/3rd.
The files which are compressed would have `.gz` extension and until we build a compactor we would have both compressed and uncompressed files in the storage which is taken care of in the read path.

While it is not necessary but it would be good to merge PR https://github.com/grafana/loki/pull/2487 before merging this to avoid having some files in both compressed and uncompressed form.

It uses gzip pool that we already have built for reducing allocations while compressing/decompressing chunks.

**Checklist**
- [x] Tests updated

