### PR TITLE
More semantically correct flush shutdown

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -37,7 +37,7 @@ The HTTP API includes the following endpoints:
     - [Examples](#examples-8)
   - [`GET /ready`](#get-ready)
   - [`POST /flush`](#post-flush)
-  - [`POST /ingester/shutdown`](#post-shutdown)
+  - [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
   - [`GET /metrics`](#get-metrics)
   - [Series](#series)
     - [Examples](#examples-9)
@@ -108,7 +108,7 @@ While these endpoints are exposed by just the distributor:
 And these endpoints are exposed by just the ingester:
 
 - [`POST /flush`](#post-flush)
-- [`POST /ingester/shutdown`](#post-ingestershutdown)
+- [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
 
 The API endpoints starting with `/loki/` are [Prometheus API-compatible](https://prometheus.io/docs/prometheus/latest/querying/api/) and the result formats can be used interchangeably.
 
@@ -846,13 +846,13 @@ backing store. Mainly used for local testing.
 
 In microservices mode, the `/flush` endpoint is exposed by the ingester.
 
-## `POST /ingester/shutdown`
+## `POST /ingester/flush_shutdown`
 
-`/ingester/shutdown` triggers a shutdown of the ingester and notably will _always_ flush any in memory chunks it holds.
+`/ingester/flush_shutdown` triggers a shutdown of the ingester and notably will _always_ flush any in memory chunks it holds.
 This is helpful for scaling down WAL-enabled ingesters where we want to ensure old WAL directories are not orphaned,
 but instead flushed to our chunk backend.
 
-In microservices mode, the `/ingester/shutdown` endpoint is exposed by the ingester.
+In microservices mode, the `/ingester/flush_shutdown` endpoint is exposed by the ingester.
 
 ## `GET /metrics`
 

--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -78,7 +78,7 @@ When scaling down, we must ensure existing data on the leaving ingesters are flu
 
 Consider you have 4 ingesters `ingester-0 ingester-1 ingester-2 ingester-3` and you want to scale down to 2 ingesters, the ingesters which will be shutdown according to statefulset rules are `ingester-3` and then `ingester-2`.
 
-Hence before actually scaling down in Kubernetes, port forward those ingesters and hit the [`/ingester/shutdown`](../../api#post-ingestershutdown) endpoint. This will flush the chunks and shut down the ingesters (while also removing itself from the ring).
+Hence before actually scaling down in Kubernetes, port forward those ingesters and hit the [`/ingester/flush_shutdown`](../../api#post-ingesterflush_shutdown) endpoint. This will flush the chunks and shut down the ingesters (while also removing itself from the ring).
 
 After hitting the endpoint for `ingester-2 ingester-3`, scale down the ingesters to 2.
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -227,8 +227,7 @@ func (t *Loki) initIngester() (_ services.Service, err error) {
 	logproto.RegisterIngesterServer(t.Server.GRPC, t.ingester)
 	grpc_health_v1.RegisterHealthServer(t.Server.GRPC, t.ingester)
 	t.Server.HTTP.Path("/flush").Handler(http.HandlerFunc(t.ingester.FlushHandler))
-	// TODO(owen-d): should this use cortex style path (/ingester/shutdown), legacy style (/shutdown), or apir prefixed (/loki/api/v1/ingester/shutdown)?
-	t.Server.HTTP.Methods("POST").Path("/ingester/shutdown").Handler(http.HandlerFunc(t.ingester.ShutdownHandler))
+	t.Server.HTTP.Methods("POST").Path("/ingester/flush_shutdown").Handler(http.HandlerFunc(t.ingester.ShutdownHandler))
 	return t.ingester, nil
 }
 


### PR DESCRIPTION
The endpoint is now a bit more explicit that it flushes then shuts down.