### PR TITLE
promtail: pass registerer to gcplog

### DIFF
--- a/pkg/promtail/targets/gcplog/metrics.go
+++ b/pkg/promtail/targets/gcplog/metrics.go
@@ -1,0 +1,37 @@
+package gcplog
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics stores gcplog entry mertrics.
+type Metrics struct {
+	// reg is the Registerer used to create this set of metrics. May be nil.
+	reg prometheus.Registerer
+
+	gcplogEntries *prometheus.CounterVec
+	gcplogErrors  *prometheus.CounterVec
+}
+
+// NewMetrics creates a new set of metrics. If reg is non-nil, the metrics
+// will be registered.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	var m Metrics
+	m.reg = reg
+
+	m.gcplogEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "gcplog_target_entries_total",
+		Help:      "Help number of successful entries sent to the gcplog target",
+	}, []string{"project"})
+
+	m.gcplogErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "gcplog_target_parsing_errors_total",
+		Help:      "Total number of parsing errors while receiving gcplog messages",
+	}, []string{"project"})
+
+	if reg != nil {
+		reg.MustRegister(m.gcplogEntries, m.gcplogErrors)
+	}
+
+	return &m
+}

--- a/pkg/promtail/targets/gcplog/metrics.go
+++ b/pkg/promtail/targets/gcplog/metrics.go
@@ -4,15 +4,14 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Metrics stores gcplog entry mertrics.
 type Metrics struct {
-	// reg is the Registerer used to create this set of metrics. May be nil.
+	// reg is the Registerer used to create this set of metrics.
 	reg prometheus.Registerer
 
 	gcplogEntries *prometheus.CounterVec
 	gcplogErrors  *prometheus.CounterVec
 }
 
-// NewMetrics creates a new set of metrics. If reg is non-nil, the metrics
-// will be registered.
+// NewMetrics creates a new set of metrics. Metrics will be registered to reg.
 func NewMetrics(reg prometheus.Registerer) *Metrics {
 	var m Metrics
 	m.reg = reg
@@ -29,9 +28,6 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Help:      "Total number of parsing errors while receiving gcplog messages",
 	}, []string{"project"})
 
-	if reg != nil {
-		reg.MustRegister(m.gcplogEntries, m.gcplogErrors)
-	}
-
+	reg.MustRegister(m.gcplogEntries, m.gcplogErrors)
 	return &m
 }

--- a/pkg/promtail/targets/gcplog/target_test.go
+++ b/pkg/promtail/targets/gcplog/target_test.go
@@ -122,6 +122,7 @@ func testGcplogTarget(t *testing.T) (*GcplogTarget, *fake.Client, *pubsub.Client
 	fakeClient := fake.New(func() {})
 
 	target := newGcplogTarget(
+		NewMetrics(nil),
 		log.NewNopLogger(),
 		fakeClient,
 		nil,

--- a/pkg/promtail/targets/gcplog/target_test.go
+++ b/pkg/promtail/targets/gcplog/target_test.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -122,7 +123,7 @@ func testGcplogTarget(t *testing.T) (*GcplogTarget, *fake.Client, *pubsub.Client
 	fakeClient := fake.New(func() {})
 
 	target := newGcplogTarget(
-		NewMetrics(nil),
+		NewMetrics(prometheus.NewRegistry()),
 		log.NewNopLogger(),
 		fakeClient,
 		nil,

--- a/pkg/promtail/targets/gcplog/targetmanager.go
+++ b/pkg/promtail/targets/gcplog/targetmanager.go
@@ -25,11 +25,6 @@ func NewGcplogTargetManager(
 	client api.EntryHandler,
 	scrape []scrapeconfig.Config,
 ) (*GcplogTargetManager, error) {
-	reg := metrics.reg
-	if reg == nil {
-		reg = prometheus.DefaultRegisterer
-	}
-
 	tm := &GcplogTargetManager{
 		logger:  logger,
 		targets: make(map[string]*GcplogTarget),
@@ -39,7 +34,7 @@ func NewGcplogTargetManager(
 		if cf.GcplogConfig == nil {
 			continue
 		}
-		pipeline, err := stages.NewPipeline(log.With(logger, "component", "pubsub_pipeline"), cf.PipelineStages, &cf.JobName, reg)
+		pipeline, err := stages.NewPipeline(log.With(logger, "component", "pubsub_pipeline"), cf.PipelineStages, &cf.JobName, metrics.reg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/promtail/targets/gcplog/targetmanager.go
+++ b/pkg/promtail/targets/gcplog/targetmanager.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/pkg/logentry/stages"
 	"github.com/grafana/loki/pkg/promtail/api"

--- a/pkg/promtail/targets/manager.go
+++ b/pkg/promtail/targets/manager.go
@@ -87,12 +87,16 @@ func NewTargetManagers(
 	var (
 		fileMetrics   *file.Metrics
 		syslogMetrics *syslog.Metrics
+		gcplogMetrics *gcplog.Metrics
 	)
 	if len(targetScrapeConfigs[FileScrapeConfigs]) > 0 {
 		fileMetrics = file.NewMetrics(reg)
 	}
 	if len(targetScrapeConfigs[SyslogScrapeConfigs]) > 0 {
 		syslogMetrics = syslog.NewMetrics(reg)
+	}
+	if len(targetScrapeConfigs[GcplogScrapeConfigs]) > 0 {
+		gcplogMetrics = gcplog.NewMetrics(reg)
 	}
 
 	for target, scrapeConfigs := range targetScrapeConfigs {
@@ -135,6 +139,7 @@ func NewTargetManagers(
 			targetManagers = append(targetManagers, syslogTargetManager)
 		case GcplogScrapeConfigs:
 			pubsubTargetManager, err := gcplog.NewGcplogTargetManager(
+				gcplogMetrics,
 				logger,
 				client,
 				scrapeConfigs,


### PR DESCRIPTION
Related to #3174, #3175; Promtail components should no longer register metrics globally with `promauto` anymore.