### PR TITLE
Docs: Add HOSTNAME env var to example daemonset manifest

### DIFF
--- a/docs/sources/clients/promtail/installation.md
+++ b/docs/sources/clients/promtail/installation.md
@@ -78,6 +78,12 @@ spec:
         image: grafana/promtail
         args:
         - -config.file=/etc/promtail/promtail.yaml
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: logs
           mountPath: MOUNT_PATH


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
An update to the the docs for deploying promtail via daemonset. I'm running a local cluster on `k3s`, and service discovery was broken for promtail after deploying using the manifest provided in the docs. I deployed another instance using helm which worked. I switched both daemonsets to use the same service account and config, and the helm one continued to work while my hand-rolled one did not. I diffed the 2 daemonsets, and only after adding this environment variable did the hand-rolled one start being able to discovery targets using `kubernetes_sd_config`

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

