### PR TITLE
helm: Create or use existingClaim only if persistance.enabled is true

### DIFF
--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -107,11 +107,11 @@ spec:
   {{- if not .Values.persistence.enabled }}
         - name: storage
           emptyDir: {}
-  {{- else if .Values.persistence.existingClaim }}
+  {{- else if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: storage
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim }}
-  {{- else }}
+  {{- else if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: storage


### PR DESCRIPTION
**What this PR does / why we need it**:
Current helm configuration creates or uses existing claim even if persistance.enabled is false.
Shown in example below should not use the existing claim since enabled is false. 
```
persistence:
  enabled: false
  existingClaim: myclaim
```
But according to present helm configuration it will consider the existingClaim.

This PR will do a check for both existingClaim and volumeClaimTemplates to consider only if persistance.enabled is true

**Special notes for your reviewer**:
A check has been added for volumeClaimTemplates as well so that it will only claim if enabled is true.

**Checklist**
- [ x ] Documentation added
- [ x ] Tests updated

