### PR TITLE
Fixes iota unexpected behaviour with bytes for chunk encoding.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -27,10 +27,9 @@ const (
 	blocksPerChunk = 10
 	maxLineLength  = 1024 * 1024 * 1024
 
-	_ byte = iota
-	chunkFormatV1
-	chunkFormatV2
-	chunkFormatV3
+	chunkFormatV1 byte = 1
+	chunkFormatV2 byte = 2
+	chunkFormatV3 byte = 3
 )
 
 var (

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -24,12 +24,13 @@ import (
 )
 
 const (
+	_ byte = iota
+	chunkFormatV1
+	chunkFormatV2
+	chunkFormatV3
+
 	blocksPerChunk = 10
 	maxLineLength  = 1024 * 1024 * 1024
-
-	chunkFormatV1 byte = 1
-	chunkFormatV2 byte = 2
-	chunkFormatV3 byte = 3
 )
 
 var (


### PR DESCRIPTION
This was introducing incompatibilities since iota with bytes starts at 2.
Seems like a weird conversion between iota int and byte.

This can currently corrupt chunks, and previous chunks are not decodable. New chunk are decodable because we encode/decode with the wrong value, this is also why tests are passing.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
