### PR TITLE
Loki: log any chunk fetch failure

### DIFF
--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -656,6 +656,7 @@ func fetchLazyChunks(ctx context.Context, chunks []*LazyChunk) error {
 			}
 			chks, err := fetcher.FetchChunks(ctx, chks, keys)
 			if err != nil {
+				level.Error(util.Logger).Log("msg", "error fetching chunks", "err", err)
 				if isInvalidChunkError(err) {
 					level.Error(util.Logger).Log("msg", "checksum of chunks does not match", "err", chunk.ErrInvalidChecksum)
 					errChan <- nil


### PR DESCRIPTION
This is a catch all for any fetch error, I have a suspicion this might happen sometimes and is silently ignored.