### PR TITLE
Add a target to find dead links in our documentation.

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -12,28 +12,28 @@ workspace:
 
 steps:
 - name: test
-  image: grafana/loki-build-image:0.13.0
+  image: grafana/loki-build-image:0.14.0
   commands:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
 
 - name: lint
-  image: grafana/loki-build-image:0.13.0
+  image: grafana/loki-build-image:0.14.0
   commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
 
 - name: check-generated-files
-  image: grafana/loki-build-image:0.13.0
+  image: grafana/loki-build-image:0.14.0
   commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
 
 - name: check-mod
-  image: grafana/loki-build-image:0.13.0
+  image: grafana/loki-build-image:0.14.0
   commands:
   - make BUILD_IN_CONTAINER=false check-mod
   depends_on:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,98 @@
+###
+### Display
+###
+# Verbose program output
+verbose = false
+
+# Show progress
+progress = false
+
+
+###
+### Runtime
+###
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+#threads = 2
+
+# Maximum number of allowed redirects
+max_redirects = 10
+
+
+###
+### Requests
+###
+# User agent to send with each request
+user_agent = "curl/7.71.1"
+
+# Website timeout from connect to response finished
+timeout = 9
+
+# Comma-separated list of accepted status codes for valid links.
+# Omit to accept all response types.
+#accept = "text/html"
+
+# Proceed for server connections considered insecure (invalid TLS)
+insecure = true
+
+# Only test links with the given scheme (e.g. https)
+# Omit to check links with any scheme
+#scheme = "https"
+
+# Request method
+method = "get"
+
+# Custom request headers
+headers = []
+
+
+###
+### Exclusions
+###
+# Exclude URLs from checking (supports regex)
+exclude = [
+    # "github", todo github token
+    "file://.*",
+    "host.docker.internal:3100",
+    "fileb://.*",
+    "ec2-user@.*.compute.amazonaws.com",
+    "querier",
+    "loki:3100",
+    "ip_or_hostname_where_loki_run:3100",
+    "dynamodb://.*",
+    "s3://.*",
+    "ec2-13-59-62-37",
+    "promtail.default",
+    "loki_addr:3100",
+    "localhost",
+    "example.com",
+    "HelloAkkaHttpServer",
+    "https://loki/",
+    "http://loki/",
+    "logs-prod-us-central1.grafana.net",
+    "ip_or_hostname_where_loki_runs",
+    "inmemory://",
+    "myloki.domain:3100",
+    "grafana/cortex-rules-action@v0.4.0",
+    "loki.git",
+    "https://github.com/grafana/website",
+    "https://github.com/settings/keys",
+]
+
+include = []
+
+# Exclude all private IPs from checking
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and `exclude_loopback` to true
+exclude_all_private = false
+
+# Exclude private IP address ranges from checking
+exclude_private = false
+
+# Exclude link-local IP address range from checking
+exclude_link_local = false
+
+# Exclude loopback IP address range from checking
+exclude_loopback = true
+
+# Exclude all mail addresses from checking
+exclude_mail = false

--- a/docs/sources/architecture/_index.md
+++ b/docs/sources/architecture/_index.md
@@ -103,7 +103,7 @@ Since all distributors share access to the same hash ring, write requests can be
 sent to any distributor.
 
 To ensure consistent query results, Loki uses
-[Dynamo-style](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf)
+[Dynamo-style](https://www.cs.princeton.edu/courses/archive/fall15/cos518/studpres/dynamo.pdf)
 quorum consistency on reads and writes. This means that the distributor will wait
 for a positive response of at least one half plus one of the ingesters to send
 the sample to before responding to the client that initiated the send.

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1281,7 +1281,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: http://ip_or_hostname_where_loki_runns:3100/loki/api/v1/push
+  - url: http://ip_or_hostname_where_loki_runs:3100/loki/api/v1/push
 
 scrape_configs:
   - job_name: journal

--- a/docs/sources/overview/_index.md
+++ b/docs/sources/overview/_index.md
@@ -62,7 +62,7 @@ Since all distributors share access to the same hash ring, write requests can be
 sent to any distributor.
 
 To ensure consistent query results, Loki uses
-[Dynamo-style](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf)
+[Dynamo-style](https://www.cs.princeton.edu/courses/archive/fall15/cos518/studpres/dynamo.pdf)
 quorum consistency on reads and writes. This means that the distributor will wait
 for a positive response of at least one half plus one of the ingesters to send
 the sample to before responding to the user.

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -7,6 +7,14 @@ RUN apk add --no-cache curl && \
     mv /tmp/linux-amd64/helm /usr/bin/helm && \
     rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
 
+FROM alpine as lychee
+ARG LYCHEE_VER="0.7.0"
+RUN apk add --no-cache curl && \
+    curl -L -o /tmp/lychee-$LYCHEE_VER.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-x86_64-unknown-linux-gnu.tar.gz && \
+    tar -xz -C /tmp -f /tmp/lychee-$LYCHEE_VER.tgz && \
+    mv /tmp/lychee /usr/bin/lychee && \
+    rm -rf /tmp/linux-amd64 /tmp/lychee-$LYCHEE_VER.tgz
+
 FROM alpine as golangci
 RUN apk add --no-cache curl && \
     cd / && \
@@ -40,6 +48,7 @@ RUN apt-get update && \
 
 COPY --from=docker /usr/bin/docker /usr/bin/docker
 COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY --from=lychee /usr/bin/lychee /usr/bin/lychee
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 COPY --from=drone /go/bin/drone /usr/bin/drone
 COPY --from=faillint /go/bin/faillint /usr/bin/faillint


### PR DESCRIPTION
This is not part of the CI because it can be throttle and it's not super fast ~2min.

But still usefull to check that no link are down if we make some big structure changes.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
