### PR TITLE
Promtail documentation: fix template example for regexReplaceAll function

### DIFF
--- a/docs/sources/clients/promtail/stages/template.md
+++ b/docs/sources/clients/promtail/stages/template.md
@@ -182,7 +182,7 @@ and trailing white space removed, as defined by Unicode.
 ```yaml
 - template:
     source: output
-    template: '{{ regexReplaceAllLiteral "(a*)bc" .Value "{1}a" }}'
+    template: '{{ regexReplaceAll "(a*)bc" .Value "${1}a" }}'
 ```
 
 `regexReplaceAllLiteral` returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement The replacement string is substituted directly, without using Expand.


### PR DESCRIPTION
Fixes an example for `regexReplaceAll` template function:
- use correct function name
- add missing $ sign when referencing a regex submatch

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Updates typos in promtail configuration example

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

