### PR TITLE
Distributor: Loki API can receive gzipped JSON

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -581,6 +581,8 @@ JSON post body can be sent in the following format:
 }
 ```
 
+You can set `Content-Type: gzip` request header and post gzipped JSON.
+
 > **NOTE**: logs sent to Loki for every stream must be in timestamp-ascending
 > order; logs with identical timestamps are only allowed if their content
 > differs. If a log line is received with a timestamp older than the most

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -581,7 +581,7 @@ JSON post body can be sent in the following format:
 }
 ```
 
-You can set `Content-Type: gzip` request header and post gzipped JSON.
+You can set `Content-Encoding: gzip` request header and post gzipped JSON.
 
 > **NOTE**: logs sent to Loki for every stream must be in timestamp-ascending
 > order; logs with identical timestamps are only allowed if their content


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR allow send gzipped `JSON` to push endpoint.

HTTP server recognize `Content-Encoding: gzip` request header (for JSON only) and unpack request body.
This option can reduce network traffic (5-30 times) and can be useful for sending logs to remote server.

**Which issue(s) this PR fixes**:

Fixes #3205

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

