### PR TITLE
Promtail: Add counter promtail_batch_retries_total

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -73,6 +73,11 @@ var (
 		Name:      "request_duration_seconds",
 		Help:      "Duration of send requests.",
 	}, []string{"status_code", HostLabel})
+	batchRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "batch_retries_total",
+		Help:      "Number of times batches has had to be retried.",
+	}, []string{HostLabel})
 	streamLag *metric.Gauges
 
 	countersWithHost = []*prometheus.CounterVec{
@@ -89,6 +94,7 @@ func init() {
 	prometheus.MustRegister(sentEntries)
 	prometheus.MustRegister(droppedEntries)
 	prometheus.MustRegister(requestDuration)
+	prometheus.MustRegister(batchRetries)
 	var err error
 	streamLag, err = metric.NewGauges("promtail_stream_lag_seconds",
 		"Difference between current time and last batch timestamp for successful sends",
@@ -280,6 +286,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		}
 
 		level.Warn(c.logger).Log("msg", "error sending batch, will retry", "status", status, "error", err)
+		batchRetries.WithLabelValues(c.cfg.URL.Host).Inc()
 		backoff.Wait()
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently there is only a metric for dropped batches. It'd be helpful to alert on things going wrong before there is data loss. This PR adds a counter on batch send retries.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

