### PR TITLE
Fixes flaky boltdb test.

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -41,16 +41,13 @@ func TestLoadTables(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "load-tables")
 	require.NoError(t, err)
 
+	boltDBIndexClient, storageClient := buildTestClients(t, testDir)
 	defer func() {
+		boltDBIndexClient.Stop()
 		require.NoError(t, os.RemoveAll(testDir))
 	}()
 
-	boltDBIndexClient, storageClient := buildTestClients(t, testDir)
 	indexPath := filepath.Join(testDir, indexDirName)
-
-	defer func() {
-		boltDBIndexClient.Stop()
-	}()
 
 	// add a legacy db which is outside of table specific folder
 	testutil.AddRecordsToDB(t, filepath.Join(indexPath, "table0"), boltDBIndexClient, 0, 10)


### PR DESCRIPTION
Mostly due to a defer gotcha which execute in FIFO  order.

see https://drone.grafana.net/grafana/loki/1162/1/2

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


