### PR TITLE
Improve marker file current time metrics.

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -201,6 +201,8 @@ func (r *markerProcessor) Start(deleteFunc func(ctx context.Context, chunkId []b
 			}
 			if len(paths) == 0 {
 				level.Info(util_log.Logger).Log("msg", "no marks file found")
+				r.sweeperMetrics.markerFileCurrentTime.Set(0)
+				continue
 			}
 			for i, path := range paths {
 				level.Debug(util_log.Logger).Log("msg", "processing mark file", "path", path)


### PR DESCRIPTION
Currently we'll keep the last recorded time, but if the marker file doesn't exist anymore we should reset it.
This would allow us to build consistent alert based on marker files that are too far behind.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
