### PR TITLE
Fixes a race in the scheduling limits.

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -56,7 +56,7 @@ type instance struct {
 }
 
 func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQuery) ([]logql.Result, error) {
-	return in.For(queries, func(qry logql.DownstreamQuery) (logql.Result, error) {
+	return in.For(ctx, queries, func(qry logql.DownstreamQuery) (logql.Result, error) {
 		req := ParamsToLokiRequest(qry.Params).WithShards(qry.Shards).WithQuery(qry.Expr.String()).(*LokiRequest)
 		logger, ctx := spanlogger.New(ctx, "DownstreamHandler.instance")
 		defer logger.Finish()
@@ -72,6 +72,7 @@ func (in instance) Downstream(ctx context.Context, queries []logql.DownstreamQue
 
 // For runs a function against a list of queries, collecting the results or returning an error. The indices are preserved such that input[i] maps to output[i].
 func (in instance) For(
+	ctx context.Context,
 	queries []logql.DownstreamQuery,
 	fn func(logql.DownstreamQuery) (logql.Result, error),
 ) ([]logql.Result, error) {
@@ -81,16 +82,15 @@ func (in instance) For(
 		err error
 	}
 
-	done := make(chan struct{})
-	defer close(done)
-
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ch := make(chan resp)
 
 	// Make one goroutine to dispatch the other goroutines, bounded by instance parallelism
 	go func() {
 		for i := 0; i < len(queries); i++ {
 			select {
-			case <-done:
+			case <-ctx.Done():
 				break
 			case <-in.locks:
 				go func(i int) {
@@ -108,7 +108,7 @@ func (in instance) For(
 
 					// Feed the result into the channel unless the work has completed.
 					select {
-					case <-done:
+					case <-ctx.Done():
 					case ch <- response:
 					}
 				}(i)
@@ -125,7 +125,6 @@ func (in instance) For(
 		results[resp.i] = resp.res
 	}
 	return results, nil
-
 }
 
 // convert to matrix
@@ -136,7 +135,6 @@ func sampleStreamToMatrix(streams []queryrange.SampleStream) parser.Value {
 		x.Metric = make(labels.Labels, 0, len(stream.Labels))
 		for _, l := range stream.Labels {
 			x.Metric = append(x.Metric, labels.Label(l))
-
 		}
 
 		x.Points = make([]promql.Point, 0, len(stream.Samples))

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -184,7 +184,6 @@ func TestResponseToResult(t *testing.T) {
 }
 
 func TestDownstreamHandler(t *testing.T) {
-
 	// Pretty poor test, but this is just a passthrough struct, so ensure we create locks
 	// and can consume them
 	h := DownstreamHandler{nil}
@@ -220,7 +219,7 @@ func TestInstanceFor(t *testing.T) {
 	var ct int
 
 	// ensure we can execute queries that number more than the parallelism parameter
-	_, err := in.For(queries, func(_ logql.DownstreamQuery) (logql.Result, error) {
+	_, err := in.For(context.TODO(), queries, func(_ logql.DownstreamQuery) (logql.Result, error) {
 		mtx.Lock()
 		defer mtx.Unlock()
 		ct++
@@ -233,7 +232,7 @@ func TestInstanceFor(t *testing.T) {
 	// ensure an early error abandons the other queues queries
 	in = mkIn()
 	ct = 0
-	_, err = in.For(queries, func(_ logql.DownstreamQuery) (logql.Result, error) {
+	_, err = in.For(context.TODO(), queries, func(_ logql.DownstreamQuery) (logql.Result, error) {
 		mtx.Lock()
 		defer mtx.Unlock()
 		ct++
@@ -250,6 +249,7 @@ func TestInstanceFor(t *testing.T) {
 
 	in = mkIn()
 	results, err := in.For(
+		context.TODO(),
 		[]logql.DownstreamQuery{
 			{
 				Shards: logql.Shards{
@@ -263,7 +263,6 @@ func TestInstanceFor(t *testing.T) {
 			},
 		},
 		func(qry logql.DownstreamQuery) (logql.Result, error) {
-
 			return logql.Result{
 				Data: logql.Streams{{
 					Labels: qry.Shards[0].String(),
@@ -285,7 +284,6 @@ func TestInstanceFor(t *testing.T) {
 		results,
 	)
 	ensureParallelism(t, in, in.parallelism)
-
 }
 
 func TestInstanceDownstream(t *testing.T) {
@@ -345,5 +343,4 @@ func TestInstanceDownstream(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, []logql.Result{expected}, results)
-
 }

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -187,7 +187,7 @@ func Test_MaxQueryParallelism(t *testing.T) {
 	require.LessOrEqual(t, maxFound, maxQueryParallelism, "max query parallelism: ", maxFound, " went over the configured one:", maxQueryParallelism)
 }
 
-func Test_MaxQueryParallelismLateCancel(t *testing.T) {
+func Test_MaxQueryParallelismLateScheduling(t *testing.T) {
 	maxQueryParallelism := 2
 	f, err := newfakeRoundTripper()
 	require.Nil(t, err)


### PR DESCRIPTION
Found out the hard way that sharding might not listen correctly to context and so still run queries
after the upstream request ends. This can lead to panic when scheduling work which send on a closed channel.

I've added a safeguard to wait for all jobs to end before ending the original request but also attempted to fix the sharding downstreamer
to properly stop sending work when context is closed.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

