### PR TITLE
Fix linting errors and use of deprecated repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,9 +135,8 @@ jobs:
       - run:
           name: Run Chart Tests
           command: |
-            helm repo add elastic https://helm.elastic.co
-            ct lint --chart-dirs=production/helm --check-version-increment=false --validate-maintainers=false
-            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack
+            ct lint --chart-dirs=production/helm --config=production/helm/ct.yaml
+            ct install --build-id=${CIRCLE_BUILD_NUM} --charts production/helm/loki-stack --config=production/helm/ct.yaml
 
   publish-helm:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,8 @@ helm:
 	@set -e; \
 	helm init -c; \
 	helm repo add elastic https://helm.elastic.co ; \
+	helm repo add grafana https://grafana.github.io/helm-charts ; \
+	helm repo add prometheus https://prometheus-community.github.io/helm-charts ; \
 	for chart in $(CHARTS); do \
 		helm dependency build $$chart; \
 		helm lint $$chart; \

--- a/production/helm/ct.yaml
+++ b/production/helm/ct.yaml
@@ -1,0 +1,6 @@
+chart-repos:
+  - elastic=https://helm.elastic.co
+  - grafana=https://grafana.github.io/helm-charts
+  - prometheus=https://prometheus-community.github.io/helm-charts
+check-version-increment: false
+validate-maintainers: false

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.41.1
+version: 0.41.2
 appVersion: v1.6.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/requirements.yaml
+++ b/production/helm/loki-stack/requirements.yaml
@@ -2,23 +2,23 @@ dependencies:
 - name: "loki"
   condition: loki.enabled
   repository: "file://../loki"
-  version: "^0.30.0"
+  version: "^0.31.1"
 - name: "promtail"
   condition: promtail.enabled
   repository: "file://../promtail"
-  version: "^0.23.0"
+  version: "^0.25.1"
 - name: "fluent-bit"
   condition: fluent-bit.enabled
   repository: "file://../fluent-bit"
-  version: "^0.1.0"
+  version: "^0.3.1"
 - name: "grafana"
   condition: grafana.enabled
-  version: "~3.8.15"
-  repository:  "https://kubernetes-charts.storage.googleapis.com/"
+  version: "~5.7.0"
+  repository:  "https://grafana.github.io/helm-charts"
 - name: "prometheus"
   condition: prometheus.enabled
-  version: "~9.3.0"
-  repository:  "https://kubernetes-charts.storage.googleapis.com/"
+  version: "~11.16.0"
+  repository:  "https://prometheus-community.github.io/helm-charts"
 - name: "filebeat"
   condition: filebeat.enabled
   version: "~7.8.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Switch away from [deprecated](https://github.com/helm/charts/blob/master/README.md#deprecation-timeline) chart repositories
- Bump dependencies to fix linting errors when mixing loki with kube-prometheus-stack
```
Error:  templates/: template: charts/loki-stack/charts/grafana/templates/deployment.yaml:48:10: executing "loki-stack/charts/grafana/templates/deployment.yaml" at <include "grafana.pod" .>: error calling include: template: kube-prometheus-stack/charts/grafana/templates/_pod.tpl:18:102: executing "grafana.pod" at <.Values.sidecar.notifiers.enabled>: nil pointer evaluating interface {}.enabled
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

