### PR TITLE
Remove `helm init`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,6 @@ helm: PACKAGE_ARGS ?=
 helm:
 	-rm -f production/helm/*/requirements.lock
 	@set -e; \
-	helm init -c; \
 	helm repo add elastic https://helm.elastic.co ; \
 	helm repo add grafana https://grafana.github.io/helm-charts ; \
 	helm repo add prometheus https://prometheus-community.github.io/helm-charts ; \
@@ -351,8 +350,6 @@ helm:
 	rm -f production/helm/*/requirements.lock
 
 helm-install:
-	kubectl apply -f tools/helm.yaml
-	helm init --wait --service-account helm --upgrade
 	HELM_ARGS="$(HELM_ARGS)" $(MAKE) helm-upgrade
 
 helm-install-fluent-bit:


### PR DESCRIPTION
As helm v2 is EOF, I removed the commands only present in helm v2.

Fixes #2966

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What this PR does / why we need it**:

This PR remove helm v2 specific commands which break the Makefile usage with helm v3.
As helm v2 is EOF I just removed the commands and didn't test which helm version is used.

**Checklist**
- [-] Documentation added
- [-] Tests updated

