### PR TITLE
Revert "tests: fix quoting issues in test output when building with Go 1.15"

### DIFF
--- a/pkg/logentry/stages/drop_test.go
+++ b/pkg/logentry/stages/drop_test.go
@@ -342,7 +342,7 @@ func Test_validateDropConfig(t *testing.T) {
 			config: &DropConfig{
 				OlderThan: &dropInvalidDur,
 			},
-			wantErr: fmt.Errorf(ErrDropStageInvalidDuration, dropInvalidDur, "time: unknown unit \"y\" in duration \"10y\""),
+			wantErr: fmt.Errorf(ErrDropStageInvalidDuration, dropInvalidDur, "time: unknown unit y in duration 10y"),
 		},
 		{
 			name: "Invalid Config",

--- a/pkg/logentry/stages/metrics_test.go
+++ b/pkg/logentry/stages/metrics_test.go
@@ -222,7 +222,7 @@ func Test(t *testing.T) {
 					IdleDuration: &metricTestInvalidIdle,
 				},
 			},
-			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit \"f\" in duration \"10f\""),
+			errors.Errorf(ErrInvalidIdleDur, "time: unknown unit f in duration 10f"),
 		},
 		"valid": {
 			MetricsConfig{


### PR DESCRIPTION
Reverts grafana/loki#2836 we need to run the CI with 1.15 which we are not yet.

Me and @kavirajk are also running on 1.15 and saw this issue, but we need more to fix this:
- updating everything to 1.15
- make sure cortex is also on 1.15. Which it is not yet https://github.com/cortexproject/cortex/blob/master/go.mod#L3