### PR TITLE
fix fluent-bit output plugin generating invalid JSON

### DIFF
--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -224,7 +224,7 @@ func createLine(records map[string]interface{}, f format) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return lineReplacer.Replace(string(js)), nil
+		return string(js), nil
 	case kvPairFormat:
 		buf := &bytes.Buffer{}
 		enc := logfmt.NewEncoder(buf)

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -52,7 +52,7 @@ func Test_loki_sendRecord(t *testing.T) {
 			},
 		},
 	}
-	var nestedJsonFixture = map[interface{}]interface{}{
+	var nestedJSONFixture = map[interface{}]interface{}{
 		"kubernetes": map[interface{}]interface{}{
 			"annotations": map[interface{}]interface{}{
 				"kubernetes.io/psp":  "test",
@@ -80,7 +80,7 @@ func Test_loki_sendRecord(t *testing.T) {
 		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{"other": "500"}, Entry: logproto.Entry{Line: `{"foo":"bar"}`, Timestamp: now}}}, false},
 		{"byte array", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, byteArrayRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"map":{"inner":"bar"},"outer":"foo"}`, Timestamp: now}}}, false},
 		{"mixed types", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, mixedTypesRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"array":[42,42.42,"foo"],"float":42.42,"int":42,"map":{"nested":{"foo":"bar","invalid":"a\ufffdz"}}}`, Timestamp: now}}}, false},
-		{"JSON inner string escaping", &config{removeKeys: []string{"kubernetes"}, labelMap: map[string]interface{}{"kubernetes": map[string]interface{}{"annotations": map[string]interface{}{"kubernetes.io/psp": "label"}}}, lineFormat: jsonFormat}, nestedJsonFixture, []api.Entry{{Labels: model.LabelSet{"label": "test"}, Entry: logproto.Entry{Line: `{"log":"\tstatus code: 403, request id: b41c1ffa-c586-4359-a7da-457dd8da4bad\n"}`, Timestamp: now}}}, false},
+		{"JSON inner string escaping", &config{removeKeys: []string{"kubernetes"}, labelMap: map[string]interface{}{"kubernetes": map[string]interface{}{"annotations": map[string]interface{}{"kubernetes.io/psp": "label"}}}, lineFormat: jsonFormat}, nestedJSONFixture, []api.Entry{{Labels: model.LabelSet{"label": "test"}, Entry: logproto.Entry{Line: `{"log":"\tstatus code: 403, request id: b41c1ffa-c586-4359-a7da-457dd8da4bad\n"}`, Timestamp: now}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -52,6 +52,15 @@ func Test_loki_sendRecord(t *testing.T) {
 			},
 		},
 	}
+	var nestedJsonFixture = map[interface{}]interface{}{
+		"kubernetes": map[interface{}]interface{}{
+			"annotations": map[interface{}]interface{}{
+				"kubernetes.io/psp":  "test",
+				"prometheus.io/port": "8085",
+			},
+		},
+		"log": "\tstatus code: 403, request id: b41c1ffa-c586-4359-a7da-457dd8da4bad\n",
+	}
 
 	tests := []struct {
 		name    string
@@ -71,6 +80,7 @@ func Test_loki_sendRecord(t *testing.T) {
 		{"labelmap", &config{labelMap: map[string]interface{}{"bar": "other"}, lineFormat: jsonFormat, removeKeys: []string{"bar", "error"}}, simpleRecordFixture, []api.Entry{{Labels: model.LabelSet{"other": "500"}, Entry: logproto.Entry{Line: `{"foo":"bar"}`, Timestamp: now}}}, false},
 		{"byte array", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, byteArrayRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"map":{"inner":"bar"},"outer":"foo"}`, Timestamp: now}}}, false},
 		{"mixed types", &config{labelKeys: []string{"label"}, lineFormat: jsonFormat}, mixedTypesRecordFixture, []api.Entry{{Labels: model.LabelSet{"label": "label"}, Entry: logproto.Entry{Line: `{"array":[42,42.42,"foo"],"float":42.42,"int":42,"map":{"nested":{"foo":"bar","invalid":"a\ufffdz"}}}`, Timestamp: now}}}, false},
+		{"JSON inner string escaping", &config{removeKeys: []string{"kubernetes"}, labelMap: map[string]interface{}{"kubernetes": map[string]interface{}{"annotations": map[string]interface{}{"kubernetes.io/psp": "label"}}}, lineFormat: jsonFormat}, nestedJsonFixture, []api.Entry{{Labels: model.LabelSet{"label": "test"}, Entry: logproto.Entry{Line: `{"log":"\tstatus code: 403, request id: b41c1ffa-c586-4359-a7da-457dd8da4bad\n"}`, Timestamp: now}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The fluent-bit output plugin incorrectly unescapes nested strings when generating JSON records. This leads to records with invalid JSON being sent to Loki, which are then no longer easily parsable with the json pipeline step as they lead to a JSON parser error in Loki's logql processor.

I added a unit-test for one of the, slightly modified, log lines that yielded the error on my fluent-bit/loki deployment, asserting a properly escaped JSON record.

An easy reproducer would be:
- Deploy fluent-bit using the community chart, and keep the `kubernetes` key by removing it from this list: https://github.com/grafana/helm-charts/blob/main/charts/fluent-bit/values.yaml#L20
- Query the generated logs in Grafana explore tab and pass them through the `json` step
- Many of the log lines (that contain newlines) will fail to be parsed because they are, in fact, not stored in Loki as valid JSON anymore

**Which issue(s) this PR fixes**:
None that i'm aware of

**Special notes for your reviewer**:
I'm honestly not sure whether the lineReplacer invocation has valid cases for JSON records. As of now, i can't think of a reason why it would be necessary/valid to un-escape any data in a JSON record, and the records generated with this fix are actually parse-able in Loki afterwards.

TBD: ~~I'll verify whether this changes the records generated by the default values.yaml of the FLB chart in any way. (which only pass the `log` field to Loki)~~
-> From my tests with and without this change with the default config, the records remain the same, so it only has any effect when wrapping extra labels in a record. Therefore this change has no unwanted side-effects IMO.

**Checklist**
- [x] Documentation added <- unsure if there is any necessary here? changelog update?
- [x] Tests updated

closes #3245