### PR TITLE
Update json.md

### DIFF
--- a/docs/sources/clients/promtail/stages/json.md
+++ b/docs/sources/clients/promtail/stages/json.md
@@ -97,6 +97,30 @@ and append the following key-value pairs to the set of extracted data:
 
 - `user`: `marco`
 
+Alternatively you can use a `.` between keys to reference sub-keys in a singe pipeline stage:
+
+```yaml
+- json:
+    expressions:
+      output:    log
+      stream:    stream
+      timestamp: time
+      extra.user:
+```
+so given log line:
+
+```
+{"log":"log message\n","stream":"stderr","time":"2019-04-30T02:12:41.8443515Z","extra":"{\"user\":\"marco\"}"}
+```
+
+This single stage would create the following key-value pairs in the set of
+extracted data:
+
+- `output`: `log message\n`
+- `stream`: `stderr`
+- `timestamp`: `2019-04-30T02:12:41.8443515`
+- `extra.user`: `marco`
+
 ### Using a JMESPath Literal
 
 This pipeline uses a literal JMESPath expression to parse JSON fields with


### PR DESCRIPTION
The original example doesn't show that you can use `.` referencing in JSON to get to subkeys that could be quite deep in the object. I think adding the above shows that and then leads nicely into the explanation on quotes for keys containing `.`

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

