### PR TITLE
log name of the file failed to open during startup by ingester

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table.go
+++ b/pkg/storage/stores/shipper/uploads/table.go
@@ -489,6 +489,7 @@ func loadBoltDBsFromDir(dir string) (map[string]*bbolt.DB, error) {
 
 		db, err := shipper_util.SafeOpenBoltdbFile(fullPath)
 		if err != nil {
+			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to open file %s. Please fix or remove this file to let Loki start successfully.", fullPath), "err", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When an active index file is corrupted due to Loki/Ingester abruptly stopping, it causes Loki/Ingester to fail to start.
We automatically clean up a corrupted file in the `boltdb-cache`, which we can download again from the object store, but we can't recover a file corrupted in the active index directory.

I would not prefer to remove the corrupt file without someone intervening manually because a corrupt file means something is wrong, and that happening frequently could cause data loss. So this PR keeps the behaviour the same but lets the user know which file is corrupt to either try to fix it or remove it.

**Which issue(s) this PR fixes**:
Helps fix Loki failing to start due to a corrupt file on the write path as noticed in https://github.com/grafana/loki/issues/3219

