### PR TITLE
Collapse multiline logs based on a start line.

### DIFF
--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -1,0 +1,93 @@
+package stages
+
+import (
+	"bytes"
+	"regexp"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	ErrMultilineStageEmptyConfig  = "multiline stage config must define `firstline` regular expression"
+	ErrMultilineStageInvalidRegex = "multiline stage first line regex compilation error: %v"
+)
+
+const MultilineDropReason = "multiline collapse"
+
+// MultilineConfig contains the configuration for a multilineStage 
+type MultilineConfig struct {
+	Expression *string `mapstructure:"firstline"`
+	regex      *regexp.Regexp
+}
+
+func validateMultilineConfig(cfg *MultilineConfig) error {
+	if cfg == nil ||
+		(cfg.Expression == nil) {
+		return errors.New(ErrMultilineStageEmptyConfig)
+	}
+	expr, err := regexp.Compile(*cfg.Expression)
+	if err != nil {
+		return errors.Errorf(ErrMultilineStageInvalidRegex, err)
+	}
+		cfg.regex = expr
+
+	return nil
+}
+
+// newMulitlineStage creates a MulitlineStage from config
+func newMultilineStage(logger log.Logger, config interface{}) (Stage, error) {
+	cfg := &MultilineConfig{}
+	err := mapstructure.WeakDecode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	err = validateMultilineConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &multilineStage{
+		logger: log.With(logger, "component", "stage", "type", "multiline"),
+		cfg:    cfg,
+		buffer: new(bytes.Buffer),
+	}, nil
+}
+
+// dropMultiline matches lines to determine whether the following lines belong to a block and should be collapsed
+type multilineStage struct {
+	logger log.Logger
+	cfg    *MultilineConfig
+	buffer *bytes.Buffer
+}
+
+// Process implements Stage
+func (m *multilineStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	isFirstLine := m.cfg.regex.MatchString(*entry)
+
+	if isFirstLine {
+		previous := m.buffer.String()
+
+		m.buffer.Reset()
+		m.buffer.WriteString(*entry)
+
+		*entry = previous
+	} else {
+		// Append block line
+		if m.buffer.Len() > 0 {
+			m.buffer.WriteRune('\n')
+		}
+		m.buffer.WriteString(*entry)
+
+		// Adds the drop label to not be sent by the api.EntryHandler
+		labels[dropLabel] = model.LabelValue(MultilineDropReason)
+	}
+}
+
+// Name implements Stage
+func (m *multilineStage) Name() string {
+	return StageTypeMultiline
+}

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 )
 
@@ -18,7 +18,7 @@ const (
 
 const MultilineDropReason = "multiline collapse"
 
-// MultilineConfig contains the configuration for a multilineStage 
+// MultilineConfig contains the configuration for a multilineStage
 type MultilineConfig struct {
 	Expression *string `mapstructure:"firstline"`
 	regex      *regexp.Regexp
@@ -33,7 +33,7 @@ func validateMultilineConfig(cfg *MultilineConfig) error {
 	if err != nil {
 		return errors.Errorf(ErrMultilineStageInvalidRegex, err)
 	}
-		cfg.regex = expr
+	cfg.regex = expr
 
 	return nil
 }

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,0 +1,40 @@
+package stages
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	ww "github.com/weaveworks/common/server"
+)
+func Test_multilineStage_Process(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"),}
+	validateMultilineConfig(mcfg)
+	stage := &multilineStage{
+		cfg: mcfg,
+		logger: util.Logger,
+		buffer: new(bytes.Buffer),
+	}
+
+	stage.Process(model.LabelSet{}, map[string]interface{}{}, ptrFromTime(time.Now()), ptrFromString("START line 1"))
+	stage.Process(model.LabelSet{}, map[string]interface{}{}, ptrFromTime(time.Now()), ptrFromString("not a start line"))
+
+	nextStart := "START line 2"
+	stage.Process(model.LabelSet{}, map[string]interface{}{}, ptrFromTime(time.Now()), &nextStart)
+
+	require.Equal(t, "START line 1\nnot a start line", nextStart)
+
+	nextStart = "START line 3"
+	stage.Process(model.LabelSet{}, map[string]interface{}{}, ptrFromTime(time.Now()), &nextStart)
+
+	require.Equal(t, "START line 2", nextStart)
+}

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ww "github.com/weaveworks/common/server"
 )
+
 func Test_multilineStage_Process(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
@@ -17,10 +18,12 @@ func Test_multilineStage_Process(t *testing.T) {
 	util.InitLogger(cfg)
 	Debug = true
 
-	mcfg := &MultilineConfig{Expression: ptrFromString("^START"),}
-	validateMultilineConfig(mcfg)
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START")}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
 	stage := &multilineStage{
-		cfg: mcfg,
+		cfg:    mcfg,
 		logger: util.Logger,
 		buffer: new(bytes.Buffer),
 	}

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -25,6 +25,7 @@ const (
 	StageTypePipeline  = "pipeline"
 	StageTypeTenant    = "tenant"
 	StageTypeDrop      = "drop"
+	StageTypeMultiline = "multiline"
 )
 
 // Stage takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -115,6 +116,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeDrop:
 		s, err = newDropStage(logger, cfg)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeMultiline:
+		s, err = newMultilineStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Summary:
This is a very simple approach based on #1380 to provide multiline
or block log entries in promtail.

A `multiline` stage is added to pipelines. This stages matches a start
line. Once a start line is matched all following lines are appended
to an entry and "dropped". Once a new start line is matched the former
block of multilines is send.

This approach has two downside because log entires are not sent until a
new start line is matched.

1. Lines can linger for a long time. The multiline stage should flush out
   lines if now new start line is matched in a certain time frame.
   However, the current pipeline interface cannot actively push entries.
   So a time based flushing would require a bigger refactoring.

2. If the observed system crashes the last log lines are not sent. Thus
   important information might be lost.