### PR TITLE
DRAFT: consider loki logcli support sso

### DIFF
--- a/cmd/logcli/auth.go
+++ b/cmd/logcli/auth.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	cv "github.com/nirasan/go-oauth-pkce-code-verifier"
+	"github.com/skratchdot/open-golang/open"
+	"gopkg.in/yaml.v2"
+)
+
+// AuthorizeUser implements the PKCE OAuth2 flow.
+func AuthorizeUser(clientID string, authURL string, tokenURL string, redirectURL string) {
+	// initialize the code verifier
+	var CodeVerifier, _ = cv.CreateCodeVerifier()
+
+	// Create code_challenge with S256 method
+	codeChallenge := CodeVerifier.CodeChallengeS256()
+
+	// construct the authorization URL (with Auth0 as the authorization provider)
+	authorizationURL := fmt.Sprintf("https://%s?scope=openid profile email offline_access"+
+		"&response_type=code&client_id=%s"+
+		"&code_challenge=%s"+
+		"&code_challenge_method=S256&redirect_uri=%s",
+		authURL, clientID, codeChallenge, redirectURL)
+
+	// start a web server to listen on a callback URL
+	server := &http.Server{Addr: redirectURL}
+
+	// define a handler that will get the authorization code, call the token endpoint, and close the HTTP server
+	http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		// get the authorization code
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			fmt.Println("logcli: Url Param 'code' is missing")
+			io.WriteString(w, "Error: could not find 'code' URL parameter\n")
+
+			// close the HTTP server and return
+			cleanup(server)
+			return
+		}
+
+		// trade the authorization code and the code verifier for an access token
+		codeVerifier := CodeVerifier.String()
+		token, err := getIDToken(tokenURL, clientID, codeVerifier, code, redirectURL)
+		if err != nil {
+			fmt.Println("logcli: could not get access token")
+			io.WriteString(w, "Error: could not retrieve access token\n")
+
+			// close the HTTP server and return
+			cleanup(server)
+			return
+		}
+
+		c.Token = token
+		data, err := yaml.Marshal(c)
+		if err != nil {
+			fmt.Println("logcli: could marshal config", err)
+			io.WriteString(w, "Error: could marshal config\n")
+
+			// close the HTTP server and return
+			cleanup(server)
+			return
+		}
+
+		err = ioutil.WriteFile(configFile, data, 644)
+		if err != nil {
+			fmt.Println("logcli: could not write config file", err)
+			io.WriteString(w, "Error: could not store access token\n")
+
+			// close the HTTP server and return
+			cleanup(server)
+			return
+		}
+
+		// return an indication of success to the caller
+		io.WriteString(w, `
+		<html>
+			<body>
+				<h1>Login successful!</h1>
+				<h2>You can close this window and return to the grafana loki CLI.</h2>
+			</body>
+		</html>`)
+
+		fmt.Println("Successfully logged into grafana loki API.")
+
+		// close the HTTP server
+		cleanup(server)
+	})
+
+	// parse the redirect URL for the port number
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		fmt.Printf("logcli: bad redirect URL: %s\n", err)
+		os.Exit(1)
+	}
+
+	// set up a listener on the redirect port
+	port := fmt.Sprintf(":%s", u.Port())
+	l, err := net.Listen("tcp", port)
+	if err != nil {
+		fmt.Printf("logcli: can't listen to port %s: %s\n", port, err)
+		os.Exit(1)
+	}
+
+	// open a browser window to the authorizationURL
+	err = open.Start(authorizationURL)
+	if err != nil {
+		fmt.Printf("logcli: can't open browser to URL %s: %s\n", authorizationURL, err)
+		os.Exit(1)
+	}
+
+	// start the blocking web server loop
+	// this will exit when the handler gets fired and calls server.Close()
+	server.Serve(l)
+}
+
+// getIDToken trades the authorization code retrieved from oidc id token
+func getIDToken(tokenURL, clientID string, codeVerifier string, authorizationCode string, callbackURL string) (string, error) {
+	// set the url and form-encoded data for the POST to the access token endpoint
+	url := fmt.Sprintf("https://%s/oauth/token", tokenURL)
+	data := fmt.Sprintf(
+		"grant_type=authorization_code&client_id=%s"+
+			"&code_verifier=%s"+
+			"&code=%s"+
+			"&redirect_uri=%s",
+		clientID, codeVerifier, authorizationCode, callbackURL)
+	payload := strings.NewReader(data)
+
+	// create the request and execute it
+	req, _ := http.NewRequest("POST", url, payload)
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Printf("logcli: HTTP error: %s", err)
+		return "", err
+	}
+
+	// process the response
+	defer res.Body.Close()
+	var responseData map[string]interface{}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		fmt.Printf("logcli: read response body error: %s", err)
+		return "", err
+	}
+
+	// unmarshal the json into a string map
+	err = json.Unmarshal(body, &responseData)
+	if err != nil {
+		fmt.Printf("logcli: JSON error: %s", err)
+		return "", err
+	}
+
+	// retrieve the id_token(JWT) out of the map, and return to caller
+	idToken := responseData["id_token"].(string)
+	return idToken, nil
+}
+
+// cleanup closes the HTTP server
+func cleanup(server *http.Server) {
+	// we run this as a goroutine so that this function falls through and
+	// the socket to the browser gets flushed/closed before the server goes away
+	go server.Close()
+}

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v3"
 
+	"github.com/grafana/loki/cmd/logcli/auth"
 	_ "github.com/grafana/loki/pkg/build"
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/labelquery"
@@ -110,18 +111,8 @@ This is helpful to find high cardinality labels.
 `)
 	seriesQuery = newSeriesQuery(seriesCmd)
 
-	c ClientConfig
+	c auth.ClientConfig
 )
-
-type ClientConfig struct {
-	AuthURL     string `yaml:"auth_url"`
-	TokenURL    string `yaml:"token_url"`
-	ClientID    string `yaml:"client_id"`
-	LokiAddr    string `yaml:"loki_addr"`
-	Token       string `yaml:"token"`
-	HeaderName  string `yaml:"header_name"`
-	RedirectUri string `yaml:"redirect_uri"`
-}
 
 func lokiConfig() (filepath string) {
 	filepath = os.Getenv("HOME") + "/.loki/config"
@@ -216,7 +207,7 @@ func login(cmd *kingpin.CmdClause) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	AuthorizeUser(c.ClientID, c.AuthURL, c.TokenURL, c.RedirectUri)
+	auth.AuthorizeUser(c, configFile)
 }
 
 func readConfig(filename string) error {

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/modern-go/reflect2 v1.0.1
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
+	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/opentracing/opentracing-go v1.2.0
 	// github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pierrec/lz4/v4 v4.1.1
@@ -56,6 +57,7 @@ require (
 	github.com/segmentio/fasthash v1.0.2
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.7.0
 	github.com/tonistiigi/fifo v0.0.0-20190226154929-a9fb20d87448

--- a/go.sum
+++ b/go.sum
@@ -1162,6 +1162,8 @@ github.com/newrelic/newrelic-telemetry-sdk-go v0.2.0/go.mod h1:G9MqE/cHGv3Hx3qpY
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2/go.mod h1:TLb2Sg7HQcgGdloNxkrmtgDNR9uVYF3lfdFIN4Ro6Sk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=
+github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da/go.mod h1:DvuJJ/w1Y59rG8UTDxsMk5U+UJXJwuvUgbiJSm9yhX8=
 github.com/nsqio/go-nsq v1.0.7/go.mod h1:XP5zaUs3pqf+Q71EqUJs3HYfBIqfK6G83WQMdNN+Ito=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -1417,6 +1419,8 @@ github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=

--- a/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/.gitignore
+++ b/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/LICENSE
+++ b/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 nirasan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/README.md
+++ b/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/README.md
@@ -1,0 +1,18 @@
+# go-oauth-pkce-code-verifier
+[OAuth PKCE](https://tools.ietf.org/html/rfc7636) code_verifier and code_challenge generator implimented golang.
+
+# How to use
+
+```go
+// Create code_verifier
+v := CreateCodeVerifier()
+code_verifier := v.String()
+
+// Create code_challenge with plain method
+code_challenge := v.CodeChallengeS256()
+code_challenge_method := "plain"
+
+// Create code_challenge with S256 method
+code_challenge := v.CodeChallengeS256()
+code_challenge_method := "S256"
+```

--- a/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/verifier.go
+++ b/vendor/github.com/nirasan/go-oauth-pkce-code-verifier/verifier.go
@@ -1,0 +1,64 @@
+package go_oauth_pkce_code_verifier
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultLength = 32
+	MinLength     = 32
+	MaxLength     = 96
+)
+
+type CodeVerifier struct {
+	Value string
+}
+
+func CreateCodeVerifier() (*CodeVerifier, error) {
+	return CreateCodeVerifierWithLength(DefaultLength)
+}
+
+func CreateCodeVerifierWithLength(length int) (*CodeVerifier, error) {
+	if length < MinLength || length > MaxLength {
+		return nil, fmt.Errorf("invalid length: %v", length)
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length, length)
+	for i := 0; i < length; i++ {
+		b[i] = byte(r.Intn(255))
+	}
+	return CreateCodeVerifierFromBytes(b)
+}
+
+func CreateCodeVerifierFromBytes(b []byte) (*CodeVerifier, error) {
+	return &CodeVerifier{
+		Value: encode(b),
+	}, nil
+}
+
+func (v *CodeVerifier) String() string {
+	return v.Value
+}
+
+func (v *CodeVerifier) CodeChallengePlain() string {
+	return v.Value
+}
+
+func (v *CodeVerifier) CodeChallengeS256() string {
+	h := sha256.New()
+	h.Write([]byte(v.Value))
+	return encode(h.Sum(nil))
+}
+
+func encode(msg []byte) string {
+	encoded := base64.StdEncoding.EncodeToString(msg)
+	encoded = strings.Replace(encoded, "+", "-", -1)
+	encoded = strings.Replace(encoded, "/", "_", -1)
+	encoded = strings.Replace(encoded, "=", "", -1)
+	return encoded
+}

--- a/vendor/github.com/skratchdot/open-golang/LICENSE
+++ b/vendor/github.com/skratchdot/open-golang/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 skratchdot
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/skratchdot/open-golang/open/exec.go
+++ b/vendor/github.com/skratchdot/open-golang/open/exec.go
@@ -1,0 +1,18 @@
+// +build !windows,!darwin
+
+package open
+
+import (
+	"os/exec"
+)
+
+// http://sources.debian.net/src/xdg-utils/1.1.0~rc1%2Bgit20111210-7.1/scripts/xdg-open/
+// http://sources.debian.net/src/xdg-utils/1.1.0~rc1%2Bgit20111210-7.1/scripts/xdg-mime/
+
+func open(input string) *exec.Cmd {
+	return exec.Command("xdg-open", input)
+}
+
+func openWith(input string, appName string) *exec.Cmd {
+	return exec.Command(appName, input)
+}

--- a/vendor/github.com/skratchdot/open-golang/open/exec_darwin.go
+++ b/vendor/github.com/skratchdot/open-golang/open/exec_darwin.go
@@ -1,0 +1,15 @@
+// +build darwin
+
+package open
+
+import (
+	"os/exec"
+)
+
+func open(input string) *exec.Cmd {
+	return exec.Command("open", input)
+}
+
+func openWith(input string, appName string) *exec.Cmd {
+	return exec.Command("open", "-a", appName, input)
+}

--- a/vendor/github.com/skratchdot/open-golang/open/exec_windows.go
+++ b/vendor/github.com/skratchdot/open-golang/open/exec_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+package open
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	// "syscall"
+)
+
+var (
+	cmd      = "url.dll,FileProtocolHandler"
+	runDll32 = filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
+)
+
+func cleaninput(input string) string {
+	r := strings.NewReplacer("&", "^&")
+	return r.Replace(input)
+}
+
+func open(input string) *exec.Cmd {
+	cmd := exec.Command(runDll32, cmd, input)
+	//cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}
+
+func openWith(input string, appName string) *exec.Cmd {
+	cmd := exec.Command("cmd", "/C", "start", "", appName, cleaninput(input))
+	//cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}

--- a/vendor/github.com/skratchdot/open-golang/open/open.go
+++ b/vendor/github.com/skratchdot/open-golang/open/open.go
@@ -1,0 +1,50 @@
+/*
+
+	Open a file, directory, or URI using the OS's default
+	application for that object type.  Optionally, you can
+	specify an application to use.
+
+	This is a proxy for the following commands:
+
+	         OSX: "open"
+	     Windows: "start"
+	 Linux/Other: "xdg-open"
+
+	This is a golang port of the node.js module: https://github.com/pwnall/node-open
+
+*/
+package open
+
+/*
+	Open a file, directory, or URI using the OS's default
+	application for that object type. Wait for the open
+	command to complete.
+*/
+func Run(input string) error {
+	return open(input).Run()
+}
+
+/*
+	Open a file, directory, or URI using the OS's default
+	application for that object type. Don't wait for the
+	open command to complete.
+*/
+func Start(input string) error {
+	return open(input).Start()
+}
+
+/*
+	Open a file, directory, or URI using the specified application.
+	Wait for the open command to complete.
+*/
+func RunWith(input string, appName string) error {
+	return openWith(input, appName).Run()
+}
+
+/*
+	Open a file, directory, or URI using the specified application.
+	Don't wait for the open command to complete.
+*/
+func StartWith(input string, appName string) error {
+	return openWith(input, appName).Start()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -685,6 +685,9 @@ github.com/morikuni/aec
 github.com/mwitkow/go-conntrack
 # github.com/ncw/swift v1.0.52
 github.com/ncw/swift
+# github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
+## explicit
+github.com/nirasan/go-oauth-pkce-code-verifier
 # github.com/oklog/run v1.1.0
 github.com/oklog/run
 # github.com/oklog/ulid v1.3.1
@@ -867,6 +870,9 @@ github.com/shurcooL/httpfs/vfsutil
 github.com/shurcooL/vfsgen
 # github.com/sirupsen/logrus v1.7.0
 github.com/sirupsen/logrus
+# github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+## explicit
+github.com/skratchdot/open-golang/open
 # github.com/soheilhy/cmux v0.1.5-0.20210205191134-5ec6847320e5
 github.com/soheilhy/cmux
 # github.com/sony/gobreaker v0.4.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

## example
add config to $HOME/.loki/config
```
# oauth auth_url, same with grafana oauth config
auth_url: ""
# oauth token_url, same with grafana oauth config
token_url: ""
# oauth client_id, same with grafana oauth config
client_id: ""
# grafana loki datasource proxy address
loki_addr: https://{grafana_addr}/api/datasources/proxy/1
redirect_uri: http://localhost:3000/callback
```

1. use grafana as OAuth proxy
2. grafana already support JWT auth(https://grafana.com/docs/grafana/latest/auth/jwt/#enable-jwt)
3. use oauth-pkce flow for `logcli login` (https://auth0.com/docs/flows/authorization-code-flow-with-proof-key-for-code-exchange-pkce) 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

