### PR TITLE
WAL backpressure

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -897,7 +897,7 @@ lifecycler:
 [query_store_max_look_back_period: <duration> | default = 0]
 
 
-# The ingester WAL records incoming logs and stores them on the local file system in order to guarantee persistence of acknowledged data in the event of a process crash.
+# The ingester WAL (Write Ahead Log) records incoming logs and stores them on the local file system in order to guarantee persistence of acknowledged data in the event of a process crash.
 wal:
   # Enables writing to WAL.
   # CLI flag: -ingester.wal-enabled
@@ -911,13 +911,17 @@ wal:
   # CLI flag: -ingester.recover-from-wal
   [recover: <boolean> | default = false]
 
-# When WAL is enabled, should chunks be flushed to long-term storage on shutdown.
-# CLI flag: -ingester.flush-on-shutdown
-[flush_on_shutdown: <boolean> | default = false]
+  # When WAL is enabled, should chunks be flushed to long-term storage on shutdown.
+  # CLI flag: -ingester.flush-on-shutdown
+  [flush_on_shutdown: <boolean> | default = false]
 
-# Interval at which checkpoints should be created.
-# CLI flag: ingester.checkpoint-duration
-[checkpoint_duration: <duration> | default = 5m]
+  # Interval at which checkpoints should be created.
+  # CLI flag: ingester.checkpoint-duration
+  [checkpoint_duration: <duration> | default = 5m]
+
+  # Maximum memory size the WAL may use during replay. After hitting this it will flush data to storage before continuing.
+  # A unit suffix (KB, MB, GB) may be applied.
+  [replay_memory_ceiling: <string> | default = 4GB]
 ```
 
 ## consul_config

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -255,7 +255,7 @@ func NewMemChunk(enc Encoding, blockSize, targetSize int) *MemChunk {
 		blocks:     []block{},
 
 		head:   &headBlock{},
-		format: chunkFormatV2,
+		format: chunkFormatV3,
 
 		encoding: enc,
 	}

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -920,13 +920,6 @@ func TestCheckpointEncoding(t *testing.T) {
 	cpy, err := MemchunkFromCheckpoint(chk.Bytes(), head.Bytes(), blockSize, targetSize)
 	require.Nil(t, err)
 
-	// TODO(owen-d): remove once v3+ is the default chunk version
-	// because that is when we started serializing uncompressed size.
-	// Until then, nil them out in order to ease equality testing.
-	for i := range c.blocks {
-		c.blocks[i].uncompressedSize = 0
-	}
-
 	require.Equal(t, c, cpy)
 }
 

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -41,12 +41,10 @@ func ensureIngesterData(ctx context.Context, t *testing.T, start, end time.Time,
 func defaultIngesterTestConfigWithWAL(t *testing.T, walDir string) Config {
 	ingesterConfig := defaultIngesterTestConfig(t)
 	ingesterConfig.MaxTransferRetries = 0
-	ingesterConfig.WAL = WALConfig{
-		Enabled:            true,
-		Dir:                walDir,
-		Recover:            true,
-		CheckpointDuration: time.Second,
-	}
+	ingesterConfig.WAL.Enabled = true
+	ingesterConfig.WAL.Dir = walDir
+	ingesterConfig.WAL.Recover = true
+	ingesterConfig.WAL.CheckpointDuration = time.Second
 
 	return ingesterConfig
 }

--- a/pkg/ingester/encoding_test.go
+++ b/pkg/ingester/encoding_test.go
@@ -42,6 +42,11 @@ func Test_Encoding_Series(t *testing.T) {
 
 	err := decodeWALRecord(buf, decoded)
 	require.Nil(t, err)
+
+	// Since we use a pool, there can be subtle differentiations between nil slices and len(0) slices.
+	// Both are valid, so check length.
+	require.Equal(t, 0, len(decoded.RefEntries))
+	decoded.RefEntries = nil
 	require.Equal(t, record, decoded)
 }
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -164,7 +164,7 @@ func (i *instance) Push(ctx context.Context, req *logproto.PushRequest) error {
 			continue
 		}
 
-		if err := stream.Push(ctx, s.Entries, record); err != nil {
+		if _, err := stream.Push(ctx, s.Entries, record); err != nil {
 			appendErr = err
 			continue
 		}

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -22,6 +22,17 @@ type ingesterMetrics struct {
 	recoveredStreamsTotal prometheus.Counter
 	recoveredChunksTotal  prometheus.Counter
 	recoveredEntriesTotal prometheus.Counter
+	recoveredBytesTotal   prometheus.Counter
+	recoveryBytesInUse    prometheus.Gauge
+}
+
+// setRecoveryBytesInUse bounds the bytes reports to >= 0.
+// TODO(owen-d): we can gain some efficiency by having the flusher never update this after recovery ends.
+func (m *ingesterMetrics) setRecoveryBytesInUse(v int64) {
+	if v < 0 {
+		v = 0
+	}
+	m.recoveryBytesInUse.Set(float64(v))
 }
 
 const (
@@ -87,6 +98,14 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 		recoveredEntriesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_wal_recovered_entries_total",
 			Help: "Total number of entries recovered from the WAL.",
+		}),
+		recoveredBytesTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_ingester_wal_recovered_bytes_total",
+			Help: "Total number of bytes recovered from the WAL.",
+		}),
+		recoveryBytesInUse: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_wal_bytes_in_use",
+			Help: "Total number of bytes in use by the WAL recovery process.",
 		}),
 	}
 }

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -128,7 +128,6 @@ func (r *ingesterRecoverer) Series(series *Series) error {
 			return err
 		}
 		r.ing.metrics.recoveredChunksTotal.Add(float64(len(series.Chunks)))
-		r.ing.metrics.recoveredBytesTotal.Add(float64(bytesAdded))
 		r.ing.metrics.recoveredEntriesTotal.Add(float64(entriesAdded))
 		r.ing.replayController.Add(int64(bytesAdded))
 

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -56,11 +56,11 @@ func newReplayController(metrics *ingesterMetrics, cfg WALConfig, flusher Flushe
 
 func (c *replayController) Add(x int64) {
 	c.metrics.recoveredBytesTotal.Add(float64(x))
-	c.metrics.setRecoveryBytesInUse(c.currentBytes.Add(int64(x)))
+	c.metrics.setRecoveryBytesInUse(c.currentBytes.Add(x))
 }
 
 func (c *replayController) Sub(x int64) {
-	c.metrics.setRecoveryBytesInUse(c.currentBytes.Sub(int64(x)))
+	c.metrics.setRecoveryBytesInUse(c.currentBytes.Sub(x))
 
 }
 

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -55,6 +55,7 @@ func newReplayController(metrics *ingesterMetrics, cfg WALConfig, flusher Flushe
 }
 
 func (c *replayController) Add(x int64) {
+	c.metrics.recoveredBytesTotal.Add(float64(x))
 	c.metrics.setRecoveryBytesInUse(c.currentBytes.Add(int64(x)))
 }
 

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -1,0 +1,71 @@
+package ingester
+
+import (
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+type Flusher interface {
+	InitFlushQueues()
+	Flush()
+}
+
+// replayController handles coordinating backpressure between WAL replays and chunk flushing.
+type replayController struct {
+	cfg          WALConfig
+	metrics      *ingesterMetrics
+	currentBytes atomic.Int64
+	cond         *sync.Cond
+	isFlushing   atomic.Bool
+	flusher      Flusher
+}
+
+// flusher is expected to reduce pressure via calling Sub
+func newReplayController(metrics *ingesterMetrics, cfg WALConfig, flusher Flusher) *replayController {
+	return &replayController{
+		cfg:     cfg,
+		metrics: metrics,
+		cond:    sync.NewCond(&sync.Mutex{}),
+		flusher: flusher,
+	}
+}
+
+func (c *replayController) Add(x int64) {
+	c.metrics.setRecoveryBytesInUse(c.currentBytes.Add(int64(x)))
+}
+
+func (c *replayController) Sub(x int64) {
+	c.metrics.setRecoveryBytesInUse(c.currentBytes.Sub(int64(x)))
+}
+
+func (c *replayController) Cur() int {
+	return int(c.currentBytes.Load())
+}
+
+func (c *replayController) Flush() {
+	if c.isFlushing.CAS(false, true) {
+		c.flusher.InitFlushQueues()
+		c.flusher.Flush()
+		c.isFlushing.Store(false)
+		c.cond.Broadcast()
+	}
+}
+
+func (c *replayController) WithBackPressure(fn func() error) error {
+	// Account for backpressure and wait until there's enough memory to continue replaying the WAL
+	c.cond.L.Lock()
+
+	// use 90% as a threshold since we'll be adding to it.
+	for c.Cur() > int(c.cfg.ReplayMemoryCeiling)*9/10 {
+		// too much backpressure, flush
+		go c.Flush()
+		c.cond.Wait()
+	}
+
+	// Don't hold the lock while executing the provided function.
+	// This ensures we can run functions concurrently.
+	c.cond.L.Unlock()
+
+	return fn()
+}

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type dumbFlusher struct {
-	onInit, onFlush, postFlush func()
+	onFlush func()
 }
 
 func newDumbFlusher(onFlush func()) *dumbFlusher {
@@ -50,7 +50,7 @@ func TestReplayController(t *testing.T) {
 		// to the internal count, introduce a brief sleep.
 		time.Sleep(time.Millisecond)
 
-		// nolint:errcheck
+		// nolint:errcheck,unparam
 		go rc.WithBackPressure(func() error {
 			rc.Add(50)
 			opLock.Lock()

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -1,0 +1,90 @@
+package ingester
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dumbFlusher struct {
+	onInit, onFlush func()
+}
+
+func newDumbFlusher(onInit, onFlush func()) *dumbFlusher {
+	return &dumbFlusher{
+		onInit:  onInit,
+		onFlush: onFlush,
+	}
+}
+
+func (f *dumbFlusher) InitFlushQueues() {
+	if f.onInit != nil {
+		f.onInit()
+	}
+}
+func (f *dumbFlusher) Flush() {
+	if f.onFlush != nil {
+		f.onFlush()
+	}
+}
+
+func nilMetrics() *ingesterMetrics { return newIngesterMetrics(nil) }
+
+func TestReplayController(t *testing.T) {
+	var ops []string
+	var opLock sync.Mutex
+
+	var rc *replayController
+	flusher := newDumbFlusher(
+		func() {
+			opLock.Lock()
+			defer opLock.Unlock()
+			ops = append(ops, "InitFlushQueues")
+		},
+		func() {
+			rc.Sub(100) // simulate flushing 100 bytes
+			opLock.Lock()
+			defer opLock.Unlock()
+			ops = append(ops, "Flush")
+		},
+	)
+	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+
+	var wg sync.WaitGroup
+	n := 5
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		// In order to prevent all the goroutines from running before they've added bytes
+		// to the internal count, introduce a brief sleep.
+		time.Sleep(time.Millisecond)
+
+		// nolint:errcheck
+		go rc.WithBackPressure(func() error {
+			rc.Add(50)
+			opLock.Lock()
+			defer opLock.Unlock()
+			ops = append(ops, "WithBackPressure")
+			wg.Done()
+			return nil
+		})
+	}
+
+	wg.Wait()
+
+	expected := []string{
+		"WithBackPressure", // add 50, total 50
+		"WithBackPressure", // add 50, total 100
+		"InitFlushQueues",
+		"Flush",            // subtract 100, total 0
+		"WithBackPressure", // add 50, total 50
+		"WithBackPressure", // add 50, total 100
+		"InitFlushQueues",
+		"Flush",            // subtract 100, total 0
+		"WithBackPressure", // add 50, total 50
+	}
+	require.Equal(t, expected, ops)
+
+}

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -44,7 +44,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 				NilMetrics,
 			)
 
-			err := s.Push(context.Background(), []logproto.Entry{
+			_, err := s.Push(context.Background(), []logproto.Entry{
 				{Timestamp: time.Unix(int64(numLogs), 0), Line: "log"},
 			}, recordPool.GetRecord())
 			require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			fmt.Fprintf(&expected, "total ignored: %d out of %d", numLogs, numLogs)
 			expectErr := httpgrpc.Errorf(http.StatusBadRequest, expected.String())
 
-			err = s.Push(context.Background(), newLines, recordPool.GetRecord())
+			_, err = s.Push(context.Background(), newLines, recordPool.GetRecord())
 			require.Error(t, err)
 			require.Equal(t, expectErr.Error(), err.Error())
 		})
@@ -82,7 +82,7 @@ func TestPushDeduplication(t *testing.T) {
 		NilMetrics,
 	)
 
-	err := s.Push(context.Background(), []logproto.Entry{
+	written, err := s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "newer, better test"},
@@ -91,6 +91,7 @@ func TestPushDeduplication(t *testing.T) {
 	require.Len(t, s.chunks, 1)
 	require.Equal(t, s.chunks[0].chunk.Size(), 2,
 		"expected exact duplicate to be dropped and newer content with same timestamp to be appended")
+	require.Equal(t, len("test"+"newer, better test"), written)
 }
 
 func TestStreamIterator(t *testing.T) {
@@ -164,7 +165,8 @@ func Benchmark_PushStream(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		rec := recordPool.GetRecord()
-		require.NoError(b, s.Push(ctx, e, rec))
+		_, err := s.Push(ctx, e, rec)
+		require.NoError(b, err)
 		recordPool.PutRecord(rec)
 	}
 }

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -2,7 +2,6 @@ package ingester
 
 import (
 	"flag"
-	fmt "fmt"
 	"sync"
 	"time"
 
@@ -50,7 +49,7 @@ func (cfg *WALConfig) RegisterFlags(f *flag.FlagSet) {
 
 	// Need to set default here
 	cfg.ReplayMemoryCeiling = flagext.ByteSize(defaultCeiling)
-	f.Var(&cfg.ReplayMemoryCeiling, "ingester.wal-replay-memory-ceiling", fmt.Sprintf("How much memory the WAL may use during replay before it needs to flush chunks to storage, i.e. 10GB. Defaults to %s.", flagext.ByteSize(defaultCeiling).String()))
+	f.Var(&cfg.ReplayMemoryCeiling, "ingester.wal-replay-memory-ceiling", "How much memory the WAL may use during replay before it needs to flush chunks to storage, i.e. 10GB. We suggest setting this to a high percentage (~75%) of available memory.")
 }
 
 // WAL interface allows us to have a no-op WAL when the WAL is disabled.

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"flag"
+	fmt "fmt"
 	"sync"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/wal"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 var (
@@ -20,13 +22,15 @@ var (
 )
 
 const walSegmentSize = wal.DefaultSegmentSize * 4
+const defaultCeiling = 8 << 30 // 8GB
 
 type WALConfig struct {
-	Enabled            bool          `yaml:"enabled"`
-	Dir                string        `yaml:"dir"`
-	Recover            bool          `yaml:"recover"`
-	CheckpointDuration time.Duration `yaml:"checkpoint_duration"`
-	FlushOnShutdown    bool          `yaml:"flush_on_shutdown"`
+	Enabled             bool             `yaml:"enabled"`
+	Dir                 string           `yaml:"dir"`
+	Recover             bool             `yaml:"recover"`
+	CheckpointDuration  time.Duration    `yaml:"checkpoint_duration"`
+	FlushOnShutdown     bool             `yaml:"flush_on_shutdown"`
+	ReplayMemoryCeiling flagext.ByteSize `yaml:"replay_memory_ceiling"`
 }
 
 func (cfg *WALConfig) Validate() error {
@@ -43,6 +47,10 @@ func (cfg *WALConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Recover, "ingester.recover-from-wal", false, "Recover data from existing WAL irrespective of WAL enabled/disabled.")
 	f.DurationVar(&cfg.CheckpointDuration, "ingester.checkpoint-duration", 5*time.Minute, "Interval at which checkpoints should be created.")
 	f.BoolVar(&cfg.FlushOnShutdown, "ingester.flush-on-shutdown", false, "When WAL is enabled, should chunks be flushed to long-term storage on shutdown.")
+
+	// Need to set default here
+	cfg.ReplayMemoryCeiling = flagext.ByteSize(defaultCeiling)
+	f.Var(&cfg.ReplayMemoryCeiling, "ingester.wal-replay-memory-ceiling", fmt.Sprintf("How much memory the WAL may use during replay before it needs to flush chunks to storage, i.e. 10GB. Defaults to %s.", flagext.ByteSize(defaultCeiling).String()))
 }
 
 // WAL interface allows us to have a no-op WAL when the WAL is disabled.

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -22,7 +22,7 @@ var (
 )
 
 const walSegmentSize = wal.DefaultSegmentSize * 4
-const defaultCeiling = 8 << 30 // 8GB
+const defaultCeiling = 4 << 30 // 4GB
 
 type WALConfig struct {
 	Enabled             bool             `yaml:"enabled"`

--- a/production/ksonnet/loki/wal.libsonnet
+++ b/production/ksonnet/loki/wal.libsonnet
@@ -13,6 +13,7 @@
           enabled: true,
           dir: '/loki/wal',
           recover: true,
+          replay_memory_ceiling: '9GB', // between the requests & limits
         },
       },
     }),


### PR DESCRIPTION
## What

This PR introduces a backpressure mechanic to the ingester during WAL replay. This is primarily to allow specifying an upper bound of memory devoted to the replay which will be drained to storage once hit. 

This also includes
- Defaults memchunk schema to v3 in order to take advantage of `UncompressedBytes`. @slim-bean graciously cut `2.0.1` as a rollback target that supports this schema in the case of unforeseen failures.
- Adds a new WAL config, `ingester.wal-replay-memory-ceiling`
- Adds two new metrics: `loki_ingester_wal_recovered_bytes_total` and `loki_ingester_wal_bytes_in_use`

## Details

Note, this will cause a drop in the chunk dedupe ratio when it is hit, thus I suggest specifying the limit as high as is tolerable to minimize the chances. Generally, the backpressure drainage should only happen after outages when the WAL is large or after moving scaling down memory budgets.
