### PR TITLE
Fixes Issue 28593: loki:fuzz_parse_expr: Timeout in fuzz_parse_expr.

### DIFF
--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -96,7 +96,8 @@ var functionTokens = map[string]int{
 
 type lexer struct {
 	scanner.Scanner
-	errs []ParseError
+	errs    []ParseError
+	builder strings.Builder
 }
 
 func (l *lexer) Lex(lval *exprSymType) int {
@@ -143,10 +144,10 @@ func (l *lexer) Lex(lval *exprSymType) int {
 
 	// scanning duration tokens
 	if r == '[' {
-		d := ""
+		l.builder.Reset()
 		for r := l.Next(); r != scanner.EOF; r = l.Next() {
-			if string(r) == "]" {
-				i, err := model.ParseDuration(d)
+			if r == ']' {
+				i, err := model.ParseDuration(l.builder.String())
 				if err != nil {
 					l.Error(err.Error())
 					return 0
@@ -154,7 +155,7 @@ func (l *lexer) Lex(lval *exprSymType) int {
 				lval.duration = time.Duration(i)
 				return RANGE
 			}
-			d += string(r)
+			_, _ = l.builder.WriteRune(r)
 		}
 		l.Error("missing closing ']' in duration")
 		return 0


### PR DESCRIPTION
This was caused by a lot of allocations when parsing range duration.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

