### PR TITLE
add a metric in compactor to record timestamp of last successful run

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -95,6 +95,7 @@ func (c *Compactor) Run(ctx context.Context) error {
 		c.metrics.compactTablesOperationTotal.WithLabelValues(status).Inc()
 		if status == statusSuccess {
 			c.metrics.compactTablesOperationDurationSeconds.Set(time.Since(start).Seconds())
+			c.metrics.compactTablesOperationLastSuccess.SetToCurrentTime()
 		}
 	}()
 

--- a/pkg/storage/stores/shipper/compactor/metrics.go
+++ b/pkg/storage/stores/shipper/compactor/metrics.go
@@ -13,6 +13,7 @@ const (
 type metrics struct {
 	compactTablesOperationTotal           *prometheus.CounterVec
 	compactTablesOperationDurationSeconds prometheus.Gauge
+	compactTablesOperationLastSuccess     prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -26,6 +27,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Namespace: "loki_boltdb_shipper",
 			Name:      "compact_tables_operation_duration_seconds",
 			Help:      "Time (in seconds) spent in compacting all the tables",
+		}),
+		compactTablesOperationLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "compact_tables_operation_last_successful_run_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful compaction run",
 		}),
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds a new metric for recording timestamp of last successful run which would help with writing alerts on problems in compaction.

