### PR TITLE
Improve wal entries encoding.

### DIFF
--- a/pkg/ingester/encoding.go
+++ b/pkg/ingester/encoding.go
@@ -113,14 +113,11 @@ outer:
 
 		for _, s := range ref.Entries {
 			buf.PutVarint64(s.Timestamp.UnixNano() - first)
-			// denote line length
-			byteLine := []byte(s.Line)
-			buf.PutUvarint(len(byteLine))
-			buf.PutBytes(byteLine)
+			buf.PutUvarint(len(s.Line))
+			buf.PutString(s.Line)
 		}
 	}
 	return buf.Get()
-
 }
 
 func decodeEntries(b []byte, rec *WALRecord) error {
@@ -164,7 +161,6 @@ func decodeEntries(b []byte, rec *WALRecord) error {
 		return errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return nil
-
 }
 
 func decodeWALRecord(b []byte, walRec *WALRecord) (err error) {
@@ -205,7 +201,6 @@ func decodeWALRecord(b []byte, walRec *WALRecord) (err error) {
 func EncWith(b []byte) (res Encbuf) {
 	res.B = b
 	return res
-
 }
 
 // Encbuf extends encoding.Encbuf with support for multi byte encoding
@@ -213,7 +208,7 @@ type Encbuf struct {
 	encoding.Encbuf
 }
 
-func (e *Encbuf) PutBytes(c []byte) { e.B = append(e.B, c...) }
+func (e *Encbuf) PutString(s string) { e.B = append(e.B, s...) }
 
 func DecWith(b []byte) (res Decbuf) {
 	res.B = b


### PR DESCRIPTION
Little trick to avoid memory allocation with regards to bytes slice and string.

benchmp:

```
❯ benchcmp  before.txt after.txt
benchmark                      old ns/op     new ns/op     delta
Benchmark_EncodeEntries-16     1699362       1055627       -37.88%

benchmark                      old allocs     new allocs     delta
Benchmark_EncodeEntries-16     20025          25             -99.88%

benchmark                      old bytes     new bytes     delta
Benchmark_EncodeEntries-16     5625393       4665376       -17.07%
```

This originated from an investigation on CPU usage of ingester, see screenshot below:

![image](https://user-images.githubusercontent.com/1053421/104166522-f261ea80-53c8-11eb-839c-6f4cddc839f7.png)


Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


