### PR TITLE
fix dir setup based on which mode it is running

### DIFF
--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -81,17 +81,12 @@ type Shipper struct {
 
 // NewShipper creates a shipper for syncing local objects with a store
 func NewShipper(cfg Config, storageClient chunk.ObjectClient, registerer prometheus.Registerer) (chunk.IndexClient, error) {
-	err := chunk_util.EnsureDirectory(cfg.CacheLocation)
-	if err != nil {
-		return nil, err
-	}
-
 	shipper := Shipper{
 		cfg:     cfg,
 		metrics: newMetrics(registerer),
 	}
 
-	err = shipper.init(storageClient, registerer)
+	err := shipper.init(storageClient, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +97,15 @@ func NewShipper(cfg Config, storageClient chunk.ObjectClient, registerer prometh
 }
 
 func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.Registerer) error {
-	uploader, err := s.getUploaderName()
-	if err != nil {
-		return err
+	// When we run with target querier we don't have ActiveIndexDirectory set so using CacheLocation instead.
+	// Also it doesn't matter which directory we use since BoltDBIndexClient doesn't do anything with it but it is good to have a valid path.
+	boltdbIndexClientDir := s.cfg.ActiveIndexDirectory
+	if boltdbIndexClientDir == "" {
+		boltdbIndexClientDir = s.cfg.CacheLocation
 	}
 
-	s.boltDBIndexClient, err = local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: s.cfg.ActiveIndexDirectory})
+	var err error
+	s.boltDBIndexClient, err = local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: boltdbIndexClientDir})
 	if err != nil {
 		return err
 	}
@@ -115,6 +113,11 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 	prefixedObjectClient := util.NewPrefixedObjectClient(storageClient, StorageKeyPrefix)
 
 	if s.cfg.Mode != ModeReadOnly {
+		uploader, err := s.getUploaderName()
+		if err != nil {
+			return err
+		}
+
 		cfg := uploads.Config{
 			Uploader:       uploader,
 			IndexDir:       s.cfg.ActiveIndexDirectory,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When boltdb-shipper runs in a querier we will have only `CacheLocation` set while for ingester we will have only `ActiveIndexDirectory` set. Based on that expectation fixing the code which sets up the directories for them.

