### PR TITLE
ignore download of missing boltdb files possibly removed during compaction

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -22,9 +22,33 @@ const (
 	objectsStorageDirName = "objects"
 )
 
+// storageClientWithFakeObjectsInList adds a fake object in the list call response which
+// helps with testing the case where objects gets deleted in the middle of a Sync/Download operation due to compaction.
+type storageClientWithFakeObjectsInList struct {
+	StorageClient
+}
+
+func newStorageClientWithFakeObjectsInList(storageClient StorageClient) StorageClient {
+	return storageClientWithFakeObjectsInList{storageClient}
+}
+
+func (o storageClientWithFakeObjectsInList) List(ctx context.Context, prefix string, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+	objects, commonPrefixes, err := o.StorageClient.List(ctx, prefix, delimiter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	objects = append(objects, chunk.StorageObject{
+		Key:        fmt.Sprintf(prefix, "fake-object"),
+		ModifiedAt: time.Now(),
+	})
+
+	return objects, commonPrefixes, nil
+}
+
 type stopFunc func()
 
-func buildTestClients(t *testing.T, path string) (*local.BoltIndexClient, *local.FSObjectClient) {
+func buildTestClients(t *testing.T, path string) (*local.BoltIndexClient, StorageClient) {
 	cachePath := filepath.Join(path, cacheDirName)
 
 	boltDBIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: cachePath})
@@ -38,10 +62,10 @@ func buildTestClients(t *testing.T, path string) (*local.BoltIndexClient, *local
 }
 
 func buildTestTable(t *testing.T, tableName, path string) (*Table, *local.BoltIndexClient, stopFunc) {
-	boltDBIndexClient, fsObjectClient := buildTestClients(t, path)
+	boltDBIndexClient, storageClient := buildTestClients(t, path)
 	cachePath := filepath.Join(path, cacheDirName)
 
-	table := NewTable(context.Background(), tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
+	table := NewTable(context.Background(), tableName, cachePath, storageClient, boltDBIndexClient, newMetrics(nil))
 
 	// wait for either table to get ready or a timeout hits
 	select {
@@ -137,6 +161,9 @@ func TestTable_Sync(t *testing.T) {
 	defer func() {
 		stopFunc()
 	}()
+
+	// replace the storage client with the one that adds fake objects in the list call
+	table.storageClient = newStorageClientWithFakeObjectsInList(table.storageClient)
 
 	// query table to see it has expected records setup
 	testutil.TestSingleTableQuery(t, []chunk.IndexQuery{{}}, table, 0, 20)
@@ -304,11 +331,13 @@ func TestLoadTable(t *testing.T) {
 	// setup the table in storage with some records
 	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, dbs, false)
 
-	boltDBIndexClient, fsObjectClient := buildTestClients(t, tempDir)
+	boltDBIndexClient, storageClient := buildTestClients(t, tempDir)
 	cachePath := filepath.Join(tempDir, cacheDirName)
 
+	storageClient = newStorageClientWithFakeObjectsInList(storageClient)
+
 	// try loading the table.
-	table, err := LoadTable(context.Background(), tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
+	table, err := LoadTable(context.Background(), tableName, cachePath, storageClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
@@ -338,7 +367,7 @@ func TestLoadTable(t *testing.T) {
 	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, dbs, false)
 
 	// try loading the table, it should skip loading corrupt file and reload it from storage.
-	table, err = LoadTable(context.Background(), tableName, cachePath, fsObjectClient, boltDBIndexClient, newMetrics(nil))
+	table, err = LoadTable(context.Background(), tableName, cachePath, storageClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We fail the sync operation when we encounter an error while downloading any of the files from the tables. When a file goes missing we fail the sync and retry it next time. A file only goes missing when it gets compacted away by the compactor so we do not want to fail the sync when a file goes missing in the middle of the sync operation.

**Checklist**
- [x] Tests updated

