### PR TITLE
Documentation: enable environment variable in configuration

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -84,7 +84,7 @@ from scraped targets, see [Pipelines](../pipelines/).
 ### Use environment variables in the configuration
 
 You can use environment variable references in the configuration file to set values that need to be configurable during deployment.
-To do this, use:
+To do this, pass `-config.expand-env=true` and use:
 
 ```
 ${VAR}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add in promtail documentation that environment variable in configuration works only if promtail is started with `-config.expand-env=true` option.

**Which issue(s) this PR fixes**:
Fix #3023

**Special notes for your reviewer**:
Should we add `Note: This feature is only available in Loki 2.1+.` too, as in [Grafana documentation](https://grafana.com/docs/loki/latest/configuration/#configuration-file-reference)?
Sorry if this PR miss something, it's my first PR to an open source documentation.  

**Checklist**
- [x] Documentation added
- [ ] Tests updated

