### PR TITLE
Extracting queue interface

### DIFF
--- a/pkg/ruler/appender.go
+++ b/pkg/ruler/appender.go
@@ -105,9 +105,9 @@ func (a *RemoteWriteAppendable) onEvict(userID, groupKey string) func() {
 }
 
 func (a *RemoteWriteAppender) Append(_ uint64, l labels.Labels, t int64, v float64) (uint64, error) {
-	a.queue.Append(queueEntry{
-		labels: l,
-		sample: cortexpb.Sample{
+	a.queue.Append(TimeSeriesEntry{
+		Labels: l,
+		Sample: cortexpb.Sample{
 			Value:       v,
 			TimestampMs: t,
 		},

--- a/pkg/ruler/appender_test.go
+++ b/pkg/ruler/appender_test.go
@@ -128,9 +128,9 @@ func TestAppendSample(t *testing.T) {
 	ts := time.Now().Unix()
 	val := 91.2
 
-	sample := queueEntry{
-		labels: labels,
-		sample: cortexpb.Sample{
+	sample := TimeSeriesEntry{
+		Labels: labels,
+		Sample: cortexpb.Sample{
 			Value:       val,
 			TimestampMs: ts,
 		},
@@ -257,8 +257,8 @@ func TestAppenderEvictOldest(t *testing.T) {
 	require.Equal(t, capacity, appender.queue.Length())
 
 	// only two newest samples are kept
-	require.Equal(t, appender.queue.Entries()[0].(queueEntry).sample.Value, 11.3)
-	require.Equal(t, appender.queue.Entries()[1].(queueEntry).sample.Value, 11.4)
+	require.Equal(t, appender.queue.Entries()[0].(TimeSeriesEntry).Sample.Value, 11.3)
+	require.Equal(t, appender.queue.Entries()[1].(TimeSeriesEntry).Sample.Value, 11.4)
 }
 
 // context is created by ruler, passing along details of the rule being executed
@@ -321,7 +321,7 @@ func (c *MockRemoteWriteClient) Name() string { return "" }
 // Endpoint is the remote read or write endpoint for the storage client.
 func (c *MockRemoteWriteClient) Endpoint() string { return "" }
 
-func (c *MockRemoteWriteClient) PrepareRequest(queue *util.EvictingQueue) ([]byte, error) {
+func (c *MockRemoteWriteClient) PrepareRequest(queue util.Queue) ([]byte, error) {
 	args := c.Called(queue)
 	return args.Get(0).([]byte), args.Error(1)
 }

--- a/pkg/ruler/remote_write_test.go
+++ b/pkg/ruler/remote_write_test.go
@@ -32,7 +32,7 @@ func TestPrepare(t *testing.T) {
 
 	// first start with 10 items
 	for i := 0; i < 10; i++ {
-		queue.Append(queueEntry{labels: lbs, sample: sample})
+		queue.Append(TimeSeriesEntry{Labels: lbs, Sample: sample})
 	}
 	require.Nil(t, client.prepare(queue))
 
@@ -45,7 +45,7 @@ func TestPrepare(t *testing.T) {
 
 	// then resize the internal slices to 100
 	for i := 0; i < 100; i++ {
-		queue.Append(queueEntry{labels: lbs, sample: sample})
+		queue.Append(TimeSeriesEntry{Labels: lbs, Sample: sample})
 	}
 	require.Nil(t, client.prepare(queue))
 
@@ -58,7 +58,7 @@ func TestPrepare(t *testing.T) {
 
 	// then reuse the existing slice (no resize necessary since 5 < 100)
 	for i := 0; i < 5; i++ {
-		queue.Append(queueEntry{labels: lbs, sample: sample})
+		queue.Append(TimeSeriesEntry{Labels: lbs, Sample: sample})
 	}
 	require.Nil(t, client.prepare(queue))
 

--- a/pkg/util/queue.go
+++ b/pkg/util/queue.go
@@ -1,0 +1,8 @@
+package util
+
+type Queue interface {
+	Append(entry interface{})
+	Entries() []interface{}
+	Length() int
+	Clear()
+}


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Extracts a queue interface, which makes the `PrepareRequest` function a bit more testable.
This is mostly just a refactoring PR.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
These changes are just refactorings meant to make integration testing easier.

**Checklist**
- [ ] Documentation added
- [X] Tests updated

