### PR TITLE
fix time duration unit

### DIFF
--- a/docs/sources/clients/promtail/stages/metrics.md
+++ b/docs/sources/clients/promtail/stages/metrics.md
@@ -158,7 +158,7 @@ config:
       type: Counter
       description: "total number of log lines"
       prefix: my_promtail_custom_
-      max_idle_duration: 1d
+      max_idle_duration: 24h
       config:
         match_all: true
         action: inc
@@ -166,7 +166,7 @@ config:
       type: Counter
       description: "total bytes of log lines"
       prefix: my_promtail_custom_
-      max_idle_duration: 1d
+      max_idle_duration: 24h
       config:
         match_all: true
         count_entry_bytes: true
@@ -179,7 +179,7 @@ by using the `match_all: true` parameter.
 It also creates a `log_bytes_total` counter which adds the byte size of every log line received
 to the counter by using the `count_entry_bytes: true` parameter.
 
-Those two metrics will disappear after 1d if they don't receive new entries, this is useful to reduce the building up of stage metrics.
+Those two metrics will disappear after 24h if they don't receive new entries, this is useful to reduce the building up of stage metrics.
 
 The combination of these two metric stages will give you two counters to track the volume of
 every log stream in both number of lines and bytes, which can be useful in identifying sources


### PR DESCRIPTION
time.ParseDuration does not support unit `d`

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

