### PR TITLE
docs: http_path_prefix as correct item of server_config

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -203,7 +203,7 @@ The `server_config` block configures the HTTP and gRPC server of the launched se
 
 # Base path to serve all API routes from (e.g., /v1/).
 # CLI flag: -server.path-prefix
-[http_prefix: <string> | default = "/api/prom"]
+[http_path_prefix: <string> | default = ""]
 ```
 
 ## distributor_config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
In https://grafana.com/docs/loki/latest/configuration/, the sub-server yaml key to configure base path for API routes should be `http_path_prefix` instead of `http_prefix`. This PR fixes the documentation.

**Which issue(s) this PR fixes**:
Not sure there is related issue yet.

**Special notes for your reviewer**:
My first PR in open-source world. Apologize if missing some details 😟 

**Checklist**
- [X] Documentation added
- [X] Tests updated --**Not needed**

