### PR TITLE
Bump fluentd plugin

### DIFF
--- a/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.15'
+  spec.version = '1.2.16'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
so we can push the last version.

```
gem push fluent-plugin-grafana-loki-1.2.15.gem
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/universal-darwin19/rbconfig.rb:229: warning: Insecure world writable dir /Users/ctovena/go/src/github.com/grafana/loki/cmd/logcli in PATH, mode 040777
Pushing gem to https://rubygems.org...
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.
```
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

