### PR TITLE
Fix documentation for memberlist to match code

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -166,6 +166,9 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 
 # Configuration for tracing
 [tracing: <tracing_config>]
+
+# Configuration for Gossip memberlist. Only applies if ring kvstore is "memberlist"
+[memberlist: <memberlist_config>]
 ```
 
 ## server_config
@@ -256,10 +259,6 @@ ring:
     # Configuration for an ETCD v3 client. Only applies if store is "etcd"
     # The CLI flags prefix for this block config is: distributor.ring
     [etcd: <etcd_config>]
-
-    # Configuration for Gossip memberlist. Only applies if store is "memberlist"
-    # The CLI flags prefix for this block config is: distributor.ring
-    [memberlist: <memberlist_config>]
 
   # The heartbeat timeout after which ingesters are skipped for
   # reading and writing.
@@ -778,10 +777,6 @@ lifecycler:
       # The etcd_config configures the etcd client.
       # CLI flag: <no prefix>
       [etcd: <etcd_config>]
-
-      # Configuration for Gossip memberlist. Only applies if store is "memberlist"
-      # CLI flag: <no prefix>
-      [memberlist: <memberlist_config>]
 
     # The heartbeat timeout after which ingesters are skipped for reads/writes.
     # CLI flag: -ring.heartbeat-timeout


### PR DESCRIPTION
**What this PR does / why we need it**: 
The documentation for `memberlist` config is incorrect and prevents loki running if followed.

`memberlist` item is a top level item, as seen in [Almost zero dependencies setup](https://grafana.com/docs/loki/latest/configuration/examples/#almost-zero-dependencies-setup) and in the code: https://github.com/grafana/loki/blob/835f710bc958eaa0dee4b22d46b58de1dc91abaa/pkg/loki/loki.go#L72

**Which issue(s) this PR fixes**:
Partial fix of #3498

