### PR TITLE
Instrumentation: Add histogram for request duration on gRPC client to Ingesters

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -9,12 +9,21 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	cortex_middleware "github.com/cortexproject/cortex/pkg/util/middleware"
 	"github.com/grafana/loki/pkg/logproto"
 )
+
+var ingesterClientRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "loki_ingester_client_request_duration_seconds",
+	Help:    "Time spent doing Ingester requests.",
+	Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+}, []string{"operation", "status_code"})
 
 type HealthAndIngesterClient interface {
 	logproto.IngesterClient
@@ -76,8 +85,10 @@ func instrumentation() ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterc
 	return []grpc.UnaryClientInterceptor{
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.ClientUserHeaderInterceptor,
+			cortex_middleware.PrometheusGRPCUnaryInstrumentation(ingesterClientRequestDuration),
 		}, []grpc.StreamClientInterceptor{
 			otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()),
 			middleware.StreamClientUserHeaderInterceptor,
+			cortex_middleware.PrometheusGRPCStreamInstrumentation(ingesterClientRequestDuration),
 		}
 }

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	cortex_middleware "github.com/cortexproject/cortex/pkg/util/middleware"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To provide more visibility on gRPC requests from distributor -> ingesters. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

The function from Cortex `grpcclient.Instrument` already takes care of setting the tracing headers. It also accepts a histogram metric to record request durations. Hence, the replacement of the code below with the function - I made sure there was no difference between the function and the code removed.

**Checklist**
- N/A Documentation added
- N/A Tests updated

