### PR TITLE
Exposing remote writer for use in integration tests

### DIFF
--- a/pkg/ruler/appender.go
+++ b/pkg/ruler/appender.go
@@ -41,7 +41,7 @@ func newRemoteWriteAppendable(cfg Config, overrides RulesLimits, logger log.Logg
 type RemoteWriteAppender struct {
 	logger       log.Logger
 	ctx          context.Context
-	remoteWriter remoteWriter
+	remoteWriter RemoteWriter
 	userID       string
 	groupKey     string
 
@@ -65,7 +65,7 @@ func (a *RemoteWriteAppendable) Appender(ctx context.Context) storage.Appender {
 		return appender
 	}
 
-	client, err := newRemoteWriter(a.cfg, a.userID)
+	client, err := NewRemoteWriter(a.cfg, a.userID)
 	if err != nil {
 		level.Error(a.logger).Log("msg", "error creating remote-write client; setting appender as noop", "err", err, "tenant", a.userID)
 		return &NoopAppender{}

--- a/pkg/ruler/remote_write_test.go
+++ b/pkg/ruler/remote_write_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPrepare(t *testing.T) {
-	client := remoteWriteClient{}
+	client := RemoteWriteClient{}
 	queue, err := util.NewEvictingQueue(1000, func() {})
 	require.Nil(t, err)
 
@@ -105,7 +105,7 @@ func createBasicAppender(t *testing.T) *RemoteWriteAppender {
 	appendable := createBasicAppendable(100)
 
 	appender := appendable.Appender(ctx).(*RemoteWriteAppender)
-	client, err := newRemoteWriter(appendable.cfg, "fake")
+	client, err := NewRemoteWriter(appendable.cfg, "fake")
 	require.Nil(t, err)
 
 	appender.remoteWriter = client


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Exposes the `ruler.RemoteWriter` interface and `ruler.RemoteWriteClient` implementation for use in integration tests.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

