### PR TITLE
Doc: fixing parameter name in configuration

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -201,7 +201,7 @@ The `server_config` block configures the HTTP and gRPC server of the launched se
 
 # Base path to serve all API routes from (e.g., /v1/).
 # CLI flag: -server.path-prefix
-[http_path_prefix: <string>]
+[http_prefix: <string> | default = "/api/prom"]
 ```
 
 ## distributor_config


### PR DESCRIPTION
- http_path_prefix should be http_prefix

Signed-off-by: Hui Kang <kangh@us.ibm.com>

