### PR TITLE
docs: add note about regex

### DIFF
--- a/docs/sources/logql/_index.md
+++ b/docs/sources/logql/_index.md
@@ -74,6 +74,8 @@ Examples:
 
 The same rules that apply for [Prometheus Label Selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) apply for Loki log stream selectors.
 
+**Important note:** The `=~` regex operator is fully anchored, meaning regex must match against the *entire* string, including newlines. The regex `.` character does not match newlines by default. If you want the regex dot character to match newlines you can use the single-line flag, like so: `(?s)search_term.+` matches `search_term\n`.
+
 ### Log Pipeline
 
 A log pipeline can be appended to a log stream selector to further process and filter log streams. It usually is composed of one or multiple expressions, each expressions is executed in sequence for each log line. If an expression filters out a log line, the pipeline will stop at this point and start processing the next line.


### PR DESCRIPTION
to prevent people from running into https://github.com/grafana/loki/issues/3436

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
* The `|~` operator is a partial match. One would intuitively expect that `=~` would behave the same way, but it is in fact a exact match. It's important to point that out.
* Many log lines have newlines in them (at least in my case), so it's important to remind users that `.` does not match newlines by default.

**Which issue(s) this PR fixes**:
Fixes #3436 

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [N/A] Tests updated

