### PR TITLE
fix(ksonnet): don't depend on specific k8s version

### DIFF
--- a/docs/sources/installation/tanka.md
+++ b/docs/sources/installation/tanka.md
@@ -30,16 +30,9 @@ Download and install the Loki and Promtail module using `jb`:
 
 ```bash
 go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-jb init
+jb init  # not required if you already ran `tk init`
 jb install github.com/grafana/loki/production/ksonnet/loki
 jb install github.com/grafana/loki/production/ksonnet/promtail
-```
-
-Note: As of 2020-08-13 we use some as of yet non GA features, please override the `lib/k.libsonnet` with the following. This step will likely not be necessary in future tanka releases.
-
-```jsonnet
-(import 'github.com/jsonnet-libs/k8s-alpha/1.14/main.libsonnet')
-+ (import 'github.com/jsonnet-libs/k8s-alpha/1.14/extensions/kausal-shim.libsonnet')
 ```
 
 Be sure to replace the username, password and the relevant `htpasswd` contents.
@@ -89,4 +82,5 @@ loki + promtail + gateway {
 Notice that `container_root_path` is your own data root for the Docker Daemon.
 Run `docker info | grep "Root Dir"` to get the root path.
 
-Run `tk show environments/loki` to see the manifests that will be deployed to the cluster. Run `tk apply environments/loki` to deploy the manifests.
+Run `tk show environments/loki` to see the manifests that will be deployed to
+the cluster. Run `tk apply environments/loki` to deploy the manifests.

--- a/production/ksonnet/loki-canary/loki-canary.libsonnet
+++ b/production/ksonnet/loki-canary/loki-canary.libsonnet
@@ -1,6 +1,9 @@
 local config = import 'config.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
 
+// backwards compatibility with ksonnet
+local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
+
 k + config {
   namespace: $.core.v1.namespace.new($._config.namespace),
 
@@ -16,8 +19,8 @@ k + config {
     container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.loki_canary_args)) +
     container.withEnv([
-      $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
-      $.core.v1.envVar.fromFieldPath('POD_NAME', 'metadata.name'),
+      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+      envVar.fromFieldPath('POD_NAME', 'metadata.name'),
     ]),
 
   local daemonSet = $.apps.v1.daemonSet,

--- a/production/ksonnet/loki/jsonnetfile.json
+++ b/production/ksonnet/loki/jsonnetfile.json
@@ -36,15 +36,6 @@
         }
       },
       "version": "master"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-alpha.git",
-          "subdir": "1.14"
-        }
-      },
-      "version": "master"
     }
   ],
   "legacyImports": true

--- a/production/ksonnet/loki/jsonnetfile.lock.json
+++ b/production/ksonnet/loki/jsonnetfile.lock.json
@@ -40,16 +40,6 @@
       },
       "version": "8629e32d04a0eefdce41224540f0d31de7d40deb",
       "sum": "AIspZ151p0qkxVc9tuoAEYNrkazV6QncWWsIsarK9GE="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-alpha.git",
-          "subdir": "1.14"
-        }
-      },
-      "version": "4423ca26d1762943b9975fd4f5cc229e814fe8b6",
-      "sum": "00qOXX9Ddf0r2AR3NX7d9A/9MFaAesdGxCs6sXUobok="
     }
   ],
   "legacyImports": false

--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -2,6 +2,9 @@ local scrape_config = import './scrape_config.libsonnet';
 local config = import 'config.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
 
+// backwards compatibility with ksonnet
+local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
+
 k + config + scrape_config {
   namespace:
     $.core.v1.namespace.new($._config.namespace),
@@ -49,7 +52,7 @@ k + config + scrape_config {
     container.withPorts($.core.v1.containerPort.new(name='http-metrics', port=80)) +
     container.withArgsMixin($.util.mapToFlags($.promtail_args)) +
     container.withEnv([
-      $.core.v1.envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
+      envVar.fromFieldPath('HOSTNAME', 'spec.nodeName'),
     ]) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort(80) +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Loki should not depend on a specific k8s version (1.14), this would make upgrading clusters much harder.

As no imports are happening directly in this library, this change should be a no-op.