### PR TITLE
Implement io.WriteTo by chunks.

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -2,6 +2,7 @@ package chunkenc
 
 import (
 	"context"
+	"io"
 	"sort"
 	"time"
 
@@ -106,6 +107,8 @@ func (c *dumbChunk) Bytes() ([]byte, error) {
 func (c *dumbChunk) BytesWith(_ []byte) ([]byte, error) {
 	return nil, nil
 }
+
+func (c *dumbChunk) WriteTo(w io.Writer) (int64, error) { return 0, nil }
 
 func (c *dumbChunk) Blocks(_ time.Time, _ time.Time) []Block {
 	return nil

--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -44,12 +44,10 @@ func (f Facade) Marshal(w io.Writer) error {
 	if f.c == nil {
 		return nil
 	}
-	buf, err := f.c.Bytes()
-	if err != nil {
+	if _, err := f.c.WriteTo(w); err != nil {
 		return err
 	}
-	_, err = w.Write(buf)
-	return err
+	return nil
 }
 
 // UnmarshalFromBuf implements encoding.Chunk.

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -105,6 +106,7 @@ type Chunk interface {
 	Size() int
 	Bytes() ([]byte, error)
 	BytesWith([]byte) ([]byte, error) // uses provided []byte for buffer instantiation
+	io.WriterTo
 	BlockCount() int
 	Utilization() float64
 	UncompressedSize() int

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"testing"
@@ -220,6 +221,8 @@ func (c *noopChunk) Bytes() ([]byte, error) {
 func (c *noopChunk) BytesWith(_ []byte) ([]byte, error) {
 	return nil, nil
 }
+
+func (c *noopChunk) WriteTo(w io.Writer) (int64, error) { return 0, nil }
 
 func (c *noopChunk) Blocks(_ time.Time, _ time.Time) []chunkenc.Block {
 	return nil


### PR DESCRIPTION
This allows to totally defer the buffer creation to the user.
`Marshal(w io.Writer) error` Now don't even need to create a buffer.


/cc @owen-d 
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


