### PR TITLE
Set the byte slice cap correctly when unsafely converting string.

### DIFF
--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -1,15 +1,14 @@
 package log
 
 import (
+	"reflect"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-var (
-	// NoopStage is a stage that doesn't process a log line.
-	NoopStage Stage = &noopStage{}
-)
+// NoopStage is a stage that doesn't process a log line.
+var NoopStage Stage = &noopStage{}
 
 // Pipeline can create pipelines for each log stream.
 type Pipeline interface {
@@ -179,7 +178,11 @@ func ReduceStages(stages []Stage) Stage {
 }
 
 func unsafeGetBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&s))
+	var buf []byte
+	p := unsafe.Pointer(&buf)
+	*(*string)(p) = s
+	(*reflect.SliceHeader)(p).Cap = len(s)
+	return buf
 }
 
 func unsafeGetString(buf []byte) string {


### PR DESCRIPTION
Fixes #3485

Should also unblock #3481

When unsafely converting string to bytes the cap of the bytes is lost but not when doing bytes to string.
It seems that this is only a problem when using go 1.16 or when using delve.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
