### PR TITLE
Boltdb shipper query readiness

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -98,7 +98,7 @@ func NewTable(spanCtx context.Context, name, cacheLocation string, storageClient
 }
 
 // LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
-func LoadTable(name, cacheLocation string, storageClient StorageClient, boltDBIndexClient BoltDBIndexClient, metrics *metrics) (*Table, error) {
+func LoadTable(ctx context.Context, name, cacheLocation string, storageClient StorageClient, boltDBIndexClient BoltDBIndexClient, metrics *metrics) (*Table, error) {
 	// see if folder for table already exists.
 	folderPath := path.Join(cacheLocation, name)
 	_, err := os.Stat(folderPath)
@@ -108,7 +108,7 @@ func LoadTable(name, cacheLocation string, storageClient StorageClient, boltDBIn
 		}
 
 		// folder for table doesn't exist, this means we have to download it from the shared store.
-		table := NewTable(context.Background(), name, cacheLocation, storageClient, boltDBIndexClient, metrics)
+		table := NewTable(ctx, name, cacheLocation, storageClient, boltDBIndexClient, metrics)
 		<-table.ready
 		if table.err != nil {
 			return nil, table.err
@@ -153,7 +153,7 @@ func LoadTable(name, cacheLocation string, storageClient StorageClient, boltDBIn
 
 	level.Debug(util.Logger).Log("msg", fmt.Sprintf("syncing files for table %s", name))
 	// sync the table to get new files and remove the deleted ones from storage.
-	err = table.Sync(context.Background())
+	err = table.Sync(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -40,11 +42,6 @@ type StorageClient interface {
 	List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error)
 }
 
-type downloadedFile struct {
-	mtime  time.Time
-	boltdb *bbolt.DB
-}
-
 // Table is a collection of multiple files created for a same table by various ingesters.
 // All the public methods are concurrency safe and take care of mutexes to avoid any data race.
 type Table struct {
@@ -55,7 +52,7 @@ type Table struct {
 	boltDBIndexClient BoltDBIndexClient
 
 	lastUsedAt time.Time
-	dbs        map[string]*downloadedFile
+	dbs        map[string]*bbolt.DB
 	dbsMtx     sync.RWMutex
 	err        error
 
@@ -73,7 +70,7 @@ func NewTable(spanCtx context.Context, name, cacheLocation string, storageClient
 		storageClient:     storageClient,
 		boltDBIndexClient: boltDBIndexClient,
 		lastUsedAt:        time.Now(),
-		dbs:               map[string]*downloadedFile{},
+		dbs:               map[string]*bbolt.DB{},
 		ready:             make(chan struct{}),
 		cancelFunc:        cancel,
 	}
@@ -98,6 +95,73 @@ func NewTable(spanCtx context.Context, name, cacheLocation string, storageClient
 	}()
 
 	return &table
+}
+
+// LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
+func LoadTable(name, cacheLocation string, storageClient StorageClient, boltDBIndexClient BoltDBIndexClient, metrics *metrics) (*Table, error) {
+	// see if folder for table already exists.
+	folderPath := path.Join(cacheLocation, name)
+	_, err := os.Stat(folderPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		// folder for table doesn't exist, this means we have to download it from the shared store.
+		table := NewTable(context.Background(), name, cacheLocation, storageClient, boltDBIndexClient, metrics)
+		<-table.ready
+		if table.err != nil {
+			return nil, table.err
+		}
+		return table, nil
+	}
+
+	// folder for table already exists, open all the boltdb files from it.
+	filesInfo, err := ioutil.ReadDir(folderPath)
+	if err != nil {
+		return nil, err
+	}
+
+	table := Table{
+		name:              name,
+		cacheLocation:     cacheLocation,
+		metrics:           metrics,
+		storageClient:     storageClient,
+		boltDBIndexClient: boltDBIndexClient,
+		lastUsedAt:        time.Now(),
+		dbs:               map[string]*bbolt.DB{},
+		ready:             make(chan struct{}),
+		cancelFunc:        func() {},
+	}
+
+	level.Debug(util.Logger).Log("msg", fmt.Sprintf("opening locally present files for table %s", name), "files", fmt.Sprint(filesInfo))
+
+	for _, fileInfo := range filesInfo {
+		if fileInfo.IsDir() {
+			continue
+		}
+
+		// if we fail to open a boltdb file, lets skip it and let sync operation re-download the file from storage.
+		boltdb, err := local.OpenBoltdbFile(filepath.Join(folderPath, fileInfo.Name()))
+		if err != nil {
+			level.Error(util.Logger).Log("msg", fmt.Sprintf("failed to open existing boltdb file %s, continuing without it to let the sync operation catch up", filepath.Join(folderPath, fileInfo.Name())), "err", err)
+			continue
+		}
+
+		table.dbs[fileInfo.Name()] = boltdb
+	}
+
+	level.Debug(util.Logger).Log("msg", fmt.Sprintf("syncing files for table %s", name))
+	// sync the table to get new files and remove the deleted ones from storage.
+	err = table.Sync(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	// close the ready channel because the query function waits for it to be closed before performing queries.
+	close(table.ready)
+
+	return &table, nil
 }
 
 // init downloads all the db files for the table from object storage.
@@ -154,10 +218,7 @@ func (t *Table) init(ctx context.Context, spanLogger log.Logger) (err error) {
 		}
 
 		filePath := path.Join(folderPath, dbName)
-		df := downloadedFile{}
-
-		df.mtime = object.ModifiedAt
-		df.boltdb, err = local.OpenBoltdbFile(filePath)
+		boltdb, err := local.OpenBoltdbFile(filePath)
 		if err != nil {
 			return err
 		}
@@ -170,7 +231,7 @@ func (t *Table) init(ctx context.Context, spanLogger log.Logger) (err error) {
 
 		totalFilesSize += stat.Size()
 
-		t.dbs[dbName] = &df
+		t.dbs[dbName] = boltdb
 	}
 
 	duration := time.Since(startTime).Seconds()
@@ -190,18 +251,12 @@ func (t *Table) Close() {
 	defer t.dbsMtx.Unlock()
 
 	for name, db := range t.dbs {
-		dbPath := db.boltdb.Path()
-
-		if err := db.boltdb.Close(); err != nil {
+		if err := db.Close(); err != nil {
 			level.Error(util.Logger).Log("msg", fmt.Sprintf("failed to close file %s for table %s", name, t.name), "err", err)
-		}
-
-		if err := os.Remove(dbPath); err != nil {
-			level.Error(util.Logger).Log("msg", fmt.Sprintf("failed to remove file %s for table %s", name, t.name), "err", err)
 		}
 	}
 
-	t.dbs = map[string]*downloadedFile{}
+	t.dbs = map[string]*bbolt.DB{}
 }
 
 // MultiQueries runs multiple queries without having to take lock multiple times for each query.
@@ -230,7 +285,7 @@ func (t *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, ca
 	id := shipper_util.NewIndexDeduper(callback)
 
 	for name, db := range t.dbs {
-		err := db.boltdb.View(func(tx *bbolt.Tx) error {
+		err := db.View(func(tx *bbolt.Tx) error {
 			bucket := tx.Bucket(bucketName)
 			if bucket == nil {
 				return nil
@@ -267,7 +322,12 @@ func (t *Table) CleanupAllDBs() error {
 			return err
 		}
 	}
-	return nil
+
+	tablePath, err := t.folderPathForTable(false)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(tablePath)
 }
 
 // Err returns the err which is usually set when there was any issue in init.
@@ -280,15 +340,19 @@ func (t *Table) LastUsedAt() time.Time {
 	return t.lastUsedAt
 }
 
+func (t *Table) UpdateLastUsedAt() {
+	t.lastUsedAt = time.Now()
+}
+
 func (t *Table) cleanupDB(fileName string) error {
 	df, ok := t.dbs[fileName]
 	if !ok {
 		return fmt.Errorf("file %s not found in files collection for cleaning up", fileName)
 	}
 
-	filePath := df.boltdb.Path()
+	filePath := df.Path()
 
-	if err := df.boltdb.Close(); err != nil {
+	if err := df.Close(); err != nil {
 		return err
 	}
 
@@ -352,9 +416,10 @@ func (t *Table) checkStorageForUpdates(ctx context.Context) (toDownload []chunk.
 		}
 		listedDBs[dbName] = struct{}{}
 
-		// Checking whether file was updated in the store after we downloaded it, if not, no need to include it in updates
-		downloadedFileDetails, ok := t.dbs[dbName]
-		if !ok || downloadedFileDetails.mtime != object.ModifiedAt {
+		// Checking whether file was already downloaded, if not, download it.
+		// We do not ever upload files in the object store with the same name but different contents so we do not consider downloading modified files again.
+		_, ok := t.dbs[dbName]
+		if !ok {
 			toDownload = append(toDownload, object)
 		}
 	}
@@ -379,10 +444,7 @@ func (t *Table) downloadFile(ctx context.Context, storageObject chunk.StorageObj
 	folderPath, _ := t.folderPathForTable(false)
 	filePath := path.Join(folderPath, dbName)
 
-	// download the file temporarily with some other name to allow boltdb client to close the existing file first if it exists
-	tempFilePath := path.Join(folderPath, fmt.Sprintf("%s.%s", dbName, "temp"))
-
-	err = shipper_util.GetFileFromStorage(ctx, t.storageClient, storageObject.Key, tempFilePath)
+	err = shipper_util.GetFileFromStorage(ctx, t.storageClient, storageObject.Key, filePath)
 	if err != nil {
 		return err
 	}
@@ -390,28 +452,12 @@ func (t *Table) downloadFile(ctx context.Context, storageObject chunk.StorageObj
 	t.dbsMtx.Lock()
 	defer t.dbsMtx.Unlock()
 
-	df, ok := t.dbs[dbName]
-	if ok {
-		if err := df.boltdb.Close(); err != nil {
-			return err
-		}
-	} else {
-		df = &downloadedFile{}
-	}
-
-	// move the file from temp location to actual location
-	err = os.Rename(tempFilePath, filePath)
+	boltdb, err := local.OpenBoltdbFile(filePath)
 	if err != nil {
 		return err
 	}
 
-	df.mtime = storageObject.ModifiedAt
-	df.boltdb, err = local.OpenBoltdbFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	t.dbs[dbName] = df
+	t.dbs[dbName] = boltdb
 
 	return nil
 }

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -68,6 +68,7 @@ func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, storageClien
 	err := tm.loadLocalTables()
 	if err != nil {
 		// call Stop to close open file references.
+		tm.Stop()
 		return nil, err
 	}
 

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -3,7 +3,12 @@ package downloads
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,12 +22,16 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 )
 
-const cacheCleanupInterval = time.Hour
+const (
+	cacheCleanupInterval = time.Hour
+	durationDay          = 24 * time.Hour
+)
 
 type Config struct {
-	CacheDir     string
-	SyncInterval time.Duration
-	CacheTTL     time.Duration
+	CacheDir          string
+	SyncInterval      time.Duration
+	CacheTTL          time.Duration
+	QueryReadyNumDays int
 }
 
 type TableManager struct {
@@ -40,11 +49,6 @@ type TableManager struct {
 }
 
 func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, storageClient StorageClient, registerer prometheus.Registerer) (*TableManager, error) {
-	// cleanup existing directory and re-create it since we do not use existing files in it.
-	if err := os.RemoveAll(cfg.CacheDir); err != nil {
-		return nil, err
-	}
-
 	if err := chunk_util.EnsureDirectory(cfg.CacheDir); err != nil {
 		return nil, err
 	}
@@ -59,6 +63,22 @@ func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, storageClien
 		ctx:             ctx,
 		cancel:          cancel,
 	}
+
+	// load the existing tables first.
+	err := tm.loadLocalTables()
+	if err != nil {
+		// call Stop to close open file references.
+		return nil, err
+	}
+
+	// download the missing tables.
+	err = tm.ensureQueryReadiness()
+	if err != nil {
+		// call Stop to close open file references.
+		tm.Stop()
+		return nil, err
+	}
+
 	go tm.loop()
 	return tm, nil
 }
@@ -79,6 +99,12 @@ func (tm *TableManager) loop() {
 			err := tm.syncTables(tm.ctx)
 			if err != nil {
 				level.Error(pkg_util.Logger).Log("msg", "error syncing local boltdb files with storage", "err", err)
+			}
+
+			// we need to keep ensuring query readiness to download every days new table which would otherwise be downloaded only during queries.
+			err = tm.ensureQueryReadiness()
+			if err != nil {
+				level.Error(pkg_util.Logger).Log("msg", "error ensuring query readiness of tables", "err", err)
 			}
 		case <-cacheCleanupTicker.C:
 			err := tm.cleanupCache()
@@ -206,8 +232,128 @@ func (tm *TableManager) cleanupCache() error {
 			}
 
 			delete(tm.tables, name)
+
+			// remove the directory where files for the table were downloaded.
+			err = os.RemoveAll(path.Join(tm.cfg.CacheDir, name))
+			if err != nil {
+				level.Error(pkg_util.Logger).Log("msg", fmt.Sprintf("failed to remove directory for table %s", name), "err", err)
+			}
 		}
 	}
 
 	return nil
+}
+
+// ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
+func (tm *TableManager) ensureQueryReadiness() error {
+	if tm.cfg.QueryReadyNumDays == 0 {
+		return nil
+	}
+
+	_, tablesInStorage, err := tm.storageClient.List(context.Background(), "", delimiter)
+	if err != nil {
+		return err
+	}
+
+	// get the names of tables required for being query ready.
+	tableNames, err := tm.tablesRequiredForQueryReadiness(tablesInStorage)
+	if err != nil {
+		return err
+	}
+
+	level.Debug(pkg_util.Logger).Log("msg", fmt.Sprintf("list of tables required for query-readiness %s", tableNames))
+
+	for _, tableName := range tableNames {
+		tm.tablesMtx.RLock()
+		table, ok := tm.tables[tableName]
+		tm.tablesMtx.RUnlock()
+		if ok {
+			// table already exists, update the last used at time to avoid cache cleanup operation removing it.
+			table.UpdateLastUsedAt()
+			continue
+		}
+
+		level.Info(pkg_util.Logger).Log("msg", "table required for query readiness does not exist locally, downloading it", "table-name", tableName)
+		// table doesn't exist, download it.
+		table, err := LoadTable(tableName, tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
+		if err != nil {
+			return err
+		}
+
+		tm.tablesMtx.Lock()
+		tm.tables[tableName] = table
+		tm.tablesMtx.Unlock()
+	}
+
+	return nil
+}
+
+// queryReadyTableNumbersRange returns the table numbers range. Table numbers are added as suffix to table names.
+func (tm *TableManager) queryReadyTableNumbersRange() (int64, int64) {
+	newestTableNumber := getActiveTableNumber()
+
+	return newestTableNumber - int64(tm.cfg.QueryReadyNumDays), newestTableNumber
+}
+
+// tablesRequiredForQueryReadiness returns the names of tables required to be downloaded for being query ready as per configured QueryReadyNumDays.
+// It only considers daily tables for simplicity and we anyways have made it mandatory to have daily tables with boltdb-shipper.
+func (tm *TableManager) tablesRequiredForQueryReadiness(tablesInStorage []chunk.StorageCommonPrefix) ([]string, error) {
+	// regex for finding daily tables which have a 5 digit number at the end.
+	re, err := regexp.Compile(`.+[0-9]{5}$`)
+	if err != nil {
+		return nil, err
+	}
+
+	minTableNumber, maxTableNumber := tm.queryReadyTableNumbersRange()
+	var requiredTableNames []string
+
+	for _, tableNameWithSep := range tablesInStorage {
+		// tableNames come with a delimiter(separator) because they are directories not objects so removing the delimiter.
+		tableName := strings.TrimSuffix(string(tableNameWithSep), delimiter)
+		if !re.MatchString(tableName) {
+			continue
+		}
+
+		tableNumber, err := strconv.ParseInt(tableName[len(tableName)-5:], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		if minTableNumber <= tableNumber && tableNumber <= maxTableNumber {
+			requiredTableNames = append(requiredTableNames, tableName)
+		}
+	}
+
+	return requiredTableNames, nil
+}
+
+// loadLocalTables loads tables present locally.
+func (tm *TableManager) loadLocalTables() error {
+	filesInfo, err := ioutil.ReadDir(tm.cfg.CacheDir)
+	if err != nil {
+		return err
+	}
+
+	for _, fileInfo := range filesInfo {
+		if !fileInfo.IsDir() {
+			continue
+		}
+
+		level.Info(pkg_util.Logger).Log("msg", fmt.Sprintf("loading local table %s", fileInfo.Name()))
+
+		table, err := LoadTable(fileInfo.Name(), tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
+		if err != nil {
+			return err
+		}
+
+		tm.tables[fileInfo.Name()] = table
+	}
+
+	return nil
+}
+
+func getActiveTableNumber() int64 {
+	periodSecs := int64(durationDay / time.Second)
+
+	return time.Now().Unix() / periodSecs
 }

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -275,7 +275,7 @@ func (tm *TableManager) ensureQueryReadiness() error {
 
 		level.Info(pkg_util.Logger).Log("msg", "table required for query readiness does not exist locally, downloading it", "table-name", tableName)
 		// table doesn't exist, download it.
-		table, err := LoadTable(tableName, tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
+		table, err := LoadTable(tm.ctx, tableName, tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func (tm *TableManager) loadLocalTables() error {
 
 		level.Info(pkg_util.Logger).Log("msg", fmt.Sprintf("loading local table %s", fileInfo.Name()))
 
-		table, err := LoadTable(fileInfo.Name(), tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
+		table, err := LoadTable(tm.ctx, fileInfo.Name(), tm.cfg.CacheDir, tm.storageClient, tm.boltIndexClient, tm.metrics)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -2,11 +2,15 @@ package downloads
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cortexproject/cortex/pkg/chunk/util"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/stretchr/testify/require"
@@ -130,4 +134,124 @@ func TestTableManager_cleanupCache(t *testing.T) {
 
 	_, ok = tableManager.tables[nonExpiredTableName]
 	require.True(t, ok)
+}
+
+func TestTableManager_ensureQueryReadiness(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		queryReadyNumDaysCfg int
+	}{
+		{
+			name: "0 queryReadyNumDaysCfg with 10 tables in storage",
+		},
+		{
+			name:                 "5 queryReadyNumDaysCfg with 10 tables in storage",
+			queryReadyNumDaysCfg: 5,
+		},
+		{
+			name:                 "20 queryReadyNumDaysCfg with 10 tables in storage",
+			queryReadyNumDaysCfg: 20,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", "table-manager-ensure-query-readiness")
+			require.NoError(t, err)
+
+			defer func() {
+				require.NoError(t, os.RemoveAll(tempDir))
+			}()
+
+			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+
+			tables := map[string]map[string]testutil.DBRecords{}
+			activeTableNumber := getActiveTableNumber()
+			for i := 0; i < 10; i++ {
+				tables[fmt.Sprintf("table_%d", activeTableNumber-int64(i))] = map[string]testutil.DBRecords{
+					"db": {
+						Start:      i * 10,
+						NumRecords: 10,
+					},
+				}
+			}
+
+			for name, dbs := range tables {
+				testutil.SetupDBTablesAtPath(t, name, objectStoragePath, dbs, true)
+			}
+
+			boltDBIndexClient, fsObjectClient := buildTestClients(t, tempDir)
+			cachePath := filepath.Join(tempDir, cacheDirName)
+			require.NoError(t, util.EnsureDirectory(cachePath))
+
+			cfg := Config{
+				CacheDir:          cachePath,
+				SyncInterval:      time.Hour,
+				CacheTTL:          time.Hour,
+				QueryReadyNumDays: tc.queryReadyNumDaysCfg,
+			}
+			tableManager := &TableManager{
+				cfg:             cfg,
+				boltIndexClient: boltDBIndexClient,
+				storageClient:   fsObjectClient,
+				tables:          make(map[string]*Table),
+				metrics:         newMetrics(nil),
+				cancel:          func() {},
+			}
+
+			defer func() {
+				tableManager.Stop()
+				boltDBIndexClient.Stop()
+			}()
+
+			require.NoError(t, tableManager.ensureQueryReadiness())
+
+			if tc.queryReadyNumDaysCfg == 0 {
+				require.Len(t, tableManager.tables, 0)
+			} else {
+				require.Len(t, tableManager.tables, int(math.Min(float64(tc.queryReadyNumDaysCfg+1), 10)))
+			}
+		})
+	}
+}
+
+func TestTableManager_tablesRequiredForQueryReadiness(t *testing.T) {
+	numDailyTablesInStorage := 10
+	var tablesInStorage []chunk.StorageCommonPrefix
+	// tables with daily table number
+	activeDailyTableNumber := getActiveTableNumber()
+	for i := 0; i < numDailyTablesInStorage; i++ {
+		tablesInStorage = append(tablesInStorage, chunk.StorageCommonPrefix(fmt.Sprintf("table_%d/", activeDailyTableNumber-int64(i))))
+	}
+
+	// tables with weekly table number
+	activeWeeklyTableNumber := time.Now().Unix() / int64((durationDay*7)/time.Second)
+	for i := 0; i < 10; i++ {
+		tablesInStorage = append(tablesInStorage, chunk.StorageCommonPrefix(fmt.Sprintf("table_%d/", activeWeeklyTableNumber-int64(i))))
+	}
+
+	// tables without a table number
+	tablesInStorage = append(tablesInStorage, "foo/", "bar/")
+
+	for i, tc := range []int{
+		0, 5, 10, 20,
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			tableManager := &TableManager{
+				cfg: Config{
+					QueryReadyNumDays: tc,
+				},
+			}
+
+			tablesNames, err := tableManager.tablesRequiredForQueryReadiness(tablesInStorage)
+			require.NoError(t, err)
+
+			numExpectedTables := 0
+			if tc != 0 {
+				numExpectedTables = int(math.Min(float64(tc+1), float64(numDailyTablesInStorage)))
+			}
+
+			for i := 0; i < numExpectedTables; i++ {
+				require.Equal(t, fmt.Sprintf("table_%d", activeDailyTableNumber-int64(i)), tablesNames[i])
+			}
+		})
+	}
 }

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -194,6 +194,7 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 				storageClient:   fsObjectClient,
 				tables:          make(map[string]*Table),
 				metrics:         newMetrics(nil),
+				ctx:             context.Background(),
 				cancel:          func() {},
 			}
 

--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -308,7 +308,7 @@ func TestLoadTable(t *testing.T) {
 	cachePath := filepath.Join(tempDir, cacheDirName)
 
 	// try loading the table.
-	table, err := LoadTable(tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
+	table, err := LoadTable(context.Background(), tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
@@ -338,7 +338,7 @@ func TestLoadTable(t *testing.T) {
 	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, dbs, false)
 
 	// try loading the table, it should skip loading corrupt file and reload it from storage.
-	table, err = LoadTable(tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
+	table, err = LoadTable(context.Background(), tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
1. Queriers would open and reuse the existing index file in cache dir during startup.
2. Adds support for being query ready for configured last n days by keeping the index always downloaded for that duration.

**Special notes for your reviewer**:
1. Query readiness only considers daily tables for simplicity, we already have made it mandatory to have daily tables for boltdb-shipper, long back.
2. I have removed the code for checking the mtime of already downloaded files during sync operation because we never upload a file with the same name but with different content. This is done to simplify the code for Sync operation.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

