### PR TITLE
Loki: sloppy quorum for writes

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -13,6 +13,9 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
 - [Configuring Loki](#configuring-loki)
   - [Printing Loki Config At Runtime](#printing-loki-config-at-runtime)
   - [Configuration File Reference](#configuration-file-reference)
+    - [Use environment variables in the configuration](#use-environment-variables-in-the-configuration)
+    - [Generic placeholders:](#generic-placeholders)
+    - [Supported contents and default values of `loki.yaml`:](#supported-contents-and-default-values-of-lokiyaml)
   - [server_config](#server_config)
   - [distributor_config](#distributor_config)
   - [querier_config](#querier_config)
@@ -24,13 +27,13 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
   - [ingester_config](#ingester_config)
   - [consul_config](#consul_config)
   - [etcd_config](#etcd_config)
-  - [compactor_config](#compactor_config)
   - [memberlist_config](#memberlist_config)
   - [storage_config](#storage_config)
   - [chunk_store_config](#chunk_store_config)
   - [cache_config](#cache_config)
   - [schema_config](#schema_config)
     - [period_config](#period_config)
+  - [compactor_config](#compactor_config)
   - [limits_config](#limits_config)
     - [grpc_client_config](#grpc_client_config)
   - [table_manager_config](#table_manager_config)
@@ -38,6 +41,7 @@ Configuration examples can be found in the [Configuration Examples](examples/) d
       - [auto_scaling_config](#auto_scaling_config)
   - [tracing_config](#tracing_config)
   - [Runtime Configuration file](#runtime-configuration-file)
+    - [Generic placeholders](#generic-placeholders-1)
 
 ## Printing Loki Config At Runtime
 
@@ -265,6 +269,8 @@ ring:
   # reading and writing.
   # CLI flag: -distributor.ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
+# When enabled, writes to the ingesters will succeed if there is a sloppy quorum of ingesters available, providing much higher availability than the default replication strategy when the number of nodes is greater than the replication factor
+[sloppy_quorum: <boolean> | default = false]
 ```
 
 ## querier_config

--- a/pkg/distributor/replication_strategy.go
+++ b/pkg/distributor/replication_strategy.go
@@ -1,0 +1,17 @@
+package distributor
+
+import "github.com/cortexproject/cortex/pkg/ring"
+
+// ReplicationStrategy is a combination of operation and filter
+type ReplicationStrategy struct {
+	ring.ReplicationStrategy
+	Op ring.Operation
+}
+
+// DefaultReplicationStrategy is the legacy strategy used by Loki
+// It selects the first RF active nodes within `ring.ReadRing.Get()`` and removes unhealthy nodes using the default strategy filter
+// When nodes > RF, it does not replace unhealthy nodes with healthy ones and writes can fail even if there is a quorum of healthy nodes for the write
+var DefaultReplicationStrategy = &ReplicationStrategy{
+	Op:                  ring.Write,
+	ReplicationStrategy: ring.NewDefaultReplicationStrategy(),
+}

--- a/pkg/distributor/sloppy_quorum.go
+++ b/pkg/distributor/sloppy_quorum.go
@@ -1,0 +1,60 @@
+package distributor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+)
+
+// WriteExtend will return all nodes in the ring that are ACTIVE (healthy or not)
+// We need this because Cortex `Write` operation won't select more than RF ACTIVE nodes, healthy or not.
+// That's not good because non-healthy hosts will get filtered out and the writes can fail,
+// even if there are enough nodes to satisfy RF
+var WriteExtend = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(_ ring.InstanceState) bool {
+	return true
+})
+
+// SloppyQuorumReplicationStrategy is a replication strategy that uses a sloppy quorum
+// It prefers writing to the same nodes than the `DefaultReplicationStrategy`, but will write to other healthy nodes if some of the preferred are unhealthy, boosting availability
+type SloppyQuorumReplicationStrategy struct{}
+
+func NewSloppyQuorumReplicationStrategy() *ReplicationStrategy {
+	return &ReplicationStrategy{
+		Op:                  WriteExtend,
+		ReplicationStrategy: &SloppyQuorumReplicationStrategy{},
+	}
+}
+
+// Filter returns a quorum of healthy instances, or an error if that's not possible
+func (r *SloppyQuorumReplicationStrategy) Filter(instances []ring.InstanceDesc, op ring.Operation, replicationFactor int, heartbeatTimeout time.Duration, zoneAwarenessEnabled bool) ([]ring.InstanceDesc, int, error) {
+	now := time.Now()
+
+	for i := 0; i < len(instances); {
+		if instances[i].IsHealthy(op, heartbeatTimeout, now) {
+			i++
+		} else {
+			instances = append(instances[:i], instances[i+1:]...)
+		}
+	}
+
+	minSuccess := (replicationFactor / 2) + 1
+
+	if len(instances) < minSuccess {
+		var err error
+
+		if zoneAwarenessEnabled {
+			err = fmt.Errorf("at least %d healthy replicas required across different availability zones, could only find %d", minSuccess, len(instances))
+		} else {
+			err = fmt.Errorf("at least %d healthy replicas required, could only find %d", minSuccess, len(instances))
+		}
+
+		return nil, 0, err
+	}
+
+	if len(instances) > replicationFactor {
+		instances = instances[:replicationFactor]
+	}
+
+	return instances, len(instances) - minSuccess, nil
+}

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -151,6 +151,7 @@ type Loki struct {
 
 	Server                   *server.Server
 	ring                     *ring.Ring
+	replicationStrategy      *distributor.ReplicationStrategy
 	overrides                *validation.Overrides
 	tenantConfigs            *runtime.TenantConfigs
 	distributor              *distributor.Distributor


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds `distributor.sloppy-quorum` opt-in flag.
When enabled, writes will succeed if there is a sloppy quorum of ingesters available, providing much higher availability than the default replication strategy.
This is needed to pretend being `Dynamo-style quorum consistency` (https://grafana.com/docs/loki/latest/overview/). Else it's `Cassandra style quorum consistency`.

**Which issue(s) this PR fixes**:
Fixes #3360

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated