### PR TITLE
Fixes all in one grpc registrations.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -144,7 +144,9 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		return nil, err
 	}
 
-	logproto.RegisterPusherServer(t.server.GRPC, t.distributor)
+	if t.cfg.Target != All {
+		logproto.RegisterPusherServer(t.server.GRPC, t.distributor)
+	}
 
 	pushHandler := middleware.Merge(
 		serverutil.RecoveryHTTPMiddleware,


### PR DESCRIPTION
We can only register push server once, in all in one, we want to register only ingester.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
