### PR TITLE
Fixes out-of-memory fuzzing issue.

### DIFF
--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -5,6 +5,7 @@ import (
 	"text/scanner"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/dustin/go-humanize"
 	"github.com/prometheus/common/model"
@@ -133,7 +134,12 @@ func (l *lexer) Lex(lval *exprSymType) int {
 
 	case scanner.String, scanner.RawString:
 		var err error
-		lval.str, err = strutil.Unquote(l.TokenText())
+		tokenText := l.TokenText()
+		if !utf8.ValidString(tokenText) {
+			l.Error("invalid UTF-8 rune")
+			return 0
+		}
+		lval.str, err = strutil.Unquote(tokenText)
 		if err != nil {
 			l.Error(err.Error())
 			return 0

--- a/pkg/logql/parser_test.go
+++ b/pkg/logql/parser_test.go
@@ -1299,6 +1299,11 @@ func TestParse(t *testing.T) {
 			),
 		},
 		{
+			in:  "{app=~\"\xa0\xa1\"}",
+			exp: nil,
+			err: ParseError{msg: "invalid UTF-8 encoding", line: 1, col: 7},
+		},
+		{
 			in: `sum_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}"[5m])`,
 			exp: nil,


### PR DESCRIPTION
Fixes Issue 28535 in oss-fuzz: loki:fuzz_parse_expr: Out-of-memory in fuzz_parse_expr

We were allowing non-utf8 and regex parsing would go crazy with this.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

