### PR TITLE
documentation: typo correction

### DIFF
--- a/docs/sources/logql/_index.md
+++ b/docs/sources/logql/_index.md
@@ -31,12 +31,12 @@ This means that the labels passed to the log stream selector will affect the rel
 The following example shows a full log query in action:
 
 ```logql
-{container="query-frontend",namespace="tempo-dev"} |= "metrics.go" | logfmt | duration > 10s and throughput_mb < 500
+{container="query-frontend",namespace="loki-dev"} |= "metrics.go" | logfmt | duration > 10s and throughput_mb < 500
 ```
 
 The query is composed of:
 
-- a log stream selector `{container="query-frontend",namespace="loki-dev"}` which targets the `query-frontend` container  in the `loki-dev`namespace.
+- a log stream selector `{container="query-frontend",namespace="loki-dev"}` which targets the `query-frontend` container  in the `loki-dev` namespace.
 - a log pipeline `|= "metrics.go" | logfmt | duration > 10s and throughput_mb < 500` which will filter out log that contains the word `metrics.go`, then parses each log line to extract more labels and filter with them.
 
 > To avoid escaping special characters you can use the `` ` ``(back-tick) instead of `"` when quoting strings.


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects typo made in example of `Log Queries` section


