### PR TITLE
Keep CA config name consistent within fluent-bit plugin (Pascal Case)

### DIFF
--- a/cmd/fluent-bit/config.go
+++ b/cmd/fluent-bit/config.go
@@ -258,9 +258,9 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		res.bufferConfig.dqueConfig.queueName = queueName
 	}
 
-	res.clientConfig.Client.TLSConfig.CAFile = cfg.Get("ca_file")
-	res.clientConfig.Client.TLSConfig.CertFile = cfg.Get("cert_file")
-	res.clientConfig.Client.TLSConfig.KeyFile = cfg.Get("key_file")
+	res.clientConfig.Client.TLSConfig.CAFile = cfg.Get("CAFile")
+	res.clientConfig.Client.TLSConfig.CertFile = cfg.Get("CertFile")
+	res.clientConfig.Client.TLSConfig.KeyFile = cfg.Get("KeyFile")
 
 	insecureSkipVerify := cfg.Get("insecure_skip_verify")
 	switch insecureSkipVerify {

--- a/cmd/fluent-bit/out_grafana_loki.go
+++ b/cmd/fluent-bit/out_grafana_loki.go
@@ -77,10 +77,10 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	level.Info(paramLogger).Log("DqueDir", conf.bufferConfig.dqueConfig.queueDir)
 	level.Info(paramLogger).Log("DqueSegmentSize", conf.bufferConfig.dqueConfig.queueSegmentSize)
 	level.Info(paramLogger).Log("DqueSync", conf.bufferConfig.dqueConfig.queueSync)
-	level.Info(paramLogger).Log("ca_file", conf.clientConfig.Client.TLSConfig.CAFile)
-	level.Info(paramLogger).Log("cert_file", conf.clientConfig.Client.TLSConfig.CertFile)
-	level.Info(paramLogger).Log("key_file", conf.clientConfig.Client.TLSConfig.KeyFile)
-	level.Info(paramLogger).Log("insecure_skip_verify", conf.clientConfig.Client.TLSConfig.InsecureSkipVerify)
+	level.Info(paramLogger).Log("CAFile", conf.clientConfig.Client.TLSConfig.CAFile)
+	level.Info(paramLogger).Log("CertFile", conf.clientConfig.Client.TLSConfig.CertFile)
+	level.Info(paramLogger).Log("KeyFile", conf.clientConfig.Client.TLSConfig.KeyFile)
+	level.Info(paramLogger).Log("InsecureSkipVerify", conf.clientConfig.Client.TLSConfig.InsecureSkipVerify)
 
 	plugin, err := newPlugin(conf, logger)
 	if err != nil {


### PR DESCRIPTION
Currently, almost all of the config naming of fluent-bit output plugin is using Pascal Case.
After this PR, https://github.com/grafana/loki/pull/2568, @zjj2wry kindly added TLS support.
However, the naming principle should follow Pascal Case.