### PR TITLE
changed provisioned_write_throughput default

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1729,7 +1729,7 @@ The `provision_config` block configures provisioning capacity for DynamoDB.
 
 # DynamoDB table default write throughput.
 # CLI flag: -<prefix>.write-throughput
-[provisioned_write_throughput: <int> | default = 3000]
+[provisioned_write_throughput: <int> | default = 1000]
 
 # DynamoDB table default read throughput.
 # CLI flag: -<prefix>.read-throughput


### PR DESCRIPTION
changed provisioned_write_throughput default  from 3000 to 1000 since this is what appears to be the default, see also https://github.com/grafana/loki/issues/2801

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

