### PR TITLE
Fixes head chunk iterator direction.

### DIFF
--- a/pkg/ingester/chunk_test.go
+++ b/pkg/ingester/chunk_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/chunkenc"
@@ -21,24 +20,24 @@ func testIteratorForward(t *testing.T, iter iter.EntryIterator, from, through in
 	i := from
 	for iter.Next() {
 		entry := iter.Entry()
-		assert.Equal(t, time.Unix(i, 0), entry.Timestamp)
-		assert.Equal(t, fmt.Sprintf("line %d", i), entry.Line)
+		require.Equal(t, time.Unix(i, 0).Unix(), entry.Timestamp.Unix())
+		require.Equal(t, fmt.Sprintf("line %d", i), entry.Line)
 		i++
 	}
-	assert.Equal(t, through, i)
-	assert.NoError(t, iter.Error())
+	require.Equal(t, through, i)
+	require.NoError(t, iter.Error())
 }
 
 func testIteratorBackward(t *testing.T, iter iter.EntryIterator, from, through int64) {
 	i := through - 1
 	for iter.Next() {
 		entry := iter.Entry()
-		assert.Equal(t, time.Unix(i, 0), entry.Timestamp)
-		assert.Equal(t, fmt.Sprintf("line %d", i), entry.Line)
+		require.Equal(t, time.Unix(i, 0).Unix(), entry.Timestamp.Unix())
+		require.Equal(t, fmt.Sprintf("line %d", i), entry.Line)
 		i--
 	}
-	assert.Equal(t, from-1, i)
-	assert.NoError(t, iter.Error())
+	require.Equal(t, from-1, i)
+	require.NoError(t, iter.Error())
 }
 
 func TestIterator(t *testing.T) {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -316,7 +316,6 @@ func (s *stream) Bounds() (from, to time.Time) {
 		_, to = s.chunks[len(s.chunks)-1].chunk.Bounds()
 	}
 	return from, to
-
 }
 
 // Returns an iterator.

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -140,7 +140,6 @@ func TestStreamIterator(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Benchmark_PushStream(b *testing.B) {

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -443,6 +443,7 @@ type timeRangedIterator struct {
 }
 
 // NewTimeRangedIterator returns an iterator which filters entries by time range.
+// Note: Only works with iterators that go forwards.
 func NewTimeRangedIterator(it EntryIterator, mint, maxt time.Time) EntryIterator {
 	return &timeRangedIterator{
 		EntryIterator: it,
@@ -502,7 +503,6 @@ func NewReversedIter(it EntryIterator, limit uint32, preload bool) (EntryIterato
 		entriesWithLabels: make([]entryWithLabels, 0, 1024),
 		limit:             limit,
 	}, it.Error()
-
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +578,6 @@ func NewEntryReversedIter(it EntryIterator) (EntryIterator, error) {
 		iter: it,
 		buf:  entryBufferPool.Get().(*entryBuffer),
 	}, it.Error()
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For backward queries, since LogQL parser we are using a heapIterator in the headchunk to re-order properly entries.
But we also reverse all iterators in the memchunk code, even the headchunk which causes reversal of already reversed entries.

This PR skips reversal of the headchunk.

Fixes #3345
Fixes #3208

This has for side effects:
-  when using replication you would not dedupe data properly anymore, since the data is not correctly ordered across batches.
-  when using limit it would miss entries.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

