### PR TITLE
logcli: Add retries to unsuccessful log queries

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -211,7 +211,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("org-id", "adds X-Scope-OrgID to API requests for representing tenant ID. Useful for requesting tenant data when bypassing an auth gateway.").Default("").Envar("LOKI_ORG_ID").StringVar(&client.OrgID)
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
-	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("1").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
+	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("0").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
 
 	return client
 }

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -211,6 +211,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("org-id", "adds X-Scope-OrgID to API requests for representing tenant ID. Useful for requesting tenant data when bypassing an auth gateway.").Default("").Envar("LOKI_ORG_ID").StringVar(&client.OrgID)
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
+	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("1").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
 
 	return client
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -56,6 +56,7 @@ type DefaultClient struct {
 	Tripperware     Tripperware
 	BearerToken     string
 	BearerTokenFile string
+	Retries         int
 }
 
 // Query uses the /api/v1/query endpoint to execute an instant query
@@ -216,21 +217,39 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 	if c.Tripperware != nil {
 		client.Transport = c.Tripperware(client.Transport)
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
+
+	var resp *http.Response
+	retries := c.Retries
+	success := false
+
+	for retries > 0 {
+		retries--
+
+		resp, err = client.Do(req)
+		if err != nil {
+			log.Println("error sending request", err)
+			continue
+		}
+		if resp.StatusCode/100 != 2 {
+			buf, _ := ioutil.ReadAll(resp.Body) // nolint
+			log.Printf("Error response from server: %s (%v) retries remaining: %d", string(buf), err, retries)
+			if err := resp.Body.Close(); err != nil {
+				log.Println("error closing body", err)
+			}
+			continue
+		}
+		success = true
+		break
 	}
+	if !success {
+		return fmt.Errorf("Run out of retries while querying the server")
+	}
+
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			log.Println("error closing body", err)
 		}
 	}()
-
-	if resp.StatusCode/100 != 2 {
-		buf, _ := ioutil.ReadAll(resp.Body) // nolint
-		return fmt.Errorf("Error response from server: %s (%v)", string(buf), err)
-	}
-
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -219,11 +219,11 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 	}
 
 	var resp *http.Response
-	retries := c.Retries
+	attempts := c.Retries + 1
 	success := false
 
-	for retries > 0 {
-		retries--
+	for attempts > 0 {
+		attempts--
 
 		resp, err = client.Do(req)
 		if err != nil {
@@ -232,7 +232,7 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 		}
 		if resp.StatusCode/100 != 2 {
 			buf, _ := ioutil.ReadAll(resp.Body) // nolint
-			log.Printf("Error response from server: %s (%v) retries remaining: %d", string(buf), err, retries)
+			log.Printf("Error response from server: %s (%v) attempts remaining: %d", string(buf), err, attempts)
 			if err := resp.Body.Close(); err != nil {
 				log.Println("error closing body", err)
 			}
@@ -242,7 +242,7 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 		break
 	}
 	if !success {
-		return fmt.Errorf("Run out of retries while querying the server")
+		return fmt.Errorf("Run out of attempts while querying the server")
 	}
 
 	defer func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This adds a possibility to retry unsuccessful queries when using logcli
Example output of a failed query (there is no server running on that port):
```
./logcli query "{type=\"logtest\"}" --addr="http://127.0.0.1" --retries 3
2021/06/22 15:28:02 http://127.0.0.1/loki/api/v1/query_range?direction=BACKWARD&end=1624368482937234835&limit=30&query=%7Btype%3D%22logtest%22%7D&start=1624364882937234835
2021/06/22 15:28:02 error sending request Get "http://127.0.0.1/loki/api/v1/query_range?direction=BACKWARD&end=1624368482937234835&limit=30&query=%7Btype%3D%22logtest%22%7D&start=1624364882937234835": dial tcp 127.0.0.1:80: connect: connection refused
2021/06/22 15:28:02 error sending request Get "http://127.0.0.1/loki/api/v1/query_range?direction=BACKWARD&end=1624368482937234835&limit=30&query=%7Btype%3D%22logtest%22%7D&start=1624364882937234835": dial tcp 127.0.0.1:80: connect: connection refused
2021/06/22 15:28:02 error sending request Get "http://127.0.0.1/loki/api/v1/query_range?direction=BACKWARD&end=1624368482937234835&limit=30&query=%7Btype%3D%22logtest%22%7D&start=1624364882937234835": dial tcp 127.0.0.1:80: connect: connection refused
2021/06/22 15:28:02 Query failed: Run out of retries while querying the server
```

**Which issue(s) this PR fixes**:
Fixes #3855

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

