### PR TITLE
fixes promtail libsonnet tag. closes #2818

### DIFF
--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    promtail: 'grafana/promtail:v2.0.0',
+    promtail: 'grafana/promtail:2.0.0',
   },
 
   _config+:: {


### PR DESCRIPTION
Erroneously used a `v` prefix.