### PR TITLE
Add ingester.autoforget-unhealthy-timeout opt-in feature

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -13,6 +13,9 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
 - [Configuring Loki](#configuring-loki)
   - [Printing Loki Config At Runtime](#printing-loki-config-at-runtime)
   - [Configuration File Reference](#configuration-file-reference)
+    - [Use environment variables in the configuration](#use-environment-variables-in-the-configuration)
+    - [Generic placeholders:](#generic-placeholders)
+    - [Supported contents and default values of `loki.yaml`:](#supported-contents-and-default-values-of-lokiyaml)
   - [server_config](#server_config)
   - [distributor_config](#distributor_config)
   - [querier_config](#querier_config)
@@ -24,13 +27,13 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
   - [ingester_config](#ingester_config)
   - [consul_config](#consul_config)
   - [etcd_config](#etcd_config)
-  - [compactor_config](#compactor_config)
   - [memberlist_config](#memberlist_config)
   - [storage_config](#storage_config)
   - [chunk_store_config](#chunk_store_config)
   - [cache_config](#cache_config)
   - [schema_config](#schema_config)
     - [period_config](#period_config)
+  - [compactor_config](#compactor_config)
   - [limits_config](#limits_config)
     - [grpc_client_config](#grpc_client_config)
   - [table_manager_config](#table_manager_config)
@@ -38,6 +41,7 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
       - [auto_scaling_config](#auto_scaling_config)
   - [tracing_config](#tracing_config)
   - [Runtime Configuration file](#runtime-configuration-file)
+    - [Generic placeholders](#generic-placeholders-1)
 
 ## Printing Loki Config At Runtime
 
@@ -892,6 +896,12 @@ lifecycler:
 # CLI flag: -ingester.query-store-max-look-back-period
 [query_store_max_look_back_period: <duration> | default = 0]
 
+# Forget ingesters having hearbeat timestamps older than `ring.kvstore.heartbeat_timeout`
+# It is equivalent to clicking on `/ring` `forget` button in the UI: the ingester is removed from the ring
+# It is useful when you are pretty sure that unhealthy nodes won't come back (ex: not using stateful sets or equivalent)
+# You may use `memberlist.rejoin_interval` > 0 to handle network partition cases when using memberlist
+# CLI flag: -ingester.autoforget-unhealthy
+[autoforget_unhealthy: <boolean> | default = false]
 
 # The ingester WAL (Write Ahead Log) records incoming logs and stores them on the local file system in order to guarantee persistence of acknowledged data in the event of a process crash.
 wal:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -53,16 +53,17 @@ type Config struct {
 	// Config for transferring chunks.
 	MaxTransferRetries int `yaml:"max_transfer_retries,omitempty"`
 
-	ConcurrentFlushes int               `yaml:"concurrent_flushes"`
-	FlushCheckPeriod  time.Duration     `yaml:"flush_check_period"`
-	FlushOpTimeout    time.Duration     `yaml:"flush_op_timeout"`
-	RetainPeriod      time.Duration     `yaml:"chunk_retain_period"`
-	MaxChunkIdle      time.Duration     `yaml:"chunk_idle_period"`
-	BlockSize         int               `yaml:"chunk_block_size"`
-	TargetChunkSize   int               `yaml:"chunk_target_size"`
-	ChunkEncoding     string            `yaml:"chunk_encoding"`
-	parsedEncoding    chunkenc.Encoding `yaml:"-"` // placeholder for validated encoding
-	MaxChunkAge       time.Duration     `yaml:"max_chunk_age"`
+	ConcurrentFlushes   int               `yaml:"concurrent_flushes"`
+	FlushCheckPeriod    time.Duration     `yaml:"flush_check_period"`
+	FlushOpTimeout      time.Duration     `yaml:"flush_op_timeout"`
+	RetainPeriod        time.Duration     `yaml:"chunk_retain_period"`
+	MaxChunkIdle        time.Duration     `yaml:"chunk_idle_period"`
+	BlockSize           int               `yaml:"chunk_block_size"`
+	TargetChunkSize     int               `yaml:"chunk_target_size"`
+	ChunkEncoding       string            `yaml:"chunk_encoding"`
+	parsedEncoding      chunkenc.Encoding `yaml:"-"` // placeholder for validated encoding
+	MaxChunkAge         time.Duration     `yaml:"max_chunk_age"`
+	AutoForgetUnhealthy bool              `yaml:"autoforget_unhealthy"`
 
 	// Synchronization settings. Used to make sure that ingesters cut their chunks at the same moments.
 	SyncPeriod         time.Duration `yaml:"sync_period"`
@@ -98,6 +99,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxReturnedErrors, "ingester.max-ignored-stream-errors", 10, "Maximum number of ignored stream errors to return. 0 to return all errors.")
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", time.Hour, "Maximum chunk age before flushing.")
 	f.DurationVar(&cfg.QueryStoreMaxLookBackPeriod, "ingester.query-store-max-look-back-period", 0, "How far back should an ingester be allowed to query the store for data, for use only with boltdb-shipper index and filesystem object store. -1 for infinite.")
+	f.BoolVar(&cfg.AutoForgetUnhealthy, "ingester.autoforget-unhealthy", false, "Enable to remove unhealthy ingesters from the ring after `ring.kvstore.heartbeat_timeout`")
 }
 
 func (cfg *Config) Validate() error {
@@ -218,11 +220,78 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
 
 	i.Service = services.NewBasicService(i.starting, i.running, i.stopping)
+
+	i.setupAutoForget()
+
 	return i, nil
 }
 
 func (i *Ingester) SetChunkFilterer(chunkFilter storage.RequestChunkFilterer) {
 	i.chunkFilter = chunkFilter
+}
+
+// setupAutoForget looks for ring status if `AutoForgetUnhealthy` is enabled
+// when enabled, unhealthy ingesters that reach `ring.kvstore.heartbeat_timeout` are removed from the ring every `HeartbeatPeriod`
+func (i *Ingester) setupAutoForget() {
+	if !i.cfg.AutoForgetUnhealthy {
+		return
+	}
+
+	go func() {
+		ctx := context.Background()
+		err := i.Service.AwaitRunning(ctx)
+		if err != nil {
+			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("autoforget received error %s, autoforget is disabled", err.Error()))
+			return
+		}
+
+		level.Info(util_log.Logger).Log("msg", fmt.Sprintf("autoforget is enabled and will remove unhealthy instances from the ring after %v with no heartbeat", i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout))
+
+		ticker := time.NewTicker(i.cfg.LifecyclerConfig.HeartbeatPeriod)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			err := i.lifecycler.KVStore.CAS(ctx, ring.IngesterRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+				if in == nil {
+					return nil, false, nil
+				}
+
+				ringDesc, ok := in.(*ring.Desc)
+				if !ok {
+					level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("ingester autoforget saw a KV store value that was not `ring.Desc`, got `%T`", in))
+					return nil, false, nil
+				}
+				var removeList []string
+				for id, ingester := range ringDesc.Ingesters {
+					if !ingester.IsHealthy(ring.Reporting, i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout, time.Now()) {
+						if i.lifecycler.ID == id {
+							level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("autoforget has seen our ID `%s` as unhealthy in the ring, network may be partitioned, skip forgeting ingesters this round", id))
+							return nil, false, nil
+						}
+						removeList = append(removeList, id)
+					}
+				}
+
+				if len(removeList) == len(ringDesc.Ingesters)-1 {
+					level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("autoforget have seen %d unhealthy ingesters out of %d, network may be partioned, skip forgeting ingesters this round", len(removeList), len(ringDesc.Ingesters)))
+					return nil, false, nil
+				}
+
+				if len(removeList) > 0 {
+					for _, id := range removeList {
+						level.Info(util_log.Logger).Log("msg", fmt.Sprintf("forgeting ingester %v because it was not healthy after %v", id, i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout))
+						ringDesc.RemoveIngester(id)
+					}
+					return ringDesc, true, nil
+				}
+
+				return nil, false, nil
+			})
+			if err != nil {
+				level.Warn(util_log.Logger).Log("msg", err)
+			}
+		}
+	}()
 }
 
 func (i *Ingester) starting(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a new parameter that allows to automatically forget unhealthy ingesters after heartbeat timeout.

**Which issue(s) this PR fixes**:
Partially fixes #3360

**Special notes for your reviewer**:
Not everyone is using stateful sets. In my case, I'm running on AWS ECS in a stateless configuration. If one of my ingester get killed for whatever reason, this is not a drama because I have RF=3. A new task is spawned. 

At the moment the failed ingester will remain in the ring forever and requires to push `forget` button on ingester `/ring`. If not, another task failing will make the cluster unavailable even if 2 out of 3 are healthy because Loki does not use a sloppy quorum.

**Checklist**
- [x] Documentation added
- [x] Tests updated