### PR TITLE
Docs: add structure for a release notes section

### DIFF
--- a/docs/sources/overview/_index.md
+++ b/docs/sources/overview/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-weight: 100
+weight: 150
 ---
 # Overview of Loki
 

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -1,0 +1,10 @@
+---
+title: Release notes
+weight: 100
+---
+# Release notes
+
+Release notes for Loki are in the CHANGELOG for the release and
+listed here by version number.
+
+- [V2.3 release notes](../release-notes/v2-3/)

--- a/docs/sources/release-notes/v2-3.md
+++ b/docs/sources/release-notes/v2-3.md
@@ -1,0 +1,24 @@
+---
+title: V2.3
+---
+
+# Version 2.3 release notes
+
+Prose here about 2.3.
+
+## Features and enhancements
+
+List of features here.
+
+- Pattern parser. [poor docs link to Parser expression](../../logql/#parser-expression)
+- Windows event log scraping. [docs link](../../clients/promtail/scraping/#windows-event-log)
+- Recording rules.
+- Index Gateway.
+- Retention.
+- `promtail_instance` label.
+
+## Bug fixes
+
+Lists of bug fixes for v2.3.x.
+
+### V2.3.0 bug fixes


### PR DESCRIPTION
The prose is not yet flushed out.  Let's do that when we know what will go into a 2.3.0 Loki release.
