### PR TITLE
better operational dashboard annotations via diff logger

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -13,7 +13,7 @@
       {
         "datasource": "$logs",
         "enable": true,
-        "expr": "{cluster=\"$cluster\", diff_namespace=\"$namespace\", container=\"kube-diff-logger\"}",
+        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"$namespace\"",
         "hide": true,
         "iconColor": "rgba(255, 96, 96, 1)",
         "name": "deployments",


### PR DESCRIPTION
This moves away from bad practice custom diff logger promtail configs that created too many streams and should work with a reasonably default config.