### PR TITLE
docs: Change redis configuration value for enabling TLS to correct syntax

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1495,8 +1495,8 @@ redis:
   [password: <string>]
 
   # Enables connecting to redis with TLS.
-  # CLI flag: -<prefix>.redis.enable-tls
-  [enable_tls: <boolean> | default = false]
+  # CLI flag: -<prefix>.redis.tls-enabled
+  [tls_enabled: <boolean> | default = false]
 
   # Close connections after remaining idle for this duration.
   # If the value is zero, then idle connections are not closed.


### PR DESCRIPTION
**What this PR does / why we need it**: This PR corrects the documentation (enable_tls: true doesn't work and this new syntax is taken from cortex documentation, works, and is tested with AWS ElastiCache Redis cluster)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

