### PR TITLE
Fixes the frontend logs to include org_id.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -354,8 +354,8 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 
 	frontendHandler := middleware.Merge(
 		serverutil.RecoveryHTTPMiddleware,
-		queryrange.StatsHTTPMiddleware,
 		t.httpAuthMiddleware,
+		queryrange.StatsHTTPMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
 		serverutil.ResponseJSONMiddleware(),
 	).Wrap(t.frontend.Handler())


### PR DESCRIPTION
The auth middleware was happening after the stats one and so org_id was not set :facepalm:.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
