### PR TITLE
Querier/Ingester: Fixing json expression parser bug

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -6,9 +6,10 @@ import (
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/loghttp/push"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/loghttp/push"
 )
 
 // PushHandler reads a snappy-compressed proto from the HTTP body.

--- a/pkg/logql/log/jsonexpr/jsonexpr_test.go
+++ b/pkg/logql/log/jsonexpr/jsonexpr_test.go
@@ -113,6 +113,12 @@ func TestJSONExpressionParser(t *testing.T) {
 			nil,
 			fmt.Errorf("syntax error: unexpected DOT, expecting FIELD"),
 		},
+		{
+			"syntax error on key access",
+			`["key`,
+			nil,
+			fmt.Errorf("syntax error: unexpected $end, expecting RSB"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/logql/log/jsonexpr/lexer.go
+++ b/pkg/logql/log/jsonexpr/lexer.go
@@ -97,7 +97,7 @@ func (sc *Scanner) scanField() string {
 			break
 		}
 
-		if r == '.' || r == scanner.EOF || r == rune(0) {
+		if r == '.' || isEndOfInput(r) {
 			sc.unread()
 			break
 		}
@@ -118,6 +118,10 @@ func (sc *Scanner) scanStr() string {
 
 	for {
 		r := sc.read()
+		if isEndOfInput(r) {
+			break
+		}
+
 		if r == '"' || r == ']' {
 			break
 		}
@@ -148,6 +152,11 @@ func (sc *Scanner) scanInt() (int, error) {
 	}
 
 	return strconv.Atoi(string(number))
+}
+
+// input is either terminated by EOF or null byte
+func isEndOfInput(r rune) bool {
+	return r == scanner.EOF || r == rune(0)
 }
 
 func (sc *Scanner) read() rune {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Fixes a tight loop in the JSON expression lexer, which results from unexpected input.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
We discovered that a query with a JSON expression like `{stream="foo"} | json key="something.["else` caused our ingesters to crash (because we were searching for recent data - it'd crashed queriers if for older data).

This bug occurred because we only break out of the scan loop if a string is terminated `"` or a closing bracket is found `]` - but we don't check for a null byte or EOF which both indicate end of input.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

