### PR TITLE
fluent-bit: Rename Fluent Bit plugin output name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,8 +272,8 @@ clean:
 	rm -rf .cache
 	rm -rf cmd/docker-driver/rootfs
 	rm -rf dist/
-	rm -rf cmd/fluent-bit/out_loki.h
-	rm -rf cmd/fluent-bit/out_loki.so
+	rm -rf cmd/fluent-bit/out_grafana_loki.h
+	rm -rf cmd/fluent-bit/out_grafana_loki.so
 	go clean $(MOD_FLAG) ./...
 
 #########
@@ -420,7 +420,7 @@ docker-driver-clean:
 # fluent-bit plugin #
 #####################
 fluent-bit-plugin:
-	go build $(DYN_GO_FLAGS) -buildmode=c-shared -o cmd/fluent-bit/out_loki.so ./cmd/fluent-bit/
+	go build $(DYN_GO_FLAGS) -buildmode=c-shared -o cmd/fluent-bit/out_grafana_loki.so ./cmd/fluent-bit/
 
 fluent-bit-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/fluent-bit-plugin-loki:$(IMAGE_TAG) -f cmd/fluent-bit/Dockerfile .

--- a/cmd/fluent-bit/Dockerfile
+++ b/cmd/fluent-bit/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin
 
 FROM fluent/fluent-bit:1.4
-COPY --from=build /src/loki/cmd/fluent-bit/out_loki.so /fluent-bit/bin
+COPY --from=build /src/loki/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/bin
 COPY cmd/fluent-bit/fluent-bit.conf /fluent-bit/etc/fluent-bit.conf
 EXPOSE 2020
-CMD ["/fluent-bit/bin/fluent-bit", "-e","/fluent-bit/bin/out_loki.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+CMD ["/fluent-bit/bin/fluent-bit", "-e","/fluent-bit/bin/out_grafana_loki.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/cmd/fluent-bit/README.md
+++ b/cmd/fluent-bit/README.md
@@ -13,7 +13,7 @@ Prerequisites:
 * Go 1.11+
 * gcc (for cgo)
 
-To build the output plugin library file (`out_loki.so`), you can use:
+To build the output plugin library file (`out_grafana_loki.so`), you can use:
 
 ```bash
 make fluent-bit-plugin

--- a/cmd/fluent-bit/fluent-bit.conf
+++ b/cmd/fluent-bit/fluent-bit.conf
@@ -2,7 +2,7 @@
     Name        tail
     Path        ${LOG_PATH}
 [Output]
-    Name loki
+    Name grafana-loki
     Match *
     Url ${LOKI_URL}
     BatchWait 1s

--- a/cmd/fluent-bit/out_grafana_loki.go
+++ b/cmd/fluent-bit/out_grafana_loki.go
@@ -37,7 +37,7 @@ func (c *pluginConfig) Get(key string) string {
 
 //export FLBPluginRegister
 func FLBPluginRegister(ctx unsafe.Pointer) int {
-	return output.FLBPluginRegister(ctx, "loki", "Ship fluent-bit logs to Grafana Loki")
+	return output.FLBPluginRegister(ctx, "grafana-loki", "Ship fluent-bit logs to Grafana Loki")
 }
 
 //export FLBPluginInit

--- a/docs/sources/clients/aws/ecs/_index.md
+++ b/docs/sources/clients/aws/ecs/_index.md
@@ -154,7 +154,7 @@ All `options` of the `logConfiguration` will be automatically translated into [f
 
 ```conf
 [OUTPUT]
-    Name loki
+    Name grafana-loki
     Match awsfirelens*
     Url https://<userid>:<grafancloud apikey>@logs-prod-us-central1.grafana.net/loki/api/v1/push
     Labels {job="firelens"}

--- a/docs/sources/clients/fluentbit/_index.md
+++ b/docs/sources/clients/fluentbit/_index.md
@@ -53,14 +53,14 @@ First, you need to follow the [instructions](https://github.com/grafana/loki/blo
 The assuming you have Fluent Bit installed in your `$PATH` you can run the plugin using:
 
 ```bash
-fluent-bit -e /path/to/built/out_loki.so -c fluent-bit.conf
+fluent-bit -e /path/to/built/out_grafana_loki.so -c fluent-bit.conf
 ```
 
 You can also adapt your plugins.conf, removing the need to change the command line options:
 
 ```conf
 [PLUGINS]
-    Path /path/to/built/out_loki.so
+    Path /path/to/built/out_grafana_loki.so
 ```
 
 ## Configuration Options
@@ -155,7 +155,7 @@ Loki output plugin has buffering mechanism based on [`dque`](https://github.com/
 
 ```properties
 [Output]
-    Name loki
+    Name grafana-loki
     Match *
     Url http://localhost:3100/loki/api/v1/push
     Buffer true
@@ -170,7 +170,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
 
 ```properties
 [Output]
-    Name loki
+    Name grafana-loki
     Match *
     Url http://localhost:3100/loki/api/v1/push
     BatchWait 1s
@@ -184,7 +184,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
 
 ```properties
 [Output]
-    Name loki
+    Name grafana-loki
     Match *
     Url http://localhost:3100/loki/api/v1/push
     BatchWait 1s

--- a/production/helm/fluent-bit/templates/configmap.yaml
+++ b/production/helm/fluent-bit/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
         K8S-Logging.Exclude {{ .Values.config.k8sLoggingExclude }}
         K8S-Logging.Parser {{ .Values.config.k8sLoggingParser }}
     [Output]
-        Name loki
+        Name grafana-loki
         Match *
         {{- if and .Values.loki.user .Values.loki.password }}
         Url {{ .Values.loki.serviceScheme }}://{{ .Values.loki.user }}:{{ .Values.loki.password }}@{{ include "loki.serviceName" . }}:{{ .Values.loki.servicePort }}{{ .Values.loki.servicePath }}


### PR DESCRIPTION
This prevents a clash with the Loki plugin now included with
the Fluent Bit agent by default.

The output plugin is now named `grafana-loki`.

Signed-off-by: Heds Simons <heds@whaleway.net>

**What this PR does / why we need it**:
Fluent Bit now ships with their version of a Loki output plugin. Unfortunately, they named it `loki`, so when trying to use the Grafana Loki Fluent Bit plugin a clash occurs and Fluent Bit exits.

This PR changes the name of the Loki output stage to `grafana-loki` to circumvent this and allow the plugin to continue working.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Tested by building both the Fluent Bit plugin (via `make fluent-bit-plugin`) and running it against the latest Fluent Bit client.
Also built and tested the Fluent Bit docker image.
Both were tested against a Grafana hosted remote Loki endpoint.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

