### PR TITLE
Update getting-in-touch.md

### DIFF
--- a/docs/sources/community/getting-in-touch.md
+++ b/docs/sources/community/getting-in-touch.md
@@ -3,13 +3,18 @@ title: Contacting the Loki Team
 ---
 # Contacting the Loki Team
 
-If you have any questions or feedback regarding Loki:
+For questions regarding Loki:
 
-- Ask a question on the Loki Slack channel. To invite yourself to the Grafana Slack, visit [http://slack.raintank.io/](http://slack.raintank.io/) and join the #loki channel.
-- [File a GitHub issue](https://github.com/grafana/loki/issues/new) for bugs, issues and feature suggestions.
+- Open source Loki users are welcome to post technical questions on the Grafana Labs Community Forums under the Grafana Loki category at [community.grafana.com](https://community.grafana.com). Please be mindful that this is a community-driven support channel moderated by Grafana Labs staff where Loki maintainers and community members answer questions when bandwidth allows. Be sure to review the [Community Guidelines](https://community.grafana.com/guidelines) before posting. 
+- Users deploying Loki via [Grafana Cloud](https://grafana.com/products/cloud/) can submit support tickets via the [Grafana.com Account Portal](https://grafana.com/login). 
+- For questions regarding Enterprise support for Loki, you can get in touch with the Grafana Labs team [here](https://grafana.com/contact?pg=docs).
+
+Your feedback is always welcome! To submit feedback or a report a potential bug:
+
+- [File a GitHub issue](https://github.com/grafana/loki/issues/new) for bugs, issues and feature suggestions. Grafana UI issues for the Loki data source plugin should be posted directly to the [Grafana repository](https://github.com/grafana/grafana/issues/new), not the Loki repository. 
 - Send an email to [lokiproject@googlegroups.com](mailto:lokiproject@googlegroups.com), or visit the [google groups](https://groups.google.com/forum/#!forum/lokiproject) page.
+- Join us for our monthly [Loki Community Call](https://docs.google.com/document/d/1MNjiHQxwFukm2J4NJRWyRgRIiK7VpokYyATzJ5ce-O8/edit?usp=sharing) on first Thursday of every month 12:00 UTC (8:00 am EST). 
 
-Please file UI issues directly to the [Grafana repository](https://github.com/grafana/grafana/issues/new).
 
-Your feedback is always welcome.
+
 


### PR DESCRIPTION
This page wasn't updated yet to reflect the community support channel shift from Grafana Community Slack -> Grafana Community Forums.  Also added clarity re: support for Grafana Cloud-hosted Loki users and included community call information.



