### PR TITLE
Boltdb shipper query performance improvements

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -263,13 +263,13 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 		case Ingester:
 			// We do not want ingester to unnecessarily keep downloading files
 			t.cfg.StorageConfig.BoltDBShipperConfig.Mode = shipper.ModeWriteOnly
-			// Do not cache index from Ingester.
-			t.cfg.StorageConfig.IndexCacheValidity = 4 * time.Minute
+			// Use fifo cache for caching index in memory.
 			t.cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{
 				EnableFifoCache: true,
 				Fifocache: cache.FifoCacheConfig{
-					MaxSizeBytes:   "200 MB",
-					DeprecatedSize: 0,
+					MaxSizeBytes: "200 MB",
+					// We snapshot the index in ingesters every minute for reads so reduce the index cache validity by a minute
+					Validity: t.cfg.StorageConfig.IndexCacheValidity - 1*time.Minute,
 				},
 			}
 		case Querier:

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -268,7 +268,10 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 				EnableFifoCache: true,
 				Fifocache: cache.FifoCacheConfig{
 					MaxSizeBytes: "200 MB",
-					// We snapshot the index in ingesters every minute for reads so reduce the index cache validity by a minute
+					// We snapshot the index in ingesters every minute for reads so reduce the index cache validity by a minute.
+					// This is usually set in StorageConfig.IndexCacheValidity but since this is exclusively used for caching the index entries,
+					// I(Sandeep) am setting it here which also helps reduce some CPU cycles and allocations required for
+					// unmarshalling the cached data to check the expiry.
 					Validity: t.cfg.StorageConfig.IndexCacheValidity - 1*time.Minute,
 				},
 			}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -264,6 +264,7 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			// We do not want ingester to unnecessarily keep downloading files
 			t.cfg.StorageConfig.BoltDBShipperConfig.Mode = shipper.ModeWriteOnly
 			// Do not cache index from Ingester.
+			t.cfg.StorageConfig.IndexCacheValidity = 4 * time.Minute
 			t.cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{
 				EnableFifoCache: true,
 				Fifocache: cache.FifoCacheConfig{

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -264,7 +264,13 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			// We do not want ingester to unnecessarily keep downloading files
 			t.cfg.StorageConfig.BoltDBShipperConfig.Mode = shipper.ModeWriteOnly
 			// Do not cache index from Ingester.
-			t.cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{}
+			t.cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{
+				EnableFifoCache: true,
+				Fifocache: cache.FifoCacheConfig{
+					MaxSizeBytes:   "200 MB",
+					DeprecatedSize: 0,
+				},
+			}
 		case Querier:
 			// We do not want query to do any updates to index
 			t.cfg.StorageConfig.BoltDBShipperConfig.Mode = shipper.ModeReadOnly

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -9,9 +9,10 @@ import (
 
 func Test_calculateMaxLookBack(t *testing.T) {
 	type args struct {
-		pc                chunk.PeriodConfig
-		maxLookBackConfig time.Duration
-		maxChunkAge       time.Duration
+		pc                               chunk.PeriodConfig
+		maxLookBackConfig                time.Duration
+		maxChunkAge                      time.Duration
+		querierBoltDBFilesResyncInterval time.Duration
 	}
 	tests := []struct {
 		name    string
@@ -25,10 +26,11 @@ func Test_calculateMaxLookBack(t *testing.T) {
 				pc: chunk.PeriodConfig{
 					ObjectType: "filesystem",
 				},
-				maxLookBackConfig: 0,
-				maxChunkAge:       1 * time.Hour,
+				maxLookBackConfig:                0,
+				maxChunkAge:                      1 * time.Hour,
+				querierBoltDBFilesResyncInterval: 5 * time.Minute,
 			},
-			want:    90 * time.Minute,
+			want:    81 * time.Minute,
 			wantErr: false,
 		},
 		{
@@ -37,8 +39,9 @@ func Test_calculateMaxLookBack(t *testing.T) {
 				pc: chunk.PeriodConfig{
 					ObjectType: "filesystem",
 				},
-				maxLookBackConfig: -1,
-				maxChunkAge:       1 * time.Hour,
+				maxLookBackConfig:                -1,
+				maxChunkAge:                      1 * time.Hour,
+				querierBoltDBFilesResyncInterval: 5 * time.Minute,
 			},
 			want:    -1,
 			wantErr: false,
@@ -49,8 +52,9 @@ func Test_calculateMaxLookBack(t *testing.T) {
 				pc: chunk.PeriodConfig{
 					ObjectType: "gcs",
 				},
-				maxLookBackConfig: -1,
-				maxChunkAge:       1 * time.Hour,
+				maxLookBackConfig:                -1,
+				maxChunkAge:                      1 * time.Hour,
+				querierBoltDBFilesResyncInterval: 5 * time.Minute,
 			},
 			want:    0,
 			wantErr: true,
@@ -61,8 +65,9 @@ func Test_calculateMaxLookBack(t *testing.T) {
 				pc: chunk.PeriodConfig{
 					ObjectType: "filesystem",
 				},
-				maxLookBackConfig: 1 * time.Hour,
-				maxChunkAge:       1 * time.Hour,
+				maxLookBackConfig:                1 * time.Hour,
+				maxChunkAge:                      1 * time.Hour,
+				querierBoltDBFilesResyncInterval: 5 * time.Minute,
 			},
 			want:    0,
 			wantErr: true,
@@ -70,7 +75,7 @@ func Test_calculateMaxLookBack(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := calculateMaxLookBack(tt.args.pc, tt.args.maxLookBackConfig, tt.args.maxChunkAge)
+			got, err := calculateMaxLookBack(tt.args.pc, tt.args.maxLookBackConfig, tt.args.maxChunkAge, tt.args.querierBoltDBFilesResyncInterval)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("calculateMaxLookBack() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -46,7 +46,7 @@ const (
 )
 
 type boltDBIndexClient interface {
-	QueryDB(ctx context.Context, db *bbolt.DB, query chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error
+	QueryWithCursor(_ context.Context, c *bbolt.Cursor, query chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error
 	NewWriteBatch() chunk.WriteBatch
 	WriteToDB(ctx context.Context, db *bbolt.DB, writes local.TableWrites) error
 	Stop()

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -41,7 +41,8 @@ const (
 
 	StorageKeyPrefix = "index/"
 
-	// UploadInterval defines interval for uploading active boltdb files from local which are being written to by ingesters.
+	// UploadInterval defines interval for when we check if there are new index files to upload.
+	// It's also used to snapshot the currently written index tables so the snapshots can be used for reads.
 	UploadInterval = 1 * time.Minute
 )
 

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -42,7 +42,7 @@ const (
 	StorageKeyPrefix = "index/"
 
 	// UploadInterval defines interval for uploading active boltdb files from local which are being written to by ingesters.
-	UploadInterval = 15 * time.Minute
+	UploadInterval = 1 * time.Minute
 )
 
 type boltDBIndexClient interface {
@@ -124,6 +124,7 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 			Uploader:       uploader,
 			IndexDir:       s.cfg.ActiveIndexDirectory,
 			UploadInterval: UploadInterval,
+			DBRetainPeriod: s.cfg.ResyncInterval + 2*time.Minute,
 		}
 		uploadsManager, err := uploads.NewTableManager(cfg, s.boltDBIndexClient, prefixedObjectClient, registerer)
 		if err != nil {

--- a/pkg/storage/stores/shipper/uploads/table_manager.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager.go
@@ -253,6 +253,7 @@ func (tm *TableManager) loadTables() (map[string]*Table, error) {
 			continue
 		}
 
+		// Queries are only done against table snapshots so it's important we snapshot as soon as the table is loaded.
 		err = table.Snapshot()
 		if err != nil {
 			return nil, err

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -138,6 +138,7 @@ func TestTableManager_BatchWrite(t *testing.T) {
 	require.Len(t, tm.tables, len(tc))
 
 	for tableName, expectedIndex := range tc {
+		require.NoError(t, tm.tables[tableName].Snapshot())
 		testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{TableName: tableName}}, tm.tables[tableName], expectedIndex.start, expectedIndex.numRecords)
 	}
 }
@@ -173,6 +174,10 @@ func TestTableManager_QueryPages(t *testing.T) {
 	queries = append(queries, chunk.IndexQuery{TableName: "non-existent"})
 
 	require.NoError(t, tm.BatchWrite(context.Background(), writeBatch))
+
+	for _, table := range tm.tables {
+		require.NoError(t, table.Snapshot())
+	}
 
 	testutil.TestMultiTableQuery(t, queries, tm, 0, 30)
 }

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -88,6 +88,8 @@ func TestLoadTable(t *testing.T) {
 		table.Stop()
 	}()
 
+	require.NoError(t, table.Snapshot())
+
 	// query the loaded table to see if it has right data.
 	testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{}}, table, 0, 20)
 }
@@ -146,6 +148,8 @@ func TestTable_Write(t *testing.T) {
 			}
 			db, ok := table.dbs[expectedDBName]
 			require.True(t, ok)
+
+			require.NoError(t, table.Snapshot())
 
 			// test that the table has current + previous records
 			testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{}}, table, 0, (i+1)*10)
@@ -283,6 +287,8 @@ func TestTable_Cleanup(t *testing.T) {
 		table.Stop()
 	}()
 
+	require.NoError(t, table.Snapshot())
+
 	// upload all the existing dbs
 	require.NoError(t, table.Upload(context.Background(), true))
 	require.Len(t, table.uploadedDBsMtime, 3)
@@ -339,7 +345,7 @@ func Test_LoadBoltDBsFromDir(t *testing.T) {
 			Start:      0,
 			NumRecords: 10,
 		},
-		"db1" + snapshotFileSuffix: { // a snapshot file which should be ignored.
+		"db1" + tempFileSuffix: { // a snapshot file which should be ignored.
 			Start:      0,
 			NumRecords: 10,
 		},
@@ -487,6 +493,8 @@ func TestTable_MultiQueries(t *testing.T) {
 	defer func() {
 		table.Stop()
 	}()
+
+	require.NoError(t, table.Snapshot())
 
 	// build queries each looking for specific value from all the dbs
 	var queries []chunk.IndexQuery

--- a/pkg/storage/stores/shipper/util/queries_test.go
+++ b/pkg/storage/stores/shipper/util/queries_test.go
@@ -87,3 +87,124 @@ func buildQueries(n int) []chunk.IndexQuery {
 
 	return queries
 }
+
+func TestIndexDeduper(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		batches        []batch
+		expectedValues map[string][][]byte
+	}{
+		{
+			name: "single batch",
+			batches: []batch{
+				{
+					hashValue:   "1",
+					rangeValues: [][]byte{[]byte("a"), []byte("b")},
+				},
+			},
+			expectedValues: map[string][][]byte{
+				"1": {[]byte("a"), []byte("b")},
+			},
+		},
+		{
+			name: "multiple batches, no duplicates",
+			batches: []batch{
+				{
+					hashValue:   "1",
+					rangeValues: [][]byte{[]byte("a"), []byte("b")},
+				},
+				{
+					hashValue:   "2",
+					rangeValues: [][]byte{[]byte("c"), []byte("d")},
+				},
+			},
+			expectedValues: map[string][][]byte{
+				"1": {[]byte("a"), []byte("b")},
+				"2": {[]byte("c"), []byte("d")},
+			},
+		},
+		{
+			name: "duplicate rangeValues but different hashValues",
+			batches: []batch{
+				{
+					hashValue:   "1",
+					rangeValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+				},
+				{
+					hashValue:   "2",
+					rangeValues: [][]byte{[]byte("a"), []byte("b")},
+				},
+			},
+			expectedValues: map[string][][]byte{
+				"1": {[]byte("a"), []byte("b"), []byte("c")},
+				"2": {[]byte("a"), []byte("b")},
+			},
+		},
+		{
+			name: "duplicate rangeValues in same hashValues",
+			batches: []batch{
+				{
+					hashValue:   "1",
+					rangeValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+				},
+				{
+					hashValue:   "1",
+					rangeValues: [][]byte{[]byte("a"), []byte("b"), []byte("d")},
+				},
+			},
+			expectedValues: map[string][][]byte{
+				"1": {[]byte("a"), []byte("b"), []byte("c"), []byte("d")},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actualValues := map[string][][]byte{}
+			deduper := NewIndexDeduper(func(query chunk.IndexQuery, readBatch chunk.ReadBatch) bool {
+				itr := readBatch.Iterator()
+				for itr.Next() {
+					actualValues[query.HashValue] = append(actualValues[query.HashValue], itr.RangeValue())
+				}
+				return true
+			})
+
+			for _, batch := range tc.batches {
+				deduper.Callback(chunk.IndexQuery{HashValue: batch.hashValue}, batch)
+			}
+
+			require.Equal(t, tc.expectedValues, actualValues)
+		})
+	}
+}
+
+type batch struct {
+	hashValue   string
+	rangeValues [][]byte
+}
+
+func (b batch) Iterator() chunk.ReadBatchIterator {
+	return &batchIterator{
+		rangeValues: b.rangeValues,
+	}
+}
+
+type batchIterator struct {
+	rangeValues [][]byte
+	idx         int
+}
+
+func (b *batchIterator) Next() bool {
+	if b.idx >= len(b.rangeValues) {
+		return false
+	}
+
+	b.idx++
+	return true
+}
+
+func (b batchIterator) RangeValue() []byte {
+	return b.rangeValues[b.idx-1]
+}
+
+func (b batchIterator) Value() []byte {
+	panic("implement me")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR includes a couple of improvements, all in a separate commit:
1. Uses new `QueryWithCursor` method which can reuse the same cursor to do all the index queries instead of having to start a new transaction for each query.
2. A new type called `IndexDeduper` which acts as a middleware for deduping the index entries which significantly improves the CPU usage and query performance.
3. Use Fifocache(an in-memory cache) in ingester which also significantly reduces the load on ingesters by caching the index in memory for serving subsequent queries. It also helps improve the query performance.
4. Snapshotting of dbs in ingesters for reads. This is again an optimization to improve query performance in ingesters. It would create a new snapshot of dbs in ingesters every minute for reads.
5. Ingesters now ship the files faster and retain fewer of them which reduces the amount of index ingesters have to deal with during queries. This also helps reduce the load on ingesters during queries.

All the changes complement each other to enhance query performance and reduce CPU usage. I have also fine-tuned some configs which have a supporting comment to explain why the change has been done.

**Checklist**
- [x] Tests updated

