### PR TITLE
fix config for statefulset rulers when using boltdb-shipper

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -10,7 +10,6 @@
     // run ingesters and queriers as statefulsets when using boltdb-shipper to avoid using node disk for storing the index.
     stateful_ingesters: if self.using_boltdb_shipper then true else super.stateful_ingesters,
     stateful_queriers: if self.using_boltdb_shipper then true else super.stateful_queriers,
-    stateful_rulers: if self.using_boltdb_shipper then true else super.stateful_rulers,
 
     boltdb_shipper_shared_store: error 'must define boltdb_shipper_shared_store when using_boltdb_shipper=true. If this is not intentional, consider disabling it. boltdb_shipper_shared_store is a backend key from the storage_config, such as (gcs) or (s3)',
     compactor_pvc_size: '10Gi',

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -7,6 +7,14 @@
 
   ruler_args:: $._config.commonArgs {
     target: 'ruler',
+  } + if $._config.using_boltdb_shipper then {
+       // Use PVC for caching
+       'boltdb.shipper.cache-location': '/data/boltdb-cache',
+     } else {},
+
+  _config+:: {
+    // run rulers as statefulsets when using boltdb-shipper to avoid using node disk for storing the index.
+    stateful_rulers: if self.using_boltdb_shipper then true else super.stateful_rulers,
   },
 
   ruler_container::


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We were setting `stateful_rulers` to `true` in `boltdb-shipper.libsonnet` which actually gets imported after `ruler.libsonnet` which causes it to define deployment type instead of statefulset type even when using `boltdb-shipper`.
This PR sets the required config in `ruler.libsonnet` including `boltdb.shipper.cache-location` when using `boltdb-shipper`.

