### PR TITLE
pkg/chunkenc: fix test using string(int) conversion

### DIFF
--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -255,7 +256,7 @@ func TestSerialization(t *testing.T) {
 			numSamples := 50000
 
 			for i := 0; i < numSamples; i++ {
-				require.NoError(t, chk.Append(logprotoEntry(int64(i), string(i))))
+				require.NoError(t, chk.Append(logprotoEntry(int64(i), strconv.Itoa(i))))
 			}
 
 			byt, err := chk.Bytes()
@@ -271,7 +272,7 @@ func TestSerialization(t *testing.T) {
 
 				e := it.Entry()
 				require.Equal(t, int64(i), e.Timestamp.UnixNano())
-				require.Equal(t, string(i), e.Line)
+				require.Equal(t, strconv.Itoa(i), e.Line)
 			}
 			require.NoError(t, it.Error())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since go1.15, there's a new vet check for code such as string(x) where x has an integer type other than rune.  This vet check is enabled by default on go test.

`TestSerialization` failed because of that, this commit replaces `string()`conversions with `strconv.Itoa` calls

**Which issue(s) this PR fixes**:
Fixes #2646

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

