### PR TITLE
Promtail: Added path information to deleted tailed file

### DIFF
--- a/pkg/promtail/targets/file/tailer.go
+++ b/pkg/promtail/targets/file/tailer.go
@@ -170,7 +170,7 @@ func (t *tailer) markPositionAndSize() error {
 	if err != nil {
 		// If the file no longer exists, no need to save position information
 		if err == os.ErrNotExist {
-			level.Info(t.logger).Log("msg", "skipping update of position for a file which does not currently exist")
+			level.Info(t.logger).Log("msg", "skipping update of position for a file which does not currently exist", "path", t.path)
 			return nil
 		}
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds more information to

```
skipping update of position for a file which does not currently exist
```

that is, it adds which file we're talking about with this log message. I've encountered a large number of such messages, and am in process of debugging them. 

