### PR TITLE
Fix fluentd plugin when kubernetes labels were missing

### DIFF
--- a/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -306,9 +306,11 @@ module Fluent
 
           if @extract_kubernetes_labels && record.key?('kubernetes')
             kubernetes_labels = record['kubernetes']['labels']
-            kubernetes_labels.each_key do |l|
-              new_key = l.gsub(%r{[.\-\/]}, '_')
-              chunk_labels[new_key] = kubernetes_labels[l]
+            if !kubernetes_labels.nil?
+              kubernetes_labels.each_key do |l|
+                new_key = l.gsub(%r{[.\-\/]}, '_')
+                chunk_labels[new_key] = kubernetes_labels[l]
+              end
             end
           end
 


### PR DESCRIPTION
When kubernetes labels were missing in the received data, plugin failed
with error "undefined method `each_key' for nil:NilClass".
