### PR TITLE
docs: promtail: Fix typo w/ windows_events hyperlink.

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -33,7 +33,7 @@ and how to scrape logs from files.
     - [syslog](#syslog)
       - [Available Labels](#available-labels)
     - [loki_push_api](#loki_push_api)
-    - [windows_events] (#windows_events)
+    - [windows_events](#windows_events)
     - [relabel_configs](#relabel_configs)
     - [static_configs](#static_configs)
     - [file_sd_config](#file_sd_config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Fixes the hyperlink in the table of contents for the windows_events section of promtail's config docs.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

