### PR TITLE
Loki: Querier APIs respond JSON Content-Type

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -171,6 +171,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		serverutil.RecoveryHTTPMiddleware,
 		t.httpAuthMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
+		serverutil.ResponseJSONMiddleware(),
 	)
 	t.server.HTTP.Handle("/loki/api/v1/query_range", httpMiddleware.Wrap(http.HandlerFunc(t.querier.RangeQueryHandler)))
 	t.server.HTTP.Handle("/loki/api/v1/query", httpMiddleware.Wrap(http.HandlerFunc(t.querier.InstantQueryHandler)))
@@ -356,6 +357,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 		queryrange.StatsHTTPMiddleware,
 		t.httpAuthMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
+		serverutil.ResponseJSONMiddleware(),
 	).Wrap(t.frontend.Handler())
 
 	var defaultHandler http.Handler

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -22,3 +22,12 @@ func NewPrepopulateMiddleware() middleware.Interface {
 		})
 	})
 }
+
+func ResponseJSONMiddleware() middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+			next.ServeHTTP(w, req)
+		})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add json response so that http client tool can display data better.