### PR TITLE
Doc: List 'compactor' as valid value for target option

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -107,7 +107,7 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 
 ```yaml
 # The module to run Loki with. Supported values
-# all, distributor, ingester, querier, query-frontend, table-manager.
+# all, compactor, distributor, ingester, querier, query-frontend, table-manager.
 [target: <string> | default = "all"]
 
 # Enables authentication through the X-Scope-OrgID header, which must be present


### PR DESCRIPTION
**What this PR does / why we need it**:

The documentation didn't list the compactor as a valid value for the `target` configuration which made us forget to run it initially. By listing it as a valid value, I think we could help others not to run into the same issue.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

