### PR TITLE
Ignore .exe files build for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .cache
 *.output
 *.tgz
+*.exe
 requirements.lock
 mixin/vendor/
 cmd/loki/loki


### PR DESCRIPTION
When building Loki on Windows with `go build ./cmd/loki` command, it creates file `/loki.exe`, but .gitignore has only `/loki`.
Same with `promtail.exe`, `logcli.exe` and `loki-canary.exe`.

Also it is safe to assume that no `.exe` files should be tracked by git in Loki.