### PR TITLE
Logs ingester and store queries boundaries.

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -42,6 +42,14 @@ type SelectLogParams struct {
 	*logproto.QueryRequest
 }
 
+func (s SelectLogParams) String() string {
+	if s.QueryRequest != nil {
+		return fmt.Sprintf("selector=%s, direction=%s, start=%s, end=%s, limit=%d, shards=%s",
+			s.Selector, logproto.Direction_name[int32(s.Direction)], s.Start, s.End, s.Limit, strings.Join(s.Shards, ","))
+	}
+	return ""
+}
+
 // LogSelector returns the LogSelectorExpr from the SelectParams.
 // The `LogSelectorExpr` can then returns all matchers and filters to use for that request.
 func (s SelectLogParams) LogSelector() (LogSelectorExpr, error) {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -107,7 +107,9 @@ func (q *Querier) SelectLogs(ctx context.Context, params logql.SelectLogParams) 
 		}
 		newParams.Start = ingesterQueryInterval.start
 		newParams.End = ingesterQueryInterval.end
-
+		level.Debug(spanlogger.FromContext(ctx)).Log(
+			"msg", "querying ingester",
+			"params", newParams)
 		ingesterIters, err := q.ingesterQuerier.SelectLogs(ctx, newParams)
 		if err != nil {
 			return nil, err
@@ -119,7 +121,9 @@ func (q *Querier) SelectLogs(ctx context.Context, params logql.SelectLogParams) 
 	if storeQueryInterval != nil {
 		params.Start = storeQueryInterval.start
 		params.End = storeQueryInterval.end
-
+		level.Debug(spanlogger.FromContext(ctx)).Log(
+			"msg", "querying store",
+			"params", params)
 		storeIter, err := q.store.SelectLogs(ctx, params)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
example:
```
 ts=2021-06-14T08:43:30.015895283Z caller=spanlogger.go:87 org_id=4336 traceID=0b6bb74a53efd739 level=debug msg="querying ingester" params="selector={stream=\"stdout\", pod=\"loki-canary-6  64d9d8d8f-99k22\"}, direction=BACKWARD, start=2021-06-14 08:17:03.037241855 +0000 UTC, end=2021-06-14 08:17:23.037241855 +0000 UTC, limit=1000, shards="
 ts=2021-06-14T08:43:30.016305592Z caller=spanlogger.go:87 org_id=4336 traceID=0b6bb74a53efd739 level=debug msg="querying store" params="selector={stream=\"stdout\", pod=\"loki-canary-664d  9d8d8f-99k22\"}, direction=BACKWARD, start=2021-06-14 08:17:03.037241855 +0000 UTC, end=2021-06-14 08:17:23.037241855 +0000 UTC, limit=1000, shards="
```

I'm seeing a lot of duplicates for short queries, this can help understand why.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

