### PR TITLE
fixes path in prom rules api docs

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1117,7 +1117,7 @@ _This experimental endpoint is disabled by default and can be enabled via the `-
 ### List rules
 
 ```
-GET /loki/api/v1/rules
+GET /prometheus/api/v1/rules
 ```
 
 Prometheus-compatible rules endpoint to list alerting and recording rules that are currently loaded.


### PR DESCRIPTION
Small path fix I found this morning, fixes the prometheus rules status endpoint in the docs.