### PR TITLE
Promtail: Guarantee Unique timestamps

### DIFF
--- a/docs/sources/clients/promtail/stages/timestamp.md
+++ b/docs/sources/clients/promtail/stages/timestamp.md
@@ -33,6 +33,11 @@ timestamp:
   # be extracted or parsed. Valid values are: [skip, fudge].
   # Defaults to "fudge".
   [action_on_failure: <string>]
+
+  # Which action should be taken in case the timestamp is identical
+  # to or before the timestamp of a log line with the same labels.
+  # Valid values are: [skip, fudge]. Defaults to "fudge".
+  [action_on_duplicate: <string>]
 ```
 
 ### Reference Time

--- a/docs/sources/clients/promtail/stages/timestamp.md
+++ b/docs/sources/clients/promtail/stages/timestamp.md
@@ -36,7 +36,8 @@ timestamp:
 
   # Which action should be taken in case the timestamp is identical
   # to or before the timestamp of a log line with the same labels.
-  # Valid values are: [skip, fudge]. Defaults to "fudge".
+  # fudge adds one nanosecond, skip does nothing
+  # Valid values are: [skip, fudge]. Defaults to "skip".
   [action_on_duplicate: <string>]
 ```
 

--- a/pkg/logentry/stages/timestamp.go
+++ b/pkg/logentry/stages/timestamp.go
@@ -175,12 +175,14 @@ func (ts *timestampStage) Process(labels model.LabelSet, extracted map[string]in
 		return
 	}
 
-	labelsStr := labels.String()
-	lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr)
-	if ok && (lastTimestamp.(time.Time).Equal(*parsedTs) ||
-		lastTimestamp.(time.Time).After(*parsedTs)) {
-		ts.processActionOnDuplicate(labels, t)
-		return
+	if ts.lastKnownTimestamps != nil {
+		labelsStr := labels.String()
+		lastTimestamp, ok := ts.lastKnownTimestamps.Get(labelsStr)
+		if ok && (lastTimestamp.(time.Time).Equal(*parsedTs) ||
+			lastTimestamp.(time.Time).After(*parsedTs)) {
+			ts.processActionOnDuplicate(labels, t)
+			return
+		}
 	}
 
 	// Update the log entry timestamp with the parsed one

--- a/pkg/logentry/stages/timestamp.go
+++ b/pkg/logentry/stages/timestamp.go
@@ -37,7 +37,7 @@ const (
 
 	TimestampActionOnDuplicateSkip    = "skip"
 	TimestampActionOnDuplicateFudge   = "fudge"
-	TimestampActionOnDuplicateDefault = TimestampActionOnDuplicateFudge
+	TimestampActionOnDuplicateDefault = TimestampActionOnDuplicateSkip
 
 	// Maximum number of "streams" for which we keep the last known timestamp
 	maxLastKnownTimestampsCacheSize = 10000


### PR DESCRIPTION
**What this PR does / why we need it**:
Logs with second-precision will fail if multiple lines has the same labels, this stops the entire ingestion. This fixes that by deciding that a nanosecond here and there on that scale doesn't matter

**Which issue(s) this PR fixes**:
Fixes #3250

**Special notes for your reviewer**:
it's possible that this slows things down because we do a labels to string and lru cache read on every timestamp, not just on failed ones and not just when action_on_dupliceate is set to fudge. but I did that to keep the structure intact Process checks if we need to run any of the actions, and the actions are self-contained

**Checklist**
- [x] Documentation added
- [x] Tests updated