### PR TITLE
Promtail: Remove non-ready filemanager targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [3627](https://github.com/grafana/loki/pull/3627) **MichelHollands**: Update vendored Cortex to 2d8477c4a325
 * [3532](https://github.com/grafana/loki/pull/3532) **MichelHollands**: Update vendored Cortex to 8a2e2c1eeb65
 * [3446](https://github.com/grafana/loki/pull/3446) **pracucci, owen-d**: Remove deprecated config `querier.split-queries-by-day` in favor of `querier.split-queries-by-interval`
+* [3586](https://github.com/grafana/loki/pull/3587) **rsteneteg** Remove filemanager targets that no longer has any tails, to allow them to be recreated with the proper path
 
 ## 2.2.0 (2021/03/10)
 

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -267,7 +267,7 @@ func (s *targetSyncer) sync(groups []*targetgroup.Group) {
 	}
 
 	for key, target := range s.targets {
-		if _, ok := targets[key]; !ok {
+		if _, ok := targets[key]; !ok || !target.Ready() {
 			level.Info(s.log).Log("msg", "Removing target", "key", key)
 			target.Stop()
 			s.metrics.targetsActive.Add(-1.)


### PR DESCRIPTION
Remove targets that dont have any tails, in order for the target to be removed and recreated during next sync

Signed-off-by: Roger Steneteg <rsteneteg@ea.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR fixes a bug that causes Promtail to stop tailing statefulset pods after they are deleted/rescheduled

**Which issue(s) this PR fixes**:
Fixes #3586

**Special notes for your reviewer**:
The bug seems to be some race condition where the pod is deleted and recreated before the filetarget has been removed, this fix removes any filetarget that no longer has any tails, allowing them to be recreated which solves the problem, but it does not address the actual race condition.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

