### PR TITLE
[Boltdb-shipper] If S3 ListObjects returns the directory itself getDBNameFromObjectKey fails

### DIFF
--- a/pkg/storage/stores/shipper/compactor/table.go
+++ b/pkg/storage/stores/shipper/compactor/table.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -105,6 +106,11 @@ func (t *table) compact() error {
 				case objectKey, ok := <-readObjectChan:
 					if !ok {
 						return
+					}
+
+					// The s3 client can also return the directory itself in the ListObjects.
+					if strings.HasSuffix(objectKey, "/") {
+						continue
 					}
 
 					var dbName string

--- a/pkg/storage/stores/shipper/compactor/table.go
+++ b/pkg/storage/stores/shipper/compactor/table.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -109,7 +108,7 @@ func (t *table) compact() error {
 					}
 
 					// The s3 client can also return the directory itself in the ListObjects.
-					if strings.HasSuffix(objectKey, "/") {
+					if shipper_util.IsDirectory(objectKey) {
 						continue
 					}
 

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -211,6 +211,12 @@ func (t *Table) init(ctx context.Context, spanLogger log.Logger) (err error) {
 
 	// open all the downloaded dbs
 	for _, object := range objects {
+
+		// The s3 client can also return the directory itself in the ListObjects.
+		if strings.HasSuffix(object.Key, "/") {
+			continue
+		}
+
 		dbName, err := getDBNameFromObjectKey(object.Key)
 		if err != nil {
 			return err
@@ -409,6 +415,10 @@ func (t *Table) checkStorageForUpdates(ctx context.Context) (toDownload []chunk.
 	defer t.dbsMtx.RUnlock()
 
 	for _, object := range objects {
+		// The s3 client can also return the directory itself in the ListObjects.
+		if strings.HasSuffix(object.Key, "/") {
+			continue
+		}
 		dbName, err := getDBNameFromObjectKey(object.Key)
 		if err != nil {
 			return nil, nil, err
@@ -504,6 +514,11 @@ func (t *Table) doParallelDownload(ctx context.Context, objects []chunk.StorageO
 				object, ok := <-queue
 				if !ok {
 					break
+				}
+
+				// The s3 client can also return the directory itself in the ListObjects.
+				if strings.HasSuffix(object.Key, "/") {
+					continue
 				}
 
 				var dbName string

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -209,13 +209,10 @@ func (t *Table) init(ctx context.Context, spanLogger log.Logger) (err error) {
 
 	level.Debug(spanLogger).Log("total-files-downloaded", len(objects))
 
+	objects = shipper_util.RemoveDirectories(objects)
+
 	// open all the downloaded dbs
 	for _, object := range objects {
-
-		// The s3 client can also return the directory itself in the ListObjects.
-		if strings.HasSuffix(object.Key, "/") {
-			continue
-		}
 
 		dbName, err := getDBNameFromObjectKey(object.Key)
 		if err != nil {
@@ -414,11 +411,9 @@ func (t *Table) checkStorageForUpdates(ctx context.Context) (toDownload []chunk.
 	t.dbsMtx.RLock()
 	defer t.dbsMtx.RUnlock()
 
+	objects = shipper_util.RemoveDirectories(objects)
+
 	for _, object := range objects {
-		// The s3 client can also return the directory itself in the ListObjects.
-		if strings.HasSuffix(object.Key, "/") {
-			continue
-		}
 		dbName, err := getDBNameFromObjectKey(object.Key)
 		if err != nil {
 			return nil, nil, err
@@ -517,7 +512,7 @@ func (t *Table) doParallelDownload(ctx context.Context, objects []chunk.StorageO
 				}
 
 				// The s3 client can also return the directory itself in the ListObjects.
-				if strings.HasSuffix(object.Key, "/") {
+				if shipper_util.IsDirectory(object.Key) {
 					continue
 				}
 

--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/local"
 	"go.etcd.io/bbolt"
 
@@ -154,4 +155,21 @@ func safeOpenBoltDbFile(path string, ret chan *result) {
 	b, err := local.OpenBoltdbFile(path)
 	res.boltdb = b
 	res.err = err
+}
+
+// RemoveDirectories will return a new slice with any StorageObjects identified as directories removed.
+func RemoveDirectories(incoming []chunk.StorageObject) []chunk.StorageObject {
+	outgoing := make([]chunk.StorageObject, 0, len(incoming))
+	for _, o := range incoming {
+		if IsDirectory(o.Key) {
+			continue
+		}
+		outgoing = append(outgoing, o)
+	}
+	return outgoing
+}
+
+// IsDirectory will return true if the string ends in a forward slash
+func IsDirectory(key string) bool {
+	return strings.HasSuffix(key, "/")
 }


### PR DESCRIPTION
Chubaofs returns the following:

```
$ s3cmd ls s3://loki/index/index_18641/
2021-01-14 08:46            0  s3://loki/index/index_18641/
2021-01-14 08:46         3952  s3://loki/index/index_18641/xxx-1610612684957170124-1610613044.gz
2021-01-14 09:01         2990  s3://loki/index/index_18641/xxx-1610612684957170124-1610613900.gz
2021-01-14 09:16         6552  s3://loki/index/index_18641/xxx-1610612684957170124-1610614800.gz
2021-01-14 09:31         9487  s3://loki/index/index_18641/xxx-1610612684957170124-1610615700.gz
```
So the directory itself is also returned, therefore we need to skip if the object ends with a `/`
