### PR TITLE
fix panic in ingester when not running with boltdb shipper while queriers does

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -390,7 +390,7 @@ func (i *Ingester) GetChunkIDs(ctx context.Context, req *logproto.GetChunkIDsReq
 
 	boltdbShipperMaxLookBack := i.boltdbShipperMaxLookBack()
 	if boltdbShipperMaxLookBack == 0 {
-		return nil, nil
+		return &logproto.GetChunkIDsResponse{}, nil
 	}
 
 	reqStart := req.Start


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When ingesters are not running `boltdb-shipper`, `GetChunkIDs` proto call returns a `nil` response instead of empty response which causes ingesters to panic, trying to marshal a nil value. This would happen when ingesters are not running `boltdb-shipper` while queriers are.

