### PR TITLE
Jsonnet: Changes ingester PVC from 5Gi to 10Gi

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -16,7 +16,7 @@
 
     // flags for running ingesters/queriers as a statefulset instead of deployment type.
     stateful_ingesters: false,
-    ingester_pvc_size: '5Gi',
+    ingester_pvc_size: '10Gi',
     ingester_pvc_class: 'fast',
 
     stateful_queriers: false,


### PR DESCRIPTION
Prior to PR #3079 which correctly fixed the ingester deployment to use this value, the hard coded value was 10Gi and this default was 5Gi. 

3079 then effectively changed the default from 10Gi to 5Gi, this is a dissalowed change in kubernetes and causes deployment failures.

Unfortunately making this change from 5Gi to 10Gi is also a breaking change for anyone who installed while it was 5Gi.

I'm making this decision strictly on the assumption that more people installed when it was 10Gi and will be impacted by it changing from 10Gi to 5Gi