### PR TITLE
parameterize PVC storage class (ingester, querier, compactor)

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -13,6 +13,7 @@
 
     boltdb_shipper_shared_store: error 'must define boltdb_shipper_shared_store',
     compactor_pvc_size: '10Gi',
+    compactor_pvc_class: 'fast',
     index_period_hours: if self.using_boltdb_shipper then 24 else super.index_period_hours,
     loki+: if self.using_boltdb_shipper then {
       chunk_store_config+: {
@@ -47,7 +48,7 @@
     pvc.new('compactor-data') +
     pvc.mixin.spec.resources.withRequests({ storage: $._config.compactor_pvc_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName('fast')
+    pvc.mixin.spec.withStorageClassName($._config.ingester_pvc_class)
   else {},
 
   compactor_args:: if $._config.using_boltdb_shipper then {

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -13,11 +13,17 @@
     using_boltdb_shipper: true,
 
     // flags for running ingesters/queriers as a statefulset instead of deployment type.
-    stateful_ingesters: false,
-    ingester_pvc_size: '5Gi',
+    stateful_ingesters:  false,
+    ingester_pvc_size:   '5Gi',
+    ingester_pvc_class:  'fast',
 
-    stateful_queriers: false,
-    querier_pvc_size: '10Gi',
+    stateful_queriers:   false,
+    querier_pvc_size:    '10Gi',
+    querier_pvc_class:   'fast',
+
+    compactor_pvc_size:  '10Gi',
+    compactor_pvc_class: 'fast',
+
 
     querier: {
       // This value should be set equal to (or less than) the CPU cores of the system the querier runs.

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -49,7 +49,7 @@
     pvc.new('ingester-data') +
     pvc.mixin.spec.resources.withRequests({ storage: '10Gi' }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName('fast')
+    pvc.mixin.spec.withStorageClassName($._config.ingester_pvc_class)
   else {},
 
   ingester_statefulset: if $._config.stateful_ingesters then

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -38,7 +38,7 @@
     pvc.new('querier-data') +
     pvc.mixin.spec.resources.withRequests({ storage: $._config.querier_pvc_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName('fast')
+    pvc.mixin.spec.withStorageClassName($._config.querier_pvc_class)
   else {},
 
   querier_statefulset: if $._config.stateful_queriers then


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve the initial UX for folks deploying Loki via ksonnet to clusters where VMWare Cloud is not being used.

* surface the StorageClass used for the Persistent Volume Claim(s) in [loki/config.libsonnet](https://github.com/grafana/loki/blob/master/production/ksonnet/loki/config.libsonnet) when running the Ingester and/or Querier as a StatefulSet (instead of a Deployment)
* It leaves the default to 'fast' (see below) to not break any existing users/systems
* While this _could_ be patched from a consumer (of loki's ksonnet), this is brittle.  By parking it here it's immediately clear to newcomers that OOTB it's using a specific PVC StorageClass.  
* The default/current behavior fails unless the VMware Cloud Provisioner is configured in a cluster, and will require folks to figure out why it does not work.  Those folks will also have to figure out why _changing the StorageClass to what they need_ then running `tk apply` don't work either, as the PVC needs to be _deleted then re-added_.

**Background / Context**

The current StorageClass is of type 'fast' and config like below will be generated.

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ingester
  namespace: loki

...

spec:
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: ingester-data
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
      storageClassName: fast
```

* https://kubernetes.io/docs/concepts/storage/storage-classes
* `fast` corresponds to the [VMware Cloud Provider (vCP) StorageClass provisioner](https://kubernetes.io/docs/concepts/storage/storage-classes/#vcp-provisioner)
* While k8s has a notion of a Default StorageClass, it relies on a cluster admin to configure the [DefaultStorageClass admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#defaultstorageclass).  This permits creating PVC's that don't specify a storage class (or use `""`). More info/overview: <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1>

While making the default `""` would also make sense, it would have the potential to break existing deployments (that use VMW Cloud) if the cluster admin's have not configured the DefaultStorageClass.






