### PR TITLE
make prefix for keys of objects created by boltdb-shipper configurable

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -131,6 +131,12 @@ func (c *Config) Validate() error {
 	if err := c.Ingester.Validate(); err != nil {
 		return errors.Wrap(err, "invalid ingester config")
 	}
+	if err := c.StorageConfig.BoltDBShipperConfig.Validate(); err != nil {
+		return errors.Wrap(err, "invalid boltdb-shipper config")
+	}
+	if err := c.CompactorConfig.Validate(); err != nil {
+		return errors.Wrap(err, "invalid compactor config")
+	}
 	return nil
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -362,7 +362,7 @@ func RegisterCustomIndexClients(cfg *Config, registerer prometheus.Registerer) {
 			return nil, err
 		}
 
-		return shipper.NewBoltDBShipperTableClient(objectClient), nil
+		return shipper.NewBoltDBShipperTableClient(objectClient, cfg.BoltDBShipperConfig.SharedStoreKeyPrefix), nil
 	})
 }
 

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -34,7 +34,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.WorkingDirectory, "boltdb.shipper.compactor.working-directory", "", "Directory where files can be downloaded for compaction.")
 	f.StringVar(&cfg.SharedStoreType, "boltdb.shipper.compactor.shared-store", "", "Shared store used for storing boltdb files. Supported types: gcs, s3, azure, swift, filesystem")
-	f.StringVar(&cfg.SharedStoreKeyPrefix, "boltdb.shipper.compactor.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator.")
+	f.StringVar(&cfg.SharedStoreKeyPrefix, "boltdb.shipper.compactor.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator but should always end with it.")
 	f.DurationVar(&cfg.CompactionInterval, "boltdb.shipper.compactor.compaction-interval", 2*time.Hour, "Interval at which to re-run the compaction operation.")
 }
 

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -18,7 +18,8 @@ func TestIsDefaults(t *testing.T) {
 		}, false},
 		{&Config{}, false},
 		{&Config{
-			CompactionInterval: 2 * time.Hour,
+			SharedStoreKeyPrefix: "index/",
+			CompactionInterval:   2 * time.Hour,
 		}, true},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -69,7 +69,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ActiveIndexDirectory, "boltdb.shipper.active-index-directory", "", "Directory where ingesters would write boltdb files which would then be uploaded by shipper to configured storage")
 	f.StringVar(&cfg.SharedStoreType, "boltdb.shipper.shared-store", "", "Shared store for keeping boltdb files. Supported types: gcs, s3, azure, filesystem")
-	f.StringVar(&cfg.SharedStoreKeyPrefix, "boltdb.shipper.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator")
+	f.StringVar(&cfg.SharedStoreKeyPrefix, "boltdb.shipper.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator but should always end with it")
 	f.StringVar(&cfg.CacheLocation, "boltdb.shipper.cache-location", "", "Cache location for restoring boltDB files for queries")
 	f.DurationVar(&cfg.CacheTTL, "boltdb.shipper.cache-ttl", 24*time.Hour, "TTL for boltDB files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, "boltdb.shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")

--- a/pkg/storage/stores/shipper/table_client.go
+++ b/pkg/storage/stores/shipper/table_client.go
@@ -21,8 +21,8 @@ type boltDBShipperTableClient struct {
 	objectClient chunk.ObjectClient
 }
 
-func NewBoltDBShipperTableClient(objectClient chunk.ObjectClient) chunk.TableClient {
-	return &boltDBShipperTableClient{util.NewPrefixedObjectClient(objectClient, StorageKeyPrefix)}
+func NewBoltDBShipperTableClient(objectClient chunk.ObjectClient, storageKeyPrefix string) chunk.TableClient {
+	return &boltDBShipperTableClient{util.NewPrefixedObjectClient(objectClient, storageKeyPrefix)}
 }
 
 func (b *boltDBShipperTableClient) ListTables(ctx context.Context) ([]string, error) {

--- a/pkg/storage/stores/shipper/table_client_test.go
+++ b/pkg/storage/stores/shipper/table_client_test.go
@@ -36,7 +36,7 @@ func TestBoltDBShipperTableClient(t *testing.T) {
 	}
 
 	// we need to use prefixed object client while creating files/folder
-	prefixedObjectClient := util.NewPrefixedObjectClient(objectClient, StorageKeyPrefix)
+	prefixedObjectClient := util.NewPrefixedObjectClient(objectClient, "index/")
 
 	for folder, files := range foldersWithFiles {
 		for _, fileName := range files {
@@ -45,7 +45,7 @@ func TestBoltDBShipperTableClient(t *testing.T) {
 		}
 	}
 
-	tableClient := NewBoltDBShipperTableClient(objectClient)
+	tableClient := NewBoltDBShipperTableClient(objectClient, "index/")
 
 	// check list of tables returns all the folders/tables created above
 	checkExpectedTables(t, tableClient, foldersWithFiles)

--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 )
 
+const delimiter = "/"
+
 type StorageClient interface {
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
 }
@@ -180,9 +182,11 @@ func ValidateSharedStoreKeyPrefix(prefix string) error {
 	} else if strings.Contains(prefix, "\\") {
 		// When using windows filesystem as object store the implementation of ObjectClient in Cortex takes care of conversion of separator.
 		// We just need to always use `/` as a path separator.
-		return errors.New("shared store key prefix should only have '/' as a path separator")
-	} else if strings.HasPrefix(prefix, "/") {
-		return errors.New("shared store key prefix should never start with a path separator")
+		return fmt.Errorf("shared store key prefix should only have '%s' as a path separator", delimiter)
+	} else if strings.HasPrefix(prefix, delimiter) {
+		return errors.New("shared store key prefix should never start with a path separator i.e '/'")
+	} else if !strings.HasSuffix(prefix, delimiter) {
+		return errors.New("shared store key prefix should end with a path separator i.e '/'")
 	}
 
 	return nil

--- a/pkg/storage/stores/shipper/util/util.go
+++ b/pkg/storage/stores/shipper/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -171,4 +172,18 @@ func RemoveDirectories(incoming []chunk.StorageObject) []chunk.StorageObject {
 // IsDirectory will return true if the string ends in a forward slash
 func IsDirectory(key string) bool {
 	return strings.HasSuffix(key, "/")
+}
+
+func ValidateSharedStoreKeyPrefix(prefix string) error {
+	if prefix == "" {
+		return errors.New("shared store key prefix must be set")
+	} else if strings.Contains(prefix, "\\") {
+		// When using windows filesystem as object store the implementation of ObjectClient in Cortex takes care of conversion of separator.
+		// We just need to always use `/` as a path separator.
+		return errors.New("shared store key prefix should only have '/' as a path separator")
+	} else if strings.HasPrefix(prefix, "/") {
+		return errors.New("shared store key prefix should never start with a path separator")
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
BoltDB Shipper stores object with the `index/` prefix which is hardcoded which limits the usage of a single bucket to a single Loki cluster when using `boltdb-shipper` as index store.
To allow users to share a bucket with multiple Loki clusters using `boltdb-shipper`, we want to make the object key prefix configurable so that different Loki clusters store the index with different prefix hence isolate the index.

**Special notes for your reviewer**:
This should not be a breaking change since we are defaulting the value of the config to `index/` which was hardcoded previously.

