### PR TITLE
set timestamp in instant query done by canaries 

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -160,6 +160,7 @@ func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query",
 		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s])", r.sName, r.sValue, r.lName, r.lVal, queryRange)) +
+			fmt.Sprintf("&time=%d", time.Now().UnixNano()) +
 			"&limit=1000",
 	}
 	fmt.Fprintf(r.w, "Querying loki for metric count with query: %v\n", u.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We do not set a timestamp in instant queries being done by canaries so loki defaults it to `time.Now()`.
This causes 2 identical loki servers to return a different timestamp in response when running behind query tee and hence treating it as a failure in getting the same response.

