### PR TITLE
removes wal recover flag

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -7,7 +7,6 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    recover: true
   lifecycler:
     address: 127.0.0.1
     ring:

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -907,10 +907,6 @@ wal:
   # CLI flag: -ingester.wal-dir
   [dir: <filename> | default = "wal"]
 
-  # Recover data from existing WAL dir irrespective of WAL enabled/disabled.
-  # CLI flag: -ingester.recover-from-wal
-  [recover: <boolean> | default = false]
-
   # When WAL is enabled, should chunks be flushed to long-term storage on shutdown.
   # CLI flag: -ingester.flush-on-shutdown
   [flush_on_shutdown: <boolean> | default = false]

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -49,7 +49,6 @@ func defaultIngesterTestConfigWithWAL(t *testing.T, walDir string) Config {
 	ingesterConfig.MaxTransferRetries = 0
 	ingesterConfig.WAL.Enabled = true
 	ingesterConfig.WAL.Dir = walDir
-	ingesterConfig.WAL.Recover = true
 	ingesterConfig.WAL.CheckpointDuration = time.Second
 
 	return ingesterConfig

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -220,7 +220,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 
 func (i *Ingester) starting(ctx context.Context) error {
 
-	if i.cfg.WAL.Recover {
+	if i.cfg.WAL.Enabled {
 		// Ignore retain period during wal replay.
 		old := i.cfg.RetainPeriod
 		i.cfg.RetainPeriod = 0

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -26,7 +26,6 @@ const defaultCeiling = 4 << 30 // 4GB
 type WALConfig struct {
 	Enabled             bool             `yaml:"enabled"`
 	Dir                 string           `yaml:"dir"`
-	Recover             bool             `yaml:"recover"`
 	CheckpointDuration  time.Duration    `yaml:"checkpoint_duration"`
 	FlushOnShutdown     bool             `yaml:"flush_on_shutdown"`
 	ReplayMemoryCeiling flagext.ByteSize `yaml:"replay_memory_ceiling"`
@@ -43,7 +42,6 @@ func (cfg *WALConfig) Validate() error {
 func (cfg *WALConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Dir, "ingester.wal-dir", "wal", "Directory to store the WAL and/or recover from WAL.")
 	f.BoolVar(&cfg.Enabled, "ingester.wal-enabled", false, "Enable writing of ingested data into WAL.")
-	f.BoolVar(&cfg.Recover, "ingester.recover-from-wal", false, "Recover data from existing WAL irrespective of WAL enabled/disabled.")
 	f.DurationVar(&cfg.CheckpointDuration, "ingester.checkpoint-duration", 5*time.Minute, "Interval at which checkpoints should be created.")
 	f.BoolVar(&cfg.FlushOnShutdown, "ingester.flush-on-shutdown", false, "When WAL is enabled, should chunks be flushed to long-term storage on shutdown.")
 

--- a/production/ksonnet/loki/wal.libsonnet
+++ b/production/ksonnet/loki/wal.libsonnet
@@ -12,7 +12,6 @@
         wal+: {
           enabled: true,
           dir: '/loki/wal',
-          recover: true,
           replay_memory_ceiling: '9GB', // between the requests & limits
         },
       },


### PR DESCRIPTION
Deemed unnecessary. Instead, we'll recover based on `wal.enabled`