### PR TITLE
Add explicit `main` to pull loki and promtail to install it via Tanka

### DIFF
--- a/docs/sources/installation/tanka.md
+++ b/docs/sources/installation/tanka.md
@@ -31,8 +31,8 @@ Download and install the Loki and Promtail module using `jb`:
 ```bash
 go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 jb init  # not required if you already ran `tk init`
-jb install github.com/grafana/loki/production/ksonnet/loki
-jb install github.com/grafana/loki/production/ksonnet/promtail
+jb install github.com/grafana/loki/production/ksonnet/loki@main
+jb install github.com/grafana/loki/production/ksonnet/promtail@main
 ```
 
 Then you'll need to install a kubernetes library:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Fixes installation in `latest` doc. using `jb` to pull latest loki and promtail fails because by default `jb` command, assumes `master` branch, but Loki repo renamed the `master` to `main` branch.

**Which issue(s) this PR fixes**:
Fixes #3808 

**Special notes for your reviewer**:
NA

**Checklist**
- [x] Documentation added
- [ ] Tests updated

