### PR TITLE
Add limit and line_returned in the query log.

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -53,6 +53,14 @@ func (Streams) String() string {
 	return ""
 }
 
+func (ss Streams) lines() int64 {
+	var res int64
+	for _, s := range ss {
+		res += int64(len(s.Entries))
+	}
+	return res
+}
+
 // Result is the result of a query execution.
 type Result struct {
 	Data       promql_parser.Value
@@ -159,7 +167,7 @@ func (q *query) Exec(ctx context.Context) (Result, error) {
 	}
 
 	if q.record {
-		RecordMetrics(ctx, q.params, status, statResult)
+		RecordMetrics(ctx, q.params, status, statResult, data)
 	}
 
 	return Result{
@@ -293,7 +301,6 @@ func (q *query) evalLiteral(_ context.Context, expr *literalExpr) (promql_parser
 	}
 
 	return PopulateMatrixFromScalar(s, q.params), nil
-
 }
 
 func PopulateMatrixFromScalar(data promql.Scalar, params Params) promql.Matrix {

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -53,9 +53,9 @@ func (Streams) String() string {
 	return ""
 }
 
-func (ss Streams) lines() int64 {
+func (streams Streams) lines() int64 {
 	var res int64
-	for _, s := range ss {
+	for _, s := range streams {
 		res += int64(len(s.Entries))
 	}
 	return res

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -76,7 +76,6 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 	if err != nil {
 		level.Warn(logger).Log("msg", "error parsing query type", "err", err)
 	}
-	rt = string(GetRangeType(p))
 
 	// Tag throughput metric by latency type based on a threshold.
 	// Latency below the threshold is fast, above is slow.

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -73,10 +73,10 @@ func TestLogSlowQuery(t *testing.T) {
 			ExecTime:                25.25,
 			TotalBytesProcessed:     100000,
 		},
-	})
+	}, Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 throughput=100kB total_bytes=100kB\n",
+			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/go-kit/kit/log/level"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/middleware"
 
 	"github.com/grafana/loki/pkg/logql"
@@ -23,27 +24,31 @@ type ctxKeyType string
 const ctxKey ctxKeyType = "stats"
 
 var (
-	defaultMetricRecorder = metricRecorderFn(func(ctx context.Context, p logql.Params, status string, stats stats.Result) {
-		logql.RecordMetrics(ctx, p, status, stats)
+	defaultMetricRecorder = metricRecorderFn(func(data *queryData) {
+		logql.RecordMetrics(data.ctx, data.params, data.status, *data.statistics, data.result)
 	})
 	// StatsHTTPMiddleware is an http middleware to record stats for query_range filter.
 	StatsHTTPMiddleware middleware.Interface = statsHTTPMiddleware(defaultMetricRecorder)
 )
 
 type metricRecorder interface {
-	Record(ctx context.Context, p logql.Params, status string, stats stats.Result)
+	Record(data *queryData)
 }
 
-type metricRecorderFn func(ctx context.Context, p logql.Params, status string, stats stats.Result)
+type metricRecorderFn func(data *queryData)
 
-func (m metricRecorderFn) Record(ctx context.Context, p logql.Params, status string, stats stats.Result) {
-	m(ctx, p, status, stats)
+func (m metricRecorderFn) Record(data *queryData) {
+	m(data)
 }
 
 type queryData struct {
+	ctx        context.Context
 	params     logql.Params
 	statistics *stats.Result
-	recorded   bool
+	result     promql_parser.Value
+	status     string
+
+	recorded bool
 }
 
 func statsHTTPMiddleware(recorder metricRecorder) middleware.Interface {
@@ -62,12 +67,9 @@ func statsHTTPMiddleware(recorder metricRecorder) middleware.Interface {
 				if data.statistics == nil {
 					data.statistics = &stats.Result{}
 				}
-				recorder.Record(
-					r.Context(),
-					data.params,
-					strconv.Itoa(interceptor.statusCode),
-					*data.statistics,
-				)
+				data.ctx = r.Context()
+				data.status = strconv.Itoa(interceptor.statusCode)
+				recorder.Record(data)
 			}
 		})
 	})
@@ -85,10 +87,12 @@ func StatsCollectorMiddleware() queryrange.Middleware {
 
 			// collect stats and status
 			var statistics *stats.Result
+			var res promql_parser.Value
 			if resp != nil {
 				switch r := resp.(type) {
 				case *LokiResponse:
 					statistics = &r.Statistics
+					res = logql.Streams(r.Data.Result)
 				case *LokiPromResponse:
 					statistics = &r.Statistics
 				default:
@@ -105,6 +109,7 @@ func StatsCollectorMiddleware() queryrange.Middleware {
 				data.recorded = true
 				data.statistics = statistics
 				data.params = paramsFromRequest(req)
+				data.result = res
 			}
 			return resp, err
 		})


### PR DESCRIPTION
This can be useful to investigate how many wasted queries have been made by the frontend.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
