### PR TITLE
Improve retention mark files.

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -269,7 +269,7 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 			defer wg.Done()
 			for key := range queue {
 				if err := processKey(r.ctx, key, dbUpdate, deleteFunc); err != nil {
-					level.Warn(util_log.Logger).Log("msg", "failed to delete key", "key", key.value.String(), "value", key.value.String(), "err", err)
+					level.Warn(util_log.Logger).Log("msg", "failed to delete key", "key", key.key.String(), "value", key.value.String(), "err", err)
 				}
 				putKeyBuffer(key)
 			}

--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -1,8 +1,8 @@
 package retention
 
 import (
-	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -21,7 +21,10 @@ import (
 	shipper_util "github.com/grafana/loki/pkg/storage/stores/shipper/util"
 )
 
-var minListMarkDelay = time.Minute
+var (
+	minListMarkDelay = time.Minute
+	maxMarkPerFile   = int64(100000)
+)
 
 type MarkerStorageWriter interface {
 	Put(chunkID []byte) error
@@ -34,42 +37,90 @@ type markerStorageWriter struct {
 	tx     *bbolt.Tx
 	bucket *bbolt.Bucket
 
-	count    int64
-	fileName string
+	count            int64
+	currentFileCount int64
+	curFileName      string
+	workDir          string
+
+	buf []byte
 }
 
 func NewMarkerStorageWriter(workingDir string) (MarkerStorageWriter, error) {
-	err := chunk_util.EnsureDirectory(filepath.Join(workingDir, markersFolder))
+	dir := filepath.Join(workingDir, markersFolder)
+	err := chunk_util.EnsureDirectory(dir)
 	if err != nil {
 		return nil, err
 	}
-	fileName := filepath.Join(workingDir, markersFolder, fmt.Sprint(time.Now().UnixNano()))
+
+	msw := &markerStorageWriter{
+		workDir:          dir,
+		currentFileCount: 0,
+		buf:              make([]byte, 8),
+	}
+
+	return msw, msw.createFile()
+}
+
+func (m *markerStorageWriter) createFile() error {
+	fileName := filepath.Join(m.workDir, fmt.Sprint(time.Now().UnixNano()))
 	db, err := shipper_util.SafeOpenBoltdbFile(fileName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	tx, err := db.Begin(true)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	bucket, err := tx.CreateBucketIfNotExists(chunkBucket)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return &markerStorageWriter{
-		db:       db,
-		tx:       tx,
-		bucket:   bucket,
-		count:    0,
-		fileName: fileName,
-	}, err
+	level.Info(util_log.Logger).Log("msg", "mark file created", "file", fileName)
+	bucket.FillPercent = 1
+	m.db = db
+	m.tx = tx
+	m.bucket = bucket
+	m.curFileName = fileName
+	m.currentFileCount = 0
+	return nil
+}
+
+func (m *markerStorageWriter) closeFile() error {
+	err := m.tx.Commit()
+	if err != nil {
+		return err
+	}
+	if err := m.db.Close(); err != nil {
+		return err
+	}
+	// The marker file is empty we can remove.
+	if m.currentFileCount == 0 {
+		return os.Remove(m.curFileName)
+	}
+	return nil
 }
 
 func (m *markerStorageWriter) Put(chunkID []byte) error {
-	if err := m.bucket.Put(chunkID, empty); err != nil {
+	if m.currentFileCount > maxMarkPerFile { // roll files when max marks is reached.
+		if err := m.closeFile(); err != nil {
+			return err
+		}
+		if err := m.createFile(); err != nil {
+			return err
+		}
+
+	}
+	// insert in order and fillpercent = 1
+	id, err := m.bucket.NextSequence()
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint64(m.buf, id) // insert in order using sequence id.
+	if err := m.bucket.Put(m.buf, chunkID); err != nil {
 		return err
 	}
 	m.count++
+	m.currentFileCount++
 	return nil
 }
 
@@ -78,17 +129,7 @@ func (m *markerStorageWriter) Count() int64 {
 }
 
 func (m *markerStorageWriter) Close() error {
-	if err := m.tx.Commit(); err != nil {
-		return err
-	}
-	if err := m.db.Close(); err != nil {
-		return err
-	}
-	// The marker file is empty we can remove.
-	if m.count == 0 {
-		return os.Remove(m.fileName)
-	}
-	return nil
+	return m.closeFile()
 }
 
 type MarkerProcessor interface {
@@ -181,7 +222,7 @@ func (r *markerProcessor) Start(deleteFunc func(ctx context.Context, chunkId []b
 func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.Context, chunkId []byte) error) error {
 	var (
 		wg    sync.WaitGroup
-		queue = make(chan *bytes.Buffer)
+		queue = make(chan *keyPair)
 	)
 	// we use a copy to view the file so that we can read and update at the same time.
 	viewFile, err := ioutil.TempFile("/tmp/", "marker-view-")
@@ -228,7 +269,7 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 			defer wg.Done()
 			for key := range queue {
 				if err := processKey(r.ctx, key, dbUpdate, deleteFunc); err != nil {
-					level.Warn(util_log.Logger).Log("msg", "failed to delete key", "key", key.String(), "err", err)
+					level.Warn(util_log.Logger).Log("msg", "failed to delete key", "key", key.value.String(), "value", key.value.String(), "err", err)
 				}
 				putKeyBuffer(key)
 			}
@@ -241,8 +282,8 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 		}
 
 		c := b.Cursor()
-		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			key, err := getKeyBuffer(k)
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			key, err := getKeyPairBuffer(k, v)
 			if err != nil {
 				return err
 			}
@@ -260,9 +301,9 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 	return nil
 }
 
-func processKey(ctx context.Context, key *bytes.Buffer, db *bbolt.DB, deleteFunc func(ctx context.Context, chunkId []byte) error) error {
-	keyData := key.Bytes()
-	if err := deleteFunc(ctx, keyData); err != nil {
+func processKey(ctx context.Context, key *keyPair, db *bbolt.DB, deleteFunc func(ctx context.Context, chunkId []byte) error) error {
+	chunkID := key.value.Bytes()
+	if err := deleteFunc(ctx, chunkID); err != nil {
 		return err
 	}
 	return db.Batch(func(tx *bbolt.Tx) error {
@@ -270,7 +311,7 @@ func processKey(ctx context.Context, key *bytes.Buffer, db *bbolt.DB, deleteFunc
 		if b == nil {
 			return nil
 		}
-		return b.Delete(keyData)
+		return b.Delete(key.key.Bytes())
 	})
 }
 

--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -116,7 +116,11 @@ func (m *markerStorageWriter) Put(chunkID []byte) error {
 		return err
 	}
 	binary.BigEndian.PutUint64(m.buf, id) // insert in order using sequence id.
-	if err := m.bucket.Put(m.buf, chunkID); err != nil {
+	// boltdb requires a the value to be valid for the whole tx.
+	// so we make a copy.
+	value := make([]byte, len(chunkID))
+	copy(value, chunkID)
+	if err := m.bucket.Put(m.buf, value); err != nil {
 		return err
 	}
 	m.count++

--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -116,7 +116,7 @@ func (m *markerStorageWriter) Put(chunkID []byte) error {
 		return err
 	}
 	binary.BigEndian.PutUint64(m.buf, id) // insert in order using sequence id.
-	// boltdb requires a the value to be valid for the whole tx.
+	// boltdb requires the value to be valid for the whole tx.
 	// so we make a copy.
 	value := make([]byte, len(chunkID))
 	copy(value, chunkID)

--- a/pkg/storage/stores/shipper/compactor/retention/marker_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker_test.go
@@ -160,3 +160,21 @@ func Test_markerProcessor_availablePath(t *testing.T) {
 		})
 	}
 }
+
+func Test_MarkFileRotation(t *testing.T) {
+	dir := t.TempDir()
+	p, err := newMarkerStorageReader(dir, 150, 0, sweepMetrics)
+	require.NoError(t, err)
+	w, err := NewMarkerStorageWriter(dir)
+	require.NoError(t, err)
+	totalMarks := int64(2 * int(maxMarkPerFile))
+	for i := int64(0); i < totalMarks; i++ {
+		require.NoError(t, w.Put([]byte(fmt.Sprintf("%d", i))))
+	}
+	require.NoError(t, w.Close())
+	paths, _, err := p.availablePath()
+	require.NoError(t, err)
+
+	require.Len(t, paths, 2)
+	require.Equal(t, totalMarks, w.Count())
+}

--- a/pkg/storage/stores/shipper/compactor/retention/pool.go
+++ b/pkg/storage/stores/shipper/compactor/retention/pool.go
@@ -20,7 +20,7 @@ var (
 	keyPool = sync.Pool{
 		New: func() interface{} {
 			return &keyPair{
-				key:   bytes.NewBuffer(make([]byte, 0, 512)),
+				key:   bytes.NewBuffer(make([]byte, 0, 8)),
 				value: bytes.NewBuffer(make([]byte, 0, 512)),
 			}
 		},

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -21,7 +21,6 @@ import (
 var (
 	bucketName  = []byte("index")
 	chunkBucket = []byte("chunks")
-	empty       = []byte("-")
 )
 
 const (


### PR DESCRIPTION
This PR is two fold:

1) Rotate mark files when they reached 100k marks, this is to ensure we max out marks file
and don't create file that may be too big.

2) Instead of inserting marks using the chunk id as the key, we insert using a natural sequence.
This has two benefits:
- Keys are ordered, and so insertion are faster.
- Allows us to use boltdb fill percent to 100%, this means boltdb won't over allocate for inserting key in between unordered data.

Why ?

I realize that when inserting huge amount of marks, this operation can take up to hours since boltdb has to re-allocate pages over and over.
This is mainly because chunkid arrive without  specific order.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
