### PR TITLE
Helm Chart: Fix schema of logstash default values

### DIFF
--- a/production/helm/loki-stack/Chart.yaml
+++ b/production/helm/loki-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki-stack
-version: 2.1.0
+version: 2.1.1
 appVersion: v2.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki-stack/values.yaml
+++ b/production/helm/loki-stack/values.yaml
@@ -38,9 +38,8 @@ filebeat:
 
 logstash:
   enabled: false
-  image:
-    repository: grafana/logstash-output-loki
-    tag: 1.0.1
+  image: grafana/logstash-output-loki
+  imageTag: 1.0.1
   filters:
     main: |-
       filter {


### PR DESCRIPTION
**What this PR does / why we need it**:
See #3003 for details. TLDR: the schema of the default values for the logstash component of the loki-stack helm chart is incorrect. This PR corrects the schema so that setting `logstash.enabled=true` will work by default.

**Which issue(s) this PR fixes**:
Fixes #3003

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added (not applicable)
- [x] Tests updated

