### PR TITLE
Update the docker-driver doc about default labels

### DIFF
--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -115,7 +115,7 @@ Custom labels can be added using the `loki-external-labels`, `loki-pipeline-stag
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
 
-If no `loki-external-labels` are provided, label `container_name` will be added to each log line by default.
+If no `loki-external-labels` are provided, the label `container_name` will be added to each log line by default.
 
 ## Pipeline stages
 

--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -109,12 +109,13 @@ By default, the Docker driver will add the following labels to each log line:
 
 - `filename`: where the log is written to on disk
 - `host`: the hostname where the log has been generated
-- `container_name`: the name of the container generating logs
 - `swarm_stack`, `swarm_service`: added when deploying from Docker Swarm.
 
 Custom labels can be added using the `loki-external-labels`, `loki-pipeline-stages`,
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
+
+If no `loki-external-labels` are provided, label `container_name` will be added to each log line by default.
 
 ## Pipeline stages
 

--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -115,12 +115,12 @@ Custom labels can be added using the `loki-external-labels`, `loki-pipeline-stag
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
 
-If no `loki-external-labels` are provided, the label `container_name` will be added to each log line by default.
+`loki-external-labels` have the default value of `container_name={{.Name}}`. If you have custom value for `loki-external-labels` then that will replace the default value, meaning you won't have `container_name` label unless you explcity add it (e.g: `loki-external-lables: "job=docker,container_name={{.Name}}"`.
 
 ## Pipeline stages
 
 While you can provide `loki-pipeline-stage-file` it can be hard to mount the configuration file to the driver root filesystem.
-This is why another option `loki-pipeline-stages` is available allowing your to pass a list of stages inlined.
+This is why another option `loki-pipeline-stages` is available allowing your to pass a list of stages inlined. Pipeline stages are run at last on every lines.
 
 The example [docker-compose](https://github.com/grafana/loki/blob/master/cmd/docker-driver/docker-compose.yaml) below configures 2 stages, one to extract level values and one to set it as a label:
 
@@ -167,6 +167,8 @@ Providing both `loki-pipeline-stage-file` and `loki-pipeline-stages` will cause 
 ## Relabeling
 
 You can use [Prometheus relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) configuration to modify labels discovered by the driver. The configuration must be passed as a YAML string like the [pipeline stages](#pipeline-stages).
+
+Relabeling phase will happen only once per container and it is applied on the container metadata when it starts. So you can for example rename the labels that are only available during the starting of the container, not the labels available on log lines. Use [pipeline stages](#pipeline-stages) instead.
 
 For example the configuration below will rename the label `swarm_stack` and `swarm_service` to respectively `namespace` and `service`.
 


### PR DESCRIPTION
Add more information on `container_name` default label and when it will be added to log line.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Makes the docker-driver docs bit clear about `container_name` default label

**Which issue(s) this PR fixes**:
Fixes #3811 #3811 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

