### PR TITLE
fix query intervals when running boltdb-shipper in single binary

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -208,6 +208,14 @@ func (q *Querier) buildQueryIntervals(queryStart, queryEnd time.Time) (*interval
 		return i, i
 	}
 
+	// since we are limiting the query interval, check if the query touches just the ingesters, if yes then query just the ingesters.
+	if ingesterOldestStartTime.Before(queryStart) {
+		return &interval{
+			start: queryStart,
+			end:   queryEnd,
+		}, nil
+	}
+
 	// limit the start of ingester query interval to ingesterOldestStartTime.
 	ingesterQueryInterval := &interval{
 		start: ingesterOldestStartTime,

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -548,15 +548,15 @@ func TestQuerier_buildQueryIntervals(t *testing.T) {
 		if expectedResponse.ingesterQueryInterval == nil {
 			require.Nil(t, actualResponse.ingesterQueryInterval)
 		} else {
-			require.InDelta(t, expectedResponse.ingesterQueryInterval.start.Second(), actualResponse.ingesterQueryInterval.start.Second(), 1)
-			require.InDelta(t, expectedResponse.ingesterQueryInterval.end.Second(), expectedResponse.ingesterQueryInterval.end.Second(), 1)
+			require.InDelta(t, expectedResponse.ingesterQueryInterval.start.Unix(), actualResponse.ingesterQueryInterval.start.Unix(), 1)
+			require.InDelta(t, expectedResponse.ingesterQueryInterval.end.Unix(), actualResponse.ingesterQueryInterval.end.Unix(), 1)
 		}
 
 		if expectedResponse.storeQueryInterval == nil {
 			require.Nil(t, actualResponse.storeQueryInterval)
 		} else {
-			require.InDelta(t, expectedResponse.storeQueryInterval.start.Second(), actualResponse.storeQueryInterval.start.Second(), 1)
-			require.InDelta(t, expectedResponse.storeQueryInterval.end.Second(), expectedResponse.storeQueryInterval.end.Second(), 1)
+			require.InDelta(t, expectedResponse.storeQueryInterval.start.Unix(), actualResponse.storeQueryInterval.start.Unix(), 1)
+			require.InDelta(t, expectedResponse.storeQueryInterval.end.Unix(), actualResponse.storeQueryInterval.end.Unix(), 1)
 		}
 	}
 
@@ -574,8 +574,8 @@ func TestQuerier_buildQueryIntervals(t *testing.T) {
 				storeQueryInterval:    &overlappingQuery,
 			},
 			nonOverlappingQueryExpectedResponse: response{ // query both store and ingesters
-				ingesterQueryInterval: &overlappingQuery,
-				storeQueryInterval:    &overlappingQuery,
+				ingesterQueryInterval: &nonOverlappingQuery,
+				storeQueryInterval:    &nonOverlappingQuery,
 			},
 		},
 		{
@@ -608,6 +608,7 @@ func TestQuerier_buildQueryIntervals(t *testing.T) {
 		{
 			name:                          "ingesterQueryStoreMaxLookback set to 1h and queryIngestersWithin set to 2h, ingesterQueryStoreMaxLookback takes precedence",
 			ingesterQueryStoreMaxLookback: time.Hour,
+			queryIngestersWithin:          2 * time.Hour,
 			overlappingQueryExpectedResponse: response{ // query ingesters for last 1h and store until last 1h.
 				ingesterQueryInterval: &interval{
 					start: time.Now().Add(-time.Hour),
@@ -624,7 +625,8 @@ func TestQuerier_buildQueryIntervals(t *testing.T) {
 		},
 		{
 			name:                          "ingesterQueryStoreMaxLookback set to 2h and queryIngestersWithin set to 1h, ingesterQueryStoreMaxLookback takes precedence",
-			ingesterQueryStoreMaxLookback: time.Hour,
+			ingesterQueryStoreMaxLookback: 2 * time.Hour,
+			queryIngestersWithin:          time.Hour,
 			overlappingQueryExpectedResponse: response{ // query ingesters for last 2h and store until last 2h.
 				ingesterQueryInterval: &interval{
 					start: time.Now().Add(-2 * time.Hour),
@@ -662,7 +664,7 @@ func TestQuerier_buildQueryIntervals(t *testing.T) {
 		},
 		{
 			name:                 "queryIngestersWithin set to 10h",
-			queryIngestersWithin: time.Hour,
+			queryIngestersWithin: 10 * time.Hour,
 			overlappingQueryExpectedResponse: response{ // query both store and ingesters since query overlaps queryIngestersWithin
 				ingesterQueryInterval: &overlappingQuery,
 				storeQueryInterval:    &overlappingQuery,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When running boltdb-shipper in single binary mode, we also make ingesters do the store query. We build a non-overlapping query interval for ingester and store query. While building ingester query, instead of clamping the start time of query to ingesters max look back period, I was setting the start time of the query to the max look back period which was causing more logs to be fetched than queried for.

While there were tests to check it, the tests were wrong too because instead of comparing unix timestamp I was comparing value returned by [time.Second](https://golang.org/pkg/time/#Time.Second). This PR also takes care of fixing the tests.

**Which issue(s) this PR fixes**:
Fixes #2816 

**Checklist**
- [x] Tests updated

