### PR TITLE
Reverts flush buffer pooling.

### DIFF
--- a/pkg/util/pool/bytesbuffer.go
+++ b/pkg/util/pool/bytesbuffer.go
@@ -44,13 +44,13 @@ func (p *BufferPool) Get(sz int) *bytes.Buffer {
 		}
 		b := p.buckets[i].Get()
 		if b == nil {
-			b = bytes.NewBuffer(make([]byte, bktSize))
+			b = bytes.NewBuffer(make([]byte, 0, bktSize))
 		}
 		buf := b.(*bytes.Buffer)
 		buf.Reset()
 		return b.(*bytes.Buffer)
 	}
-	return bytes.NewBuffer(make([]byte, sz))
+	return bytes.NewBuffer(make([]byte, 0, sz))
 }
 
 // Put adds a byte buffer to the right bucket in the pool.

--- a/pkg/util/pool/bytesbuffer_test.go
+++ b/pkg/util/pool/bytesbuffer_test.go
@@ -1,0 +1,17 @@
+package pool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ZeroBuffer(t *testing.T) {
+	p := NewBuffer(2, 10, 2)
+	require.Equal(t, 0, p.Get(1).Len())
+	require.Equal(t, 0, p.Get(1).Len())
+	require.Equal(t, 0, p.Get(2).Len())
+	require.Equal(t, 0, p.Get(2).Len())
+	require.Equal(t, 0, p.Get(20).Len())
+	require.Equal(t, 0, p.Get(20).Len())
+}


### PR DESCRIPTION
Currently this requires more work, as the cache is asynchronously using the buffer when flushing chunks.

We still benefits from other improvements like computing the right size for a chunk.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
