### PR TITLE
Fixes a bug where slice of Entries where not zeroed 

### DIFF
--- a/pkg/loghttp/entry.go
+++ b/pkg/loghttp/entry.go
@@ -23,10 +23,10 @@ type jsonExtension struct {
 	jsoniter.DummyExtension
 }
 
-type sliceEntryDecoder struct {
-}
+type sliceEntryDecoder struct{}
 
 func (sliceEntryDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	*((*[]Entry)(ptr)) = (*((*[]Entry)(ptr)))[:0]
 	iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
 		i := 0
 		var ts time.Time

--- a/pkg/logql/unmarshal/unmarshal_test.go
+++ b/pkg/logql/unmarshal/unmarshal_test.go
@@ -129,4 +129,18 @@ func Test_ReadTailResponse(t *testing.T) {
 			{Timestamp: time.Unix(0, 1), Labels: loghttp.LabelSet{"app": "foo"}},
 		},
 	}, res)
+	// Do it twice to verify we reset correctly slices.
+	require.NoError(t, ReadTailResponseJSON(res, ws))
+
+	require.Equal(t, &loghttp.TailResponse{
+		Streams: []loghttp.Stream{
+			{
+				Labels:  loghttp.LabelSet{"app": "bar"},
+				Entries: []loghttp.Entry{{Timestamp: time.Unix(0, 2), Line: "2"}},
+			},
+		},
+		DroppedStreams: []loghttp.DroppedStream{
+			{Timestamp: time.Unix(0, 1), Labels: loghttp.LabelSet{"app": "foo"}},
+		},
+	}, res)
 }


### PR DESCRIPTION
This was happening before decoding json. This is affecting logcli and canaries.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

