### PR TITLE
Labels computation LogQLv2

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -5,11 +5,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/labels"
-
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 const (
@@ -72,7 +70,7 @@ func (c *dumbChunk) Encoding() Encoding { return EncNone }
 
 // Returns an iterator that goes from _most_ recent to _least_ recent (ie,
 // backwards).
-func (c *dumbChunk) Iterator(_ context.Context, from, through time.Time, direction logproto.Direction, _ labels.Labels, _ logql.Pipeline) (iter.EntryIterator, error) {
+func (c *dumbChunk) Iterator(_ context.Context, from, through time.Time, direction logproto.Direction, _ log.StreamPipeline) (iter.EntryIterator, error) {
 	i := sort.Search(len(c.entries), func(i int) bool {
 		return !from.After(c.entries[i].Timestamp)
 	})
@@ -97,7 +95,7 @@ func (c *dumbChunk) Iterator(_ context.Context, from, through time.Time, directi
 	}, nil
 }
 
-func (c *dumbChunk) SampleIterator(_ context.Context, from, through time.Time, _ labels.Labels, _ logql.SampleExtractor) iter.SampleIterator {
+func (c *dumbChunk) SampleIterator(_ context.Context, from, through time.Time, _ log.StreamSampleExtractor) iter.SampleIterator {
 	return nil
 }
 

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/labels"
-
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 // Errors returned by the chunk interface.
@@ -100,8 +98,8 @@ type Chunk interface {
 	Bounds() (time.Time, time.Time)
 	SpaceFor(*logproto.Entry) bool
 	Append(*logproto.Entry) error
-	Iterator(ctx context.Context, mintT, maxtT time.Time, direction logproto.Direction, lbs labels.Labels, pipeline logql.Pipeline) (iter.EntryIterator, error)
-	SampleIterator(ctx context.Context, from, through time.Time, lbs labels.Labels, extractor logql.SampleExtractor) iter.SampleIterator
+	Iterator(ctx context.Context, mintT, maxtT time.Time, direction logproto.Direction, pipeline log.StreamPipeline) (iter.EntryIterator, error)
+	SampleIterator(ctx context.Context, from, through time.Time, extractor log.StreamSampleExtractor) iter.SampleIterator
 	// Returns the list of blocks in the chunks.
 	Blocks(mintT, maxtT time.Time) []Block
 	Size() int
@@ -126,7 +124,7 @@ type Block interface {
 	// Entries is the amount of entries in the block.
 	Entries() int
 	// Iterator returns an entry iterator for the block.
-	Iterator(ctx context.Context, lbs labels.Labels, pipeline logql.Pipeline) iter.EntryIterator
+	Iterator(ctx context.Context, pipeline log.StreamPipeline) iter.EntryIterator
 	// SampleIterator returns a sample iterator for the block.
-	SampleIterator(ctx context.Context, lbs labels.Labels, extractor logql.SampleExtractor) iter.SampleIterator
+	SampleIterator(ctx context.Context, extractor log.StreamSampleExtractor) iter.SampleIterator
 }

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -814,11 +814,11 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 		},
 	}
 	for _, test := range []string{
-		`{app="foo"}`,
+		// `{app="foo"}`,
 		`{app="foo"} != "foo"`,
-		`{app="foo"} != "foo" | logfmt `,
-		`{app="foo"} != "foo" | logfmt | duration > 10ms`,
-		`{app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"`,
+		// `{app="foo"} != "foo" | logfmt `,
+		// `{app="foo"} != "foo" | logfmt | duration > 10ms`,
+		// `{app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"`,
 	} {
 		b.Run(test, func(b *testing.B) {
 			b.ReportAllocs()
@@ -851,12 +851,13 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 	}
 
 	for _, test := range []string{
-		`rate({app="foo"}[1m])`,
-		`sum by (cluster) (rate({app="foo"}[10s]))`,
-		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt[10s]))`,
-		`sum by (caller) (rate({app="foo"} != "foo" | logfmt[10s]))`,
-		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms[10s]))`,
-		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"[1m]))`,
+		// `rate({app="foo"}[1m])`,
+		// `sum by (cluster) (rate({app="foo"}[10s]))`,
+		// `sum by (cluster) (rate({app="foo"} != "foo" [10s]))`,
+		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt[10s]))`,
+		// `sum by (caller) (rate({app="foo"} != "foo" | logfmt[10s]))`,
+		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms[10s]))`,
+		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"[1m]))`,
 	} {
 		b.Run(test, func(b *testing.B) {
 			b.ReportAllocs()

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -814,11 +814,11 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 		},
 	}
 	for _, test := range []string{
-		// `{app="foo"}`,
+		`{app="foo"}`,
 		`{app="foo"} != "foo"`,
-		// `{app="foo"} != "foo" | logfmt `,
-		// `{app="foo"} != "foo" | logfmt | duration > 10ms`,
-		// `{app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"`,
+		`{app="foo"} != "foo" | logfmt `,
+		`{app="foo"} != "foo" | logfmt | duration > 10ms`,
+		`{app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"`,
 	} {
 		b.Run(test, func(b *testing.B) {
 			b.ReportAllocs()
@@ -851,13 +851,13 @@ func BenchmarkBufferedIteratorLabels(b *testing.B) {
 	}
 
 	for _, test := range []string{
-		// `rate({app="foo"}[1m])`,
-		// `sum by (cluster) (rate({app="foo"}[10s]))`,
-		// `sum by (cluster) (rate({app="foo"} != "foo" [10s]))`,
-		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt[10s]))`,
-		// `sum by (caller) (rate({app="foo"} != "foo" | logfmt[10s]))`,
-		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms[10s]))`,
-		// `sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"[1m]))`,
+		`rate({app="foo"}[1m])`,
+		`sum by (cluster) (rate({app="foo"}[10s]))`,
+		`sum by (cluster) (rate({app="foo"} != "foo" [10s]))`,
+		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt[10s]))`,
+		`sum by (caller) (rate({app="foo"} != "foo" | logfmt[10s]))`,
+		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms[10s]))`,
+		`sum by (cluster) (rate({app="foo"} != "foo" | logfmt | duration > 10ms and component="tsdb"[1m]))`,
 	} {
 		b.Run(test, func(b *testing.B) {
 			b.ReportAllocs()

--- a/pkg/ingester/chunk_test.go
+++ b/pkg/ingester/chunk_test.go
@@ -64,7 +64,7 @@ func TestIterator(t *testing.T) {
 			for i := 0; i < entries; i++ {
 				from := rand.Intn(entries - 1)
 				len := rand.Intn(entries-from) + 1
-				iter, err := chunk.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.FORWARD, labels.Labels{}, logql.NoopPipeline)
+				iter, err := chunk.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.FORWARD, logql.NoopPipeline.ForStream(labels.Labels{}))
 				require.NoError(t, err)
 				testIteratorForward(t, iter, int64(from), int64(from+len))
 				_ = iter.Close()
@@ -73,7 +73,7 @@ func TestIterator(t *testing.T) {
 			for i := 0; i < entries; i++ {
 				from := rand.Intn(entries - 1)
 				len := rand.Intn(entries-from) + 1
-				iter, err := chunk.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.BACKWARD, labels.Labels{}, logql.NoopPipeline)
+				iter, err := chunk.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.BACKWARD, logql.NoopPipeline.ForStream(labels.Labels{}))
 				require.NoError(t, err)
 				testIteratorBackward(t, iter, int64(from), int64(from+len))
 				_ = iter.Close()

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -320,7 +320,7 @@ func (s *testStore) getChunksForUser(userID string) []chunk.Chunk {
 }
 
 func buildStreamsFromChunk(t *testing.T, lbs string, chk chunkenc.Chunk) logproto.Stream {
-	it, err := chk.Iterator(context.TODO(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, labels.Labels{}, logql.NoopPipeline)
+	it, err := chk.Iterator(context.TODO(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, logql.NoopPipeline.ForStream(labels.Labels{}))
 	require.NoError(t, err)
 
 	stream := logproto.Stream{

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -211,7 +211,7 @@ func (i *instance) Query(ctx context.Context, req logql.SelectLogParams) ([]iter
 		expr.Matchers(),
 		func(stream *stream) error {
 			ingStats.TotalChunksMatched += int64(len(stream.chunks))
-			iter, err := stream.Iterator(ctx, req.Start, req.End, req.Direction, pipeline)
+			iter, err := stream.Iterator(ctx, req.Start, req.End, req.Direction, pipeline.ForStream(stream.labels))
 			if err != nil {
 				return err
 			}
@@ -242,7 +242,7 @@ func (i *instance) QuerySample(ctx context.Context, req logql.SelectSampleParams
 		expr.Selector().Matchers(),
 		func(stream *stream) error {
 			ingStats.TotalChunksMatched += int64(len(stream.chunks))
-			iter, err := stream.SampleIterator(ctx, req.Start, req.End, extractor)
+			iter, err := stream.SampleIterator(ctx, req.Start, req.End, extractor.ForStream(stream.labels))
 			if err != nil {
 				return err
 			}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 var (
@@ -258,10 +258,10 @@ func (s *stream) cutChunkForSynchronization(entryTimestamp, prevEntryTimestamp t
 }
 
 // Returns an iterator.
-func (s *stream) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, pipeline logql.Pipeline) (iter.EntryIterator, error) {
+func (s *stream) Iterator(ctx context.Context, from, through time.Time, direction logproto.Direction, pipeline log.StreamPipeline) (iter.EntryIterator, error) {
 	iterators := make([]iter.EntryIterator, 0, len(s.chunks))
 	for _, c := range s.chunks {
-		itr, err := c.chunk.Iterator(ctx, from, through, direction, s.labels, pipeline)
+		itr, err := c.chunk.Iterator(ctx, from, through, direction, pipeline)
 		if err != nil {
 			return nil, err
 		}
@@ -280,10 +280,10 @@ func (s *stream) Iterator(ctx context.Context, from, through time.Time, directio
 }
 
 // Returns an SampleIterator.
-func (s *stream) SampleIterator(ctx context.Context, from, through time.Time, extractor logql.SampleExtractor) (iter.SampleIterator, error) {
+func (s *stream) SampleIterator(ctx context.Context, from, through time.Time, extractor log.StreamSampleExtractor) (iter.SampleIterator, error) {
 	iterators := make([]iter.SampleIterator, 0, len(s.chunks))
 	for _, c := range s.chunks {
-		if itr := c.chunk.SampleIterator(ctx, from, through, s.labels, extractor); itr != nil {
+		if itr := c.chunk.SampleIterator(ctx, from, through, extractor); itr != nil {
 			iterators = append(iterators, itr)
 		}
 	}

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -120,7 +120,7 @@ func TestStreamIterator(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				from := rand.Intn(chunks*entries - 1)
 				len := rand.Intn(chunks*entries-from) + 1
-				iter, err := s.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.FORWARD, logql.NoopPipeline)
+				iter, err := s.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.FORWARD, logql.NoopPipeline.ForStream(s.labels))
 				require.NotNil(t, iter)
 				require.NoError(t, err)
 				testIteratorForward(t, iter, int64(from), int64(from+len))
@@ -130,7 +130,7 @@ func TestStreamIterator(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				from := rand.Intn(entries - 1)
 				len := rand.Intn(chunks*entries-from) + 1
-				iter, err := s.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.BACKWARD, logql.NoopPipeline)
+				iter, err := s.Iterator(context.TODO(), time.Unix(int64(from), 0), time.Unix(int64(from+len), 0), logproto.BACKWARD, logql.NoopPipeline.ForStream(s.labels))
 				require.NotNil(t, iter)
 				require.NoError(t, err)
 				testIteratorBackward(t, iter, int64(from), int64(from+len))

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -145,18 +145,18 @@ func (t *tailer) processStream(stream logproto.Stream) ([]logproto.Stream, error
 	if err != nil {
 		return nil, err
 	}
+	sp := t.pipeline.ForStream(lbs)
 	for _, e := range stream.Entries {
-		newLine, parsedLbs, ok := t.pipeline.Process([]byte(e.Line), lbs)
+		newLine, parsedLbs, ok := sp.Process([]byte(e.Line))
 		if !ok {
 			continue
 		}
 		var stream *logproto.Stream
-		lhash := parsedLbs.Hash()
-		if stream, ok = streams[lhash]; !ok {
+		if stream, ok = streams[parsedLbs.Hash()]; !ok {
 			stream = &logproto.Stream{
 				Labels: parsedLbs.String(),
 			}
-			streams[lhash] = stream
+			streams[parsedLbs.Hash()] = stream
 		}
 		stream.Entries = append(stream.Entries, logproto.Entry{
 			Timestamp: e.Timestamp,

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -95,7 +95,7 @@ func TestTransferOut(t *testing.T) {
 				time.Unix(0, 0),
 				time.Unix(10, 0),
 				logproto.FORWARD,
-				logql.NoopPipeline,
+				logql.NoopPipeline.ForStream(stream.labels),
 			)
 			if !assert.NoError(t, err) {
 				continue

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -132,7 +132,8 @@ func (m *matcherStage) Process(lbs model.LabelSet, extracted map[string]interfac
 		}
 	}
 
-	if newLine, newLabels, ok := m.pipeline.Process([]byte(*entry), labels.FromMap(util.ModelLabelSetToMap(lbs))); ok {
+	sp := m.pipeline.ForStream(labels.FromMap(util.ModelLabelSetToMap(lbs)))
+	if newLine, newLabels, ok := sp.Process([]byte(*entry)); ok {
 		switch m.action {
 		case MatchActionDrop:
 			// Adds the drop label to not be sent by the api.EntryHandler
@@ -142,7 +143,7 @@ func (m *matcherStage) Process(lbs model.LabelSet, extracted map[string]interfac
 			for k := range lbs {
 				delete(lbs, k)
 			}
-			for _, l := range newLabels {
+			for _, l := range newLabels.Labels() {
 				lbs[model.LabelName(l.Name)] = model.LabelValue(l.Value)
 			}
 			m.stage.Process(lbs, extracted, t, entry)

--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -85,7 +85,7 @@ type Pipeline = log.Pipeline
 type SampleExtractor = log.SampleExtractor
 
 var (
-	NoopPipeline = log.NoopPipeline
+	NoopPipeline = log.NewNoopPipeline()
 )
 
 // PipelineExpr is an expression defining a log pipeline.
@@ -109,7 +109,7 @@ func (m MultiStageExpr) Pipeline() (log.Pipeline, error) {
 		return nil, err
 	}
 	if len(stages) == 0 {
-		return log.NoopPipeline, nil
+		return NoopPipeline, nil
 	}
 	return log.NewPipeline(stages), nil
 }
@@ -169,7 +169,7 @@ func (e *matchersExpr) String() string {
 }
 
 func (e *matchersExpr) Pipeline() (log.Pipeline, error) {
-	return log.NoopPipeline, nil
+	return NoopPipeline, nil
 }
 
 func (e *matchersExpr) HasFilter() bool {
@@ -719,7 +719,7 @@ func (e *vectorAggregationExpr) Extractor() (log.SampleExtractor, error) {
 	// inject in the range vector extractor the outer groups to improve performance.
 	// This is only possible if the operation is a sum. Anything else needs all labels.
 	if r, ok := e.left.(*rangeAggregationExpr); ok && e.operation == OpTypeSum {
-		return r.extractor(e.grouping, true)
+		return r.extractor(e.grouping, len(e.grouping.groups) == 0)
 	}
 	return e.left.Extractor()
 }
@@ -860,7 +860,7 @@ func (e *literalExpr) String() string {
 func (e *literalExpr) Selector() LogSelectorExpr               { return e }
 func (e *literalExpr) HasFilter() bool                         { return false }
 func (e *literalExpr) Operations() []string                    { return nil }
-func (e *literalExpr) Pipeline() (log.Pipeline, error)         { return log.NoopPipeline, nil }
+func (e *literalExpr) Pipeline() (log.Pipeline, error)         { return NoopPipeline, nil }
 func (e *literalExpr) Matchers() []*labels.Matcher             { return nil }
 func (e *literalExpr) Extractor() (log.SampleExtractor, error) { return nil, nil }
 

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -43,7 +43,7 @@ func Test_logSelectorExpr_String(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get filter: %s", err)
 			}
-			require.Equal(t, tt.expectFilter, p != log.NoopPipeline)
+			require.Equal(t, tt.expectFilter, p != NoopPipeline)
 			if expr.String() != tt.selector {
 				t.Fatalf("error expected: %s got: %s", tt.selector, expr.String())
 			}
@@ -132,7 +132,7 @@ func Test_NilFilterDoesntPanic(t *testing.T) {
 
 			p, err := expr.Pipeline()
 			require.Nil(t, err)
-			_, _, ok := p.Process([]byte("bleepbloop"), labelBar)
+			_, _, ok := p.ForStream(labelBar).Process([]byte("bleepbloop"))
 
 			require.True(t, ok)
 		})
@@ -216,10 +216,11 @@ func Test_FilterMatcher(t *testing.T) {
 			p, err := expr.Pipeline()
 			assert.Nil(t, err)
 			if tt.lines == nil {
-				assert.Equal(t, p, log.NoopPipeline)
+				assert.Equal(t, p, NoopPipeline)
 			} else {
+				sp := p.ForStream(labelBar)
 				for _, lc := range tt.lines {
-					_, _, ok := p.Process([]byte(lc.l), labelBar)
+					_, _, ok := sp.Process([]byte(lc.l))
 					assert.Equal(t, lc.e, ok)
 				}
 			}
@@ -281,8 +282,9 @@ func BenchmarkContainsFilter(b *testing.B) {
 
 	b.ResetTimer()
 
+	sp := p.ForStream(labelBar)
 	for i := 0; i < b.N; i++ {
-		if _, _, ok := p.Process(line, labelBar); !ok {
+		if _, _, ok := sp.Process(line); !ok {
 			b.Fatal("doesn't match")
 		}
 	}

--- a/pkg/logql/functions.go
+++ b/pkg/logql/functions.go
@@ -68,9 +68,9 @@ func (r rangeAggregationExpr) extractor(gr *grouping, all bool) (log.SampleExtra
 	// otherwise we extract metrics from the log line.
 	switch r.operation {
 	case OpRangeTypeRate, OpRangeTypeCount:
-		return log.LineExtractorWithStages(log.CountExtractor, stages, groups, without, all)
+		return log.NewLineSampleExtractor(log.CountExtractor, stages, groups, without, all)
 	case OpRangeTypeBytes, OpRangeTypeBytesRate:
-		return log.LineExtractorWithStages(log.BytesExtractor, stages, groups, without, all)
+		return log.NewLineSampleExtractor(log.BytesExtractor, stages, groups, without, all)
 	default:
 		return nil, fmt.Errorf(unsupportedErr, r.operation)
 	}

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -41,11 +41,11 @@ func Test_lineFormatter_Format(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
-			outLine, _ := tt.fmter.Process(nil, b)
+			builder := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			builder.Reset()
+			outLine, _ := tt.fmter.Process(nil, builder)
 			require.Equal(t, tt.want, outLine)
-			require.Equal(t, tt.wantLbs, b.Labels())
+			require.Equal(t, tt.wantLbs, builder.Labels())
 		})
 	}
 }
@@ -94,11 +94,11 @@ func Test_labelsFormatter_Format(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLabelsBuilder()
-			b.Reset(tt.in)
-			_, _ = tt.fmter.Process(nil, b)
+			builder := NewBaseLabelsBuilder().ForLabels(tt.in, tt.in.Hash())
+			builder.Reset()
+			_, _ = tt.fmter.Process(nil, builder)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, builder.Labels())
 		})
 	}
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -151,8 +151,8 @@ func TestBinary_Filter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.f.String(), func(t *testing.T) {
 			sort.Sort(tt.lbs)
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b.Reset()
 			_, got := tt.f.Process(nil, b)
 			require.Equal(t, tt.want, got)
 			sort.Sort(tt.wantLbs)
@@ -231,8 +231,8 @@ func TestErrorFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.f.String(), func(t *testing.T) {
 			sort.Sort(tt.lbs)
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b.Reset()
 			b.SetErr(tt.err)
 			_, got := tt.f.Process(nil, b)
 			require.Equal(t, tt.want, got)

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -6,26 +6,128 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-// LabelsBuilder is the same as labels.Builder but tailored for this package.
-type LabelsBuilder struct {
+var (
+	emptyLabelsResult = NewLabelsResult(labels.Labels{}, labels.Labels{}.Hash())
+)
+
+type LabelsResult interface {
+	String() string
+	Labels() labels.Labels
+	Hash() uint64
+}
+
+func NewLabelsResult(lbs labels.Labels, hash uint64) LabelsResult {
+	return &labelsResult{lbs: lbs, s: lbs.String(), h: hash}
+}
+
+type labelsResult struct {
+	lbs labels.Labels
+	s   string
+	h   uint64
+}
+
+func (l labelsResult) String() string {
+	return l.s
+}
+
+func (l labelsResult) Labels() labels.Labels {
+	return l.lbs
+}
+
+func (l labelsResult) Hash() uint64 {
+	return l.h
+}
+
+type hasher struct {
+	buf []byte // buffer for computing hash without bytes slice allocation.
+}
+
+func newHasher() *hasher {
+	return &hasher{
+		buf: make([]byte, 0, 1024),
+	}
+}
+
+func (h *hasher) Hash(lbs labels.Labels) uint64 {
+	var hash uint64
+	hash, h.buf = lbs.HashWithoutLabels(h.buf, []string(nil)...)
+	return hash
+}
+
+func (h *hasher) hashWithoutLabels(lbs labels.Labels, groups ...string) uint64 {
+	var hash uint64
+	hash, h.buf = lbs.HashWithoutLabels(h.buf, groups...)
+	return hash
+}
+
+func (h *hasher) hashForLabels(lbs labels.Labels, groups ...string) uint64 {
+	var hash uint64
+	hash, h.buf = lbs.HashForLabels(h.buf, groups...)
+	return hash
+}
+
+type BaseLabelsBuilder struct {
+	// the current base
 	base labels.Labels
 	del  []string
 	add  []labels.Label
 
 	err string
+
+	groups            []string
+	without, noLabels bool
+
+	resultCache map[uint64]LabelsResult
+	*hasher
 }
 
-// NewLabelsBuilder creates a new labels builder.
-func NewLabelsBuilder() *LabelsBuilder {
-	return &LabelsBuilder{
-		del: make([]string, 0, 5),
-		add: make([]labels.Label, 0, 5),
+// LabelsBuilder is the same as labels.Builder but tailored for this package.
+type LabelsBuilder struct {
+	currentLabels labels.Labels
+	currentResult LabelsResult
+
+	*BaseLabelsBuilder
+}
+
+func NewBaseLabelsBuilderWithGrouping(groups []string, without, noLabels bool) *BaseLabelsBuilder {
+	return &BaseLabelsBuilder{
+		del:         make([]string, 0, 5),
+		add:         make([]labels.Label, 0, 16),
+		resultCache: make(map[uint64]LabelsResult),
+		hasher:      newHasher(),
+		groups:      groups,
+		noLabels:    noLabels,
+		without:     without,
 	}
 }
 
+// NewLabelsBuilder creates a new labels builder.
+func NewBaseLabelsBuilder() *BaseLabelsBuilder {
+	return NewBaseLabelsBuilderWithGrouping(nil, false, false)
+}
+
+func (b *BaseLabelsBuilder) ForLabels(lbs labels.Labels, hash uint64) *LabelsBuilder {
+	if labelResult, ok := b.resultCache[hash]; ok {
+		res := &LabelsBuilder{
+			currentLabels:     lbs,
+			currentResult:     labelResult,
+			BaseLabelsBuilder: b,
+		}
+		return res
+	}
+	labelResult := NewLabelsResult(lbs, hash)
+	b.resultCache[hash] = labelResult
+	res := &LabelsBuilder{
+		currentLabels:     lbs,
+		currentResult:     labelResult,
+		BaseLabelsBuilder: b,
+	}
+	return res
+}
+
 // Reset clears all current state for the builder.
-func (b *LabelsBuilder) Reset(base labels.Labels) {
-	b.base = base
+func (b *LabelsBuilder) Reset() {
+	b.base = b.currentLabels
 	b.del = b.del[:0]
 	b.add = b.add[:0]
 	b.err = ""
@@ -47,9 +149,9 @@ func (b *LabelsBuilder) HasErr() bool {
 	return b.err != ""
 }
 
-// Base returns the base labels unmodified
-func (b *LabelsBuilder) Base() labels.Labels {
-	return b.base
+// BaseHas returns the base labels have the given key
+func (b *LabelsBuilder) BaseHas(key string) bool {
+	return b.base.Has(key)
 }
 
 func (b *LabelsBuilder) Get(key string) (string, bool) {
@@ -136,12 +238,160 @@ Outer:
 	return res
 }
 
-func (b *LabelsBuilder) WithoutLabels(names ...string) labels.Labels {
-	// naive implementation for now.
-	return b.Labels().WithoutLabels(names...)
+// Labels returns the labels from the builder. If no modifications
+// were made, the original labels are returned.
+func (b *LabelsBuilder) LabelsResult() LabelsResult {
+	// unchanged path.
+	if len(b.del) == 0 && len(b.add) == 0 {
+		if b.err == "" {
+			return b.currentResult
+		}
+		// unchanged but with error.
+		res := append(b.base.Copy(), labels.Label{Name: ErrorLabel, Value: b.err})
+		sort.Sort(res)
+		return b.toResult(res)
+	}
+
+	// In the general case, labels are removed, modified or moved
+	// rather than added.
+	res := make(labels.Labels, 0, len(b.base)+len(b.add))
+Outer:
+	for _, l := range b.base {
+		for _, n := range b.del {
+			if l.Name == n {
+				continue Outer
+			}
+		}
+		for _, la := range b.add {
+			if l.Name == la.Name {
+				continue Outer
+			}
+		}
+		res = append(res, l)
+	}
+	res = append(res, b.add...)
+	if b.err != "" {
+		res = append(res, labels.Label{Name: ErrorLabel, Value: b.err})
+	}
+	sort.Sort(res)
+
+	return b.toResult(res)
 }
 
-func (b *LabelsBuilder) WithLabels(names ...string) labels.Labels {
-	// naive implementation for now.
-	return b.Labels().WithLabels(names...)
+func (b *BaseLabelsBuilder) toResult(lbs labels.Labels) LabelsResult {
+	hash := b.hasher.Hash(lbs)
+	if cached, ok := b.resultCache[hash]; ok {
+		return cached
+	}
+	res := NewLabelsResult(lbs, hash)
+	b.resultCache[hash] = res
+	return res
+}
+
+// Labels returns the labels from the builder. If no modifications
+// were made, the original labels are returned.
+func (b *LabelsBuilder) GroupedLabels() LabelsResult {
+	if b.err != "" {
+		// We need to return now before applying grouping otherwise the error might get lost.
+		return b.LabelsResult()
+	}
+	if b.noLabels {
+		return emptyLabelsResult
+	}
+	// unchanged path.
+	if len(b.del) == 0 && len(b.add) == 0 {
+		if len(b.groups) == 0 {
+			return b.currentResult
+		}
+		return b.toGroup(b.currentLabels)
+	}
+
+	if b.without {
+		return b.withoutResult()
+	}
+	return b.withResult()
+}
+
+func (b *LabelsBuilder) withResult() LabelsResult {
+	res := make(labels.Labels, 0, len(b.groups))
+Outer:
+	for _, g := range b.groups {
+		for _, n := range b.del {
+			if g == n {
+				continue Outer
+			}
+		}
+		for _, la := range b.add {
+			if g == la.Name {
+				res = append(res, la)
+				continue Outer
+			}
+		}
+		for _, l := range b.base {
+			if g == l.Name {
+				res = append(res, l)
+				continue Outer
+			}
+		}
+	}
+	return b.toResult(res)
+}
+
+func (b *LabelsBuilder) withoutResult() LabelsResult {
+	size := len(b.base) + len(b.add) - len(b.del) - len(b.groups)
+	if size < 0 {
+		size = 0
+	}
+	res := make(labels.Labels, 0, size)
+Outer:
+	for _, l := range b.base {
+		for _, n := range b.del {
+			if l.Name == n {
+				continue Outer
+			}
+		}
+		for _, la := range b.add {
+			if l.Name == la.Name {
+				continue Outer
+			}
+		}
+		for _, lg := range b.groups {
+			if l.Name == lg {
+				continue Outer
+			}
+		}
+		res = append(res, l)
+	}
+OuterAdd:
+	for _, la := range b.add {
+		for _, lg := range b.groups {
+			if la.Name == lg {
+				continue OuterAdd
+			}
+		}
+		res = append(res, la)
+	}
+	sort.Sort(res)
+	return b.toResult(res)
+}
+
+func (b *LabelsBuilder) toGroup(from labels.Labels) LabelsResult {
+	var hash uint64
+	if b.without {
+		hash = b.hasher.hashWithoutLabels(from, b.groups...)
+	} else {
+		hash = b.hasher.hashForLabels(from, b.groups...)
+	}
+	if cached, ok := b.resultCache[hash]; ok {
+		return cached
+	}
+	var lbs labels.Labels
+	if b.without {
+		lbs = from.WithoutLabels(b.groups...)
+	} else {
+		lbs = from.WithLabels(b.groups...)
+	}
+	res := NewLabelsResult(lbs, hash)
+	b.resultCache[hash] = res
+	return res
 }

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -54,18 +54,6 @@ func (h *hasher) Hash(lbs labels.Labels) uint64 {
 	return hash
 }
 
-func (h *hasher) hashWithoutLabels(lbs labels.Labels, groups ...string) uint64 {
-	var hash uint64
-	hash, h.buf = lbs.HashWithoutLabels(h.buf, groups...)
-	return hash
-}
-
-func (h *hasher) hashForLabels(lbs labels.Labels, groups ...string) uint64 {
-	var hash uint64
-	hash, h.buf = lbs.HashForLabels(h.buf, groups...)
-	return hash
-}
-
 type BaseLabelsBuilder struct {
 	// the current base
 	base labels.Labels

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -46,4 +47,103 @@ func TestLabelsBuilder_LabelsError(t *testing.T) {
 	)
 	// make sure the original labels is unchanged.
 	require.Equal(t, labels.Labels{labels.Label{Name: "already", Value: "in"}}, lbs)
+}
+
+func TestLabelsBuilder_LabelsResult(t *testing.T) {
+	lbs := labels.Labels{
+		labels.Label{Name: "namespace", Value: "loki"},
+		labels.Label{Name: "job", Value: "us-central1/loki"},
+		labels.Label{Name: "cluster", Value: "us-central1"},
+	}
+	sort.Sort(lbs)
+	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b.Reset()
+	assertLabelResult(t, lbs, b.LabelsResult())
+	b.SetErr("err")
+	withErr := append(lbs, labels.Label{Name: ErrorLabel, Value: "err"})
+	sort.Sort(withErr)
+	assertLabelResult(t, withErr, b.LabelsResult())
+
+	b.Set("foo", "bar")
+	b.Set("namespace", "tempo")
+	b.Set("buzz", "fuzz")
+	b.Del("job")
+	expected := labels.Labels{
+		labels.Label{Name: ErrorLabel, Value: "err"},
+		labels.Label{Name: "namespace", Value: "tempo"},
+		labels.Label{Name: "cluster", Value: "us-central1"},
+		labels.Label{Name: "foo", Value: "bar"},
+		labels.Label{Name: "buzz", Value: "fuzz"},
+	}
+	sort.Sort(expected)
+	assertLabelResult(t, expected, b.LabelsResult())
+	// cached.
+	assertLabelResult(t, expected, b.LabelsResult())
+}
+
+func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
+	lbs := labels.Labels{
+		labels.Label{Name: "namespace", Value: "loki"},
+		labels.Label{Name: "job", Value: "us-central1/loki"},
+		labels.Label{Name: "cluster", Value: "us-central1"},
+	}
+	sort.Sort(lbs)
+	b := NewBaseLabelsBuilderWithGrouping([]string{"namespace"}, false, false).ForLabels(lbs, lbs.Hash())
+	b.Reset()
+	assertLabelResult(t, labels.Labels{labels.Label{Name: "namespace", Value: "loki"}}, b.GroupedLabels())
+	b.SetErr("err")
+	withErr := append(lbs, labels.Label{Name: ErrorLabel, Value: "err"})
+	sort.Sort(withErr)
+	assertLabelResult(t, withErr, b.GroupedLabels())
+
+	b.Reset()
+	b.Set("foo", "bar")
+	b.Set("namespace", "tempo")
+	b.Set("buzz", "fuzz")
+	b.Del("job")
+	expected := labels.Labels{
+		labels.Label{Name: "namespace", Value: "tempo"},
+	}
+	sort.Sort(expected)
+	assertLabelResult(t, expected, b.GroupedLabels())
+	// cached.
+	assertLabelResult(t, expected, b.GroupedLabels())
+
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, false, false).ForLabels(lbs, lbs.Hash())
+	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
+	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
+	b.Del("job")
+	assertLabelResult(t, labels.Labels{}, b.GroupedLabels())
+	b.Reset()
+	b.Set("namespace", "tempo")
+	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
+
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, true, false).ForLabels(lbs, lbs.Hash())
+	b.Del("job")
+	b.Set("foo", "bar")
+	b.Set("job", "something")
+	expected = labels.Labels{
+		labels.Label{Name: "namespace", Value: "loki"},
+		labels.Label{Name: "cluster", Value: "us-central1"},
+		labels.Label{Name: "foo", Value: "bar"},
+	}
+	sort.Sort(expected)
+	assertLabelResult(t, expected, b.GroupedLabels())
+
+}
+
+func assertLabelResult(t *testing.T, lbs labels.Labels, res LabelsResult) {
+	t.Helper()
+	require.Equal(t,
+		lbs,
+		res.Labels(),
+	)
+	require.Equal(t,
+		lbs.Hash(),
+		res.Hash(),
+	)
+	require.Equal(t,
+		lbs.String(),
+		res.String(),
+	)
 }

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestLabelsBuilder_Get(t *testing.T) {
-	b := NewLabelsBuilder()
-	b.Reset(labels.Labels{labels.Label{Name: "already", Value: "in"}})
+	lbs := labels.Labels{labels.Label{Name: "already", Value: "in"}}
+	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b.Reset()
 	b.Set("foo", "bar")
 	b.Set("bar", "buzz")
 	b.Del("foo")
@@ -31,8 +32,8 @@ func TestLabelsBuilder_Get(t *testing.T) {
 
 func TestLabelsBuilder_LabelsError(t *testing.T) {
 	lbs := labels.Labels{labels.Label{Name: "already", Value: "in"}}
-	b := NewLabelsBuilder()
-	b.Reset(lbs)
+	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+	b.Reset()
 	b.SetErr("err")
 	lbsWithErr := b.Labels()
 	require.Equal(

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -17,96 +17,82 @@ const (
 	ConvertFloat    = "float"
 )
 
-// SampleExtractor extracts sample for a log line.
-type SampleExtractor interface {
-	Process(line []byte, lbs labels.Labels) (float64, labels.Labels, bool)
-}
-
-type SampleExtractorFunc func(line []byte, lbs labels.Labels) (float64, labels.Labels, bool)
-
-func (fn SampleExtractorFunc) Process(line []byte, lbs labels.Labels) (float64, labels.Labels, bool) {
-	return fn(line, lbs)
-}
-
 // LineExtractor extracts a float64 from a log line.
 type LineExtractor func([]byte) float64
-
-// ToSampleExtractor transform a LineExtractor into a SampleExtractor.
-// Useful for metric conversion without log Pipeline.
-func (l LineExtractor) ToSampleExtractor(groups []string, without bool, noLabels bool) SampleExtractor {
-	return SampleExtractorFunc(func(line []byte, lbs labels.Labels) (float64, labels.Labels, bool) {
-		// todo(cyriltovena) grouping should be done once per stream/chunk not for everyline.
-		// so for now we'll cover just vector without grouping. This requires changes to SampleExtractor interface.
-		// For another day !
-		if len(groups) == 0 && noLabels {
-			return l(line), labels.Labels{}, true
-		}
-		return l(line), lbs, true
-	})
-}
 
 var (
 	CountExtractor LineExtractor = func(line []byte) float64 { return 1. }
 	BytesExtractor LineExtractor = func(line []byte) float64 { return float64(len(line)) }
 )
 
+// SampleExtractor extracts sample for a log line.
+type SampleExtractor interface {
+	ForStream(labels labels.Labels) StreamSampleExtractor
+}
+
+type StreamSampleExtractor interface {
+	Process(line []byte) (float64, LabelsResult, bool)
+}
+
 type lineSampleExtractor struct {
 	Stage
 	LineExtractor
 
-	groups   []string
-	without  bool
-	noLabels bool
-	builder  *LabelsBuilder
+	baseBuilder      *BaseLabelsBuilder
+	streamExtractors map[uint64]StreamSampleExtractor
 }
 
-func (l lineSampleExtractor) Process(line []byte, lbs labels.Labels) (float64, labels.Labels, bool) {
-	l.builder.Reset(lbs)
+// NewLineSampleExtractor creates a SampleExtractor from a LineExtractor.
+// Multiple log stages are run before converting the log line.
+func NewLineSampleExtractor(ex LineExtractor, stages []Stage, groups []string, without bool, noLabels bool) (SampleExtractor, error) {
+	return &lineSampleExtractor{
+		Stage:            ReduceStages(stages),
+		LineExtractor:    ex,
+		baseBuilder:      NewBaseLabelsBuilderWithGrouping(groups, without, noLabels),
+		streamExtractors: make(map[uint64]StreamSampleExtractor),
+	}, nil
+}
+
+func (l *lineSampleExtractor) ForStream(labels labels.Labels) StreamSampleExtractor {
+	hash := l.baseBuilder.Hash(labels)
+	if res, ok := l.streamExtractors[hash]; ok {
+		return res
+	}
+
+	res := &streamLineSampleExtractor{
+		Stage:         l.Stage,
+		LineExtractor: l.LineExtractor,
+		builder:       l.baseBuilder.ForLabels(labels, hash),
+	}
+	l.streamExtractors[hash] = res
+	return res
+}
+
+type streamLineSampleExtractor struct {
+	Stage
+	LineExtractor
+	builder *LabelsBuilder
+}
+
+func (l *streamLineSampleExtractor) Process(line []byte) (float64, LabelsResult, bool) {
+	l.builder.Reset()
 	line, ok := l.Stage.Process(line, l.builder)
 	if !ok {
 		return 0, nil, false
 	}
-	if len(l.groups) != 0 {
-		if l.without {
-			return l.LineExtractor(line), l.builder.WithoutLabels(l.groups...), true
-		}
-		return l.LineExtractor(line), l.builder.WithLabels(l.groups...), true
-	}
-	if l.noLabels {
-		// no grouping but it was a vector operation so we return a single vector
-		return l.LineExtractor(line), labels.Labels{}, true
-	}
-	return l.LineExtractor(line), l.builder.Labels(), true
-}
-
-// LineExtractorWithStages creates a SampleExtractor from a LineExtractor.
-// Multiple log stages are run before converting the log line.
-func LineExtractorWithStages(ex LineExtractor, stages []Stage, groups []string, without bool, noLabels bool) (SampleExtractor, error) {
-	if len(stages) == 0 {
-		return ex.ToSampleExtractor(groups, without, noLabels), nil
-	}
-	return lineSampleExtractor{
-		Stage:         ReduceStages(stages),
-		LineExtractor: ex,
-		builder:       NewLabelsBuilder(),
-		groups:        groups,
-		without:       without,
-		noLabels:      noLabels,
-	}, nil
+	return l.LineExtractor(line), l.builder.GroupedLabels(), true
 }
 
 type convertionFn func(value string) (float64, error)
 
 type labelSampleExtractor struct {
-	preStage   Stage
-	postFilter Stage
-	builder    *LabelsBuilder
-
+	preStage     Stage
+	postFilter   Stage
 	labelName    string
 	conversionFn convertionFn
-	groups       []string
-	without      bool
-	noLabels     bool
+
+	baseBuilder      *BaseLabelsBuilder
+	streamExtractors map[uint64]StreamSampleExtractor
 }
 
 // LabelExtractorWithStages creates a SampleExtractor that will extract metrics from a labels.
@@ -129,25 +115,43 @@ func LabelExtractorWithStages(
 	default:
 		return nil, errors.Errorf("unsupported conversion operation %s", conversion)
 	}
-	if len(groups) != 0 && without {
+	if len(groups) == 0 || without {
+		without = true
 		groups = append(groups, labelName)
 		sort.Strings(groups)
 	}
 	return &labelSampleExtractor{
-		preStage:     ReduceStages(preStages),
-		conversionFn: convFn,
-		groups:       groups,
-		labelName:    labelName,
-		postFilter:   postFilter,
-		without:      without,
-		builder:      NewLabelsBuilder(),
-		noLabels:     noLabels,
+		preStage:         ReduceStages(preStages),
+		conversionFn:     convFn,
+		labelName:        labelName,
+		postFilter:       postFilter,
+		baseBuilder:      NewBaseLabelsBuilderWithGrouping(groups, without, noLabels),
+		streamExtractors: make(map[uint64]StreamSampleExtractor),
 	}, nil
 }
 
-func (l *labelSampleExtractor) Process(line []byte, lbs labels.Labels) (float64, labels.Labels, bool) {
+type streamLabelSampleExtractor struct {
+	*labelSampleExtractor
+	builder *LabelsBuilder
+}
+
+func (l *labelSampleExtractor) ForStream(labels labels.Labels) StreamSampleExtractor {
+	hash := l.baseBuilder.Hash(labels)
+	if res, ok := l.streamExtractors[hash]; ok {
+		return res
+	}
+
+	res := &streamLabelSampleExtractor{
+		labelSampleExtractor: l,
+		builder:              l.baseBuilder.ForLabels(labels, hash),
+	}
+	l.streamExtractors[hash] = res
+	return res
+}
+
+func (l *streamLabelSampleExtractor) Process(line []byte) (float64, LabelsResult, bool) {
 	// Apply the pipeline first.
-	l.builder.Reset(lbs)
+	l.builder.Reset()
 	line, ok := l.preStage.Process(line, l.builder)
 	if !ok {
 		return 0, nil, false
@@ -168,25 +172,7 @@ func (l *labelSampleExtractor) Process(line []byte, lbs labels.Labels) (float64,
 	if _, ok = l.postFilter.Process(line, l.builder); !ok {
 		return 0, nil, false
 	}
-	if l.builder.HasErr() {
-		// we still have an error after post filtering.
-		// We need to return now before applying grouping otherwise the error might get lost.
-		return v, l.builder.Labels(), true
-	}
-	return v, l.groupLabels(l.builder), true
-}
-
-func (l *labelSampleExtractor) groupLabels(lbs *LabelsBuilder) labels.Labels {
-	if len(l.groups) != 0 {
-		if l.without {
-			return lbs.WithoutLabels(l.groups...)
-		}
-		return lbs.WithLabels(l.groups...)
-	}
-	if l.noLabels {
-		return labels.Labels{}
-	}
-	return lbs.WithoutLabels(l.labelName)
+	return v, l.builder.GroupedLabels(), true
 }
 
 func convertFloat(v string) (float64, error) {

--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -112,10 +112,11 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sort.Sort(tt.in)
-			outval, outlbs, ok := tt.ex.Process([]byte(""), tt.in)
+
+			outval, outlbs, ok := tt.ex.ForStream(tt.in).Process([]byte(""))
 			require.Equal(t, tt.wantOk, ok)
 			require.Equal(t, tt.want, outval)
-			require.Equal(t, tt.wantLbs, outlbs)
+			require.Equal(t, tt.wantLbs, outlbs.Labels())
 		})
 	}
 }

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -77,8 +77,8 @@ func Test_jsonParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		j := NewJSONParser()
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b.Reset()
 			_, _ = j.Process(tt.line, b)
 			sort.Sort(tt.want)
 			require.Equal(t, tt.want, b.Labels())
@@ -169,8 +169,8 @@ func Test_regexpParser_Parse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b.Reset()
 			_, _ = tt.parser.Process(tt.line, b)
 			sort.Sort(tt.want)
 			require.Equal(t, tt.want, b.Labels())
@@ -281,8 +281,8 @@ func Test_logfmtParser_Parse(t *testing.T) {
 	p := NewLogfmtParser()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLabelsBuilder()
-			b.Reset(tt.lbs)
+			b := NewBaseLabelsBuilder().ForLabels(tt.lbs, tt.lbs.Hash())
+			b.Reset()
 			_, _ = p.Process(tt.line, b)
 			sort.Sort(tt.want)
 			require.Equal(t, tt.want, b.Labels())

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -5,14 +5,16 @@ import (
 )
 
 var (
+	// NoopStage is a stage that doesn't process a log line.
 	NoopStage Stage = &noopStage{}
 )
 
-// Pipeline transform and filter log lines and labels.
+// Pipeline can create pipelines for each log stream.
 type Pipeline interface {
 	ForStream(labels labels.Labels) StreamPipeline
 }
 
+// StreamPipeline transform and filter log lines and labels.
 type StreamPipeline interface {
 	Process(line []byte) ([]byte, LabelsResult, bool)
 }
@@ -22,6 +24,7 @@ type Stage interface {
 	Process(line []byte, lbs *LabelsBuilder) ([]byte, bool)
 }
 
+// NewNoopPipeline creates a pipelines that does not process anything and returns log streams as is.
 func NewNoopPipeline() Pipeline {
 	return &noopPipeline{
 		cache: map[uint64]*noopStreamPipeline{},
@@ -71,6 +74,7 @@ type pipeline struct {
 	streamPipelines map[uint64]StreamPipeline
 }
 
+// NewPipeline creates a new pipeline for a given set of stages.
 func NewPipeline(stages []Stage) Pipeline {
 	if len(stages) == 0 {
 		return NewNoopPipeline()

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -4,9 +4,17 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
+var (
+	NoopStage Stage = &noopStage{}
+)
+
 // Pipeline transform and filter log lines and labels.
 type Pipeline interface {
-	Process(line []byte, lbs labels.Labels) ([]byte, labels.Labels, bool)
+	ForStream(labels labels.Labels) StreamPipeline
+}
+
+type StreamPipeline interface {
+	Process(line []byte) ([]byte, LabelsResult, bool)
 }
 
 // Stage is a single step of a Pipeline.
@@ -14,15 +22,32 @@ type Stage interface {
 	Process(line []byte, lbs *LabelsBuilder) ([]byte, bool)
 }
 
-var (
-	NoopPipeline Pipeline = &noopPipeline{}
-	NoopStage    Stage    = &noopStage{}
-)
+func NewNoopPipeline() Pipeline {
+	return &noopPipeline{
+		cache: map[uint64]*noopStreamPipeline{},
+	}
+}
 
-type noopPipeline struct{}
+type noopPipeline struct {
+	cache map[uint64]*noopStreamPipeline
+}
 
-func (noopPipeline) Process(line []byte, lbs labels.Labels) ([]byte, labels.Labels, bool) {
-	return line, lbs, true
+type noopStreamPipeline struct {
+	LabelsResult
+}
+
+func (n noopStreamPipeline) Process(line []byte) ([]byte, LabelsResult, bool) {
+	return line, n.LabelsResult, true
+}
+
+func (n *noopPipeline) ForStream(labels labels.Labels) StreamPipeline {
+	h := labels.Hash()
+	if cached, ok := n.cache[h]; ok {
+		return cached
+	}
+	sp := &noopStreamPipeline{LabelsResult: NewLabelsResult(labels, h)}
+	n.cache[h] = sp
+	return sp
 }
 
 type noopStage struct{}
@@ -40,30 +65,52 @@ func (fn StageFunc) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 // pipeline is a combinations of multiple stages.
 // It can also be reduced into a single stage for convenience.
 type pipeline struct {
+	stages      []Stage
+	baseBuilder *BaseLabelsBuilder
+
+	streamPipelines map[uint64]StreamPipeline
+}
+
+func NewPipeline(stages []Stage) Pipeline {
+	if len(stages) == 0 {
+		return NewNoopPipeline()
+	}
+	return &pipeline{
+		stages:          stages,
+		baseBuilder:     NewBaseLabelsBuilder(),
+		streamPipelines: make(map[uint64]StreamPipeline),
+	}
+}
+
+type streamPipeline struct {
 	stages  []Stage
 	builder *LabelsBuilder
 }
 
-func NewPipeline(stages []Stage) Pipeline {
-	return &pipeline{
-		stages:  stages,
-		builder: NewLabelsBuilder(),
+func (p *pipeline) ForStream(labels labels.Labels) StreamPipeline {
+	hash := p.baseBuilder.Hash(labels)
+	if res, ok := p.streamPipelines[hash]; ok {
+		return res
 	}
+
+	res := &streamPipeline{
+		stages:  p.stages,
+		builder: p.baseBuilder.ForLabels(labels, hash),
+	}
+	p.streamPipelines[hash] = res
+	return res
 }
 
-func (p *pipeline) Process(line []byte, lbs labels.Labels) ([]byte, labels.Labels, bool) {
+func (p *streamPipeline) Process(line []byte) ([]byte, LabelsResult, bool) {
 	var ok bool
-	if len(p.stages) == 0 {
-		return line, lbs, true
-	}
-	p.builder.Reset(lbs)
+	p.builder.Reset()
 	for _, s := range p.stages {
 		line, ok = s.Process(line, p.builder)
 		if !ok {
 			return nil, nil, false
 		}
 	}
-	return line, p.builder.Labels(), true
+	return line, p.builder.LabelsResult(), true
 }
 
 // ReduceStages reduces multiple stages into one.

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -10,7 +10,7 @@ import (
 var (
 	resOK   bool
 	resLine []byte
-	resLbs  labels.Labels
+	resLbs  LabelsResult
 )
 
 func Benchmark_Pipeline(b *testing.B) {
@@ -39,8 +39,9 @@ func Benchmark_Pipeline(b *testing.B) {
 		{Name: "pod_template_hash", Value: "5896759c79"},
 	}
 	b.ResetTimer()
+	sp := p.ForStream(lbs)
 	for n := 0; n < b.N; n++ {
-		resLine, resLbs, resOK = p.Process(line, lbs)
+		resLine, resLbs, resOK = sp.Process(line)
 	}
 
 }

--- a/pkg/logql/parser_test.go
+++ b/pkg/logql/parser_test.go
@@ -1990,13 +1990,13 @@ func Test_PipelineCombined(t *testing.T) {
 
 	p, err := expr.Pipeline()
 	require.Nil(t, err)
-
-	line, lbs, ok := p.Process([]byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`), labels.Labels{})
+	sp := p.ForStream(labels.Labels{})
+	line, lbs, ok := sp.Process([]byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`))
 	require.True(t, ok)
 	require.Equal(
 		t,
 		labels.Labels{labels.Label{Name: "caller", Value: "logging.go:66"}, labels.Label{Name: "duration", Value: "1.5s"}, labels.Label{Name: "level", Value: "debug"}, labels.Label{Name: "method", Value: "POST"}, labels.Label{Name: "msg", Value: "POST /api/prom/api/v1/query_range (200) 1.5s"}, labels.Label{Name: "path", Value: "/api/prom/api/v1/query_range"}, labels.Label{Name: "status", Value: "200"}, labels.Label{Name: "traceID", Value: "a9d4d8a928d8db1"}, labels.Label{Name: "ts", Value: "2020-10-02T10:10:42.092268913Z"}},
-		lbs,
+		lbs.Labels(),
 	)
 	require.Equal(t, string([]byte(`1.5s|POST|200`)), string(line))
 }

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -97,7 +97,8 @@ func processStream(in []logproto.Stream, pipeline log.Pipeline) []logproto.Strea
 
 	for _, stream := range in {
 		for _, e := range stream.Entries {
-			if l, out, ok := pipeline.Process([]byte(e.Line), mustParseLabels(stream.Labels)); ok {
+			sp := pipeline.ForStream(mustParseLabels(stream.Labels))
+			if l, out, ok := sp.Process([]byte(e.Line)); ok {
 				var s *logproto.Stream
 				var found bool
 				s, found = resByStream[out.String()]
@@ -124,7 +125,8 @@ func processSeries(in []logproto.Stream, ex log.SampleExtractor) []logproto.Seri
 
 	for _, stream := range in {
 		for _, e := range stream.Entries {
-			if f, lbs, ok := ex.Process([]byte(e.Line), mustParseLabels(stream.Labels)); ok {
+			exs := ex.ForStream(mustParseLabels(stream.Labels))
+			if f, lbs, ok := exs.Process([]byte(e.Line)); ok {
 				var s *logproto.Series
 				var found bool
 				s, found = resBySeries[lbs.String()]

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -6,12 +6,11 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 // LazyChunk loads the chunk when it is accessed.
@@ -33,7 +32,7 @@ func (c *LazyChunk) Iterator(
 	ctx context.Context,
 	from, through time.Time,
 	direction logproto.Direction,
-	pipeline logql.Pipeline,
+	pipeline log.StreamPipeline,
 	nextChunk *LazyChunk,
 ) (iter.EntryIterator, error) {
 
@@ -59,7 +58,7 @@ func (c *LazyChunk) Iterator(
 		// if the block is overlapping cache it with the next chunk boundaries.
 		if nextChunk != nil && IsBlockOverlapping(b, nextChunk, direction) {
 			// todo(cyriltovena) we can avoid to drop the metric name for each chunks since many chunks have the same metric/labelset.
-			it := iter.NewCachedIterator(b.Iterator(ctx, dropLabels(c.Chunk.Metric, labels.MetricName), pipeline), b.Entries())
+			it := iter.NewCachedIterator(b.Iterator(ctx, pipeline), b.Entries())
 			its = append(its, it)
 			if c.overlappingBlocks == nil {
 				c.overlappingBlocks = make(map[int]iter.CacheEntryIterator)
@@ -71,7 +70,7 @@ func (c *LazyChunk) Iterator(
 			delete(c.overlappingBlocks, b.Offset())
 		}
 		// non-overlapping block with the next chunk are not cached.
-		its = append(its, b.Iterator(ctx, dropLabels(c.Chunk.Metric, labels.MetricName), pipeline))
+		its = append(its, b.Iterator(ctx, pipeline))
 	}
 
 	if direction == logproto.FORWARD {
@@ -106,7 +105,7 @@ func (c *LazyChunk) Iterator(
 func (c *LazyChunk) SampleIterator(
 	ctx context.Context,
 	from, through time.Time,
-	extractor logql.SampleExtractor,
+	extractor log.StreamSampleExtractor,
 	nextChunk *LazyChunk,
 ) (iter.SampleIterator, error) {
 
@@ -132,7 +131,7 @@ func (c *LazyChunk) SampleIterator(
 		// if the block is overlapping cache it with the next chunk boundaries.
 		if nextChunk != nil && IsBlockOverlapping(b, nextChunk, logproto.FORWARD) {
 			// todo(cyriltovena) we can avoid to drop the metric name for each chunks since many chunks have the same metric/labelset.
-			it := iter.NewCachedSampleIterator(b.SampleIterator(ctx, dropLabels(c.Chunk.Metric, labels.MetricName), extractor), b.Entries())
+			it := iter.NewCachedSampleIterator(b.SampleIterator(ctx, extractor), b.Entries())
 			its = append(its, it)
 			if c.overlappingSampleBlocks == nil {
 				c.overlappingSampleBlocks = make(map[int]iter.CacheSampleIterator)
@@ -144,7 +143,7 @@ func (c *LazyChunk) SampleIterator(
 			delete(c.overlappingSampleBlocks, b.Offset())
 		}
 		// non-overlapping block with the next chunk are not cached.
-		its = append(its, b.SampleIterator(ctx, dropLabels(c.Chunk.Metric, labels.MetricName), extractor))
+		its = append(its, b.SampleIterator(ctx, extractor))
 	}
 
 	// build the final iterator bound to the requested time range.

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/util"
 )
 
@@ -46,7 +47,7 @@ func TestLazyChunkIterator(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			it, err := tc.chunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, logql.NoopPipeline, nil)
+			it, err := tc.chunk.Iterator(context.Background(), time.Unix(0, 0), time.Unix(1000, 0), logproto.FORWARD, logql.NoopPipeline.ForStream(labels.Labels{labels.Label{Name: "foo", Value: "bar"}}), nil)
 			require.Nil(t, err)
 			streams, _, err := iter.ReadBatch(it, 1000)
 			require.Nil(t, err)
@@ -174,10 +175,10 @@ func (fakeBlock) Entries() int     { return 0 }
 func (fakeBlock) Offset() int      { return 0 }
 func (f fakeBlock) MinTime() int64 { return f.mint }
 func (f fakeBlock) MaxTime() int64 { return f.maxt }
-func (fakeBlock) Iterator(context.Context, labels.Labels, logql.Pipeline) iter.EntryIterator {
+func (fakeBlock) Iterator(context.Context, log.StreamPipeline) iter.EntryIterator {
 	return nil
 }
-func (fakeBlock) SampleIterator(context.Context, labels.Labels, logql.SampleExtractor) iter.SampleIterator {
+func (fakeBlock) SampleIterator(context.Context, log.StreamSampleExtractor) iter.SampleIterator {
 	return nil
 }
 


### PR DESCRIPTION
Improve labels computation for labels in logqlv2 pipeline, by using caches and pushing computation all at the same places.

see benchmark diff:

```
 benchcmp before.txt after4.txt
benchmark                                                                                                                                old ns/op     new ns/op     delta
BenchmarkBufferedIteratorLabels/{app="foo"}-16                                                                                           42.1          36.4          -13.54%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"-16                                                                                  42.3          36.8          -13.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_-16                                                                        85.6          44.9          -47.55%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms-16                                                       40.7          39.5          -2.95%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"-16                                  40.3          39.9          -0.99%
BenchmarkBufferedIteratorLabels/rate({app="foo"}[1m])-16                                                                                 30.9          25.3          -18.12%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}[10s]))-16                                                             33.4          25.0          -25.15%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                           32.2          28.4          -11.80%
BenchmarkBufferedIteratorLabels/sum_by_(caller)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                            33.4          28.1          -15.87%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms[10s]))-16                         28.3          27.0          -4.59%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"[1m]))-16     28.9          27.2          -5.88%

benchmark                                                                                                                                old allocs     new allocs     delta
BenchmarkBufferedIteratorLabels/{app="foo"}-16                                                                                           0              0              +0.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"-16                                                                                  0              0              +0.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_-16                                                                        0              0              +0.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms-16                                                       0              0              +0.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"-16                                  0              0              +0.00%
BenchmarkBufferedIteratorLabels/rate({app="foo"}[1m])-16                                                                                 0              0              +0.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}[10s]))-16                                                             0              0              +0.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                           0              0              +0.00%
BenchmarkBufferedIteratorLabels/sum_by_(caller)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                            0              0              +0.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms[10s]))-16                         0              0              +0.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"[1m]))-16     0              0              +0.00%

benchmark                                                                                                                                old bytes     new bytes     delta
BenchmarkBufferedIteratorLabels/{app="foo"}-16                                                                                           6             0             -100.00%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"-16                                                                                  6             1             -83.33%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_-16                                                                        32            4             -87.50%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms-16                                                       3             1             -66.67%
BenchmarkBufferedIteratorLabels/{app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"-16                                  3             1             -66.67%
BenchmarkBufferedIteratorLabels/rate({app="foo"}[1m])-16                                                                                 4             0             -100.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}[10s]))-16                                                             4             0             -100.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                           4             0             -100.00%
BenchmarkBufferedIteratorLabels/sum_by_(caller)_(rate({app="foo"}_!=_"foo"_|_logfmt[10s]))-16                                            4             0             -100.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms[10s]))-16                         1             0             -100.00%
BenchmarkBufferedIteratorLabels/sum_by_(cluster)_(rate({app="foo"}_!=_"foo"_|_logfmt_|_duration_>_10ms_and_component="tsdb"[1m]))-16     1             0             -100.00%

```

Fixes https://github.com/grafana/loki/issues/2827, metrics queries without pipeline should not suffer from regression anymore.

