### PR TITLE
Collapse multiline logs based on a start line.

### DIFF
--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -206,6 +206,7 @@ Parsing stages:
 
 Transform stages:
 
+  - [multiline](../stages/multiline/): Merges multiple lines, e.g. stack traces, into multiline blocks.
   - [template](../stages/template/): Use Go templates to modify extracted data.
 
 Action stages:

--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -4,18 +4,63 @@ title: multiline
 
 # `multiline` stage
 
-...
+The `multiline` stage multiple lines into a multiline block before passing it on to the next stage in the pipeline.
+
+A new block is identified by the `firstline` regular expression. Any line that does *not* match the expression is considered to be part of the block of the previous match.
 
 ## Schema
 
 ```yaml
 multiline:
-  # TODO: document
+  # RE2 regular expression, if matched will start a new multiline block.
+  # This expresion must be provided.
   firstline: <string>
 
-  # TODO: document
-  max_lines: <integer>
-
-  # TODO: document
+  # The maximum wait time will be parsed as a Go duration: https://golang.org/pkg/time/#ParseDuration.
+  # If now new logs arrive withing this maximum wait time the current block will be sent on.
+  # This is useful if the opserved application dies with e.g. an exception. No new logs will arrive and the exception
+  # block is sent *after* the maximum wait time expired.
   max_wait_time: <duration>
+
+  # Maximum number of lines a block can have. If block has more lines a new block is started.
+  # The default is 128 lines.
+  max_lines: <integer>
+```
+
+## Examples
+
+Let's say we have the following logs from a very simple [flask](https://flask.palletsprojects.com) service.
+
+```
+[2020-12-03 11:36:20] "GET /hello HTTP/1.1" 200 -
+[2020-12-03 11:36:23] ERROR in app: Exception on /error [GET]
+Traceback (most recent call last):
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
+    response = self.full_dispatch_request()
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
+    rv = self.handle_user_exception(e)
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception
+    reraise(exc_type, exc_value, tb)
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
+    raise value
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
+    rv = self.dispatch_request()
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
+    return self.view_functions[rule.endpoint](**req.view_args)
+  File "/home/pallets/src/deployment_tools/hello.py", line 10, in error
+    raise Exception("Sorry, this route always breaks")
+Exception: Sorry, this route always breaks
+[2020-12-03 11:36:23] "GET /error HTTP/1.1" 500 -
+[2020-12-03 11:36:26] "GET /hello HTTP/1.1" 200 -
+[2020-12-03 11:36:27] "GET /hello HTTP/1.1" 200 -
+```
+
+We would like to collapse all lines of the traceback into one multiline block. All blocks start with a timestamp in brackets. Thus we configure a `multiline` stage with the `firstline` regular expression `^\[\d{4}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2}\]`. This will match the start of the traceback but not the following lines until `Exception: Sorry, this route always breaks`. These will be part of a multiline block and one log entry in Loki.
+
+```yaml
+multiline:
+  # Identify timestamps as first line of a multiline block.
+  firstline: "^\[\d{4}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2}\]"
+
+  max_wait_time: 3s
 ```

--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -20,6 +20,7 @@ multiline:
   # If now new logs arrive withing this maximum wait time the current block will be sent on.
   # This is useful if the opserved application dies with e.g. an exception. No new logs will arrive and the exception
   # block is sent *after* the maximum wait time expired.
+  # It defaults to 3s.
   max_wait_time: <duration>
 
   # Maximum number of lines a block can have. If block has more lines a new block is started.

--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -1,0 +1,21 @@
+---
+title: multiline 
+---
+
+# `multiline` stage
+
+...
+
+## Schema
+
+```yaml
+multiline:
+  # TODO: document
+  firstline: <string>
+
+  # TODO: document
+  max_lines: <integer>
+
+  # TODO: document
+  max_wait_time: <duration>
+```

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -175,7 +175,7 @@ func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.Wa
 	}
 }
 
-func (m *multilineStage) flush(out chan Entry, s *multilineState) {
+flush(out chan Entry, s *multilineState) {
 	if s.buffer.Len() == 0 {
 		level.Debug(m.logger).Log("msg", "nothing to flush", "buffer_len", s.buffer.Len())
 		return

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -102,6 +102,13 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 			key := e.Labels.FastFingerprint()
 			s, ok := streams[key]
 			if !ok {
+				// Pass through entries until we hit first start line.
+				if !m.cfg.regex.MatchString(e.Line) {
+					level.Debug(m.logger).Log("msg", "pass through entry", "stream", key)
+					out <- e
+					continue
+				}
+
 				level.Debug(m.logger).Log("msg", "creating new stream", "stream", key)
 				s = make(chan Entry)
 				streams[key] = s

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -15,15 +15,15 @@ import (
 )
 
 const (
-	ErrMultilineStageEmptyConfig  = "multiline stage config must define `firstline` regular expression"
-	ErrMultilineStageInvalidRegex = "multiline stage first line regex compilation error: %v"
+	ErrMultilineStageEmptyConfig        = "multiline stage config must define `firstline` regular expression"
+	ErrMultilineStageInvalidRegex       = "multiline stage first line regex compilation error: %v"
 	ErrMultilineStageInvalidMaxWaitTime = "multiline stage `max_wait_time` parse error: %v"
 )
 
 // MultilineConfig contains the configuration for a multilineStage
 type MultilineConfig struct {
 	Expression  *string `mapstructure:"firstline"`
-	MaxWaitTime *string  `mapstructure:"max_wait_time"`
+	MaxWaitTime *string `mapstructure:"max_wait_time"`
 	maxWait     time.Duration
 	regex       *regexp.Regexp
 }
@@ -50,9 +50,9 @@ func validateMultilineConfig(cfg *MultilineConfig) error {
 
 // dropMultiline matches lines to determine whether the following lines belong to a block and should be collapsed
 type multilineStage struct {
-	logger log.Logger
-	cfg    *MultilineConfig
-	buffer *bytes.Buffer
+	logger         log.Logger
+	cfg            *MultilineConfig
+	buffer         *bytes.Buffer
 	startLineEntry Entry
 }
 
@@ -81,14 +81,14 @@ func (m *multilineStage) Run(in chan Entry) chan Entry {
 		defer close(out)
 		for {
 			select {
-			case <- time.After(m.cfg.maxWait):
+			case <-time.After(m.cfg.maxWait):
 				level.Debug(m.logger).Log("msg", fmt.Sprintf("flush multiline block due to %v timeout", m.cfg.maxWait), "block", m.buffer.String())
 				m.flush(out)
-			case e, ok := <- in:
+			case e, ok := <-in:
 				if !ok {
 					level.Debug(m.logger).Log("msg", "flush multiline block because inbound closed", "block", m.buffer.String())
 					m.flush(out)
-					return	
+					return
 				}
 
 				isFirstLine := m.cfg.regex.MatchString(e.Line)
@@ -121,7 +121,7 @@ func (m *multilineStage) flush(out chan Entry) {
 			Labels: m.startLineEntry.Entry.Labels,
 			Entry: logproto.Entry{
 				Timestamp: m.startLineEntry.Entry.Entry.Timestamp,
-				Line: m.buffer.String(),
+				Line:      m.buffer.String(),
 			},
 		},
 	}

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -25,7 +25,7 @@ const (
 
 const (
 	maxLineDefault uint64 = 128
-	maxWaitDefault = 3 * time.Second
+	maxWaitDefault        = 3 * time.Second
 )
 
 // MultilineConfig contains the configuration for a multilineStage
@@ -196,7 +196,7 @@ func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.Wa
 	}
 }
 
-func(m *multilineStage) flush(out chan Entry, s *multilineState) {
+func (m *multilineStage) flush(out chan Entry, s *multilineState) {
 	if s.buffer.Len() == 0 {
 		if Debug {
 			level.Debug(m.logger).Log("msg", "nothing to flush", "buffer_len", s.buffer.Len())

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -1,0 +1,125 @@
+package stages
+
+import (
+	"bytes"
+	"regexp"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+const (
+	ErrMultilineStageEmptyConfig  = "multiline stage config must define `firstline` regular expression"
+	ErrMultilineStageInvalidRegex = "multiline stage first line regex compilation error: %v"
+	ErrMultilineStageInvalidMaxWaitTime = "multiline stage `max_wait_time` parse error: %v"
+)
+
+// MultilineConfig contains the configuration for a multilineStage
+type MultilineConfig struct {
+	Expression  *string `mapstructure:"firstline"`
+	MaxWaitTime *string  `mapstructure:"max_wait_time"`
+	maxWait     time.Duration
+	regex       *regexp.Regexp
+}
+
+func validateMultilineConfig(cfg *MultilineConfig) error {
+	if cfg == nil ||
+		(cfg.Expression == nil) {
+		return errors.New(ErrMultilineStageEmptyConfig)
+	}
+
+	expr, err := regexp.Compile(*cfg.Expression)
+	if err != nil {
+		return errors.Errorf(ErrMultilineStageInvalidRegex, err)
+	}
+	cfg.regex = expr
+
+	maxWait, err := time.ParseDuration(*cfg.MaxWaitTime)
+	if err != nil {
+		return errors.Errorf(ErrMultilineStageInvalidMaxWaitTime, err)
+	}
+	cfg.maxWait = maxWait
+
+	return nil
+}
+
+// dropMultiline matches lines to determine whether the following lines belong to a block and should be collapsed
+type multilineStage struct {
+	logger log.Logger
+	cfg    *MultilineConfig
+	buffer *bytes.Buffer
+	startLineEntry Entry
+}
+
+// newMulitlineStage creates a MulitlineStage from config
+func newMultilineStage(logger log.Logger, config interface{}) (Stage, error) {
+	cfg := &MultilineConfig{}
+	err := mapstructure.WeakDecode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	err = validateMultilineConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &multilineStage{
+		logger: log.With(logger, "component", "stage", "type", "multiline"),
+		cfg:    cfg,
+		buffer: new(bytes.Buffer),
+	}, nil
+}
+
+func (m *multilineStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <- time.After(m.cfg.maxWait):
+				m.flush(out)
+			case e, ok := <- in:
+				if !ok {
+					return	
+				}
+
+				isFirstLine := m.cfg.regex.MatchString(e.Line)
+				if isFirstLine {
+					m.flush(out)
+					// TODO: we only consider the labels and timestamp from the firt entry. Should merge all entries?
+					m.startLineEntry = e
+				}
+
+				// Append block line
+				if m.buffer.Len() > 0 {
+					m.buffer.WriteRune('\n')
+				}
+				m.buffer.WriteString(e.Line)
+			}
+		}
+	}()
+	return out
+}
+
+func (m *multilineStage) flush(out chan Entry) {
+	if m.buffer.Len() == 0 {
+		return
+	}
+
+	collapsed := &Entry{
+		Labels: m.startLineEntry.Labels,
+		Extracted: m.startLineEntry.Extracted,
+		Timestamp: m.startLineEntry.Timestamp,
+		Line: m.buffer.String(),
+	}
+	m.buffer.Reset()
+
+	out <- *collapsed
+}
+
+// Name implements Stage
+func (m *multilineStage) Name() string {
+	return StageTypeMultiline
+}

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -182,7 +182,7 @@ func (m *multilineStage) runMultiline(in chan Entry, out chan Entry, wg *sync.Wa
 	}
 }
 
-flush(out chan Entry, s *multilineState) {
+func flush(out chan Entry, s *multilineState) {
 	if s.buffer.Len() == 0 {
 		level.Debug(m.logger).Log("msg", "nothing to flush", "buffer_len", s.buffer.Len())
 		return

--- a/pkg/logentry/stages/multiline.go
+++ b/pkg/logentry/stages/multiline.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 )
 
 const (

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -33,15 +33,19 @@ func Test_multilineStage_Process(t *testing.T) {
 	}
 
 	out := processEntries(stage,
+		simpleEntry("not a start line before 1", "label"),
+		simpleEntry("not a start line before 2", "label"),
 		simpleEntry("START line 1", "label"),
 		simpleEntry("not a start line", "label"),
 		simpleEntry("START line 2", "label"),
 		simpleEntry("START line 3", "label"))
 
-	require.Len(t, out, 3)
-	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
-	require.Equal(t, "START line 2", out[1].Line)
-	require.Equal(t, "START line 3", out[2].Line)
+	require.Len(t, out, 5)
+	require.Equal(t, "not a start line before 1", out[0].Line)
+	require.Equal(t, "not a start line before 2", out[1].Line)
+	require.Equal(t, "START line 1\nnot a start line", out[2].Line)
+	require.Equal(t, "START line 2", out[3].Line)
+	require.Equal(t, "START line 3", out[4].Line)
 }
 func Test_multilineStage_MultiStreams(t *testing.T) {
 	// Enable debug logging

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,0 +1,47 @@
+package stages
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	ww "github.com/weaveworks/common/server"
+)
+
+func Test_multilineStage_Process(t *testing.T) {
+
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START")}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+		buffer: new(bytes.Buffer),
+	}
+
+	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
+
+	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
+	require.Equal(t, "START line 2", out[1].Line)
+	require.Equal(t, "START line 3", out[2].Line)
+}
+
+func simpleEntry(line string) Entry {
+	return Entry{
+				Labels:    model.LabelSet{},
+				Line:      ptrFromString(line),
+				Extracted: map[string]interface{}{},
+				Timestamp: ptrFromTime(time.Now()),
+			}
+
+}

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,7 +1,6 @@
 package stages
 
 import (
-	"bytes"
 	"sync"
 	"testing"
 	"time"
@@ -29,7 +28,6 @@ func Test_multilineStage_Process(t *testing.T) {
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: util.Logger,
-		buffer: new(bytes.Buffer),
 	}
 
 	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
@@ -54,7 +52,6 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	stage := &multilineStage{
 		cfg:    mcfg,
 		logger: util.Logger,
-		buffer: new(bytes.Buffer),
 	}
 
 	in := make(chan Entry, 2)

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -87,21 +87,21 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 		return
 	}()
 
-	require.Eventually(t, func() bool {mu.Lock(); defer mu.Unlock(); return len(res) == 2;}, time.Duration(3 * maxWait), time.Second)
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(res) == 2 }, time.Duration(3*maxWait), time.Second)
 	require.Equal(t, "START line", res[0].Line)
 	require.Equal(t, "not a start line hitting timeout", res[1].Line)
 }
 
 func simpleEntry(line string) Entry {
 	return Entry{
-				Extracted: map[string]interface{}{},
-				Entry: api.Entry{
-					Labels:    model.LabelSet{},
-					Entry: logproto.Entry{
-						Timestamp: time.Now(),
-						Line: line,
-					},
-				},
-			}
+		Extracted: map[string]interface{}{},
+		Entry: api.Entry{
+			Labels: model.LabelSet{},
+			Entry: logproto.Entry{
+				Timestamp: time.Now(),
+				Line:      line,
+			},
+		},
+	}
 
 }

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	ww "github.com/weaveworks/common/server"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 )
 
 func Test_multilineStage_Process(t *testing.T) {
@@ -94,7 +95,7 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	util.InitLogger(cfg)
 	Debug = true
 
-	maxWait := time.Duration(2 * time.Second)
+	maxWait := 2 * time.Second
 	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString(maxWait.String())}
 	err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
@@ -117,7 +118,6 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 			res = append(res, e)
 			mu.Unlock()
 		}
-		return
 	}()
 
 	// Write input with a delay
@@ -131,10 +131,9 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 
 		// Signal pipeline we are done.
 		close(in)
-		return
 	}()
 
-	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(res) == 2 }, time.Duration(3*maxWait), time.Second)
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(res) == 2 }, 3*maxWait, time.Second)
 	require.Equal(t, "START line", res[0].Line)
 	require.Equal(t, "not a start line hitting timeout", res[1].Line)
 }

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -30,13 +31,62 @@ func Test_multilineStage_Process(t *testing.T) {
 		logger: util.Logger,
 	}
 
-	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
+	out := processEntries(stage,
+		simpleEntry("START line 1", "label"),
+		simpleEntry("not a start line", "label"),
+		simpleEntry("START line 2", "label"),
+		simpleEntry("START line 3", "label"))
 
 	require.Len(t, out, 3)
 	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
 	require.Equal(t, "START line 2", out[1].Line)
 	require.Equal(t, "START line 3", out[2].Line)
 }
+func Test_multilineStage_MultiStreams(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+	}
+
+	out := processEntries(stage,
+		simpleEntry("START line 1", "one"),
+		simpleEntry("not a start line 1", "one"),
+		simpleEntry("START line 1", "two"),
+		simpleEntry("not a start line 2", "one"),
+		simpleEntry("START line 2", "two"),
+		simpleEntry("START line 2", "one"),
+		simpleEntry("not a start line 1", "one"),
+	)
+
+	sort.Slice(out, func(l, r int) bool {
+		return out[l].Timestamp.Before(out[r].Timestamp)
+	})
+
+	require.Len(t, out, 4)
+
+	require.Equal(t, "START line 1\nnot a start line 1\nnot a start line 2", out[0].Line)
+	require.Equal(t, model.LabelValue("one"), out[0].Labels["value"])
+
+	require.Equal(t, "START line 1", out[1].Line)
+	require.Equal(t, model.LabelValue("two"), out[1].Labels["value"])
+
+	require.Equal(t, "START line 2", out[2].Line)
+	require.Equal(t, model.LabelValue("two"), out[2].Labels["value"])
+
+	require.Equal(t, "START line 2\nnot a start line 1", out[3].Line)
+	require.Equal(t, model.LabelValue("one"), out[3].Labels["value"])
+}
+
 func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
@@ -72,12 +122,12 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 
 	// Write input with a delay
 	go func() {
-		in <- simpleEntry("START line")
+		in <- simpleEntry("START line", "label")
 
 		// Trigger flush due to max wait timeout
 		time.Sleep(2 * maxWait)
 
-		in <- simpleEntry("not a start line hitting timeout")
+		in <- simpleEntry("not a start line hitting timeout", "label")
 
 		// Signal pipeline we are done.
 		close(in)
@@ -89,11 +139,11 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	require.Equal(t, "not a start line hitting timeout", res[1].Line)
 }
 
-func simpleEntry(line string) Entry {
+func simpleEntry(line, label string) Entry {
 	return Entry{
 		Extracted: map[string]interface{}{},
 		Entry: api.Entry{
-			Labels: model.LabelSet{},
+			Labels: model.LabelSet{"value": model.LabelValue(label)},
 			Entry: logproto.Entry{
 				Timestamp: time.Now(),
 				Line:      line,

--- a/pkg/logentry/stages/multiline_test.go
+++ b/pkg/logentry/stages/multiline_test.go
@@ -2,10 +2,13 @@ package stages
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/promtail/api"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	ww "github.com/weaveworks/common/server"
@@ -19,7 +22,7 @@ func Test_multilineStage_Process(t *testing.T) {
 	util.InitLogger(cfg)
 	Debug = true
 
-	mcfg := &MultilineConfig{Expression: ptrFromString("^START")}
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
 	err := validateMultilineConfig(mcfg)
 	require.NoError(t, err)
 
@@ -31,17 +34,74 @@ func Test_multilineStage_Process(t *testing.T) {
 
 	out := processEntries(stage, simpleEntry("START line 1"), simpleEntry("not a start line"), simpleEntry("START line 2"), simpleEntry("START line 3"))
 
+	require.Len(t, out, 3)
 	require.Equal(t, "START line 1\nnot a start line", out[0].Line)
 	require.Equal(t, "START line 2", out[1].Line)
 	require.Equal(t, "START line 3", out[2].Line)
 }
+func Test_multilineStage_MaxWaitTime(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util.InitLogger(cfg)
+	Debug = true
+
+	maxWait := time.Duration(2 * time.Second)
+	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString(maxWait.String())}
+	err := validateMultilineConfig(mcfg)
+	require.NoError(t, err)
+
+	stage := &multilineStage{
+		cfg:    mcfg,
+		logger: util.Logger,
+		buffer: new(bytes.Buffer),
+	}
+
+	in := make(chan Entry, 2)
+	out := stage.Run(in)
+
+	// Accumulate result
+	mu := new(sync.Mutex)
+	var res []Entry
+	go func() {
+		for e := range out {
+			mu.Lock()
+			t.Logf("appending %s", e.Line)
+			res = append(res, e)
+			mu.Unlock()
+		}
+		return
+	}()
+
+	// Write input with a delay
+	go func() {
+		in <- simpleEntry("START line")
+
+		// Trigger flush due to max wait timeout
+		time.Sleep(2 * maxWait)
+
+		in <- simpleEntry("not a start line hitting timeout")
+
+		// Signal pipeline we are done.
+		close(in)
+		return
+	}()
+
+	require.Eventually(t, func() bool {mu.Lock(); defer mu.Unlock(); return len(res) == 2;}, time.Duration(3 * maxWait), time.Second)
+	require.Equal(t, "START line", res[0].Line)
+	require.Equal(t, "not a start line hitting timeout", res[1].Line)
+}
 
 func simpleEntry(line string) Entry {
 	return Entry{
-				Labels:    model.LabelSet{},
-				Line:      ptrFromString(line),
 				Extracted: map[string]interface{}{},
-				Timestamp: ptrFromTime(time.Now()),
+				Entry: api.Entry{
+					Labels:    model.LabelSet{},
+					Entry: logproto.Entry{
+						Timestamp: time.Now(),
+						Line: line,
+					},
+				},
 			}
 
 }

--- a/pkg/logentry/stages/stage.go
+++ b/pkg/logentry/stages/stage.go
@@ -27,6 +27,7 @@ const (
 	StageTypePipeline  = "pipeline"
 	StageTypeTenant    = "tenant"
 	StageTypeDrop      = "drop"
+	StageTypeMultiline = "multiline"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -136,6 +137,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeDrop:
 		s, err = newDropStage(logger, cfg, registerer)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeMultiline:
+		s, err = newMultilineStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Summary:
This is a very simple approach based on #1380 to provide multiline
or block log entries in promtail.

A `multiline` stage is added to pipelines. This stages matches a start
line. Once a start line is matched all following lines are appended
to an entry and not passed on to downstream stages. Once a new start
line is matched the former block of multilines is sent.

If no new line arrives within `max_wait_time` the block is flushed to
the next stage and a new block is started.

If a block exceeds `max_lines` it is flushed as well.

**Which issue(s) this PR fixes**:
Resolves #74

**Checklist**
- [x] Documentation added
- [x] Tests updated

