### PR TITLE
Update reference to old helm chart repo

### DIFF
--- a/docs/sources/clients/aws/eks/_index.md
+++ b/docs/sources/clients/aws/eks/_index.md
@@ -55,8 +55,6 @@ To ship all your pods logs we're going to set up [Promtail](../../promtail/) as 
 
 What's nice about Promtail is that it uses the same [service discovery as Prometheus][prometheus conf], you should make sure the `scrape_configs` of Promtail matches the Prometheus one. Not only this is simpler to configure, but this also means Metrics and Logs will have the same metadata (labels) attached by the Prometheus service discovery. When querying Grafana you will be able to correlate metrics and logs very quickly, you can read more about this on our [blogpost][correlate].
 
-We'll use helm 3, but if you want to use helm 2 it's also fine just make sure you have properly [installed tiller][tiller install].
-
 Let's add the Loki repository and list all available charts.
 
 ```bash
@@ -245,7 +243,6 @@ If you want to push this further you can check out [Joe's blog post][blog annota
 [GrafanaCloud]: https://grafana.com/signup/
 [blog ship log with fargate]: https://aws.amazon.com/blogs/containers/how-to-capture-application-logs-when-using-amazon-eks-on-aws-fargate/
 [correlate]: https://grafana.com/blog/2020/03/31/how-to-successfully-correlate-metrics-logs-and-traces-in-grafana/
-[tiller install]: https://v2.helm.sh/docs/using_helm/
 [default value file]: https://github.com/grafana/helm-charts/blob/main/charts/promtail/values.yaml
 [systemd]: ../../../installation/helm#run-promtail-with-systemd-journal-support
 [grafana logs namespace]: namespace-grafana.png

--- a/docs/sources/clients/fluentbit/_index.md
+++ b/docs/sources/clients/fluentbit/_index.md
@@ -23,12 +23,10 @@ You can run Fluent Bit as a [Daemonset](https://kubernetes.io/docs/concepts/work
 
 To do so you can use our [Fluent Bit helm chart](https://github.com/grafana/helm-charts/tree/main/charts/fluent-bit):
 
-> Make sure [tiller](https://helm.sh/docs/install/) is installed correctly in your cluster
-
 ```bash
-helm repo add loki https://grafana.github.io/loki/charts
+helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
-helm upgrade --install fluent-bit loki/fluent-bit \
+helm upgrade --install fluent-bit grafana/fluent-bit \
     --set loki.serviceName=loki.svc.cluster.local
 ```
 
@@ -37,7 +35,7 @@ By default it will collect all containers logs and extract labels from Kubernete
 Alternatively you can install the Loki and Fluent Bit all together using:
 
 ```bash
-helm upgrade --install loki-stack loki/loki-stack \
+helm upgrade --install loki-stack grafana/loki-stack \
     --set fluent-bit.enabled=true,promtail.enabled=false
 ```
 

--- a/docs/sources/clients/promtail/installation.md
+++ b/docs/sources/clients/promtail/installation.md
@@ -21,12 +21,11 @@ docker pull grafana/promtail:2.0.0
 ## Helm
 
 Make sure that Helm is
-[installed](https://helm.sh/docs/using_helm/#installing-helm) and
-[deployed](https://helm.sh/docs/using_helm/#installing-tiller) to your cluster.
-Then you can add Loki's chart repository to Helm:
+[installed](https://helm.sh/docs/using_helm/#installing-helm).
+Then you can add Grafana's chart repository to Helm:
 
 ```bash
-helm repo add loki https://grafana.github.io/loki/charts
+helm repo add grafana https://grafana.github.io/helm-charts
 ```
 
 And the chart repository can be updated by running:
@@ -38,7 +37,7 @@ helm repo update
 Finally, Promtail can be deployed with:
 
 ```bash
-$ helm upgrade --install promtail loki/promtail --set "loki.serviceName=loki"
+$ helm upgrade --install promtail grafana/promtail --set "loki.serviceName=loki"
 ```
 
 ## Kubernetes

--- a/docs/sources/installation/helm.md
+++ b/docs/sources/installation/helm.md
@@ -5,8 +5,7 @@ title: Helm
 
 ## Prerequisites
 
-Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm) and
-[deployed](https://helm.sh/docs/using_helm/#installing-tiller) to your cluster.
+Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm).
 
 Add [Loki's chart repository](https://github.com/grafana/helm-charts) to Helm:
 

--- a/production/helm/README.md
+++ b/production/helm/README.md
@@ -1,4 +1,6 @@
-# Loki Helm Chart
+# ⚠️  DEPRECATED - Loki Helm Chart
+
+This chart was moved to <https://github.com/grafana/helm-charts>.
 
 ## Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove old references to the old Helm chart repo and to Tiller.
**Special notes for your reviewer**:

This is a follow-up of #2720.