### PR TITLE
logcli: Fix logcli logql document URL

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -70,7 +70,7 @@ you should always use the "query" command when you are running log queries.
 For more information about log queries and metric queries, refer to the
 LogQL documentation:
 
-https://github.com/grafana/loki/blob/master/docs/logql.md`)
+https://grafana.com/docs/loki/latest/logql/`)
 	instantQuery = newQuery(true, instantQueryCmd)
 
 	labelsCmd   = app.Command("labels", "Find values for a given label.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
I was unable to open the logql url contained in the logcli help message. Thus I fixed the URL to logql documentation of grafana.com.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

