### PR TITLE
Helm chart: Update grafana install instructions

### DIFF
--- a/docs/sources/installation/helm.md
+++ b/docs/sources/installation/helm.md
@@ -5,8 +5,7 @@ title: Helm
 
 ## Prerequisites
 
-Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm) and
-[deployed](https://helm.sh/docs/using_helm/#installing-tiller) to your cluster.
+Make sure you have Helm 3 [installed](https://helm.sh/docs/intro/install/).
 
 Add [Loki's chart repository](https://github.com/grafana/loki/tree/master/production/helm/loki) to Helm:
 
@@ -64,7 +63,7 @@ helm upgrade --install loki loki/loki-stack \
 To install Grafana on your cluster with Helm, use the following command:
 
 ```bash
-helm install stable/grafana -n loki-grafana
+helm upgrade --install loki loki/loki-stack --set grafana.enabled=true
 ```
 
 To get the admin password for the Grafana pod, run the following command:
@@ -79,8 +78,9 @@ To access the Grafana UI, run the following command:
 kubectl port-forward --namespace <YOUR-NAMESPACE> service/loki-grafana 3000:80
 ```
 
-Navigate to `http://localhost:3000` and login with `admin` and the password
-output above. Then follow the [instructions for adding the Loki Data Source](../../getting-started/grafana/), using the URL
+Navigate to `http://localhost:3000` and login with `admin` and the
+password output above. Loki is added as a [Data
+Source](../../getting-started/grafana/) automatically using URL
 `http://loki:3100/` for Loki.
 
 ## Run Loki behind HTTPS ingress

--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm) and
-[deployed](https://helm.sh/docs/using_helm/#installing-tiller) to your cluster. Then add
+Make sure you have Helm 3
+[installed](https://helm.sh/docs/intro/install/). Then add
 Loki's chart repository to Helm:
 
 ```bash
@@ -84,11 +84,7 @@ $ helm upgrade --install loki loki/loki-stack \
 To install Grafana on your cluster with helm, use the following command:
 
 ```bash
-# with Helm 2
-$ helm install stable/grafana -n loki-grafana --namespace <YOUR-NAMESPACE>
-
-# with Helm 3
-$ helm install loki-grafana stable/grafana -n <YOUR-NAMESPACE>
+helm upgrade --install loki loki/loki-stack --set grafana.enabled=true
 ```
 
 > The chart loki-stack contains a pre-configured Grafana, simply use `--set grafana.enabled=true`
@@ -105,8 +101,10 @@ To access the Grafana UI, run the following command:
 $ kubectl port-forward --namespace <YOUR-NAMESPACE> service/loki-grafana 3000:80
 ```
 
-Navigate to http://localhost:3000 and login with `admin` and the password output above.
-Then follow the [instructions for adding the loki datasource](/docs/getting-started/grafana.md), using the URL `http://loki:3100/`.
+Navigate to `http://localhost:3000` and login with `admin` and the
+password output above. Loki is added as a [Data
+Source](../../getting-started/grafana/) automatically using URL
+`http://loki:3100/` for Loki.
 
 ## Run Loki behind https ingress
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

`stable/grafna` is deprecated and no longer indexed by default for helm 3.
helm 2 is unsupported. The helm chart is maintained in
https://github.com/grafana/helm-charts which requires a `halm add`.

Update the instructions to use the loki helm chart that provides grafana
out of the box and automatic setup of the data source.

**Special notes for your reviewer**:

`docs/sources/installation/helm.md` and `production/helm/README.md` seem to be duplicated documentation, would it make sense to have them as a symlink in the future so we don't have to update both files with the same changes?

**Checklist**
- [x] Documentation added
- [x] Tests updated

