### PR TITLE
add a metric for counting number of failures in opening existing active index files

### DIFF
--- a/pkg/storage/stores/shipper/uploads/metrics.go
+++ b/pkg/storage/stores/shipper/uploads/metrics.go
@@ -11,7 +11,8 @@ const (
 )
 
 type metrics struct {
-	tablesUploadOperationTotal *prometheus.CounterVec
+	tablesUploadOperationTotal    *prometheus.CounterVec
+	openExistingFileFailuresTotal prometheus.Counter
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -21,5 +22,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "tables_upload_operation_total",
 			Help:      "Total number of upload operations done by status",
 		}, []string{"status"}),
+		openExistingFileFailuresTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "open_existing_file_failures_total",
+			Help:      "Total number of failures in opening of existing files while loading active index tables during startup",
+		}),
 	}
 }

--- a/pkg/storage/stores/shipper/uploads/table_manager.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager.go
@@ -239,7 +239,7 @@ func (tm *TableManager) loadTables() (map[string]*Table, error) {
 		}
 
 		level.Info(util_log.Logger).Log("msg", fmt.Sprintf("loading table %s", fileInfo.Name()))
-		table, err := LoadTable(filepath.Join(tm.cfg.IndexDir, fileInfo.Name()), tm.cfg.Uploader, tm.storageClient, tm.boltIndexClient)
+		table, err := LoadTable(filepath.Join(tm.cfg.IndexDir, fileInfo.Name()), tm.cfg.Uploader, tm.storageClient, tm.boltIndexClient, tm.metrics)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -80,14 +80,27 @@ func TestLoadTable(t *testing.T) {
 		},
 	}, false)
 
+	// change a boltdb file to text file which would fail to open.
+	invalidFilePath := filepath.Join(tablePath, "invalid")
+	require.NoError(t, ioutil.WriteFile(invalidFilePath, []byte("invalid boltdb file"), 0666))
+
+	// verify that changed boltdb file can't be opened.
+	_, err = local.OpenBoltdbFile(invalidFilePath)
+	require.Error(t, err)
+
 	// try loading the table.
-	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient)
+	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
 	defer func() {
 		table.Stop()
 	}()
+
+	// verify that we still have 3 files(2 valid, 1 invalid)
+	filesInfo, err := ioutil.ReadDir(tablePath)
+	require.NoError(t, err)
+	require.Len(t, filesInfo, 3)
 
 	require.NoError(t, table.Snapshot())
 
@@ -269,7 +282,7 @@ func TestTable_Cleanup(t *testing.T) {
 	testutil.AddRecordsToDB(t, notUploaded, boltDBIndexClient, 20, 10)
 
 	// load existing dbs
-	table, err := LoadTable(indexPath, "test", storageClient, boltDBIndexClient)
+	table, err := LoadTable(indexPath, "test", storageClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.Len(t, table.dbs, 3)
 
@@ -353,7 +366,7 @@ func Test_LoadBoltDBsFromDir(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// try loading the dbs
-	dbs, err := loadBoltDBsFromDir(tablePath)
+	dbs, err := loadBoltDBsFromDir(tablePath, newMetrics(nil))
 	require.NoError(t, err)
 
 	// check that we have just 2 dbs
@@ -406,7 +419,7 @@ func TestTable_ImmutableUploads(t *testing.T) {
 	// setup some dbs for a table at a path.
 	tablePath := testutil.SetupDBTablesAtPath(t, "test-table", indexPath, dbs, false)
 
-	table, err := LoadTable(tablePath, "test", storageClient, boltDBIndexClient)
+	table, err := LoadTable(tablePath, "test", storageClient, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
@@ -487,7 +500,7 @@ func TestTable_MultiQueries(t *testing.T) {
 	}, false)
 
 	// try loading the table.
-	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient)
+	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds a metric to count the failures in opening active index files while loading the tables.
The file would be left untouched with its path logged as error and the code would move ahead, not causing the service to stop until the file gets fixed. The metric would help users setup an alert on it to make sure the corrupt file does not go unnoticed.
 
**Which issue(s) this PR fixes**:
Fixes #3219 

