### PR TITLE
Fixes metric query issue with no grouping.

### DIFF
--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -272,6 +272,10 @@ func (b *LabelsBuilder) GroupedLabels() LabelsResult {
 		}
 		return b.toBaseGroup()
 	}
+	// no grouping
+	if len(b.groups) == 0 {
+		return b.LabelsResult()
+	}
 
 	if b.without {
 		return b.withoutResult()

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -130,6 +130,18 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	sort.Sort(expected)
 	assertLabelResult(t, expected, b.GroupedLabels())
 
+	b = NewBaseLabelsBuilderWithGrouping(nil, false, false).ForLabels(lbs, lbs.Hash())
+	b.Set("foo", "bar")
+	b.Set("job", "something")
+	expected = labels.Labels{
+		labels.Label{Name: "namespace", Value: "loki"},
+		labels.Label{Name: "job", Value: "something"},
+		labels.Label{Name: "cluster", Value: "us-central1"},
+		labels.Label{Name: "foo", Value: "bar"},
+	}
+	sort.Sort(expected)
+	assertLabelResult(t, expected, b.GroupedLabels())
+
 }
 
 func assertLabelResult(t *testing.T, lbs labels.Labels, res LabelsResult) {


### PR DESCRIPTION
This would remove all labels for metrics queries that does not have grouping, instead of adding all labels.
It was introduced by https://github.com/grafana/loki/pull/2875

I added a regression test.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


