### PR TITLE
Expose UserAgent and fix User-Agent version source

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -21,8 +21,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
 
-	"github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/logproto"
 )
@@ -72,7 +72,7 @@ var (
 		encodedBytes, sentBytes, droppedBytes, sentEntries, droppedEntries,
 	}
 
-	userAgent = fmt.Sprintf("promtail/%s", build.Version)
+	userAgent = fmt.Sprintf("promtail/%s", version.Version)
 )
 
 func init() {

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -72,7 +72,7 @@ var (
 		encodedBytes, sentBytes, droppedBytes, sentEntries, droppedEntries,
 	}
 
-	userAgent = fmt.Sprintf("promtail/%s", version.Version)
+	UserAgent = fmt.Sprintf("promtail/%s", version.Version)
 )
 
 func init() {
@@ -262,7 +262,7 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", UserAgent)
 
 	// If the tenant ID is not empty promtail is running in multi-tenant mode, so
 	// we should send it to Loki


### PR DESCRIPTION
This PR exposes UserAgent as an equivalent to a similar PR recently made for [Prometheus](https://github.com/prometheus/prometheus/pull/7832), This allows importers (like grafana/agent) to customize the User-Agent to allow tracking which clients are sending data through Promtail. 

As a secondary fix, this PR also changes the User Agent's version info to be pulled from `github.com/prometheus/common/version` rather than `github.com/grafana/loki/pkg/build`. `grafana/agent` has its own equivalent build package that sets the build version and needs a [hack](https://github.com/grafana/agent/pull/187) to ensure its own overrides take precedence. The clean fix is to get the version from the common dependency rather than the package responsible for setting the version globals.
