### PR TITLE
Return build info under `/loki/api/v1/status/buildinfo`.

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -19,6 +19,7 @@ These endpoints are exposed by all components:
 - [`GET /ready`](#get-ready)
 - [`GET /metrics`](#get-metrics)
 - [`GET /config`](#get-config)
+- [`GET /version`](#get-version)
 
 These endpoints are exposed by the querier and the frontend:
 
@@ -822,6 +823,12 @@ modify the output. If it has the value `diff` only the differences between the d
 and the current are returned. A value of `defaults` returns the default configuration.
 
 In microservices mode, the `/config` endpoint is exposed by all components.
+
+## `GET /version`
+
+`/version` exposes the build information in a JSON object. The fields are `version`, `revision ``build_date`, `build_user`, and `revision`.
+
+In microservices mode, the `/version` endpoint is exposed by all components.
 
 ## Series
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -19,7 +19,7 @@ These endpoints are exposed by all components:
 - [`GET /ready`](#get-ready)
 - [`GET /metrics`](#get-metrics)
 - [`GET /config`](#get-config)
-- [`GET /version`](#get-version)
+- [`GET /loki/api/v1/status/buildinfo`](#get-buildinfo)
 
 These endpoints are exposed by the querier and the frontend:
 
@@ -824,9 +824,9 @@ and the current are returned. A value of `defaults` returns the default configur
 
 In microservices mode, the `/config` endpoint is exposed by all components.
 
-## `GET /version`
+## `GET buildinfo`
 
-`/version` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `build_date`, and `build_user`.
+`/loki/api/v1/status/buildinfo` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `buildDate`, `buildUser`, and `goVersion`.
 
 In microservices mode, the `/version` endpoint is exposed by all components.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -826,7 +826,7 @@ In microservices mode, the `/config` endpoint is exposed by all components.
 
 ## `GET /version`
 
-`/version` exposes the build information in a JSON object. The fields are `version`, `revision ``build_date`, `build_user`, and `revision`.
+`/version` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `build_date`, and `build_user`.
 
 In microservices mode, the `/version` endpoint is exposed by all components.
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -261,7 +261,7 @@ func (t *Loki) Run() error {
 	t.Server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
 
 	// This adds a way to see the config and the changes compared to the defaults
-	t.Server.HTTP.Path("/config").HandlerFunc(configHandler(t.Cfg, newDefaultConfig()))
+	t.Server.HTTP.Path("/loki/api/v1/status/buildinfo").HandlerFunc(configHandler(t.Cfg, newDefaultConfig()))
 
 	// Each component serves its version.
 	t.Server.HTTP.Path("/version").HandlerFunc(versionHandler())

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -263,6 +263,9 @@ func (t *Loki) Run() error {
 	// This adds a way to see the config and the changes compared to the defaults
 	t.Server.HTTP.Path("/config").HandlerFunc(configHandler(t.Cfg, newDefaultConfig()))
 
+	// Each component serves its version.
+	t.Server.HTTP.Path("/version").HandlerFunc(versionHandler())
+
 	t.Server.HTTP.Path("/debug/fgprof").Handler(fgprof.Handler())
 
 	// Let's listen for events from this manager, and log them.

--- a/pkg/loki/version_handler.go
+++ b/pkg/loki/version_handler.go
@@ -1,0 +1,32 @@
+package loki
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/grafana/loki/pkg/util/build"
+)
+
+type buildInfo struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"build_user"`
+	BuildDate string `json:"build_date"`
+}
+
+func versionHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		info := buildInfo {
+			Version: build.Version,
+			Revision: build.Revision, 
+			Branch: build.Branch,
+			BuildUser: build.BuildUser, 
+			BuildDate: build.BuildDate,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+    	w.WriteHeader(http.StatusOK)
+    	json.NewEncoder(w).Encode(info)
+	}
+}

--- a/pkg/loki/version_handler.go
+++ b/pkg/loki/version_handler.go
@@ -4,25 +4,20 @@ import (
 	"encoding/json"
 	"net/http"
 
+	prom "github.com/prometheus/prometheus/web/api/v1"
+
 	"github.com/grafana/loki/pkg/util/build"
 )
 
-type buildInfo struct {
-	Version   string `json:"version"`
-	Revision  string `json:"revision"`
-	Branch    string `json:"branch"`
-	BuildUser string `json:"build_user"`
-	BuildDate string `json:"build_date"`
-}
-
 func versionHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		info := buildInfo{
+		info := prom.PrometheusVersion{
 			Version:   build.Version,
 			Revision:  build.Revision,
 			Branch:    build.Branch,
 			BuildUser: build.BuildUser,
 			BuildDate: build.BuildDate,
+			GoVersion: build.GoVersion,
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/loki/version_handler.go
+++ b/pkg/loki/version_handler.go
@@ -17,16 +17,16 @@ type buildInfo struct {
 
 func versionHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		info := buildInfo {
-			Version: build.Version,
-			Revision: build.Revision, 
-			Branch: build.Branch,
-			BuildUser: build.BuildUser, 
+		info := buildInfo{
+			Version:   build.Version,
+			Revision:  build.Revision,
+			Branch:    build.Branch,
+			BuildUser: build.BuildUser,
 			BuildDate: build.BuildDate,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-    	w.WriteHeader(http.StatusOK)
-    	json.NewEncoder(w).Encode(info)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(info)
 	}
 }

--- a/pkg/loki/version_handler.go
+++ b/pkg/loki/version_handler.go
@@ -27,6 +27,10 @@ func versionHandler() http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(info)
+
+		// We ignore errors here, because we cannot do anything about them.
+		// Write will trigger sending Status code, so we cannot send a different status code afterwards.
+		// Also this isn't internal error, but error communicating with client.
+		_ = json.NewEncoder(w).Encode(info)
 	}
 }

--- a/pkg/loki/version_handler_test.go
+++ b/pkg/loki/version_handler_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/loki/pkg/util/build"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/loki/pkg/util/build"
 )
 
 func TestVersionHandler(t *testing.T) {

--- a/pkg/loki/version_handler_test.go
+++ b/pkg/loki/version_handler_test.go
@@ -17,6 +17,7 @@ func TestVersionHandler(t *testing.T) {
 	build.Revision = "foobar"
 	build.BuildDate = "yesterday"
 	build.BuildUser = "Turing"
+	build.GoVersion = "42"
 
 	req := httptest.NewRequest("GET", "http://test.com/config?mode=diff", nil)
 	w := httptest.NewRecorder()
@@ -29,9 +30,10 @@ func TestVersionHandler(t *testing.T) {
 	expected := `{
 		"version":"0.0.1",
 		"branch":"main",
-		"build_date":"yesterday",
-		"build_user":"Turing",
-		"revision":"foobar"
+		"buildDate":"yesterday",
+		"buildUser":"Turing",
+		"revision":"foobar",
+		"goVersion": "42"
 	}`
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)

--- a/pkg/loki/version_handler_test.go
+++ b/pkg/loki/version_handler_test.go
@@ -1,0 +1,38 @@
+package loki
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/loki/pkg/util/build"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionHandler(t *testing.T) {
+	build.Version = "0.0.1"
+	build.Branch = "main"
+	build.Revision= "foobar"
+	build.BuildDate = "yesterday"
+	build.BuildUser = "Turing"
+
+	req := httptest.NewRequest("GET", "http://test.com/config?mode=diff", nil)
+	w := httptest.NewRecorder()
+
+	h := versionHandler()
+	h(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	expected := `{
+		"version":"0.0.1",
+		"branch":"main",
+		"build_date":"yesterday",
+		"build_user":"Turing",
+		"revision":"foobar"
+	}`
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(body))
+}

--- a/pkg/loki/version_handler_test.go
+++ b/pkg/loki/version_handler_test.go
@@ -13,7 +13,7 @@ import (
 func TestVersionHandler(t *testing.T) {
 	build.Version = "0.0.1"
 	build.Branch = "main"
-	build.Revision= "foobar"
+	build.Revision = "foobar"
 	build.BuildDate = "yesterday"
 	build.BuildUser = "Turing"
 

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -254,7 +254,7 @@ func NewLogFilterTripperware(
 	}, nil
 }
 
-// NewSeriesripperware creates a new frontend tripperware responsible for handling series requests
+// NewSeriesTripperware creates a new frontend tripperware responsible for handling series requests
 func NewSeriesTripperware(
 	cfg Config,
 	log log.Logger,

--- a/pkg/util/build/build.go
+++ b/pkg/util/build/build.go
@@ -12,6 +12,7 @@ var (
 	Branch    string
 	BuildUser string
 	BuildDate string
+	GoVersion string
 )
 
 func init() {
@@ -20,4 +21,5 @@ func init() {
 	version.Branch = Branch
 	version.BuildUser = BuildUser
 	version.BuildDate = BuildDate
+	version.GoVersion = "???"
 }

--- a/pkg/util/build/build.go
+++ b/pkg/util/build/build.go
@@ -1,6 +1,10 @@
 package build
 
-import "github.com/prometheus/common/version"
+import (
+	"runtime"
+
+	"github.com/prometheus/common/version"
+)
 
 // Version information passed to Prometheus version package.
 // Package path as used by linker changes based on vendoring being used or not,
@@ -21,5 +25,5 @@ func init() {
 	version.Branch = Branch
 	version.BuildUser = BuildUser
 	version.BuildDate = BuildDate
-	version.GoVersion = "???"
+	version.GoVersion = runtime.Version()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes introduces the `/version` endpoint for all components. It returns the build info in JSON. This should ease debugging.

**Which issue(s) this PR fixes**:
Fixes #3221

**Checklist**
- [x] Documentation added
- [x] Tests updated

