### PR TITLE
loki-mixin: Remove logmetrics and use loki for logs count

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-logs.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-logs.json
@@ -715,7 +715,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$logmetrics",
+      "datasource": "$logs",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -857,19 +857,6 @@
         "name": "logs",
         "options": [],
         "query": "loki",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "logmetrics",
-        "options": [],
-        "query": "prometheus",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -26,11 +26,6 @@ local lokiLogs = (import './dashboard-loki-logs.json');
           query:: 'loki',
         },
         {
-          name:: 'logmetrics',
-          type:: 'datasource',
-          query:: 'prometheus',
-        },
-        {
           name:: 'metrics',
           type:: 'datasource',
           query:: 'prometheus',


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
I think that the log count should be computed from loki instead of prometheus because:
- there is a $filter at the end of the query and this should be a logql filter AFAIK
- there is no metric name on the query

So the PR removes the "logmetrics" input and uses the loki input (`$logs`) to get the log count.
I may have misunderstood the reason to use a prometheus input instead of loki for this, do not hesitate if I'm wrong :).
