### PR TITLE
FluentD loki plugin: add support for bearer_token_file parameter

### DIFF
--- a/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.14'
+  spec.version = '1.2.15'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -42,6 +42,9 @@ module Fluent
       config_param :username, :string, default: nil
       config_param :password, :string, default: nil, secret: true
 
+      desc 'Authentication: Authorization header with Bearer token scheme'
+      config_param :bearer_token_file, :string, default: nil
+
       desc 'TLS: parameters for presenting a client certificate'
       config_param :cert, :string, default: nil
       config_param :key, :string, default: nil
@@ -101,6 +104,8 @@ module Fluent
           load_client_cert
           validate_client_cert_key
         end
+
+        raise "bearer_token_file #{@bearer_token_file} not found" if !@bearer_token_file.nil? && !File.exist?(@bearer_token_file)
 
         raise "CA certificate file #{@ca_cert} not found" if !@ca_cert.nil? && !File.exist?(@ca_cert)
       end

--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -154,7 +154,10 @@ module Fluent
         # add ingest path to loki url
         res = loki_http_request(body, tenant)
 
-        return if res.is_a?(Net::HTTPSuccess)
+        if res.is_a?(Net::HTTPSuccess)
+          log.debug "POST request was responded to with status code #{res.code})"
+          return
+        end
 
         res_summary = "#{res.code} #{res.message} #{res.body}"
         log.warn "failed to write post to #{@uri} (#{res_summary})"
@@ -208,7 +211,7 @@ module Fluent
           @uri.request_uri
         )
         req.add_field('Content-Type', 'application/json')
-        req.add_field('Authorization', 'Bearer #{@auth_token_bearer}') if !@auth_token_bearer.nil?
+        req.add_field('Authorization', "Bearer #{@auth_token_bearer}") if !@auth_token_bearer.nil?
         req.add_field('X-Scope-OrgID', tenant) if tenant
         req.body = Yajl.dump(body)
         req.basic_auth(@username, @password) if @username

--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -35,21 +35,21 @@ module Fluent
 
       DEFAULT_BUFFER_TYPE = 'memory'
 
-      desc 'url of loki server'
+      desc 'Loki API base URL'
       config_param :url, :string, default: 'https://logs-prod-us-central1.grafana.net'
 
       desc 'BasicAuth credentials'
       config_param :username, :string, default: nil
       config_param :password, :string, default: nil, secret: true
 
-      desc 'Client certificate'
+      desc 'TLS: parameters for presenting a client certificate'
       config_param :cert, :string, default: nil
       config_param :key, :string, default: nil
 
-      desc 'TLS'
+      desc 'TLS: CA certificate file for server certificate verification'
       config_param :ca_cert, :string, default: nil
 
-      desc 'Disable server certificate verification'
+      desc 'TLS: disable server certificate verification'
       config_param :insecure_tls, :bool, default: false
 
       desc 'Loki tenant id'

--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -118,6 +118,7 @@ module Fluent
           if @auth_token_bearer.empty?
             raise "bearer_token_file #{@bearer_token_file} is empty"
           end
+          log.info "will use Bearer token from bearer_token_file #{@bearer_token_file} in Authorization header"
         end
 
 
@@ -155,7 +156,7 @@ module Fluent
         res = loki_http_request(body, tenant)
 
         if res.is_a?(Net::HTTPSuccess)
-          log.debug "POST request was responded to with status code #{res.code})"
+          log.debug "POST request was responded to with status code #{res.code}"
           return
         end
 

--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -83,7 +83,7 @@ module Fluent
         super
         @uri = URI.parse(@url + '/loki/api/v1/push')
         unless @uri.is_a?(URI::HTTP) || @uri.is_a?(URI::HTTPS)
-          raise Fluent::ConfigError, 'url parameter must be valid HTTP'
+          raise Fluent::ConfigError, 'URL parameter must have HTTP/HTTPS scheme'
         end
 
         @record_accessors = {}


### PR DESCRIPTION
This pull request adds a configuration parameter `bearer_token_file` for the Loki FluentD plugin.

The value is expected to be a file path. When specified, the corresponding file is read (once, during startup). The content is assumed to be an authentication token. In all subsequent POST HTTP requests towards the Loki API, the plugin then sets an HTTP header of the shape `Authorization: Bearer <token>`.

In the cloud native ecosystem the `Bearer` authentication scheme gains more and more popularity(`*`) for communicating authentication proof within HTTP requests, and it is not uncommon to have an authenticator in front of the Loki API that requires the presentation of such authentication proof.

The name of the configuration parameter and the concept in general is inspired by Prometheus' `bearer_token_file` parameter, documented here: https://prometheus.io/docs/prometheus/latest/configuration/configuration/

In addition to this feature change, this PR also contains 
- a few code clarifications, both via function/variable naming changes as well as via code comments / parameter descriptions
- new log statements


Two new log statements in action (helping with debugging)
```
...
2020-10-08 10:27:30 +0000 [info]: will use Bearer token from bearer_token_file /tmp/api-token in Authorization header
...
2020-10-08 10:27:34 +0000 [debug]: #0 POST request was responded to with status code 204
```

Security note: the token itself is sensitive data, and with the file-based approach the FluentD config document can stay non-sensitive, and the FluentD log will also not show the value of the token (at least not that I am aware of).

`*`: The `Bearer` scheme was once reserved for usage in the context of OAuth2, see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml and https://tools.ietf.org/html/rfc6750. But it has morphed into something more generic in the meantime, at least in practice.

**Which issue(s) this PR fixes**:

I did not create an issue for this, can do if desired :-).

**Special notes for your reviewer**:

- This is manually tested and seems to work well. 
- I would love to get some initial feedback here @cyriltovena maybe :-) -- thanks for taking a look! Please let me know which changes/additions you'd like to see.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

