### PR TITLE
helm/fluentbit K8S-Logging.Exclude &  and Mem_Buf_Limit toggle

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 0.3.1
+version: 0.3.2
 appVersion: v1.6.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/README.md
+++ b/production/helm/fluent-bit/README.md
@@ -83,6 +83,8 @@ For more details, read the [Fluent Bit documentation](../../../cmd/fluent-bit/RE
 | `config.loglevel`        | the Fluent Bit log level (debug,info,warn,error).                                                  | `warn`                           |
 | `config.lineFormat`      | The line format to use to send a record (json/key_value)                                           | `json`                           |
 | `config.k8sLoggingParser`| Allow Kubernetes Pods to suggest a pre-defined Parser. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/filter/kubernetes#kubernetes-annotations).                                                                                      | `Off`                           |
+| `config.k8sLoggingExclude`| Allow Kubernetes Pods to exclude their logs from the log processor. See [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes)                                                                                             | `Off`
+| `config.memBufLimit`     | Override the default  Mem_Buf_Limit [Official Fluent Bit documentation](https://docs.fluentbit.io/manual/administration/backpressure#mem_buf_limit) | `5MB`
 | `config.removeKeys`      | The list of key to remove from each record                                                         | `[removeKeys,stream]`            |
 | `config.labels`          | A set of labels to send for every log                                                              | `'{job="fluent-bit"}'`           |
 | `config.autoKubernetesLabels` | If set to true, it will add all Kubernetes labels to Loki labels                                   | `false`                          |

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -24,12 +24,13 @@ data:
         Path           /var/log/containers/*.log
         Parser         docker
         DB             /run/fluent-bit/flb_kube.db
-        Mem_Buf_Limit  5MB
+        Mem_Buf_Limit  {{ .Values.config.memBufLimit }}
     [FILTER]
         Name           kubernetes
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc:443
         Merge_Log On
+        K8S-Logging.Exclude {{ .Values.config.k8sLoggingExclude }}
         K8S-Logging.Parser {{ .Values.config.k8sLoggingParser }}
     [Output]
         Name loki

--- a/production/helm/fluent-bit/values.yaml
+++ b/production/helm/fluent-bit/values.yaml
@@ -13,7 +13,9 @@ config:
   batchSize: 1048576
   loglevel: warn
   lineFormat: json
+  k8sLoggingExclude: "Off"
   k8sLoggingParser: "Off"
+  memBufLimit: "5MB"
   removeKeys:
     - kubernetes
     - stream

--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 0.41.1
+version: 0.41.2
 appVersion: v1.6.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to set K8S-Logging.Exclude for stopping logs getting to loki (default Off like it is now)
Adds the ability to set Mem_Buf_Limit to any value you want (default 5MB)

**Which issue(s) this PR fixes**:
n/a its something that I need and figure others might want this

**Special notes for your reviewer**:
when I run  make helm and deplyo fluent-bit  this (not my change) 
```
batchSize: 1048576
```
gets converted and then prevents starting (so I quoted it locally and built the chart to make it work, didn't add that to the pr though, however I pretty sure its not correct so can fix at same time by quoting if you guys wish)

I think I catered for everything I used vim to edit as my vscode linter was basically changing everything, so would be great to know what one is used here so I can follow.

I updated the readme, I have deployed to a k3d cluster and looked good
```
loki-promtail-j4shw          1/1     Running   0          24m
loki-promtail-mr7p7          1/1     Running   0          24m
loki-0                       1/1     Running   0          24m
loki-fluent-bit-loki-hp2wt   1/1     Running   0          23m
loki-fluent-bit-loki-dfbm2   1/1     Running   0          23m
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

