### PR TITLE
improves numeric literal stringer impl

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -495,7 +495,7 @@ func mustNewLiteralExpr(s string, invert bool) *literalExpr {
 }
 
 func (e *literalExpr) String() string {
-	return fmt.Sprintf("%f", e.value)
+	return fmt.Sprint(e.value)
 }
 
 // literlExpr impls SampleExpr & LogSelectorExpr mainly to reduce the need for more complicated typings

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -196,24 +196,28 @@ func TestStringer(t *testing.T) {
 	}{
 		{
 			in:  `1 > 1 > 1`,
-			out: `0.000000`,
+			out: `0`,
+		},
+		{
+			in:  `1.6`,
+			out: `1.6`,
 		},
 		{
 			in:  `1 > 1 > bool 1`,
-			out: `0.000000`,
+			out: `0`,
 		},
 		{
 			in:  `1 > bool 1 > count_over_time({foo="bar"}[1m])`,
-			out: `0.000000 > count_over_time({foo="bar"}[1m])`,
+			out: `0 > count_over_time({foo="bar"}[1m])`,
 		},
 		{
 			in:  `1 > bool 1 > bool count_over_time({foo="bar"}[1m])`,
-			out: `0.000000 > bool count_over_time({foo="bar"}[1m])`,
+			out: `0 > bool count_over_time({foo="bar"}[1m])`,
 		},
 		{
 
-			in:  `0.000000 > count_over_time({foo="bar"}[1m])`,
-			out: `0.000000 > count_over_time({foo="bar"}[1m])`,
+			in:  `0 > count_over_time({foo="bar"}[1m])`,
+			out: `0 > count_over_time({foo="bar"}[1m])`,
 		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -136,7 +136,7 @@ func TestMappingStrings(t *testing.T) {
 		},
 		{
 			in:  `max(count(rate({foo="bar"}[5m]))) / 2`,
-			out: `max(sum(downstream<count(rate({foo="bar"}[5m])), shard=0_of_2> ++ downstream<count(rate({foo="bar"}[5m])), shard=1_of_2>)) / 2.000000`,
+			out: `max(sum(downstream<count(rate({foo="bar"}[5m])), shard=0_of_2> ++ downstream<count(rate({foo="bar"}[5m])), shard=1_of_2>)) / 2`,
 		},
 		{
 			in:  `topk(3, rate({foo="bar"}[5m]))`,


### PR DESCRIPTION
Realized I could simplify our string method for numeric literals. This copies how promql does it and is much cleaner (no more `1.000000` in logs/etc.