### PR TITLE
Fix: Update docs for logcli

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -48,7 +48,21 @@ of excluded labels. This extra information can be suppressed with the
 --quiet flag.
 
 By default we look over the last hour of data; use --since to modify
-or provide specific start and end times with --start and --end.
+or provide specific start and end times with --from and --to respectively.
+
+Notice that when using --from and --to then ensure to use RFC3339Nano
+time format, but without timezone at the end. The local timezone will be added
+automatically or if using  --timezone flag.
+
+Example:
+
+	logcli query
+	   --timezone=UTC
+	   --from="2021-01-19T10:00:00.000000000Z"
+	   --to="2021-01-19T20:00:00.000000000Z"
+	   --output=jsonl
+	   'my-query'
+
 The output is limited to 30 entries by default; use --limit to increase.
 
 While "query" does support metrics queries, its output contains multiple

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -58,8 +58,8 @@ Example:
 
 	logcli query
 	   --timezone=UTC
-	   --from="2021-01-19T10:00:00.000000000Z"
-	   --to="2021-01-19T20:00:00.000000000Z"
+	   --from="2021-01-19T10:00:00Z"
+	   --to="2021-01-19T20:00:00Z"
 	   --output=jsonl
 	   'my-query'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix description for logcli, use proper flag names.
Extend docs with example using timestamp.

**Which issue(s) this PR fixes**:
Maybe not fixes but helps to acheive log download from loki described in #409

**Special notes for your reviewer**:
I tried to use command as described but there was an issue that:
- there were unrecognized flags (`--start` and  `--end` were replaced with `--from` and `--to`)
- the timestamp message was pretty vague, apparetnly logcli appends timezone string, so the `--from` and `--to` are not exackly `RFC3339Nano` but more like `RFC3339Nano without timezone`.

**Checklist**
- [v] Documentation added


