### PR TITLE
Improve JSON parser and add labels parser hints.

### DIFF
--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -39,9 +39,11 @@ func (n notFilter) Filter(line []byte) bool {
 }
 
 func (n notFilter) ToStage() Stage {
-	return StageFunc(func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
-		return line, n.Filter(line)
-	})
+	return StageFunc{
+		process: func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, n.Filter(line)
+		},
+	}
 }
 
 // newNotFilter creates a new filter which matches only if the base filter doesn't match.
@@ -81,9 +83,11 @@ func (a andFilter) Filter(line []byte) bool {
 }
 
 func (a andFilter) ToStage() Stage {
-	return StageFunc(func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
-		return line, a.Filter(line)
-	})
+	return StageFunc{
+		process: func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, a.Filter(line)
+		},
+	}
 }
 
 type orFilter struct {
@@ -120,9 +124,11 @@ func (a orFilter) Filter(line []byte) bool {
 }
 
 func (a orFilter) ToStage() Stage {
-	return StageFunc(func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
-		return line, a.Filter(line)
-	})
+	return StageFunc{
+		process: func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, a.Filter(line)
+		},
+	}
 }
 
 type regexpFilter struct {
@@ -148,9 +154,11 @@ func (r regexpFilter) Filter(line []byte) bool {
 }
 
 func (r regexpFilter) ToStage() Stage {
-	return StageFunc(func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
-		return line, r.Filter(line)
-	})
+	return StageFunc{
+		process: func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, r.Filter(line)
+		},
+	}
 }
 
 type containsFilter struct {
@@ -166,9 +174,11 @@ func (l containsFilter) Filter(line []byte) bool {
 }
 
 func (l containsFilter) ToStage() Stage {
-	return StageFunc(func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
-		return line, l.Filter(line)
-	})
+	return StageFunc{
+		process: func(line []byte, _ *LabelsBuilder) ([]byte, bool) {
+			return line, l.Filter(line)
+		},
+	}
 }
 
 func (l containsFilter) String() string {

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -290,3 +290,22 @@ func Test_substring(t *testing.T) {
 		})
 	}
 }
+
+func TestLineFormatter_RequiredLabelNames(t *testing.T) {
+	tests := []struct {
+		fmt  string
+		want []string
+	}{
+		{`{{.foo}} and {{.bar}}`, []string{"foo", "bar"}},
+		{`{{ .foo | ToUpper | .buzz }} and {{.bar}}`, []string{"foo", "buzz", "bar"}},
+		{`{{ regexReplaceAllLiteral "(p)" .foo "${1}" }}`, []string{"foo"}},
+		{`{{ if  .foo | hasSuffix "Ip" }} {{.bar}} {{end}}-{{ if  .foo | hasSuffix "pw"}}no{{end}}`, []string{"foo", "bar"}},
+		{`{{with .foo}}{{printf "%q" .}} {{end}}`, []string{"foo"}},
+		{`{{with .foo}}{{printf "%q" .}} {{else}} {{ .buzz | lower }} {{end}}`, []string{"foo", "buzz"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fmt, func(t *testing.T) {
+			require.Equal(t, tt.want, newMustLineFormatter(tt.fmt).RequiredLabelNames())
+		})
+	}
+}

--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -95,6 +95,13 @@ func (b *BinaryLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, bo
 	return line, lok && rok
 }
 
+func (b *BinaryLabelFilter) RequiredLabelNames() []string {
+	var names []string
+	names = append(names, b.Left.RequiredLabelNames()...)
+	names = append(names, b.Right.RequiredLabelNames()...)
+	return uniqueString(names)
+}
+
 func (b *BinaryLabelFilter) String() string {
 	var sb strings.Builder
 	sb.WriteString("( ")
@@ -113,6 +120,7 @@ type noopLabelFilter struct{}
 
 func (noopLabelFilter) String() string                                         { return "" }
 func (noopLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) { return line, true }
+func (noopLabelFilter) RequiredLabelNames() []string                           { return []string{} }
 
 // ReduceAndLabelFilter Reduces multiple label filterer into one using binary and operation.
 func ReduceAndLabelFilter(filters []LabelFilterer) LabelFilterer {
@@ -179,6 +187,10 @@ func (d *BytesLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, boo
 	}
 }
 
+func (d *BytesLabelFilter) RequiredLabelNames() []string {
+	return []string{d.Name}
+}
+
 func (d *BytesLabelFilter) String() string {
 	b := strings.Map(func(r rune) rune {
 		if unicode.IsSpace(r) {
@@ -239,6 +251,10 @@ func (d *DurationLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, 
 	}
 }
 
+func (d *DurationLabelFilter) RequiredLabelNames() []string {
+	return []string{d.Name}
+}
+
 func (d *DurationLabelFilter) String() string {
 	return fmt.Sprintf("%s%s%s", d.Name, d.Type, d.Value)
 }
@@ -294,6 +310,10 @@ func (n *NumericLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, b
 
 }
 
+func (n *NumericLabelFilter) RequiredLabelNames() []string {
+	return []string{n.Name}
+}
+
 func (n *NumericLabelFilter) String() string {
 	return fmt.Sprintf("%s%s%s", n.Name, n.Type, strconv.FormatFloat(n.Value, 'f', -1, 64))
 }
@@ -317,4 +337,8 @@ func (s *StringLabelFilter) Process(line []byte, lbs *LabelsBuilder) ([]byte, bo
 	}
 	v, _ := lbs.Get(s.Name)
 	return line, s.Matches(v)
+}
+
+func (s *StringLabelFilter) RequiredLabelNames() []string {
+	return []string{s.Name}
 }

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -68,6 +68,7 @@ type BaseLabelsBuilder struct {
 	err string
 
 	groups            []string
+	parserKeyHints    []string // label key hints for metric queries that allows to limit parser extractions to only this list of labels.
 	without, noLabels bool
 
 	resultCache map[uint64]LabelsResult
@@ -84,21 +85,22 @@ type LabelsBuilder struct {
 }
 
 // NewBaseLabelsBuilderWithGrouping creates a new base labels builder with grouping to compute results.
-func NewBaseLabelsBuilderWithGrouping(groups []string, without, noLabels bool) *BaseLabelsBuilder {
+func NewBaseLabelsBuilderWithGrouping(groups []string, parserKeyHints []string, without, noLabels bool) *BaseLabelsBuilder {
 	return &BaseLabelsBuilder{
-		del:         make([]string, 0, 5),
-		add:         make([]labels.Label, 0, 16),
-		resultCache: make(map[uint64]LabelsResult),
-		hasher:      newHasher(),
-		groups:      groups,
-		noLabels:    noLabels,
-		without:     without,
+		del:            make([]string, 0, 5),
+		add:            make([]labels.Label, 0, 16),
+		resultCache:    make(map[uint64]LabelsResult),
+		hasher:         newHasher(),
+		groups:         groups,
+		parserKeyHints: parserKeyHints,
+		noLabels:       noLabels,
+		without:        without,
 	}
 }
 
 // NewLabelsBuilder creates a new base labels builder.
 func NewBaseLabelsBuilder() *BaseLabelsBuilder {
-	return NewBaseLabelsBuilderWithGrouping(nil, false, false)
+	return NewBaseLabelsBuilderWithGrouping(nil, nil, false, false)
 }
 
 // ForLabels creates a labels builder for a given labels set as base.
@@ -127,6 +129,12 @@ func (b *LabelsBuilder) Reset() {
 	b.del = b.del[:0]
 	b.add = b.add[:0]
 	b.err = ""
+}
+
+// ExpectedLabels returns a limited list of expected labels to extract for metric queries.
+// Returns nil when it's impossible to hint labels extractions.
+func (b *BaseLabelsBuilder) ParserLabelHints() []string {
+	return b.parserKeyHints
 }
 
 // SetErr sets the error label.

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -131,7 +131,7 @@ func (b *LabelsBuilder) Reset() {
 	b.err = ""
 }
 
-// ExpectedLabels returns a limited list of expected labels to extract for metric queries.
+// ParserLabelHints returns a limited list of expected labels to extract for metric queries.
 // Returns nil when it's impossible to hint labels extractions.
 func (b *BaseLabelsBuilder) ParserLabelHints() []string {
 	return b.parserKeyHints

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -88,7 +88,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 		labels.Label{Name: "cluster", Value: "us-central1"},
 	}
 	sort.Sort(lbs)
-	b := NewBaseLabelsBuilderWithGrouping([]string{"namespace"}, false, false).ForLabels(lbs, lbs.Hash())
+	b := NewBaseLabelsBuilderWithGrouping([]string{"namespace"}, nil, false, false).ForLabels(lbs, lbs.Hash())
 	b.Reset()
 	assertLabelResult(t, labels.Labels{labels.Label{Name: "namespace", Value: "loki"}}, b.GroupedLabels())
 	b.SetErr("err")
@@ -109,7 +109,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	// cached.
 	assertLabelResult(t, expected, b.GroupedLabels())
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, false, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, false, false).ForLabels(lbs, lbs.Hash())
 	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
 	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
 	b.Del("job")
@@ -118,7 +118,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	b.Set("namespace", "tempo")
 	assertLabelResult(t, labels.Labels{labels.Label{Name: "job", Value: "us-central1/loki"}}, b.GroupedLabels())
 
-	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, true, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping([]string{"job"}, nil, true, false).ForLabels(lbs, lbs.Hash())
 	b.Del("job")
 	b.Set("foo", "bar")
 	b.Set("job", "something")
@@ -130,7 +130,7 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	sort.Sort(expected)
 	assertLabelResult(t, expected, b.GroupedLabels())
 
-	b = NewBaseLabelsBuilderWithGrouping(nil, false, false).ForLabels(lbs, lbs.Hash())
+	b = NewBaseLabelsBuilderWithGrouping(nil, nil, false, false).ForLabels(lbs, lbs.Hash())
 	b.Set("foo", "bar")
 	b.Set("job", "something")
 	expected = labels.Labels{

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -51,7 +51,8 @@ func NewLineSampleExtractor(ex LineExtractor, stages []Stage, groups []string, w
 	s := ReduceStages(stages)
 	var expectedLabels []string
 	if !without {
-		expectedLabels = uniqueString(append(s.RequiredLabelNames(), groups...))
+		expectedLabels = append(expectedLabels, s.RequiredLabelNames()...)
+		expectedLabels = uniqueString(append(expectedLabels, groups...))
 	}
 	return &lineSampleExtractor{
 		Stage:            s,
@@ -137,14 +138,16 @@ func LabelExtractorWithStages(
 		groups = append(groups, labelName)
 		sort.Strings(groups)
 	}
+	preStage := ReduceStages(preStages)
 	var expectedLabels []string
 	if !without {
-		expectedLabels = append(postFilter.RequiredLabelNames(), groups...)
+		expectedLabels = append(expectedLabels, preStage.RequiredLabelNames()...)
+		expectedLabels = append(expectedLabels, groups...)
 		expectedLabels = append(expectedLabels, postFilter.RequiredLabelNames()...)
 		expectedLabels = uniqueString(expectedLabels)
 	}
 	return &labelSampleExtractor{
-		preStage:         ReduceStages(preStages),
+		preStage:         preStage,
 		conversionFn:     convFn,
 		labelName:        labelName,
 		postFilter:       postFilter,

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -58,7 +58,7 @@ func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 func (j *JSONParser) readObject(it *jsoniter.Iterator) error {
 	// we only care about object and values.
 	if nextType := it.WhatIsNext(); nextType != jsoniter.ObjectValue {
-		return errors.New("not a json object")
+		return fmt.Errorf("expecting json object(%d), got %d", jsoniter.ObjectValue, nextType)
 	}
 	_ = it.ReadMapCB(j.parseMap(""))
 	if it.Error != nil && it.Error != io.EOF {

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -88,7 +88,7 @@ func (j *JSONParser) parseMap(prefix string) func(iter *jsoniter.Iterator, field
 }
 
 func (j *JSONParser) nextKeyPrefix(prefix, field string) (string, bool) {
-	// first time time we add return the field as prefix.
+	// first time we add return the field as prefix.
 	if len(prefix) == 0 {
 		field = sanitizeLabelKey(field, true)
 		if isValidKeyPrefix(field, j.lbs.ParserLabelHints()) {
@@ -139,7 +139,7 @@ func (j *JSONParser) parseLabelValue(iter *jsoniter.Iterator, prefix, field stri
 		return
 
 	}
-	// other we build the label key using the buffer
+	// otherwise we build the label key using the buffer
 	j.buf = j.buf[:0]
 	j.buf = append(j.buf, prefix...)
 	j.buf = append(j.buf, byte(jsonSpacer))

--- a/pkg/logql/log/util.go
+++ b/pkg/logql/log/util.go
@@ -1,0 +1,35 @@
+package log
+
+import (
+	"strings"
+)
+
+func uniqueString(s []string) []string {
+	unique := make(map[string]bool, len(s))
+	us := make([]string, len(unique))
+	for _, elem := range s {
+		if len(elem) != 0 {
+			if !unique[elem] {
+				us = append(us, elem)
+				unique[elem] = true
+			}
+		}
+	}
+	return us
+}
+
+func sanitizeLabelKey(key string, isPrefix bool) string {
+	if len(key) == 0 {
+		return key
+	}
+	key = strings.TrimSpace(key)
+	if isPrefix && key[0] >= '0' && key[0] <= '9' {
+		key = "_" + key
+	}
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '_'
+	}, key)
+}

--- a/pkg/logql/log/util_test.go
+++ b/pkg/logql/log/util_test.go
@@ -1,0 +1,24 @@
+package log
+
+import "testing"
+
+func Test_sanitizeLabelKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"1", "_1"},
+		{"1 1 1", "_1_1_1"},
+		{"abc", "abc"},
+		{"$a$bc", "_a_bc"},
+		{"$a$bc", "_a_bc"},
+		{"   1 1 1  \t", "_1_1_1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := sanitizeLabelKey(tt.key, true); got != tt.want {
+				t.Errorf("sanitizeKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a rework of the json parser, that now uses iteration over reflection allowing to avoid allocations.

I've also implemented a way to guess and hints  what labels needs to be parsed when doing metric queries, this means we can extract only the few labels required from the log line.

benchcmp

```
❯ benchcmp  before.txt after.txt5
benchmark                                      old ns/op     new ns/op     delta
Benchmark_Parser/json/no_labels_hints-16       9889          3281          -66.82%
Benchmark_Parser/logfmt/no_labels_hints-16     1624          1671          +2.89%
Benchmark_Parser/logfmt/labels_hints-16        1601          790           -50.66%
benchmark                                      old allocs     new allocs     delta
Benchmark_Parser/json/no_labels_hints-16       139            56             -59.71%
Benchmark_Parser/logfmt/no_labels_hints-16     31             31             +0.00%
Benchmark_Parser/logfmt/labels_hints-16        31             5              -83.87%
benchmark                                      old bytes     new bytes     delta
Benchmark_Parser/json/no_labels_hints-16       3671          912           -75.16%
Benchmark_Parser/logfmt/no_labels_hints-16     464           464           +0.00%
Benchmark_Parser/logfmt/labels_hints-16        464           144           -68.97%
```

I've experienced a 2x to 4x improvement in my cluster.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>