### PR TITLE
fixes chunk size method in facade

### DIFF
--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -77,7 +77,8 @@ func (f Facade) Size() int {
 	if f.c == nil {
 		return 0
 	}
-	return f.c.Size()
+	// Note this is an estimation (which is OK)
+	return f.c.CompressedSize()
 }
 
 // LokiChunk returns the chunkenc.Chunk.

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -111,6 +111,7 @@ type Chunk interface {
 	SampleIterator(ctx context.Context, from, through time.Time, extractor log.StreamSampleExtractor) iter.SampleIterator
 	// Returns the list of blocks in the chunks.
 	Blocks(mintT, maxtT time.Time) []Block
+	// Size returns the number of entries in a chunk
 	Size() int
 	Bytes() ([]byte, error)
 	BytesWith([]byte) ([]byte, error) // uses provided []byte for buffer instantiation


### PR DESCRIPTION
I noticed we've misrepresented the `Chunk.Size` method across Loki & Cortex. [Loki](https://github.com/grafana/loki/blob/main/pkg/ingester/flush.go#L398) uses this to describe the chunk's entry count, while [Cortex](https://github.com/cortexproject/cortex/blob/master/pkg/chunk/encoding/chunk.go#L72-L73) uses this to describe the byte size. You can see this by comparing the following two metrics:

`sum(rate(loki_ingester_chunk_size_bytes_sum[1m]))`
vs
`sum(rate(cortex_chunk_store_stored_chunk_bytes_total[1m]))`

This hasn't hurt us asides from misaligning metrics, but it's good to fix.