### PR TITLE
fix flaky tests in boltdb-shipper

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -60,7 +60,7 @@ func buildTestTable(t *testing.T, tableName, path string) (*Table, *local.BoltIn
 }
 
 func TestTable_MultiQueries(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-writes")
+	tempDir, err := ioutil.TempDir("", "table-downloads-multi-queries")
 	require.NoError(t, err)
 
 	defer func() {
@@ -102,7 +102,7 @@ func TestTable_MultiQueries(t *testing.T) {
 }
 
 func TestTable_Sync(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-writes")
+	tempDir, err := ioutil.TempDir("", "table-sync")
 	require.NoError(t, err)
 
 	defer func() {
@@ -178,7 +178,7 @@ func TestTable_Sync(t *testing.T) {
 }
 
 func TestTable_LastUsedAt(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-writes")
+	tempDir, err := ioutil.TempDir("", "table-last-used-at")
 	require.NoError(t, err)
 
 	table, _, stopFunc := buildTestTable(t, "test", tempDir)
@@ -240,7 +240,7 @@ func TestTable_doParallelDownload(t *testing.T) {
 }
 
 func TestTable_DuplicateIndex(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-writes")
+	tempDir, err := ioutil.TempDir("", "table-duplicate-index")
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -38,7 +38,7 @@ func buildTestTableManager(t *testing.T, testDir string) (*TableManager, *local.
 }
 
 func TestLoadTables(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cleanup")
+	testDir, err := ioutil.TempDir("", "load-tables")
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/storage/stores/shipper/util/util_test.go
+++ b/pkg/storage/stores/shipper/util/util_test.go
@@ -52,7 +52,7 @@ func Test_GetFileFromStorage(t *testing.T) {
 }
 
 func Test_CompressFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-compaction")
+	tempDir, err := ioutil.TempDir("", "compress-file")
 	require.NoError(t, err)
 
 	defer func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Some of the tests in `boltdb-shipper` were failing intermittently due to possible reuse of the same directories to build test data.
This is a possible fix for it which makes sure temp directories are created with distinct prefixes.

