### PR TITLE
locks trailers during iteration

### DIFF
--- a/pkg/logql/stats/grpc.go
+++ b/pkg/logql/stats/grpc.go
@@ -90,6 +90,8 @@ func decodeTrailers(ctx context.Context) Result {
 	if !ok {
 		return res
 	}
+	collector.Lock()
+	defer collector.Unlock()
 	res.Ingester.TotalReached = int32(len(collector.trailers))
 	for _, meta := range collector.trailers {
 		ing := decodeTrailer(ctx, meta)


### PR DESCRIPTION
I was recently debugging a panic in our queriers and found out we acquire a lock for mutating this slice but don't acquire the lock for reading. I'm guessing this was an oversight as the lock was only used in one place prior (the `addTrailer` method).
```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 34388532 [running]:
github.com/grafana/loki/pkg/util/server.onPanic(0x2072aa0, 0x3787ff0, 0x3787ff0, 0x0)
/src/loki/pkg/util/server/recovery.go:41 +0x7b
github.com/grafana/loki/pkg/util/server.glob..func1.1.1(0x2834870, 0xc004b2e8c0)
/src/loki/pkg/util/server/recovery.go:29 +0x55
panic(0x2072aa0, 0x3787ff0)
/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/grafana/loki/pkg/logql/stats.decodeTrailer(0x283eea8, 0xc054461d10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
/src/loki/pkg/logql/stats/grpc.go:115 +0xc8
github.com/grafana/loki/pkg/logql/stats.decodeTrailers(0x283eea8, 0xc054461d10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
/src/loki/pkg/logql/stats/grpc.go:95 +0x117
github.com/grafana/loki/pkg/logql/stats.Snapshot(0x283eea8, 0xc054461d10, 0x12b0ec7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
/src/loki/pkg/logql/stats/context.go:149 +0x71
github.com/grafana/loki/pkg/logql.(*query).Exec(0xc02dc7e190, 0x283ee70, 0xc054461d10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
/src/loki/pkg/logql/engine.go:155 +0x3a5
github.com/grafana/loki/pkg/querier.(*Querier).RangeQueryHandler(0xc000502a10, 0x2834870, 0xc004b2e8c0, 0xc0266f1500)
/src/loki/pkg/querier/http.go:61 +0x362


```