### PR TITLE
fix a panic when trying to stop boltdb-shipper multiple times using sync.once

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -782,6 +782,8 @@ func TestStore_MultipleBoltDBShippersInConfig(t *testing.T) {
 	}}, limits, nil)
 	require.NoError(t, err)
 
+	defer store.Stop()
+
 	// time ranges adding a chunk for each store and a chunk which overlaps both the stores
 	chunksToBuildForTimeRanges := []timeRange{
 		{

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -76,7 +77,8 @@ type Shipper struct {
 	uploadsManager    *uploads.TableManager
 	downloadsManager  *downloads.TableManager
 
-	metrics *metrics
+	metrics  *metrics
+	stopOnce sync.Once
 }
 
 // NewShipper creates a shipper for syncing local objects with a store
@@ -179,6 +181,10 @@ func (s *Shipper) getUploaderName() (string, error) {
 }
 
 func (s *Shipper) Stop() {
+	s.stopOnce.Do(s.stop)
+}
+
+func (s *Shipper) stop() {
 	if s.uploadsManager != nil {
 		s.uploadsManager.Stop()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When boltdb-shipper is used in multiple schema configs we share the same instance. When we stop the store service it tries to stop the same boltdb-shipper client multiple times causing it to panic on already closed channel.
This PR fixes the issue by using sync.Once.

**Which issue(s) this PR fixes**:
Fixes #2609 

**Checklist**
- [x] Tests updated

