### PR TITLE
Ignore flushed chunks during checkpointing

### DIFF
--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -167,7 +167,7 @@ func (i *ingesterSeriesIter) Iter() <-chan *SeriesWithErr {
 				}
 
 				// TODO(owen-d): use a pool
-				chunks, err := toWireChunks(stream.chunks, nil)
+				chunks, err := toWireChunks(unflushedChunks(stream.chunks), nil)
 				stream.chunkMtx.RUnlock()
 
 				var s *Series
@@ -505,4 +505,16 @@ func (c *Checkpointer) Run() {
 			return
 		}
 	}
+}
+
+func unflushedChunks(descs []chunkDesc) []chunkDesc {
+	filtered := make([]chunkDesc, 0, len(descs))
+
+	for _, d := range descs {
+		if d.flushed.IsZero() {
+			filtered = append(filtered, d)
+		}
+	}
+
+	return filtered
 }

--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -167,6 +167,7 @@ func (i *ingesterSeriesIter) Iter() <-chan *SeriesWithErr {
 				}
 
 				// TODO(owen-d): use a pool
+				// Only send chunks for checkpointing that have yet to be flushed.
 				chunks, err := toWireChunks(unflushedChunks(stream.chunks), nil)
 				stream.chunkMtx.RUnlock()
 

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -227,6 +227,20 @@ func TestIngesterWALIgnoresStreamLimits(t *testing.T) {
 
 }
 
+func TestUnflushedChunks(t *testing.T) {
+	chks := []chunkDesc{
+		{
+			flushed: time.Now(),
+		},
+		{},
+		{
+			flushed: time.Now(),
+		},
+	}
+
+	require.Equal(t, 1, len(unflushedChunks(chks)))
+}
+
 func expectCheckpoint(t *testing.T, walDir string, shouldExist bool) {
 	fs, err := ioutil.ReadDir(walDir)
 	require.Nil(t, err)


### PR DESCRIPTION
Will not attempt to checkpoint chunks which have already been flushed.