### PR TITLE
Make `overrides` configmap names and mount path as variables.

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -30,6 +30,12 @@
     compactor_pvc_size: '10Gi',
     compactor_pvc_class: 'fast',
 
+    // This is the configmap created with `$._config.overrides` data
+    overrides_configmap_name: 'overrides',
+
+    // This is the configmap which will be used by workloads.
+    overrides_configmap_mount_name: 'overrides',
+    overrides_configmap_mount_path: '/etc/loki/overrides',
 
     querier: {
       // This value should be set equal to (or less than) the CPU cores of the system the querier runs.

--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -24,7 +24,10 @@
     deployment.new('distributor', 3, [$.distributor_container]) +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity,
 
   distributor_service:

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -37,7 +37,10 @@
     deployment.new(name, 3, [$.ingester_container]) +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity +
     deployment.mixin.spec.withMinReadySeconds(60) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
@@ -58,7 +61,10 @@
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile

--- a/production/ksonnet/loki/overrides.libsonnet
+++ b/production/ksonnet/loki/overrides.libsonnet
@@ -17,7 +17,7 @@
   local configMap = $.core.v1.configMap,
 
   overrides_config:
-    configMap.new('overrides') +
+    configMap.new($._config.overrides_configmap_name) +
     configMap.withData({
       'overrides.yaml': $.util.manifestYaml(
         {

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -29,7 +29,10 @@
     deployment.new('querier', 3, [$.querier_container]) +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity
   else {},
 
@@ -47,7 +50,10 @@
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile

--- a/production/ksonnet/loki/query-frontend.libsonnet
+++ b/production/ksonnet/loki/query-frontend.libsonnet
@@ -32,7 +32,10 @@
     deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity,
 
   local service = $.core.v1.service,

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -8,9 +8,9 @@
   ruler_args:: $._config.commonArgs {
     target: 'ruler',
   } + if $._config.using_boltdb_shipper then {
-       // Use PVC for caching
-       'boltdb.shipper.cache-location': '/data/boltdb-cache',
-     } else {},
+    // Use PVC for caching
+    'boltdb.shipper.cache-location': '/data/boltdb-cache',
+  } else {},
 
   _config+:: {
     // run rulers as statefulsets when using boltdb-shipper to avoid using node disk for storing the index.
@@ -38,7 +38,10 @@
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
       $.config_hash_mixin +
       $.util.configVolumeMount('loki', '/etc/loki/config') +
-      $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+      $.util.configVolumeMount(
+        $._config.overrides_configmap_mount_name,
+        $._config.overrides_configmap_mount_path,
+      ) +
       $.util.antiAffinity
     else {},
 
@@ -64,7 +67,10 @@
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
     $.config_hash_mixin +
     $.util.configVolumeMount('loki', '/etc/loki/config') +
-    $.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    $.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
     $.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile

--- a/production/ksonnet/loki/wal.libsonnet
+++ b/production/ksonnet/loki/wal.libsonnet
@@ -3,8 +3,8 @@
 
   _config+:: {
     stateful_ingesters: if $._config.wal_enabled then true else super.stateful_ingesters,
-    loki+:with({
-      ingester+:{
+    loki+: with({
+      ingester+: {
         // disables transfers when running as statefulsets.
         // pod rolling stragety will always fail transfers
         // and the WAL supersedes this.
@@ -12,7 +12,7 @@
         wal+: {
           enabled: true,
           dir: '/loki/wal',
-          replay_memory_ceiling: '7GB', // should be set upto ~50% of available memory
+          replay_memory_ceiling: '7GB',  // should be set upto ~50% of available memory
         },
       },
     }),


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Instead of hardcoding the names and mount path of configmap`overrides`, make it as variables.
Note: This doesn't impact any of the existing workloads, as the default value for these variables are same the one hardcoded!

**Which issue(s) this PR fixes**:
Fixes: NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

