### PR TITLE
Promtail: Add a stream lagging metric

### DIFF
--- a/pkg/logentry/metric/metricvec.go
+++ b/pkg/logentry/metric/metricvec.go
@@ -58,6 +58,17 @@ func (c *metricVec) With(labels model.LabelSet) prometheus.Metric {
 	return metric
 }
 
+func (c *metricVec) Delete(labels model.LabelSet) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	fp := labels.Fingerprint()
+	_, ok := c.metrics[fp]
+	if ok {
+		delete(c.metrics, fp)
+	}
+	return ok
+}
+
 // prune will remove all metrics which implement the Expirable interface and have expired
 // it does not take out a lock on the metrics map so whoever calls this function should do so.
 func (c *metricVec) prune() {

--- a/pkg/promtail/api/types.go
+++ b/pkg/promtail/api/types.go
@@ -8,7 +8,6 @@ import (
 
 type InstrumentedEntryHandler interface {
 	EntryHandler
-	RegisterLatencyMetric(labels model.LabelSet)
 	UnregisterLatencyMetric(labels model.LabelSet)
 }
 

--- a/pkg/promtail/api/types.go
+++ b/pkg/promtail/api/types.go
@@ -4,7 +4,14 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
+
+type InstrumentedEntryHandler interface {
+	EntryHandler
+	RegisterLatencyMetric(labels labels.Labels)
+	UnregisterLatencyMetric(labels labels.Labels)
+}
 
 // EntryHandler is something that can "handle" entries.
 type EntryHandler interface {

--- a/pkg/promtail/api/types.go
+++ b/pkg/promtail/api/types.go
@@ -4,13 +4,12 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 type InstrumentedEntryHandler interface {
 	EntryHandler
-	RegisterLatencyMetric(labels labels.Labels)
-	UnregisterLatencyMetric(labels labels.Labels)
+	RegisterLatencyMetric(labels model.LabelSet)
+	UnregisterLatencyMetric(labels model.LabelSet)
 }
 
 // EntryHandler is something that can "handle" entries.

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/pkg/logentry/metric"
@@ -360,4 +361,12 @@ func (c *client) Handle(ls model.LabelSet, t time.Time, s string) error {
 		Line:      s,
 	}}
 	return nil
+}
+
+func (c *client) RegisterLatencyMetric(labels labels.Labels) {
+
+}
+
+func (c *client) UnregisterLatencyMetric(labels labels.Labels) {
+
 }

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -255,11 +255,15 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 					level.Warn(c.logger).Log("msg", "error converting stream label string to label.Labels, cannot update lagging metric", "error", err)
 					return
 				}
-				lblSet := make(model.LabelSet, len(lbls))
+				var lblSet model.LabelSet
 				for i := range lbls {
-					lblSet[model.LabelName(lbls[i].Name)] = model.LabelValue(lbls[i].Value)
+					if lbls[i].Name == "filename" {
+						lblSet = model.LabelSet{model.LabelName(lbls[i].Name): model.LabelValue(lbls[i].Value)}
+					}
 				}
-				streamLag.With(lblSet).Set(time.Now().Sub(s.Entries[len(s.Entries)-1].Timestamp).Seconds())
+				if lblSet != nil {
+					streamLag.With(lblSet).Set(time.Now().Sub(s.Entries[len(s.Entries)-1].Timestamp).Seconds())
+				}
 			}
 			return
 		}

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -92,7 +92,7 @@ func init() {
 	streamLag, err = metric.NewGauges("promtail_stream_lag_seconds",
 		"Difference between current time and last batch timestamp for successful sends",
 		metric.GaugeConfig{Action: "set"},
-		int64(5*time.Minute.Seconds()),
+		int64(1*time.Minute.Seconds()), // This strips out files which update slowly and reduces noise in this metric.
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -39,6 +39,7 @@ const (
 	ReservedLabelTenantID = "__tenant_id__"
 
 	LatencyLabel = "filename"
+	HostLabel    = "host"
 )
 
 var (
@@ -46,32 +47,32 @@ var (
 		Namespace: "promtail",
 		Name:      "encoded_bytes_total",
 		Help:      "Number of bytes encoded and ready to send.",
-	}, []string{"host"})
+	}, []string{HostLabel})
 	sentBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "sent_bytes_total",
 		Help:      "Number of bytes sent.",
-	}, []string{"host"})
+	}, []string{HostLabel})
 	droppedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "dropped_bytes_total",
 		Help:      "Number of bytes dropped because failed to be sent to the ingester after all retries.",
-	}, []string{"host"})
+	}, []string{HostLabel})
 	sentEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "sent_entries_total",
 		Help:      "Number of log entries sent to the ingester.",
-	}, []string{"host"})
+	}, []string{HostLabel})
 	droppedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "dropped_entries_total",
 		Help:      "Number of log entries dropped because failed to be sent to the ingester after all retries.",
-	}, []string{"host"})
+	}, []string{HostLabel})
 	requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "promtail",
 		Name:      "request_duration_seconds",
 		Help:      "Duration of send requests.",
-	}, []string{"status_code", "host"})
+	}, []string{"status_code", HostLabel})
 	streamLag *metric.Gauges
 
 	countersWithHost = []*prometheus.CounterVec{
@@ -260,7 +261,10 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 				var lblSet model.LabelSet
 				for i := range lbls {
 					if lbls[i].Name == LatencyLabel {
-						lblSet = model.LabelSet{model.LabelName(lbls[i].Name): model.LabelValue(lbls[i].Value)}
+						lblSet = model.LabelSet{
+							model.LabelName(HostLabel):    model.LabelValue(c.cfg.URL.Host),
+							model.LabelName(LatencyLabel): model.LabelValue(lbls[i].Value),
+						}
 					}
 				}
 				if lblSet != nil {

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -37,6 +37,8 @@ const (
 	// Label reserved to override the tenant ID while processing
 	// pipeline stages
 	ReservedLabelTenantID = "__tenant_id__"
+
+	LatencyLabel = "filename"
 )
 
 var (
@@ -257,7 +259,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 				}
 				var lblSet model.LabelSet
 				for i := range lbls {
-					if lbls[i].Name == "filename" {
+					if lbls[i].Name == LatencyLabel {
 						lblSet = model.LabelSet{model.LabelName(lbls[i].Name): model.LabelValue(lbls[i].Value)}
 					}
 				}

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -95,6 +95,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	prometheus.MustRegister(streamLag)
 }
 
 // Client pushes entries to Loki and can be stopped

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/pkg/logentry/metric"
@@ -363,10 +362,10 @@ func (c *client) Handle(ls model.LabelSet, t time.Time, s string) error {
 	return nil
 }
 
-func (c *client) RegisterLatencyMetric(labels labels.Labels) {
+func (c *client) RegisterLatencyMetric(labels model.LabelSet) {
 
 }
 
-func (c *client) UnregisterLatencyMetric(labels labels.Labels) {
-
+func (c *client) UnregisterLatencyMetric(labels model.LabelSet) {
+	streamLag.Delete(labels)
 }

--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -368,10 +368,7 @@ func (c *client) Handle(ls model.LabelSet, t time.Time, s string) error {
 	return nil
 }
 
-func (c *client) RegisterLatencyMetric(labels model.LabelSet) {
-
-}
-
 func (c *client) UnregisterLatencyMetric(labels model.LabelSet) {
+	labels[HostLabel] = model.LabelValue(c.cfg.URL.Host)
 	streamLag.Delete(labels)
 }

--- a/pkg/promtail/client/config.go
+++ b/pkg/promtail/client/config.go
@@ -34,7 +34,7 @@ type Config struct {
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&c.URL, prefix+"client.url", "URL of log server")
 	f.DurationVar(&c.BatchWait, prefix+"client.batch-wait", 1*time.Second, "Maximum wait period before sending batch.")
-	f.IntVar(&c.BatchSize, prefix+"client.batch-size-bytes", 100*1024, "Maximum batch size to accrue before sending. ")
+	f.IntVar(&c.BatchSize, prefix+"client.batch-size-bytes", 1024*1024, "Maximum batch size to accrue before sending. ")
 	// Default backoff schedule: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(4.267m) For a total time of 511.5s(8.5m) before logs are lost
 	f.IntVar(&c.BackoffConfig.MaxRetries, prefix+"client.max-retries", 10, "Maximum number of retires when sending batches.")
 	f.DurationVar(&c.BackoffConfig.MinBackoff, prefix+"client.min-backoff", 500*time.Millisecond, "Initial backoff time between retries.")

--- a/pkg/promtail/targets/file/filetarget.go
+++ b/pkg/promtail/targets/file/filetarget.go
@@ -304,6 +304,9 @@ func (t *FileTarget) startTailing(ps []string) {
 			continue
 		}
 		t.tails[p] = tailer
+		if h, ok := t.handler.(api.InstrumentedEntryHandler); ok {
+			h.RegisterLatencyMetric(nil)
+		}
 	}
 }
 
@@ -315,6 +318,9 @@ func (t *FileTarget) stopTailingAndRemovePosition(ps []string) {
 			tailer.stop()
 			t.positions.Remove(tailer.path)
 			delete(t.tails, p)
+		}
+		if h, ok := t.handler.(api.InstrumentedEntryHandler); ok {
+			h.UnregisterLatencyMetric(nil)
 		}
 	}
 }

--- a/pkg/promtail/targets/file/filetarget.go
+++ b/pkg/promtail/targets/file/filetarget.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/loki/pkg/helpers"
 	"github.com/grafana/loki/pkg/promtail/api"
+	"github.com/grafana/loki/pkg/promtail/client"
 	"github.com/grafana/loki/pkg/promtail/positions"
 	"github.com/grafana/loki/pkg/promtail/targets/target"
 )
@@ -304,9 +305,6 @@ func (t *FileTarget) startTailing(ps []string) {
 			continue
 		}
 		t.tails[p] = tailer
-		if h, ok := t.handler.(api.InstrumentedEntryHandler); ok {
-			h.RegisterLatencyMetric(nil)
-		}
 	}
 }
 
@@ -320,7 +318,7 @@ func (t *FileTarget) stopTailingAndRemovePosition(ps []string) {
 			delete(t.tails, p)
 		}
 		if h, ok := t.handler.(api.InstrumentedEntryHandler); ok {
-			h.UnregisterLatencyMetric(nil)
+			h.UnregisterLatencyMetric(model.LabelSet{model.LabelName(client.LatencyLabel): model.LabelValue(p)})
 		}
 	}
 }


### PR DESCRIPTION
This is similar to what we accomplish with `promtail_file_bytes_total - promtail_read_bytes_total` which gives a difference between the current file size and how far Promtail has read into it.

There are problems with those metrics however, and unfortunately there are also problems with this approach too, but I think there are less problems with this approach and the output is more meaningful.

How it works:

Every time a successful batch is sent to Loki, we iterate through all the streams in the batch, take the most recent entry and subtract it from time.Now() and then report this as a gauge named `promtail_stream_lag_seconds` with a label for the filename.

Problems with this approach:

* This metric adds very little value if promtail is assigning the timestamp when the line is read, it still might be useful but not as useful as having promtail extract the timestamp from the log line.
* If you are extracting the log line timestamp and the timestamps are somehow old or delayed, then this metric will be skewed.
* Slowly updated log files will show a lag when none really exists, i.e. a log file writes an entry and it took 3s to send it, that metric will be present and scraped until the next log line for that stream is processed and changes that value, however if no new log lines are written to that file the metric will continue to output 3s until it expires and auto removes after 1m or the file stops being tailed.  This leads to some strange artifacts of 1m long flat lines in the output, we could crank the expiration to a much smaller value but then you would likely lose visibility into slowly written log lines which are actually way behind.

All that being said I do think this helps close the loop in normal circumstances for normal volume log streams on how long it takes from when they are written until we get a 200 indicating Loki has stored them.

**NOTE** this PR also changes the default batch size from 100kb to 1MB, it was discovered 100KB is too small for high volume log files which can generate log's at a rate of over 100kb/sec, meaning multiple batches per second were required and would cause Promtail to get behind. Increasing this to 1MB addresses this issue and does not affect slower streams which will still be sent based on the BatchWait setting of default 1s