### PR TITLE
Boltdb shipper deletion fixes

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -226,6 +226,10 @@ func (c *Compactor) RunCompaction(ctx context.Context) error {
 	}
 
 	for _, tableName := range tables {
+		if tableName == deletion.DeleteRequestsTableName {
+			// we do not want to compact or apply retention on delete requests table
+			continue
+		}
 		if err := c.CompactTable(ctx, tableName); err != nil {
 			status = statusFailure
 		}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -58,7 +58,7 @@ func (d *DeleteRequestsManager) loop() {
 				level.Error(util_log.Logger).Log("msg", "failed to update metrics", "err", err)
 			}
 		case <-d.done:
-			break
+			return
 		}
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
@@ -30,10 +30,10 @@ type deleteRequestsTable struct {
 	wg                sync.WaitGroup
 }
 
-const objectPathInStorage = deleteRequestsTableName + "/" + deleteRequestsTableName + ".gz"
+const objectPathInStorage = DeleteRequestsTableName + "/" + DeleteRequestsTableName + ".gz"
 
 func newDeleteRequestsTable(workingDirectory string, objectClient chunk.ObjectClient) (chunk.IndexClient, error) {
-	dbPath := filepath.Join(workingDirectory, deleteRequestsTableName, deleteRequestsTableName)
+	dbPath := filepath.Join(workingDirectory, DeleteRequestsTableName, DeleteRequestsTableName)
 	boltdbIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: filepath.Dir(dbPath)})
 	if err != nil {
 		return nil, err

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
@@ -41,7 +41,7 @@ func TestDeleteRequestsTable(t *testing.T) {
 
 	// add some records to the db
 	batch := testDeleteRequestsTable.NewWriteBatch()
-	testutil.AddRecordsToBatch(batch, deleteRequestsTableName, 0, 10)
+	testutil.AddRecordsToBatch(batch, DeleteRequestsTableName, 0, 10)
 	require.NoError(t, testDeleteRequestsTable.BatchWrite(context.Background(), batch))
 
 	// see if right records were written
@@ -56,7 +56,7 @@ func TestDeleteRequestsTable(t *testing.T) {
 	checkRecordsInStorage(t, storageFilePath, 0, 10)
 
 	// add more records to the db
-	testutil.AddRecordsToBatch(batch, deleteRequestsTableName, 10, 10)
+	testutil.AddRecordsToBatch(batch, DeleteRequestsTableName, 10, 10)
 	require.NoError(t, testDeleteRequestsTable.BatchWrite(context.Background(), batch))
 
 	// stop the table which should upload the db to storage
@@ -88,7 +88,7 @@ func checkRecordsInStorage(t *testing.T, storageFilePath string, start, numRecor
 	defer func() {
 		require.NoError(t, os.RemoveAll(tempDir))
 	}()
-	tempFilePath := filepath.Join(tempDir, deleteRequestsTableName)
+	tempFilePath := filepath.Join(tempDir, DeleteRequestsTableName)
 	require.NoError(t, err)
 	testutil.DecompressFile(t, storageFilePath, tempFilePath)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It comprises of 2 fixes related to deletion support for `boltdb-shipper`:
1. I had used `break` instead of `return` in a select case which caused the loop to continue and not stop the compactor.
2. We need to skip compaction or apply retention on delete requests table.

