### PR TITLE
Deploy loki with Drone plugin instead of CircleCI job

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -873,15 +873,29 @@ platform:
   arch: amd64
 
 steps:
-- name: trigger
-  image: grafana/loki-build-image:0.13.0
+- name: image-tag
+  image: alpine
   commands:
-  - ./tools/deploy.sh
-  environment:
-    CIRCLE_TOKEN:
-      from_secret: circle_token
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  - echo $(./tools/image-tag) > .tag
   depends_on:
   - clone
+
+- name: trigger
+  image: us.gcr.io/kubernetes-dev/drone/plugins/deploy-image
+  settings:
+    docker_tag_file: .tag
+    github_token:
+      from_secret: github_token
+    images_json:
+      from_secret: deploy_config
+  depends_on:
+  - clone
+  - image-tag
+
+image_pull_secrets:
+- dockerconfigjson
 
 trigger:
   ref:
@@ -906,5 +920,45 @@ steps:
   image: golang:windowsservercore-1809
   commands:
   - go test .\clients\pkg\promtail\targets\windows\... -v
+
+---
+kind: secret
+name: github_token
+
+get:
+  path: infra/data/ci/github/grafanabot
+  name: pat
+
+---
+kind: secret
+name: dockerconfigjson
+
+get:
+  path: secret/data/common/gcr
+  name: .dockerconfigjson
+
+---
+kind: secret
+name: docker_username
+
+get:
+  path: infra/data/ci/docker_hub
+  name: username
+
+---
+kind: secret
+name: docker_password
+
+get:
+  path: infra/data/ci/docker_hub
+  name: password
+
+---
+kind: secret
+name: deploy_config
+
+get:
+  path: infra/data/ci/loki/deploy
+  name: config.json
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ endif
 #############
 
 DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
-IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,$(shell basename $(dir))))
 
 # Certain aspects of the build are done in containers for consistency (e.g. yacc/protobuf generation)
 # If you have the correct tools installed and you want to speed up development you can run
@@ -450,12 +449,6 @@ push-bigtable-backup: bigtable-backup
 ##########
 
 images: promtail-image loki-image loki-canary-image docker-driver fluent-bit-image fluentd-image
-
-print-images:
-	$(info $(patsubst %,%:$(IMAGE_TAG),$(IMAGE_NAMES)))
-	@echo > /dev/null
-
-IMAGE_NAMES := grafana/loki grafana/promtail grafana/loki-canary
 
 # push(app, optional tag)
 # pushes the app, optionally tagging it differently before

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-curl -s --header "Content-Type: application/json" \
-  --data "{\"build_parameters\":{\"CIRCLE_JOB\": \"deploy-loki\", \"IMAGE_NAMES\": \"$(make print-images)\"}}" \
-  --request POST \
-  https://circleci.com/api/v1.1/project/github/grafana/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN


### PR DESCRIPTION
We are deprecating the CircleCI job
Also, moved secrets to Vault instead of Drone

Note that this will require Flux in all environments that are updated

Issue: grafana/deployment_tools#5307
