### PR TITLE
[docs/clients] fix header for "Unofficial clients" and add a reference to said section.

### DIFF
--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -13,6 +13,8 @@ Loki supports the following official clients for sending logs:
 - [Logstash](logstash/)
 - [Lambda Promtail](lambda-promtail/)
 
+There are also a number of third-party clients, see [Unofficial clients](#unofficial-clients).
+
 ## Picking a client
 
 While all clients can be used simultaneously to cover multiple use cases, which
@@ -58,7 +60,7 @@ This is a workflow combining the promtail push-api [scrape config](promtail/conf
 
 This is a good choice if you're looking to try out Loki in a low-footprint way or if you wish to monitor AWS lambda logs in Loki.
 
-# Unofficial clients
+## Unofficial clients
 
 Please note that the Loki API is not stable yet, so breaking changes might occur
 when using or writing a third-party client.


### PR DESCRIPTION
The current H1 heading is not rendered by Hugo, so updated to a H2 heading.
Before:
![Screenshot from 2021-05-12 23-19-09](https://user-images.githubusercontent.com/11698744/118045742-9c05b800-b378-11eb-839e-5f8f5c2d82ac.png)

After:
![Screenshot from 2021-05-12 23-19-42](https://user-images.githubusercontent.com/11698744/118045757-a2942f80-b378-11eb-8b12-5c5ed813e1b1.png)


I also added a reference to this section at the top of the `/clients` index page since it was very difficult to discover (perhaps that was the point, and in that case I can revert it of course).