### PR TITLE
Improve tailer matching by using the index.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -637,7 +637,9 @@ func (i *Ingester) Tail(req *logproto.TailRequest, queryServer logproto.Querier_
 		return err
 	}
 
-	instance.addNewTailer(tailer)
+	if err := instance.addNewTailer(tailer); err != nil {
+		return err
+	}
 	tailer.loop()
 	return nil
 }

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -430,18 +430,17 @@ outer:
 	return nil
 }
 
-func (i *instance) addNewTailer(t *tailer) {
-	i.streamsMtx.RLock()
-	for _, stream := range i.streams {
-		if stream.matchesTailer(t) {
-			stream.addTailer(t)
-		}
+func (i *instance) addNewTailer(t *tailer) error {
+	if err := i.forMatchingStreams(t.matchers, func(s *stream) error {
+		s.addTailer(t)
+		return nil
+	}); err != nil {
+		return err
 	}
-	i.streamsMtx.RUnlock()
-
 	i.tailerMtx.Lock()
 	defer i.tailerMtx.Unlock()
 	i.tailers[t.getID()] = t
+	return nil
 }
 
 func (i *instance) addTailersToNewStream(stream *stream) {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -454,7 +454,7 @@ func (i *instance) addTailersToNewStream(stream *stream) {
 			continue
 		}
 
-		if stream.matchesTailer(t) {
+		if isMatching(stream.labels, t.matchers) {
 			stream.addTailer(t)
 		}
 	}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -364,7 +364,3 @@ func (s *stream) addTailer(t *tailer) {
 
 	s.tailers[t.getID()] = t
 }
-
-func (s *stream) matchesTailer(t *tailer) bool {
-	return t.isWatchingLabels(s.labels)
-}

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -174,16 +174,13 @@ func (t *tailer) processStream(stream logproto.Stream, lbs labels.Labels) []*log
 	return streamsResult
 }
 
-// Returns true if tailer is interested in the passed labelset
-func (t *tailer) isWatchingLabels(lbs labels.Labels) bool {
-	for _, l := range lbs {
-		for _, matcher := range t.matchers {
-			if l.Name == matcher.Name && !matcher.Matches(l.Value) {
-				return false
-			}
+// isMatching returns true if lbs matches all matchers.
+func isMatching(lbs labels.Labels, matchers []*labels.Matcher) bool {
+	for _, matcher := range matchers {
+		if !matcher.Matches(lbs.Get(matcher.Name)) {
+			return false
 		}
 	}
-
 	return true
 }
 

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -176,9 +176,11 @@ func (t *tailer) processStream(stream logproto.Stream, lbs labels.Labels) []*log
 
 // Returns true if tailer is interested in the passed labelset
 func (t *tailer) isWatchingLabels(lbs labels.Labels) bool {
-	for _, matcher := range t.matchers {
-		if !matcher.Matches(lbs.Get(matcher.Name)) {
-			return false
+	for _, l := range lbs {
+		for _, matcher := range t.matchers {
+			if l.Name == matcher.Name && !matcher.Matches(l.Value) {
+				return false
+			}
 		}
 	}
 

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -76,3 +76,20 @@ func Test_TailerSendRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func Test_IsMatching(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		lbs      labels.Labels
+		matchers []*labels.Matcher
+		matches  bool
+	}{
+		{"not in lbs", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}, false},
+		{"equal", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{{Type: labels.MatchEqual, Name: "job", Value: "foo"}}, true},
+		{"regex", labels.Labels{{Name: "job", Value: "foo"}}, []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "job", ".+oo")}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.matches, isMatching(tt.lbs, tt.matchers))
+		})
+	}
+}


### PR DESCRIPTION
```
❯ benchcmp  before.txt after
benchmark                              old ns/op     new ns/op     delta
Benchmark_instance_addNewTailer-16     537731        1479          -99.72%

benchmark                              old allocs     new allocs     delta
Benchmark_instance_addNewTailer-16     244            3              -98.77%

benchmark                              old bytes     new bytes     delta
Benchmark_instance_addNewTailer-16     22098         121           -99.45%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

