### PR TITLE
Properly release the ticker in Loki client.

### DIFF
--- a/pkg/promtail/client/client.go
+++ b/pkg/promtail/client/client.go
@@ -217,6 +217,7 @@ func (c *client) run() {
 	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
 
 	defer func() {
+		maxWaitCheck.Stop()
 		// Send all pending batches
 		for tenantID, batch := range batches {
 			c.sendBatch(tenantID, batch)


### PR DESCRIPTION
I think this was only impacting the docker driver who would start/stop for each new followed containers.
My assumption is that this would slowly build up and eat CPU over time.

Fixes #3319

I arrived to this conclusion since strace was showing a crazy amount of futex syscall and nothing else seems to be the cause.

:pray:


big thanks to @glebsam @till 
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
