### PR TITLE
Remove default docker pipeline stage

### DIFF
--- a/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -240,11 +240,7 @@ type PushTargetConfig struct {
 
 // DefaultScrapeConfig is the default Config.
 var DefaultScrapeConfig = Config{
-	PipelineStages: []interface{}{
-		map[interface{}]interface{}{
-			stages.StageTypeDocker: nil,
-		},
-	},
+	PipelineStages: stages.PipelineStages{},
 }
 
 // HasServiceDiscoveryConfig checks to see if the service discovery used for

--- a/pkg/promtail/scrapeconfig/scrapeconfig_test.go
+++ b/pkg/promtail/scrapeconfig/scrapeconfig_test.go
@@ -80,6 +80,18 @@ relabel_configs:
   target_label: __path__
 `
 
+var noPipelineStagesYaml = `
+job_name: kubernetes-pods-name
+static_configs:
+- targets:
+    - localhost
+  labels:
+    job: varlogs
+    __path__: /var/log/*log
+kubernetes_sd_configs:
+- role: pod
+`
+
 func TestLoadSmallConfig(t *testing.T) {
 	var config Config
 	err := yaml.Unmarshal([]byte(smallYaml), &config)
@@ -107,6 +119,15 @@ func TestLoadSmallConfig(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, config)
+}
+
+// bugfix: https://github.com/grafana/loki/issues/3403
+func TestEmptyPipelineStagesConfig(t *testing.T) {
+	var config Config
+	err := yaml.Unmarshal([]byte(noPipelineStagesYaml), &config)
+	require.Nil(t, err)
+
+	require.Zero(t, len(config.PipelineStages))
 }
 
 func TestLoadConfig(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR resolves a bug whereby an omitted `pipeline_stages` key in a `scrape_configs` entry would result in a `docker` pipeline being created by default; this is unexpected and undocumented behaviour. This change was [introduced](https://github.com/grafana/loki/pull/2752) when we deprecated the `entry_parser` configuration.

**Which issue(s) this PR fixes**:
Fixes #3403

**Special notes for your reviewer**:
We will probably need to  communicate this change clearly when it is released; this may lead to unexpected breakages of `promtail` configurations that rely on this bug.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

