### PR TITLE
Documentation: Unify spelling of backtick in documentation

### DIFF
--- a/docs/sources/logql/_index.md
+++ b/docs/sources/logql/_index.md
@@ -39,7 +39,7 @@ The query is composed of:
 - a log stream selector `{container="query-frontend",namespace="loki-dev"}` which targets the `query-frontend` container  in the `loki-dev` namespace.
 - a log pipeline `|= "metrics.go" | logfmt | duration > 10s and throughput_mb < 500` which will filter out log that contains the word `metrics.go`, then parses each log line to extract more labels and filter with them.
 
-> To avoid escaping special characters you can use the `` ` ``(back-tick) instead of `"` when quoting strings.
+> To avoid escaping special characters you can use the `` ` ``(backtick) instead of `"` when quoting strings.
 For example `` `\w+` `` is the same as `"\\w+"`.
 This is specially useful when writing a regular expression which contains multiple backslashes that require escaping.
 


### PR DESCRIPTION
We are using the word `backtick` at couple of places and `back-tick` is used just once. Improves searchability. 🙂
![image](https://user-images.githubusercontent.com/30407135/122902428-b6a35780-d34e-11eb-8db4-b4055659294a.png)

![image](https://user-images.githubusercontent.com/30407135/122902472-c0c55600-d34e-11eb-8d9f-4647be1383a3.png)
