### PR TITLE
Improve distributors validation and apply in-place filtering.

### DIFF
--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -24,27 +24,55 @@ func NewValidator(l Limits) (*Validator, error) {
 	return &Validator{l}, nil
 }
 
+type validationContext struct {
+	rejectOldSample       bool
+	rejectOldSampleMaxAge int64
+	creationGracePeriod   int64
+	maxLineSize           int
+
+	maxLabelNamesPerSeries int
+	maxLabelNameLength     int
+	maxLabelValueLength    int
+
+	userID string
+}
+
+func (v Validator) getValidationContextFor(userID string) validationContext {
+	now := time.Now()
+	return validationContext{
+		userID:                 userID,
+		rejectOldSample:        v.RejectOldSamples(userID),
+		rejectOldSampleMaxAge:  now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
+		creationGracePeriod:    now.Add(v.CreationGracePeriod(userID)).UnixNano(),
+		maxLineSize:            v.MaxLineSize(userID),
+		maxLabelNamesPerSeries: v.MaxLabelNamesPerSeries(userID),
+		maxLabelNameLength:     v.MaxLabelNameLength(userID),
+		maxLabelValueLength:    v.MaxLabelValueLength(userID),
+	}
+}
+
 // ValidateEntry returns an error if the entry is invalid
-func (v Validator) ValidateEntry(userID string, labels string, entry logproto.Entry) error {
-	if v.RejectOldSamples(userID) && entry.Timestamp.UnixNano() < time.Now().Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano() {
-		validation.DiscardedSamples.WithLabelValues(validation.GreaterThanMaxSampleAge, userID).Inc()
-		validation.DiscardedBytes.WithLabelValues(validation.GreaterThanMaxSampleAge, userID).Add(float64(len(entry.Line)))
+func (v Validator) ValidateEntry(ctx validationContext, labels string, entry logproto.Entry) error {
+	ts := entry.Timestamp.UnixNano()
+	if ctx.rejectOldSample && ts < ctx.rejectOldSampleMaxAge {
+		validation.DiscardedSamples.WithLabelValues(validation.GreaterThanMaxSampleAge, ctx.userID).Inc()
+		validation.DiscardedBytes.WithLabelValues(validation.GreaterThanMaxSampleAge, ctx.userID).Add(float64(len(entry.Line)))
 		return httpgrpc.Errorf(http.StatusBadRequest, validation.GreaterThanMaxSampleAgeErrorMsg(labels, entry.Timestamp))
 	}
 
-	if entry.Timestamp.UnixNano() > time.Now().Add(v.CreationGracePeriod(userID)).UnixNano() {
-		validation.DiscardedSamples.WithLabelValues(validation.TooFarInFuture, userID).Inc()
-		validation.DiscardedBytes.WithLabelValues(validation.TooFarInFuture, userID).Add(float64(len(entry.Line)))
+	if ts > ctx.creationGracePeriod {
+		validation.DiscardedSamples.WithLabelValues(validation.TooFarInFuture, ctx.userID).Inc()
+		validation.DiscardedBytes.WithLabelValues(validation.TooFarInFuture, ctx.userID).Add(float64(len(entry.Line)))
 		return httpgrpc.Errorf(http.StatusBadRequest, validation.TooFarInFutureErrorMsg(labels, entry.Timestamp))
 	}
 
-	if maxSize := v.MaxLineSize(userID); maxSize != 0 && len(entry.Line) > maxSize {
+	if maxSize := ctx.maxLineSize; maxSize != 0 && len(entry.Line) > maxSize {
 		// I wish we didn't return httpgrpc errors here as it seems
 		// an orthogonal concept (we need not use ValidateLabels in this context)
 		// but the upstream cortex_validation pkg uses it, so we keep this
 		// for parity.
-		validation.DiscardedSamples.WithLabelValues(validation.LineTooLong, userID).Inc()
-		validation.DiscardedBytes.WithLabelValues(validation.LineTooLong, userID).Add(float64(len(entry.Line)))
+		validation.DiscardedSamples.WithLabelValues(validation.LineTooLong, ctx.userID).Inc()
+		validation.DiscardedBytes.WithLabelValues(validation.LineTooLong, ctx.userID).Add(float64(len(entry.Line)))
 		return httpgrpc.Errorf(http.StatusBadRequest, validation.LineTooLongErrorMsg(maxSize, len(entry.Line), labels))
 	}
 
@@ -52,30 +80,28 @@ func (v Validator) ValidateEntry(userID string, labels string, entry logproto.En
 }
 
 // Validate labels returns an error if the labels are invalid
-func (v Validator) ValidateLabels(userID string, ls labels.Labels, stream logproto.Stream) error {
+func (v Validator) ValidateLabels(ctx validationContext, ls labels.Labels, stream logproto.Stream) error {
 	numLabelNames := len(ls)
-	if numLabelNames > v.MaxLabelNamesPerSeries(userID) {
-		validation.DiscardedSamples.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Inc()
+	if numLabelNames > ctx.maxLabelNamesPerSeries {
+		validation.DiscardedSamples.WithLabelValues(validation.MaxLabelNamesPerSeries, ctx.userID).Inc()
 		bytes := 0
 		for _, e := range stream.Entries {
 			bytes += len(e.Line)
 		}
-		validation.DiscardedBytes.WithLabelValues(validation.MaxLabelNamesPerSeries, userID).Add(float64(bytes))
-		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg(stream.Labels, numLabelNames, v.MaxLabelNamesPerSeries(userID)))
+		validation.DiscardedBytes.WithLabelValues(validation.MaxLabelNamesPerSeries, ctx.userID).Add(float64(bytes))
+		return httpgrpc.Errorf(http.StatusBadRequest, validation.MaxLabelNamesPerSeriesErrorMsg(stream.Labels, numLabelNames, ctx.maxLabelNamesPerSeries))
 	}
 
-	maxLabelNameLength := v.MaxLabelNameLength(userID)
-	maxLabelValueLength := v.MaxLabelValueLength(userID)
 	lastLabelName := ""
 	for _, l := range ls {
-		if len(l.Name) > maxLabelNameLength {
-			updateMetrics(validation.LabelNameTooLong, userID, stream)
+		if len(l.Name) > ctx.maxLabelNameLength {
+			updateMetrics(validation.LabelNameTooLong, ctx.userID, stream)
 			return httpgrpc.Errorf(http.StatusBadRequest, validation.LabelNameTooLongErrorMsg(stream.Labels, l.Name))
-		} else if len(l.Value) > maxLabelValueLength {
-			updateMetrics(validation.LabelValueTooLong, userID, stream)
+		} else if len(l.Value) > ctx.maxLabelValueLength {
+			updateMetrics(validation.LabelValueTooLong, ctx.userID, stream)
 			return httpgrpc.Errorf(http.StatusBadRequest, validation.LabelValueTooLongErrorMsg(stream.Labels, l.Value))
 		} else if cmp := strings.Compare(lastLabelName, l.Name); cmp == 0 {
-			updateMetrics(validation.DuplicateLabelNames, userID, stream)
+			updateMetrics(validation.DuplicateLabelNames, ctx.userID, stream)
 			return httpgrpc.Errorf(http.StatusBadRequest, validation.DuplicateLabelNamesErrorMsg(stream.Labels, l.Name))
 		}
 		lastLabelName = l.Name

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -73,7 +73,7 @@ func TestValidator_ValidateEntry(t *testing.T) {
 			v, err := NewValidator(o)
 			assert.NoError(t, err)
 
-			err = v.ValidateEntry(tt.userID, testStreamLabels, tt.entry)
+			err = v.ValidateEntry(v.getValidationContextFor(tt.userID), testStreamLabels, tt.entry)
 			assert.Equal(t, tt.expected, err)
 		})
 	}
@@ -151,7 +151,7 @@ func TestValidator_ValidateLabels(t *testing.T) {
 			v, err := NewValidator(o)
 			assert.NoError(t, err)
 
-			err = v.ValidateLabels(tt.userID, mustParseLabels(tt.labels), logproto.Stream{Labels: tt.labels})
+			err = v.ValidateLabels(v.getValidationContextFor(tt.userID), mustParseLabels(tt.labels), logproto.Stream{Labels: tt.labels})
 			assert.Equal(t, tt.expected, err)
 		})
 	}


### PR DESCRIPTION
```bash
❯ benchcmp  before.txt after.txt
benchmark             old ns/op     new ns/op     delta
Benchmark_Push-16     18708519      1348876       -92.79%

benchmark             old allocs     new allocs     delta
Benchmark_Push-16     44             42             -4.55%

benchmark             old bytes     new bytes     delta
Benchmark_Push-16     4008391       2079          -99.95%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


