### PR TITLE
Promtail: fix typo in config variable name - BookmarkPath

### DIFF
--- a/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -190,11 +190,11 @@ type WindowsEventsTargetConfig struct {
 	// timestamp if it's set.
 	UseIncomingTimestamp bool `yaml:"use_incoming_timestamp"`
 
-	// BoorkmarkPath sets the bookmark location on the filesystem.
+	// BookmarkPath sets the bookmark location on the filesystem.
 	// The bookmark contains the current position of the target in XML.
 	// When restarting or rollingout promtail, the target will continue to scrape events where it left off based on the bookmark position.
 	// The position is updated after each entry processed.
-	BoorkmarkPath string `yaml:"bookmark_path"`
+	BookmarkPath string `yaml:"bookmark_path"`
 
 	// PollInterval is the interval at which we're looking if new events are available. By default the target will check every 3seconds.
 	PollInterval time.Duration `yaml:"poll_interval"`

--- a/pkg/promtail/targets/windows/target.go
+++ b/pkg/promtail/targets/windows/target.go
@@ -54,9 +54,9 @@ func New(
 	}
 	defer windows.CloseHandle(sigEvent)
 
-	bm, err := newBookMark(cfg.BoorkmarkPath)
+	bm, err := newBookMark(cfg.BookmarkPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create bookmark using path=%s: %w", cfg.BoorkmarkPath, err)
+		return nil, fmt.Errorf("failed to create bookmark using path=%s: %w", cfg.BookmarkPath, err)
 	}
 
 	t := &Target{

--- a/pkg/promtail/targets/windows/target_test.go
+++ b/pkg/promtail/targets/windows/target_test.go
@@ -58,7 +58,7 @@ func Test_GetCreateBookrmark(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 	ta, err := New(util_log.Logger, client, nil, &scrapeconfig.WindowsEventsTargetConfig{
-		BoorkmarkPath: "c:foo.xml",
+		BookmarkPath: "c:foo.xml",
 		PollInterval:  time.Microsecond,
 		Query: `<QueryList>
 			<Query Id="0" Path="Application">
@@ -92,7 +92,7 @@ func Test_GetCreateBookrmark(t *testing.T) {
 	client = fake.New(func() {})
 	defer client.Stop()
 	ta, err = New(util_log.Logger, client, nil, &scrapeconfig.WindowsEventsTargetConfig{
-		BoorkmarkPath: "c:foo.xml",
+		BookmarkPath: "c:foo.xml",
 		PollInterval:  time.Microsecond,
 		Query: `<QueryList>
 			<Query Id="0" Path="Application">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Fixing typo in config variable name: BoorkmarkPath -> BookmarkPath (an "r" just before first "k")

**Special notes for your reviewer**:
I believe this is just a typo and not intentional misspelling. Google search for dictionary entry for term "Boorkmark" doesn't find anything interesting.

@cyriltovena can you have a look at this? Found it when playing with the new addition to the promtail. Great work!

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

