### PR TITLE
run multiple queries per table at once with boltdb-shipper

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 )
 
 const cacheCleanupInterval = time.Hour
@@ -102,27 +104,35 @@ func (tm *TableManager) Stop() {
 }
 
 func (tm *TableManager) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback chunk_util.Callback) error {
-	return chunk_util.DoParallelQueries(ctx, tm.query, queries, callback)
+	queriesByTable := util.QueriesByTable(queries)
+	for tableName, queries := range queriesByTable {
+		err := tm.query(ctx, tableName, queries, callback)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func (tm *TableManager) query(ctx context.Context, query chunk.IndexQuery, callback chunk_util.Callback) error {
+func (tm *TableManager) query(ctx context.Context, tableName string, queries []chunk.IndexQuery, callback chunk_util.Callback) error {
 	log, ctx := spanlogger.New(ctx, "Shipper.Downloads.Query")
 	defer log.Span.Finish()
 
-	level.Debug(log).Log("table-name", query.TableName)
+	level.Debug(log).Log("table-name", tableName)
 
-	table := tm.getOrCreateTable(ctx, query.TableName)
+	table := tm.getOrCreateTable(ctx, tableName)
 
-	err := table.Query(ctx, query, callback)
+	err := util.DoParallelQueries(ctx, table, queries, callback)
 	if err != nil {
 		if table.Err() != nil {
 			// table is in invalid state, remove the table so that next queries re-create it.
 			tm.tablesMtx.Lock()
 			defer tm.tablesMtx.Unlock()
 
-			level.Error(pkg_util.Logger).Log("msg", fmt.Sprintf("table %s has some problem, cleaning it up", query.TableName), "err", table.Err())
+			level.Error(pkg_util.Logger).Log("msg", fmt.Sprintf("table %s has some problem, cleaning it up", tableName), "err", table.Err())
 
-			delete(tm.tables, query.TableName)
+			delete(tm.tables, tableName)
 			return table.Err()
 		}
 	}

--- a/pkg/storage/stores/shipper/testutil/testutil.go
+++ b/pkg/storage/stores/shipper/testutil/testutil.go
@@ -43,15 +43,15 @@ func AddRecordsToBatch(batch chunk.WriteBatch, tableName string, start, numRecor
 }
 
 type SingleTableQuerier interface {
-	Query(ctx context.Context, query chunk.IndexQuery, callback chunk_util.Callback) error
+	MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk_util.Callback) error
 }
 
-func TestSingleQuery(t *testing.T, query chunk.IndexQuery, querier SingleTableQuerier, start, numRecords int) {
+func TestSingleTableQuery(t *testing.T, queries []chunk.IndexQuery, querier SingleTableQuerier, start, numRecords int) {
 	minValue := start
 	maxValue := start + numRecords
 	fetchedRecords := make(map[string]string)
 
-	err := querier.Query(context.Background(), query, makeTestCallback(t, minValue, maxValue, fetchedRecords))
+	err := querier.MultiQueries(context.Background(), queries, makeTestCallback(t, minValue, maxValue, fetchedRecords))
 
 	require.NoError(t, err)
 	require.Len(t, fetchedRecords, numRecords)

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -101,7 +101,7 @@ func TestLoadTables(t *testing.T) {
 	require.True(t, !stat.IsDir())
 
 	for tableName, expectedIndex := range expectedTables {
-		testutil.TestSingleQuery(t, chunk.IndexQuery{TableName: tableName}, tm.tables[tableName], expectedIndex.start, expectedIndex.numRecords)
+		testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{TableName: tableName}}, tm.tables[tableName], expectedIndex.start, expectedIndex.numRecords)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestTableManager_BatchWrite(t *testing.T) {
 	require.Len(t, tm.tables, len(tc))
 
 	for tableName, expectedIndex := range tc {
-		testutil.TestSingleQuery(t, chunk.IndexQuery{TableName: tableName}, tm.tables[tableName], expectedIndex.start, expectedIndex.numRecords)
+		testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{TableName: tableName}}, tm.tables[tableName], expectedIndex.start, expectedIndex.numRecords)
 	}
 }
 

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -88,7 +89,7 @@ func TestLoadTable(t *testing.T) {
 	}()
 
 	// query the loaded table to see if it has right data.
-	testutil.TestSingleQuery(t, chunk.IndexQuery{}, table, 0, 20)
+	testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{}}, table, 0, 20)
 }
 
 func TestTable_Write(t *testing.T) {
@@ -147,7 +148,7 @@ func TestTable_Write(t *testing.T) {
 			require.True(t, ok)
 
 			// test that the table has current + previous records
-			testutil.TestSingleQuery(t, chunk.IndexQuery{}, table, 0, (i+1)*10)
+			testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{}}, table, 0, (i+1)*10)
 			testutil.TestSingleDBQuery(t, chunk.IndexQuery{}, db, boltIndexClient, i*10, 10)
 		})
 	}
@@ -439,7 +440,7 @@ func TestTable_ImmutableUploads(t *testing.T) {
 	dir, err := ioutil.ReadDir(filepath.Join(objectStorageDir, table.name))
 	require.NoError(t, err)
 	for _, d := range dir {
-		os.RemoveAll(filepath.Join(objectStorageDir, table.name, d.Name()))
+		require.NoError(t, os.RemoveAll(filepath.Join(objectStorageDir, table.name, d.Name())))
 	}
 
 	// force upload of dbs
@@ -449,4 +450,50 @@ func TestTable_ImmutableUploads(t *testing.T) {
 	for _, expectedDB := range expectedDBsToUpload {
 		require.NoFileExists(t, filepath.Join(objectStorageDir, table.buildObjectKey(fmt.Sprint(expectedDB))))
 	}
+}
+
+func TestTable_MultiQueries(t *testing.T) {
+	indexPath, err := ioutil.TempDir("", "table-multi-queries")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(indexPath))
+	}()
+
+	boltDBIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: indexPath})
+	require.NoError(t, err)
+
+	defer func() {
+		boltDBIndexClient.Stop()
+	}()
+
+	// setup some dbs for a table at a path.
+	tablePath := testutil.SetupDBTablesAtPath(t, "test-table", indexPath, map[string]testutil.DBRecords{
+		"db1": {
+			Start:      0,
+			NumRecords: 10,
+		},
+		"db2": {
+			Start:      10,
+			NumRecords: 10,
+		},
+	}, false)
+
+	// try loading the table.
+	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	defer func() {
+		table.Stop()
+	}()
+
+	// build queries each looking for specific value from all the dbs
+	var queries []chunk.IndexQuery
+	for i := 5; i < 15; i++ {
+		queries = append(queries, chunk.IndexQuery{ValueEqual: []byte(strconv.Itoa(i))})
+	}
+
+	// query the loaded table to see if it has right data.
+	testutil.TestSingleTableQuery(t, queries, table, 5, 10)
 }

--- a/pkg/storage/stores/shipper/util/queries.go
+++ b/pkg/storage/stores/shipper/util/queries.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"context"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+const maxQueriesPerGoroutine = 100
+
+type TableQuerier interface {
+	MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk_util.Callback) error
+}
+
+// QueriesByTable groups and returns queries by tables.
+func QueriesByTable(queries []chunk.IndexQuery) map[string][]chunk.IndexQuery {
+	queriesByTable := make(map[string][]chunk.IndexQuery)
+	for _, query := range queries {
+		if _, ok := queriesByTable[query.TableName]; !ok {
+			queriesByTable[query.TableName] = []chunk.IndexQuery{}
+		}
+
+		queriesByTable[query.TableName] = append(queriesByTable[query.TableName], query)
+	}
+
+	return queriesByTable
+}
+
+func DoParallelQueries(ctx context.Context, tableQuerier TableQuerier, queries []chunk.IndexQuery, callback chunk_util.Callback) error {
+	errs := make(chan error)
+
+	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
+		q := queries[i:util.Min(i+maxQueriesPerGoroutine, len(queries))]
+		go func(queries []chunk.IndexQuery) {
+			errs <- tableQuerier.MultiQueries(ctx, queries, callback)
+		}(q)
+	}
+
+	var lastErr error
+	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
+		err := <-errs
+		if err != nil {
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}

--- a/pkg/storage/stores/shipper/util/queries_test.go
+++ b/pkg/storage/stores/shipper/util/queries_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"context"
+	"github.com/cortexproject/cortex/pkg/chunk"
+	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+type mockTableQuerier struct {
+	sync.Mutex
+	queries map[string]chunk.IndexQuery
+}
+
+func (m *mockTableQuerier) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk_util.Callback) error {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, query := range queries{
+		m.queries[query.HashValue] = query
+	}
+
+	return nil
+}
+
+func (m *mockTableQuerier) hasQueries(t *testing.T, count int)  {
+	require.Len(t, m.queries, count)
+	for i := 0; i < count; i++ {
+		idx := strconv.Itoa(i)
+
+		require.Equal(t, m.queries[idx], chunk.IndexQuery{
+			HashValue: idx,
+			ValueEqual: []byte(idx),
+		})
+	}
+}
+
+func TestDoParallelQueries(t *testing.T) {
+	for _, tc := range []struct{
+		name string
+		queryCount int
+	}{
+		{
+			name: "queries < maxQueriesPerGoroutine",
+			queryCount: maxQueriesPerGoroutine/2,
+		},
+		{
+			name: "queries = maxQueriesPerGoroutine",
+			queryCount: maxQueriesPerGoroutine,
+		},
+		{
+			name: "queries > maxQueriesPerGoroutine",
+			queryCount: maxQueriesPerGoroutine*2,
+		},
+	}{
+		t.Run(tc.name, func(t *testing.T) {
+			queries := buildQueries(tc.queryCount)
+
+			tableQuerier := mockTableQuerier{
+				queries: map[string]chunk.IndexQuery{},
+			}
+
+			err := DoParallelQueries(context.Background(), &tableQuerier, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+				return false
+			})
+			require.NoError(t, err)
+
+			tableQuerier.hasQueries(t, tc.queryCount)
+		})
+	}
+
+	
+}
+
+func buildQueries(n int) []chunk.IndexQuery {
+	queries := make([]chunk.IndexQuery, 0, n)
+	for i := 0; i < n; i ++ {
+		idx := strconv.Itoa(i)
+		queries = append(queries, chunk.IndexQuery{
+			HashValue: idx,
+			ValueEqual: []byte(idx),
+		})
+	}
+	
+	return queries
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
While investigating query performance I found labels query to be slower because it does a lot of index queries, with our internal cluster it was close to 33k queries. After digging deeper I found we were doing mutex and channel operation in downloads path for each query [here](https://github.com/grafana/loki/blob/master/pkg/storage/stores/shipper/downloads/table.go#L204-L211) which is inefficient.

This PR changes the code to do mutex and channel operation and run all queries per table at once and run. With my local testing I found 7x improvement in query performance with this change.

**Checklist**
- [x] Tests updated

