### PR TITLE
Distributor registers logproto.Pusher service to receive logs via GRPC

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -144,6 +144,8 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		return nil, err
 	}
 
+	logproto.RegisterPusherServer(t.server.GRPC, t.distributor)
+
 	pushHandler := middleware.Merge(
 		serverutil.RecoveryHTTPMiddleware,
 		t.httpAuthMiddleware,


### PR DESCRIPTION
**What this PR does / why we need it**:
Distributor registers the logproto.Pusher service so that logs can be pushed to the distributor using GRPC. GRPC has a number of benefits over REST and this change would allow clients to push to the distributor using GRPC instead of REST. 

**Special notes for your reviewer**:
See discussion: https://app.slack.com/client/T05675Y01/CEPJRLQNL/thread/CEPJRLQNL-1605100868.117200

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

Resolves #2921 
