### PR TITLE
Logstash cpu usage fix

### DIFF
--- a/cmd/logstash/lib/logstash/outputs/loki.rb
+++ b/cmd/logstash/lib/logstash/outputs/loki.rb
@@ -4,7 +4,7 @@ require "logstash/outputs/loki/entry"
 require "logstash/outputs/loki/batch"
 require "logstash/namespace"
 require 'net/http'
-require 'concurrent-edge'
+require 'agent'
 require 'time'
 require 'uri'
 require 'json'
@@ -68,10 +68,10 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
 
     @logger.info("Loki output plugin", :class => self.class.name)
 
-    # initialize channels
-    @Channel = Concurrent::Channel
-    @entries = @Channel.new
-    @stop = @Channel.new
+    # initialize Queue and Mutex
+    @entries = Queue.new 
+    @mutex = Mutex.new
+    @stop = false
 
     # create nil batch object.
     @batch = nil
@@ -82,7 +82,50 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
       validate_ssl_key
     end
 
-    @Channel.go{run()}
+    # start batch_max_wait and batch_max_size threads
+    @batch_wait_thread = Thread.new{max_batch_wait()}
+    @batch_size_thread = Thread.new{max_batch_size()}
+  end
+
+  def max_batch_size
+    loop do
+      if @stop
+        return
+      end
+      e = @entries.deq
+      if e.nil?
+        return
+      end
+      @mutex.synchronize do
+        if !add_entry_to_batch(e)
+          @logger.debug("Max batch_size is reached. Sending batch to loki")
+          send(@batch)
+          @batch = Batch.new(e)
+        end
+      end
+    end
+  end
+
+  def max_batch_wait
+    # minimum wait frequency is 10 milliseconds
+	  min_wait_checkfrequency = 1/100
+	  max_wait_checkfrequency = @batch_wait
+	  if max_wait_checkfrequency < min_wait_checkfrequency
+		  max_wait_checkfrequency = min_wait_checkfrequency
+    end
+    loop do
+      if @stop
+        return
+      end
+      sleep(max_wait_checkfrequency)
+      if is_batch_expired
+        @mutex.synchronize do
+          @logger.debug("Max batch_wait time is reached. Sending batch to loki")
+          send(@batch)
+          @batch = nil
+        end
+      end
+    end
   end
 
   def ssl_cert?
@@ -128,39 +171,6 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
     opts
   end
 
-  def run()
-    # minimum wait frequency is 10 millisecond
-	  min_wait_checkfrequency = 1/100
-	  max_wait_checkfrequency = @batch_wait
-	  if max_wait_checkfrequency < min_wait_checkfrequency
-		  max_wait_checkfrequency = min_wait_checkfrequency
-    end
-
-    @max_wait_check = Concurrent::Channel.tick(max_wait_checkfrequency)
-    loop do
-      Concurrent::Channel.select do |s|
-        s.take(@stop) {
-          return
-        }
-        s.take(@entries) { |e|
-         if !add_entry_to_batch(e)
-           @logger.debug("Max batch_size is reached. Sending batch to loki")
-           send(@batch)
-           @batch = Batch.new(e)
-         end
-        }
-        s.take(@max_wait_check) {
-          # send batch if max wait time has been reached
-          if is_batch_expired
-            @logger.debug("Max batch_wait time is reached. Sending batch to loki")
-            send(@batch)
-            @batch = nil
-          end
-        }
-      end
-    end
-  end
-
   # Add an entry to the current batch returns false if the batch is full
   # and the entry can't be added.
   def add_entry_to_batch(e)
@@ -192,8 +202,9 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
 
   def close
     @entries.close
-    @max_wait_check.close if !@max_wait_check.nil?
-    @stop << true # stop will block until it's accepted by the worker.
+    @stop = true 
+    @batch_wait_thread.join
+    @batch_size_thread.join
 
     # if by any chance we still have a forming batch, we need to send it.
     send(@batch) if !@batch.nil?

--- a/cmd/logstash/lib/logstash/outputs/loki.rb
+++ b/cmd/logstash/lib/logstash/outputs/loki.rb
@@ -4,7 +4,6 @@ require "logstash/outputs/loki/entry"
 require "logstash/outputs/loki/batch"
 require "logstash/namespace"
 require 'net/http'
-require 'agent'
 require 'time'
 require 'uri'
 require 'json'

--- a/cmd/logstash/lib/logstash/outputs/loki.rb
+++ b/cmd/logstash/lib/logstash/outputs/loki.rb
@@ -129,9 +129,9 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
   end
 
   def run()
-    # minimum wait frequency is 1 millisecond
-	  min_wait_checkfrequency = 1/100 
-	  max_wait_checkfrequency = @batch_wait / 10
+    # minimum wait frequency is 10 millisecond
+	  min_wait_checkfrequency = 1/100
+	  max_wait_checkfrequency = @batch_wait
 	  if max_wait_checkfrequency < min_wait_checkfrequency
 		  max_wait_checkfrequency = min_wait_checkfrequency
     end

--- a/cmd/logstash/logstash-output-loki.gemspec
+++ b/cmd/logstash/logstash-output-loki.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name    = 'logstash-output-loki'
-  s.version = '1.0.2'
+  s.version = '1.0.3'
   s.authors = ['Aditya C S','Cyril Tovena']
   s.email   = ['aditya.gnu@gmail.com','cyril.tovena@grafana.com']
 

--- a/cmd/logstash/logstash-output-loki.gemspec
+++ b/cmd/logstash/logstash-output-loki.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   #
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-plain", "3.0.6"
-  s.add_runtime_dependency "concurrent-ruby-edge", "0.6.0"
   s.add_development_dependency 'logstash-devutils', "2.0.2"
 end


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes unnecessary cpu usage by logstash. This is happening because `loop select` is expected to block on multiple channels and not just run the `loop` indefinitely. Looks like `concurrent-ruby` library is not handling this.  Also, tried [agent](https://github.com/igrigorik/agent/) but even this library is not handling channel block and receive as expected. So, changed the implementation to handle concurrency using just Ruby Threads.
  
**Which issue(s) this PR fixes**:
Fixes #2551 

After the initial startup, CPU usage is minimal

<img width="774" alt="Screenshot 2020-09-09 at 5 08 13 PM" src="https://user-images.githubusercontent.com/7681197/92596927-34b4d700-f2c4-11ea-9a1a-7f4b879dd899.png">
