### PR TITLE
docker-compose: Update docker-compose.yml to use current releae 2.2.0

### DIFF
--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.0.0
+    image: grafana/loki:2.2.0
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.0.0
+    image: grafana/promtail:2.2.0
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml


### PR DESCRIPTION
**What this PR does / why we need it**:
While first time playing with loki I stumbled upon the version mismatch between release and promoted docker-compose.yml
