### PR TITLE
Only append tailed entries if needed.

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -19,11 +19,6 @@ func NewDumbChunk() Chunk {
 	return &dumbChunk{}
 }
 
-// NewDumbChunk returns a new chunk that isn't very good.
-func NewDumbChunkWithArray(entries []logproto.Entry) Chunk {
-	return &dumbChunk{entries: entries}
-}
-
 type dumbChunk struct {
 	entries []logproto.Entry
 }

--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -19,6 +19,11 @@ func NewDumbChunk() Chunk {
 	return &dumbChunk{}
 }
 
+// NewDumbChunk returns a new chunk that isn't very good.
+func NewDumbChunkWithArray(entries []logproto.Entry) Chunk {
+	return &dumbChunk{entries: entries}
+}
+
 type dumbChunk struct {
 	entries []logproto.Entry
 }

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -240,7 +240,7 @@ func Test_SeriesQuery(t *testing.T) {
 }
 
 func entries(n int, t time.Time) []logproto.Entry {
-	var result []logproto.Entry
+	result := make([]logproto.Entry, 0, n)
 	for i := 0; i < n; i++ {
 		result = append(result, logproto.Entry{Timestamp: t, Line: fmt.Sprintf("hello %d", i)})
 		t = t.Add(time.Nanosecond)


### PR DESCRIPTION
This avoid to doing allocations on slices when there is no tailers.

We could potentially pooled the slice too but the tailing code is using the stream in an
async fashion so we can't put it back.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


