### PR TITLE
Allow no overrides config for tenants.

### DIFF
--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -50,6 +50,9 @@ type tenantLimitsFromRuntimeConfig struct {
 }
 
 func (t *tenantLimitsFromRuntimeConfig) TenantLimits(userID string) *validation.Limits {
+	if t.c == nil {
+		return nil
+	}
 	cfg, ok := t.c.GetConfig().(*runtimeConfigValues)
 	if !ok || cfg == nil {
 		return nil
@@ -59,6 +62,9 @@ func (t *tenantLimitsFromRuntimeConfig) TenantLimits(userID string) *validation.
 }
 
 func (t *tenantLimitsFromRuntimeConfig) ForEachTenantLimit(callback validation.ForEachTenantLimitCallback) {
+	if t.c == nil {
+		return
+	}
 	cfg, ok := t.c.GetConfig().(*runtimeConfigValues)
 	if !ok || cfg == nil {
 		return

--- a/pkg/loki/runtime_config_test.go
+++ b/pkg/loki/runtime_config_test.go
@@ -116,3 +116,15 @@ func newTestOverrides(t *testing.T, yaml string) *validation.Overrides {
 	require.NoError(t, err)
 	return overrides
 }
+
+func Test_NoOverrides(t *testing.T) {
+	flagset := flag.NewFlagSet("", flag.PanicOnError)
+
+	var defaults validation.Limits
+	defaults.RegisterFlags(flagset)
+	require.NoError(t, flagset.Parse(nil))
+	validation.SetDefaultLimitsForYAMLUnmarshalling(defaults)
+	overrides, err := validation.NewOverrides(defaults, newtenantLimitsFromRuntimeConfig(nil))
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(defaults.QuerySplitDuration), overrides.QuerySplitDuration("foo"))
+}


### PR DESCRIPTION
Recently came across this issue when testing Loki, if we don't provide overrides, Loki will crash on a nil pointer.
This PR fixes this issue, having no overrides is a valid use case.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
