### PR TITLE
Fixes logql.QueryType.

### DIFF
--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -110,13 +110,14 @@ func QueryType(query string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch expr.(type) {
+	switch e := expr.(type) {
 	case SampleExpr:
 		return QueryTypeMetric, nil
-	case *matchersExpr:
+	case LogSelectorExpr:
+		if e.HasFilter() {
+			return QueryTypeFilter, nil
+		}
 		return QueryTypeLimited, nil
-	case *pipelineExpr:
-		return QueryTypeFilter, nil
 	default:
 		return "", nil
 	}

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -28,10 +28,14 @@ func TestQueryType(t *testing.T) {
 		{"bad", "ddd", "", true},
 		{"limited", `{app="foo"}`, QueryTypeLimited, false},
 		{"limited multi label", `{app="foo" ,fuzz=~"foo"}`, QueryTypeLimited, false},
+		{"limited with parser", `{app="foo" ,fuzz=~"foo"} | logfmt`, QueryTypeLimited, false},
 		{"filter", `{app="foo"} |= "foo"`, QueryTypeFilter, false},
+		{"filter string extracted label", `{app="foo"} | json | foo="a"`, QueryTypeFilter, false},
+		{"filter duration", `{app="foo"} | json | duration > 5s`, QueryTypeFilter, false},
 		{"metrics", `rate({app="foo"} |= "foo"[5m])`, QueryTypeMetric, false},
 		{"metrics binary", `rate({app="foo"} |= "foo"[5m]) + count_over_time({app="foo"} |= "foo"[5m]) / rate({app="foo"} |= "foo"[5m]) `, QueryTypeMetric, false},
 		{"filters", `{app="foo"} |= "foo" |= "f" != "b"`, QueryTypeFilter, false},
+		{"filters and labels filters", `{app="foo"} |= "foo" |= "f" != "b" | json | a > 5`, QueryTypeFilter, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The bug was introduced with LogQL extensions.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
