### PR TITLE
Bound parallelism frontend

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	"github.com/opentracing/opentracing-go"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
 )
 
 const (
@@ -143,4 +145,113 @@ func (sl *seriesLimiter) isLimitReached() bool {
 	sl.rw.RLock()
 	defer sl.rw.RUnlock()
 	return len(sl.hashes) > sl.maxSeries
+}
+
+type limitedRoundTripper struct {
+	next   http.RoundTripper
+	limits Limits
+
+	codec      queryrange.Codec
+	middleware queryrange.Middleware
+}
+
+// NewLimitedRoundTripper creates a new roundtripper that enforces MaxQueryParallelism to the `next` roundtripper across `middlewares`.
+func NewLimitedRoundTripper(next http.RoundTripper, codec queryrange.Codec, limits Limits, middlewares ...queryrange.Middleware) http.RoundTripper {
+	transport := limitedRoundTripper{
+		next:       next,
+		codec:      codec,
+		limits:     limits,
+		middleware: queryrange.MergeMiddlewares(middlewares...),
+	}
+	return transport
+}
+
+type work struct {
+	req    queryrange.Request
+	ctx    context.Context
+	result chan result
+}
+
+type result struct {
+	response queryrange.Response
+	err      error
+}
+
+func newWork(ctx context.Context, req queryrange.Request) work {
+	return work{
+		req:    req,
+		ctx:    ctx,
+		result: make(chan result, 1),
+	}
+}
+
+func (rt limitedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	request, err := rt.codec.DecodeRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		request.LogToSpan(span)
+	}
+	userid, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+	}
+
+	parallelism := rt.limits.MaxQueryParallelism(userid)
+	intermediate := make(chan work)
+	defer close(intermediate)
+
+	for i := 0; i < parallelism; i++ {
+		go func() {
+			for w := range intermediate {
+				resp, err := rt.do(ctx, w.req)
+				select {
+				case w.result <- result{response: resp, err: err}:
+				case <-ctx.Done():
+					w.result <- result{err: ctx.Err()}
+				}
+
+			}
+		}()
+	}
+
+	response, err := rt.middleware.Wrap(
+		queryrange.HandlerFunc(func(ctx context.Context, r queryrange.Request) (queryrange.Response, error) {
+			w := newWork(ctx, r)
+			intermediate <- w
+			select {
+			case response := <-w.result:
+				return response.response, response.err
+			case <-ctx.Done():
+				return nil, err
+			}
+		})).Do(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return rt.codec.EncodeResponse(ctx, response)
+}
+
+func (rt limitedRoundTripper) do(ctx context.Context, r queryrange.Request) (queryrange.Response, error) {
+	request, err := rt.codec.EncodeRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := user.InjectOrgIDIntoHTTPRequest(ctx, request); err != nil {
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+	}
+
+	response, err := rt.next.RoundTrip(request)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	return rt.codec.DecodeResponse(ctx, response, r)
 }

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -209,11 +209,11 @@ func (rt limitedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 	for i := 0; i < parallelism; i++ {
 		go func() {
 			for w := range intermediate {
-				resp, err := rt.do(ctx, w.req)
+				resp, err := rt.do(w.ctx, w.req)
 				select {
 				case w.result <- result{response: resp, err: err}:
-				case <-ctx.Done():
-					w.result <- result{err: ctx.Err()}
+				case <-w.ctx.Done():
+					w.result <- result{err: w.ctx.Err()}
 				}
 
 			}

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ func Test_seriesLimiter(t *testing.T) {
 	lreq := &LokiRequest{
 		Query:     `rate({app="foo"} |= "foo"[1m])`,
 		Limit:     1000,
-		Step:      30000, //30sec
+		Step:      30000, // 30sec
 		StartTs:   testTime.Add(-6 * time.Hour),
 		EndTs:     testTime,
 		Direction: logproto.FORWARD,
@@ -144,4 +145,42 @@ func Test_seriesLimiter(t *testing.T) {
 	_, err = tpw(rt).RoundTrip(req)
 	require.Error(t, err)
 	require.LessOrEqual(t, *c, 4)
+}
+
+func Test_MaxQueryPallelism(t *testing.T) {
+	maxQueryParallelism := 2
+	f, err := newfakeRoundTripper()
+	require.Nil(t, err)
+	var count int32
+	var over int32
+	f.setHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt32(&count, 1)
+		if int(cur) > maxQueryParallelism {
+			atomic.StoreInt32(&over, 1)
+		}
+		defer atomic.AddInt32(&count, -1)
+		time.Sleep(20 * time.Millisecond)
+	}))
+	ctx := user.InjectOrgID(context.Background(), "foo")
+
+	r, err := http.NewRequestWithContext(ctx, "GET", "/query_range", http.NoBody)
+	require.Nil(t, err)
+
+	_, _ = NewLimitedRoundTripper(f, lokiCodec, fakeLimits{maxQueryParallelism: maxQueryParallelism},
+		queryrange.MiddlewareFunc(func(next queryrange.Handler) queryrange.Handler {
+			return queryrange.HandlerFunc(func(c context.Context, r queryrange.Request) (queryrange.Response, error) {
+				var wg sync.WaitGroup
+				for i := 0; i < 10; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						_, _ = next.Do(c, &LokiRequest{})
+					}()
+				}
+				wg.Wait()
+				return nil, nil
+			})
+		}),
+	).RoundTrip(r)
+	require.Equal(t, 0, int(atomic.LoadInt32(&over)), "max query parallelism went over the configured one")
 }

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -152,13 +152,14 @@ func Test_MaxQueryPallelism(t *testing.T) {
 	f, err := newfakeRoundTripper()
 	require.Nil(t, err)
 	var count int32
-	var over int32
+	var max int32
 	f.setHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		cur := atomic.AddInt32(&count, 1)
-		if int(cur) > maxQueryParallelism {
-			atomic.StoreInt32(&over, 1)
+		if cur > atomic.LoadInt32(&max) {
+			atomic.StoreInt32(&max, cur)
 		}
 		defer atomic.AddInt32(&count, -1)
+		// simulate some work
 		time.Sleep(20 * time.Millisecond)
 	}))
 	ctx := user.InjectOrgID(context.Background(), "foo")
@@ -166,7 +167,7 @@ func Test_MaxQueryPallelism(t *testing.T) {
 	r, err := http.NewRequestWithContext(ctx, "GET", "/query_range", http.NoBody)
 	require.Nil(t, err)
 
-	_, _ = NewLimitedRoundTripper(f, lokiCodec, fakeLimits{maxQueryParallelism: maxQueryParallelism},
+	_, _ = NewLimitedRoundTripper(f, lokiCodec, fakeLimits{maxQueryParallelism: 10},
 		queryrange.MiddlewareFunc(func(next queryrange.Handler) queryrange.Handler {
 			return queryrange.HandlerFunc(func(c context.Context, r queryrange.Request) (queryrange.Response, error) {
 				var wg sync.WaitGroup
@@ -182,5 +183,6 @@ func Test_MaxQueryPallelism(t *testing.T) {
 			})
 		}),
 	).RoundTrip(r)
-	require.Equal(t, 0, int(atomic.LoadInt32(&over)), "max query parallelism went over the configured one")
+	maxFound := int(atomic.LoadInt32(&max))
+	require.LessOrEqual(t, maxFound, maxQueryParallelism, "max query parallelism: ", maxFound, " went over the configured one:", maxQueryParallelism)
 }

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -249,7 +249,7 @@ func NewLogFilterTripperware(
 
 	return func(next http.RoundTripper) http.RoundTripper {
 		if len(queryRangeMiddleware) > 0 {
-			return queryrange.NewRoundTripper(next, codec, queryRangeMiddleware...)
+			return NewLimitedRoundTripper(next, codec, limits, queryRangeMiddleware...)
 		}
 		return next
 	}, nil
@@ -404,7 +404,7 @@ func NewMetricTripperware(
 	return func(next http.RoundTripper) http.RoundTripper {
 		// Finally, if the user selected any query range middleware, stitch it in.
 		if len(queryRangeMiddleware) > 0 {
-			rt := queryrange.NewRoundTripper(next, codec, queryRangeMiddleware...)
+			rt := NewLimitedRoundTripper(next, codec, limits, queryRangeMiddleware...)
 			return queryrange.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 				if !strings.HasSuffix(r.URL.Path, "/query_range") {
 					return next.RoundTrip(r)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensure that the parallelism in the frontend is correctly bound per query. Currently we only do that at each level in each middleware which means they don't know each other. This translate into  explosion of parallelism when we split by time **and** by shard.

Example:

a 1h query splitted by 15m and sharded by 16 would use 64 parallelism even though the max parallelism per query is 16.

I believe this means that we will need to increase parallelism now that we really do listen to the `max_query_parallelism`.

I suggest we default to 64, but that's for another review.

**Special notes for your reviewer**:

This will be backported to Cortex, but to avoid the review burden I want to first try it in Loki. I don't think cortex suffers from this since it doesn't have yet sharding.

cc @pracucci @pstibrany @gouthamve 

**Checklist**
- [x] Tests updated

