### PR TITLE
(fix: cmd/docker-driver): Insert a space in the error message

### DIFF
--- a/cmd/docker-driver/config.go
+++ b/cmd/docker-driver/config.go
@@ -291,7 +291,7 @@ func parseConfig(logCtx logger.Info) (*config, error) {
 	if relabelString, ok := logCtx.Config[cfgRelabelKey]; ok && relabelString != "" {
 		relabeled, err := relabelConfig(relabelString, labels)
 		if err != nil {
-			return nil, fmt.Errorf("error applying relabel config: %s err:%s", relabelString, err)
+			return nil, fmt.Errorf("error applying relabel config: %s err: %s", relabelString, err)
 		}
 		labels = relabeled
 	}


### PR DESCRIPTION
Hello :)

In the error message, there is a space after the colon, but there is a part which is no space after the colon, so I inserted a space.


