### PR TITLE
Removes file sync syscall for compaction.

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -203,6 +203,8 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 	if err != nil {
 		return err
 	}
+	// we don't need to force sync to file, we just view the file.
+	dbView.NoSync = true
 	defer func() {
 		if err := dbView.Close(); err != nil {
 			level.Warn(util_log.Logger).Log("msg", "failed to close db view", "err", err)
@@ -212,6 +214,7 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 	if err != nil {
 		return err
 	}
+	dbUpdate.MaxBatchDelay = 1 * time.Second // 1 s is way enough for saving changes, worst case this operation is idempotent.
 	defer func() {
 		close(queue)
 		wg.Wait()

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -307,7 +307,6 @@ func (t *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, ca
 
 			return nil
 		})
-
 		if err != nil {
 			return err
 		}
@@ -453,7 +452,7 @@ func (t *Table) downloadFile(ctx context.Context, storageObject chunk.StorageObj
 	folderPath, _ := t.folderPathForTable(false)
 	filePath := path.Join(folderPath, dbName)
 
-	err = shipper_util.GetFileFromStorage(ctx, t.storageClient, storageObject.Key, filePath)
+	err = shipper_util.GetFileFromStorage(ctx, t.storageClient, storageObject.Key, filePath, true)
 	if err != nil {
 		return err
 	}
@@ -528,7 +527,7 @@ func (t *Table) doParallelDownload(ctx context.Context, objects []chunk.StorageO
 				}
 
 				filePath := path.Join(folderPathForTable, dbName)
-				err = shipper_util.GetFileFromStorage(ctx, t.storageClient, object.Key, filePath)
+				err = shipper_util.GetFileFromStorage(ctx, t.storageClient, object.Key, filePath, true)
 				if err != nil {
 					break
 				}
@@ -546,7 +545,6 @@ func (t *Table) doParallelDownload(ctx context.Context, objects []chunk.StorageO
 			case <-ctx.Done():
 				break
 			}
-
 		}
 		close(queue)
 	}()

--- a/pkg/storage/stores/shipper/util/util_test.go
+++ b/pkg/storage/stores/shipper/util/util_test.go
@@ -31,7 +31,7 @@ func Test_GetFileFromStorage(t *testing.T) {
 	objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: tempDir})
 	require.NoError(t, err)
 
-	require.NoError(t, GetFileFromStorage(context.Background(), objectClient, "src", filepath.Join(tempDir, "dest")))
+	require.NoError(t, GetFileFromStorage(context.Background(), objectClient, "src", filepath.Join(tempDir, "dest"), false))
 
 	// verify the contents of the downloaded file.
 	b, err := ioutil.ReadFile(filepath.Join(tempDir, "dest"))
@@ -40,11 +40,11 @@ func Test_GetFileFromStorage(t *testing.T) {
 	require.Equal(t, testData, b)
 
 	// compress the file in storage
-	err = CompressFile(filepath.Join(tempDir, "src"), filepath.Join(tempDir, "src.gz"))
+	err = CompressFile(filepath.Join(tempDir, "src"), filepath.Join(tempDir, "src.gz"), true)
 	require.NoError(t, err)
 
 	// get the compressed file from storage
-	require.NoError(t, GetFileFromStorage(context.Background(), objectClient, "src.gz", filepath.Join(tempDir, "dest.gz")))
+	require.NoError(t, GetFileFromStorage(context.Background(), objectClient, "src.gz", filepath.Join(tempDir, "dest.gz"), false))
 
 	// verify the contents of the downloaded gz file.
 	b, err = ioutil.ReadFile(filepath.Join(tempDir, "dest.gz"))
@@ -69,7 +69,7 @@ func Test_CompressFile(t *testing.T) {
 
 	require.NoError(t, ioutil.WriteFile(uncompressedFilePath, testData, 0666))
 
-	require.NoError(t, CompressFile(uncompressedFilePath, compressedFilePath))
+	require.NoError(t, CompressFile(uncompressedFilePath, compressedFilePath, true))
 	require.FileExists(t, compressedFilePath)
 
 	testutil.DecompressFile(t, compressedFilePath, decompressedFilePath)


### PR DESCRIPTION
Because we mostly download, read and upload but also  because all those operations are idempotent we don't
need to try to outsmart the OS by forcefully syncing the file to disk. The OS will use cache on files and we'll most likely not suffer from high disk io.

This was a conclusion I made after some digging of why the operation of compaction+retention was a bit slow sometimes. (+5s)

I've tried the PR in dev and the whole process execute now below 40s whereas because it was 4min.

strace before:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 75.75   12.333637        2122      5812       561 futex
 10.81    1.760698         242      7267           nanosleep
  7.69    1.252697          88     14287           epoll_pwait
  2.86    0.464888          22     21608           write
  1.08    0.175313       19479         9           fsync                <----------
  1.06    0.172173          15     11249      4334 read
  0.40    0.064422        2147        30        15 unlinkat
  0.15    0.023945          19      1246           madvise
  0.09    0.015288        1529        10           munmap
  0.04    0.006098          23       263           tgkill
  0.03    0.004134          16       263           getpid
```

strace after:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 77.01   58.085485        4599     12631       840 futex
  9.81    7.395901         230     32145           nanosleep
  8.34    6.287953         175     35882           epoll_pwait
  3.33    2.512512          18    141141           write
  0.79    0.596351          16     37911     13536 read
  0.51    0.382579        3985        96        48 unlinkat
  0.08    0.058465        1720        34           munmap
  0.04    0.031904          26      1219           tgkill
  0.03    0.023962          22      1082           madvise
  0.02    0.013831          11      1219           getpid
  0.01    0.011042           9      1219        12 rt_sigreturn
  0.01    0.005348         111        48           fdatasync
  0.01    0.003785          36       105           openat
  0.00    0.003603           8       435           pwrite64
  0.00    0.003005          13       229       200 epoll_ctl
  0.00    0.001828          19        96        34 newfstatat
```

As you can see the fsync and write are less intensive after.

![image](https://user-images.githubusercontent.com/1053421/117272755-826ce980-ae29-11eb-8093-bcac863bf972.png)


I did not changed the write and read path though, I did not investigate if this was needed.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
