### PR TITLE
fix table deletion in table client for boltdb-shipper

### DIFF
--- a/pkg/storage/stores/shipper/table_client.go
+++ b/pkg/storage/stores/shipper/table_client.go
@@ -48,7 +48,7 @@ func (b *boltDBShipperTableClient) Stop() {
 }
 
 func (b *boltDBShipperTableClient) DeleteTable(ctx context.Context, name string) error {
-	objects, dirs, err := b.objectClient.List(ctx, name, delimiter)
+	objects, dirs, err := b.objectClient.List(ctx, name+delimiter, delimiter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When listing contents of a directory in hosted object stores(s3, gcs etc), it needs to end with a separator otherwise get the list of all the directories starting with that prefix. The code was missing the delimiter causing deletion operation to find directories instead of files and hence fail the deletion operation.
This PR fixes it by adding a delimiter to the name of the table during list operation.

