### PR TITLE
Refactor logcli Client interface to use time objects for LiveTailQueryConn

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -156,7 +156,7 @@ func main() {
 		}
 
 		if *tail {
-			rangeQuery.TailQuery(*delayFor, queryClient, out)
+			rangeQuery.TailQuery(time.Duration(*delayFor)*time.Second, queryClient, out)
 		} else {
 			rangeQuery.DoQuery(queryClient, out, *statistics)
 		}

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -551,7 +551,7 @@ func (t *testQueryClient) Series(matchers []string, from, through time.Time, qui
 	panic("implement me")
 }
 
-func (t *testQueryClient) LiveTailQueryConn(queryStr string, delayFor int, limit int, from int64, quiet bool) (*websocket.Conn, error) {
+func (t *testQueryClient) LiveTailQueryConn(queryStr string, delayFor time.Duration, limit int, start time.Time, quiet bool) (*websocket.Conn, error) {
 	panic("implement me")
 }
 

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/gorilla/websocket"
@@ -17,8 +18,8 @@ import (
 )
 
 // TailQuery connects to the Loki websocket endpoint and tails logs
-func (q *Query) TailQuery(delayFor int, c client.Client, out output.LogOutput) {
-	conn, err := c.LiveTailQueryConn(q.QueryString, delayFor, q.Limit, q.Start.UnixNano(), q.Quiet)
+func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.LogOutput) {
+	conn, err := c.LiveTailQueryConn(q.QueryString, delayFor, q.Limit, q.Start, q.Quiet)
 	if err != nil {
 		log.Fatalf("Tailing logs failed: %+v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors the logcli Client interface to use `time.Time` and `time.Duration` like
all the other methods use, for consistency and to reduce possible user-errors
when converting between times and integers.

**Special notes for your reviewer**:

Depends on #3270, which this PR builds upon. Separate PRs to handle bug fixes
and refactoring separately.