### PR TITLE
fix flaky load tables test for boltdb-shipper uploads table-manager

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -95,6 +95,8 @@ func TestLoadTables(t *testing.T) {
 
 	tm, err := NewTableManager(cfg, boltDBIndexClient, storageClient, nil)
 	require.NoError(t, err)
+	defer tm.Stop()
+
 	require.Len(t, tm.tables, len(expectedTables))
 
 	stat, err := os.Stat(filepath.Join(indexPath, "table0", "table0"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Possible fix for flaky `TestLoadTables` test.
https://drone.grafana.net/grafana/loki/1162/1/2

