### PR TITLE
Wal/recover corruption

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -225,7 +225,11 @@ func (i *Ingester) starting(ctx context.Context) error {
 		checkpointRecoveryErr := RecoverCheckpoint(checkpointReader, recoverer)
 		if checkpointRecoveryErr != nil {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeCheckpoint).Inc()
-			level.Error(util.Logger).Log("msg", "recovered from checkpoint with errors", "elapsed", time.Since(start).String())
+			level.Error(util.Logger).Log(
+				"msg",
+				`Recovered from checkpoint with errors. Some streams were likely not recovered due to WAL checkpoint file corruptions. No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.`,
+				"elapsed", time.Since(start).String(),
+			)
 		}
 		level.Info(util.Logger).Log(
 			"msg", "recovered WAL checkpoint recovery finished",
@@ -243,7 +247,11 @@ func (i *Ingester) starting(ctx context.Context) error {
 		segmentRecoveryErr := RecoverWAL(segmentReader, recoverer)
 		if segmentRecoveryErr != nil {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeSegment).Inc()
-			level.Error(util.Logger).Log("msg", "recovered from WAL segments with errors", "elapsed", time.Since(start).String())
+			level.Error(util.Logger).Log(
+				"msg",
+				"Recovered from WAL segments with errors. Some streams and/or entries were likely not recovered due to WAL segment file corruptions. No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.",
+				"elapsed", time.Since(start).String(),
+			)
 		}
 		level.Info(util.Logger).Log(
 			"msg", "WAL segment recovery finished",

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -225,13 +225,13 @@ func (i *Ingester) starting(ctx context.Context) error {
 		checkpointRecoveryErr := RecoverCheckpoint(checkpointReader, recoverer)
 		if checkpointRecoveryErr != nil {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeCheckpoint).Inc()
-			level.Error(util.Logger).Log(
-				"msg", "failed to recover from checkpoint",
-				"elapsed", time.Since(start).String(),
-				"errors", checkpointRecoveryErr != nil,
-			)
+			level.Error(util.Logger).Log("msg", "failed to recover from checkpoint", "elapsed", time.Since(start).String())
 		}
-		level.Info(util.Logger).Log("msg", "recovered from checkpoint", "elapsed", time.Since(start).String())
+		level.Info(util.Logger).Log(
+			"msg", "recovered WAL checkpoint recovery finished",
+			"elapsed", time.Since(start).String(),
+			"errors", checkpointRecoveryErr != nil,
+		)
 
 		level.Info(util.Logger).Log("msg", "recovering from WAL")
 		segmentReader, segmentCloser, err := newWalReader(i.cfg.WAL.Dir, -1)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -225,7 +225,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 		checkpointRecoveryErr := RecoverCheckpoint(checkpointReader, recoverer)
 		if checkpointRecoveryErr != nil {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeCheckpoint).Inc()
-			level.Error(util.Logger).Log("msg", "failed to recover from checkpoint", "elapsed", time.Since(start).String())
+			level.Error(util.Logger).Log("msg", "recovered from checkpoint with errors", "elapsed", time.Since(start).String())
 		}
 		level.Info(util.Logger).Log(
 			"msg", "recovered WAL checkpoint recovery finished",
@@ -243,7 +243,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 		segmentRecoveryErr := RecoverWAL(segmentReader, recoverer)
 		if segmentRecoveryErr != nil {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeSegment).Inc()
-			level.Error(util.Logger).Log("msg", "failed to recover from WAL segments", "elapsed", time.Since(start).String())
+			level.Error(util.Logger).Log("msg", "recovered from WAL segments with errors", "elapsed", time.Since(start).String())
 		}
 		level.Info(util.Logger).Log(
 			"msg", "WAL segment recovery finished",

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -249,7 +249,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeSegment).Inc()
 			level.Error(util.Logger).Log(
 				"msg",
-				"Recovered from WAL segments with errors. Some streams and/or entries were likely not recovered due to WAL segment file corruptions. No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.",
+				"Recovered from WAL segments with errors. Some streams and/or entries were likely not recovered due to WAL segment file corruptions (or WAL file deletions while Loki is running). No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.",
 				"elapsed", time.Since(start).String(),
 			)
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -227,7 +227,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeCheckpoint).Inc()
 			level.Error(util.Logger).Log(
 				"msg",
-				`Recovered from checkpoint with errors. Some streams were likely not recovered due to WAL checkpoint file corruptions. No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.`,
+				`Recovered from checkpoint with errors. Some streams were likely not recovered due to WAL checkpoint file corruptions (or WAL file deletions while Loki is running). No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.`,
 				"elapsed", time.Since(start).String(),
 			)
 		}


### PR DESCRIPTION
This PR introduces a change which notes WAL recovery failures, but allows the process to continue after logging/incrementing metrics. It also simplifies some of the recovery code.

Notably this enables the ingester to optimistically recover what data it can, including allowing later data to recover after i.e. a segment failure. The mentioned metrics can be used with alerts, especially in conjunction with `quorum(replication_factor)` to warn of data loss.