### PR TITLE
cleanup boltdb files in queriers during startup/shutdown

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -184,8 +184,14 @@ func (t *Table) Close() {
 	defer t.dbsMtx.Unlock()
 
 	for name, db := range t.dbs {
+		dbPath := db.boltdb.Path()
+
 		if err := db.boltdb.Close(); err != nil {
-			level.Error(util.Logger).Log("msg", fmt.Errorf("failed to close file %s for table %s", name, t.name))
+			level.Error(util.Logger).Log("msg", fmt.Sprintf("failed to close file %s for table %s", name, t.name), "err", err)
+		}
+
+		if err := os.Remove(dbPath); err != nil {
+			level.Error(util.Logger).Log("msg", fmt.Sprintf("failed to remove file %s for table %s", name, t.name), "err", err)
 		}
 	}
 

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -3,6 +3,7 @@ package downloads
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -37,6 +38,15 @@ type TableManager struct {
 }
 
 func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, storageClient StorageClient, registerer prometheus.Registerer) (*TableManager, error) {
+	// cleanup existing directory and re-create it since we do not use existing files in it.
+	if err := os.RemoveAll(cfg.CacheDir); err != nil {
+		return nil, err
+	}
+
+	if err := chunk_util.EnsureDirectory(cfg.CacheDir); err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	tm := &TableManager{
 		cfg:             cfg,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Queriers do not use existing boltdb files when they receive a query for a new table(never served queries for it since startup) and we do not remove boltdb files when queriers stop which means unwanted files would be lying around.

This PR removes files from the cache directory during graceful shutdown or during startup if it didn't get to remove them for some reason.

Ideally, it would be good to reuse those files but the files could be stale and we would have to sync them first with the store which would add up to startup delay. We can handle this in future incremental changes.

