### PR TITLE
[doc] fix:querier do not handle "/flush" api

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -95,7 +95,6 @@ These endpoints are exposed by the querier and the frontend:
   - [`POST /api/prom/push`](#post-apiprompush)
     - [Examples](#examples-8)
   - [`GET /ready`](#get-ready)
-  - [`POST /flush`](#post-flush)
   - [`GET /metrics`](#get-metrics)
   - [Series](#series)
     - [Examples](#examples-9)


### PR DESCRIPTION
[doc] fix:querier do not handle "/flush" api