### PR TITLE
Allow dependabot to keep github actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This change allows dependabot to check any GitHub action which this project uses on a weekly basis and submit PRs with version bumps in order to keep packages up-to-date.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

I don't necessarily believe that this project _needs_ it, rather its more of a chore or a nice to have.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

The grafana project currently makes use of this.

https://github.com/grafana/grafana/blob/master/.github/dependabot.yml

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

