### PR TITLE
nit: fix formatting for ksonnet/loki

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -48,14 +48,14 @@
     pvc.mixin.spec.resources.withRequests({ storage: $._config.compactor_pvc_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
     pvc.mixin.spec.withStorageClassName('fast')
-    else {},
+  else {},
 
   compactor_args:: if $._config.using_boltdb_shipper then {
-      'config.file': '/etc/loki/config/config.yaml',
-      'boltdb.shipper.compactor.working-directory': '/data/compactor',
-      'boltdb.shipper.compactor.shared-store': $._config.boltdb_shipper_shared_store,
-      target: 'compactor',
-    } else {},
+    'config.file': '/etc/loki/config/config.yaml',
+    'boltdb.shipper.compactor.working-directory': '/data/compactor',
+    'boltdb.shipper.compactor.shared-store': $._config.boltdb_shipper_shared_store,
+    target: 'compactor',
+  } else {},
 
   local compactor_ports =
     [
@@ -71,7 +71,7 @@
     container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('4', '2Gi')
-    else {},
+  else {},
 
   compactor_statefulset: if $._config.using_boltdb_shipper then
     statefulSet.new('compactor', 1, [$.compactor_container], $.compactor_data_pvc) +
@@ -80,5 +80,5 @@
     $.util.configVolumeMount('loki', '/etc/loki/config') +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile
-    else {}
+  else {},
 }

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -8,11 +8,11 @@
     $._config.commonArgs {
       target: 'ingester',
     } + if $._config.stateful_ingesters then
-    {
-      // Disable chunk transfer when using statefulset since ingester which is going down won't find another
-      // ingester which is joining the ring for transferring chunks.
-      'ingester.max-transfer-retries': 0,
-    } else {},
+      {
+        // Disable chunk transfer when using statefulset since ingester which is going down won't find another
+        // ingester which is joining the ring for transferring chunks.
+        'ingester.max-transfer-retries': 0,
+      } else {},
 
   ingester_container::
     container.new('ingester', $._images.ingester) +
@@ -25,9 +25,9 @@
     $.util.resourcesRequests('1', '5Gi') +
     $.util.resourcesLimits('2', '10Gi') +
     if $._config.stateful_ingesters then
-        container.withVolumeMountsMixin([
-          volumeMount.new('ingester-data', '/data'),
-        ]) else {},
+      container.withVolumeMountsMixin([
+        volumeMount.new('ingester-data', '/data'),
+      ]) else {},
 
   local deployment = $.apps.v1.deployment,
 
@@ -43,14 +43,14 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800)
-    else {},
+  else {},
 
   ingester_data_pvc:: if $._config.stateful_ingesters then
     pvc.new('ingester-data') +
     pvc.mixin.spec.resources.withRequests({ storage: '10Gi' }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
     pvc.mixin.spec.withStorageClassName('fast')
-    else {},
+  else {},
 
   ingester_statefulset: if $._config.stateful_ingesters then
     statefulSet.new('ingester', 3, [$.ingester_container], $.ingester_data_pvc) +
@@ -62,7 +62,7 @@
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800)
-    else {},
+  else {},
 
   ingester_service:
     if !$._config.stateful_ingesters then

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -31,7 +31,7 @@
     $.util.configVolumeMount('loki', '/etc/loki/config') +
     $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
     $.util.antiAffinity
-    else {},
+  else {},
 
   // PVC for queriers when running as statefulsets
   querier_data_pvc:: if $._config.stateful_queriers then
@@ -39,7 +39,7 @@
     pvc.mixin.spec.resources.withRequests({ storage: $._config.querier_pvc_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
     pvc.mixin.spec.withStorageClassName('fast')
-    else {},
+  else {},
 
   querier_statefulset: if $._config.stateful_queriers then
     statefulSet.new('querier', 3, [$.querier_container], $.querier_data_pvc) +
@@ -50,7 +50,7 @@
     $.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile
-    else {},
+  else {},
 
   querier_service:
     if !$._config.stateful_queriers then


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor patch resulting from `tk fmt .`

In testing / experimenting with Loki running `tk fmt` as part of workflow makes local changes (unrelated to any local edits).

