### PR TITLE
Fixes docker driver that would panic when closed.

### DIFF
--- a/clients/cmd/docker-driver/loki_test.go
+++ b/clients/cmd/docker-driver/loki_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/docker/docker/daemon/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_loki_LogWhenClosed(t *testing.T) {
+	l, err := New(logger.Info{
+		Config: map[string]string{
+			"loki-url": "http://localhost:3000",
+		},
+	}, util_log.Logger)
+	require.Nil(t, err)
+	msg := logger.NewMessage()
+	msg.Line = []byte(`foo`)
+	msg.Timestamp = time.Now()
+	require.Nil(t, l.Log(msg))
+	require.Nil(t, l.Close())
+	require.NotNil(t, l.Log(msg))
+}


### PR DESCRIPTION
This is happening because it can still received log, but the client might be already closed.

Fixes #3705

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
