### PR TITLE
Cache label strings in ingester to improve memory usage.

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -81,7 +81,7 @@ func TestDistributor(t *testing.T) {
 			limits.IngestionBurstSizeMB = ingestionRateLimit
 			limits.MaxLineSize = fe.ByteSize(tc.maxLineSize)
 
-			d := prepare(t, limits, nil)
+			d := prepare(t, limits, nil, nil)
 			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			request := makeWriteRequest(tc.lines, 10)
@@ -95,6 +95,21 @@ func TestDistributor(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}
+}
+
+func Test_SortLabelsOnPush(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	limits.EnforceMetricName = false
+	ingester := &mockIngester{}
+	d := prepare(t, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
+
+	request := makeWriteRequest(10, 10)
+	request.Streams[0].Labels = `{buzz="f", a="b"}`
+	_, err := d.Push(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, `{a="b", buzz="f"}`, ingester.pushed[0].Streams[0].Labels)
 }
 
 func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
@@ -165,7 +180,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			// Start all expected distributors
 			distributors := make([]*Distributor, testData.distributors)
 			for i := 0; i < testData.distributors; i++ {
-				distributors[i] = prepare(t, limits, kvStore)
+				distributors[i] = prepare(t, limits, kvStore, nil)
 				defer services.StopAndAwaitTerminated(context.Background(), distributors[i]) //nolint:errcheck
 			}
 
@@ -211,7 +226,7 @@ func loopbackInterfaceName() (string, error) {
 	return "", fmt.Errorf("can't retrieve loopback interface name")
 }
 
-func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client) *Distributor {
+func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory func(addr string) (ring_client.PoolClient, error)) *Distributor {
 	var (
 		distributorConfig Config
 		clientConfig      client.Config
@@ -243,8 +258,11 @@ func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client) *Distri
 	distributorConfig.DistributorRing.InstanceID = strconv.Itoa(rand.Int())
 	distributorConfig.DistributorRing.KVStore.Mock = kvStore
 	distributorConfig.DistributorRing.InstanceInterfaceNames = []string{loopbackName}
-	distributorConfig.factory = func(addr string) (ring_client.PoolClient, error) {
-		return ingesters[addr], nil
+	distributorConfig.factory = factory
+	if factory == nil {
+		distributorConfig.factory = func(addr string) (ring_client.PoolClient, error) {
+			return ingesters[addr], nil
+		}
 	}
 
 	d, err := New(distributorConfig, clientConfig, ingestersRing, overrides, nil)
@@ -279,9 +297,12 @@ func makeWriteRequest(lines int, size int) *logproto.PushRequest {
 type mockIngester struct {
 	grpc_health_v1.HealthClient
 	logproto.PusherClient
+
+	pushed []*logproto.PushRequest
 }
 
 func (i *mockIngester) Push(ctx context.Context, in *logproto.PushRequest, opts ...grpc.CallOption) (*logproto.PushResponse, error) {
+	i.pushed = append(i.pushed, in)
 	return nil, nil
 }
 

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
@@ -53,16 +52,7 @@ func (v Validator) ValidateEntry(userID string, labels string, entry logproto.En
 }
 
 // Validate labels returns an error if the labels are invalid
-func (v Validator) ValidateLabels(userID string, stream logproto.Stream) error {
-	ls, err := util.ToClientLabels(stream.Labels)
-	if err != nil {
-		// I wish we didn't return httpgrpc errors here as it seems
-		// an orthogonal concept (we need not use ValidateLabels in this context)
-		// but the upstream cortex_validation pkg uses it, so we keep this
-		// for parity.
-		return httpgrpc.Errorf(http.StatusBadRequest, "error parsing labels: %v", err)
-	}
-
+func (v Validator) ValidateLabels(userID string, ls []cortex_client.LabelAdapter, stream logproto.Stream) error {
 	numLabelNames := len(ls)
 	if numLabelNames > v.MaxLabelNamesPerSeries(userID) {
 		validation.DiscardedSamples.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Inc()

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
@@ -149,8 +151,16 @@ func TestValidator_ValidateLabels(t *testing.T) {
 			v, err := NewValidator(o)
 			assert.NoError(t, err)
 
-			err = v.ValidateLabels(tt.userID, logproto.Stream{Labels: tt.labels})
+			err = v.ValidateLabels(tt.userID, mustParseLabels(tt.labels), logproto.Stream{Labels: tt.labels})
 			assert.Equal(t, tt.expected, err)
 		})
 	}
+}
+
+func mustParseLabels(s string) []client.LabelAdapter {
+	labels, err := util.ToClientLabels(s)
+	if err != nil {
+		panic(err)
+	}
+	return labels
 }

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -239,7 +239,7 @@ func (i *Ingester) collectChunksToFlush(instance *instance, fp model.Fingerprint
 	instance.streamsMtx.Lock()
 	defer instance.streamsMtx.Unlock()
 
-	stream, ok := instance.streams[fp]
+	stream, ok := instance.streamsByFP[fp]
 	if !ok {
 		return nil, nil
 	}
@@ -300,7 +300,8 @@ func (i *Ingester) removeFlushedChunks(instance *instance, stream *stream) {
 	memoryChunks.Sub(float64(prevNumChunks - len(stream.chunks)))
 
 	if len(stream.chunks) == 0 {
-		delete(instance.streams, stream.fp)
+		delete(instance.streamsByFP, stream.fp)
+		delete(instance.streams, stream.labelsString)
 		instance.index.Delete(stream.labels, stream.fp)
 		instance.streamsRemovedTotal.Inc()
 		memoryStreams.WithLabelValues(instance.instanceID).Dec()

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -195,7 +195,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream) (*stream, er
 func (i *instance) getHashForLabels(labels []client.LabelAdapter) model.Fingerprint {
 	var fp uint64
 	lbsModel := client.FromLabelAdaptersToLabels(labels)
-	fp, i.buf = lbsModel.HashForLabels(i.buf, []string(nil)...)
+	fp, i.buf = lbsModel.HashWithoutLabels(i.buf, []string(nil)...)
 	return i.mapper.mapFP(model.Fingerprint(fp), labels)
 }
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -257,3 +257,43 @@ func makeRandomLabels() string {
 	}
 	return ls.Labels().String()
 }
+
+func Benchmark_PushInstance(b *testing.B) {
+	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
+	require.NoError(b, err)
+	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+
+	i := newInstance(&Config{}, "test", defaultFactory, limiter, 0, 0)
+	ctx := context.Background()
+
+	for n := 0; n < b.N; n++ {
+		_ = i.Push(ctx, &logproto.PushRequest{
+			Streams: []logproto.Stream{
+				{
+					Labels: `{cpu="10",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"}`,
+					Entries: []logproto.Entry{
+						{Timestamp: time.Now(), Line: "1"},
+						{Timestamp: time.Now(), Line: "2"},
+						{Timestamp: time.Now(), Line: "3"},
+					},
+				},
+				{
+					Labels: `{cpu="35",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"}`,
+					Entries: []logproto.Entry{
+						{Timestamp: time.Now(), Line: "1"},
+						{Timestamp: time.Now(), Line: "2"},
+						{Timestamp: time.Now(), Line: "3"},
+					},
+				},
+				{
+					Labels: `{cpu="89",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"}`,
+					Entries: []logproto.Entry{
+						{Timestamp: time.Now(), Line: "1"},
+						{Timestamp: time.Now(), Line: "2"},
+						{Timestamp: time.Now(), Line: "3"},
+					},
+				},
+			},
+		})
+	}
+}


### PR DESCRIPTION
This reduces allocations in ingesters, but assume that labels comes in sorted which is now ensured in the distributors.
The distributors will take a performance hit, but that's easier to scale or improve later.(added some todos)

see benchmark:

```
❯ benchcmp before.txt after.txt
benchmark                     old ns/op     new ns/op     delta
Benchmark_PushInstance-16     43505         4950          -88.62%

benchmark                     old allocs     new allocs     delta
Benchmark_PushInstance-16     240            12             -95.00%

benchmark                     old bytes     new bytes     delta
Benchmark_PushInstance-16     42568         1787          -95.80%
```