### PR TITLE
Use better memory metric on operational dashboard

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -2023,7 +2023,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "container_memory_usage_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"distributor.*\"}",
+              "expr": "go_memstats_heap_inuse_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"distributor.*\"}",
               "instant": false,
               "intervalFactor": 3,
               "legendFormat": "{{pod}}",
@@ -2687,7 +2687,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "container_memory_usage_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"ingester.*\"}",
+              "expr": "go_memstats_heap_inuse_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"ingester.*\"}",
               "instant": false,
               "intervalFactor": 3,
               "legendFormat": "{{pod}}",
@@ -3633,7 +3633,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "container_memory_usage_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"querier.*\"}",
+              "expr": "go_memstats_heap_inuse_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"querier.*\"}",
               "instant": false,
               "intervalFactor": 3,
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
Seeing as I'm used to disregarding the `container_memory_usage_bytes` metric due to it's interaction with go runtimes from ~1.13->1.15 (which don't proactively release memory), this changes to the preferred `go_memstats_heap_inuse_bytes` which I end up replacing it with.