### PR TITLE
promtail: Add support for using syslog message timestamp

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -765,6 +765,11 @@ label_structured_data: <bool>
 # Label map to add to every log message.
 labels:
   [ <labelname>: <labelvalue> ... ]
+
+# Whether promtail should pass on the timestamp from the incoming syslog message.
+# When false, or if no timestamp is present on the syslog message, Promtail will assign the current timestamp to the log when it was processed.
+# Default is false
+use_incoming_timestamp: <bool>
 ```
 
 #### Available Labels

--- a/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -158,6 +158,10 @@ type SyslogTargetConfig struct {
 
 	// Labels optionally holds labels to associate with each record read from syslog.
 	Labels model.LabelSet `yaml:"labels"`
+
+	// UseIncomingTimestamp sets the timestamp to the incoming syslog mesages
+	// timestamp if it's set.
+	UseIncomingTimestamp bool `yaml:"use_incoming_timestamp"`
 }
 
 // PushTargetConfig describes a scrape config that listens for Loki push messages.


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently promtail sets the timestamp of incoming syslog messages to the
time it was received by promtail. In some cases, it is preferable to use
the source timestamp instead.

This adds a new `use_incoming_timestamp` option to the syslog target
config, which allows users to opt-in to the behavior of using the
timestamp on the message, if one exists.

**Checklist**
- [x] Documentation added
- [ ] Tests updated