### PR TITLE
Improve tailer matcher function.

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -310,6 +310,5 @@ func (s *stream) addTailer(t *tailer) {
 }
 
 func (s *stream) matchesTailer(t *tailer) bool {
-	metric := util.LabelsToMetric(s.labels)
-	return t.isWatchingLabels(metric)
+	return t.isWatchingLabels(s.labels)
 }

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -8,7 +8,6 @@ import (
 
 	cortex_util "github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"golang.org/x/net/context"
 
@@ -183,9 +182,9 @@ func (t *tailer) processStream(stream logproto.Stream) ([]logproto.Stream, error
 }
 
 // Returns true if tailer is interested in the passed labelset
-func (t *tailer) isWatchingLabels(metric model.Metric) bool {
+func (t *tailer) isWatchingLabels(lbs labels.Labels) bool {
 	for _, matcher := range t.matchers {
-		if !matcher.Matches(string(metric[model.LabelName(matcher.Name)])) {
+		if !matcher.Matches(lbs.Get(matcher.Name)) {
 			return false
 		}
 	}


### PR DESCRIPTION
Don't create a map on every new push of a stream or appearance of a new stream.

```
 benchcmp before.txt after.txt
benchmark                   old ns/op     new ns/op     delta
Benchmark_PushStream-16     10942         10801         -1.29%

benchmark                   old allocs     new allocs     delta
Benchmark_PushStream-16     6              4              -33.33%

benchmark                   old bytes     new bytes     delta
Benchmark_PushStream-16     4440          4427          -0.29%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

