### PR TITLE
Added docs for GCP internal labels.

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -196,6 +196,9 @@ Configs are set in `gcplog` section in `scrape_config`
       use_incoming_timestamp: false # default rewrite timestamps.
       labels:
         job: "gcplog"
+    relabel_configs:
+      - source_labels: ['__project_id']
+        target_label: 'project'
 ```
 Here `project_id` and `subscription` are the only required fields.
 
@@ -204,7 +207,9 @@ Here `project_id` and `subscription` are the only required fields.
 
 Before using `gcplog` target, GCP should be [configured](../gcplog-cloud) with pubsub subscription to receive logs from.
 
-It also support `relabeling` and `pipeline` stages just like other targets.
+It also support `relabeling` and `pipeline` stages just like other targets. 
+
+When Promtail receives GCP logs the labels that are set on the GCP resources are available as internal labels. Like in the example above, the `__project_id` label from a GCP resource was transformed into a label called `project` through `relabel_configs`. See [Relabeling](#relabeling) for more information.
 
 Log entries scraped by `gcplog` will add an additional label called `promtail_instance`. This label uniquely identifies each promtail instance trying to scrape gcplog (from a single `subscription_id`).
 We need this unique identifier to avoid out-of-order errors from Loki servers.


### PR DESCRIPTION
Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>

**What this PR does / why we need it**:

Added some extra documentation regarding the `gcplog` job and it's internal labels. 

**Checklist**
- [x] Documentation added

