### PR TITLE
gateway: fix regression in tanka jsonnet

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -93,7 +93,7 @@
     ]) +
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({
       config_hash: std.md5(std.toString($.gateway_config)),
-    }),
+    }) +
     $.util.configVolumeMount('gateway-config', '/etc/nginx') +
     $.util.secretVolumeMount('gateway-secret', '/etc/nginx/secrets', defaultMode=420) +
     $.util.antiAffinity,


### PR DESCRIPTION
**What this PR does / why we need it**:

Seeing the following when importing loki...

evaluating jsonnet: RUNTIME ERROR: {snip}everquoteinc/loki-du/tanka/vendor/loki/gateway.libsonnet:97:5-6 Unexpected: "$" while parsing field definition

**Special notes for your reviewer**:

Related to:

https://github.com/grafana/loki/pull/2852
https://github.com/grafana/loki/commit/cb383d69067ab66a6b33e0e4fd8bff531122a9e7
