### PR TITLE
single import of jsoniter in logql subpackages

### DIFF
--- a/pkg/logql/marshal/marshal.go
+++ b/pkg/logql/marshal/marshal.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/loki/pkg/logql"
 
 	"github.com/gorilla/websocket"
-	json "github.com/json-iterator/go"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/loki/pkg/loghttp"
@@ -33,7 +32,7 @@ func WriteQueryResponseJSON(v logql.Result, w io.Writer) error {
 		},
 	}
 
-	return json.NewEncoder(w).Encode(q)
+	return jsoniter.NewEncoder(w).Encode(q)
 }
 
 // WriteLabelResponseJSON marshals a logproto.LabelResponse to v1 loghttp JSON
@@ -44,7 +43,7 @@ func WriteLabelResponseJSON(l logproto.LabelResponse, w io.Writer) error {
 		Data:   l.GetValues(),
 	}
 
-	return json.NewEncoder(w).Encode(v1Response)
+	return jsoniter.NewEncoder(w).Encode(v1Response)
 }
 
 // WebsocketWriter knows how to write message to a websocket connection.
@@ -78,7 +77,7 @@ func WriteSeriesResponseJSON(r logproto.SeriesResponse, w io.Writer) error {
 		adapter.Data = append(adapter.Data, series.GetLabels())
 	}
 
-	return json.NewEncoder(w).Encode(adapter)
+	return jsoniter.NewEncoder(w).Encode(adapter)
 }
 
 // This struct exists primarily because we can't specify a repeated map in proto v3.

--- a/pkg/logql/unmarshal/unmarshal.go
+++ b/pkg/logql/unmarshal/unmarshal.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"unsafe"
 
-	json "github.com/json-iterator/go"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/loki/pkg/loghttp"
@@ -15,7 +14,7 @@ import (
 func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
 	var request loghttp.PushRequest
 
-	if err := json.NewDecoder(b).Decode(&request); err != nil {
+	if err := jsoniter.NewDecoder(b).Decode(&request); err != nil {
 		return err
 	}
 	*r = NewPushRequest(request)


### PR DESCRIPTION
This changes two places under `pkg/logql` where `"github.com/json-iterator/go"` was being imported twice. I chose to stick with the `jsoniter` import alias to leave it obvious that something other than `encoding/json` was present.