### PR TITLE
upgrade the fluent-bit to latest version

### DIFF
--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -3,7 +3,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin
 
-FROM fluent/fluent-bit:1.4
+FROM fluent/fluent-bit:1.7
 COPY --from=build /src/loki/clients/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/bin
 COPY clients/cmd/fluent-bit/fluent-bit.conf /fluent-bit/etc/fluent-bit.conf
 EXPOSE 2020


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

We want to use fluent-bit to send logs to Loki and Other backends such as Elastic Search. The latest fluent-bit has built-in output plugins for es and loki, but the loki plugin isn't as good as grafana developed plugin.

**Which issue(s) this PR fixes**:
Fixes #3791

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

I manually tested in my local and works fine.

My configuration:

```
[INPUT]
    Name dummy
    Tag  dummy.log
    Dummy {"message":"dummy", "toremove":"dummy-remove", "dummy_msg_2":"dummy-msg-20", "kubernetes":{"pod_name":"basic-tidb-0","pod_id":"697ccefa-c1b1-4afb-b318-20138944c830"}}
[Output]
    Name grafana-loki
    Match *
    Url https://**:**@logs-prod-us-central1.grafana.net/api/prom/push
    BatchWait 1s
    BatchSize 1001024
    Labels {job="fluent-bit-docker-grafana"}
    LineFormat json
    LogLevel info
    RemoveKeys kubernetes,toremove,dummy_msg_2
[Output]
    Name loki
    Match *
    host logs-prod-us-central1.grafana.net
    port 443
    tls On
    tls.verify Off
    http_user ***
    http_passwd ***
    tenant_id ""
    labels job=fluent-bit-docker-loki, instance=$kubernetes['pod_name']
    remove_keys kubernetes,stream
    drop_single_key true
    auto_kubernetes_labels off
    line_format json
[OUTPUT]
    Name es
    Match *
    Cloud_Auth ***
    Cloud_ID ***
    Index fluent_bit_docker_es
    tls true
    tls.verify false
```

