### PR TITLE
correct logcli instant query timestamp param name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [3532](https://github.com/grafana/loki/pull/3532) **MichelHollands**: Update vendored Cortex to 8a2e2c1eeb65
 * [3446](https://github.com/grafana/loki/pull/3446) **pracucci, owen-d**: Remove deprecated config `querier.split-queries-by-day` in favor of `querier.split-queries-by-interval`
 * [3586](https://github.com/grafana/loki/pull/3587) **rsteneteg** Remove filemanager targets that no longer has any tails, to allow them to be recreated with the proper path
+* [3739](https://github.com/grafana/loki/pull/3739) **rsteneteg** Allow users to run instant queries in the past using LogCLI
 
 ## 2.2.0 (2021/03/10)
 

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -63,7 +63,7 @@ func (c *DefaultClient) Query(queryStr string, limit int, time time.Time, direct
 	qsb := util.NewQueryStringBuilder()
 	qsb.SetString("query", queryStr)
 	qsb.SetInt("limit", int64(limit))
-	qsb.SetInt("start", time.UnixNano())
+	qsb.SetInt("time", time.UnixNano())
 	qsb.SetString("direction", direction.String())
 
 	return c.doQuery(queryPath, qsb.Encode(), quiet)


### PR DESCRIPTION
Signed-off-by: Roger Steneteg <rsteneteg@ea.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
It allows user to run instant queries in LogCLI with a start time in the past

**Which issue(s) this PR fixes**:
Fixes #3738

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

