### PR TITLE
config.libsonnet: support S3-compaible storages that don't work with a s3 endpoint url alone

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -74,11 +74,13 @@
     cassandra_addresses: error 'must specify cassandra_addresses',
 
     // S3 variables
+    s3_region: '',
     s3_access_key: '',
     s3_secret_access_key: '',
     s3_address: error 'must specify s3_address',
     s3_bucket_name: error 'must specify s3_bucket_name',
     s3_path_style: false,
+    s3_insecure: '',
 
     // Dynamodb variables
     dynamodb_access_key: '',
@@ -95,8 +97,16 @@
       },
       s3: {
         s3forcepathstyle: $._config.s3_path_style,
-      } + (
-        if $._config.s3_access_key != '' then {
+      } + ( 
+        // Some S3-compartible APIs require a full set of parameters
+        if $._config.s3_region != '' then {
+          region: $._config.s3_region,
+          endpoint: $._config.s3_address,
+          bucketnames: $._config.s3_bucket_name,
+          access_key_id: $._config.s3_access_key,
+          secret_access_key: $._config.s3_secret_access_key,
+          insecure: $._config.s3_insecure,
+        } else if $._config.s3_access_key != '' then {
           s3: 's3://' + $._config.s3_access_key + ':' + $._config.s3_secret_access_key + '@' + $._config.s3_address + '/' + $._config.s3_bucket_name,
         } else {
           s3: 's3://' + $._config.s3_address + '/' + $._config.s3_bucket_name,


### PR DESCRIPTION
**What this PR does / why we need it**:

The current version of config.libsonnet creates a S3 endpoint URL (s3://<URL>) for loki.yaml in case of using S3 compatible storage. 

However, this doesn't work with some S3 compatible storage. For example, Oracle Object Storage's [S3-compatible API](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm) returns an error of ["MissingEndpoint: 'Endpoint' configuration is required for this service"](https://docs.aws.amazon.com/sdk-for-go/api/aws/#pkg-variables).

The solution is putting S3 parameters to loki.yaml like the following example (a region info must be passed).

```
storage_config:
    aws:
        access_key_id: <key>
        bucketnames: <bucket>
        endpoint: https://<customer>.compat.objectstorage.us-phoenix-1.oraclecloud.com
        insecure: false
        region: us-phoenix-1
        s3forcepathstyle: true
        secret_access_key:  <secret>
``` 
So, we should allow users to configure for such S3-compatible APIs. 

A fix is simple that 
- if a region is specified by a user, config.libsonnet generate loki.yaml as the above style. 
- If a region is not specified, generate a S3 endpoint URL as before.

**Which issue(s) this PR fixes**:
N/A - I didn't create an issue for this nor found a relevant issue
