### PR TITLE
dist: Build promtail for windows/386 to support 32 bit windows hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ dist: clean
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/loki
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/logcli
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/loki-canary
-	CGO_ENABLED=0 $(GOX) -osarch="linux/arm64 linux/arm darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/promtail
+	CGO_ENABLED=0 $(GOX) -osarch="linux/arm64 linux/arm darwin/amd64 windows/amd64 windows/386 freebsd/amd64" ./cmd/promtail
 	CGO_ENABLED=1 $(CGO_GOX) -osarch="linux/amd64" ./cmd/promtail
 	for i in dist/*; do zip -j -m $$i.zip $$i; done
 	pushd dist && sha256sum * > SHA256SUMS && popd


### PR DESCRIPTION
**What this PR does / why we need it**:

It builds promtail for 32-bit Windows, to support deploying promtail on 32 bit
Windows hosts.

In our environment, we have a number of "Appliances" for industrial hardware
that ships with it's own PC and installation of Windows included, that isn't
necessarily "modern", nor something we can change/upgrade. We want to collect the logs for these systems, but
sometimes the hosts are 32 bit.