### PR TITLE
split series api queries by day in query-frontend

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -269,7 +269,9 @@ func NewSeriesTripperware(
 		queryRangeMiddleware = append(queryRangeMiddleware,
 			queryrange.InstrumentMiddleware("split_by_interval", instrumentMetrics),
 			// The Series API needs to pull one chunk per series to extract the label set, which is much cheaper than iterating through all matching chunks.
-			SplitByIntervalMiddleware(WithSplitByLimits(limits, cfg.SplitQueriesByInterval), codec, splitByTime, splitByMetrics),
+			// Force a 24 hours split by for series API, this will be more efficient with our static daily bucket storage.
+			// This would avoid queriers downloading chunks for same series over and over again for serving smaller queries.
+			SplitByIntervalMiddleware(WithSplitByLimits(limits, 24*time.Hour), codec, splitByTime, splitByMetrics),
 		)
 	}
 	if cfg.MaxRetries > 0 {

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -215,7 +215,7 @@ func TestSeriesTripperware(t *testing.T) {
 
 	lreq := &LokiSeriesRequest{
 		Match:   []string{`{job="varlogs"}`},
-		StartTs: testTime.Add(-5 * time.Hour), // bigger than the limit
+		StartTs: testTime.Add(-25 * time.Hour), // bigger than the limit
 		EndTs:   testTime,
 		Path:    "/loki/api/v1/series",
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Series APIs are one of the most expensive queries in Loki which is used by Grafana Explore to suggest relevant labels to the users while building logql query. It is quite easy to run those queries accidentally for longer durations when the selected time window is a week or even a month-long and a user tries to write a query.

The problem here is we split the series API queries the same as other queries and we split the queries by smaller intervals like 15 or 30 minutes to get max parallelism. Now the series API downloads a single chunk per series in each split query which means the smaller the split interval more the work for queries since they would download chunks for the same series over and over again for each split queries. This PR changes the code to split the series API queries by 24h which also aligns with our daily buckets and reaps the same benefits as labels API splitting.

