### PR TITLE
fix jsonnet for memcached-writes when using boltdb-shipper

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -40,7 +40,7 @@
   } else {},
 
   // we don't dedupe index writes when using boltdb-shipper so don't deploy a cache for it.
-  memcached_index_writes:: if $._config.using_boltdb_shipper then {} else self.memcached_index_writes,
+  memcached_index_writes: if $._config.using_boltdb_shipper then {} else super.memcached_index_writes,
 
   // Use PVC for compactor instead of node disk.
   compactor_data_pvc:: if $._config.using_boltdb_shipper then

--- a/production/ksonnet/loki/loki.libsonnet
+++ b/production/ksonnet/loki/loki.libsonnet
@@ -14,8 +14,8 @@
 (import 'query-frontend.libsonnet') +
 (import 'ruler.libsonnet') +
 
-// BoltDB Shipper support
-(import 'boltdb_shipper.libsonnet') +
-
 // Supporting services
-(import 'memcached.libsonnet')
+(import 'memcached.libsonnet') +
+
+// BoltDB Shipper support. This should be the last one to get imported.
+(import 'boltdb_shipper.libsonnet')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
`boltdb-shipper.libsonnet` should be imported last and there was some problem in jsonnet removing memcached-writes definition even when not using `boltdb-shipper` which is fixed in this PR.

