### PR TITLE
Loki: handle faults when opening boltdb files

### DIFF
--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -138,7 +138,7 @@ func SafeOpenBoltdbFile(path string) (*bbolt.DB, error) {
 }
 
 func safeOpenBoltDbFile(path string, ret chan *result) {
-	// boltdb can throw faults which are not caught be recover unless we turn them into panics
+	// boltdb can throw faults which are not caught by recover unless we turn them into panics
 	debug.SetPanicOnFault(true)
 	res := &result{}
 

--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -127,7 +127,7 @@ type result struct {
 }
 
 // SafeOpenBoltdbFile will recover from a panic opening a DB file, and return the panic message in the err return object.
-func SafeOpenBoltdbFile(path string) (boltdb *bbolt.DB, err error) {
+func SafeOpenBoltdbFile(path string) (*bbolt.DB, error) {
 	result := make(chan *result)
 	// Open the file in a separate goroutine because we want to change
 	// the behavior of a Fault for just this operation and not for the

--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -123,7 +123,7 @@ func CompressFile(src, dest string) error {
 
 type result struct {
 	boltdb *bbolt.DB
-	err error
+	err    error
 }
 
 // SafeOpenBoltdbFile will recover from a panic opening a DB file, and return the panic message in the err return object.


### PR DESCRIPTION
A recent PR handled panics, however we also get faults when opening boltdb files.

This PR launches the opening of the file in a new goroutine so we can enable debug.SetPanicOnFault for just this operation and catch these faults to recover from them.