### PR TITLE
fix closing of compressed file from boltdb-shipper compactor

### DIFF
--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -96,7 +96,7 @@ func CompressFile(src, dest string) error {
 	}
 
 	defer func() {
-		if err := uncompressedFile.Close(); err != nil {
+		if err := compressedFile.Close(); err != nil {
 			level.Error(util.Logger).Log("msg", "failed to close compressed file", "path", dest, "err", err)
 		}
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Fix a mistake in code trying to close uncompressed file again instead of compressed one.

