### PR TITLE
documentation: add tail_proxy_url option to query_frontend_config section

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -296,6 +296,10 @@ The query_frontend_config configures the Loki query-frontend.
 # Set to < 0 to enable on all queries.
 # CLI flag: -frontend.log-queries-longer-than
 [log_queries_longer_than: <duration> | default = 0s]
+
+# URL of querier for tail proxy.
+# CLI flag: -frontend.tail-proxy-url
+[tail_proxy_url: <string> | default = ""]
 ```
 
 ## queryrange_config

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -383,6 +383,13 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 			return nil, err
 		}
 		tp := httputil.NewSingleHostReverseProxy(tailURL)
+
+		director := tp.Director
+		tp.Director = func(req *http.Request) {
+			director(req)
+			req.Host = tailURL.Host
+		}
+
 		defaultHandler = httpMiddleware.Wrap(tp)
 	} else {
 		defaultHandler = frontendHandler


### PR DESCRIPTION
**What this PR does / why we need it**:

Add tail_proxy_url  option to query_frontend_config,  It is supported but no doc.

**Which issue(s) this PR fixes**:
Fixes  #2878 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added

