### PR TITLE
feat: Delete logs support

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -122,6 +122,10 @@ func (c *dumbChunk) Close() error {
 	return nil
 }
 
+func (c *dumbChunk) Rebound(start, end time.Time) (Chunk, error) {
+	return nil, nil
+}
+
 type dumbChunkIterator struct {
 	direction logproto.Direction
 	i         int

--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -2,6 +2,9 @@ package chunkenc
 
 import (
 	"io"
+	"time"
+
+	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
@@ -81,6 +84,16 @@ func (f Facade) Size() int {
 // LokiChunk returns the chunkenc.Chunk.
 func (f Facade) LokiChunk() Chunk {
 	return f.c
+}
+
+func (f Facade) Rebound(start, end model.Time) (encoding.Chunk, error) {
+	newChunk, err := f.c.Rebound(start.Time(), end.Time().Add(time.Nanosecond))
+	if err != nil {
+		return nil, err
+	}
+	return &Facade{
+		c: newChunk,
+	}, nil
 }
 
 // UncompressedSize is a helper function to hide the type assertion kludge when wanting the uncompressed size of the Cortex interface encoding.Chunk.

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -121,6 +121,7 @@ type Chunk interface {
 	CompressedSize() int
 	Close() error
 	Encoding() Encoding
+	Rebound(start, end time.Time) (Chunk, error)
 }
 
 // Block is a chunk block.

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -12,10 +12,13 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/chunk/encoding"
+
 	"github.com/cespare/xxhash/v2"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
@@ -31,6 +34,11 @@ const (
 
 	blocksPerChunk = 10
 	maxLineLength  = 1024 * 1024 * 1024
+
+	// defaultBlockSize is used for target block size when cutting partially deleted chunks from a delete request.
+	// This could wary from configured block size using `ingester.chunks-block-size` flag or equivalent yaml config resulting in
+	// different block size in the new chunk which should be fine.
+	defaultBlockSize = 256 * 1024
 )
 
 var magicNumber = uint32(0x12EE56A)
@@ -744,6 +752,32 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 		}
 	}
 	return blocks
+}
+
+func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
+	// add a nanosecond to end time because the delete intervals are inclusive while the Chunk.Iterator considers end time to be non-inclusive.
+	itr, err := c.Iterator(context.Background(), start, end.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+	if err != nil {
+		return nil, err
+	}
+
+	// Using defaultBlockSize for target block size.
+	// The alternative here could be going over all the blocks and using the size of the largest block as target block size but I(Sandeep) feel that it is not worth the complexity.
+	// For target chunk size I am using compressed size of original chunk since the newChunk should anyways be lower in size than that.
+	newChunk := NewMemChunk(c.Encoding(), defaultBlockSize, c.CompressedSize())
+
+	for itr.Next() {
+		entry := itr.Entry()
+		if err := newChunk.Append(&entry); err != nil {
+			return nil, err
+		}
+	}
+
+	if newChunk.Size() == 0 {
+		return nil, encoding.ErrSliceNoDataInRange
+	}
+
+	return newChunk, nil
 }
 
 // encBlock is an internal wrapper for a block, mainly to avoid binding an encoding in a block itself.

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/chunk/encoding"
+
 	"github.com/dustin/go-humanize"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
@@ -1029,4 +1031,97 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 			series = series[:0]
 		})
 	}
+}
+
+func TestMemChunk_Rebound(t *testing.T) {
+	chkFrom := time.Unix(0, 0)
+	chkThrough := chkFrom.Add(time.Hour)
+	originalChunk := buildTestMemChunk(t, chkFrom, chkThrough)
+
+	for _, tc := range []struct {
+		name               string
+		sliceFrom, sliceTo time.Time
+		err                error
+	}{
+		{
+			name:      "slice whole chunk",
+			sliceFrom: chkFrom,
+			sliceTo:   chkThrough,
+		},
+		{
+			name:      "slice first half",
+			sliceFrom: chkFrom,
+			sliceTo:   chkFrom.Add(30 * time.Minute),
+		},
+		{
+			name:      "slice second half",
+			sliceFrom: chkFrom.Add(30 * time.Minute),
+			sliceTo:   chkThrough,
+		},
+		{
+			name:      "slice in the middle",
+			sliceFrom: chkFrom.Add(15 * time.Minute),
+			sliceTo:   chkFrom.Add(45 * time.Minute),
+		},
+		{
+			name:      "slice interval not aligned with sample intervals",
+			sliceFrom: chkFrom.Add(time.Second),
+			sliceTo:   chkThrough.Add(-time.Second),
+		},
+		{
+			name:      "slice out of bounds without overlap",
+			err:       encoding.ErrSliceNoDataInRange,
+			sliceFrom: chkThrough.Add(time.Minute),
+			sliceTo:   chkThrough.Add(time.Hour),
+		},
+		{
+			name:      "slice out of bounds with overlap",
+			sliceFrom: chkFrom.Add(10 * time.Minute),
+			sliceTo:   chkThrough.Add(10 * time.Minute),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			newChunk, err := originalChunk.Rebound(tc.sliceFrom, tc.sliceTo)
+			if tc.err != nil {
+				require.Equal(t, tc.err, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// iterate originalChunk from slice start to slice end + nanosecond. Adding a nanosecond here to be inclusive of sample at end time.
+			originalChunkItr, err := originalChunk.Iterator(context.Background(), tc.sliceFrom, tc.sliceTo.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+
+			// iterate newChunk for whole chunk interval which should include all the samples in the chunk and hence align it with expected values.
+			newChunkItr, err := newChunk.Iterator(context.Background(), chkFrom, chkThrough, logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+
+			for {
+				originalChunksHasMoreSamples := originalChunkItr.Next()
+				newChunkHasMoreSamples := newChunkItr.Next()
+
+				// either both should have samples or none of them
+				require.Equal(t, originalChunksHasMoreSamples, newChunkHasMoreSamples)
+				if !originalChunksHasMoreSamples {
+					break
+				}
+
+				require.Equal(t, originalChunkItr.Entry(), newChunkItr.Entry())
+			}
+
+		})
+	}
+}
+
+func buildTestMemChunk(t *testing.T, from, through time.Time) *MemChunk {
+	chk := NewMemChunk(EncGZIP, defaultBlockSize, 0)
+	for ; from.Before(through); from = from.Add(time.Second) {
+		err := chk.Append(&logproto.Entry{
+			Line:      from.String(),
+			Timestamp: from,
+		})
+		require.NoError(t, err)
+	}
+
+	return chk
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -643,7 +643,7 @@ func calculateMaxLookBack(pc chunk.PeriodConfig, maxLookBackConfig, maxChunkAge,
 }
 
 // middleware for setting cache gen header to let consumer of response know all previous responses could be invalid due to delete operation
-func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
+func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader cortex_queryrange.CacheGenNumberLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			userID, err := user.ExtractOrgID(r.Context())

--- a/pkg/purger/http.go
+++ b/pkg/purger/http.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
 	"github.com/cortexproject/cortex/pkg/util"
+
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/logql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/logql"
 )
 
 type DeleteRequestHandler struct {

--- a/pkg/purger/http.go
+++ b/pkg/purger/http.go
@@ -1,0 +1,118 @@
+package purger
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/weaveworks/common/user"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type DeleteRequestHandler struct {
+	*purger.DeleteRequestHandler
+	deleteStore               *purger.DeleteStore
+}
+
+// NewDeleteRequestHandler creates a DeleteRequestHandler
+func NewDeleteRequestHandler(deleteStore *purger.DeleteStore, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
+	return &DeleteRequestHandler{
+		purger.NewDeleteRequestHandler(deleteStore, deleteRequestCancelPeriod, registerer),
+		deleteStore,
+	}
+}
+
+func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
+	params := r.URL.Query()
+	match := params["match[]"]
+	if len(match) == 0 {
+		http.Error(w, "selectors not set", http.StatusBadRequest)
+		return
+	}
+
+	params.Del("match[]")
+
+	for i := range match {
+		lbls, err := logql.ParseMatchers(match[i])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		lbls = append(lbls, &labels.Matcher{
+			Type: labels.MatchEqual,
+			Name:  labels.MetricName,
+			Value: "logs",
+		})
+
+
+
+		params.Set("match[]", convertMatchersToString(lbls))
+	}
+
+	r.URL.RawQuery = params.Encode()
+	dm.DeleteRequestHandler.AddDeleteRequestHandler(w, r)
+}
+
+func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWriter, r *http.Request)  {
+	ctx := r.Context()
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	deleteRequests, err := dm.deleteStore.GetAllDeleteRequestsForUser(ctx, userID)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error getting delete requests from the store", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	for i := range deleteRequests {
+		for j, selector := range deleteRequests[i].Selectors {
+
+			matchers, err := logql.ParseMatchers(selector)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			for i, matcher := range matchers {
+				if matcher.Name == labels.MetricName{
+					matchers = append(matchers[:i], matchers[i+1:]...)
+					break
+				}
+			}
+
+			deleteRequests[i].Selectors[j] = convertMatchersToString(matchers)
+		}
+	}
+
+	if err := json.NewEncoder(w).Encode(deleteRequests); err != nil {
+		level.Error(util.Logger).Log("msg", "error marshalling response", "err", err)
+		http.Error(w, fmt.Sprintf("Error marshalling response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func convertMatchersToString(matchers []*labels.Matcher) string {
+	out := strings.Builder{}
+	out.WriteRune('{')
+
+	for idx, m := range matchers {
+		if idx > 0 {
+			out.WriteRune(',')
+		}
+
+		out.WriteString(m.String())
+	}
+
+	out.WriteRune('}')
+	return out.String()
+}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
+
 	ring_client "github.com/cortexproject/cortex/pkg/ring/client"
 
 	"github.com/grafana/loki/pkg/ingester/client"
@@ -40,7 +42,7 @@ func newQuerier(cfg Config, clientCfg client.Config, clientFactory ring_client.P
 	if err != nil {
 		return nil, err
 	}
-	return New(cfg, store, iq, limits)
+	return New(cfg, store, iq, limits, purger.NewTombstonesLoader(nil, nil))
 }
 
 func TestQuerier_Label_QueryTimeoutConfigFlag(t *testing.T) {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -8,16 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/chunk/purger"
-
-	ring_client "github.com/cortexproject/cortex/pkg/ring/client"
-
-	"github.com/grafana/loki/pkg/ingester/client"
-
-	"github.com/grafana/loki/pkg/storage"
-
-	"github.com/grafana/loki/pkg/logql"
-
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -25,10 +15,15 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
 	"github.com/cortexproject/cortex/pkg/ring"
+	ring_client "github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 
+	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -62,7 +62,7 @@ func Test_seriesLimiter(t *testing.T) {
 	cfg.SplitQueriesByInterval = time.Hour
 	cfg.CacheResults = false
 	// split in 6 with 4 in // max.
-	tpw, stopper, err := NewTripperware(cfg, util.Logger, fakeLimits{maxSeries: 1, maxQueryParallelism: 2}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(cfg, util.Logger, fakeLimits{maxSeries: 1, maxQueryParallelism: 2}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -92,7 +92,7 @@ var (
 // those tests are mostly for testing the glue between all component and make sure they activate correctly.
 func TestMetricsTripperware(t *testing.T) {
 
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{maxSeries: math.MaxInt32}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{maxSeries: math.MaxInt32}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -156,7 +156,7 @@ func TestMetricsTripperware(t *testing.T) {
 
 func TestLogFilterTripperware(t *testing.T) {
 
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -204,7 +204,7 @@ func TestLogFilterTripperware(t *testing.T) {
 
 func TestSeriesTripperware(t *testing.T) {
 
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -246,7 +246,7 @@ func TestSeriesTripperware(t *testing.T) {
 
 func TestLabelsTripperware(t *testing.T) {
 
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -292,7 +292,7 @@ func TestLabelsTripperware(t *testing.T) {
 }
 
 func TestLogNoRegex(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -326,7 +326,7 @@ func TestLogNoRegex(t *testing.T) {
 }
 
 func TestUnhandledPath(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -350,7 +350,7 @@ func TestUnhandledPath(t *testing.T) {
 }
 
 func TestRegexpParamsSupport(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -429,7 +429,7 @@ func TestPostQueries(t *testing.T) {
 }
 
 func TestEntriesLimitsTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{maxEntriesLimitPerQuery: 5000}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{maxEntriesLimitPerQuery: 5000}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -460,7 +460,7 @@ func TestEntriesLimitsTripperware(t *testing.T) {
 }
 
 func TestEntriesLimitWithZeroTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util.Logger, fakeLimits{}, chunk.SchemaConfig{}, 0, nil, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds support for deletion of logs. The feature is still experimental so it is required to be enabled explicitly by setting `purger.enable` config to `true`.

**NOTE**: This feature is only supported when using index stores other than `boltdb-shipper`. Support for it would be added in a separate PR.

This feature works the same as [delete series support in Cortex](https://github.com/cortexproject/cortex/blob/6db67a4efbbf62b1133fa037a95382a21f752bbf/docs/guides/deleting-series.md), the only change is the URLs used for performing various operations, which are outlined below:

* Requesting Deletion:
```
PUT,POST <loki-addr>/loki/api/admin/delete?match[]=<matcher>&start=<start-time>&end=<end-time>
```

* List Delete Requests:
```
PUT,POST <loki-addr>/loki/api/admin/delete
```

* Cancelling a Delete Requests:
```
PUT,POST <loki-addr>/loki/api/admin/delete?request_id=<request-id>
```
Request ID of the request can be grabbed from the List Delete Request API response.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

