### PR TITLE
Investigation: Adds logs to debug a flakky test in our CI

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/index_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/index_test.go
@@ -25,7 +25,7 @@ func Test_schemaPeriodForTable(t *testing.T) {
 		{"out of scope", schemaCfg, "index_" + indexFromTime(start.Time().Add(-24*time.Hour)), chunk.PeriodConfig{}, false},
 		{"first table", schemaCfg, "index_" + indexFromTime(dayFromTime(start).Time.Time()), schemaCfg.Configs[0], true},
 		{"4 hour after first table", schemaCfg, "index_" + indexFromTime(dayFromTime(start).Time.Time().Add(4*time.Hour)), schemaCfg.Configs[0], true},
-		{"second schema", schemaCfg, "index_" + indexFromTime(dayFromTime(start.Add(28*time.Hour)).Time.Time()), schemaCfg.Configs[1], true},
+		{"second schema", schemaCfg, "index_" + indexFromTime(dayFromTime(start.Add(28*time.Hour+1*time.Hour)).Time.Time()), schemaCfg.Configs[1], true},
 		{"now", schemaCfg, "index_" + indexFromTime(time.Now()), schemaCfg.Configs[2], true},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -163,7 +163,11 @@ func Test_Retention(t *testing.T) {
 				require.Eventually(t, func() bool {
 					actual := chunkClient.getDeletedChunkIds()
 					sort.Strings(actual)
-					return assert.ObjectsAreEqual(expectDeleted, actual)
+					if !assert.ObjectsAreEqual(expectDeleted, actual) {
+						t.Logf("expected:%+v actual:%+v", expectDeleted, actual)
+						return false
+					}
+					return true
 				}, 10*time.Second, 1*time.Second)
 			}
 		})


### PR DESCRIPTION
Cannot reproduce the flakky tests we've been experiencing recently.

This PR will add more logs around the problem, if it reappears. This also fixes a config test that was also flaky.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
