### PR TITLE
Makefile: Only set PROMTAIL_CGO if CGO_ENABLED is not 0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,13 +202,13 @@ PROMTAIL_GO_FLAGS := $(GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS := $(DEBUG_GO_FLAGS)
 
 # Validate GOHOSTOS=linux && GOOS=linux to use CGO.
-ifneq ($(CGO_ENABLED), 0)
 ifeq ($(shell go env GOHOSTOS),linux)
 ifeq ($(shell go env GOOS),linux)
+ifneq ($(CGO_ENABLED), 0)
 PROMTAIL_CGO = 1
+endif
 PROMTAIL_GO_FLAGS = $(DYN_GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS = $(DYN_DEBUG_GO_FLAGS)
-endif
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -202,11 +202,13 @@ PROMTAIL_GO_FLAGS := $(GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS := $(DEBUG_GO_FLAGS)
 
 # Validate GOHOSTOS=linux && GOOS=linux to use CGO.
+ifneq ($(CGO_ENABLED), 0)
 ifeq ($(shell go env GOHOSTOS),linux)
 ifeq ($(shell go env GOOS),linux)
 PROMTAIL_CGO = 1
 PROMTAIL_GO_FLAGS = $(DYN_GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS = $(DYN_DEBUG_GO_FLAGS)
+endif
 endif
 endif
 


### PR DESCRIPTION
This allows to build promtail without journald support on linux distributions that don't have systemd.

Run as
CGO_ENABLED=0 make promtail

Fixes #3933

