### PR TITLE
Allocate entries array with correct size  while decoding WAL entries.

### DIFF
--- a/pkg/ingester/encoding.go
+++ b/pkg/ingester/encoding.go
@@ -134,6 +134,7 @@ func decodeEntries(b []byte, rec *WALRecord) error {
 		}
 
 		nEntries := dec.Uvarint()
+		refEntries.Entries = make([]logproto.Entry, 0, nEntries)
 		rem := nEntries
 		for ; dec.Err() == nil && rem > 0; rem-- {
 			timeOffset := dec.Varint64()


### PR DESCRIPTION
Small optimization I found while deployment the new version.
We might want to have a pool of entries here.

```
❯ benchcmp  before.txt after.txt
benchmark                  old ns/op     new ns/op     delta
Benchmark_DecodeWAL-16     2350024       1591633       -32.27%

benchmark                  old allocs     new allocs     delta
Benchmark_DecodeWAL-16     20043          20005          -0.19%

benchmark                  old bytes     new bytes     delta
Benchmark_DecodeWAL-16     4946246       1763270       -64.35%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
