### PR TITLE
Fix error 'Unexpected: ("$", "$") while parsing field definition'

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -93,7 +93,7 @@
     ]) +
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({
       config_hash: std.md5(std.toString($.gateway_config)),
-    }),
+    }) +
     $.util.configVolumeMount('gateway-config', '/etc/nginx') +
     $.util.secretVolumeMount('gateway-secret', '/etc/nginx/secrets', defaultMode=420) +
     $.util.antiAffinity,


### PR DESCRIPTION
**What this PR does / why we need it**:
I got the following error when running tk show
```
-> % tk show environments/loki
evaluating jsonnet: RUNTIME ERROR: /Users/shokada/src/loki-test/vendor/loki/gateway.libsonnet:97:5-6 Unexpected: ("$", "$") while parsing field definition
        main.jsonnet:1:17-48    thunk <gateway> from <$>
        main.jsonnet:5:19-26    $
        During evaluation
```

refs: https://github.com/grafana/loki/pull/2852
