### PR TITLE
Fixes promtail mixin dashboard.

### DIFF
--- a/production/promtail-mixin/dashboards.libsonnet
+++ b/production/promtail-mixin/dashboards.libsonnet
@@ -76,7 +76,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       g.row('Requests')
       .addPanel(
         g.panel('QPS') +
-        g.qpsPanel('promtail_request_duration_seconds_count{%s}')
+        g.qpsPanel('promtail_request_duration_seconds_count{%s}' % dashboards['promtail.json'].selector)
       )
       .addPanel(
         g.panel('Latency') +

--- a/production/promtail-mixin/recording_rules.libsonnet
+++ b/production/promtail-mixin/recording_rules.libsonnet
@@ -5,6 +5,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     groups+: [{
       name: 'promtail_rules',
       rules:
+        utils.histogramRules('promtail_request_duration_seconds', ['job']) +
         utils.histogramRules('promtail_request_duration_seconds', ['job', 'namespace']) +
         utils.histogramRules('promtail_request_duration_seconds', ['job', 'status_code', 'namespace']),
     }],


### PR DESCRIPTION
 e14463b  removed a metric that was used previously in a dashboard could not find a better way yet to use the new metric so instead I added back the recording rules.

Also fixes a missing template expansion from 899e8cc.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


