### PR TITLE
Docs: added new target (docs-next) to the docs' Makefile.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,6 +5,11 @@ docs:
 	docker pull ${IMAGE}
 	docker run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/latest -p 3002:3002 $(IMAGE) /bin/bash -c 'mkdir -p content/docs/grafana/latest/ && touch content/docs/grafana/latest/menu.yaml && make server-quick'
 
+.PHONY: docs-next
+docs-next:
+	docker pull ${IMAGE}
+	docker run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/next -p 3002:3002 $(IMAGE) /bin/bash -c 'mkdir -p content/docs/grafana/next/ && touch content/docs/grafana/next/menu.yaml && make server-quick'
+
 .PHONY: docs-test
 docs-test:
 	docker pull ${IMAGE}


### PR DESCRIPTION
This target builds local docs as they should look for commits that are
placed into the main branch, showing the next up, but not yet released
Loki docs.
