### PR TITLE
Fixes a swallowed context err in the batch storage.

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -150,7 +150,10 @@ func (q *query) Exec(ctx context.Context) (Result, error) {
 	status := "200"
 	if err != nil {
 		status = "500"
-		if errors.Is(err, ErrParse) || errors.Is(err, ErrPipeline) || errors.Is(err, ErrLimit) {
+		if errors.Is(err, ErrParse) ||
+			errors.Is(err, ErrPipeline) ||
+			errors.Is(err, ErrLimit) ||
+			errors.Is(err, context.Canceled) {
 			status = "400"
 		}
 	}

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -143,6 +143,7 @@ func (it *batchChunkIterator) loop(ctx context.Context) {
 		}
 		select {
 		case <-ctx.Done():
+			it.next <- &chunkBatch{err: ctx.Err()}
 			close(it.next)
 			return
 		case it.next <- it.nextBatch():


### PR DESCRIPTION
Fixes #2999

There's still a potential cases where, the context is done (and so the Err is not nil) and we're finished (line 141)
with iterating over the list of batches. I didn't introduce the error here because I think I would prefer a success in this case.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

