### PR TITLE
Update README.md

### DIFF
--- a/cmd/fluent-bit/README.md
+++ b/cmd/fluent-bit/README.md
@@ -10,7 +10,7 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 
 Prerequisites:
 
-* Go 1.11+
+* Go 1.16+
 * gcc (for cgo)
 
 To build the output plugin library file (`out_grafana_loki.so`), you can use:


### PR DESCRIPTION
With Go 1.11 it's not possible to build the Fluent Bit plugin with the following error.

```
build github.com/sercand/kuberesolver: cannot find module for path github.com/sercand/kuberesolver
```
Needed to use Go 1.16.2 to resolve the issue. 

This should be related to https://github.com/sercand/kuberesolver/issues/11

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

