### PR TITLE
Don't auto-include pod labels as loki labels as a sane default

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -53,8 +53,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -100,8 +98,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -153,8 +149,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -208,8 +202,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:
@@ -256,8 +248,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
       - replacement: /var/log/pods/*$1/*.log
         separator: /
         source_labels:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Don't auto-include pod labels as loki labels as a sane default. Folks regularly run into stream limits when they have a bunch of labels on their pods, so better to remove this to get them a nicer first onboarding experience.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

