### PR TITLE
Parser: Allow literal control chars in logfmt decoder

### DIFF
--- a/pkg/logql/log/logfmt/jsonstring.go
+++ b/pkg/logql/log/logfmt/jsonstring.go
@@ -36,7 +36,7 @@ func unquoteBytes(s []byte) (t []byte, ok bool) {
 	r := 0
 	for r < len(s) {
 		c := s[r]
-		if c == '\\' || c == '"' || c < ' ' {
+		if c == '\\' || c == '"' {
 			break
 		}
 		if c < utf8.RuneSelf {
@@ -118,8 +118,8 @@ func unquoteBytes(s []byte) (t []byte, ok bool) {
 				w += utf8.EncodeRune(b[w:], rr)
 			}
 
-		// Quote, control characters are invalid.
-		case c == '"', c < ' ':
+		// Unescaped quote is invalid.
+		case c == '"':
 			return
 
 		// ASCII

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -575,6 +575,39 @@ func Test_logfmtParser_Parse(t *testing.T) {
 			},
 		},
 		{
+			"newline logfmt",
+			[]byte("foobar=\"foo\nbar baz\""),
+			labels.Labels{
+				{Name: "a", Value: "b"},
+			},
+			labels.Labels{
+				{Name: "a", Value: "b"},
+				{Name: "foobar", Value: "foo\nbar baz"},
+			},
+		},
+		{
+			"escaped logfmt",
+			[]byte(`foobar="foo ba\\r baz"`),
+			labels.Labels{
+				{Name: "a", Value: "b"},
+			},
+			labels.Labels{
+				{Name: "a", Value: "b"},
+				{Name: "foobar", Value: `foo ba\r baz`},
+			},
+		},
+		{
+			"newline and escaped logfmt",
+			[]byte("foobar=\"foo bar\nb\\\\az\""),
+			labels.Labels{
+				{Name: "a", Value: "b"},
+			},
+			labels.Labels{
+				{Name: "a", Value: "b"},
+				{Name: "foobar", Value: "foo bar\nb\\az"},
+			},
+		},
+		{
 			"double property logfmt",
 			[]byte(`foobar="foo bar" latency=10ms`),
 			labels.Labels{

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -575,18 +575,29 @@ func Test_logfmtParser_Parse(t *testing.T) {
 			},
 		},
 		{
-			"newline logfmt",
-			[]byte("foobar=\"foo\nbar baz\""),
+			"escaped control chars in logfmt",
+			[]byte(`foobar="foo\nbar\tbaz"`),
 			labels.Labels{
 				{Name: "a", Value: "b"},
 			},
 			labels.Labels{
 				{Name: "a", Value: "b"},
-				{Name: "foobar", Value: "foo\nbar baz"},
+				{Name: "foobar", Value: "foo\nbar\tbaz"},
 			},
 		},
 		{
-			"escaped logfmt",
+			"literal control chars in logfmt",
+			[]byte("foobar=\"foo\nbar\tbaz\""),
+			labels.Labels{
+				{Name: "a", Value: "b"},
+			},
+			labels.Labels{
+				{Name: "a", Value: "b"},
+				{Name: "foobar", Value: "foo\nbar\tbaz"},
+			},
+		},
+		{
+			"escaped slash logfmt",
 			[]byte(`foobar="foo ba\\r baz"`),
 			labels.Labels{
 				{Name: "a", Value: "b"},
@@ -597,7 +608,7 @@ func Test_logfmtParser_Parse(t *testing.T) {
 			},
 		},
 		{
-			"newline and escaped logfmt",
+			"literal newline and escaped slash logfmt",
 			[]byte("foobar=\"foo bar\nb\\\\az\""),
 			labels.Labels{
 				{Name: "a", Value: "b"},


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows logfmt to handle newlines so long as they are quoted as expected. It still unquotes control chars so nothing should ever break. It just throws less errors.

**Rant**
There are other issues I have ignored. The main one being that the `ScanKeyval` parser tries to be more efficient by avoiding calling `unquoteBytes` unless it sees a `\`, but it relies on `unquoteBytes` to handle utf8. So a unicode token without a `\` may not be decoded correctly. 
`unquoteBytes` also has its own logic to check for slashes so it's inefficient
`unquoteBytes` also seems to expect that the given string starts and ends with `"` but surely anything passing the string has already checked for these delimiters so, why pass them?.. another mystery. And also why does it care if it finds an unescaped quote char, if its not a stream scanner?
Basically someone should inline some of `unquoteBytes` code into `ScanKeyval`, is what I'm getting at.

**Which issue(s) this PR fixes**:
Fixes #3927


**Checklist**
- [ ] Documentation added
- [x] Tests updated

