### PR TITLE
pkg/storage/stores/shipper/uploads: fix test error

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -437,6 +437,7 @@ func TestTable_ImmutableUploads(t *testing.T) {
 
 	// delete everything uploaded
 	dir, err := ioutil.ReadDir(filepath.Join(objectStorageDir, table.name))
+	require.NoError(t, err)
 	for _, d := range dir {
 		os.RemoveAll(filepath.Join(objectStorageDir, table.name, d.Name()))
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in the tests for `pkg/storage/stores/shipper/uploads`.