### PR TITLE
improvements for boltdb-shipper compactor

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -349,6 +349,12 @@ func (t *Loki) setupModuleManager() error {
 		All:           {Querier, Ingester, Distributor, TableManager},
 	}
 
+	// If we are running Loki with boltdb-shipper as a single binary, without clustered mode(which should always be the case when using inmemory ring),
+	// we should start compactor as well for better user experience.
+	if storage.UsingBoltdbShipper(t.cfg.SchemaConfig) && t.cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.Store == "inmemory" {
+		deps[All] = append(deps[All], Compactor)
+	}
+
 	for mod, targets := range deps {
 		if err := mm.AddDependency(mod, targets...); err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Does the following improvements to `boltdb-shipper` compactor:
1. Run the compaction process on startup instead of waiting for the first tick.
2. Make the interval at which compaction runs configurable and reduce the default interval to 2 hours because lesser the files faster the query response.
3. Run the compactor service when using loki with boltdb-shipper in a single binary mode without clustering.

