### PR TITLE
Add ProcessString to Pipeline.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -623,8 +623,7 @@ func (hb *headBlock) iterator(ctx context.Context, direction logproto.Direction,
 	streams := map[uint64]*logproto.Stream{}
 	for _, e := range hb.entries {
 		chunkStats.HeadChunkBytes += int64(len(e.s))
-		line := []byte(e.s)
-		newLine, parsedLbs, ok := pipeline.Process(line)
+		newLine, parsedLbs, ok := pipeline.ProcessString(e.s)
 		if !ok {
 			continue
 		}
@@ -638,7 +637,7 @@ func (hb *headBlock) iterator(ctx context.Context, direction logproto.Direction,
 		}
 		stream.Entries = append(stream.Entries, logproto.Entry{
 			Timestamp: time.Unix(0, e.t),
-			Line:      string(newLine),
+			Line:      newLine,
 		})
 
 	}
@@ -662,8 +661,7 @@ func (hb *headBlock) sampleIterator(ctx context.Context, mint, maxt int64, extra
 	series := map[uint64]*logproto.Series{}
 	for _, e := range hb.entries {
 		chunkStats.HeadChunkBytes += int64(len(e.s))
-		line := []byte(e.s)
-		value, parsedLabels, ok := extractor.Process(line)
+		value, parsedLabels, ok := extractor.ProcessString(e.s)
 		if !ok {
 			continue
 		}

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -676,7 +676,7 @@ func (hb *headBlock) sampleIterator(ctx context.Context, mint, maxt int64, extra
 		}
 
 		// []byte here doesn't create allocation because Sum64 has go:noescape directive
-		// which means the pointer created cannot escape the heap.
+		// It specifies that the function does not allow any of the pointers passed as arguments to escape into the heap or into the values returned from the function.
 		h := xxhash.Sum64([]byte(e.s))
 		s.Samples = append(s.Samples, logproto.Sample{
 			Timestamp: e.t,

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -674,10 +674,14 @@ func (hb *headBlock) sampleIterator(ctx context.Context, mint, maxt int64, extra
 			}
 			series[lhash] = s
 		}
+
+		// []byte here doesn't create allocation because Sum64 has go:noescape directive
+		// which means the pointer created cannot escape the heap.
+		h := xxhash.Sum64([]byte(e.s))
 		s.Samples = append(s.Samples, logproto.Sample{
 			Timestamp: e.t,
 			Value:     value,
-			Hash:      xxhash.Sum64([]byte(e.s)),
+			Hash:      h,
 		})
 	}
 

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -717,6 +717,32 @@ func BenchmarkHeadBlockIterator(b *testing.B) {
 	}
 }
 
+func BenchmarkHeadBlockSampleIterator(b *testing.B) {
+
+	for _, j := range []int{100000, 50000, 15000, 10000} {
+		b.Run(fmt.Sprintf("Size %d", j), func(b *testing.B) {
+
+			h := headBlock{}
+
+			for i := 0; i < j; i++ {
+				if err := h.append(int64(i), "this is the append string"); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				iter := h.sampleIterator(context.Background(), 0, math.MaxInt64, countExtractor)
+
+				for iter.Next() {
+					_ = iter.Sample()
+				}
+			}
+		})
+	}
+}
+
 func TestMemChunk_IteratorBounds(t *testing.T) {
 
 	var createChunk = func() *MemChunk {

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -158,7 +158,7 @@ func (t *tailer) processStream(stream logproto.Stream) ([]logproto.Stream, error
 	}
 	sp := t.pipeline.ForStream(lbs)
 	for _, e := range stream.Entries {
-		newLine, parsedLbs, ok := sp.Process([]byte(e.Line))
+		newLine, parsedLbs, ok := sp.ProcessString(e.Line)
 		if !ok {
 			continue
 		}
@@ -171,7 +171,7 @@ func (t *tailer) processStream(stream logproto.Stream) ([]logproto.Stream, error
 		}
 		stream.Entries = append(stream.Entries, logproto.Entry{
 			Timestamp: e.Timestamp,
-			Line:      string(newLine),
+			Line:      newLine,
 		})
 	}
 	streamsResult := make([]logproto.Stream, 0, len(streams))

--- a/pkg/logentry/stages/match.go
+++ b/pkg/logentry/stages/match.go
@@ -133,13 +133,13 @@ func (m *matcherStage) Process(lbs model.LabelSet, extracted map[string]interfac
 	}
 
 	sp := m.pipeline.ForStream(labels.FromMap(util.ModelLabelSetToMap(lbs)))
-	if newLine, newLabels, ok := sp.Process([]byte(*entry)); ok {
+	if newLine, newLabels, ok := sp.ProcessString(*entry); ok {
 		switch m.action {
 		case MatchActionDrop:
 			// Adds the drop label to not be sent by the api.EntryHandler
 			lbs[dropLabel] = model.LabelValue(m.dropReason)
 		case MatchActionKeep:
-			*entry = string(newLine)
+			*entry = newLine
 			for k := range lbs {
 				delete(lbs, k)
 			}

--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -117,6 +117,11 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 			require.Equal(t, tt.wantOk, ok)
 			require.Equal(t, tt.want, outval)
 			require.Equal(t, tt.wantLbs, outlbs.Labels())
+
+			outval, outlbs, ok = tt.ex.ForStream(tt.in).ProcessString("")
+			require.Equal(t, tt.wantOk, ok)
+			require.Equal(t, tt.want, outval)
+			require.Equal(t, tt.wantLbs, outlbs.Labels())
 		})
 	}
 }
@@ -139,6 +144,11 @@ func TestNewLineSampleExtractor(t *testing.T) {
 	sort.Sort(lbs)
 	sse := se.ForStream(lbs)
 	f, l, ok := sse.Process([]byte(`foo`))
+	require.True(t, ok)
+	require.Equal(t, 1., f)
+	assertLabelResult(t, lbs, l)
+
+	f, l, ok = sse.ProcessString(`foo`)
 	require.True(t, ok)
 	require.Equal(t, 1., f)
 	assertLabelResult(t, lbs, l)


### PR DESCRIPTION
Most of the time, you have a buffer that you want to test again a log pipeline, when it passed you usually copy via string(buff).

In some cases like headchunk and tailer you already have an allocated immutable string, since pipeline never mutate the line passed as parameter, we can create ProcessString pipeline method that will avoid re-allocating the line.

I've also added some missing tests.

benchmp:

```
❯ benchcmp before.txt after.txt
benchmark                                           old ns/op     new ns/op     delta
BenchmarkHeadBlockIterator/Size_100000-16           20264242      16112591      -20.49%
BenchmarkHeadBlockIterator/Size_50000-16            10186969      7905259       -22.40%
BenchmarkHeadBlockIterator/Size_15000-16            3229052       2202770       -31.78%
BenchmarkHeadBlockIterator/Size_10000-16            1916537       1392355       -27.35%
BenchmarkHeadBlockSampleIterator/Size_100000-16     18364773      16106425      -12.30%
BenchmarkHeadBlockSampleIterator/Size_50000-16      8988422       7730226       -14.00%
BenchmarkHeadBlockSampleIterator/Size_15000-16      2788746       2306161       -17.30%
BenchmarkHeadBlockSampleIterator/Size_10000-16      1773766       1488861       -16.06%

benchmark                                           old allocs     new allocs     delta
BenchmarkHeadBlockIterator/Size_100000-16           200039         39             -99.98%
BenchmarkHeadBlockIterator/Size_50000-16            100036         36             -99.96%
BenchmarkHeadBlockIterator/Size_15000-16            30031          31             -99.90%
BenchmarkHeadBlockIterator/Size_10000-16            20029          29             -99.86%
BenchmarkHeadBlockSampleIterator/Size_100000-16     100040         40             -99.96%
BenchmarkHeadBlockSampleIterator/Size_50000-16      50036          36             -99.93%
BenchmarkHeadBlockSampleIterator/Size_15000-16      15031          31             -99.79%
BenchmarkHeadBlockSampleIterator/Size_10000-16      10029          29             -99.71%

benchmark                                           old bytes     new bytes     delta
BenchmarkHeadBlockIterator/Size_100000-16           27604042      21203941      -23.19%
BenchmarkHeadBlockIterator/Size_50000-16            13860654      10660652      -23.09%
BenchmarkHeadBlockIterator/Size_15000-16            4231360       3271363       -22.69%
BenchmarkHeadBlockIterator/Size_10000-16            2633436       1993420       -24.30%
BenchmarkHeadBlockSampleIterator/Size_100000-16     17799137      14598973      -17.98%
BenchmarkHeadBlockSampleIterator/Size_50000-16      7433260       5833137       -21.53%
BenchmarkHeadBlockSampleIterator/Size_15000-16      2258099       1778096       -21.26%
BenchmarkHeadBlockSampleIterator/Size_10000-16      1393600       1073605       -22.96%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


