### PR TITLE
reduce number of list calls on shared object store when using boltdb-shipper

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -72,9 +72,14 @@ func NewCompactor(cfg Config, storageConfig storage.Config, r prometheus.Registe
 		return nil, err
 	}
 
+	objectClient = util.NewPrefixedObjectClient(objectClient, cfg.SharedStoreKeyPrefix)
+	if cfg.SharedStoreType != "filesystem" {
+		objectClient = shipper_util.NewCachedObjectClient(objectClient)
+	}
+
 	compactor := Compactor{
 		cfg:          cfg,
-		objectClient: util.NewPrefixedObjectClient(objectClient, cfg.SharedStoreKeyPrefix),
+		objectClient: objectClient,
 		metrics:      newMetrics(r),
 	}
 

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -107,7 +107,7 @@ func NewShipper(cfg Config, storageClient chunk.ObjectClient, registerer prometh
 	return &shipper, nil
 }
 
-func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.Registerer) error {
+func (s *Shipper) init(objectClient chunk.ObjectClient, registerer prometheus.Registerer) error {
 	// When we run with target querier we don't have ActiveIndexDirectory set so using CacheLocation instead.
 	// Also it doesn't matter which directory we use since BoltDBIndexClient doesn't do anything with it but it is good to have a valid path.
 	boltdbIndexClientDir := s.cfg.ActiveIndexDirectory
@@ -121,7 +121,11 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 		return err
 	}
 
-	prefixedObjectClient := util.NewPrefixedObjectClient(storageClient, s.cfg.SharedStoreKeyPrefix)
+	objectClient = util.NewPrefixedObjectClient(objectClient, s.cfg.SharedStoreKeyPrefix)
+
+	if s.cfg.SharedStoreType != "filesystem" {
+		objectClient = shipper_util.NewCachedObjectClient(objectClient)
+	}
 
 	if s.cfg.Mode != ModeReadOnly {
 		uploader, err := s.getUploaderName()
@@ -135,7 +139,7 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 			UploadInterval: UploadInterval,
 			DBRetainPeriod: s.cfg.IngesterDBRetainPeriod,
 		}
-		uploadsManager, err := uploads.NewTableManager(cfg, s.boltDBIndexClient, prefixedObjectClient, registerer)
+		uploadsManager, err := uploads.NewTableManager(cfg, s.boltDBIndexClient, objectClient, registerer)
 		if err != nil {
 			return err
 		}
@@ -150,7 +154,7 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 			CacheTTL:          s.cfg.CacheTTL,
 			QueryReadyNumDays: s.cfg.QueryReadyNumDays,
 		}
-		downloadsManager, err := downloads.NewTableManager(cfg, s.boltDBIndexClient, prefixedObjectClient, registerer)
+		downloadsManager, err := downloads.NewTableManager(cfg, s.boltDBIndexClient, objectClient, registerer)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/util/cached_client.go
+++ b/pkg/storage/stores/shipper/util/cached_client.go
@@ -1,0 +1,109 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+const cacheTimeout = time.Minute
+
+// CachedObjectClient is meant for reducing number of LIST calls on hosted object stores(S3, GCS, Azure Blob Storage and Swift).
+// We as of now do a LIST call per table when we need to find its objects.
+// CachedObjectClient does flat listing of objects which is only supported by hosted object stores mentioned above.
+// In case of boltdb files stored by shipper, the listed objects would have keys like <table-name>/<filename>.
+// For each List call without a prefix(which is actually done to get list of tables),
+// CachedObjectClient would build a map of TableName -> chunk.StorageObject which would be used as a cache for subsequent List calls for getting list of objects for tables.
+// Cache items are evicted after first read or a timeout. The cache is rebuilt during List call with empty prefix or we encounter a cache miss.
+type CachedObjectClient struct {
+	chunk.ObjectClient
+	tables       map[string][]chunk.StorageObject
+	tablesMtx    sync.Mutex
+	cacheBuiltAt time.Time
+}
+
+func NewCachedObjectClient(downstreamClient chunk.ObjectClient) *CachedObjectClient {
+	return &CachedObjectClient{
+		ObjectClient: downstreamClient,
+		tables:       map[string][]chunk.StorageObject{},
+	}
+}
+
+func (c *CachedObjectClient) List(ctx context.Context, prefix, _ string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+	c.tablesMtx.Lock()
+	defer c.tablesMtx.Unlock()
+
+	if prefix == "" {
+		tables, err := c.listTables(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return []chunk.StorageObject{}, tables, nil
+	}
+
+	// While listing objects in a table, prefix is set to <table-name>+delimiter so trim the delimiter first.
+	tableName := strings.TrimSuffix(prefix, delimiter)
+	if strings.Contains(tableName, delimiter) {
+		return nil, nil, fmt.Errorf("invalid prefix %s for listing table objects", prefix)
+	}
+	tableObjects, err := c.listTableObjects(ctx, tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tableObjects, []chunk.StorageCommonPrefix{}, nil
+}
+
+// listTables assumes that tablesMtx is already locked by the caller
+func (c *CachedObjectClient) listTables(ctx context.Context) ([]chunk.StorageCommonPrefix, error) {
+	// do a flat listing by setting delimiter to empty string
+	objects, _, err := c.ObjectClient.List(ctx, "", "")
+	if err != nil {
+		return nil, err
+	}
+	c.tables = map[string][]chunk.StorageObject{}
+
+	// build the cache and response containing just table names as chunk.StorageCommonPrefix
+	var tableNames []chunk.StorageCommonPrefix
+	for _, object := range objects {
+		ss := strings.Split(object.Key, delimiter)
+		if len(ss) != 2 {
+			return nil, fmt.Errorf("invalid object key found %s", object.Key)
+		}
+
+		if _, ok := c.tables[ss[0]]; !ok {
+			tableNames = append(tableNames, chunk.StorageCommonPrefix(ss[0]))
+		}
+		c.tables[ss[0]] = append(c.tables[ss[0]], object)
+	}
+
+	c.cacheBuiltAt = time.Now()
+
+	return tableNames, nil
+}
+
+// listTableObjects assumes that tablesMtx is already locked by the caller
+func (c *CachedObjectClient) listTableObjects(ctx context.Context, tableName string) ([]chunk.StorageObject, error) {
+	objects, ok := c.tables[tableName]
+	if ok && c.cacheBuiltAt.Add(cacheTimeout).After(time.Now()) {
+		// evict the element read from cache
+		delete(c.tables, tableName)
+		return objects, nil
+	}
+
+	// requested element not found in the cache, rebuild the cache.
+	_, err := c.listTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	objects = c.tables[tableName]
+	// evict the element read from cache
+	delete(c.tables, tableName)
+	return objects, nil
+}

--- a/pkg/storage/stores/shipper/util/cached_client_test.go
+++ b/pkg/storage/stores/shipper/util/cached_client_test.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/stretchr/testify/require"
+)
+
+type mockHostedObjectClient struct {
+	chunk.ObjectClient
+	objects []chunk.StorageObject
+}
+
+func (m *mockHostedObjectClient) List(_ context.Context, _, _ string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+	return m.objects, []chunk.StorageCommonPrefix{}, nil
+}
+
+func TestCachedObjectClient_List(t *testing.T) {
+	objectClient := &mockHostedObjectClient{
+		objects: []chunk.StorageObject{
+			{
+				Key: "table1/obj1",
+			},
+			{
+				Key: "table1/obj2",
+			},
+			{
+				Key: "table2/obj1",
+			},
+			{
+				Key: "table2/obj2",
+			},
+			{
+				Key: "table3/obj1",
+			},
+			{
+				Key: "table3/obj2",
+			},
+		},
+	}
+
+	cachedObjectClient := NewCachedObjectClient(objectClient)
+
+	// list tables which should build the cache
+	_, tables, err := cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, []chunk.StorageCommonPrefix{"table1", "table2", "table3"}, tables)
+
+	// verify whether cache has right items
+	require.Len(t, cachedObjectClient.tables, 3)
+	require.Equal(t, objectClient.objects[:2], cachedObjectClient.tables["table1"])
+	require.Equal(t, objectClient.objects[2:4], cachedObjectClient.tables["table2"])
+	require.Equal(t, objectClient.objects[4:], cachedObjectClient.tables["table3"])
+
+	// remove table 3
+	objectClient.objects = objectClient.objects[:4]
+
+	// list tables again which should clear the cache before building it again
+	_, tables, err = cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, []chunk.StorageCommonPrefix{"table1", "table2"}, tables)
+
+	// verify whether cache has right items and table3 is gone
+	require.Len(t, cachedObjectClient.tables, 2)
+	require.Equal(t, objectClient.objects[:2], cachedObjectClient.tables["table1"])
+	require.Equal(t, objectClient.objects[2:], cachedObjectClient.tables["table2"])
+
+	// list table1 objects
+	objects, _, err := cachedObjectClient.List(context.Background(), "table1/", "")
+	require.NoError(t, err)
+	require.Equal(t, objectClient.objects[:2], objects)
+
+	// verify whether table1 got evicted
+	require.Len(t, cachedObjectClient.tables, 1)
+	require.Contains(t, cachedObjectClient.tables, "table2")
+
+	// list table2 objects
+	objects, _, err = cachedObjectClient.List(context.Background(), "table2/", "")
+	require.NoError(t, err)
+	require.Equal(t, objectClient.objects[2:], objects)
+
+	// verify whether table2 got evicted as well
+	require.Len(t, cachedObjectClient.tables, 0)
+
+	// list table1 again which should rebuild the cache
+	objects, _, err = cachedObjectClient.List(context.Background(), "table1/", "")
+	require.NoError(t, err)
+	require.Equal(t, objectClient.objects[:2], objects)
+
+	// verify whether cache was rebuilt and table1 got evicted already
+	require.Len(t, cachedObjectClient.tables, 1)
+	require.Contains(t, cachedObjectClient.tables, "table2")
+
+	// verify whether listing non-existing table should not error
+	objects, _, err = cachedObjectClient.List(context.Background(), "table3/", "")
+	require.NoError(t, err)
+	require.Len(t, objects, 0)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR contains the same code from PR #3283 but was reverted by PR #3396 due to a bug in the code causing multiple goroutines to attempt to open the same boltdb files. The bug was in caching layer which was not cleared before being rebuilt which means subsequent list calls would add the same filenames again to the cache if they still exist. This PR just fixes that bug and adds a test case for it.

**Checklist**
- [x] Tests updated

