### PR TITLE
tests: fix quoting issues in test output when building with Go 1.15

### DIFF
--- a/pkg/logentry/stages/drop_test.go
+++ b/pkg/logentry/stages/drop_test.go
@@ -342,7 +342,7 @@ func Test_validateDropConfig(t *testing.T) {
 			config: &DropConfig{
 				OlderThan: &dropInvalidDur,
 			},
-			wantErr: fmt.Errorf(ErrDropStageInvalidDuration, dropInvalidDur, "time: unknown unit y in duration 10y"),
+			wantErr: fmt.Errorf(ErrDropStageInvalidDuration, dropInvalidDur, "time: unknown unit \"y\" in duration \"10y\""),
 		},
 		{
 			name: "Invalid Config",

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -222,7 +222,7 @@ func Test(t *testing.T) {
 					IdleDuration: &metricTestInvalidIdle,
 				},
 			},
-			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit f in duration 10f"),
+			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit \"f\" in duration \"10f\""),
 		},
 		"valid": {
 			MetricsConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

While packaging Loki with Go 1.15 for NixOS I noticed that the quoting in the tests didn't match the new quoting that Go applies.

**Which issue(s) this PR fixes**:
Fixes #2519 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

