### PR TITLE
Implement offset modifier for range vector aggregation in LogQL

### DIFF
--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -60,19 +60,27 @@ func Test_SampleExpr_String(t *testing.T) {
 	for _, tc := range []string{
 		`rate( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
 		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
+		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] offset 10m )`,
 		`sum without(a) ( rate ( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum by(a) (rate( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum(count_over_time({job="mysql"}[5m]))`,
+		`sum(count_over_time({job="mysql"}[5m] offset 10m))`,
 		`sum(count_over_time({job="mysql"} | json [5m]))`,
+		`sum(count_over_time({job="mysql"} | json [5m] offset 10m))`,
 		`sum(count_over_time({job="mysql"} | logfmt [5m]))`,
+		`sum(count_over_time({job="mysql"} | logfmt [5m] offset 10m))`,
 		`sum(count_over_time({job="mysql"} | unpack | json [5m]))`,
 		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m]))`,
+		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m] offset 10m))`,
 		`topk(10,sum(rate({region="us-east1"}[5m])) by (name))`,
 		`topk by (name)(10,sum(rate({region="us-east1"}[5m])))`,
 		`avg( rate( ( {job="nginx"} |= "GET" ) [10s] ) ) by (region)`,
 		`avg(min_over_time({job="nginx"} |= "GET" | unwrap foo[10s])) by (region)`,
+		`avg(min_over_time({job="nginx"} |= "GET" | unwrap foo[10s] offset 10m)) by (region)`,
 		`sum by (cluster) (count_over_time({job="mysql"}[5m]))`,
+		`sum by (cluster) (count_over_time({job="mysql"}[5m] offset 10m))`,
 		`sum by (cluster) (count_over_time({job="mysql"}[5m])) / sum by (cluster) (count_over_time({job="postgres"}[5m])) `,
+		`sum by (cluster) (count_over_time({job="mysql"}[5m] offset 10m)) / sum by (cluster) (count_over_time({job="postgres"}[5m] offset 10m)) `,
 		`
 		sum by (cluster) (count_over_time({job="postgres"}[5m])) /
 		sum by (cluster) (count_over_time({job="postgres"}[5m])) /
@@ -86,6 +94,8 @@ func Test_SampleExpr_String(t *testing.T) {
 		)`,
 		`stdvar_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 		| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo [5m])`,
+		`stdvar_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
+		| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo [5m] offset 10m)`,
 		`sum_over_time({namespace="tns"} |= "level=error" | json |foo>=5,bar<25ms|unwrap latency [5m])`,
 		`sum by (job) (
 			sum_over_time({namespace="tns"} |= "level=error" | json | foo=5 and bar<25ms | unwrap latency[5m])
@@ -130,6 +140,20 @@ func Test_SampleExpr_String(t *testing.T) {
 		`10 / (5/2)`,
 		`10 / (count_over_time({job="postgres"}[5m])/2)`,
 		`{app="foo"} | json response_status="response.status.code", first_param="request.params[0]"`,
+		`label_replace(
+			sum by (job) (
+				sum_over_time(
+					{namespace="tns"} |= "level=error" | json | avg=5 and bar<25ms | unwrap duration(latency)  | __error__!~".*" [5m] offset 1h
+				)
+			/
+				count_over_time({namespace="tns"} | logfmt | label_format foo=bar[5m] offset 1h)
+			),
+			"foo",
+			"$1",
+			"service",
+			"(.*):.*"
+		)
+		`,
 	} {
 		t.Run(tc, func(t *testing.T) {
 			expr, err := ParseExpr(tc)

--- a/pkg/logql/expr.y.go
+++ b/pkg/logql/expr.y.go
@@ -6,6 +6,7 @@ package logql
 import __yyfmt__ "fmt"
 
 //line pkg/logql/expr.y:2
+
 import (
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -55,6 +56,7 @@ type exprSymType struct {
 	JSONExpression        log.JSONExpression
 	JSONExpressionList    []log.JSONExpression
 	UnwrapExpr            *unwrapExpr
+	OffsetExpr            *offsetExpr
 }
 
 const BYTES = 57346
@@ -114,21 +116,22 @@ const DURATION_SECONDS_CONV = 57399
 const ABSENT_OVER_TIME = 57400
 const LABEL_REPLACE = 57401
 const UNPACK = 57402
-const OR = 57403
-const AND = 57404
-const UNLESS = 57405
-const CMP_EQ = 57406
-const NEQ = 57407
-const LT = 57408
-const LTE = 57409
-const GT = 57410
-const GTE = 57411
-const ADD = 57412
-const SUB = 57413
-const MUL = 57414
-const DIV = 57415
-const MOD = 57416
-const POW = 57417
+const OFFSET = 57403
+const OR = 57404
+const AND = 57405
+const UNLESS = 57406
+const CMP_EQ = 57407
+const NEQ = 57408
+const LT = 57409
+const LTE = 57410
+const GT = 57411
+const GTE = 57412
+const ADD = 57413
+const SUB = 57414
+const MUL = 57415
+const DIV = 57416
+const MOD = 57417
+const POW = 57418
 
 var exprToknames = [...]string{
 	"$end",
@@ -191,6 +194,7 @@ var exprToknames = [...]string{
 	"ABSENT_OVER_TIME",
 	"LABEL_REPLACE",
 	"UNPACK",
+	"OFFSET",
 	"OR",
 	"AND",
 	"UNLESS",
@@ -207,13 +211,14 @@ var exprToknames = [...]string{
 	"MOD",
 	"POW",
 }
+
 var exprStatenames = [...]string{}
 
 const exprEofCode = 1
 const exprErrCode = 2
 const exprInitialStackSize = 16
 
-//line pkg/logql/expr.y:378
+//line pkg/logql/expr.y:386
 
 //line yacctab:1
 var exprExca = [...]int{
@@ -224,204 +229,209 @@ var exprExca = [...]int{
 
 const exprPrivate = 57344
 
-const exprLast = 456
+const exprLast = 465
 
 var exprAct = [...]int{
-
-	73, 181, 4, 163, 157, 56, 190, 106, 152, 64,
-	55, 66, 2, 5, 126, 45, 46, 47, 48, 48,
-	69, 40, 41, 42, 49, 50, 53, 54, 51, 52,
-	43, 44, 45, 46, 47, 48, 41, 42, 49, 50,
+	73, 183, 4, 163, 179, 56, 192, 157, 152, 64,
+	55, 106, 15, 5, 126, 66, 2, 48, 237, 234,
+	12, 279, 62, 80, 69, 59, 294, 261, 6, 60,
+	61, 233, 19, 20, 31, 32, 34, 35, 33, 36,
+	37, 38, 39, 21, 22, 43, 44, 45, 46, 47,
+	48, 290, 185, 23, 24, 25, 26, 27, 28, 29,
+	284, 95, 234, 30, 18, 62, 234, 99, 45, 46,
+	47, 48, 60, 61, 63, 130, 16, 17, 261, 235,
+	276, 135, 62, 96, 62, 128, 122, 124, 125, 60,
+	61, 60, 61, 282, 269, 136, 233, 137, 138, 139,
+	140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+	150, 268, 58, 234, 185, 74, 75, 63, 160, 49,
+	50, 53, 54, 51, 52, 43, 44, 45, 46, 47,
+	48, 234, 172, 246, 63, 190, 63, 246, 248, 184,
+	123, 195, 247, 186, 187, 40, 41, 42, 49, 50,
 	53, 54, 51, 52, 43, 44, 45, 46, 47, 48,
-	43, 44, 45, 46, 47, 48, 165, 124, 125, 233,
-	112, 95, 122, 124, 125, 62, 59, 99, 230, 256,
-	112, 272, 60, 61, 154, 130, 80, 286, 109, 255,
-	72, 135, 74, 75, 154, 128, 74, 75, 109, 201,
-	282, 136, 277, 137, 138, 139, 140, 141, 142, 143,
-	144, 145, 146, 147, 148, 149, 150, 255, 171, 166,
-	169, 170, 167, 168, 230, 123, 63, 153, 160, 258,
-	259, 260, 275, 229, 96, 231, 155, 153, 172, 242,
-	62, 242, 265, 240, 244, 188, 243, 60, 61, 182,
-	263, 193, 230, 184, 185, 49, 50, 53, 54, 51,
-	52, 43, 44, 45, 46, 47, 48, 186, 230, 117,
-	183, 180, 196, 197, 198, 231, 62, 127, 116, 270,
-	62, 112, 134, 60, 61, 12, 234, 60, 61, 225,
-	177, 63, 227, 129, 232, 154, 235, 238, 95, 109,
-	239, 228, 99, 128, 226, 236, 183, 229, 180, 192,
-	183, 62, 252, 62, 246, 112, 248, 62, 60, 61,
-	60, 61, 262, 177, 60, 61, 203, 63, 194, 154,
-	133, 63, 192, 109, 177, 112, 132, 155, 153, 78,
-	253, 183, 230, 183, 95, 237, 71, 58, 264, 254,
-	284, 191, 95, 109, 266, 119, 178, 112, 15, 12,
-	281, 268, 63, 269, 63, 241, 12, 129, 63, 118,
-	121, 200, 120, 271, 6, 109, 276, 202, 19, 20,
-	31, 32, 34, 35, 33, 36, 37, 38, 39, 21,
-	22, 199, 195, 102, 104, 103, 187, 110, 111, 23,
-	24, 25, 26, 27, 28, 29, 179, 189, 280, 30,
-	18, 274, 105, 273, 208, 12, 174, 209, 207, 77,
-	261, 16, 17, 6, 250, 251, 285, 19, 20, 31,
-	32, 34, 35, 33, 36, 37, 38, 39, 21, 22,
-	205, 76, 173, 206, 204, 283, 278, 247, 23, 24,
-	25, 26, 27, 28, 29, 279, 131, 223, 30, 18,
-	224, 222, 220, 245, 12, 221, 219, 3, 176, 175,
-	16, 17, 6, 112, 65, 174, 19, 20, 31, 32,
-	34, 35, 33, 36, 37, 38, 39, 21, 22, 79,
-	217, 109, 214, 218, 216, 215, 213, 23, 24, 25,
-	26, 27, 28, 29, 173, 161, 159, 30, 18, 102,
-	104, 103, 151, 110, 111, 233, 115, 267, 211, 16,
-	17, 212, 210, 249, 68, 158, 164, 70, 105, 70,
-	164, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-	90, 91, 92, 93, 94, 107, 156, 98, 162, 101,
-	100, 57, 113, 108, 114, 97, 11, 10, 9, 14,
-	8, 257, 13, 7, 67, 1,
+	271, 262, 198, 199, 200, 41, 42, 49, 50, 53,
+	54, 51, 52, 43, 44, 45, 46, 47, 48, 227,
+	177, 177, 177, 244, 231, 228, 236, 194, 239, 242,
+	95, 188, 243, 232, 99, 128, 230, 240, 165, 124,
+	125, 117, 257, 241, 178, 182, 196, 112, 252, 250,
+	62, 264, 265, 266, 235, 127, 12, 60, 61, 62,
+	238, 154, 116, 12, 129, 109, 60, 61, 194, 256,
+	72, 129, 74, 75, 259, 258, 277, 134, 95, 180,
+	185, 180, 270, 260, 133, 112, 95, 193, 272, 185,
+	132, 171, 166, 169, 170, 167, 168, 78, 275, 191,
+	112, 71, 63, 109, 155, 153, 292, 12, 289, 278,
+	274, 63, 283, 245, 154, 6, 204, 286, 109, 19,
+	20, 31, 32, 34, 35, 33, 36, 37, 38, 39,
+	21, 22, 201, 197, 189, 181, 121, 205, 202, 119,
+	23, 24, 25, 26, 27, 28, 29, 182, 112, 131,
+	30, 18, 62, 118, 288, 281, 120, 12, 153, 60,
+	61, 280, 154, 16, 17, 6, 109, 203, 267, 19,
+	20, 31, 32, 34, 35, 33, 36, 37, 38, 39,
+	21, 22, 185, 229, 112, 112, 254, 255, 287, 77,
+	23, 24, 25, 26, 27, 28, 29, 76, 79, 154,
+	30, 18, 109, 109, 63, 155, 153, 210, 293, 174,
+	211, 209, 225, 16, 17, 226, 224, 291, 112, 273,
+	102, 104, 103, 285, 110, 111, 237, 207, 3, 173,
+	208, 206, 251, 249, 222, 65, 109, 223, 221, 105,
+	81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+	91, 92, 93, 94, 102, 104, 103, 219, 110, 111,
+	220, 218, 216, 176, 213, 217, 215, 214, 212, 253,
+	175, 174, 164, 105, 173, 161, 159, 151, 115, 68,
+	158, 70, 70, 164, 107, 156, 98, 162, 101, 100,
+	57, 113, 108, 114, 97, 11, 10, 9, 14, 8,
+	263, 13, 7, 67, 1,
 }
+
 var exprPact = [...]int{
-
-	241, -1000, -40, -1000, -1000, 193, 241, -1000, -1000, -1000,
-	-1000, -1000, 412, 213, 57, -1000, 324, 302, 206, -1000,
+	5, -1000, 83, -1000, -1000, 68, 5, -1000, -1000, -1000,
+	-1000, -1000, 437, 238, 207, -1000, 350, 342, 234, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	36, 36, 36, 36, 36, 36, 36, 36, 36, 36,
-	36, 36, 36, 36, 36, 193, -1000, 51, 242, 400,
-	-1000, -1000, -1000, -1000, 144, 135, -40, 243, 244, -1000,
-	50, 160, 339, 203, 197, 149, -1000, -1000, 241, 241,
-	-1000, 241, 241, 241, 241, 241, 241, 241, 241, 241,
-	241, 241, 241, 241, 241, -1000, 396, -1000, -1000, 166,
-	-1000, -1000, 410, -1000, 390, -1000, -1000, -1000, -1000, 220,
-	389, 415, 44, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	414, -1000, 388, 359, 353, 352, 222, 277, 189, 234,
-	133, 267, 290, 217, 194, 263, -26, 81, 81, -57,
-	-57, -56, -56, -56, -56, -20, -20, -20, -20, -20,
-	-20, -1000, 166, 220, 220, 220, 262, -1000, 249, -1000,
-	65, -1000, 248, -1000, 204, 326, 300, 404, 378, 376,
-	348, 343, -1000, -1000, -1000, -1000, -1000, -1000, 61, 234,
-	187, 114, 156, 358, 152, 211, 61, 241, 109, 236,
-	112, -1000, -1000, 110, -1000, 347, 200, 166, 55, 410,
-	331, -1000, 411, 309, -1000, -1000, -1000, -1000, -1000, -1000,
+	-17, -17, -17, -17, -17, -17, -17, -17, -17, -17,
+	-17, -17, -17, -17, -17, 68, -1000, 51, 373, 432,
+	-1000, -1000, -1000, -1000, 198, 177, 83, 297, 280, -1000,
+	74, 208, 302, 227, 221, 214, -1000, -1000, 5, 5,
+	-1000, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+	5, 5, 5, 5, 5, -1000, 431, -1000, -1000, 202,
+	-1000, -1000, 435, -1000, 430, -1000, -1000, -1000, -1000, 240,
+	429, 438, 186, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	436, -1000, 428, 425, 424, 417, 180, 276, 298, 201,
+	167, 275, 252, 223, 182, 274, 102, 54, 54, -5,
+	-5, -59, -59, -59, -59, -26, -26, -26, -26, -26,
+	-26, -1000, 202, 240, 240, 240, 273, -1000, 286, -1000,
+	303, -1000, 257, -1000, 285, 383, 363, 420, 418, 413,
+	390, 368, -1000, -1000, -1000, -1000, -1000, -1000, 90, 161,
+	335, 201, 8, 22, 205, 339, 196, 179, 90, 5,
+	159, 254, 118, -1000, -1000, 114, -1000, 387, 340, 202,
+	255, 435, 386, -1000, 427, 341, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, 178, 24, 187, -1000,
-	220, -1000, 70, 64, 301, 188, 116, -1000, -1000, 108,
-	-1000, 241, 402, -1000, -1000, 232, -1000, -1000, -1000, -1000,
-	-1000, -1000, 61, 24, 166, -1000, -1000, 146, -1000, -1000,
-	-1000, 27, 294, 292, 98, 61, 68, -1000, 330, -1000,
-	340, 24, 12, -1000, -1000, 289, -1000, -1000, 231, 66,
-	-1000, 329, -1000, 221, 310, 53, -1000,
+	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, 90, -1000,
+	178, -25, 8, -1000, 240, -1000, 18, 156, 319, 87,
+	70, -1000, -1000, 136, -1000, 5, 374, -1000, -1000, 251,
+	-1000, -1000, -1000, -1000, -1000, -1000, -1000, 90, 56, -25,
+	202, -1000, -1000, 213, -1000, -1000, -1000, -23, 312, 306,
+	69, 90, 36, -1000, 377, -1000, 90, 343, -25, -29,
+	-1000, -1000, 305, -1000, -1000, 249, -1000, 27, -1000, 371,
+	-1000, 247, 362, 2, -1000,
 }
+
 var exprPgo = [...]int{
-
-	0, 455, 11, 66, 0, 6, 357, 2, 14, 7,
-	454, 453, 452, 451, 13, 450, 449, 448, 447, 446,
-	379, 445, 10, 5, 444, 443, 442, 8, 441, 440,
-	439, 3, 438, 437, 4, 436, 1, 435,
+	0, 464, 15, 25, 0, 6, 388, 2, 14, 11,
+	463, 462, 461, 460, 13, 459, 458, 457, 456, 455,
+	358, 454, 10, 5, 453, 452, 451, 8, 450, 449,
+	448, 3, 447, 446, 7, 445, 1, 444, 4,
 }
-var exprR1 = [...]int{
 
+var exprR1 = [...]int{
 	0, 1, 2, 2, 7, 7, 7, 7, 7, 7,
 	6, 6, 6, 8, 8, 8, 8, 8, 8, 8,
 	8, 8, 8, 8, 8, 8, 8, 36, 36, 36,
-	13, 13, 13, 11, 11, 11, 11, 15, 15, 15,
-	15, 15, 15, 19, 3, 3, 3, 3, 14, 14,
-	14, 10, 10, 9, 9, 9, 9, 22, 22, 23,
-	23, 23, 23, 23, 23, 28, 28, 21, 21, 21,
-	21, 33, 29, 31, 31, 32, 32, 32, 30, 27,
-	27, 27, 27, 27, 27, 27, 27, 34, 35, 35,
-	37, 37, 26, 26, 26, 26, 26, 26, 26, 24,
-	24, 24, 24, 24, 24, 24, 25, 25, 25, 25,
-	25, 25, 25, 17, 17, 17, 17, 17, 17, 17,
-	17, 17, 17, 17, 17, 17, 17, 17, 20, 20,
-	18, 18, 18, 16, 16, 16, 16, 16, 16, 16,
-	16, 16, 12, 12, 12, 12, 12, 12, 12, 12,
-	12, 12, 12, 12, 5, 5, 4, 4, 4, 4,
+	13, 13, 13, 11, 11, 11, 11, 11, 11, 11,
+	11, 15, 15, 15, 15, 15, 15, 19, 3, 3,
+	3, 3, 14, 14, 14, 10, 10, 9, 9, 9,
+	9, 22, 22, 23, 23, 23, 23, 23, 23, 28,
+	28, 21, 21, 21, 21, 33, 29, 31, 31, 32,
+	32, 32, 30, 27, 27, 27, 27, 27, 27, 27,
+	27, 34, 35, 35, 37, 37, 26, 26, 26, 26,
+	26, 26, 26, 24, 24, 24, 24, 24, 24, 24,
+	25, 25, 25, 25, 25, 25, 25, 17, 17, 17,
+	17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+	17, 17, 20, 20, 18, 18, 18, 16, 16, 16,
+	16, 16, 16, 16, 16, 16, 12, 12, 12, 12,
+	12, 12, 12, 12, 12, 12, 12, 12, 38, 5,
+	5, 4, 4, 4, 4,
 }
-var exprR2 = [...]int{
 
+var exprR2 = [...]int{
 	0, 1, 1, 1, 1, 1, 1, 1, 1, 3,
 	1, 2, 3, 2, 4, 3, 5, 3, 5, 3,
 	5, 4, 6, 3, 4, 3, 2, 3, 6, 3,
-	1, 1, 1, 4, 6, 5, 7, 4, 5, 5,
-	6, 7, 7, 12, 1, 1, 1, 1, 3, 3,
-	3, 1, 3, 3, 3, 3, 3, 1, 2, 1,
-	2, 2, 2, 2, 2, 2, 3, 1, 1, 2,
-	1, 2, 2, 3, 3, 1, 3, 3, 2, 1,
-	1, 1, 3, 2, 3, 3, 3, 3, 1, 3,
-	1, 1, 3, 3, 3, 3, 3, 3, 3, 3,
+	1, 1, 1, 4, 6, 5, 7, 5, 7, 6,
+	8, 4, 5, 5, 6, 7, 7, 12, 1, 1,
+	1, 1, 3, 3, 3, 1, 3, 3, 3, 3,
+	3, 1, 2, 1, 2, 2, 2, 2, 2, 2,
+	3, 1, 1, 2, 1, 2, 2, 3, 3, 1,
+	3, 3, 2, 1, 1, 1, 3, 2, 3, 3,
+	3, 3, 1, 3, 1, 1, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 3, 4, 4, 4, 4, 4, 4, 4,
-	4, 4, 4, 4, 4, 4, 4, 4, 0, 1,
-	1, 2, 2, 1, 1, 1, 1, 1, 1, 1,
+	3, 3, 3, 3, 3, 3, 3, 4, 4, 4,
+	4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	4, 4, 0, 1, 1, 2, 2, 1, 1, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 3, 4, 4, 3, 3,
+	1, 1, 1, 1, 1, 1, 1, 1, 2, 1,
+	3, 4, 4, 3, 3,
 }
-var exprChk = [...]int{
 
+var exprChk = [...]int{
 	-1000, -1, -2, -6, -7, -14, 23, -11, -15, -17,
-	-18, -19, 15, -12, -16, 7, 70, 71, 59, 27,
+	-18, -19, 15, -12, -16, 7, 71, 72, 59, 27,
 	28, 38, 39, 48, 49, 50, 51, 52, 53, 54,
 	58, 29, 30, 33, 31, 32, 34, 35, 36, 37,
-	61, 62, 63, 70, 71, 72, 73, 74, 75, 64,
-	65, 68, 69, 66, 67, -22, -23, -28, 44, -3,
-	21, 22, 14, 65, -7, -6, -2, -10, 2, -9,
+	62, 63, 64, 71, 72, 73, 74, 75, 76, 65,
+	66, 69, 70, 67, 68, -22, -23, -28, 44, -3,
+	21, 22, 14, 66, -7, -6, -2, -10, 2, -9,
 	5, 23, 23, -4, 25, 26, 7, 7, 23, -20,
 	40, -20, -20, -20, -20, -20, -20, -20, -20, -20,
 	-20, -20, -20, -20, -20, -23, -3, -21, -33, -27,
 	-29, -30, 41, 43, 42, 60, -9, -37, -25, 23,
 	45, 46, 5, -26, -24, 6, 24, 24, 16, 2,
-	19, 16, 12, 65, 13, 14, -8, 7, -14, 23,
+	19, 16, 12, 66, 13, 14, -8, 7, -14, 23,
 	-7, 7, 23, 23, 23, -7, -2, -2, -2, -2,
 	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, 6, -27, 62, 19, 61, -35, -34, 5, 6,
-	-27, 6, -32, -31, 5, 12, 65, 68, 69, 66,
-	67, 64, -9, 6, 6, 6, 6, 2, 24, 19,
-	9, -36, -22, 44, -14, -8, 24, 19, -7, 7,
-	-5, 24, 5, -5, 24, 19, -27, -27, -27, 19,
-	12, 24, 19, 12, 8, 4, 7, 8, 4, 7,
-	8, 4, 7, 8, 4, 7, 8, 4, 7, 8,
-	4, 7, 8, 4, 7, -4, -8, -36, -22, 9,
-	44, 9, -36, 47, 24, -36, -22, 24, -4, -7,
-	24, 19, 19, 24, 24, 6, -34, 6, -31, 2,
-	5, 6, 24, -36, -27, 9, 5, -13, 55, 56,
-	57, 9, 24, 24, -36, 24, -7, 5, 19, -4,
-	23, -36, 44, 9, 9, 24, -4, 24, 6, 5,
-	9, 19, 24, 6, 19, 6, 24,
+	-2, 6, -27, 63, 19, 62, -35, -34, 5, 6,
+	-27, 6, -32, -31, 5, 12, 66, 69, 70, 67,
+	68, 65, -9, 6, 6, 6, 6, 2, 24, -38,
+	61, 19, 9, -36, -22, 44, -14, -8, 24, 19,
+	-7, 7, -5, 24, 5, -5, 24, 19, -27, -27,
+	-27, 19, 12, 24, 19, 12, 8, 4, 7, 8,
+	4, 7, 8, 4, 7, 8, 4, 7, 8, 4,
+	7, 8, 4, 7, 8, 4, 7, -4, 24, 8,
+	-8, -36, -22, 9, 44, 9, -36, 47, 24, -36,
+	-22, 24, -4, -7, 24, 19, 19, 24, 24, 6,
+	-34, 6, -31, 2, 5, 6, -4, 24, -38, -36,
+	-27, 9, 5, -13, 55, 56, 57, 9, 24, 24,
+	-36, 24, -7, 5, 19, -4, 24, 23, -36, 44,
+	9, 9, 24, -4, 24, 6, -4, 5, 9, 19,
+	24, 6, 19, 6, 24,
 }
+
 var exprDef = [...]int{
-
 	0, -2, 1, 2, 3, 10, 0, 4, 5, 6,
-	7, 8, 0, 0, 0, 130, 0, 0, 0, 142,
-	143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-	153, 133, 134, 135, 136, 137, 138, 139, 140, 141,
-	128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
-	128, 128, 128, 128, 128, 11, 57, 59, 0, 0,
-	44, 45, 46, 47, 3, 2, 0, 0, 0, 51,
-	0, 0, 0, 0, 0, 0, 131, 132, 0, 0,
-	129, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 58, 0, 60, 61, 62,
-	63, 64, 67, 68, 0, 70, 79, 80, 81, 0,
-	0, 0, 0, 90, 91, 65, 9, 12, 48, 49,
-	0, 50, 0, 0, 0, 0, 0, 0, 0, 0,
-	3, 130, 0, 0, 0, 3, 113, 114, 115, 116,
-	117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
-	127, 66, 83, 0, 0, 0, 71, 88, 0, 69,
-	0, 72, 78, 75, 0, 0, 0, 0, 0, 0,
-	0, 0, 52, 53, 54, 55, 56, 26, 33, 0,
-	13, 0, 0, 0, 0, 0, 37, 0, 3, 130,
-	0, 158, 154, 0, 159, 0, 84, 85, 86, 0,
-	0, 82, 0, 0, 97, 104, 111, 96, 103, 110,
-	92, 99, 106, 93, 100, 107, 94, 101, 108, 95,
-	102, 109, 98, 105, 112, 35, 0, 15, 23, 17,
-	0, 19, 0, 0, 0, 0, 0, 25, 39, 3,
-	38, 0, 0, 156, 157, 0, 89, 87, 76, 77,
-	73, 74, 34, 24, 29, 21, 27, 0, 30, 31,
-	32, 14, 0, 0, 0, 40, 3, 155, 0, 36,
-	0, 16, 0, 18, 20, 0, 41, 42, 0, 0,
-	22, 0, 28, 0, 0, 0, 43,
+	7, 8, 0, 0, 0, 134, 0, 0, 0, 146,
+	147, 148, 149, 150, 151, 152, 153, 154, 155, 156,
+	157, 137, 138, 139, 140, 141, 142, 143, 144, 145,
+	132, 132, 132, 132, 132, 132, 132, 132, 132, 132,
+	132, 132, 132, 132, 132, 11, 61, 63, 0, 0,
+	48, 49, 50, 51, 3, 2, 0, 0, 0, 55,
+	0, 0, 0, 0, 0, 0, 135, 136, 0, 0,
+	133, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 62, 0, 64, 65, 66,
+	67, 68, 71, 72, 0, 74, 83, 84, 85, 0,
+	0, 0, 0, 94, 95, 69, 9, 12, 52, 53,
+	0, 54, 0, 0, 0, 0, 0, 0, 0, 0,
+	3, 134, 0, 0, 0, 3, 117, 118, 119, 120,
+	121, 122, 123, 124, 125, 126, 127, 128, 129, 130,
+	131, 70, 87, 0, 0, 0, 75, 92, 0, 73,
+	0, 76, 82, 79, 0, 0, 0, 0, 0, 0,
+	0, 0, 56, 57, 58, 59, 60, 26, 33, 0,
+	0, 0, 13, 0, 0, 0, 0, 0, 41, 0,
+	3, 134, 0, 163, 159, 0, 164, 0, 88, 89,
+	90, 0, 0, 86, 0, 0, 101, 108, 115, 100,
+	107, 114, 96, 103, 110, 97, 104, 111, 98, 105,
+	112, 99, 106, 113, 102, 109, 116, 35, 37, 158,
+	0, 15, 23, 17, 0, 19, 0, 0, 0, 0,
+	0, 25, 43, 3, 42, 0, 0, 161, 162, 0,
+	93, 91, 80, 81, 77, 78, 39, 34, 0, 24,
+	29, 21, 27, 0, 30, 31, 32, 14, 0, 0,
+	0, 44, 3, 160, 0, 36, 38, 0, 16, 0,
+	18, 20, 0, 45, 46, 0, 40, 0, 22, 0,
+	28, 0, 0, 0, 47,
 }
-var exprTok1 = [...]int{
 
+var exprTok1 = [...]int{
 	1,
 }
-var exprTok2 = [...]int{
 
+var exprTok2 = [...]int{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -429,8 +439,9 @@ var exprTok2 = [...]int{
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 	52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
 	62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-	72, 73, 74, 75,
+	72, 73, 74, 75, 76,
 }
+
 var exprTok3 = [...]int{
 	0,
 }
@@ -774,942 +785,972 @@ exprdefault:
 
 	case 1:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:113
+//line pkg/logql/expr.y:115
 		{
 			exprlex.(*parser).expr = exprDollar[1].Expr
 		}
 	case 2:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:116
+//line pkg/logql/expr.y:118
 		{
 			exprVAL.Expr = exprDollar[1].LogExpr
 		}
 	case 3:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:117
+//line pkg/logql/expr.y:119
 		{
 			exprVAL.Expr = exprDollar[1].MetricExpr
 		}
 	case 4:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:121
+//line pkg/logql/expr.y:123
 		{
 			exprVAL.MetricExpr = exprDollar[1].RangeAggregationExpr
 		}
 	case 5:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:122
+//line pkg/logql/expr.y:124
 		{
 			exprVAL.MetricExpr = exprDollar[1].VectorAggregationExpr
 		}
 	case 6:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:123
+//line pkg/logql/expr.y:125
 		{
 			exprVAL.MetricExpr = exprDollar[1].BinOpExpr
 		}
 	case 7:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:124
+//line pkg/logql/expr.y:126
 		{
 			exprVAL.MetricExpr = exprDollar[1].LiteralExpr
 		}
 	case 8:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:125
+//line pkg/logql/expr.y:127
 		{
 			exprVAL.MetricExpr = exprDollar[1].LabelReplaceExpr
 		}
 	case 9:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:126
+//line pkg/logql/expr.y:128
 		{
 			exprVAL.MetricExpr = exprDollar[2].MetricExpr
 		}
 	case 10:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:130
+//line pkg/logql/expr.y:132
 		{
 			exprVAL.LogExpr = newMatcherExpr(exprDollar[1].Selector)
 		}
 	case 11:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:131
+//line pkg/logql/expr.y:133
 		{
 			exprVAL.LogExpr = newPipelineExpr(newMatcherExpr(exprDollar[1].Selector), exprDollar[2].PipelineExpr)
 		}
 	case 12:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:132
+//line pkg/logql/expr.y:134
 		{
 			exprVAL.LogExpr = exprDollar[2].LogExpr
 		}
 	case 13:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:136
+//line pkg/logql/expr.y:138
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[1].Selector), exprDollar[2].duration, nil)
 		}
 	case 14:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:137
+//line pkg/logql/expr.y:139
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[2].Selector), exprDollar[4].duration, nil)
 		}
 	case 15:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:138
+//line pkg/logql/expr.y:140
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[1].Selector), exprDollar[2].duration, exprDollar[3].UnwrapExpr)
 		}
 	case 16:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:139
+//line pkg/logql/expr.y:141
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[2].Selector), exprDollar[4].duration, exprDollar[5].UnwrapExpr)
 		}
 	case 17:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:140
+//line pkg/logql/expr.y:142
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[1].Selector), exprDollar[3].duration, exprDollar[2].UnwrapExpr)
 		}
 	case 18:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:141
+//line pkg/logql/expr.y:143
 		{
 			exprVAL.LogRangeExpr = newLogRange(newMatcherExpr(exprDollar[2].Selector), exprDollar[5].duration, exprDollar[3].UnwrapExpr)
 		}
 	case 19:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:142
+//line pkg/logql/expr.y:144
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[1].Selector), exprDollar[2].PipelineExpr), exprDollar[3].duration, nil)
 		}
 	case 20:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:143
+//line pkg/logql/expr.y:145
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[2].Selector), exprDollar[3].PipelineExpr), exprDollar[5].duration, nil)
 		}
 	case 21:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:144
+//line pkg/logql/expr.y:146
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[1].Selector), exprDollar[2].PipelineExpr), exprDollar[4].duration, exprDollar[3].UnwrapExpr)
 		}
 	case 22:
 		exprDollar = exprS[exprpt-6 : exprpt+1]
-//line pkg/logql/expr.y:145
+//line pkg/logql/expr.y:147
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[2].Selector), exprDollar[3].PipelineExpr), exprDollar[6].duration, exprDollar[4].UnwrapExpr)
 		}
 	case 23:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:146
+//line pkg/logql/expr.y:148
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[1].Selector), exprDollar[3].PipelineExpr), exprDollar[2].duration, nil)
 		}
 	case 24:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:147
+//line pkg/logql/expr.y:149
 		{
 			exprVAL.LogRangeExpr = newLogRange(newPipelineExpr(newMatcherExpr(exprDollar[1].Selector), exprDollar[3].PipelineExpr), exprDollar[2].duration, exprDollar[4].UnwrapExpr)
 		}
 	case 25:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:148
+//line pkg/logql/expr.y:150
 		{
 			exprVAL.LogRangeExpr = exprDollar[2].LogRangeExpr
 		}
 	case 27:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:153
+//line pkg/logql/expr.y:155
 		{
 			exprVAL.UnwrapExpr = newUnwrapExpr(exprDollar[3].str, "")
 		}
 	case 28:
 		exprDollar = exprS[exprpt-6 : exprpt+1]
-//line pkg/logql/expr.y:154
+//line pkg/logql/expr.y:156
 		{
 			exprVAL.UnwrapExpr = newUnwrapExpr(exprDollar[5].str, exprDollar[3].ConvOp)
 		}
 	case 29:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:155
+//line pkg/logql/expr.y:157
 		{
 			exprVAL.UnwrapExpr = exprDollar[1].UnwrapExpr.addPostFilter(exprDollar[3].LabelFilter)
 		}
 	case 30:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:159
+//line pkg/logql/expr.y:161
 		{
 			exprVAL.ConvOp = OpConvBytes
 		}
 	case 31:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:160
+//line pkg/logql/expr.y:162
 		{
 			exprVAL.ConvOp = OpConvDuration
 		}
 	case 32:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:161
+//line pkg/logql/expr.y:163
 		{
 			exprVAL.ConvOp = OpConvDurationSeconds
 		}
 	case 33:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:165
+//line pkg/logql/expr.y:167
 		{
 			exprVAL.RangeAggregationExpr = newRangeAggregationExpr(exprDollar[3].LogRangeExpr, exprDollar[1].RangeOp, nil, nil)
 		}
 	case 34:
 		exprDollar = exprS[exprpt-6 : exprpt+1]
-//line pkg/logql/expr.y:166
+//line pkg/logql/expr.y:168
 		{
 			exprVAL.RangeAggregationExpr = newRangeAggregationExpr(exprDollar[5].LogRangeExpr, exprDollar[1].RangeOp, nil, &exprDollar[3].str)
 		}
 	case 35:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:167
+//line pkg/logql/expr.y:169
 		{
 			exprVAL.RangeAggregationExpr = newRangeAggregationExpr(exprDollar[3].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[5].Grouping, nil)
 		}
 	case 36:
 		exprDollar = exprS[exprpt-7 : exprpt+1]
-//line pkg/logql/expr.y:168
+//line pkg/logql/expr.y:170
 		{
 			exprVAL.RangeAggregationExpr = newRangeAggregationExpr(exprDollar[5].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[7].Grouping, &exprDollar[3].str)
 		}
 	case 37:
-		exprDollar = exprS[exprpt-4 : exprpt+1]
+		exprDollar = exprS[exprpt-5 : exprpt+1]
+//line pkg/logql/expr.y:171
+		{
+			exprVAL.RangeAggregationExpr = newRangeAggregationExprWithOffset(exprDollar[3].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[4].OffsetExpr, nil, nil)
+		}
+	case 38:
+		exprDollar = exprS[exprpt-7 : exprpt+1]
+//line pkg/logql/expr.y:172
+		{
+			exprVAL.RangeAggregationExpr = newRangeAggregationExprWithOffset(exprDollar[5].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[6].OffsetExpr, nil, &exprDollar[3].str)
+		}
+	case 39:
+		exprDollar = exprS[exprpt-6 : exprpt+1]
 //line pkg/logql/expr.y:173
+		{
+			exprVAL.RangeAggregationExpr = newRangeAggregationExprWithOffset(exprDollar[3].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[4].OffsetExpr, exprDollar[6].Grouping, nil)
+		}
+	case 40:
+		exprDollar = exprS[exprpt-8 : exprpt+1]
+//line pkg/logql/expr.y:174
+		{
+			exprVAL.RangeAggregationExpr = newRangeAggregationExprWithOffset(exprDollar[5].LogRangeExpr, exprDollar[1].RangeOp, exprDollar[6].OffsetExpr, exprDollar[8].Grouping, &exprDollar[3].str)
+		}
+	case 41:
+		exprDollar = exprS[exprpt-4 : exprpt+1]
+//line pkg/logql/expr.y:179
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[3].MetricExpr, exprDollar[1].VectorOp, nil, nil)
 		}
-	case 38:
+	case 42:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:174
+//line pkg/logql/expr.y:180
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[4].MetricExpr, exprDollar[1].VectorOp, exprDollar[2].Grouping, nil)
 		}
-	case 39:
+	case 43:
 		exprDollar = exprS[exprpt-5 : exprpt+1]
-//line pkg/logql/expr.y:175
+//line pkg/logql/expr.y:181
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[3].MetricExpr, exprDollar[1].VectorOp, exprDollar[5].Grouping, nil)
 		}
-	case 40:
+	case 44:
 		exprDollar = exprS[exprpt-6 : exprpt+1]
-//line pkg/logql/expr.y:177
+//line pkg/logql/expr.y:183
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[5].MetricExpr, exprDollar[1].VectorOp, nil, &exprDollar[3].str)
 		}
-	case 41:
+	case 45:
 		exprDollar = exprS[exprpt-7 : exprpt+1]
-//line pkg/logql/expr.y:178
+//line pkg/logql/expr.y:184
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[5].MetricExpr, exprDollar[1].VectorOp, exprDollar[7].Grouping, &exprDollar[3].str)
 		}
-	case 42:
+	case 46:
 		exprDollar = exprS[exprpt-7 : exprpt+1]
-//line pkg/logql/expr.y:179
+//line pkg/logql/expr.y:185
 		{
 			exprVAL.VectorAggregationExpr = mustNewVectorAggregationExpr(exprDollar[6].MetricExpr, exprDollar[1].VectorOp, exprDollar[2].Grouping, &exprDollar[4].str)
 		}
-	case 43:
+	case 47:
 		exprDollar = exprS[exprpt-12 : exprpt+1]
-//line pkg/logql/expr.y:184
+//line pkg/logql/expr.y:190
 		{
 			exprVAL.LabelReplaceExpr = mustNewLabelReplaceExpr(exprDollar[3].MetricExpr, exprDollar[5].str, exprDollar[7].str, exprDollar[9].str, exprDollar[11].str)
 		}
-	case 44:
+	case 48:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:188
+//line pkg/logql/expr.y:194
 		{
 			exprVAL.Filter = labels.MatchRegexp
 		}
-	case 45:
+	case 49:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:189
+//line pkg/logql/expr.y:195
 		{
 			exprVAL.Filter = labels.MatchEqual
 		}
-	case 46:
+	case 50:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:190
+//line pkg/logql/expr.y:196
 		{
 			exprVAL.Filter = labels.MatchNotRegexp
 		}
-	case 47:
+	case 51:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:191
+//line pkg/logql/expr.y:197
 		{
 			exprVAL.Filter = labels.MatchNotEqual
 		}
-	case 48:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:195
-		{
-			exprVAL.Selector = exprDollar[2].Matchers
-		}
-	case 49:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:196
-		{
-			exprVAL.Selector = exprDollar[2].Matchers
-		}
-	case 50:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:197
-		{
-		}
-	case 51:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:201
-		{
-			exprVAL.Matchers = []*labels.Matcher{exprDollar[1].Matcher}
-		}
 	case 52:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:202
+//line pkg/logql/expr.y:201
 		{
-			exprVAL.Matchers = append(exprDollar[1].Matchers, exprDollar[3].Matcher)
+			exprVAL.Selector = exprDollar[2].Matchers
 		}
 	case 53:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:206
+//line pkg/logql/expr.y:202
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchEqual, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Selector = exprDollar[2].Matchers
 		}
 	case 54:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:207
+//line pkg/logql/expr.y:203
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchNotEqual, exprDollar[1].str, exprDollar[3].str)
 		}
 	case 55:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:208
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:207
 		{
-			exprVAL.Matcher = mustNewMatcher(labels.MatchRegexp, exprDollar[1].str, exprDollar[3].str)
+			exprVAL.Matchers = []*labels.Matcher{exprDollar[1].Matcher}
 		}
 	case 56:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:209
+//line pkg/logql/expr.y:208
+		{
+			exprVAL.Matchers = append(exprDollar[1].Matchers, exprDollar[3].Matcher)
+		}
+	case 57:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:212
+		{
+			exprVAL.Matcher = mustNewMatcher(labels.MatchEqual, exprDollar[1].str, exprDollar[3].str)
+		}
+	case 58:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:213
+		{
+			exprVAL.Matcher = mustNewMatcher(labels.MatchNotEqual, exprDollar[1].str, exprDollar[3].str)
+		}
+	case 59:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:214
+		{
+			exprVAL.Matcher = mustNewMatcher(labels.MatchRegexp, exprDollar[1].str, exprDollar[3].str)
+		}
+	case 60:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:215
 		{
 			exprVAL.Matcher = mustNewMatcher(labels.MatchNotRegexp, exprDollar[1].str, exprDollar[3].str)
 		}
-	case 57:
+	case 61:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:213
+//line pkg/logql/expr.y:219
 		{
 			exprVAL.PipelineExpr = MultiStageExpr{exprDollar[1].PipelineStage}
 		}
-	case 58:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:214
-		{
-			exprVAL.PipelineExpr = append(exprDollar[1].PipelineExpr, exprDollar[2].PipelineStage)
-		}
-	case 59:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:218
-		{
-			exprVAL.PipelineStage = exprDollar[1].LineFilters
-		}
-	case 60:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:219
-		{
-			exprVAL.PipelineStage = exprDollar[2].LabelParser
-		}
-	case 61:
+	case 62:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
 //line pkg/logql/expr.y:220
 		{
-			exprVAL.PipelineStage = exprDollar[2].JSONExpressionParser
-		}
-	case 62:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:221
-		{
-			exprVAL.PipelineStage = &labelFilterExpr{LabelFilterer: exprDollar[2].LabelFilter}
+			exprVAL.PipelineExpr = append(exprDollar[1].PipelineExpr, exprDollar[2].PipelineStage)
 		}
 	case 63:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:222
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:224
 		{
-			exprVAL.PipelineStage = exprDollar[2].LineFormatExpr
+			exprVAL.PipelineStage = exprDollar[1].LineFilters
 		}
 	case 64:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:223
+//line pkg/logql/expr.y:225
 		{
-			exprVAL.PipelineStage = exprDollar[2].LabelFormatExpr
+			exprVAL.PipelineStage = exprDollar[2].LabelParser
 		}
 	case 65:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:227
+//line pkg/logql/expr.y:226
 		{
-			exprVAL.LineFilters = newLineFilterExpr(nil, exprDollar[1].Filter, exprDollar[2].str)
+			exprVAL.PipelineStage = exprDollar[2].JSONExpressionParser
 		}
 	case 66:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:228
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:227
 		{
-			exprVAL.LineFilters = newLineFilterExpr(exprDollar[1].LineFilters, exprDollar[2].Filter, exprDollar[3].str)
+			exprVAL.PipelineStage = &labelFilterExpr{LabelFilterer: exprDollar[2].LabelFilter}
 		}
 	case 67:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:231
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:228
 		{
-			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeJSON, "")
+			exprVAL.PipelineStage = exprDollar[2].LineFormatExpr
 		}
 	case 68:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:232
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:229
 		{
-			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeLogfmt, "")
+			exprVAL.PipelineStage = exprDollar[2].LabelFormatExpr
 		}
 	case 69:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
 //line pkg/logql/expr.y:233
 		{
-			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeRegexp, exprDollar[2].str)
+			exprVAL.LineFilters = newLineFilterExpr(nil, exprDollar[1].Filter, exprDollar[2].str)
 		}
 	case 70:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
+		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:234
+		{
+			exprVAL.LineFilters = newLineFilterExpr(exprDollar[1].LineFilters, exprDollar[2].Filter, exprDollar[3].str)
+		}
+	case 71:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:237
+		{
+			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeJSON, "")
+		}
+	case 72:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:238
+		{
+			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeLogfmt, "")
+		}
+	case 73:
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:239
+		{
+			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeRegexp, exprDollar[2].str)
+		}
+	case 74:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:240
 		{
 			exprVAL.LabelParser = newLabelParserExpr(OpParserTypeUnpack, "")
 		}
-	case 71:
+	case 75:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:238
+//line pkg/logql/expr.y:244
 		{
 			exprVAL.JSONExpressionParser = newJSONExpressionParser(exprDollar[2].JSONExpressionList)
 		}
-	case 72:
+	case 76:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:240
+//line pkg/logql/expr.y:246
 		{
 			exprVAL.LineFormatExpr = newLineFmtExpr(exprDollar[2].str)
 		}
-	case 73:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:243
-		{
-			exprVAL.LabelFormat = log.NewRenameLabelFmt(exprDollar[1].str, exprDollar[3].str)
-		}
-	case 74:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:244
-		{
-			exprVAL.LabelFormat = log.NewTemplateLabelFmt(exprDollar[1].str, exprDollar[3].str)
-		}
-	case 75:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:248
-		{
-			exprVAL.LabelsFormat = []log.LabelFmt{exprDollar[1].LabelFormat}
-		}
-	case 76:
+	case 77:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:249
 		{
-			exprVAL.LabelsFormat = append(exprDollar[1].LabelsFormat, exprDollar[3].LabelFormat)
+			exprVAL.LabelFormat = log.NewRenameLabelFmt(exprDollar[1].str, exprDollar[3].str)
 		}
 	case 78:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:253
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:250
 		{
-			exprVAL.LabelFormatExpr = newLabelFmtExpr(exprDollar[2].LabelsFormat)
+			exprVAL.LabelFormat = log.NewTemplateLabelFmt(exprDollar[1].str, exprDollar[3].str)
 		}
 	case 79:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:256
+//line pkg/logql/expr.y:254
+		{
+			exprVAL.LabelsFormat = []log.LabelFmt{exprDollar[1].LabelFormat}
+		}
+	case 80:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:255
+		{
+			exprVAL.LabelsFormat = append(exprDollar[1].LabelsFormat, exprDollar[3].LabelFormat)
+		}
+	case 82:
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:259
+		{
+			exprVAL.LabelFormatExpr = newLabelFmtExpr(exprDollar[2].LabelsFormat)
+		}
+	case 83:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:262
 		{
 			exprVAL.LabelFilter = log.NewStringLabelFilter(exprDollar[1].Matcher)
 		}
-	case 80:
+	case 84:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:257
+//line pkg/logql/expr.y:263
 		{
 			exprVAL.LabelFilter = exprDollar[1].UnitFilter
 		}
-	case 81:
+	case 85:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:258
+//line pkg/logql/expr.y:264
 		{
 			exprVAL.LabelFilter = exprDollar[1].NumberFilter
 		}
-	case 82:
+	case 86:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:259
+//line pkg/logql/expr.y:265
 		{
 			exprVAL.LabelFilter = exprDollar[2].LabelFilter
 		}
-	case 83:
+	case 87:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:260
+//line pkg/logql/expr.y:266
 		{
 			exprVAL.LabelFilter = log.NewAndLabelFilter(exprDollar[1].LabelFilter, exprDollar[2].LabelFilter)
 		}
-	case 84:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:261
-		{
-			exprVAL.LabelFilter = log.NewAndLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
-		}
-	case 85:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:262
-		{
-			exprVAL.LabelFilter = log.NewAndLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
-		}
-	case 86:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:263
-		{
-			exprVAL.LabelFilter = log.NewOrLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
-		}
-	case 87:
+	case 88:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:267
 		{
-			exprVAL.JSONExpression = log.NewJSONExpr(exprDollar[1].str, exprDollar[3].str)
-		}
-	case 88:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:270
-		{
-			exprVAL.JSONExpressionList = []log.JSONExpression{exprDollar[1].JSONExpression}
+			exprVAL.LabelFilter = log.NewAndLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
 		}
 	case 89:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:271
+//line pkg/logql/expr.y:268
 		{
-			exprVAL.JSONExpressionList = append(exprDollar[1].JSONExpressionList, exprDollar[3].JSONExpression)
+			exprVAL.LabelFilter = log.NewAndLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
 		}
 	case 90:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:275
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:269
 		{
-			exprVAL.UnitFilter = exprDollar[1].DurationFilter
+			exprVAL.LabelFilter = log.NewOrLabelFilter(exprDollar[1].LabelFilter, exprDollar[3].LabelFilter)
 		}
 	case 91:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:273
+		{
+			exprVAL.JSONExpression = log.NewJSONExpr(exprDollar[1].str, exprDollar[3].str)
+		}
+	case 92:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 //line pkg/logql/expr.y:276
 		{
-			exprVAL.UnitFilter = exprDollar[1].BytesFilter
-		}
-	case 92:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:279
-		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.JSONExpressionList = []log.JSONExpression{exprDollar[1].JSONExpression}
 		}
 	case 93:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:280
+//line pkg/logql/expr.y:277
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.JSONExpressionList = append(exprDollar[1].JSONExpressionList, exprDollar[3].JSONExpression)
 		}
 	case 94:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
+		exprDollar = exprS[exprpt-1 : exprpt+1]
 //line pkg/logql/expr.y:281
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.UnitFilter = exprDollar[1].DurationFilter
 		}
 	case 95:
-		exprDollar = exprS[exprpt-3 : exprpt+1]
+		exprDollar = exprS[exprpt-1 : exprpt+1]
 //line pkg/logql/expr.y:282
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.UnitFilter = exprDollar[1].BytesFilter
 		}
 	case 96:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:283
+//line pkg/logql/expr.y:285
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 97:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:284
+//line pkg/logql/expr.y:286
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 98:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:285
+//line pkg/logql/expr.y:287
 		{
-			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].duration)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 99:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:289
+//line pkg/logql/expr.y:288
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 100:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:290
+//line pkg/logql/expr.y:289
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 101:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:291
+//line pkg/logql/expr.y:290
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 102:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:292
+//line pkg/logql/expr.y:291
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.DurationFilter = log.NewDurationLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].duration)
 		}
 	case 103:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:293
+//line pkg/logql/expr.y:295
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 104:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:294
+//line pkg/logql/expr.y:296
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 105:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:295
+//line pkg/logql/expr.y:297
 		{
-			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].bytes)
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 106:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:299
+//line pkg/logql/expr.y:298
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 107:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:300
+//line pkg/logql/expr.y:299
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 108:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:301
+//line pkg/logql/expr.y:300
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 109:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:302
+//line pkg/logql/expr.y:301
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.BytesFilter = log.NewBytesLabelFilter(log.LabelFilterEqual, exprDollar[1].str, exprDollar[3].bytes)
 		}
 	case 110:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:303
+//line pkg/logql/expr.y:305
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterGreaterThan, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
 		}
 	case 111:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:304
+//line pkg/logql/expr.y:306
 		{
-			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
 		}
 	case 112:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:305
+//line pkg/logql/expr.y:307
+		{
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterLesserThan, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+		}
+	case 113:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:308
+		{
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+		}
+	case 114:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:309
+		{
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterNotEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
+		}
+	case 115:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
+//line pkg/logql/expr.y:310
 		{
 			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
 		}
-	case 113:
-		exprDollar = exprS[exprpt-4 : exprpt+1]
+	case 116:
+		exprDollar = exprS[exprpt-3 : exprpt+1]
 //line pkg/logql/expr.y:311
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("or", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
-		}
-	case 114:
-		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:312
-		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("and", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
-		}
-	case 115:
-		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:313
-		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("unless", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
-		}
-	case 116:
-		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:314
-		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("+", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.NumberFilter = log.NewNumericLabelFilter(log.LabelFilterEqual, exprDollar[1].str, mustNewFloat(exprDollar[3].str))
 		}
 	case 117:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:315
+//line pkg/logql/expr.y:317
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("-", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("or", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 118:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:316
+//line pkg/logql/expr.y:318
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("*", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("and", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 119:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:317
+//line pkg/logql/expr.y:319
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("/", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("unless", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 120:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:318
+//line pkg/logql/expr.y:320
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("%", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("+", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 121:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:319
+//line pkg/logql/expr.y:321
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("^", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("-", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 122:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:320
+//line pkg/logql/expr.y:322
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("==", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("*", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 123:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:321
+//line pkg/logql/expr.y:323
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("!=", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("/", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 124:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:322
+//line pkg/logql/expr.y:324
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr(">", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("%", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 125:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:323
+//line pkg/logql/expr.y:325
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr(">=", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("^", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 126:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:324
+//line pkg/logql/expr.y:326
 		{
-			exprVAL.BinOpExpr = mustNewBinOpExpr("<", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+			exprVAL.BinOpExpr = mustNewBinOpExpr("==", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
 	case 127:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:325
+//line pkg/logql/expr.y:327
+		{
+			exprVAL.BinOpExpr = mustNewBinOpExpr("!=", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+		}
+	case 128:
+		exprDollar = exprS[exprpt-4 : exprpt+1]
+//line pkg/logql/expr.y:328
+		{
+			exprVAL.BinOpExpr = mustNewBinOpExpr(">", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+		}
+	case 129:
+		exprDollar = exprS[exprpt-4 : exprpt+1]
+//line pkg/logql/expr.y:329
+		{
+			exprVAL.BinOpExpr = mustNewBinOpExpr(">=", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+		}
+	case 130:
+		exprDollar = exprS[exprpt-4 : exprpt+1]
+//line pkg/logql/expr.y:330
+		{
+			exprVAL.BinOpExpr = mustNewBinOpExpr("<", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
+		}
+	case 131:
+		exprDollar = exprS[exprpt-4 : exprpt+1]
+//line pkg/logql/expr.y:331
 		{
 			exprVAL.BinOpExpr = mustNewBinOpExpr("<=", exprDollar[3].BinOpModifier, exprDollar[1].Expr, exprDollar[4].Expr)
 		}
-	case 128:
+	case 132:
 		exprDollar = exprS[exprpt-0 : exprpt+1]
-//line pkg/logql/expr.y:329
+//line pkg/logql/expr.y:335
 		{
 			exprVAL.BinOpModifier = BinOpOptions{}
 		}
-	case 129:
+	case 133:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:330
+//line pkg/logql/expr.y:336
 		{
 			exprVAL.BinOpModifier = BinOpOptions{ReturnBool: true}
 		}
-	case 130:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:334
-		{
-			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[1].str, false)
-		}
-	case 131:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:335
-		{
-			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[2].str, false)
-		}
-	case 132:
-		exprDollar = exprS[exprpt-2 : exprpt+1]
-//line pkg/logql/expr.y:336
-		{
-			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[2].str, true)
-		}
-	case 133:
+	case 134:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 //line pkg/logql/expr.y:340
 		{
-			exprVAL.VectorOp = OpTypeSum
-		}
-	case 134:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:341
-		{
-			exprVAL.VectorOp = OpTypeAvg
+			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[1].str, false)
 		}
 	case 135:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:342
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:341
 		{
-			exprVAL.VectorOp = OpTypeCount
+			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[2].str, false)
 		}
 	case 136:
-		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:343
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:342
 		{
-			exprVAL.VectorOp = OpTypeMax
+			exprVAL.LiteralExpr = mustNewLiteralExpr(exprDollar[2].str, true)
 		}
 	case 137:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:344
+//line pkg/logql/expr.y:346
 		{
-			exprVAL.VectorOp = OpTypeMin
+			exprVAL.VectorOp = OpTypeSum
 		}
 	case 138:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:345
+//line pkg/logql/expr.y:347
 		{
-			exprVAL.VectorOp = OpTypeStddev
+			exprVAL.VectorOp = OpTypeAvg
 		}
 	case 139:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:346
+//line pkg/logql/expr.y:348
 		{
-			exprVAL.VectorOp = OpTypeStdvar
+			exprVAL.VectorOp = OpTypeCount
 		}
 	case 140:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:347
+//line pkg/logql/expr.y:349
 		{
-			exprVAL.VectorOp = OpTypeBottomK
+			exprVAL.VectorOp = OpTypeMax
 		}
 	case 141:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:348
+//line pkg/logql/expr.y:350
 		{
-			exprVAL.VectorOp = OpTypeTopK
+			exprVAL.VectorOp = OpTypeMin
 		}
 	case 142:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:352
+//line pkg/logql/expr.y:351
 		{
-			exprVAL.RangeOp = OpRangeTypeCount
+			exprVAL.VectorOp = OpTypeStddev
 		}
 	case 143:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:353
+//line pkg/logql/expr.y:352
 		{
-			exprVAL.RangeOp = OpRangeTypeRate
+			exprVAL.VectorOp = OpTypeStdvar
 		}
 	case 144:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:354
+//line pkg/logql/expr.y:353
 		{
-			exprVAL.RangeOp = OpRangeTypeBytes
+			exprVAL.VectorOp = OpTypeBottomK
 		}
 	case 145:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:355
+//line pkg/logql/expr.y:354
 		{
-			exprVAL.RangeOp = OpRangeTypeBytesRate
+			exprVAL.VectorOp = OpTypeTopK
 		}
 	case 146:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:356
+//line pkg/logql/expr.y:358
 		{
-			exprVAL.RangeOp = OpRangeTypeAvg
+			exprVAL.RangeOp = OpRangeTypeCount
 		}
 	case 147:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:357
+//line pkg/logql/expr.y:359
 		{
-			exprVAL.RangeOp = OpRangeTypeSum
+			exprVAL.RangeOp = OpRangeTypeRate
 		}
 	case 148:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:358
+//line pkg/logql/expr.y:360
 		{
-			exprVAL.RangeOp = OpRangeTypeMin
+			exprVAL.RangeOp = OpRangeTypeBytes
 		}
 	case 149:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:359
+//line pkg/logql/expr.y:361
 		{
-			exprVAL.RangeOp = OpRangeTypeMax
+			exprVAL.RangeOp = OpRangeTypeBytesRate
 		}
 	case 150:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:360
+//line pkg/logql/expr.y:362
 		{
-			exprVAL.RangeOp = OpRangeTypeStdvar
+			exprVAL.RangeOp = OpRangeTypeAvg
 		}
 	case 151:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:361
+//line pkg/logql/expr.y:363
 		{
-			exprVAL.RangeOp = OpRangeTypeStddev
+			exprVAL.RangeOp = OpRangeTypeSum
 		}
 	case 152:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:362
+//line pkg/logql/expr.y:364
 		{
-			exprVAL.RangeOp = OpRangeTypeQuantile
+			exprVAL.RangeOp = OpRangeTypeMin
 		}
 	case 153:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
-//line pkg/logql/expr.y:363
+//line pkg/logql/expr.y:365
 		{
-			exprVAL.RangeOp = OpRangeTypeAbsent
+			exprVAL.RangeOp = OpRangeTypeMax
 		}
 	case 154:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:366
+		{
+			exprVAL.RangeOp = OpRangeTypeStdvar
+		}
+	case 155:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:367
+		{
+			exprVAL.RangeOp = OpRangeTypeStddev
+		}
+	case 156:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
 //line pkg/logql/expr.y:368
+		{
+			exprVAL.RangeOp = OpRangeTypeQuantile
+		}
+	case 157:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:369
+		{
+			exprVAL.RangeOp = OpRangeTypeAbsent
+		}
+	case 158:
+		exprDollar = exprS[exprpt-2 : exprpt+1]
+//line pkg/logql/expr.y:373
+		{
+			exprVAL.OffsetExpr = newOffsetExpr(exprDollar[2].duration)
+		}
+	case 159:
+		exprDollar = exprS[exprpt-1 : exprpt+1]
+//line pkg/logql/expr.y:376
 		{
 			exprVAL.Labels = []string{exprDollar[1].str}
 		}
-	case 155:
+	case 160:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:369
+//line pkg/logql/expr.y:377
 		{
 			exprVAL.Labels = append(exprDollar[1].Labels, exprDollar[3].str)
 		}
-	case 156:
+	case 161:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:373
+//line pkg/logql/expr.y:381
 		{
 			exprVAL.Grouping = &grouping{without: false, groups: exprDollar[3].Labels}
 		}
-	case 157:
+	case 162:
 		exprDollar = exprS[exprpt-4 : exprpt+1]
-//line pkg/logql/expr.y:374
+//line pkg/logql/expr.y:382
 		{
 			exprVAL.Grouping = &grouping{without: true, groups: exprDollar[3].Labels}
 		}
-	case 158:
+	case 163:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:375
+//line pkg/logql/expr.y:383
 		{
 			exprVAL.Grouping = &grouping{without: false, groups: nil}
 		}
-	case 159:
+	case 164:
 		exprDollar = exprS[exprpt-3 : exprpt+1]
-//line pkg/logql/expr.y:376
+//line pkg/logql/expr.y:384
 		{
 			exprVAL.Grouping = &grouping{without: true, groups: nil}
 		}

--- a/pkg/logql/functions_test.go
+++ b/pkg/logql/functions_test.go
@@ -11,12 +11,14 @@ func Test_Extractor(t *testing.T) {
 	for _, tc := range []string{
 		`rate( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
 		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
+		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] offset 30s )`,
 		`sum without(a) ( rate ( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum by(a) (rate( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum(count_over_time({job="mysql"}[5m]))`,
 		`sum(count_over_time({job="mysql"} | json [5m]))`,
 		`sum(count_over_time({job="mysql"} | logfmt [5m]))`,
 		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m]))`,
+		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m] offset 1h))`,
 		`topk(10,sum(rate({region="us-east1"}[5m])) by (name))`,
 		`topk by (name)(10,sum(rate({region="us-east1"}[5m])))`,
 		`avg( rate( ( {job="nginx"} |= "GET" ) [10s] ) ) by (region)`,
@@ -71,6 +73,20 @@ func Test_Extractor(t *testing.T) {
 					)
 				/
 					count_over_time({namespace="tns"} | logfmt | label_format foo=bar[5m])
+				),
+				"foo",
+				"$1",
+				"service",
+				"(.*):.*"
+			)
+			`,
+		`label_replace(
+				sum by (job) (
+					sum_over_time(
+						{namespace="tns"} |= "level=error" | json | avg=5 and bar<25ms | unwrap duration(latency)  | __error__!~".*" [5m] offset 1h
+					)
+				/
+					count_over_time({namespace="tns"} | logfmt | label_format foo=bar[5m] offset 1h)
 				),
 				"foo",
 				"$1",

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -32,6 +32,7 @@ var tokens = map[string]int{
 	"[":            OPEN_BRACKET,
 	"]":            CLOSE_BRACKET,
 	OpLabelReplace: LABEL_REPLACE,
+	OpOffset:       OFFSET,
 
 	// binops
 	OpTypeOr:     OR,

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -151,7 +151,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 			fmt.Sprintf("logs[%s] - step: %s", time.Duration(tt.selRange), time.Duration(tt.step)),
 			func(t *testing.T) {
 				it := newRangeVectorIterator(newfakePeekingSampleIterator(), tt.selRange,
-					tt.step, tt.start.UnixNano(), tt.end.UnixNano())
+					tt.step, tt.start.UnixNano(), tt.end.UnixNano(), 0)
 
 				i := 0
 				for it.Next() {
@@ -173,7 +173,7 @@ func Test_RangeVectorIteratorBadLabels(t *testing.T) {
 			Samples: samples,
 		}))
 	it := newRangeVectorIterator(badIterator, (30 * time.Second).Nanoseconds(),
-		(30 * time.Second).Nanoseconds(), time.Unix(10, 0).UnixNano(), time.Unix(100, 0).UnixNano())
+		(30 * time.Second).Nanoseconds(), time.Unix(10, 0).UnixNano(), time.Unix(100, 0).UnixNano(), 0)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer cancel()


### PR DESCRIPTION
implementation for https://github.com/grafana/loki/issues/2785, the offset modifier allows changing the time offset for range vectors in a query to support e.g. selective timeshift in Grafana

Signed-off-by: garrettlish <garrettlish@163.com>
