### PR TITLE
Logql/foldable

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -476,6 +476,10 @@ func newJSONExpressionParser(expressions []log.JSONExpression) *jsonExpressionPa
 	}
 }
 
+func (e *jsonExpressionParser) Fold(fn FoldFn, x interface{}) (interface{}, error) {
+	return fn(x, e)
+}
+
 func (j *jsonExpressionParser) Shardable() bool { return true }
 
 func (j *jsonExpressionParser) Stage() (log.Stage, error) {

--- a/pkg/logql/fold.go
+++ b/pkg/logql/fold.go
@@ -1,0 +1,25 @@
+package logql
+
+// type signature isn't great. Will be overloaded with receivers
+type FoldFn = func(accum interface{}, x interface{}) (interface{}, error)
+
+func foldAll(fn FoldFn, initial interface{}, xs ...Foldable) (interface{}, error) {
+	next := initial
+	var err error
+	for _, x := range xs {
+		next, err = x.Fold(fn, next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return next, nil
+}
+
+// Foldable
+// Generally we try to fold child nodes before parents
+type Foldable interface {
+	Fold(
+		FoldFn,
+		interface{},
+	) (interface{}, error)
+}

--- a/pkg/logql/fold.go
+++ b/pkg/logql/fold.go
@@ -1,6 +1,5 @@
 package logql
 
-// type signature isn't great. Will be overloaded with receivers
 type FoldFn = func(accum interface{}, x interface{}) (interface{}, error)
 
 func foldAll(fn FoldFn, initial interface{}, xs ...Foldable) (interface{}, error) {

--- a/pkg/logql/fold_test.go
+++ b/pkg/logql/fold_test.go
@@ -1,0 +1,57 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Foldable(t *testing.T) {
+
+	expr, err := ParseExpr(`sum by (cluster) (rate({job="foo"} |= "bar" | logfmt | bazz="buzz" [5m]))`)
+	require.Nil(t, err)
+
+	type audit struct {
+		groupings         []*grouping
+		logfmt            bool
+		filter            string
+		postParseMatchers string
+	}
+
+	expected := audit{
+		groupings: []*grouping{
+			&grouping{
+				groups:  []string{"cluster"},
+				without: false,
+			},
+		},
+		logfmt:            true,
+		filter:            "bar",
+		postParseMatchers: `bazz="buzz"`,
+	}
+
+	got, err := expr.Fold(
+		func(accum, x interface{}) (interface{}, error) {
+			acc := accum.(audit)
+
+			switch e := x.(type) {
+			case *vectorAggregationExpr:
+				acc.groupings = append(acc.groupings, e.grouping)
+			case *lineFilterExpr:
+				acc.filter = e.match
+			case *labelParserExpr:
+				if e.op == OpParserTypeLogfmt {
+					acc.logfmt = true
+				}
+			case *labelFilterExpr:
+				acc.postParseMatchers = e.LabelFilterer.String()
+
+			}
+			return acc, nil
+		},
+		audit{},
+	)
+	require.Nil(t, err)
+	require.Equal(t, expected, got)
+
+}

--- a/pkg/logql/fold_test.go
+++ b/pkg/logql/fold_test.go
@@ -20,7 +20,7 @@ func Test_Foldable(t *testing.T) {
 
 	expected := audit{
 		groupings: []*grouping{
-			&grouping{
+			{
 				groups:  []string{"cluster"},
 				without: false,
 			},


### PR DESCRIPTION
I pulled this out from an experiment I'm working on because I think it's a good standalone library feature. This introduces the `Foldable` interface and embeds it into the `logql.Expr`. This interface is used for reducing, or _folding_ an implementor to a value.  See the test case included for an example of how we can easily fold a complex AST into an "audit" which shows certain metadata.