### PR TITLE
pkg/querier: fix dropped error

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -303,6 +303,9 @@ func (q *Querier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer,
 	defer cancelQuery()
 
 	tailClients, err := q.ingesterQuerier.Tail(tailCtx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	histIterators, err := q.SelectLogs(queryCtx, histReq)
 	if err != nil {


### PR DESCRIPTION
This fixes a dropped error in `pkg/querier`.