### PR TITLE
logcli: support --include-label when not using --tail

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -274,12 +274,20 @@ func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastE
 		log.Println("Ignoring labels key:", color.RedString(strings.Join(q.IgnoreLabelsKey, ",")))
 	}
 
+	if len(q.ShowLabelsKey) > 0 && !q.Quiet {
+		log.Println("Print only labels key:", color.RedString(strings.Join(q.ShowLabelsKey, ",")))
+	}
+
 	// Remove ignored and common labels from the cached labels and
 	// calculate the max labels length
 	maxLabelsLen := q.FixedLabelsLen
 	for i, s := range streams {
 		// Remove common labels
 		ls := subtract(s.Labels, common)
+
+		if len(q.ShowLabelsKey) > 0 {
+			ls = matchLabels(true, ls, q.ShowLabelsKey)
+		}
 
 		// Remove ignored labels
 		if len(q.IgnoreLabelsKey) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

logcli currently only supports `--include-label` in combination with `--tail`. This seems like a bug to me since `--exclude-label` is supported with or without `--tail`. 

This PR adds support for `--include-label` inside `printStream()`, which fix the issue.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

