### PR TITLE
Iss2734

### DIFF
--- a/production/helm/fluent-bit/Chart.yaml
+++ b/production/helm/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: fluent-bit
-version: 2.0.0
+version: 2.0.1
 appVersion: v2.0.0
 kubeVersion: "^1.10.0-0"
 description: "Uses fluent-bit Loki go plugin for gathering logs and sending them to Loki"

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -42,7 +42,7 @@ data:
         {{- end }}
         TenantID {{ .Values.config.tenantID }}
         BatchWait {{ .Values.config.batchWait }}
-        BatchSize {{ .Values.config.batchSize }}
+        BatchSize {{ int .Values.config.batchSize }}
         Labels {{ .Values.config.labels }}
         RemoveKeys {{ include "helm-toolkit.utils.joinListWithComma" .Values.config.removeKeys }}
         AutoKubernetesLabels {{ .Values.config.autoKubernetesLabels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Works around a helm issue (https://github.com/helm/helm/issues/1707#issuecomment-613133567) where a value that is meant to be an int gets cast to a float. In this case the fluent-bit helm chart BatchSize default value of `1048576` was being sent to the configmap in scientific notation  `1.048576e+06`.

**Which issue(s) this PR fixes**:
Fixes #2734 

**Special notes for your reviewer**:

**Checklist**
- [ n/a ] Documentation added
- [ n/a ] Tests updated

