### PR TITLE
limit query range in async store for ingesters when query-ingesters-within flag is set

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -315,7 +315,10 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 		case Querier, Ruler:
 			// Use AsyncStore to query both ingesters local store and chunk store for store queries.
 			// Only queriers should use the AsyncStore, it should never be used in ingesters.
-			chunkStore = loki_storage.NewAsyncStore(chunkStore, t.ingesterQuerier)
+			chunkStore = loki_storage.NewAsyncStore(chunkStore, t.ingesterQuerier,
+				calculateAsyncStoreQueryIngestersWithin(t.cfg.Querier.QueryIngestersWithin,
+					t.cfg.Ingester.MaxChunkAge, t.cfg.StorageConfig.BoltDBShipperConfig.ResyncInterval),
+			)
 		case All:
 			// We want ingester to also query the store when using boltdb-shipper but only when running with target All.
 			// We do not want to use AsyncStore otherwise it would start spiraling around doing queries over and over again to the ingesters and store.
@@ -580,4 +583,17 @@ func calculateMaxLookBack(pc chunk.PeriodConfig, maxLookBackConfig, maxChunkAge,
 			"greater than the default or remove it from the configuration to use the default", maxLookBackConfig, defaultMaxLookBack)
 	}
 	return maxLookBackConfig, nil
+}
+
+func calculateAsyncStoreQueryIngestersWithin(queryIngestersWithinConfig, maxChunkAge, querierResyncInterval time.Duration) time.Duration {
+	// 0 means do not limit queries, we would also not limit ingester queries from AsyncStore.
+	if queryIngestersWithinConfig == 0 {
+		return 0
+	}
+
+	minVal := maxChunkAge + shipper.UploadInterval + querierResyncInterval + (15 * time.Minute)
+	if queryIngestersWithinConfig < minVal {
+		return minVal
+	}
+	return queryIngestersWithinConfig
 }

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -86,3 +86,53 @@ func Test_calculateMaxLookBack(t *testing.T) {
 		})
 	}
 }
+
+func Test_calculateAsyncStoreQueryIngestersWithin(t *testing.T) {
+	type args struct {
+		queryIngestersWithin             time.Duration
+		maxChunkAge                      time.Duration
+		querierBoltDBFilesResyncInterval time.Duration
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			name: "default",
+			args: args{
+				0,
+				time.Hour,
+				5 * time.Minute,
+			},
+			want: 0,
+		},
+		{
+			name: "queryIngestersWithin more than min val",
+			args: args{
+				3 * time.Hour,
+				time.Hour,
+				5 * time.Minute,
+			},
+			want: 3 * time.Hour,
+		},
+		{
+			name: "queryIngestersWithin less than min val",
+			args: args{
+				time.Hour,
+				time.Hour,
+				5 * time.Minute,
+			},
+			want: 81 * time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateAsyncStoreQueryIngestersWithin(tt.args.queryIngestersWithin, tt.args.maxChunkAge, tt.args.querierBoltDBFilesResyncInterval)
+
+			if got != tt.want {
+				t.Errorf("calculateAsyncStoreQueryIngestersWithin() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When using boltdb-shipper we do an extra query(GetChunkIDs) to ingesters to get ids of chunks from their local store which otherwise would lead to missing data in query response due to a delay in ingesters uploading their local index and queriers syncing them. We were always querying the ingesters for whole query duration without considering `query-ingesters-within` flag.

In this PR we are changing the behaviour by limiting the `GetChunkIDs` query range when `query-ingesters-within` flag is non-zero. Considering the working of `boltdb-shipper` we calculate the value for query ingesters within for `GetChunkIDs` queries as follows:
MaxValueOf(`querier.query-ingesters-within`,`ingester.max-chunk-age`+`boltdb shipper files upload interval`+`boltdb.shipper.resync-interval`+`15 mins`).

