### PR TITLE
Disables the stream limiter until wal has recovered

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -249,6 +249,9 @@ func (i *Ingester) starting(ctx context.Context) error {
 
 	}
 
+	// Once the WAL has replayed, signal the stream limiter to start.
+	i.limiter.Begin()
+
 	i.flushQueuesDone.Add(i.cfg.ConcurrentFlushes)
 	for j := 0; j < i.cfg.ConcurrentFlushes; j++ {
 		i.flushQueues[j] = util.NewPriorityQueue(flushQueueLength)

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -25,15 +25,20 @@ type Limiter struct {
 	ring              RingCount
 	replicationFactor int
 
-	mtx     sync.RWMutex
-	started bool
+	mtx      sync.RWMutex
+	disabled bool
 }
 
-// Begins Begin
-func (l *Limiter) Begin() {
+func (l *Limiter) Disable() {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
-	l.started = true
+	l.disabled = true
+}
+
+func (l *Limiter) Enable() {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	l.disabled = false
 }
 
 // NewLimiter makes a new limiter
@@ -52,7 +57,7 @@ func (l *Limiter) AssertMaxStreamsPerUser(userID string, streams int) error {
 	// This is used to disable limits while recovering from the WAL.
 	l.mtx.RLock()
 	defer l.mtx.RUnlock()
-	if !l.started {
+	if l.disabled {
 		return nil
 	}
 


### PR DESCRIPTION
This helps prevent log loss when changing ingester configurations which reduce in process stream limits.