### PR TITLE
Give another example for multiline.

### DIFF
--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -123,4 +123,4 @@ multiline:
   max_wait_time: 3s
 ```
 
-Zero-width space micht not suite everyone. Any special character that is unlikely to be part of your regular logs should do just fine.
+Zero-width space might not suite everyone. Any special character that is unlikely to be part of your regular logs should do just fine.

--- a/docs/sources/clients/promtail/stages/multiline.md
+++ b/docs/sources/clients/promtail/stages/multiline.md
@@ -113,7 +113,7 @@ At first sight these seem be like the others. Let's look at the log format.
 </configuration>
 ```
 
-There is nothing special for a [Logback](http://logback.qos.ch/) configurations except for `&ZeroWidthSpace;` at the beginning of each log line. This is the HTML-code for the [Zero-width space](https://en.wikipedia.org/wiki/Zero-width_space) character. It makes identifying first lines much simpler and is not visible. Thus it will not change the view of the log. The new first line matching regular expression is then `\x{200B}\[`. `200B` is the Uncode code point for the zero-width space character.
+There is nothing special for a [Logback](http://logback.qos.ch/) configuration except for `&ZeroWidthSpace;` at the beginning of each log line. This is the HTML-code for the [Zero-width space](https://en.wikipedia.org/wiki/Zero-width_space) character. It makes identifying first lines much simpler and is not visible. Thus it will not change the view of the log. The new first line matching regular expression is then `\x{200B}\[`. `200B` is the Unicode code point for the zero-width space character.
 
 ```yaml
 multiline:


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a new example I've tested. It uses the zero-width space
character `U+200B` to identify the first line of a multiline block.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

