### PR TITLE
Set a max size for the logql parser to 5k.

### DIFF
--- a/pkg/logql/parser.go
+++ b/pkg/logql/parser.go
@@ -57,7 +57,7 @@ func (p *parser) Parse() (Expr, error) {
 // ParseExpr parses a string and returns an Expr.
 func ParseExpr(input string) (expr Expr, err error) {
 	if len(input) >= maxInputSize {
-		return nil, newParseError(fmt.Sprintf("input size too long > %d", maxInputSize), 0, 0)
+		return nil, newParseError(fmt.Sprintf("input size too long (%d > %d)", len(input), maxInputSize), 0, 0)
 	}
 
 	defer func() {


### PR DESCRIPTION
The API anyway receives the query via querystring which is normally max out by 2k based on RFC2616.
This will improve fuzzing too.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
