### PR TITLE
Add missing `-querier.max-concurrent` config in the doc

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -260,6 +260,10 @@ The `querier_config` block configures the Loki Querier.
 # CLI flag: -querier.query-ingesters-within
 [query_ingesters_within: <duration> | default = 0s]
 
+# The maximum number of concurrent queries allowed.
+# CLI flag: -querier.max-concurrent
+[max_concurrent: <int> | default = 20]
+
 # Only query the store, do not attempt to query any ingesters,
 # useful for running a standalone querier pool opearting only against stored data.
 # CLI flag: -querier.query-store-only


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Add missing `-querier.max-concurrent` config in the doc

Motivation: https://community.grafana.com/t/loki-total-worker-concurrency-is-greater-than-promql-max-concurrency/49283

**Which issue(s) this PR fixes**:
Fixes NA

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

