### PR TITLE
strict rule unmarshaling

### DIFF
--- a/pkg/ruler/manager/compat.go
+++ b/pkg/ruler/manager/compat.go
@@ -138,10 +138,9 @@ func (groupLoader) parseRules(content []byte) (*rulefmt.RuleGroups, []error) {
 	)
 
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
-	err := decoder.Decode(&groups)
+	decoder.KnownFields(true)
 
-	// err := yaml.Unmarshal(content, &groups)
-	if err != nil {
+	if err := decoder.Decode(&groups); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/ruler/manager/compat_test.go
+++ b/pkg/ruler/manager/compat_test.go
@@ -220,6 +220,24 @@ groups:
             's.ummary': High request latency
 `,
 		},
+		{
+			desc:  "unknown fields",
+			match: "field unknown not found",
+			data: `
+unknown: true
+groups:
+  - name: grp1
+    interval: 0s
+    rules:
+      - alert: HighThroughputLogStreams
+        expr: sum by (cluster, job, pod) (rate({namespace=~"%s"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)
+        for: 2m
+        labels:
+            severity: page
+        annotations:
+            's.ummary': High request latency
+`,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			var loader groupLoader


### PR DESCRIPTION
Ensures that unmentioned fields error instead of being ignored silently.