### PR TITLE
Fixes vector grouping injection.

### DIFF
--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -3,10 +3,11 @@ package logql
 import (
 	"testing"
 
-	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logql/log"
 )
 
 func Test_logSelectorExpr_String(t *testing.T) {

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/grafana/loki/pkg/logql/log"
-
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,4 +338,41 @@ func mustNewRegexParser(re string) log.Stage {
 		panic(err)
 	}
 	return r
+}
+
+func Test_canInjectVectorGrouping(t *testing.T) {
+
+	tests := []struct {
+		vecOp   string
+		rangeOp string
+		want    bool
+	}{
+		{OpTypeSum, OpRangeTypeBytes, true},
+		{OpTypeSum, OpRangeTypeBytesRate, true},
+		{OpTypeSum, OpRangeTypeSum, true},
+		{OpTypeSum, OpRangeTypeRate, true},
+		{OpTypeSum, OpRangeTypeCount, true},
+
+		{OpTypeSum, OpRangeTypeAvg, false},
+		{OpTypeSum, OpRangeTypeMax, false},
+		{OpTypeSum, OpRangeTypeQuantile, false},
+		{OpTypeSum, OpRangeTypeStddev, false},
+		{OpTypeSum, OpRangeTypeStdvar, false},
+		{OpTypeSum, OpRangeTypeMin, false},
+		{OpTypeSum, OpRangeTypeMax, false},
+
+		{OpTypeAvg, OpRangeTypeBytes, false},
+		{OpTypeCount, OpRangeTypeBytesRate, false},
+		{OpTypeBottomK, OpRangeTypeSum, false},
+		{OpTypeMax, OpRangeTypeRate, false},
+		{OpTypeMin, OpRangeTypeCount, false},
+		{OpTypeTopK, OpRangeTypeCount, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.vecOp+"_"+tt.rangeOp, func(t *testing.T) {
+			if got := canInjectVectorGrouping(tt.vecOp, tt.rangeOp); got != tt.want {
+				t.Errorf("canInjectVectorGrouping() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
During an improvement I introduced a bug where we would pre-aggregate some range vector
aggregations, although the result is not the same.

We can only inject vector grouping in range vector if the operation is associative through grouping.

This is not the case for max/min/stddev/stddvar/quantile/avg_over_time.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

