### PR TITLE
Promtail: Fix timestamp parser for short year format

### DIFF
--- a/pkg/logentry/stages/util.go
+++ b/pkg/logentry/stages/util.go
@@ -112,7 +112,7 @@ func convertDateLayout(predef string, location *time.Location) parser {
 			return time.Unix(0, i), nil
 		}
 	default:
-		if !strings.Contains(predef, "2006") {
+		if !strings.Contains(predef, "06") && !strings.Contains(predef, "2006") {
 			return func(t string) (time.Time, error) {
 				return parseTimestampWithoutYear(predef, location, t, time.Now())
 			}

--- a/pkg/logentry/stages/util_test.go
+++ b/pkg/logentry/stages/util_test.go
@@ -83,11 +83,29 @@ func TestConvertDateLayout(t *testing.T) {
 		timestamp string
 		expected  time.Time
 	}{
-		"custom layout with year": {
+		"custom layout with short year": {
+			"06 Jan 02 15:04:05",
+			nil,
+			"19 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom layout with long year": {
 			"2006 Jan 02 15:04:05",
 			nil,
 			"2019 Jul 15 01:02:03",
 			time.Date(2019, 7, 15, 1, 2, 3, 0, time.UTC),
+		},
+		"custom layout with short year and location": {
+			"06 Jan 02 15:04:05",
+			location,
+			"19 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
+		},
+		"custom layout with long year and location": {
+			"2006 Jan 02 15:04:05",
+			location,
+			"2019 Jul 15 01:02:03",
+			time.Date(2019, 7, 15, 1, 2, 3, 0, location),
 		},
 		"custom layout without year": {
 			"Jan 02 15:04:05",
@@ -95,7 +113,7 @@ func TestConvertDateLayout(t *testing.T) {
 			"Jul 15 01:02:03",
 			time.Date(time.Now().Year(), 7, 15, 1, 2, 3, 0, time.UTC),
 		},
-		"custom layout with year and location": {
+		"custom layout without year and location": {
 			"Jan 02 15:04:05",
 			location,
 			"Jul 15 01:02:03",


### PR DESCRIPTION
**What this PR does / why we need it**:
Using a short year format for timestamp in the pipeline break if trying to parse older log files.

```yaml
...
scrape_configs:
- pipeline_stages:
...
  - timestamp:
      source: time
      format: 02.01.06 03:04:05.000
...
```

**Which issue(s) this PR fixes**:
Fixes #2653

**Special notes for your reviewer**:
I don't have a golang environment on my machine and was not able to properly run the Makefile on windows either. Only traced the cause by looking into the code base. I hope there is CI testing it.

**Checklist**
- [ ] Documentation added
-- Not necessary as it's a bug fix
- [X] Tests updated