### PR TITLE
Build: Fix drone dependencies on manifest step

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -236,6 +236,9 @@ local manifest(apps) = pipeline('manifest') {
   depends_on: [
     'docker-%s' % arch
     for arch in archs
+  ] + [
+    'promtail-%s' % arch
+    for arch in archs
   ],
 };
 

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -860,6 +860,9 @@ depends_on:
 - docker-amd64
 - docker-arm64
 - docker-arm
+- promtail-amd64
+- promtail-arm64
+- promtail-arm
 
 ---
 kind: pipeline


### PR DESCRIPTION
Now that the promtail builds are part of a separate pipeline they need to be included as dependencies on the manifest step
