### PR TITLE
Expose underlying promtail client

### DIFF
--- a/pkg/promtail/promtail.go
+++ b/pkg/promtail/promtail.go
@@ -98,6 +98,11 @@ func (p *Promtail) Run() error {
 	return p.server.Run()
 }
 
+// Client returns the underlying client Promtail uses to write to Loki.
+func (p *Promtail) Client() client.Client {
+	return p.client
+}
+
 // Shutdown the promtail.
 func (p *Promtail) Shutdown() {
 	p.mtx.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:

I want to add a mode to [grafana/agent](https://github.com/grafana/agent) where it can send its own logs directly to Loki without reading from a log file. This will enable a scenario where the Agent can be run in a docker-compose environment to serve as an all-in-one testing scenario where the Agent monitors its own metrics, logs, and traces. 

To do this, I need the Promtail's underlying client exposed so I can access it and write logs directly to it.