### PR TITLE
Stats: Adding metrics collector GitHub action

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -1,0 +1,22 @@
+name: Github repo and issue stats collection
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run metrics collector
+        uses: ./actions/metrics-collector
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}


### PR DESCRIPTION
This adds a GitHub action that collect repo & issue stats every 30min. 

We use it in the Grafana repo for issue triage and more:
https://play.grafana.org/d/aw0AkS5Gz/grafana-issue-triage?orgId=1 

Recently added it in Tempo repo:
https://play.grafana.org/d/YckFzEtGk/grafana-tempo-github-stats?orgId=1 

By default, it just tracks some basic metrics like stars, forks, repo size, open issue count etc. You can also add a json config file with queries that can give you trends over time for open PRs and unlabeled issues for example.  

https://github.com/grafana/grafana/blob/master/.github/metrics-collector.json

Data is sent to a Grafana cloud metrictank instance. Added the API key to the secrets for this repo so this should work after merge as GH_BOT_ACCESS_TOKEN was already there. 