### PR TITLE
Docs: revise the LogCLI subsection

### DIFF
--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -70,7 +70,7 @@ LogCLI sends queries to Loki such that query results arrive in batches.
 The `--limit` option for a `logcli query` command caps the quantity of
 log lines for a single query.
 When not set, `--limit` defaults to 30.
-This low default value protects the user from overwhelming the system
+The limit protects the user from overwhelming the system
 for cases in which the specified query would have returned a large quantity
 of log lines.
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -73,6 +73,7 @@ When not set, `--limit` defaults to 30.
 The limit protects the user from overwhelming the system
 for cases in which the specified query would have returned a large quantity
 of log lines.
+The limit also protects the user from unexpectedly large responses. 
 
 The quantity of log line results that arrive in each batch
 is set by the `--batch` option in a `logcli query` command.


### PR DESCRIPTION
In this revision:
- I recaptured the help output from LogCLI for the various commands
- I separated the help output for the various commands into different sections.  Makes it easier to read, and makes it possible to use the horizontal scroll bar.
- New section title
- Rewrote the section on batching queries
- Corrected section/subsection nesting levels and made minor spelling changes

