### PR TITLE
docs: add title to Lambda Promtail

### DIFF
--- a/docs/sources/clients/lambda-promtail/_index.md
+++ b/docs/sources/clients/lambda-promtail/_index.md
@@ -1,3 +1,6 @@
+---
+title: Lambda Promtail
+---
 # Lambda Promtail
 
 Loki includes an [AWS SAM](https://aws.amazon.com/serverless/sam/) package template for shipping Cloudwatch logs to Loki via a [set of promtails](https://github.com/grafana/loki/tree/master/tools/lambda-promtail). This is done via an intermediary [lambda function](https://aws.amazon.com/lambda/) which processes cloudwatch events and propagates them to a promtail instance (or set of instances behind a load balancer) via the push-api [scrape config](../promtail/configuration#loki_push_api_config).


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a title to https://grafana.com/docs/loki/latest/clients/lambda-promtail/. Currently the page is not showing a menu or page title.

