### PR TITLE
Fixes a bug that would add __error__ label incorrectly.

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -105,7 +105,7 @@ func (b *LabelsBuilder) Labels() labels.Labels {
 		if b.err == "" {
 			return b.base
 		}
-		res := append(b.base, labels.Label{Name: ErrorLabel, Value: b.err})
+		res := append(b.base.Copy(), labels.Label{Name: ErrorLabel, Value: b.err})
 		sort.Sort(res)
 		return res
 	}

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -28,3 +28,21 @@ func TestLabelsBuilder_Get(t *testing.T) {
 	_, ok = b.Get("already")
 	require.False(t, ok)
 }
+
+func TestLabelsBuilder_LabelsError(t *testing.T) {
+	lbs := labels.Labels{labels.Label{Name: "already", Value: "in"}}
+	b := NewLabelsBuilder()
+	b.Reset(lbs)
+	b.SetErr("err")
+	lbsWithErr := b.Labels()
+	require.Equal(
+		t,
+		labels.Labels{
+			labels.Label{Name: ErrorLabel, Value: "err"},
+			labels.Label{Name: "already", Value: "in"},
+		},
+		lbsWithErr,
+	)
+	// make sure the original labels is unchanged.
+	require.Equal(t, labels.Labels{labels.Label{Name: "already", Value: "in"}}, lbs)
+}


### PR DESCRIPTION
Wrong usage of slices would add error label to the original set of labels.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

