### PR TITLE
just log a warning when a store type other than boltdb-shipper is detected when custom retention is enabled

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/index.go
+++ b/pkg/storage/stores/shipper/compactor/retention/index.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"time"
 
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/storage/stores/shipper"
-
-	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/prometheus/common/model"
 
+	"github.com/cortexproject/cortex/pkg/chunk"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/kit/log/level"
+
 	"github.com/grafana/loki/pkg/storage"
+	"github.com/grafana/loki/pkg/storage/stores/shipper"
 )
 
 const (

--- a/pkg/storage/stores/shipper/compactor/retention/index.go
+++ b/pkg/storage/stores/shipper/compactor/retention/index.go
@@ -208,7 +208,7 @@ func parseLabelSeriesRangeKey(hashKey, rangeKey []byte) (LabelSeriesRangeKey, bo
 func validatePeriods(config storage.SchemaConfig) error {
 	for _, schema := range config.Configs {
 		if schema.IndexType != shipper.BoltDBShipperType {
-			level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("custom retention is not supported for store %s", schema.IndexType))
+			level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("custom retention is not supported for store %s, no retention will be applied for schema entry with start date %s", schema.IndexType, schema.From))
 			continue
 		}
 		if schema.IndexTables.Period != 24*time.Hour {

--- a/pkg/storage/stores/shipper/compactor/retention/index.go
+++ b/pkg/storage/stores/shipper/compactor/retention/index.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 	"time"
 
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/loki/pkg/storage/stores/shipper"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/prometheus/common/model"
 
@@ -203,6 +207,10 @@ func parseLabelSeriesRangeKey(hashKey, rangeKey []byte) (LabelSeriesRangeKey, bo
 
 func validatePeriods(config storage.SchemaConfig) error {
 	for _, schema := range config.Configs {
+		if schema.IndexType != shipper.BoltDBShipperType {
+			level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("custom retention is not supported for store %s", schema.IndexType))
+			continue
+		}
 		if schema.IndexTables.Period != 24*time.Hour {
 			return fmt.Errorf("schema period must be daily, was: %s", schema.IndexTables.Period)
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We fail the compactor's startup when we detect a store type other boltdb-shipper and the custom retention is enabled. This PR changes it to log a warning at startup because this would otherwise make users wait till their existing logs index in other store types go out of retention.


