### PR TITLE
fix panic in compactor when retention is not enabled

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -216,15 +216,17 @@ func (c *Compactor) RunCompaction(ctx context.Context) error {
 
 	defer func() {
 		c.metrics.compactTablesOperationTotal.WithLabelValues(status).Inc()
-		dmCallback := c.expirationChecker.MarkPhaseFailed
 		if status == statusSuccess {
-			dmCallback = c.expirationChecker.MarkPhaseFinished
 			c.metrics.compactTablesOperationDurationSeconds.Set(time.Since(start).Seconds())
 			c.metrics.compactTablesOperationLastSuccess.SetToCurrentTime()
 		}
 
 		if c.cfg.RetentionEnabled {
-			dmCallback()
+			if status == statusSuccess {
+				c.expirationChecker.MarkPhaseFinished()
+			} else {
+				c.expirationChecker.MarkPhaseFailed()
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Compactor panics when retention is not enabled. This PR fixes it by moving access to `expirationChecker`, which is only initialized when retention is enabled, behind the checks.

