### PR TITLE
Only applies entry limits to non-SampleExprs.

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1598,7 +1598,7 @@ logs in Loki.
 # CLI flag: -distributor.max-line-size
 [max_line_size: <string> | default = none ]
 
-# Maximum number of log entries that will be returned for a query. 0 to disable.
+# Maximum number of log entries that will be returned for a query.
 # CLI flag: -validation.max-entries-limit
 [max_entries_limit_per_query: <int> | default = 5000 ]
 

--- a/pkg/logentry/stages/drop_test.go
+++ b/pkg/logentry/stages/drop_test.go
@@ -342,7 +342,11 @@ func Test_validateDropConfig(t *testing.T) {
 			config: &DropConfig{
 				OlderThan: &dropInvalidDur,
 			},
-			wantErr: fmt.Errorf(ErrDropStageInvalidDuration, dropInvalidDur, "time: unknown unit \"y\" in duration \"10y\""),
+			wantErr: fmt.Errorf(
+				ErrDropStageInvalidDuration,
+				dropInvalidDur,
+				"time: unknown unit y in duration 10y",
+			),
 		},
 		{
 			name: "Invalid Config",

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -222,7 +222,7 @@ func Test(t *testing.T) {
 					IdleDuration: &metricTestInvalidIdle,
 				},
 			},
-			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit \"f\" in duration \"10f\""),
+			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit f in duration 10f"),
 		},
 		"valid": {
 			MetricsConfig{


### PR DESCRIPTION
Two issues:
1) The docs were incorrect for `-validation.max-entries-limit`. `0` does not mean disabled.
2) We were incorrectly validating against the API limit param on metric queries. This didn't make sense so I've added a check and avoided this case.