### PR TITLE
ksonnet: Remove invalid hostname from default promtail configuration

### DIFF
--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -10,7 +10,7 @@
         username:: '',
         password:: '',
         scheme:: 'https',
-        hostname:: 'logs-us-west1.grafana.net',
+        hostname:: error 'must define a valid hostname',
         external_labels: {},
       }],
       container_root_path: '/var/lib/docker',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

We're seeing traffic attempting to hit this host (and failing), and I'm guessing it's coming from misconfigured promtail instances that are using this config. Simply changing this won't help instances that already have this configuration, but in case they're updated at a future date they'll at least fail with a semi-recognizable error.

There may be a better way to declare that the value is required, but I am a jsonnet novice 😅.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>
