### PR TITLE
Cleanup labels parsing.

### DIFF
--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	cortex_client "github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/logproto"
@@ -52,7 +52,7 @@ func (v Validator) ValidateEntry(userID string, labels string, entry logproto.En
 }
 
 // Validate labels returns an error if the labels are invalid
-func (v Validator) ValidateLabels(userID string, ls []cortex_client.LabelAdapter, stream logproto.Stream) error {
+func (v Validator) ValidateLabels(userID string, ls labels.Labels, stream logproto.Stream) error {
 	numLabelNames := len(ls)
 	if numLabelNames > v.MaxLabelNamesPerSeries(userID) {
 		validation.DiscardedSamples.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Inc()
@@ -61,7 +61,7 @@ func (v Validator) ValidateLabels(userID string, ls []cortex_client.LabelAdapter
 			bytes += len(e.Line)
 		}
 		validation.DiscardedBytes.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Add(float64(bytes))
-		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg(cortex_client.FromLabelAdaptersToMetric(ls).String(), numLabelNames, v.MaxLabelNamesPerSeries(userID)))
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg(stream.Labels, numLabelNames, v.MaxLabelNamesPerSeries(userID)))
 	}
 
 	maxLabelNameLength := v.MaxLabelNameLength(userID)

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -101,7 +101,7 @@ func TestValidator_ValidateLabels(t *testing.T) {
 				return &validation.Limits{MaxLabelNamesPerSeries: 2}
 			},
 			"{foo=\"bar\",food=\"bars\",fed=\"bears\"}",
-			httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg("{fed=\"bears\", foo=\"bar\", food=\"bars\"}", 3, 2)),
+			httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg("{foo=\"bar\",food=\"bars\",fed=\"bears\"}", 3, 2)),
 		},
 		{
 			"label name too long",

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
@@ -157,10 +157,10 @@ func TestValidator_ValidateLabels(t *testing.T) {
 	}
 }
 
-func mustParseLabels(s string) []client.LabelAdapter {
-	labels, err := util.ToClientLabels(s)
+func mustParseLabels(s string) labels.Labels {
+	ls, err := logql.ParseLabels(s)
 	if err != nil {
 		panic(err)
 	}
-	return labels
+	return ls
 }

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -61,7 +61,7 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric labels.Labels) model.Finge
 	s := m.fpToLabels(fp)
 	if s != nil {
 		// FP exists in memory, but is it for the same metric?
-		if equalLabels(metric, s) {
+		if labels.Equal(metric, s) {
 			// Yupp. We are done.
 			return fp
 		}
@@ -85,39 +85,6 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric labels.Labels) model.Finge
 		}
 	}
 	return fp
-}
-
-func valueForName(s labels.Labels, name string) (string, bool) {
-	pos := sort.Search(len(s), func(i int) bool { return s[i].Name >= name })
-	if pos == len(s) || s[pos].Name != name {
-		return "", false
-	}
-	return s[pos].Value, true
-}
-
-// Check if a and b contain the same name/value pairs
-func equalLabels(a labels.Labels, b labels.Labels) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	// Check as many as we can where the two sets are in the same order
-	i := 0
-	for ; i < len(a); i++ {
-		if b[i].Name != a[i].Name {
-			break
-		}
-		if b[i].Value != a[i].Value {
-			return false
-		}
-	}
-	// Now check remaining values using binary search
-	for ; i < len(a); i++ {
-		v, found := valueForName(b, a[i].Name)
-		if !found || v != a[i].Value {
-			return false
-		}
-	}
-	return true
 }
 
 // maybeAddMapping is only used internally. It takes a detected collision and

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -4,8 +4,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/ingester/client"
-
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
@@ -20,34 +18,34 @@ var (
 	fp1  = model.Fingerprint(maxMappedFP + 1)
 	fp2  = model.Fingerprint(maxMappedFP + 2)
 	fp3  = model.Fingerprint(1)
-	cm11 = []client.LabelAdapter{
+	cm11 = []labels.Label{
 		{Name: "foo", Value: "bar"},
 		{Name: "dings", Value: "bumms"},
 	}
-	cm12 = []client.LabelAdapter{
+	cm12 = []labels.Label{
 		{Name: "bar", Value: "foo"},
 	}
-	cm13 = []client.LabelAdapter{
+	cm13 = []labels.Label{
 		{Name: "foo", Value: "bar"},
 	}
-	cm21 = []client.LabelAdapter{
+	cm21 = []labels.Label{
 		{Name: "foo", Value: "bumms"},
 		{Name: "dings", Value: "bar"},
 	}
-	cm22 = []client.LabelAdapter{
+	cm22 = []labels.Label{
 		{Name: "dings", Value: "foo"},
 		{Name: "bar", Value: "bumms"},
 	}
-	cm31 = []client.LabelAdapter{
+	cm31 = []labels.Label{
 		{Name: "bumms", Value: "dings"},
 	}
-	cm32 = []client.LabelAdapter{
+	cm32 = []labels.Label{
 		{Name: "bumms", Value: "dings"},
 		{Name: "bar", Value: "foo"},
 	}
 )
 
-func copyValuesAndSort(a []client.LabelAdapter) labels.Labels {
+func copyValuesAndSort(a []labels.Label) labels.Labels {
 	c := make(labels.Labels, len(a))
 	for i, pair := range a {
 		c[i].Name = pair.Name

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -19,8 +19,8 @@ var (
 	fp2  = model.Fingerprint(maxMappedFP + 2)
 	fp3  = model.Fingerprint(1)
 	cm11 = []labels.Label{
-		{Name: "foo", Value: "bar"},
 		{Name: "dings", Value: "bumms"},
+		{Name: "foo", Value: "bar"},
 	}
 	cm12 = []labels.Label{
 		{Name: "bar", Value: "foo"},
@@ -29,19 +29,19 @@ var (
 		{Name: "foo", Value: "bar"},
 	}
 	cm21 = []labels.Label{
-		{Name: "foo", Value: "bumms"},
 		{Name: "dings", Value: "bar"},
+		{Name: "foo", Value: "bumms"},
 	}
 	cm22 = []labels.Label{
-		{Name: "dings", Value: "foo"},
 		{Name: "bar", Value: "bumms"},
+		{Name: "dings", Value: "foo"},
 	}
 	cm31 = []labels.Label{
 		{Name: "bumms", Value: "dings"},
 	}
 	cm32 = []labels.Label{
-		{Name: "bumms", Value: "dings"},
 		{Name: "bar", Value: "foo"},
+		{Name: "bumms", Value: "dings"},
 	}
 )
 
@@ -129,6 +129,7 @@ func TestFPMapper(t *testing.T) {
 
 // assertFingerprintEqual asserts that two fingerprints are equal.
 func assertFingerprintEqual(t *testing.T, gotFP, wantFP model.Fingerprint) {
+	t.Helper()
 	if gotFP != wantFP {
 		t.Errorf("got fingerprint %v, want fingerprint %v", gotFP, wantFP)
 	}

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/user"
 	"golang.org/x/net/context"
 
@@ -101,9 +101,9 @@ func (i *Ingester) TransferChunks(stream logproto.Ingester_TransferChunksServer)
 
 		userCtx := user.InjectOrgID(stream.Context(), chunkSet.UserId)
 
-		lbls := []client.LabelAdapter{}
+		lbls := make([]labels.Label, 0, len(chunkSet.Labels))
 		for _, lbl := range chunkSet.Labels {
-			lbls = append(lbls, client.LabelAdapter{Name: lbl.Name, Value: lbl.Value})
+			lbls = append(lbls, labels.Label{Name: lbl.Name, Value: lbl.Value})
 		}
 
 		instance := i.getOrCreateInstance(chunkSet.UserId)

--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -2,25 +2,12 @@ package util
 
 import (
 	"math"
-	"sort"
 	"time"
 	"unsafe"
 
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/promql/parser"
 )
-
-// ToClientLabels parses the labels and converts them to the Cortex type.
-func ToClientLabels(labels string) ([]client.LabelAdapter, error) {
-	ls, err := parser.ParseMetric(labels)
-	if err != nil {
-		return nil, err
-	}
-	sort.Sort(ls)
-	return client.FromLabelsToLabelAdapters(ls), nil
-}
 
 // ModelLabelSetToMap convert a model.LabelSet to a map[string]string
 func ModelLabelSetToMap(m model.LabelSet) map[string]string {


### PR DESCRIPTION
Make sure we only use one type of labels parsing.
This just reduce the amount of code we have to maintain.

We can also now ensure that labels are sent to the ingester ordered, so no need for special equality.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


