### PR TITLE
Fixes some 500 returned by querier when storage cancellation happens.

### DIFF
--- a/pkg/util/server/error_test.go
+++ b/pkg/util/server/error_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
@@ -28,6 +29,7 @@ func Test_writeError(t *testing.T) {
 	}{
 		{"cancelled", context.Canceled, ErrClientCanceled, StatusClientClosedRequest},
 		{"cancelled multi", util.MultiError{context.Canceled, context.Canceled}, ErrClientCanceled, StatusClientClosedRequest},
+		{"cancelled storage", promql.ErrStorage{Err: context.Canceled}, ErrClientCanceled, StatusClientClosedRequest},
 		{"orgid", user.ErrNoOrgID, user.ErrNoOrgID.Error(), http.StatusBadRequest},
 		{"deadline", context.DeadlineExceeded, ErrDeadlineExceeded, http.StatusGatewayTimeout},
 		{"parse error", logql.ParseError{}, "parse error : ", http.StatusBadRequest},


### PR DESCRIPTION
For unknown reasons,  Cortex is transforming all errors to promql.ErrStorage
on the storage layer.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

