### PR TITLE
Fix docs header inconsistency

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -364,7 +364,7 @@ results_cache:
 [parallelise_shardable_queries: <boolean> | default = false]
 ```
 
-## `ruler_config`
+## ruler_config
 
 The `ruler_config` configures the Loki ruler.
 


### PR DESCRIPTION
Wrapping the heading in a code block breaks its style rendering.

Example:

All other H2s:

![image](https://user-images.githubusercontent.com/1579899/101043193-54cffb80-357e-11eb-82b8-66739142770a.png)

ruler_config H2:

![image](https://user-images.githubusercontent.com/1579899/101043232-5f8a9080-357e-11eb-84c8-f719d1245f63.png)

---

Removing the backticks fixes the issue.