### PR TITLE
fix live tailing of logs from Loki

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -244,7 +244,7 @@ func (q *IngesterQuerier) TailersCount(ctx context.Context) ([]uint32, error) {
 	}
 
 	responses, err := q.forGivenIngesters(ctx, replicationSet, func(querierClient logproto.QuerierClient) (interface{}, error) {
-		resp, err := querierClient.TailersCount(ctx, nil)
+		resp, err := querierClient.TailersCount(ctx, &logproto.TailersCountRequest{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We were sending a `nil` value to [TailersCount](https://github.com/grafana/loki/blob/923671a17e250542e10037f514e8f5c21fa205b9/pkg/querier/ingester_querier.go#L247) which was working fine until we upgraded grpc client which probably had a check for it. This was causing Live Tailing of logs to fail. This PR fixes the issue by passing a pointer to a  concrete value instead.

**Which issue(s) this PR fixes**:
Fixes #3506 

