### PR TITLE
Add a chunk filterer field to the config

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -77,6 +77,8 @@ type Config struct {
 	QueryStoreMaxLookBackPeriod time.Duration `yaml:"query_store_max_look_back_period"`
 
 	WAL WALConfig `yaml:"wal,omitempty"`
+
+	ChunkFilterer storage.RequestChunkFilterer `yaml:"-"`
 }
 
 // RegisterFlags registers the flags.
@@ -218,6 +220,10 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
 
 	i.Service = services.NewBasicService(i.starting, i.running, i.stopping)
+
+	if i.cfg.ChunkFilterer != nil {
+		i.SetChunkFilterer(i.cfg.ChunkFilterer)
+	}
 	return i, nil
 }
 


### PR DESCRIPTION
Setting a ChunkFilterer on the ingester currently has to be done after the ingester is created using the `SetChunkFilterer()` function. This means another target had to be added that depends on the `ingester` target just to set this.

This  PR adds a field to the config so this can be set before the `ingester` target runs. No flag is added to set the new field.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

