### PR TITLE
Add config endpoint

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -39,6 +39,7 @@ The HTTP API includes the following endpoints:
   - [`POST /flush`](#post-flush)
   - [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
   - [`GET /metrics`](#get-metrics)
+  - [`GET /config`](#get-config)
   - [Series](#series)
     - [Examples](#examples-9)
   - [Statistics](#statistics)
@@ -67,6 +68,7 @@ These endpoints are exposed by all components:
 
 - [`GET /ready`](#get-ready)
 - [`GET /metrics`](#get-metrics)
+- [`GET /config`](#get-config)
 
 These endpoints are exposed by the querier and the frontend:
 
@@ -860,6 +862,14 @@ In microservices mode, the `/ingester/flush_shutdown` endpoint is exposed by the
 for a list of exported metrics.
 
 In microservices mode, the `/metrics` endpoint is exposed by all components.
+
+## `GET /config`
+
+`/config` exposes the current configuration. The optional `mode` query parameter can be used to
+modify the output. If it has the value `diff` only the differences between the default configuration
+and the current are returned. A value of `defaults` returns the default configuration.
+
+In microservices mode, the `/config` endpoint is exposed by all components.
 
 ## Series
 

--- a/pkg/loki/config_handler.go
+++ b/pkg/loki/config_handler.go
@@ -1,0 +1,132 @@
+package loki
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+)
+
+func yamlMarshalUnmarshal(in interface{}) (map[interface{}]interface{}, error) {
+	yamlBytes, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	object := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal(yamlBytes, object); err != nil {
+		return nil, err
+	}
+
+	return object, nil
+}
+
+func diffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+	output := make(map[interface{}]interface{})
+
+	for key, value := range actualConfig {
+
+		defaultValue, ok := defaultConfig[key]
+		if !ok {
+			output[key] = value
+			continue
+		}
+
+		switch v := value.(type) {
+		case int:
+			defaultV, ok := defaultValue.(int)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case string:
+			defaultV, ok := defaultValue.(string)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case bool:
+			defaultV, ok := defaultValue.(bool)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case []interface{}:
+			defaultV, ok := defaultValue.([]interface{})
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case float64:
+			defaultV, ok := defaultValue.(float64)
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case map[interface{}]interface{}:
+			defaultV, ok := defaultValue.(map[interface{}]interface{})
+			if !ok {
+				output[key] = value
+			}
+			diff, err := diffConfig(defaultV, v)
+			if err != nil {
+				return nil, err
+			}
+			if len(diff) > 0 {
+				output[key] = diff
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type %T", v)
+		}
+	}
+
+	return output, nil
+}
+
+func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var output interface{}
+		switch r.URL.Query().Get("mode") {
+		case "diff":
+			defaultCfgObj, err := yamlMarshalUnmarshal(defaultCfg)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			actualCfgObj, err := yamlMarshalUnmarshal(actualCfg)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			diff, err := diffConfig(defaultCfgObj, actualCfgObj)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			output = diff
+
+		case "defaults":
+			output = defaultCfg
+		default:
+			output = actualCfg
+		}
+
+		writeYAMLResponse(w, output)
+	}
+}
+
+// writeYAMLResponse writes some YAML as a HTTP response.
+func writeYAMLResponse(w http.ResponseWriter, v interface{}) {
+	// There is not standardised content-type for YAML, text/plain ensures the
+	// YAML is displayed in the browser instead of offered as a download
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// We ignore errors here, because we cannot do anything about them.
+	// Write will trigger sending Status code, so we cannot send a different status code afterwards.
+	// Also this isn't internal error, but error communicating with client.
+	_, _ = w.Write(data)
+}

--- a/pkg/loki/config_handler_test.go
+++ b/pkg/loki/config_handler_test.go
@@ -1,0 +1,116 @@
+package loki
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type diffConfigMock struct {
+	MyInt          int          `yaml:"my_int"`
+	MyFloat        float64      `yaml:"my_float"`
+	MySlice        []string     `yaml:"my_slice"`
+	IgnoredField   func() error `yaml:"-"`
+	MyNestedStruct struct {
+		MyString      string   `yaml:"my_string"`
+		MyBool        bool     `yaml:"my_bool"`
+		MyEmptyStruct struct{} `yaml:"my_empty_struct"`
+	} `yaml:"my_nested_struct"`
+}
+
+func newDefaultDiffConfigMock() *diffConfigMock {
+	c := &diffConfigMock{
+		MyInt:        666,
+		MyFloat:      6.66,
+		MySlice:      []string{"value1", "value2"},
+		IgnoredField: func() error { return nil },
+	}
+	c.MyNestedStruct.MyString = "string1"
+	return c
+}
+
+func TestConfigDiffHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		expectedStatusCode int
+		expectedBody       string
+		actualConfig       func() interface{}
+	}{
+		{
+			name:               "no config parameters overridden",
+			expectedStatusCode: 200,
+			expectedBody:       "{}\n",
+		},
+		{
+			name: "slice changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MySlice = append(c.MySlice, "value3")
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_slice:\n" +
+				"- value1\n" +
+				"- value2\n" +
+				"- value3\n",
+		},
+		{
+			name: "string in nested struct changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MyNestedStruct.MyString = "string2"
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_nested_struct:\n" +
+				"  my_string: string2\n",
+		},
+		{
+			name: "bool in nested struct changed",
+			actualConfig: func() interface{} {
+				c := newDefaultDiffConfigMock()
+				c.MyNestedStruct.MyBool = true
+				return c
+			},
+			expectedStatusCode: 200,
+			expectedBody: "my_nested_struct:\n" +
+				"  my_bool: true\n",
+		},
+		{
+			name: "test invalid input",
+			actualConfig: func() interface{} {
+				c := "x"
+				return &c
+			},
+			expectedStatusCode: 500,
+			expectedBody: "yaml: unmarshal errors:\n" +
+				"  line 1: cannot unmarshal !!str `x` into map[interface {}]interface {}\n",
+		},
+	} {
+		defaultCfg := newDefaultDiffConfigMock()
+		t.Run(tc.name, func(t *testing.T) {
+
+			var actualCfg interface{}
+			if tc.actualConfig != nil {
+				actualCfg = tc.actualConfig()
+			} else {
+				actualCfg = newDefaultDiffConfigMock()
+			}
+
+			req := httptest.NewRequest("GET", "http://test.com/config?mode=diff", nil)
+			w := httptest.NewRecorder()
+
+			h := configHandler(actualCfg, defaultCfg)
+			h(w, req)
+			resp := w.Result()
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedBody, string(body))
+		})
+	}
+
+}


### PR DESCRIPTION
This PR adds a /config endpoint which works the same as in Cortex. See the documentation for an explanation of the `mode` parameter.

Here's an example running it against Loki running in a Docker container built by the Makefile:

```
cortex % curl "http://localhost:3100/config?mode=diff"
compactor:
  shared_store: filesystem
  working_directory: /loki/boltdb-shipper-compactor
ingester:
  chunk_idle_period: 1h0m0s
  chunk_retain_period: 30s
  chunk_target_size: 1048576
  lifecycler:
    address: 127.0.0.1
    final_sleep: 0s
    ring:
      kvstore:
        store: inmemory
      replication_factor: 1
  query_store_max_look_back_period: 1h21m0s
limits_config:
  reject_old_samples: true
  reject_old_samples_max_age: 168h0m0s
ruler:
  alertmanager_url: http://localhost:9093
  enable_api: true
  ring:
    kvstore:
      store: inmemory
  rule_path: /loki/rules-temp
  storage:
    local:
      directory: /loki/rules
    type: local
schema_config:
  configs:
  - chunks:
      period: 0s
      prefix: ""
      tags: {}
    from: "2020-10-24"
    index:
      period: 1d
      prefix: index_
      tags: {}
    object_store: filesystem
    row_shards: 16
    schema: v11
    store: boltdb-shipper
server:
  http_listen_port: 3100
storage_config:
  boltdb_shipper:
    active_index_directory: /loki/boltdb-shipper-active
    cache_location: /loki/boltdb-shipper-cache
    shared_store: filesystem
  filesystem:
    directory: /loki/chunks
cortex %
```

**Checklist**
- [x] Documentation added
- [ ] Tests updated

