### PR TITLE
promtail: added timezone to logger in dry-run mode #3679"

### DIFF
--- a/clients/pkg/promtail/client/logger.go
+++ b/clients/pkg/promtail/client/logger.go
@@ -74,7 +74,7 @@ func (l *logger) Chan() chan<- api.Entry {
 
 func (l *logger) run() {
 	for e := range l.entries {
-		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05")))
+		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05-0700")))
 		fmt.Fprint(l.Writer, "\t")
 		fmt.Fprint(l.Writer, yellow.Sprint(e.Labels.String()))
 		fmt.Fprint(l.Writer, "\t")

--- a/docs/sources/clients/aws/ec2/_index.md
+++ b/docs/sources/clients/aws/ec2/_index.md
@@ -166,7 +166,7 @@ Alright we should be ready to fire up promtail, we're going to run it using the 
 If everything is going well Promtail should print out log lines with their labels discovered instead of sending them to Loki, like shown below:
 
 ```bash
-2020-07-08T14:51:38	{filename="/var/log/cloud-init.log", instance="i-041b0be05c2d5cfad", name="promtail-demo", zone="us-east-2c"}	Jul 07 21:37:24 cloud-init[3035]: util.py[DEBUG]: loaded blob returned None, returning default.
+2020-07-08T14:51:38-0700	{filename="/var/log/cloud-init.log", instance="i-041b0be05c2d5cfad", name="promtail-demo", zone="us-east-2c"}	Jul 07 21:37:24 cloud-init[3035]: util.py[DEBUG]: loaded blob returned None, returning default.
 ```
 
 Don't hesitate to edit the your config file and start Promtail again to try your config out.


### PR DESCRIPTION
**What this PR does / why we need it**:
Promtail --dry-run is missing the timezone in output. 
If you want to test test stage "timestamp" you are unable to see if it works or not without importing the data into loki.

With this PR you just have to check dry-run output.

**Which issue(s) this PR fixes**:
Fixes #3679 


Signed-off-by: Kris Budde <Kris@budd.ee>
