### PR TITLE
Documentation:  Add a missing field to the extended config s3 example

### DIFF
--- a/docs/sources/configuration/examples.md
+++ b/docs/sources/configuration/examples.md
@@ -162,6 +162,7 @@ or expanded config can be used.
 ```yaml
 storage_config:
   aws:
+    bucketnames: bucket_name1, bucket_name2
     endpoint: s3.endpoint.com
     region: s3_region
     access_key_id: s3_access_key_id


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki does not do a great job complaining when the S3 configuration is invalid - instead, apparently [it tries to hang indefinitely](https://github.com/grafana/loki/issues/1331).  It then naturally follows that good documentation is required, so that we don't lose hours combing through code, force deleting pods, and the like.

This PR addresses a gap in documentation, where _how to get a bucket name into the config_ is not demonstrated.  Notably, the code suggests that this new parameter can be used to evenly distribute logs to multiple buckets, so we add that to the example.

**Which issue(s) this PR fixes**:
Fixes life-stealing frustrations and dental bills from gnashed teeth.

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated

