### PR TITLE
fix a flaky test in boltdb shipper

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -378,13 +378,14 @@ func TestTable_ImmutableUploads(t *testing.T) {
 		boltDBIndexClient.Stop()
 	}()
 
-	activeShard := time.Now().Truncate(shardDBsByDuration)
+	// shardCutoff is calulated based on when shards are considered to not be active anymore and are safe to be uploaded.
+	shardCutoff := getOldestActiveShardTime()
 
 	// some dbs to setup
 	dbNames := []int64{
-		activeShard.Add(-shardDBsByDuration).Unix(), // inactive shard, should upload
-		activeShard.Add(-2 * time.Minute).Unix(),    // 2 minutes before active shard, should upload
-		activeShard.Unix(),                          // active shard, should not upload
+		shardCutoff.Add(-shardDBsByDuration).Unix(),    // inactive shard, should upload
+		shardCutoff.Add(-1 * time.Minute).Unix(),       // 1 minute before shard cutoff, should upload
+		time.Now().Truncate(shardDBsByDuration).Unix(), // active shard, should not upload
 	}
 
 	dbs := map[string]testutil.DBRecords{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The test `TestTable_ImmutableUploads` was flaky and was failing based on when tests are running.
This PR fixes the tests by making the time calculation for oldest active shard time uniform between the actual code and the test by moving it to a function.

**Checklist**
- [x] Tests updated

