### PR TITLE
Add docker-recombine stage and use it in docker pipeline

### DIFF
--- a/clients/pkg/logentry/stages/docker_recombine.go
+++ b/clients/pkg/logentry/stages/docker_recombine.go
@@ -1,0 +1,54 @@
+package stages
+
+import (
+	"strings"
+
+	"github.com/go-kit/kit/log"
+)
+
+type dockerRecombineStage struct {
+	logger log.Logger
+}
+
+func newDockerRecombine(logger log.Logger) (Stage, error) {
+	return &dockerRecombineStage{
+		logger: log.With(logger,
+			"component", "stage",
+			"type", StageTypeDockerRecombine,
+		),
+	}, nil
+}
+
+func (*dockerRecombineStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		logBufs := make(map[string]*strings.Builder)
+		for e := range in {
+			stream, ok := e.Extracted["stream"].(string)
+			if !ok {
+				out <- e
+				continue
+			}
+			buf, ok := logBufs[stream]
+			if !ok {
+				buf = new(strings.Builder)
+				logBufs[stream] = buf
+			}
+			// FIXME: OK to "drop" log with valid stream and non-string msg?
+			logStr, _ := e.Extracted["output"].(string)
+			buf.WriteString(logStr)
+			eol := len(logStr) > 0 && logStr[len(logStr)-1] == '\n'
+			if eol {
+				e.Extracted["output"] = buf.String()
+				buf.Reset()
+				out <- e
+			}
+		}
+	}()
+	return out
+}
+
+func (*dockerRecombineStage) Name() string {
+	return StageTypeDockerRecombine
+}

--- a/clients/pkg/logentry/stages/docker_recombine_test.go
+++ b/clients/pkg/logentry/stages/docker_recombine_test.go
@@ -1,0 +1,63 @@
+package stages
+
+import (
+	"testing"
+	"time"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	json "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDockerRecombine(t *testing.T) {
+	m, err := newDockerRecombine(util_log.Logger)
+	require.NoError(t, err)
+
+	h := func(s, stream string, t time.Time) Entry {
+		buf, err := json.Marshal(struct {
+			Output    string    `json:"output"`
+			Stream    string    `json:"stream"`
+			Timestamp time.Time `json:"timestamp"`
+		}{s, stream, t})
+		if err != nil {
+			panic(err)
+		}
+		return newEntry(map[string]interface{}{
+			"output":    s,
+			"stream":    stream,
+			"timestamp": t,
+		}, nil, string(buf), t)
+	}
+	t1 := time.Now()
+	t2 := t1.Add(1 * time.Minute)
+	t3 := t2.Add(1 * time.Minute)
+	in := []Entry{
+		h("abc\n", "stdout", t1),
+
+		h("no end of line here, ", "stdout", t1),
+		h("but here it is\n", "stdout", t2),
+
+		h("stdout start, ", "stdout", t1),
+		h("stdout middle, ", "stdout", t2),
+		h("stderr start, ", "stderr", t1),
+		h("stdout end\n", "stdout", t3),
+
+		h("stderr middle, ", "stderr", t2),
+		h("stderr end\n", "stderr", t3),
+	}
+	expectedOut := []Entry{
+		h("abc\n", "stdout", t1),
+		h("no end of line here, but here it is\n", "stdout", t2),
+		h("stdout start, stdout middle, stdout end\n", "stdout", t3),
+		h("stderr start, stderr middle, stderr end\n", "stderr", t3),
+	}
+	out := processEntries(m, in...)
+	require.Len(t, out, len(expectedOut))
+	for i, o := range out {
+		eo := expectedOut[i]
+		assert.Equal(t, eo.Extracted, o.Extracted)
+		assert.Equal(t, eo.Timestamp, o.Timestamp)
+		assert.Equal(t, eo.Labels, o.Labels)
+	}
+}

--- a/clients/pkg/logentry/stages/extensions.go
+++ b/clients/pkg/logentry/stages/extensions.go
@@ -19,6 +19,9 @@ func NewDocker(logger log.Logger, registerer prometheus.Registerer) (Stage, erro
 				},
 			}},
 		PipelineStage{
+			StageTypeDockerRecombine: nil,
+		},
+		PipelineStage{
 			StageTypeLabel: LabelsConfig{
 				"stream": nil,
 			}},

--- a/clients/pkg/logentry/stages/extensions_test.go
+++ b/clients/pkg/logentry/stages/extensions_test.go
@@ -52,8 +52,8 @@ func TestNewDocker(t *testing.T) {
 			},
 		},
 		"invalid json": {
-			"i'm not json!",
-			"i'm not json!",
+			"i'm not json!\n",
+			"i'm not json!\n",
 			dockerTestTimeNow,
 			dockerTestTimeNow,
 			map[string]string{},

--- a/clients/pkg/logentry/stages/pipeline_test.go
+++ b/clients/pkg/logentry/stages/pipeline_test.go
@@ -23,8 +23,8 @@ import (
 
 var (
 	ct                = time.Now()
-	rawTestLine       = `{"log":"11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] \"GET /1986.js HTTP/1.1\" 200 932 \"-\" \"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6\"","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}`
-	processedTestLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"`
+	rawTestLine       = `{"log":"11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] \"GET /1986.js HTTP/1.1\" 200 932 \"-\" \"Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6\"\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z"}`
+	processedTestLine = `11.11.11.11 - frank [25/Jan/2000:14:00:01 -0500] "GET /1986.js HTTP/1.1" 200 932 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 GTB6"` + "\n"
 )
 
 var testMultiStageYaml = `
@@ -34,7 +34,7 @@ pipeline_stages:
     stages:
     - docker:
     - regex:
-        expression: "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?$"
+        expression: "^(?P<ip>\\S+) (?P<identd>\\S+) (?P<user>\\S+) \\[(?P<timestamp>[\\w:/]+\\s[+\\-]\\d{4})\\] \"(?P<action>\\S+)\\s?(?P<path>\\S+)?\\s?(?P<protocol>\\S+)?\" (?P<status>\\d{3}|-) (?P<size>\\d+|-)\\s?\"?(?P<referer>[^\"]*)\"?\\s?\"?(?P<useragent>[^\"]*)?\"?\\s*$"
     - regex:
         source:     filename
         expression: "(?P<service>[^\\/]+)\\.log"

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -12,24 +12,25 @@ import (
 )
 
 const (
-	StageTypeJSON       = "json"
-	StageTypeRegex      = "regex"
-	StageTypeReplace    = "replace"
-	StageTypeMetric     = "metrics"
-	StageTypeLabel      = "labels"
-	StageTypeLabelDrop  = "labeldrop"
-	StageTypeTimestamp  = "timestamp"
-	StageTypeOutput     = "output"
-	StageTypeDocker     = "docker"
-	StageTypeCRI        = "cri"
-	StageTypeMatch      = "match"
-	StageTypeTemplate   = "template"
-	StageTypePipeline   = "pipeline"
-	StageTypeTenant     = "tenant"
-	StageTypeDrop       = "drop"
-	StageTypeMultiline  = "multiline"
-	StageTypePack       = "pack"
-	StageTypeLabelAllow = "labelallow"
+	StageTypeJSON            = "json"
+	StageTypeRegex           = "regex"
+	StageTypeReplace         = "replace"
+	StageTypeMetric          = "metrics"
+	StageTypeLabel           = "labels"
+	StageTypeLabelDrop       = "labeldrop"
+	StageTypeTimestamp       = "timestamp"
+	StageTypeOutput          = "output"
+	StageTypeDocker          = "docker"
+	StageTypeDockerRecombine = "docker-recombine"
+	StageTypeCRI             = "cri"
+	StageTypeMatch           = "match"
+	StageTypeTemplate        = "template"
+	StageTypePipeline        = "pipeline"
+	StageTypeTenant          = "tenant"
+	StageTypeDrop            = "drop"
+	StageTypeMultiline       = "multiline"
+	StageTypePack            = "pack"
+	StageTypeLabelAllow      = "labelallow"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -74,6 +75,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 	switch stageType {
 	case StageTypeDocker:
 		s, err = NewDocker(logger, registerer)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeDockerRecombine:
+		s, err = newDockerRecombine(logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch adds a new log stage called docker-recombine. The stage isn't (currently) meant to be configured by the user directly; instead, it is internal to the docker log pipeline (it assumes that certain values have been extracted from the JSON log, such as "stream" or "output").

Within the docker pipeline, the stage takes care of accumulating incomplete log lines. Please see #2920 for description.

**Which issue(s) this PR fixes**:

Fixes #2920.

**Special notes for your reviewer**:

Please note that this is only a proof of concept and it needs some further tweaks, see my bullets bellow and comments in code.

Things to solve:

- We are accumulating the current log line forever, so no cap on line length. Obviously this is not acceptable.
- Whatever cap will be chosen, it should be less than gRPC message size limit.
- If somebody can provide help how to best introduce the limit so that we are able to monitor for "log lines being split due to insane length" (roughly), that would be much appreciated.
- All other comments are also welcome.

**Checklist**

- [ ] Documentation added
- [x] Tests updated

