### PR TITLE
Logs deletion support for boltdb-shipper store

### DIFF
--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -122,6 +122,10 @@ func (c *dumbChunk) Close() error {
 	return nil
 }
 
+func (c *dumbChunk) Rebound(start, end time.Time) (Chunk, error) {
+	return nil, nil
+}
+
 type dumbChunkIterator struct {
 	direction logproto.Direction
 	i         int

--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -3,6 +3,8 @@ package chunkenc
 import (
 	"io"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
@@ -81,6 +83,16 @@ func (f Facade) Size() int {
 // LokiChunk returns the chunkenc.Chunk.
 func (f Facade) LokiChunk() Chunk {
 	return f.c
+}
+
+func (f Facade) Rebound(start, end model.Time) (encoding.Chunk, error) {
+	newChunk, err := f.c.Rebound(start.Time(), end.Time())
+	if err != nil {
+		return nil, err
+	}
+	return &Facade{
+		c: newChunk,
+	}, nil
 }
 
 // UncompressedSize is a helper function to hide the type assertion kludge when wanting the uncompressed size of the Cortex interface encoding.Chunk.

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -121,6 +121,7 @@ type Chunk interface {
 	CompressedSize() int
 	Close() error
 	Encoding() Encoding
+	Rebound(start, end time.Time) (Chunk, error)
 }
 
 // Block is a chunk block.

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -16,6 +16,9 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
@@ -31,6 +34,11 @@ const (
 
 	blocksPerChunk = 10
 	maxLineLength  = 1024 * 1024 * 1024
+
+	// defaultBlockSize is used for target block size when cutting partially deleted chunks from a delete request.
+	// This could wary from configured block size using `ingester.chunks-block-size` flag or equivalent yaml config resulting in
+	// different block size in the new chunk which should be fine.
+	defaultBlockSize = 256 * 1024
 )
 
 var magicNumber = uint32(0x12EE56A)
@@ -754,6 +762,37 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 		}
 	}
 	return blocks
+}
+
+// Rebound builds a smaller chunk with logs having timestamp from start and end(both inclusive)
+func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
+	// add a nanosecond to end time because the Chunk.Iterator considers end time to be non-inclusive.
+	itr, err := c.Iterator(context.Background(), start, end.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+	if err != nil {
+		return nil, err
+	}
+
+	// Using defaultBlockSize for target block size.
+	// The alternative here could be going over all the blocks and using the size of the largest block as target block size but I(Sandeep) feel that it is not worth the complexity.
+	// For target chunk size I am using compressed size of original chunk since the newChunk should anyways be lower in size than that.
+	newChunk := NewMemChunk(c.Encoding(), defaultBlockSize, c.CompressedSize())
+
+	for itr.Next() {
+		entry := itr.Entry()
+		if err := newChunk.Append(&entry); err != nil {
+			return nil, err
+		}
+	}
+
+	if newChunk.Size() == 0 {
+		return nil, encoding.ErrSliceNoDataInRange
+	}
+
+	if err := newChunk.Close(); err != nil {
+		return nil, err
+	}
+
+	return newChunk, nil
 }
 
 // encBlock is an internal wrapper for a block, mainly to avoid binding an encoding in a block itself.

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cortexproject/cortex/pkg/chunk/encoding"
+
 	"github.com/grafana/loki/pkg/chunkenc/testdata"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
@@ -1054,4 +1056,97 @@ func Test_HeadIteratorReverse(t *testing.T) {
 	// let's try again without the headblock.
 	require.NoError(t, c.cut())
 	assertOrder(t, i)
+}
+
+func TestMemChunk_Rebound(t *testing.T) {
+	chkFrom := time.Unix(0, 0)
+	chkThrough := chkFrom.Add(time.Hour)
+	originalChunk := buildTestMemChunk(t, chkFrom, chkThrough)
+
+	for _, tc := range []struct {
+		name               string
+		sliceFrom, sliceTo time.Time
+		err                error
+	}{
+		{
+			name:      "slice whole chunk",
+			sliceFrom: chkFrom,
+			sliceTo:   chkThrough,
+		},
+		{
+			name:      "slice first half",
+			sliceFrom: chkFrom,
+			sliceTo:   chkFrom.Add(30 * time.Minute),
+		},
+		{
+			name:      "slice second half",
+			sliceFrom: chkFrom.Add(30 * time.Minute),
+			sliceTo:   chkThrough,
+		},
+		{
+			name:      "slice in the middle",
+			sliceFrom: chkFrom.Add(15 * time.Minute),
+			sliceTo:   chkFrom.Add(45 * time.Minute),
+		},
+		{
+			name:      "slice interval not aligned with sample intervals",
+			sliceFrom: chkFrom.Add(time.Second),
+			sliceTo:   chkThrough.Add(-time.Second),
+		},
+		{
+			name:      "slice out of bounds without overlap",
+			err:       encoding.ErrSliceNoDataInRange,
+			sliceFrom: chkThrough.Add(time.Minute),
+			sliceTo:   chkThrough.Add(time.Hour),
+		},
+		{
+			name:      "slice out of bounds with overlap",
+			sliceFrom: chkFrom.Add(10 * time.Minute),
+			sliceTo:   chkThrough.Add(10 * time.Minute),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			newChunk, err := originalChunk.Rebound(tc.sliceFrom, tc.sliceTo)
+			if tc.err != nil {
+				require.Equal(t, tc.err, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// iterate originalChunk from slice start to slice end + nanosecond. Adding a nanosecond here to be inclusive of sample at end time.
+			originalChunkItr, err := originalChunk.Iterator(context.Background(), tc.sliceFrom, tc.sliceTo.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+
+			// iterate newChunk for whole chunk interval which should include all the samples in the chunk and hence align it with expected values.
+			newChunkItr, err := newChunk.Iterator(context.Background(), chkFrom, chkThrough, logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+
+			for {
+				originalChunksHasMoreSamples := originalChunkItr.Next()
+				newChunkHasMoreSamples := newChunkItr.Next()
+
+				// either both should have samples or none of them
+				require.Equal(t, originalChunksHasMoreSamples, newChunkHasMoreSamples)
+				if !originalChunksHasMoreSamples {
+					break
+				}
+
+				require.Equal(t, originalChunkItr.Entry(), newChunkItr.Entry())
+			}
+
+		})
+	}
+}
+
+func buildTestMemChunk(t *testing.T, from, through time.Time) *MemChunk {
+	chk := NewMemChunk(EncGZIP, defaultBlockSize, 0)
+	for ; from.Before(through); from = from.Add(time.Second) {
+		err := chk.Append(&logproto.Entry{
+			Line:      from.String(),
+			Timestamp: from,
+		})
+		require.NoError(t, err)
+	}
+
+	return chk
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -598,6 +598,10 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		return nil, err
 	}
 
+	t.Server.HTTP.Path("/loki/api/admin/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
+	t.Server.HTTP.Path("/loki/api/admin/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
+	t.Server.HTTP.Path("/loki/api/admin/cancel_delete_request").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
+
 	return t.compactor, nil
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -598,9 +598,11 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		return nil, err
 	}
 
-	t.Server.HTTP.Path("/loki/api/admin/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
-	t.Server.HTTP.Path("/loki/api/admin/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
-	t.Server.HTTP.Path("/loki/api/admin/cancel_delete_request").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
+	if t.Cfg.CompactorConfig.RetentionEnabled {
+		t.Server.HTTP.Path("/loki/api/admin/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
+		t.Server.HTTP.Path("/loki/api/admin/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
+		t.Server.HTTP.Path("/loki/api/admin/cancel_delete_request").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
+	}
 
 	return t.compactor, nil
 }

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -118,8 +118,8 @@ func NewCompactor(cfg Config, storageConfig storage.Config, schemaConfig loki_st
 		metrics:               newMetrics(r),
 		sweeper:               sweeper,
 		deleteRequestsStore:   deletesStore,
-		DeleteRequestsHandler: deletion.NewDeleteRequestHandler(deletesStore, time.Hour, prometheus.DefaultRegisterer),
-		deleteRequestsManager: deletion.NewDeleteRequestsManager(deletesStore, cfg.DeleteRequestCancelPeriod),
+		DeleteRequestsHandler: deletion.NewDeleteRequestHandler(deletesStore, time.Hour, r),
+		deleteRequestsManager: deletion.NewDeleteRequestsManager(deletesStore, cfg.DeleteRequestCancelPeriod, r),
 	}
 
 	expirationChecker := newExpirationChecker(retention.NewExpirationChecker(limits), compactor.deleteRequestsManager)
@@ -172,6 +172,7 @@ func (c *Compactor) loop(ctx context.Context) error {
 	}
 
 	wg.Wait()
+	c.deleteRequestsManager.Stop()
 	c.deleteRequestsStore.Stop()
 	return nil
 }

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -70,6 +70,7 @@ type Compactor struct {
 	objectClient          chunk.ObjectClient
 	tableMarker           retention.TableMarker
 	sweeper               *retention.Sweeper
+	deleteRequestsStore   deletion.DeleteRequestsStore
 	DeleteRequestsHandler *deletion.DeleteRequestHandler
 	deleteRequestsManager *deletion.DeleteRequestsManager
 	metrics               *metrics
@@ -116,6 +117,7 @@ func NewCompactor(cfg Config, storageConfig storage.Config, schemaConfig loki_st
 		objectClient:          prefixedClient,
 		metrics:               newMetrics(r),
 		sweeper:               sweeper,
+		deleteRequestsStore:   deletesStore,
 		DeleteRequestsHandler: deletion.NewDeleteRequestHandler(deletesStore, time.Hour, prometheus.DefaultRegisterer),
 		deleteRequestsManager: deletion.NewDeleteRequestsManager(deletesStore, cfg.DeleteRequestCancelPeriod),
 	}
@@ -170,6 +172,7 @@ func (c *Compactor) loop(ctx context.Context) error {
 	}
 
 	wg.Wait()
+	c.deleteRequestsStore.Stop()
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -18,10 +18,11 @@ func TestIsDefaults(t *testing.T) {
 		}, false},
 		{&Config{}, false},
 		{&Config{
-			SharedStoreKeyPrefix:     "index/",
-			CompactionInterval:       10 * time.Minute,
-			RetentionDeleteDelay:     2 * time.Hour,
-			RetentionDeleteWorkCount: 150,
+			SharedStoreKeyPrefix:      "index/",
+			CompactionInterval:        10 * time.Minute,
+			RetentionDeleteDelay:      2 * time.Hour,
+			RetentionDeleteWorkCount:  150,
+			DeleteRequestCancelPeriod: 24 * time.Hour,
 		}, true},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -11,13 +11,14 @@ import (
 // DeleteRequest holds all the details about a delete request.
 type DeleteRequest struct {
 	RequestID string              `json:"request_id"`
-	UserID    string              `json:"-"`
 	StartTime model.Time          `json:"start_time"`
 	EndTime   model.Time          `json:"end_time"`
 	Selectors []string            `json:"selectors"`
 	Status    DeleteRequestStatus `json:"status"`
-	Matchers  [][]*labels.Matcher `json:"-"`
 	CreatedAt model.Time          `json:"created_at"`
+
+	UserID   string              `json:"-"`
+	Matchers [][]*labels.Matcher `json:"-"`
 }
 
 func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, []model.Interval) {

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -1,0 +1,90 @@
+package deletion
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+)
+
+// DeleteRequest holds all the details about a delete request.
+type DeleteRequest struct {
+	RequestID string              `json:"request_id"`
+	UserID    string              `json:"-"`
+	StartTime model.Time          `json:"start_time"`
+	EndTime   model.Time          `json:"end_time"`
+	Selectors []string            `json:"selectors"`
+	Status    DeleteRequestStatus `json:"status"`
+	Matchers  [][]*labels.Matcher `json:"-"`
+	CreatedAt model.Time          `json:"created_at"`
+}
+
+func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, []model.Interval) {
+	if d.UserID != unsafeGetString(entry.UserID) {
+		return false, nil
+	}
+
+	if !intervalsOverlap(model.Interval{
+		Start: entry.From,
+		End:   entry.Through,
+	}, model.Interval{
+		Start: d.StartTime,
+		End:   d.EndTime,
+	}) {
+		return false, nil
+	}
+
+	matchers := make([][]*labels.Matcher, len(d.Selectors))
+	var err error
+
+	for j, selector := range d.Selectors {
+		matchers[j], err = parser.ParseMetricSelector(selector)
+
+		if err != nil {
+			return false, nil
+		}
+	}
+
+	matches := false
+	for _, matchers := range matchers {
+		if labels.Selector(matchers).Matches(entry.Labels) {
+			matches = true
+			break
+		}
+	}
+
+	if !matches {
+		return false, nil
+	}
+
+	if d.StartTime <= entry.From && d.EndTime >= entry.Through {
+		return true, nil
+	}
+
+	intervals := make([]model.Interval, 0, 2)
+
+	if d.StartTime > entry.From {
+		intervals = append(intervals, model.Interval{
+			Start: entry.From,
+			End:   d.StartTime - 1,
+		})
+	}
+
+	if d.EndTime < entry.Through {
+		intervals = append(intervals, model.Interval{
+			Start: d.EndTime + 1,
+			End:   entry.Through,
+		})
+	}
+
+	return true, intervals
+}
+
+func intervalsOverlap(interval1, interval2 model.Interval) bool {
+	if interval1.Start > interval2.End || interval2.Start > interval1.End {
+		return false
+	}
+
+	return true
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
@@ -1,0 +1,181 @@
+package deletion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+)
+
+func TestDeleteRequest_IsDeleted(t *testing.T) {
+	now := model.Now()
+	user1 := "user1"
+
+	lbls := `{foo="bar", fizz="buzz"}`
+
+	chunkEntry := retention.ChunkEntry{
+		ChunkRef: retention.ChunkRef{
+			UserID:  []byte(user1),
+			From:    now.Add(-3 * time.Hour),
+			Through: now.Add(-time.Hour),
+		},
+		Labels: mustParseLabel(lbls),
+	}
+
+	type resp struct {
+		isDeleted           bool
+		nonDeletedIntervals []model.Interval
+	}
+
+	for _, tc := range []struct {
+		name          string
+		deleteRequest DeleteRequest
+		expectedResp  resp
+	}{
+		{
+			name: "whole chunk deleted",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-3 * time.Hour),
+				EndTime:   now.Add(-time.Hour),
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted:           true,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "chunk deleted from beginning",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-3 * time.Hour),
+				EndTime:   now.Add(-2 * time.Hour),
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: true,
+				nonDeletedIntervals: []model.Interval{
+					{
+						Start: now.Add(-2*time.Hour) + 1,
+						End:   now.Add(-time.Hour),
+					},
+				},
+			},
+		},
+		{
+			name: "chunk deleted from end",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-2 * time.Hour),
+				EndTime:   now,
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: true,
+				nonDeletedIntervals: []model.Interval{
+					{
+						Start: now.Add(-3 * time.Hour),
+						End:   now.Add(-2*time.Hour) - 1,
+					},
+				},
+			},
+		},
+		{
+			name: "chunk deleted from end",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-2 * time.Hour),
+				EndTime:   now,
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: true,
+				nonDeletedIntervals: []model.Interval{
+					{
+						Start: now.Add(-3 * time.Hour),
+						End:   now.Add(-2*time.Hour) - 1,
+					},
+				},
+			},
+		},
+		{
+			name: "chunk deleted in the middle",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-(2*time.Hour + 30*time.Minute)),
+				EndTime:   now.Add(-(time.Hour + 30*time.Minute)),
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: true,
+				nonDeletedIntervals: []model.Interval{
+					{
+						Start: now.Add(-3 * time.Hour),
+						End:   now.Add(-(2*time.Hour + 30*time.Minute)) - 1,
+					},
+					{
+						Start: now.Add(-(time.Hour + 30*time.Minute)) + 1,
+						End:   now.Add(-time.Hour),
+					},
+				},
+			},
+		},
+		{
+			name: "delete request out of range",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-12 * time.Hour),
+				EndTime:   now.Add(-10 * time.Hour),
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: false,
+			},
+		},
+		{
+			name: "request not matching due to matchers",
+			deleteRequest: DeleteRequest{
+				UserID:    user1,
+				StartTime: now.Add(-3 * time.Hour),
+				EndTime:   now.Add(-time.Hour),
+				Selectors: []string{`{foo1="bar"}`, `{fizz1="buzz"}`},
+			},
+			expectedResp: resp{
+				isDeleted: false,
+			},
+		},
+		{
+			name: "request for a different user",
+			deleteRequest: DeleteRequest{
+				UserID:    "user2",
+				StartTime: now.Add(-3 * time.Hour),
+				EndTime:   now.Add(-time.Hour),
+				Selectors: []string{lbls},
+			},
+			expectedResp: resp{
+				isDeleted: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isDeleted, nonDeletedIntervals := tc.deleteRequest.IsDeleted(chunkEntry)
+			require.Equal(t, tc.expectedResp.isDeleted, isDeleted)
+			require.Equal(t, tc.expectedResp.nonDeletedIntervals, nonDeletedIntervals)
+		})
+	}
+}
+
+func mustParseLabel(input string) labels.Labels {
+	lbls, err := logql.ParseLabels(input)
+	if err != nil {
+		panic(err)
+	}
+
+	return lbls
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -14,11 +14,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
 )
 
-type DeleteRequestsStore interface {
-	GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error)
-	UpdateStatus(ctx context.Context, userID, requestID string, newStatus DeleteRequestStatus) error
-}
-
 type DeleteRequestsManager struct {
 	deleteRequestsStore       DeleteRequestsStore
 	deleteRequestCancelPeriod time.Duration

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -104,7 +104,7 @@ func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
 	d.deleteRequestsToProcessMtx.Lock()
 	defer d.deleteRequestsToProcessMtx.Unlock()
 
-	d.deleteRequestsToProcess = nil
+	d.deleteRequestsToProcess = d.deleteRequestsToProcess[:0]
 	deleteRequests, err := d.deleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
 	if err != nil {
 		return err
@@ -174,7 +174,7 @@ func (d *DeleteRequestsManager) MarkPhaseFailed() {
 	d.deleteRequestsToProcessMtx.Lock()
 	defer d.deleteRequestsToProcessMtx.Unlock()
 
-	d.deleteRequestsToProcess = nil
+	d.deleteRequestsToProcess = d.deleteRequestsToProcess[:0]
 }
 
 func (d *DeleteRequestsManager) MarkPhaseFinished() {

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -1,0 +1,118 @@
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+)
+
+type DeleteRequestsStore interface {
+	GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error)
+	UpdateStatus(ctx context.Context, userID, requestID string, newStatus DeleteRequestStatus) error
+}
+
+type DeleteRequestsManager struct {
+	deleteRequestsStore       DeleteRequestsStore
+	deleteRequestCancelPeriod time.Duration
+
+	deleteRequestsToProcess    []DeleteRequest
+	deleteRequestsToProcessMtx sync.Mutex
+}
+
+func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeriod time.Duration) *DeleteRequestsManager {
+	return &DeleteRequestsManager{
+		deleteRequestsStore:       store,
+		deleteRequestCancelPeriod: deleteRequestCancelPeriod,
+	}
+}
+
+func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
+	d.deleteRequestsToProcessMtx.Lock()
+	defer d.deleteRequestsToProcessMtx.Unlock()
+
+	d.deleteRequestsToProcess = nil
+	deleteRequests, err := d.deleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	if err != nil {
+		return err
+	}
+
+	for _, deleteRequest := range deleteRequests {
+		// adding an extra minute here to avoid a race between cancellation of request and picking up the request for processing
+		if deleteRequest.CreatedAt.Add(d.deleteRequestCancelPeriod).Add(time.Minute).After(model.Now()) {
+			continue
+		}
+		d.deleteRequestsToProcess = append(d.deleteRequestsToProcess, deleteRequest)
+	}
+
+	return nil
+}
+
+func (d *DeleteRequestsManager) Expired(ref retention.ChunkEntry, _ model.Time) (bool, []model.Interval) {
+	d.deleteRequestsToProcessMtx.Lock()
+	defer d.deleteRequestsToProcessMtx.Unlock()
+
+	intervalsToRetain := []model.Interval{
+		{
+			Start: ref.From,
+			End:   ref.Through,
+		},
+	}
+
+	for _, deleteRequest := range d.deleteRequestsToProcess {
+		rebuiltIntervals := make([]model.Interval, 0, len(intervalsToRetain))
+		for _, interval := range intervalsToRetain {
+			entry := ref
+			entry.From = interval.Start
+			entry.Through = interval.End
+			isDeleted, newIntervalsToRetain := deleteRequest.IsDeleted(entry)
+			if !isDeleted {
+				rebuiltIntervals = append(rebuiltIntervals, interval)
+			} else {
+				rebuiltIntervals = append(rebuiltIntervals, newIntervalsToRetain...)
+			}
+		}
+
+		intervalsToRetain = rebuiltIntervals
+		if len(intervalsToRetain) == 0 {
+			return true, nil
+		}
+	}
+
+	if len(intervalsToRetain) == 1 && intervalsToRetain[0].Start == ref.From && intervalsToRetain[0].End == ref.Through {
+		return false, nil
+	}
+
+	return true, intervalsToRetain
+}
+
+func (d *DeleteRequestsManager) MarkPhaseStarted() {
+	if err := d.loadDeleteRequestsToProcess(); err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to load delete requests to process", "err", err)
+	}
+}
+
+func (d *DeleteRequestsManager) MarkPhaseFailed() {
+	d.deleteRequestsToProcessMtx.Lock()
+	defer d.deleteRequestsToProcessMtx.Unlock()
+
+	d.deleteRequestsToProcess = nil
+}
+
+func (d *DeleteRequestsManager) MarkPhaseFinished() {
+	d.deleteRequestsToProcessMtx.Lock()
+	defer d.deleteRequestsToProcessMtx.Unlock()
+
+	for _, deleteRequest := range d.deleteRequestsToProcess {
+		if err := d.deleteRequestsStore.UpdateStatus(context.Background(), deleteRequest.UserID, deleteRequest.RequestID, StatusProcessed); err != nil {
+			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to mark delete request %s for user %s as processed", deleteRequest.RequestID, deleteRequest.UserID), "err", err)
+		}
+	}
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -7,11 +7,17 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 
 	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+)
+
+const (
+	statusSuccess = "success"
+	statusFail    = "fail"
 )
 
 type DeleteRequestsManager struct {
@@ -20,13 +26,78 @@ type DeleteRequestsManager struct {
 
 	deleteRequestsToProcess    []DeleteRequest
 	deleteRequestsToProcessMtx sync.Mutex
+	metrics                    *deleteRequestsManagerMetrics
+	wg                         sync.WaitGroup
+	done                       chan struct{}
 }
 
-func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeriod time.Duration) *DeleteRequestsManager {
-	return &DeleteRequestsManager{
+func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestsManager {
+	dm := &DeleteRequestsManager{
 		deleteRequestsStore:       store,
 		deleteRequestCancelPeriod: deleteRequestCancelPeriod,
+		metrics:                   newDeleteRequestsManagerMetrics(registerer),
+		done:                      make(chan struct{}),
 	}
+
+	go dm.loop()
+
+	return dm
+}
+
+func (d *DeleteRequestsManager) loop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	d.wg.Add(1)
+	defer d.wg.Done()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := d.updateMetrics(); err != nil {
+				level.Error(util_log.Logger).Log("msg", "failed to update metrics", "err", err)
+			}
+		case <-d.done:
+			break
+		}
+	}
+}
+
+func (d *DeleteRequestsManager) Stop() {
+	close(d.done)
+	d.wg.Wait()
+}
+
+func (d *DeleteRequestsManager) updateMetrics() error {
+	deleteRequests, err := d.deleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	if err != nil {
+		return err
+	}
+
+	pendingDeleteRequestsCount := 0
+	oldestPendingRequestCreatedAt := model.Time(0)
+
+	for _, deleteRequest := range deleteRequests {
+		// adding an extra minute here to avoid a race between cancellation of request and picking up the request for processing
+		if deleteRequest.Status != StatusReceived || deleteRequest.CreatedAt.Add(d.deleteRequestCancelPeriod).Add(time.Minute).After(model.Now()) {
+			continue
+		}
+
+		pendingDeleteRequestsCount++
+		if oldestPendingRequestCreatedAt == 0 || deleteRequest.CreatedAt.Before(oldestPendingRequestCreatedAt) {
+			oldestPendingRequestCreatedAt = deleteRequest.CreatedAt
+		}
+	}
+
+	// track age of oldest delete request since they became eligible for processing
+	oldestPendingRequestAge := time.Duration(0)
+	if oldestPendingRequestCreatedAt != 0 {
+		oldestPendingRequestAge = model.Now().Sub(oldestPendingRequestCreatedAt.Add(d.deleteRequestCancelPeriod))
+	}
+	d.metrics.oldestPendingDeleteRequestAgeSeconds.Set(float64(oldestPendingRequestAge / time.Second))
+	d.metrics.pendingDeleteRequestsCount.Set(float64(pendingDeleteRequestsCount))
+
+	return nil
 }
 
 func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
@@ -77,6 +148,7 @@ func (d *DeleteRequestsManager) Expired(ref retention.ChunkEntry, _ model.Time) 
 
 		intervalsToRetain = rebuiltIntervals
 		if len(intervalsToRetain) == 0 {
+			d.metrics.deleteRequestsChunksSelectedTotal.WithLabelValues(string(ref.UserID)).Inc()
 			return true, nil
 		}
 	}
@@ -85,13 +157,17 @@ func (d *DeleteRequestsManager) Expired(ref retention.ChunkEntry, _ model.Time) 
 		return false, nil
 	}
 
+	d.metrics.deleteRequestsChunksSelectedTotal.WithLabelValues(string(ref.UserID)).Inc()
 	return true, intervalsToRetain
 }
 
 func (d *DeleteRequestsManager) MarkPhaseStarted() {
+	status := statusSuccess
 	if err := d.loadDeleteRequestsToProcess(); err != nil {
+		status = statusFail
 		level.Error(util_log.Logger).Log("msg", "failed to load delete requests to process", "err", err)
 	}
+	d.metrics.loadPendingRequestsAttemptsTotal.WithLabelValues(status).Inc()
 }
 
 func (d *DeleteRequestsManager) MarkPhaseFailed() {
@@ -109,5 +185,6 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 		if err := d.deleteRequestsStore.UpdateStatus(context.Background(), deleteRequest.UserID, deleteRequest.RequestID, StatusProcessed); err != nil {
 			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to mark delete request %s for user %s as processed", deleteRequest.RequestID, deleteRequest.UserID), "err", err)
 		}
+		d.metrics.deleteRequestsProcessedTotal.WithLabelValues(deleteRequest.UserID).Inc()
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
@@ -26,6 +26,34 @@ func (m mockDeleteRequestsStore) UpdateStatus(ctx context.Context, userID, reque
 	return nil
 }
 
+func (m mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID string, startTime, endTime model.Time, selectors []string) error {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) GetDeleteRequestsForUserByStatus(ctx context.Context, userID string, status DeleteRequestStatus) ([]DeleteRequest, error) {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (*DeleteRequest, error) {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) GetPendingDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID, requestID string, createdAt, startTime, endTime model.Time) error {
+	panic("implement me")
+}
+
+func (m mockDeleteRequestsStore) Stop() {
+	panic("implement me")
+}
+
 func TestDeleteRequestsManager_Expired(t *testing.T) {
 	type resp struct {
 		isExpired           bool

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
@@ -1,0 +1,230 @@
+package deletion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+)
+
+const testUserID = "test-user"
+
+type mockDeleteRequestsStore struct {
+	deleteRequests []DeleteRequest
+}
+
+func (m mockDeleteRequestsStore) GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error) {
+	return m.deleteRequests, nil
+}
+
+func (m mockDeleteRequestsStore) UpdateStatus(ctx context.Context, userID, requestID string, newStatus DeleteRequestStatus) error {
+	return nil
+}
+
+func TestDeleteRequestsManager_Expired(t *testing.T) {
+	type resp struct {
+		isExpired           bool
+		nonDeletedIntervals []model.Interval
+	}
+
+	now := model.Now()
+	lblFoo, err := logql.ParseLabels(`{foo="bar"}`)
+	require.NoError(t, err)
+
+	chunkEntry := retention.ChunkEntry{
+		ChunkRef: retention.ChunkRef{
+			UserID:  []byte(testUserID),
+			From:    now.Add(-12 * time.Hour),
+			Through: now.Add(-time.Hour),
+		},
+		Labels: lblFoo,
+	}
+
+	for _, tc := range []struct {
+		name                    string
+		deleteRequestsFromStore []DeleteRequest
+		expectedResp            resp
+	}{
+		{
+			name: "no delete requests",
+			expectedResp: resp{
+				isExpired:           false,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "no relevant delete requests",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    "different-user",
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-24 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired:           false,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "whole chunk deleted by single request",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-24 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired:           true,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "deleted interval out of range",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-48 * time.Hour),
+					EndTime:   now.Add(-24 * time.Hour),
+				},
+			},
+			expectedResp: resp{
+				isExpired:           false,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "multiple delete requests with one deleting the whole chunk",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-48 * time.Hour),
+					EndTime:   now.Add(-24 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-12 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired:           true,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "multiple delete requests causing multiple holes",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-13 * time.Hour),
+					EndTime:   now.Add(-11 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-10 * time.Hour),
+					EndTime:   now.Add(-8 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-6 * time.Hour),
+					EndTime:   now.Add(-5 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-2 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired: true,
+				nonDeletedIntervals: []model.Interval{
+					{
+						Start: now.Add(-11*time.Hour) + 1,
+						End:   now.Add(-10*time.Hour) - 1,
+					},
+					{
+						Start: now.Add(-8*time.Hour) + 1,
+						End:   now.Add(-6*time.Hour) - 1,
+					},
+					{
+						Start: now.Add(-5*time.Hour) + 1,
+						End:   now.Add(-2*time.Hour) - 1,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple overlapping requests deleting the whole chunk",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-13 * time.Hour),
+					EndTime:   now.Add(-6 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-8 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired:           true,
+				nonDeletedIntervals: nil,
+			},
+		},
+		{
+			name: "multiple non-overlapping requests deleting the whole chunk",
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-12 * time.Hour),
+					EndTime:   now.Add(-6*time.Hour) - 1,
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-6 * time.Hour),
+					EndTime:   now.Add(-4*time.Hour) - 1,
+				},
+				{
+					UserID:    testUserID,
+					Selectors: []string{lblFoo.String()},
+					StartTime: now.Add(-4 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired:           true,
+				nonDeletedIntervals: nil,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour)
+			require.NoError(t, mgr.loadDeleteRequestsToProcess())
+
+			isExpired, nonDeletedIntervals := mgr.Expired(chunkEntry, model.Now())
+			require.Equal(t, tc.expectedResp.isExpired, isExpired)
+			require.Equal(t, tc.expectedResp.nonDeletedIntervals, nonDeletedIntervals)
+		})
+	}
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
@@ -247,7 +247,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour)
+			mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, nil)
 			require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
 			isExpired, nonDeletedIntervals := mgr.Expired(chunkEntry, model.Now())

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store.go
@@ -13,7 +13,6 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
@@ -44,18 +43,6 @@ var (
 
 type Interval struct {
 	from, through model.Time
-}
-
-// DeleteRequest holds all the details about a delete request.
-type DeleteRequest struct {
-	RequestID string              `json:"request_id"`
-	UserID    string              `json:"-"`
-	StartTime model.Time          `json:"start_time"`
-	EndTime   model.Time          `json:"end_time"`
-	Selectors []string            `json:"selectors"`
-	Status    DeleteRequestStatus `json:"status"`
-	Matchers  [][]*labels.Matcher `json:"-"`
-	CreatedAt model.Time          `json:"created_at"`
 }
 
 // deleteRequestsStore provides all the methods required to manage lifecycle of delete request and things related to it.

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store.go
@@ -1,0 +1,328 @@
+package deletion
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+type (
+	DeleteRequestStatus string
+	indexType           string
+)
+
+const (
+	StatusReceived  DeleteRequestStatus = "received"
+	StatusProcessed DeleteRequestStatus = "processed"
+
+	separator = "\000" // separator for series selectors in delete requests
+
+	deleteRequestID      indexType = "1"
+	deleteRequestDetails indexType = "2"
+
+	tempFileSuffix          = ".temp"
+	deleteRequestsTableName = "delete_requests"
+)
+
+var (
+	pendingDeleteRequestStatuses = []DeleteRequestStatus{StatusReceived}
+
+	ErrDeleteRequestNotFound = errors.New("could not find matching delete request")
+)
+
+type Interval struct {
+	from, through model.Time
+}
+
+// DeleteRequest holds all the details about a delete request.
+type DeleteRequest struct {
+	RequestID string              `json:"request_id"`
+	UserID    string              `json:"-"`
+	StartTime model.Time          `json:"start_time"`
+	EndTime   model.Time          `json:"end_time"`
+	Selectors []string            `json:"selectors"`
+	Status    DeleteRequestStatus `json:"status"`
+	Matchers  [][]*labels.Matcher `json:"-"`
+	CreatedAt model.Time          `json:"created_at"`
+}
+
+// deleteRequestsStore provides all the methods required to manage lifecycle of delete request and things related to it.
+type deleteRequestsStore struct {
+	indexClient chunk.IndexClient
+	done        chan struct{}
+}
+
+// NewDeleteStore creates a store for managing delete requests.
+func NewDeleteStore(workingDirectory string, objectClient chunk.ObjectClient) (*deleteRequestsStore, error) {
+	indexClient, err := newDeleteRequestsTable(workingDirectory, objectClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deleteRequestsStore{indexClient: indexClient}, nil
+}
+
+// AddDeleteRequest creates entries for a new delete request.
+func (ds *deleteRequestsStore) AddDeleteRequest(ctx context.Context, userID string, startTime, endTime model.Time, selectors []string) error {
+	return ds.addDeleteRequest(ctx, userID, model.Now(), startTime, endTime, selectors)
+
+}
+
+// addDeleteRequest is also used for tests to create delete requests with different createdAt time.
+func (ds *deleteRequestsStore) addDeleteRequest(ctx context.Context, userID string, createdAt, startTime, endTime model.Time, selectors []string) error {
+	requestID := generateUniqueID(userID, selectors)
+
+	for {
+		_, err := ds.GetDeleteRequest(ctx, userID, string(requestID))
+		if err != nil {
+			if err == ErrDeleteRequestNotFound {
+				break
+			}
+			return err
+		}
+
+		// we have a collision here, lets recreate a new requestID and check for collision
+		time.Sleep(time.Millisecond)
+		requestID = generateUniqueID(userID, selectors)
+	}
+
+	// userID, requestID
+	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
+
+	// Add an entry with userID, requestID as range key and status as value to make it easy to manage and lookup status
+	// We don't want to set anything in hash key here since we would want to find delete requests by just status
+	writeBatch := ds.indexClient.NewWriteBatch()
+	writeBatch.Add(deleteRequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID), []byte(StatusReceived))
+
+	// Add another entry with additional details like creation time, time range of delete request and selectors in value
+	rangeValue := fmt.Sprintf("%x:%x:%x", int64(createdAt), int64(startTime), int64(endTime))
+	writeBatch.Add(deleteRequestsTableName, fmt.Sprintf("%s:%s", deleteRequestDetails, userIDAndRequestID),
+		[]byte(rangeValue), []byte(strings.Join(selectors, separator)))
+
+	return ds.indexClient.BatchWrite(ctx, writeBatch)
+}
+
+// GetDeleteRequestsByStatus returns all delete requests for given status.
+func (ds *deleteRequestsStore) GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error) {
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:  deleteRequestsTableName,
+		HashValue:  string(deleteRequestID),
+		ValueEqual: []byte(status),
+	})
+}
+
+// GetDeleteRequestsForUserByStatus returns all delete requests for a user with given status.
+func (ds *deleteRequestsStore) GetDeleteRequestsForUserByStatus(ctx context.Context, userID string, status DeleteRequestStatus) ([]DeleteRequest, error) {
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        deleteRequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userID),
+		ValueEqual:       []byte(status),
+	})
+}
+
+// GetAllDeleteRequestsForUser returns all delete requests for a user.
+func (ds *deleteRequestsStore) GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        deleteRequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userID),
+	})
+}
+
+// UpdateStatus updates status of a delete request.
+func (ds *deleteRequestsStore) UpdateStatus(ctx context.Context, userID, requestID string, newStatus DeleteRequestStatus) error {
+	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
+
+	writeBatch := ds.indexClient.NewWriteBatch()
+	writeBatch.Add(deleteRequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID), []byte(newStatus))
+
+	return ds.indexClient.BatchWrite(ctx, writeBatch)
+}
+
+// GetDeleteRequest returns delete request with given requestID.
+func (ds *deleteRequestsStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (*DeleteRequest, error) {
+	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
+
+	deleteRequests, err := ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        deleteRequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userIDAndRequestID),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deleteRequests) == 0 {
+		return nil, ErrDeleteRequestNotFound
+	}
+
+	return &deleteRequests[0], nil
+}
+
+// GetPendingDeleteRequestsForUser returns all delete requests for a user which are not processed.
+func (ds *deleteRequestsStore) GetPendingDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
+	pendingDeleteRequests := []DeleteRequest{}
+	for _, status := range pendingDeleteRequestStatuses {
+		deleteRequests, err := ds.GetDeleteRequestsForUserByStatus(ctx, userID, status)
+		if err != nil {
+			return nil, err
+		}
+
+		pendingDeleteRequests = append(pendingDeleteRequests, deleteRequests...)
+	}
+
+	return pendingDeleteRequests, nil
+}
+
+func (ds *deleteRequestsStore) queryDeleteRequests(ctx context.Context, deleteQuery chunk.IndexQuery) ([]DeleteRequest, error) {
+	deleteRequests := []DeleteRequest{}
+	// No need to lock inside the callback since we run a single index query.
+	err := ds.indexClient.QueryPages(ctx, []chunk.IndexQuery{deleteQuery}, func(query chunk.IndexQuery, batch chunk.ReadBatch) (shouldContinue bool) {
+		itr := batch.Iterator()
+		for itr.Next() {
+			userID, requestID := splitUserIDAndRequestID(string(itr.RangeValue()))
+
+			deleteRequests = append(deleteRequests, DeleteRequest{
+				UserID:    userID,
+				RequestID: requestID,
+				Status:    DeleteRequestStatus(itr.Value()),
+			})
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i, deleteRequest := range deleteRequests {
+		deleteRequestQuery := []chunk.IndexQuery{
+			{
+				TableName: deleteRequestsTableName,
+				HashValue: fmt.Sprintf("%s:%s:%s", deleteRequestDetails, deleteRequest.UserID, deleteRequest.RequestID),
+			},
+		}
+
+		var parseError error
+		err := ds.indexClient.QueryPages(ctx, deleteRequestQuery, func(query chunk.IndexQuery, batch chunk.ReadBatch) (shouldContinue bool) {
+			itr := batch.Iterator()
+			itr.Next()
+
+			deleteRequest, err = parseDeleteRequestTimestamps(itr.RangeValue(), deleteRequest)
+			if err != nil {
+				parseError = err
+				return false
+			}
+
+			deleteRequest.Selectors = strings.Split(string(itr.Value()), separator)
+			deleteRequests[i] = deleteRequest
+
+			return true
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if parseError != nil {
+			return nil, parseError
+		}
+	}
+
+	return deleteRequests, nil
+}
+
+// RemoveDeleteRequest removes a delete request
+func (ds *deleteRequestsStore) RemoveDeleteRequest(ctx context.Context, userID, requestID string, createdAt, startTime, endTime model.Time) error {
+	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
+
+	writeBatch := ds.indexClient.NewWriteBatch()
+	writeBatch.Delete(deleteRequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID))
+
+	// Add another entry with additional details like creation time, time range of delete request and selectors in value
+	rangeValue := fmt.Sprintf("%x:%x:%x", int64(createdAt), int64(startTime), int64(endTime))
+	writeBatch.Delete(deleteRequestsTableName, fmt.Sprintf("%s:%s", deleteRequestDetails, userIDAndRequestID),
+		[]byte(rangeValue))
+
+	return ds.indexClient.BatchWrite(ctx, writeBatch)
+}
+
+func parseDeleteRequestTimestamps(rangeValue []byte, deleteRequest DeleteRequest) (DeleteRequest, error) {
+	hexParts := strings.Split(string(rangeValue), ":")
+	if len(hexParts) != 3 {
+		return deleteRequest, errors.New("invalid key in parsing delete request lookup response")
+	}
+
+	createdAt, err := strconv.ParseInt(hexParts[0], 16, 64)
+	if err != nil {
+		return deleteRequest, err
+	}
+
+	from, err := strconv.ParseInt(hexParts[1], 16, 64)
+	if err != nil {
+		return deleteRequest, err
+
+	}
+	through, err := strconv.ParseInt(hexParts[2], 16, 64)
+	if err != nil {
+		return deleteRequest, err
+
+	}
+
+	deleteRequest.CreatedAt = model.Time(createdAt)
+	deleteRequest.StartTime = model.Time(from)
+	deleteRequest.EndTime = model.Time(through)
+
+	return deleteRequest, nil
+}
+
+// An id is useful in managing delete requests
+func generateUniqueID(orgID string, selectors []string) []byte {
+	uniqueID := fnv.New32()
+	_, _ = uniqueID.Write([]byte(orgID))
+
+	timeNow := make([]byte, 8)
+	binary.LittleEndian.PutUint64(timeNow, uint64(time.Now().UnixNano()))
+	_, _ = uniqueID.Write(timeNow)
+
+	for _, selector := range selectors {
+		_, _ = uniqueID.Write([]byte(selector))
+	}
+
+	return encodeUniqueID(uniqueID.Sum32())
+}
+
+func encodeUniqueID(t uint32) []byte {
+	throughBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(throughBytes, t)
+	encodedThroughBytes := make([]byte, 8)
+	hex.Encode(encodedThroughBytes, throughBytes)
+	return encodedThroughBytes
+}
+
+func splitUserIDAndRequestID(rangeValue string) (userID, requestID string) {
+	lastIndex := strings.LastIndex(rangeValue, ":")
+
+	userID = rangeValue[:lastIndex]
+	requestID = rangeValue[lastIndex+1:]
+
+	return
+}
+
+// unsafeGetString is like yolostring but with a meaningful name
+func unsafeGetString(buf []byte) string {
+	return *((*string)(unsafe.Pointer(&buf)))
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
@@ -64,7 +64,7 @@ func TestDeleteRequestsStore(t *testing.T) {
 
 	// add requests for both the users to the store
 	for i := 0; i < len(user1ExpectedRequests); i++ {
-		requestId, err := testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
+		requestID, err := testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
 			context.Background(),
 			user1ExpectedRequests[i].UserID,
 			user1ExpectedRequests[i].CreatedAt,
@@ -73,9 +73,9 @@ func TestDeleteRequestsStore(t *testing.T) {
 			user1ExpectedRequests[i].Selectors,
 		)
 		require.NoError(t, err)
-		user1ExpectedRequests[i].RequestID = string(requestId)
+		user1ExpectedRequests[i].RequestID = string(requestID)
 
-		requestId, err = testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
+		requestID, err = testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
 			context.Background(),
 			user2ExpectedRequests[i].UserID,
 			user2ExpectedRequests[i].CreatedAt,
@@ -84,7 +84,7 @@ func TestDeleteRequestsStore(t *testing.T) {
 			user2ExpectedRequests[i].Selectors,
 		)
 		require.NoError(t, err)
-		user2ExpectedRequests[i].RequestID = string(requestId)
+		user2ExpectedRequests[i].RequestID = string(requestID)
 	}
 
 	// get all requests with StatusReceived and see if they have expected values

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
@@ -1,0 +1,172 @@
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk/local"
+)
+
+func TestDeleteRequestsStore(t *testing.T) {
+	now := model.Now()
+	user1 := "user1"
+	user2 := "user2"
+
+	// build some test requests to add to the store
+	var user1ExpectedRequests []DeleteRequest
+	var user2ExpectedRequests []DeleteRequest
+	for i := time.Duration(1); i <= 24; i++ {
+		user1ExpectedRequests = append(user1ExpectedRequests, DeleteRequest{
+			UserID:    user1,
+			StartTime: now.Add(-i * time.Hour),
+			EndTime:   now.Add(-i * time.Hour).Add(30 * time.Minute),
+			CreatedAt: now.Add(-i * time.Hour).Add(30 * time.Minute),
+			Selectors: []string{fmt.Sprintf(`{foo="%d", user="%s"}`, i, user1)},
+			Status:    StatusReceived,
+		})
+		user2ExpectedRequests = append(user2ExpectedRequests, DeleteRequest{
+			UserID:    user2,
+			StartTime: now.Add(-i * time.Hour),
+			EndTime:   now.Add(-(i + 1) * time.Hour),
+			CreatedAt: now.Add(-(i + 1) * time.Hour),
+			Selectors: []string{fmt.Sprintf(`{foo="%d", user="%s"}`, i, user2)},
+			Status:    StatusReceived,
+		})
+	}
+
+	// build the store
+	tempDir, err := ioutil.TempDir("", "test-delete-requests-store")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	workingDir := filepath.Join(tempDir, "working-dir")
+	objectStorePath := filepath.Join(tempDir, "object-store")
+
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: objectStorePath,
+	})
+	require.NoError(t, err)
+	testDeleteRequestsStore, err := NewDeleteStore(workingDir, objectClient)
+	require.NoError(t, err)
+
+	defer testDeleteRequestsStore.Stop()
+
+	// add requests for both the users to the store
+	for i := 0; i < len(user1ExpectedRequests); i++ {
+		requestId, err := testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
+			context.Background(),
+			user1ExpectedRequests[i].UserID,
+			user1ExpectedRequests[i].CreatedAt,
+			user1ExpectedRequests[i].StartTime,
+			user1ExpectedRequests[i].EndTime,
+			user1ExpectedRequests[i].Selectors,
+		)
+		require.NoError(t, err)
+		user1ExpectedRequests[i].RequestID = string(requestId)
+
+		requestId, err = testDeleteRequestsStore.(*deleteRequestsStore).addDeleteRequest(
+			context.Background(),
+			user2ExpectedRequests[i].UserID,
+			user2ExpectedRequests[i].CreatedAt,
+			user2ExpectedRequests[i].StartTime,
+			user2ExpectedRequests[i].EndTime,
+			user2ExpectedRequests[i].Selectors,
+		)
+		require.NoError(t, err)
+		user2ExpectedRequests[i].RequestID = string(requestId)
+	}
+
+	// get all requests with StatusReceived and see if they have expected values
+	deleteRequests, err := testDeleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	require.NoError(t, err)
+	compareRequests(t, append(user1ExpectedRequests, user2ExpectedRequests...), deleteRequests)
+
+	// get user specific requests and see if they have expected values
+	user1Requests, err := testDeleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user1)
+	require.NoError(t, err)
+	compareRequests(t, user1ExpectedRequests, user1Requests)
+
+	user2Requests, err := testDeleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user2)
+	require.NoError(t, err)
+	compareRequests(t, user2ExpectedRequests, user2Requests)
+
+	// get individual delete requests by id and see if they have expected values
+	for _, expectedRequest := range append(user1Requests, user2Requests...) {
+		actualRequest, err := testDeleteRequestsStore.GetDeleteRequest(context.Background(), expectedRequest.UserID, expectedRequest.RequestID)
+		require.NoError(t, err)
+		require.Equal(t, expectedRequest, *actualRequest)
+	}
+
+	// try a non-existent request and see if it throws ErrDeleteRequestNotFound
+	_, err = testDeleteRequestsStore.GetDeleteRequest(context.Background(), "user3", "na")
+	require.ErrorIs(t, err, ErrDeleteRequestNotFound)
+
+	// update some of the delete requests for both the users to processed
+	for i := 0; i < len(user1ExpectedRequests); i++ {
+		var request DeleteRequest
+		if i%2 != 0 {
+			user1ExpectedRequests[i].Status = StatusProcessed
+			request = user1ExpectedRequests[i]
+		} else {
+			user2ExpectedRequests[i].Status = StatusProcessed
+			request = user2ExpectedRequests[i]
+		}
+
+		require.NoError(t, testDeleteRequestsStore.UpdateStatus(context.Background(), request.UserID, request.RequestID, StatusProcessed))
+	}
+
+	// see if requests in the store have right values
+	user1Requests, err = testDeleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user1)
+	require.NoError(t, err)
+	compareRequests(t, user1ExpectedRequests, user1Requests)
+
+	user2Requests, err = testDeleteRequestsStore.GetAllDeleteRequestsForUser(context.Background(), user2)
+	require.NoError(t, err)
+	compareRequests(t, user2ExpectedRequests, user2Requests)
+
+	// delete the requests from the store updated previously
+	var remainingRequests []DeleteRequest
+	for i := 0; i < len(user1ExpectedRequests); i++ {
+		var request DeleteRequest
+		if i%2 != 0 {
+			user1ExpectedRequests[i].Status = StatusProcessed
+			request = user1ExpectedRequests[i]
+			remainingRequests = append(remainingRequests, user2ExpectedRequests[i])
+		} else {
+			user2ExpectedRequests[i].Status = StatusProcessed
+			request = user2ExpectedRequests[i]
+			remainingRequests = append(remainingRequests, user1ExpectedRequests[i])
+		}
+
+		require.NoError(t, testDeleteRequestsStore.RemoveDeleteRequest(context.Background(), request.UserID, request.RequestID, request.CreatedAt, request.StartTime, request.EndTime))
+	}
+
+	// see if the store has the right remaining requests
+	deleteRequests, err = testDeleteRequestsStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
+	require.NoError(t, err)
+	compareRequests(t, remainingRequests, deleteRequests)
+}
+
+func compareRequests(t *testing.T, expected []DeleteRequest, actual []DeleteRequest) {
+	require.Len(t, actual, len(expected))
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].RequestID < expected[j].RequestID
+	})
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i].RequestID < actual[j].RequestID
+	})
+	for i, deleteRequest := range actual {
+		require.Equal(t, expected[i], deleteRequest)
+	}
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
@@ -64,7 +64,7 @@ func (t *deleteRequestsTable) init() error {
 
 	_, err := os.Stat(t.dbPath)
 	if err != nil {
-		err = shipper_util.GetFileFromStorage(context.Background(), t.objectClient, objectPathInStorage, t.dbPath)
+		err = shipper_util.GetFileFromStorage(context.Background(), t.objectClient, objectPathInStorage, t.dbPath, true)
 		if err != nil && !errors.Is(err, chunk.ErrStorageObjectNotFound) {
 			return err
 		}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
@@ -43,6 +43,7 @@ func newDeleteRequestsTable(workingDirectory string, objectClient chunk.ObjectCl
 		objectClient:      objectClient,
 		dbPath:            dbPath,
 		boltdbIndexClient: boltdbIndexClient,
+		done:              make(chan struct{}),
 	}
 
 	err = table.init()
@@ -78,6 +79,7 @@ func (t *deleteRequestsTable) loop() {
 	defer uploadTicker.Stop()
 
 	t.wg.Add(1)
+	defer t.wg.Done()
 
 	for {
 		select {
@@ -86,7 +88,6 @@ func (t *deleteRequestsTable) loop() {
 				level.Error(util_log.Logger).Log("msg", "failed to upload delete requests file", "err", err)
 			}
 		case <-t.done:
-			t.wg.Done()
 			return
 		}
 	}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
@@ -1,0 +1,180 @@
+package deletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"go.etcd.io/bbolt"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/local"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+
+	"github.com/grafana/loki/pkg/chunkenc"
+	shipper_util "github.com/grafana/loki/pkg/storage/stores/shipper/util"
+)
+
+type deleteRequestsTable struct {
+	objectClient chunk.ObjectClient
+	dbPath       string
+
+	boltdbIndexClient *local.BoltIndexClient
+	db                *bbolt.DB
+	done              chan struct{}
+}
+
+const objectPathInStorage = deleteRequestsTableName + "/" + deleteRequestsTableName + ".gz"
+
+func newDeleteRequestsTable(workingDirectory string, objectClient chunk.ObjectClient) (chunk.IndexClient, error) {
+	dbPath := filepath.Join(workingDirectory, deleteRequestsTableName, deleteRequestsTableName)
+	boltdbIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: filepath.Dir(dbPath)})
+	if err != nil {
+		return nil, err
+	}
+
+	table := &deleteRequestsTable{
+		objectClient:      objectClient,
+		dbPath:            dbPath,
+		boltdbIndexClient: boltdbIndexClient,
+	}
+
+	err = table.init()
+	if err != nil {
+		return nil, err
+	}
+
+	go table.loop()
+	return table, nil
+}
+
+func (t *deleteRequestsTable) init() error {
+	tempFilePath := fmt.Sprintf("%s.%s", t.dbPath, tempFileSuffix)
+
+	if err := os.Remove(tempFilePath); err != nil {
+		level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to remove temp file %s", tempFilePath), "err", err)
+	}
+
+	_, err := os.Stat(t.dbPath)
+	if err != nil {
+		err = shipper_util.GetFileFromStorage(context.Background(), t.objectClient, objectPathInStorage, t.dbPath)
+		if err != nil && !errors.Is(err, chunk.ErrStorageObjectNotFound) {
+			return err
+		}
+	}
+
+	t.db, err = shipper_util.SafeOpenBoltdbFile(t.dbPath)
+	return err
+}
+
+func (t *deleteRequestsTable) loop() {
+	uploadTicker := time.NewTicker(5 * time.Minute)
+	defer uploadTicker.Stop()
+
+	for {
+		select {
+		case <-uploadTicker.C:
+			if err := t.uploadFile(); err != nil {
+				level.Error(util_log.Logger).Log("msg", "failed to upload delete requests file", "err", err)
+			}
+		case <-t.done:
+			return
+		}
+	}
+}
+
+func (t *deleteRequestsTable) uploadFile() error {
+	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("uploading delete requests db"))
+
+	tempFilePath := fmt.Sprintf("%s.%s", t.dbPath, tempFileSuffix)
+	f, err := os.Create(tempFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close temp file", "path", tempFilePath, "err", err)
+		}
+
+		if err := os.Remove(tempFilePath); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to remove temp file", "path", tempFilePath, "err", err)
+		}
+	}()
+
+	err = t.db.View(func(tx *bbolt.Tx) (err error) {
+		compressedWriter := chunkenc.Gzip.GetWriter(f)
+		defer chunkenc.Gzip.PutWriter(compressedWriter)
+
+		defer func() {
+			cerr := compressedWriter.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		_, err = tx.WriteTo(compressedWriter)
+		return
+	})
+	if err != nil {
+		return err
+	}
+
+	// flush the file to disk and seek the file to the beginning.
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	if _, err := f.Seek(0, 0); err != nil {
+		return err
+	}
+
+	return t.objectClient.PutObject(context.Background(), objectPathInStorage, f)
+}
+
+func (t *deleteRequestsTable) Stop() {
+	close(t.done)
+
+	if err := t.uploadFile(); err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to upload delete requests file during shutdown", "err", err)
+	}
+
+	if err := t.db.Close(); err != nil {
+		level.Error(util_log.Logger).Log("msg", "failed to close delete requests db", "err", err)
+	}
+
+	t.boltdbIndexClient.Stop()
+}
+
+func (t *deleteRequestsTable) NewWriteBatch() chunk.WriteBatch {
+	return t.boltdbIndexClient.NewWriteBatch()
+}
+
+func (t *deleteRequestsTable) BatchWrite(ctx context.Context, batch chunk.WriteBatch) error {
+	boltWriteBatch, ok := batch.(*local.BoltWriteBatch)
+	if !ok {
+		return errors.New("invalid write batch")
+	}
+
+	for _, tableWrites := range boltWriteBatch.Writes {
+		if err := t.boltdbIndexClient.WriteToDB(ctx, t.db, tableWrites); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *deleteRequestsTable) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error {
+	for _, query := range queries {
+		if err := t.boltdbIndexClient.QueryDB(ctx, t.db, query, callback); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
@@ -1,0 +1,108 @@
+package deletion
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/local"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
+)
+
+func TestDeleteRequestsTable(t *testing.T) {
+	// build test table
+	tempDir, err := ioutil.TempDir("", "test-delete-requests-table")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	workingDir := filepath.Join(tempDir, "working-dir")
+	objectStorePath := filepath.Join(tempDir, "object-store")
+
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: objectStorePath,
+	})
+	require.NoError(t, err)
+	indexClient, err := newDeleteRequestsTable(workingDir, objectClient)
+	require.NoError(t, err)
+
+	// see if delete requests db was created
+	testDeleteRequestsTable := indexClient.(*deleteRequestsTable)
+	require.NotEmpty(t, testDeleteRequestsTable.dbPath)
+	require.FileExists(t, testDeleteRequestsTable.dbPath)
+
+	// add some records to the db
+	batch := testDeleteRequestsTable.NewWriteBatch()
+	testutil.AddRecordsToBatch(batch, deleteRequestsTableName, 0, 10)
+	require.NoError(t, testDeleteRequestsTable.BatchWrite(context.Background(), batch))
+
+	// see if right records were written
+	testutil.TestSingleDBQuery(t, chunk.IndexQuery{}, testDeleteRequestsTable.db, testDeleteRequestsTable.boltdbIndexClient, 0, 10)
+
+	// upload the file to the storage
+	require.NoError(t, testDeleteRequestsTable.uploadFile())
+	storageFilePath := filepath.Join(objectStorePath, objectPathInStorage)
+	require.FileExists(t, storageFilePath)
+
+	// validate records in the storage db
+	checkRecordsInStorage(t, storageFilePath, 0, 10)
+
+	// add more records to the db
+	testutil.AddRecordsToBatch(batch, deleteRequestsTableName, 10, 10)
+	require.NoError(t, testDeleteRequestsTable.BatchWrite(context.Background(), batch))
+
+	// stop the table which should upload the db to storage
+	testDeleteRequestsTable.Stop()
+
+	// see if the storage db got the new records
+	checkRecordsInStorage(t, storageFilePath, 0, 20)
+
+	// remove local db
+	require.NoError(t, os.Remove(testDeleteRequestsTable.dbPath))
+	require.NoError(t, err)
+
+	// re-create table to see if the db gets downloaded locally since it does not exist anymore
+	indexClient, err = newDeleteRequestsTable(workingDir, objectClient)
+	require.NoError(t, err)
+	defer indexClient.Stop()
+
+	testDeleteRequestsTable = indexClient.(*deleteRequestsTable)
+	require.NotEmpty(t, testDeleteRequestsTable.dbPath)
+
+	// validate records in local db
+	testutil.TestSingleDBQuery(t, chunk.IndexQuery{}, testDeleteRequestsTable.db, testDeleteRequestsTable.boltdbIndexClient, 0, 20)
+}
+
+func checkRecordsInStorage(t *testing.T, storageFilePath string, start, numRecords int) {
+	tempDir, err := ioutil.TempDir("", "compare-delete-requests-db")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+	tempFilePath := filepath.Join(tempDir, deleteRequestsTableName)
+	require.NoError(t, err)
+	testutil.DecompressFile(t, storageFilePath, tempFilePath)
+
+	tempDB, err := util.SafeOpenBoltdbFile(tempFilePath)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, tempDB.Close())
+	}()
+
+	boltdbIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: tempDir})
+	require.NoError(t, err)
+
+	defer boltdbIndexClient.Stop()
+
+	testutil.TestSingleDBQuery(t, chunk.IndexQuery{}, tempDB, boltdbIndexClient, start, numRecords)
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/metrics.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/metrics.go
@@ -1,0 +1,62 @@
+package deletion
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type deleteRequestHandlerMetrics struct {
+	deleteRequestsReceivedTotal *prometheus.CounterVec
+}
+
+func newDeleteRequestHandlerMetrics(r prometheus.Registerer) *deleteRequestHandlerMetrics {
+	m := deleteRequestHandlerMetrics{}
+
+	m.deleteRequestsReceivedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "compactor_delete_requests_received_total",
+		Help:      "Number of delete requests received per user",
+	}, []string{"user"})
+
+	return &m
+}
+
+type deleteRequestsManagerMetrics struct {
+	deleteRequestsProcessedTotal         *prometheus.CounterVec
+	deleteRequestsChunksSelectedTotal    *prometheus.CounterVec
+	loadPendingRequestsAttemptsTotal     *prometheus.CounterVec
+	oldestPendingDeleteRequestAgeSeconds prometheus.Gauge
+	pendingDeleteRequestsCount           prometheus.Gauge
+}
+
+func newDeleteRequestsManagerMetrics(r prometheus.Registerer) *deleteRequestsManagerMetrics {
+	m := deleteRequestsManagerMetrics{}
+
+	m.deleteRequestsProcessedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "compactor_delete_requests_processed_total",
+		Help:      "Number of delete requests processed per user",
+	}, []string{"user"})
+	m.deleteRequestsChunksSelectedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "compactor_delete_requests_chunks_selected_total",
+		Help:      "Number of chunks selected while building delete plans per user",
+	}, []string{"user"})
+	m.loadPendingRequestsAttemptsTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "compactor_load_pending_requests_attempts_total",
+		Help:      "Number of attempts that were made to load pending requests with status",
+	}, []string{"status"})
+	m.oldestPendingDeleteRequestAgeSeconds = promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Namespace: "loki",
+		Name:      "compactor_oldest_pending_delete_request_age_seconds",
+		Help:      "Age of oldest pending delete request in seconds, since they are over their cancellation period",
+	})
+	m.pendingDeleteRequestsCount = promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Namespace: "loki",
+		Name:      "compactor_pending_delete_requests_count",
+		Help:      "Count of delete requests which are over their cancellation period and have not finished processing yet",
+	})
+
+	return &m
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -16,22 +15,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
-
-type deleteRequestHandlerMetrics struct {
-	deleteRequestsReceivedTotal *prometheus.CounterVec
-}
-
-func newDeleteRequestHandlerMetrics(r prometheus.Registerer) *deleteRequestHandlerMetrics {
-	m := deleteRequestHandlerMetrics{}
-
-	m.deleteRequestsReceivedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-		Namespace: "cortex",
-		Name:      "purger_delete_requests_received_total",
-		Help:      "Number of delete requests received per user",
-	}, []string{"user"})
-
-	return &m
-}
 
 // DeleteRequestHandler provides handlers for delete requests
 type DeleteRequestHandler struct {

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
@@ -1,0 +1,182 @@
+package deletion
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/cortexproject/cortex/pkg/tenant"
+	"github.com/cortexproject/cortex/pkg/util"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+)
+
+type deleteRequestHandlerMetrics struct {
+	deleteRequestsReceivedTotal *prometheus.CounterVec
+}
+
+func newDeleteRequestHandlerMetrics(r prometheus.Registerer) *deleteRequestHandlerMetrics {
+	m := deleteRequestHandlerMetrics{}
+
+	m.deleteRequestsReceivedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cortex",
+		Name:      "purger_delete_requests_received_total",
+		Help:      "Number of delete requests received per user",
+	}, []string{"user"})
+
+	return &m
+}
+
+// DeleteRequestHandler provides handlers for delete requests
+type DeleteRequestHandler struct {
+	deleteRequestsStore       *deleteRequestsStore
+	metrics                   *deleteRequestHandlerMetrics
+	deleteRequestCancelPeriod time.Duration
+}
+
+// NewDeleteRequestHandler creates a DeleteRequestHandler
+func NewDeleteRequestHandler(deleteStore *deleteRequestsStore, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
+	deleteMgr := DeleteRequestHandler{
+		deleteRequestsStore:       deleteStore,
+		deleteRequestCancelPeriod: deleteRequestCancelPeriod,
+		metrics:                   newDeleteRequestHandlerMetrics(registerer),
+	}
+
+	return &deleteMgr
+}
+
+// AddDeleteRequestHandler handles addition of new delete request
+func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	params := r.URL.Query()
+	match := params["match[]"]
+	if len(match) == 0 {
+		http.Error(w, "selectors not set", http.StatusBadRequest)
+		return
+	}
+
+	for i := range match {
+		_, err := parser.ParseMetricSelector(match[i])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	startParam := params.Get("start")
+	startTime := int64(0)
+	if startParam != "" {
+		startTime, err = util.ParseTime(startParam)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	endParam := params.Get("end")
+	endTime := int64(model.Now())
+
+	if endParam != "" {
+		endTime, err = util.ParseTime(endParam)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if endTime > int64(model.Now()) {
+			http.Error(w, "deletes in future not allowed", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if startTime > endTime {
+		http.Error(w, "start time can't be greater than end time", http.StatusBadRequest)
+		return
+	}
+
+	if err := dm.deleteRequestsStore.AddDeleteRequest(ctx, userID, model.Time(startTime), model.Time(endTime), match); err != nil {
+		level.Error(util_log.Logger).Log("msg", "error adding delete request to the store", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	dm.metrics.deleteRequestsReceivedTotal.WithLabelValues(userID).Inc()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetAllDeleteRequestsHandler handles get all delete requests
+func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	deleteRequests, err := dm.deleteRequestsStore.GetAllDeleteRequestsForUser(ctx, userID)
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "error getting delete requests from the store", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(deleteRequests); err != nil {
+		level.Error(util_log.Logger).Log("msg", "error marshalling response", "err", err)
+		http.Error(w, fmt.Sprintf("Error marshalling response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// CancelDeleteRequestHandler handles delete request cancellation
+func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	params := r.URL.Query()
+	requestID := params.Get("request_id")
+
+	deleteRequest, err := dm.deleteRequestsStore.GetDeleteRequest(ctx, userID, requestID)
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "error getting delete request from the store", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if deleteRequest == nil {
+		http.Error(w, "could not find delete request with given id", http.StatusBadRequest)
+		return
+	}
+
+	if deleteRequest.Status != StatusReceived {
+		http.Error(w, "deletion of request which is in process or already processed is not allowed", http.StatusBadRequest)
+		return
+	}
+
+	if deleteRequest.CreatedAt.Add(dm.deleteRequestCancelPeriod).Before(model.Now()) {
+		http.Error(w, fmt.Sprintf("deletion of request past the deadline of %s since its creation is not allowed", dm.deleteRequestCancelPeriod.String()), http.StatusBadRequest)
+		return
+	}
+
+	if err := dm.deleteRequestsStore.RemoveDeleteRequest(ctx, userID, requestID, deleteRequest.CreatedAt, deleteRequest.StartTime, deleteRequest.EndTime); err != nil {
+		level.Error(util_log.Logger).Log("msg", "error cancelling the delete request", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
@@ -35,13 +35,13 @@ func newDeleteRequestHandlerMetrics(r prometheus.Registerer) *deleteRequestHandl
 
 // DeleteRequestHandler provides handlers for delete requests
 type DeleteRequestHandler struct {
-	deleteRequestsStore       *deleteRequestsStore
+	deleteRequestsStore       DeleteRequestsStore
 	metrics                   *deleteRequestHandlerMetrics
 	deleteRequestCancelPeriod time.Duration
 }
 
 // NewDeleteRequestHandler creates a DeleteRequestHandler
-func NewDeleteRequestHandler(deleteStore *deleteRequestsStore, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
+func NewDeleteRequestHandler(deleteStore DeleteRequestsStore, deleteRequestCancelPeriod time.Duration, registerer prometheus.Registerer) *DeleteRequestHandler {
 	deleteMgr := DeleteRequestHandler{
 		deleteRequestsStore:       deleteStore,
 		deleteRequestCancelPeriod: deleteRequestCancelPeriod,

--- a/pkg/storage/stores/shipper/compactor/retention/expiration.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ExpirationChecker interface {
-	Expired(ref ChunkEntry, now model.Time) bool
+	Expired(ref ChunkEntry, now model.Time) (bool, []model.Interval)
 }
 
 type expirationChecker struct {
@@ -28,7 +28,7 @@ func NewExpirationChecker(limits Limits) ExpirationChecker {
 }
 
 // Expired tells if a ref chunk is expired based on retention rules.
-func (e *expirationChecker) Expired(ref ChunkEntry, now model.Time) bool {
+func (e *expirationChecker) Expired(ref ChunkEntry, now model.Time) (bool, []model.Interval) {
 	userID := unsafeGetString(ref.UserID)
 	streamRetentions := e.limits.StreamRetention(userID)
 	globalRetention := e.limits.RetentionPeriod(userID)
@@ -58,7 +58,7 @@ Outer:
 		matchedRule = streamRetention
 	}
 	if found {
-		return now.Sub(ref.Through) > time.Duration(matchedRule.Period)
+		return now.Sub(ref.Through) > time.Duration(matchedRule.Period), nil
 	}
-	return now.Sub(ref.Through) > globalRetention
+	return now.Sub(ref.Through) > globalRetention, nil
 }

--- a/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
@@ -55,7 +55,9 @@ func Test_expirationChecker_Expired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, e.Expired(tt.ref, model.Now()))
+			actual, nonDeletedIntervals := e.Expired(tt.ref, model.Now())
+			require.Equal(t, tt.want, actual)
+			require.Nil(t, nonDeletedIntervals)
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -175,7 +175,7 @@ func markforDelete(ctx context.Context, marker MarkerStorageWriter, chunkIt Chun
 }
 
 type ChunkClient interface {
-	DeleteChunk(ctx context.Context, userId, chunkId string) error
+	DeleteChunk(ctx context.Context, userID, chunkID string) error
 }
 
 type Sweeper struct {
@@ -205,12 +205,12 @@ func (s *Sweeper) Start() {
 			s.sweeperMetrics.deleteChunkDurationSeconds.WithLabelValues(status).Observe(time.Since(start).Seconds())
 		}()
 		chunkIDString := unsafeGetString(chunkId)
-		userId, err := getUserIdFromChunkId(chunkIDString)
+		userID, err := getUserIDFromChunkID(chunkIDString)
 		if err != nil {
 			return err
 		}
 
-		err = s.chunkClient.DeleteChunk(ctx, userId, chunkIDString)
+		err = s.chunkClient.DeleteChunk(ctx, userID, chunkIDString)
 		if err == chunk.ErrStorageObjectNotFound {
 			status = statusNotFound
 			level.Debug(util_log.Logger).Log("msg", "delete on not found chunk", "chunkID", chunkIDString)
@@ -224,10 +224,10 @@ func (s *Sweeper) Start() {
 	})
 }
 
-func getUserIdFromChunkId(chunkId string) (string, error) {
-	parts := strings.Split(chunkId, "/")
+func getUserIDFromChunkID(chunkID string) (string, error) {
+	parts := strings.Split(chunkID, "/")
 	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid chunk ID %q", chunkId)
+		return "", fmt.Errorf("invalid chunk ID %q", chunkID)
 	}
 
 	return parts[0], nil
@@ -238,11 +238,9 @@ func (s *Sweeper) Stop() {
 }
 
 type chunkRewriter struct {
-	chunkFetcher *chunk.Fetcher
-	chunkClient  chunk.Client
-	schemaCfg    chunk.PeriodConfig
-	tableName    string
-	bucket       *bbolt.Bucket
+	chunkClient chunk.Client
+	tableName   string
+	bucket      *bbolt.Bucket
 
 	seriesStoreSchema chunk.SeriesStoreSchema
 }

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -225,7 +225,7 @@ func (s *Sweeper) Start() {
 }
 
 func getUserIDFromChunkID(chunkID []byte) ([]byte, error) {
-	idx := bytes.Index(chunkID, []byte("/"))
+	idx := bytes.IndexByte(chunkID, '/')
 	if idx <= 0 {
 		return nil, fmt.Errorf("invalid chunk ID %q", chunkID)
 	}

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -31,11 +31,11 @@ type mockChunkClient struct {
 	deletedChunks []string
 }
 
-func (m *mockChunkClient) DeleteChunk(_ context.Context, _, chunkId string) error {
+func (m *mockChunkClient) DeleteChunk(_ context.Context, _, chunkID string) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	m.deletedChunks = append(m.deletedChunks, string([]byte(chunkId))) // forces a copy, because this string is only valid within the delete fn.
+	m.deletedChunks = append(m.deletedChunks, string([]byte(chunkID))) // forces a copy, because this string is only valid within the delete fn.
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/objectclient"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -124,7 +125,7 @@ func Test_Retention(t *testing.T) {
 			sweep.Start()
 			defer sweep.Stop()
 
-			marker, err := NewMarker(workDir, store.schemaCfg, expiration, prometheus.NewRegistry())
+			marker, err := NewMarker(workDir, store.schemaCfg, expiration, nil, prometheus.NewRegistry())
 			require.NoError(t, err)
 			for _, table := range store.indexTables() {
 				_, _, err := marker.MarkForDelete(context.Background(), table.name, table.DB)
@@ -182,7 +183,8 @@ func Test_EmptyTable(t *testing.T) {
 	err := tables[0].DB.Update(func(tx *bbolt.Tx) error {
 		it, err := newChunkIndexIterator(tx.Bucket(bucketName), schema.config)
 		require.NoError(t, err)
-		empty, err := markforDelete(context.Background(), noopWriter{}, it, noopCleaner{}, NewExpirationChecker(&fakeLimits{perTenant: map[string]time.Duration{"1": 0, "2": 0}}))
+		empty, err := markforDelete(context.Background(), noopWriter{}, it, noopCleaner{},
+			NewExpirationChecker(&fakeLimits{perTenant: map[string]time.Duration{"1": 0, "2": 0}}), nil)
 		require.NoError(t, err)
 		require.True(t, empty)
 		return nil

--- a/pkg/storage/stores/shipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util_test.go
@@ -169,6 +169,19 @@ func (t *testStore) HasChunk(c chunk.Chunk) bool {
 	return len(chunks) == 1 && c.ExternalKey() == chunks[0].ExternalKey()
 }
 
+func (t *testStore) GetChunks(userID string, from, through model.Time, metric labels.Labels) []chunk.Chunk {
+	t.t.Helper()
+	var matchers []*labels.Matcher
+	for _, l := range metric {
+		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
+	}
+	chunks, err := t.Store.Get(user.InjectOrgID(context.Background(), userID),
+		userID, from, through, matchers...)
+	require.NoError(t.t, err)
+
+	return chunks
+}
+
 func (t *testStore) open() {
 	chunkStore, err := cortex_storage.NewStore(
 		t.cfg.Config,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR leverages existing code for retention to support deletion for `boltdb-shipper`.
It relies on the Mark phase of retention which now also looks at eligible delete requests by talking to `DeleteRequestsManager` to decide whether the chunk is supposed to be deleted or not. For partially deleted chunks I have added a chunk rewriter which would build chunks for the interval for which they are not deleted and writes them to the store. A successful Mark process over all the tables considers delete requests as processed and the relevant chunk should be deleted later by the Sweep process.

The delete requests are persisted in a table called `delete_requests` which is a boltdb file. The file is uploaded to the object store every 5 mins or during shutdown and is downloaded locally if it does not exist during startup.

Here is how deletion would roughly work:
1. Call `MarkPhaseStarted` of `DeleteRequestsManager` before starting the compaction which would load eligible delete requests in memory.
2. Each Mark phase of the table would check if one or more delete requests deletes the chunks in it and take care of deleting the chunk index and rewriting it if it was partially deleted.
3. Call `MarkPhaseFinished` after successful compaction of all the tables which would mark the in-memory requests as processed.
4. Call `MarkPhaseFailed` if any of the tables fails to compact which would just drop requests from memory.


**Checklist**
- [ ] Documentation added
- [x] Tests updated

