### PR TITLE
Docs: Amazon S3 as chunk storage

### DIFF
--- a/docs/sources/operations/storage/table-manager.md
+++ b/docs/sources/operations/storage/table-manager.md
@@ -31,6 +31,7 @@ The Table Manager supports the following backends:
   - [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
   - [Google Bigtable](https://cloud.google.com/bigtable)
   - [Apache Cassandra](https://cassandra.apache.org)
+  - [Amazon S3](https://aws.amazon.com/s3)
   - Filesystem (primarily used for local environments)
 
 The object storages - like Amazon S3 and Google Cloud Storage - supported by Loki


### PR DESCRIPTION
**What this PR does / why we need it**:
That PR fix missing chunk storage type Amazon S3

