### PR TITLE
Ensure we have parentheses for bin ops.

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -83,8 +83,10 @@ type LogSelectorExpr interface {
 }
 
 // Type alias for backward compatibility
-type Pipeline = log.Pipeline
-type SampleExtractor = log.SampleExtractor
+type (
+	Pipeline        = log.Pipeline
+	SampleExtractor = log.SampleExtractor
+)
 
 // PipelineExpr is an expression defining a log pipeline.
 type PipelineExpr interface {
@@ -251,7 +253,6 @@ func AddFilterExpr(expr LogSelectorExpr, ty labels.MatchType, match string) (Log
 	default:
 		return nil, fmt.Errorf("unknown LogSelector: %v+", expr)
 	}
-
 }
 
 func (e *lineFilterExpr) Shardable() bool { return true }
@@ -787,9 +788,9 @@ type binOpExpr struct {
 
 func (e *binOpExpr) String() string {
 	if e.opts.ReturnBool {
-		return fmt.Sprintf("%s %s bool %s", e.SampleExpr.String(), e.op, e.RHS.String())
+		return fmt.Sprintf("(%s %s bool %s)", e.SampleExpr.String(), e.op, e.RHS.String())
 	}
-	return fmt.Sprintf("%s %s %s", e.SampleExpr.String(), e.op, e.RHS.String())
+	return fmt.Sprintf("(%s %s %s)", e.SampleExpr.String(), e.op, e.RHS.String())
 }
 
 // impl SampleExpr

--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -125,6 +125,8 @@ func Test_SampleExpr_String(t *testing.T) {
 			"(.*):.*"
 		)
 		`,
+		`10 / (5/2)`,
+		`10 / (count_over_time({job="postgres"}[5m])/2)`,
 	} {
 		t.Run(tc, func(t *testing.T) {
 			expr, err := ParseExpr(tc)
@@ -157,7 +159,6 @@ func Test_NilFilterDoesntPanic(t *testing.T) {
 			require.True(t, ok)
 		})
 	}
-
 }
 
 type linecheck struct {
@@ -274,16 +275,16 @@ func TestStringer(t *testing.T) {
 		},
 		{
 			in:  `1 > bool 1 > count_over_time({foo="bar"}[1m])`,
-			out: `0 > count_over_time({foo="bar"}[1m])`,
+			out: `(0 > count_over_time({foo="bar"}[1m]))`,
 		},
 		{
 			in:  `1 > bool 1 > bool count_over_time({foo="bar"}[1m])`,
-			out: `0 > bool count_over_time({foo="bar"}[1m])`,
+			out: `(0 > bool count_over_time({foo="bar"}[1m]))`,
 		},
 		{
 
 			in:  `0 > count_over_time({foo="bar"}[1m])`,
-			out: `0 > count_over_time({foo="bar"}[1m])`,
+			out: `(0 > count_over_time({foo="bar"}[1m]))`,
 		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
@@ -359,7 +360,6 @@ func mustNewRegexParser(re string) log.Stage {
 }
 
 func Test_canInjectVectorGrouping(t *testing.T) {
-
 	tests := []struct {
 		vecOp   string
 		rangeOp string

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -140,7 +140,6 @@ func NewDefaultEvaluator(querier Querier, maxLookBackPeriod time.Duration) *Defa
 		querier:           querier,
 		maxLookBackPeriod: maxLookBackPeriod,
 	}
-
 }
 
 func (ev *DefaultEvaluator) Iterator(ctx context.Context, expr LogSelectorExpr, q Params) (iter.EntryIterator, error) {
@@ -160,7 +159,6 @@ func (ev *DefaultEvaluator) Iterator(ctx context.Context, expr LogSelectorExpr, 
 	}
 
 	return ev.querier.SelectLogs(ctx, params)
-
 }
 
 func (ev *DefaultEvaluator) StepEvaluator(
@@ -188,7 +186,6 @@ func (ev *DefaultEvaluator) StepEvaluator(
 				}
 				return rangeAggEvaluator(iter.NewPeekingSampleIterator(it), rangExpr, q)
 			})
-
 		}
 		return vectorAggEvaluator(ctx, nextEv, e, q)
 	case *rangeAggregationExpr:
@@ -237,14 +234,11 @@ func vectorAggEvaluator(
 			if expr.params < 1 {
 				return next, ts, promql.Vector{}
 			}
-
 		}
 		for _, s := range vec {
 			metric := s.Metric
 
-			var (
-				groupingKey uint64
-			)
+			var groupingKey uint64
 			if expr.grouping.without {
 				groupingKey, buf = metric.HashWithoutLabels(buf, expr.grouping.groups...)
 			} else {
@@ -406,7 +400,6 @@ func vectorAggEvaluator(
 			})
 		}
 		return next, ts, vec
-
 	}, nextEvaluator.Close, nextEvaluator.Error)
 }
 
@@ -594,7 +587,6 @@ func binOpStepEvaluator(
 
 		results := make(promql.Vector, 0, len(pairs))
 		for _, pair := range pairs {
-
 			// merge
 			if merged := mergeBinOp(expr.op, pair[0], pair[1], !expr.opts.ReturnBool, IsComparisonOperator(expr.op)); merged != nil {
 				results = append(results, *merged)
@@ -703,7 +695,7 @@ func mergeBinOp(op string, left, right *promql.Sample, filter, isVectorCompariso
 				return nil
 			}
 			res := promql.Sample{
-				Metric: left.Metric.Copy(),
+				Metric: left.Metric,
 				Point:  left.Point,
 			}
 
@@ -906,7 +898,6 @@ func mergeBinOp(op string, left, right *promql.Sample, filter, isVectorCompariso
 		res.Point.V = 0
 	}
 	return res
-
 }
 
 // literalStepEvaluator merges a literal with a StepEvaluator. Since order matters in

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -116,7 +116,6 @@ func TestMapSampleExpr(t *testing.T) {
 		t.Run(tc.in.String(), func(t *testing.T) {
 			require.Equal(t, tc.out, m.mapSampleExpr(tc.in, nilMetrics.shardRecorder()))
 		})
-
 	}
 }
 
@@ -141,7 +140,7 @@ func TestMappingStrings(t *testing.T) {
 		},
 		{
 			in:  `max(count(rate({foo="bar"}[5m]))) / 2`,
-			out: `max(sum(downstream<count(rate({foo="bar"}[5m])), shard=0_of_2> ++ downstream<count(rate({foo="bar"}[5m])), shard=1_of_2>)) / 2`,
+			out: `(max(sum(downstream<count(rate({foo="bar"}[5m])), shard=0_of_2> ++ downstream<count(rate({foo="bar"}[5m])), shard=1_of_2>)) / 2)`,
 		},
 		{
 			in:  `topk(3, rate({foo="bar"}[5m]))`,
@@ -202,7 +201,6 @@ func TestMappingStrings(t *testing.T) {
 			require.Nil(t, err)
 
 			require.Equal(t, strings.ReplaceAll(tc.out, " ", ""), strings.ReplaceAll(mapped.String(), " ", ""))
-
 		})
 	}
 }


### PR DESCRIPTION
This ensure we correctly keep the order of execution when we stringify a bin operation.
This has recently introduced a bug because we now use stringify to deep clone a LogQL expression.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
