### PR TITLE
Helm: Allow to define existing secret for Loki configuration (#3042)

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 2.1.0
+version: 2.2.0
 appVersion: v2.0.0
 kubeVersion: "^1.10.0-0"
 description: "Loki: like Prometheus, but for logs."

--- a/production/helm/loki/templates/secret.yaml
+++ b/production/helm/loki/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   loki.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
+{{- end -}}

--- a/production/helm/loki/templates/statefulset.yaml
+++ b/production/helm/loki/templates/statefulset.yaml
@@ -30,7 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+      {{- if not .Values.config.existingSecret }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -113,7 +115,11 @@ spec:
         {{- end }}
         - name: config
           secret:
+          {{- if .Values.config.existingSecret }}
+            secretName: {{ .Values.config.existingSecret }}
+          {{- else }}
             secretName: {{ template "loki.fullname" . }}
+          {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8}}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -44,6 +44,8 @@ tracing:
   jaegerAgentHost:
 
 config:
+  ## Name of the existing secret containing loki.yaml key and the configuration as value
+  # existingSecret:
   auth_enabled: false
   ingester:
     chunk_idle_period: 3m


### PR DESCRIPTION
**What this PR does / why we need it**:
Add alternative solution to let users provide secrets which holds Loki configuration.
**Which issue(s) this PR fixes**:
Fixes #3042

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

