### PR TITLE
Update local and docker default config files to use boltdb-shipper with a few other config changes

### DIFF
--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -11,29 +11,32 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  chunk_idle_period: 5m
-  chunk_retain_period: 30s
-  max_transfer_retries: 0
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
 
 schema_config:
   configs:
-    - from: 2018-04-15
-      store: boltdb
+    - from: 2020-10-24
+      store: boltdb-shipper
       object_store: filesystem
       schema: v11
       index:
         prefix: index_
-        period: 168h
+        period: 24h
 
 storage_config:
-  boltdb:
-    directory: /loki/index
-
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
 
 limits_config:
-  enforce_metric_name: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
 

--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -36,6 +36,10 @@ storage_config:
   filesystem:
     directory: /loki/chunks
 
+compactor:
+  working_directory: /loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h

--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -52,8 +52,8 @@ ruler:
     type: local
     local:
       directory: /loki/rules
-  rule_path: /loki/tmprules
-  alertmanager_url: http://localhost
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
   ring:
     kvstore:
       store: inmemory

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -11,29 +11,32 @@ ingester:
         store: inmemory
       replication_factor: 1
     final_sleep: 0s
-  chunk_idle_period: 5m
-  chunk_retain_period: 30s
-  max_transfer_retries: 0
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
 
 schema_config:
   configs:
-    - from: 2018-04-15
-      store: boltdb
+    - from: 2020-10-24
+      store: boltdb-shipper
       object_store: filesystem
       schema: v11
       index:
         prefix: index_
-        period: 168h
+        period: 24h
 
 storage_config:
-  boltdb:
-    directory: /tmp/loki/index
-
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
   filesystem:
     directory: /tmp/loki/chunks
 
 limits_config:
-  enforce_metric_name: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
 

--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -36,6 +36,10 @@ storage_config:
   filesystem:
     directory: /tmp/loki/chunks
 
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
@@ -51,9 +55,9 @@ ruler:
   storage:
     type: local
     local:
-      directory: /tmp/rules
-  rule_path: /tmp/scratch
-  alertmanager_url: http://localhost
+      directory: /tmp/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://localhost:9093
   ring:
     kvstore:
       store: inmemory

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -428,7 +428,7 @@ func (t *Loki) initRulerStorage() (_ services.Service, err error) {
 	}
 
 	// Make sure storage directory exists if using filesystem store
-	if t.cfg.Ruler.StoreConfig.Local.Directory != "" {
+	if t.cfg.Ruler.StoreConfig.Type == "local" && t.cfg.Ruler.StoreConfig.Local.Directory != "" {
 		err := chunk_util.EnsureDirectory(t.cfg.Ruler.StoreConfig.Local.Directory)
 		if err != nil {
 			return nil, err
@@ -444,14 +444,6 @@ func (t *Loki) initRuler() (_ services.Service, err error) {
 	if t.RulerStorage == nil {
 		level.Info(util.Logger).Log("msg", "RulerStorage is nil.  Not starting the ruler.")
 		return nil, nil
-	}
-
-	// Make sure the prometheus rules temp directory exists
-	if t.cfg.Ruler.RulePath != "" {
-		err := chunk_util.EnsureDirectory(t.cfg.Ruler.RulePath)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	t.cfg.Ruler.Ring.ListenPort = t.cfg.Server.GRPCListenPort


### PR DESCRIPTION
Setting boltdb-shipper to be the default index type in the local example and docker config files

This also tells loki to use the chunk_target_size config 