### PR TITLE
Better rule loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/klog v1.0.0
 )
 

--- a/pkg/ruler/manager/compat_test.go
+++ b/pkg/ruler/manager/compat_test.go
@@ -1,0 +1,249 @@
+package manager
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Load(t *testing.T) {
+	for _, tc := range []struct {
+		desc  string
+		data  string
+		match string
+	}{
+		{
+			desc: "load correctly",
+			data: `
+groups:
+  - name: testgrp2
+    interval: 0s
+    rules:
+      - alert: HTTPCredentialsLeaked
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail empty groupname",
+			match: "Groupname must not be empty",
+			data: `
+groups:
+  - name:
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail duplicate grps",
+			match: "repeated in the same file",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail record & alert",
+			match: "only one of 'record' and 'alert' must be set",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        record: doublevision
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail neither record nor alert",
+			match: "one of 'record' or 'alert' must be set",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail empty expr",
+			match: "field 'expr' must be set in rule",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail bad expr",
+			match: "could not parse expression",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: garbage
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail annotations in recording rule",
+			match: "invalid field 'annotations' in recording rule",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - record: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail for in recording rule",
+			match: "invalid field 'for' in recording rule",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - record: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+`,
+		},
+		{
+			desc:  "fail recording rule name",
+			match: "invalid recording rule name:",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - record: 'Hi.ghThroughputLogStreams'
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+`,
+		},
+		{
+			desc:  "fail invalid label name",
+			match: "invalid label name:",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            'se.verity': page
+        annotations:
+            summary: High request latency
+`,
+		},
+		{
+			desc:  "fail invalid annotation",
+			match: "invalid annotation name:",
+			data: `
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            's.ummary': High request latency
+`,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var loader groupLoader
+			f, err := ioutil.TempFile(os.TempDir(), "rules")
+			require.Nil(t, err)
+			defer os.Remove(f.Name())
+			err = ioutil.WriteFile(f.Name(), []byte(tc.data), 0777)
+			require.Nil(t, err)
+
+			_, errs := loader.Load(f.Name())
+			if tc.match != "" {
+				require.NotNil(t, errs)
+				var found bool
+				for _, err := range errs {
+					found = found || strings.Contains(err.Error(), tc.match)
+				}
+				if !found {
+					fmt.Printf("\nerrors did not contain desired (%s): %v", tc.match, errs)
+				}
+				require.Equal(t, true, found)
+			} else {
+				require.Nil(t, errs)
+			}
+		})
+
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1255,6 +1255,7 @@ gopkg.in/tomb.v1
 ## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+## explicit
 gopkg.in/yaml.v3
 # honnef.co/go/tools v0.0.1-2020.1.3
 honnef.co/go/tools/arg


### PR DESCRIPTION
Fixes an issue where the underlying prometheus `rulefmt` loader parsed expressions as promql -- now we rip out the bits we need for a logql version.