### PR TITLE
Bypass sharding middleware when a query can't be sharded.

### DIFF
--- a/pkg/logql/sharding_test.go
+++ b/pkg/logql/sharding_test.go
@@ -71,12 +71,19 @@ func TestMappingEquivalence(t *testing.T) {
 				nil,
 			)
 			qry := regular.Query(params)
-			shardedQry := sharded.Query(params, shards)
+			ctx := context.Background()
 
-			res, err := qry.Exec(context.Background())
+			mapper, err := NewShardMapper(shards, nilMetrics)
+			require.Nil(t, err)
+			_, mapped, err := mapper.Parse(tc.query)
 			require.Nil(t, err)
 
-			shardedRes, err := shardedQry.Exec(context.Background())
+			shardedQry := sharded.Query(params, mapped)
+
+			res, err := qry.Exec(ctx)
+			require.Nil(t, err)
+
+			shardedRes, err := shardedQry.Exec(ctx)
 			require.Nil(t, err)
 
 			if tc.approximate {

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -63,18 +63,20 @@ func newASTMapperware(
 ) *astMapperware {
 
 	return &astMapperware{
-		confs:  confs,
-		logger: log.With(logger, "middleware", "QueryShard.astMapperware"),
-		next:   next,
-		ng:     logql.NewShardedEngine(logql.EngineOpts{}, DownstreamHandler{next}, metrics),
+		confs:   confs,
+		logger:  log.With(logger, "middleware", "QueryShard.astMapperware"),
+		next:    next,
+		ng:      logql.NewShardedEngine(logql.EngineOpts{}, DownstreamHandler{next}, metrics),
+		metrics: metrics,
 	}
 }
 
 type astMapperware struct {
-	confs  queryrange.ShardingConfigs
-	logger log.Logger
-	next   queryrange.Handler
-	ng     *logql.ShardedEngine
+	confs   queryrange.ShardingConfigs
+	logger  log.Logger
+	next    queryrange.Handler
+	ng      *logql.ShardedEngine
+	metrics *logql.ShardingMetrics
 }
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrange.Request) (queryrange.Response, error) {
@@ -92,8 +94,26 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrange.Request) (queryra
 	if !ok {
 		return nil, fmt.Errorf("expected *LokiRequest, got (%T)", r)
 	}
-	params := paramsFromRequest(req)
-	query := ast.ng.Query(params, int(conf.RowShards))
+
+	mapper, err := logql.NewShardMapper(int(conf.RowShards), ast.metrics)
+	if err != nil {
+		return nil, err
+	}
+
+	noop, parsed, err := mapper.Parse(r.GetQuery())
+	if err != nil {
+		level.Warn(shardedLog).Log("msg", "failed mapping AST", "err", err.Error(), "query", r.GetQuery())
+		return nil, err
+	}
+	level.Debug(shardedLog).Log("no-op", noop, "mapped", parsed.String())
+
+	if noop {
+		// the ast can't be mapped to a sharded equivalent
+		// so we can bypass the sharding engine.
+		return ast.next.Do(ctx, r)
+	}
+
+	query := ast.ng.Query(paramsFromRequest(req), parsed)
 
 	res, err := query.Exec(ctx)
 	if err != nil {

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -159,6 +159,29 @@ func Test_astMapper(t *testing.T) {
 
 }
 
+func Test_ShardingByPass(t *testing.T) {
+	called := 0
+	handler := queryrange.HandlerFunc(func(ctx context.Context, req queryrange.Request) (queryrange.Response, error) {
+		called++
+		return nil, nil
+	})
+
+	mware := newASTMapperware(
+		queryrange.ShardingConfigs{
+			chunk.PeriodConfig{
+				RowShards: 2,
+			},
+		},
+		handler,
+		log.NewNopLogger(),
+		nilShardingMetrics,
+	)
+
+	_, err := mware.Do(context.Background(), defaultReq().WithQuery(`1+1`))
+	require.Nil(t, err)
+	require.Equal(t, called, 1)
+}
+
 func Test_hasShards(t *testing.T) {
 	for i, tc := range []struct {
 		input    queryrange.ShardingConfigs


### PR DESCRIPTION
Found this issue while working on LogQL v2.


Need to rebase to this once merged to make some new cool expr working with the frontend.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>