### PR TITLE
minor fixes and improvements for boltdb shipper

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table_manager.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager.go
@@ -71,10 +71,7 @@ func (tm *TableManager) loop() {
 	for {
 		select {
 		case <-syncTicker.C:
-			err := tm.uploadTables(context.Background())
-			if err != nil {
-				level.Error(pkg_util.Logger).Log("msg", "error uploading local boltdb files to the storage", "err", err)
-			}
+			tm.uploadTables(context.Background())
 		case <-tm.ctx.Done():
 			return
 		}
@@ -87,10 +84,7 @@ func (tm *TableManager) Stop() {
 	tm.cancel()
 	tm.wg.Wait()
 
-	err := tm.uploadTables(context.Background())
-	if err != nil {
-		level.Error(pkg_util.Logger).Log("msg", "error uploading local boltdb files to the storage before stopping", "err", err)
-	}
+	tm.uploadTables(context.Background())
 }
 
 func (tm *TableManager) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback chunk_util.Callback) error {
@@ -157,24 +151,20 @@ func (tm *TableManager) getOrCreateTable(tableName string) (*Table, error) {
 	return table, nil
 }
 
-func (tm *TableManager) uploadTables(ctx context.Context) (err error) {
+func (tm *TableManager) uploadTables(ctx context.Context) {
 	tm.tablesMtx.RLock()
 	defer tm.tablesMtx.RUnlock()
 
 	level.Info(pkg_util.Logger).Log("msg", "uploading tables")
 
-	defer func() {
-		status := statusSuccess
-		if err != nil {
-			status = statusFailure
-		}
-		tm.metrics.tablesUploadOperationTotal.WithLabelValues(status).Inc()
-	}()
-
+	status := statusSuccess
 	for _, table := range tm.tables {
 		err := table.Upload(ctx)
 		if err != nil {
-			return err
+			// continue uploading other tables while skipping cleanup for a failed one.
+			status = statusFailure
+			level.Error(pkg_util.Logger).Log("msg", "failed to upload dbs", "table", table.name, "err", err)
+			continue
 		}
 
 		// cleanup unwanted dbs from the table
@@ -185,7 +175,7 @@ func (tm *TableManager) uploadTables(ctx context.Context) (err error) {
 		}
 	}
 
-	return
+	tm.metrics.tablesUploadOperationTotal.WithLabelValues(status).Inc()
 }
 
 func (tm *TableManager) loadTables() (map[string]*Table, error) {
@@ -236,6 +226,11 @@ func (tm *TableManager) loadTables() (map[string]*Table, error) {
 		}
 
 		if table == nil {
+			// if table is nil it means it has no files in it so remove the folder for that table.
+			err := os.Remove(filepath.Join(tm.cfg.IndexDir, fileInfo.Name()))
+			if err != nil {
+				level.Error(pkg_util.Logger).Log("msg", "failed to remove empty table folder", "table", fileInfo.Name(), "err", err)
+			}
 			continue
 		}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
It includes the following fixes and improvements:
1. Continue uploading of other tables during failures otherwise a problem in single table's upload would avoid other tables from getting uploaded.
2. Remove `.temp` files while loading dbs during startup. A `.temp` file was left off due to ingester getting OOM killed while uploading a table which caused problems in uploading that table when ingester restarted.
3. Remove empty table folders while loading tables during startup. This is just to clean up unwanted folders.

**Checklist**
- [x] Tests updated

