### PR TITLE
production/ksonnet: Add config_hash annotation to gateway deployment based on gateway configmap

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -91,6 +91,9 @@
     deployment.new('gateway', 3, [
       $.gateway_container,
     ]) +
+    deployment.mixin.spec.template.metadata.withAnnotationsMixin({
+      config_hash: std.md5(std.toString($.gateway_config)),
+    }),
     $.util.configVolumeMount('gateway-config', '/etc/nginx') +
     $.util.secretVolumeMount('gateway-secret', '/etc/nginx/secrets', defaultMode=420) +
     $.util.antiAffinity,


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds a hash of the gateway configmap to the gateway deployment, causing a
rolling update on the gateway if the configmap changes.

This prevents stale configurations from being used and makes it easier to roll
out gateway configuration changes.