### PR TITLE
Promtail: do not mark the position if the file is removed

### DIFF
--- a/pkg/promtail/targets/file/filetarget.go
+++ b/pkg/promtail/targets/file/filetarget.go
@@ -163,7 +163,7 @@ func (t *FileTarget) run() {
 	defer func() {
 		helpers.LogError("closing watcher", t.watcher.Close)
 		for _, v := range t.tails {
-			v.stop()
+			v.stop(false)
 		}
 		level.Debug(t.logger).Log("msg", "watcher closed, tailer stopped, positions saved")
 		close(t.done)
@@ -313,7 +313,7 @@ func (t *FileTarget) startTailing(ps []string) {
 func (t *FileTarget) stopTailingAndRemovePosition(ps []string) {
 	for _, p := range ps {
 		if tailer, ok := t.tails[p]; ok {
-			tailer.stop()
+			tailer.stop(true)
 			t.positions.Remove(tailer.path)
 			delete(t.tails, p)
 		}

--- a/pkg/promtail/targets/file/tailer.go
+++ b/pkg/promtail/targets/file/tailer.go
@@ -152,11 +152,13 @@ func (t *tailer) markPositionAndSize() error {
 	return nil
 }
 
-func (t *tailer) stop() {
+func (t *tailer) stop(removed bool) {
 	// Save the current position before shutting down tailer
-	err := t.markPositionAndSize()
-	if err != nil {
-		level.Error(t.logger).Log("msg", "error marking file position when stopping tailer", "path", t.path, "error", err)
+	if !removed {
+		err := t.markPositionAndSize()
+		if err != nil {
+			level.Error(t.logger).Log("msg", "error marking file position when stopping tailer", "path", t.path, "error", err)
+		}
 	}
 	close(t.quit)
 	<-t.done


### PR DESCRIPTION
Currently when we shutdown the tailer we always try to update the positions file, however there are 2 cases we shutdown the tailer.

1. promtail is shutting down
2. the file is gone and should no longer be tailed.

In this second case we are currently trying to mark the position of a file which doesn't exist and this logs an error message.

This PR adds a bool to the stop method to indicate if we are stopping because the file was removed, and if so we can skip marking the position.