### PR TITLE
Add LogQL AST walker

### DIFF
--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -367,7 +367,7 @@ func Test_parserExpr_Parser(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &labelParserExpr{
+			e := &LabelParserExpr{
 				op:    tt.op,
 				param: tt.param,
 			}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -173,7 +173,7 @@ func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
 
 // evalSample evaluate a sampleExpr
 func (q *query) evalSample(ctx context.Context, expr SampleExpr) (promql_parser.Value, error) {
-	if lit, ok := expr.(*literalExpr); ok {
+	if lit, ok := expr.(*LiteralExpr); ok {
 		return q.evalLiteral(ctx, lit)
 	}
 
@@ -257,7 +257,7 @@ func (q *query) evalSample(ctx context.Context, expr SampleExpr) (promql_parser.
 	return result, stepEvaluator.Error()
 }
 
-func (q *query) evalLiteral(_ context.Context, expr *literalExpr) (promql_parser.Value, error) {
+func (q *query) evalLiteral(_ context.Context, expr *LiteralExpr) (promql_parser.Value, error) {
 	s := promql.Scalar{
 		T: q.params.Start().UnixNano() / int64(time.Millisecond),
 		V: expr.value,

--- a/pkg/logql/expr.y
+++ b/pkg/logql/expr.y
@@ -15,7 +15,7 @@ import (
   Grouping                *grouping
   Labels                  []string
   LogExpr                 LogSelectorExpr
-  LogRangeExpr            *logRange
+  LogRangeExpr            *LogRange
   Matcher                 *labels.Matcher
   Matchers                []*labels.Matcher
   RangeAggregationExpr    SampleExpr
@@ -31,10 +31,10 @@ import (
   bytes                   uint64
   str                     string
   duration                time.Duration
-  LiteralExpr             *literalExpr
+  LiteralExpr             *LiteralExpr
   BinOpModifier           BinOpOptions
-  LabelParser             *labelParserExpr
-  LineFilters             *lineFilterExpr
+  LabelParser             *LabelParserExpr
+  LineFilters             *LineFilterExpr
   PipelineExpr            MultiStageExpr
   PipelineStage           StageExpr
   BytesFilter             log.LabelFilterer
@@ -42,15 +42,15 @@ import (
   DurationFilter          log.LabelFilterer
   LabelFilter             log.LabelFilterer
   UnitFilter              log.LabelFilterer
-  LineFormatExpr          *lineFmtExpr
-  LabelFormatExpr         *labelFmtExpr
+  LineFormatExpr          *LineFmtExpr
+  LabelFormatExpr         *LabelFmtExpr
   LabelFormat             log.LabelFmt
   LabelsFormat            []log.LabelFmt
   JSONExpressionParser    *jsonExpressionParser
   JSONExpression          log.JSONExpression
   JSONExpressionList      []log.JSONExpression
-  UnwrapExpr              *unwrapExpr
-  OffsetExpr              *offsetExpr
+  UnwrapExpr              *UnwrapExpr
+  OffsetExpr              *OffsetExpr
 }
 
 %start root
@@ -232,7 +232,7 @@ pipelineStage:
    lineFilters                   { $$ = $1 }
   | PIPE labelParser             { $$ = $2 }
   | PIPE jsonExpressionParser    { $$ = $2 }
-  | PIPE labelFilter             { $$ = &labelFilterExpr{LabelFilterer: $2 }}
+  | PIPE labelFilter             { $$ = &LabelFilterExpr{LabelFilterer: $2 }}
   | PIPE lineFormatExpr          { $$ = $2 }
   | PIPE labelFormatExpr         { $$ = $2 }
   ;

--- a/pkg/logql/expr.y.go
+++ b/pkg/logql/expr.y.go
@@ -17,7 +17,7 @@ type exprSymType struct {
 	Grouping              *grouping
 	Labels                []string
 	LogExpr               LogSelectorExpr
-	LogRangeExpr          *logRange
+	LogRangeExpr          *LogRange
 	Matcher               *labels.Matcher
 	Matchers              []*labels.Matcher
 	RangeAggregationExpr  SampleExpr
@@ -33,10 +33,10 @@ type exprSymType struct {
 	bytes                 uint64
 	str                   string
 	duration              time.Duration
-	LiteralExpr           *literalExpr
+	LiteralExpr           *LiteralExpr
 	BinOpModifier         BinOpOptions
-	LabelParser           *labelParserExpr
-	LineFilters           *lineFilterExpr
+	LabelParser           *LabelParserExpr
+	LineFilters           *LineFilterExpr
 	PipelineExpr          MultiStageExpr
 	PipelineStage         StageExpr
 	BytesFilter           log.LabelFilterer
@@ -44,15 +44,15 @@ type exprSymType struct {
 	DurationFilter        log.LabelFilterer
 	LabelFilter           log.LabelFilterer
 	UnitFilter            log.LabelFilterer
-	LineFormatExpr        *lineFmtExpr
-	LabelFormatExpr       *labelFmtExpr
+	LineFormatExpr        *LineFmtExpr
+	LabelFormatExpr       *LabelFmtExpr
 	LabelFormat           log.LabelFmt
 	LabelsFormat          []log.LabelFmt
-	JSONExpressionParser  *jsonExpressionParser
+	JSONExpressionParser  *JSONExpressionParser
 	JSONExpression        log.JSONExpression
 	JSONExpressionList    []log.JSONExpression
-	UnwrapExpr            *unwrapExpr
-	OffsetExpr            *offsetExpr
+	UnwrapExpr            *UnwrapExpr
+	OffsetExpr            *OffsetExpr
 }
 
 const BYTES = 57346
@@ -218,7 +218,6 @@ var exprStatenames = [...]string{}
 const exprEofCode = 1
 const exprErrCode = 2
 const exprInitialStackSize = 16
-
 
 var exprExca = [...]int{
 	-1, 1,
@@ -457,7 +456,6 @@ var exprErrorMessages = [...]struct {
 	token int
 	msg   string
 }{}
-
 
 /*	parser for yacc output	*/
 
@@ -1150,7 +1148,7 @@ exprdefault:
 	case 74:
 		exprDollar = exprS[exprpt-2 : exprpt+1]
 		{
-			exprVAL.PipelineStage = &labelFilterExpr{LabelFilterer: exprDollar[2].LabelFilter}
+			exprVAL.PipelineStage = &LabelFilterExpr{LabelFilterer: exprDollar[2].LabelFilter}
 		}
 	case 75:
 		exprDollar = exprS[exprpt-2 : exprpt+1]

--- a/pkg/logql/functions.go
+++ b/pkg/logql/functions.go
@@ -13,12 +13,12 @@ import (
 
 const unsupportedErr = "unsupported range vector aggregation operation: %s"
 
-func (r rangeAggregationExpr) Extractor() (log.SampleExtractor, error) {
+func (r RangeAggregationExpr) Extractor() (log.SampleExtractor, error) {
 	return r.extractor(nil)
 }
 
 // extractor creates a SampleExtractor but allows for the grouping to be overridden.
-func (r rangeAggregationExpr) extractor(override *grouping) (log.SampleExtractor, error) {
+func (r RangeAggregationExpr) extractor(override *grouping) (log.SampleExtractor, error) {
 	if err := r.validate(); err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (r rangeAggregationExpr) extractor(override *grouping) (log.SampleExtractor
 	sort.Strings(groups)
 
 	var stages []log.Stage
-	if p, ok := r.left.left.(*pipelineExpr); ok {
+	if p, ok := r.left.left.(*PipelineExpr); ok {
 		// if the expression is a pipeline then take all stages into account first.
 		st, err := p.pipeline.stages()
 		if err != nil {
@@ -89,7 +89,7 @@ func (r rangeAggregationExpr) extractor(override *grouping) (log.SampleExtractor
 	}
 }
 
-func (r rangeAggregationExpr) aggregator() (RangeVectorAggregator, error) {
+func (r RangeAggregationExpr) aggregator() (RangeVectorAggregator, error) {
 	switch r.operation {
 	case OpRangeTypeRate:
 		return rateLogs(r.left.interval, r.left.unwrap != nil), nil

--- a/pkg/logql/parser.go
+++ b/pkg/logql/parser.go
@@ -138,7 +138,7 @@ func ParseMatchers(input string) ([]*labels.Matcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	matcherExpr, ok := expr.(*matchersExpr)
+	matcherExpr, ok := expr.(*MatchersExpr)
 	if !ok {
 		return nil, errors.New("only label matchers is supported")
 	}
@@ -161,13 +161,13 @@ func ParseSampleExpr(input string) (SampleExpr, error) {
 
 func validateSampleExpr(expr SampleExpr) error {
 	switch e := expr.(type) {
-	case *binOpExpr:
+	case *BinOpExpr:
 		if err := validateSampleExpr(e.SampleExpr); err != nil {
 			return err
 		}
 
 		return validateSampleExpr(e.RHS)
-	case *literalExpr:
+	case *LiteralExpr:
 		return nil
 	default:
 		return validateMatchers(expr.Selector().Matchers())

--- a/pkg/logql/parser_test.go
+++ b/pkg/logql/parser_test.go
@@ -26,14 +26,14 @@ func TestParse(t *testing.T) {
 		{
 			// raw string
 			in: "count_over_time({foo=~`bar\\w+`}[12h] |~ `error\\`)",
-			exp: &rangeAggregationExpr{
+			exp: &RangeAggregationExpr{
 				operation: "count_over_time",
-				left: &logRange{
-					left: &pipelineExpr{
+				left: &LogRange{
+					left: &PipelineExpr{
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchRegexp, "error\\"),
 						},
-						left: &matchersExpr{
+						left: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchRegexp, "foo", "bar\\w+"),
 							},
@@ -46,9 +46,9 @@ func TestParse(t *testing.T) {
 		{
 			// test [12h] before filter expr
 			in: `count_over_time({foo="bar"}[12h] |= "error")`,
-			exp: &rangeAggregationExpr{
+			exp: &RangeAggregationExpr{
 				operation: "count_over_time",
-				left: &logRange{
+				left: &LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}),
 						MultiStageExpr{
@@ -62,9 +62,9 @@ func TestParse(t *testing.T) {
 		{
 			// test [12h] after filter expr
 			in: `count_over_time({foo="bar"} |= "error" [12h])`,
-			exp: &rangeAggregationExpr{
+			exp: &RangeAggregationExpr{
 				operation: "count_over_time",
-				left: &logRange{
+				left: &LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}),
 						MultiStageExpr{newLineFilterExpr(nil, labels.MatchEqual, "error")},
@@ -75,35 +75,35 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  `{foo="bar"}`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 		},
 		{
 			in:  `{ foo = "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 		},
 		{
 			in: `{ namespace="buzz", foo != "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{
+			exp: &MatchersExpr{matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, "namespace", "buzz"),
 				mustNewMatcher(labels.MatchNotEqual, "foo", "bar"),
 			}},
 		},
 		{
 			in:  `{ foo =~ "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchRegexp, "foo", "bar")}},
+			exp: &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchRegexp, "foo", "bar")}},
 		},
 		{
 			in: `{ namespace="buzz", foo !~ "bar" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{
+			exp: &MatchersExpr{matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, "namespace", "buzz"),
 				mustNewMatcher(labels.MatchNotRegexp, "foo", "bar"),
 			}},
 		},
 		{
 			in: `count_over_time({ foo = "bar" }[12m])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 12 * time.Minute,
 				},
 				operation: "count_over_time",
@@ -111,9 +111,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `bytes_over_time({ foo = "bar" }[12m])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 12 * time.Minute,
 				},
 				operation: OpRangeTypeBytes,
@@ -121,9 +121,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `bytes_rate({ foo = "bar" }[12m])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 12 * time.Minute,
 				},
 				operation: OpRangeTypeBytesRate,
@@ -131,9 +131,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `rate({ foo = "bar" }[5h])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "rate",
@@ -141,9 +141,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `rate({ foo = "bar" }[5d])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * 24 * time.Hour,
 				},
 				operation: "rate",
@@ -151,9 +151,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `count_over_time({ foo = "bar" }[1w])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 7 * 24 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -161,9 +161,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `absent_over_time({ foo = "bar" }[1w])`,
-			exp: &rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: &RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 7 * 24 * time.Hour,
 				},
 				operation: OpRangeTypeAbsent,
@@ -171,9 +171,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `sum(rate({ foo = "bar" }[5h]))`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "rate",
@@ -181,9 +181,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `sum(rate({ foo ="bar" }[1y]))`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 365 * 24 * time.Hour,
 				},
 				operation: "rate",
@@ -191,9 +191,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `avg(count_over_time({ foo = "bar" }[5h])) by (bar,foo)`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -214,9 +214,9 @@ func TestParse(t *testing.T) {
 				) by (bar,foo)`,
 			exp: mustNewVectorAggregationExpr(
 				mustNewLabelReplaceExpr(
-					&rangeAggregationExpr{
-						left: &logRange{
-							left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+					&RangeAggregationExpr{
+						left: &LogRange{
+							left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 							interval: 5 * time.Hour,
 						},
 						operation: "count_over_time",
@@ -230,9 +230,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `avg(count_over_time({ foo = "bar" }[5h])) by ()`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -243,9 +243,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `max without (bar) (count_over_time({ foo = "bar" }[5h]))`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -256,9 +256,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `max without () (count_over_time({ foo = "bar" }[5h]))`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -269,9 +269,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `topk(10,count_over_time({ foo = "bar" }[5h])) without (bar)`,
-			exp: mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -282,9 +282,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `bottomk(30 ,sum(rate({ foo = "bar" }[5h])) by (foo))`,
-			exp: mustNewVectorAggregationExpr(mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "rate",
@@ -296,9 +296,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `max( sum(count_over_time({ foo = "bar" }[5h])) without (foo,bar) ) by (foo)`,
-			exp: mustNewVectorAggregationExpr(mustNewVectorAggregationExpr(&rangeAggregationExpr{
-				left: &logRange{
-					left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+			exp: mustNewVectorAggregationExpr(mustNewVectorAggregationExpr(&RangeAggregationExpr{
+				left: &LogRange{
+					left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 					interval: 5 * time.Hour,
 				},
 				operation: "count_over_time",
@@ -360,7 +360,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{ foo = "bar", bar != "baz" }`,
-			exp: &matchersExpr{matchers: []*labels.Matcher{
+			exp: &MatchersExpr{matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 				mustNewMatcher(labels.MatchNotEqual, "bar", "baz"),
 			}},
@@ -390,7 +390,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `count_over_time(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap")[5m])`,
 			exp: newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -409,7 +409,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `bytes_over_time(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap")[5m])`,
 			exp: newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -428,7 +428,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `bytes_over_time(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap" | unpack)[5m])`,
 			exp: newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -457,7 +457,7 @@ func TestParse(t *testing.T) {
 			`,
 			exp: mustNewLabelReplaceExpr(
 				newRangeAggregationExpr(
-					&logRange{
+					&LogRange{
 						left: newPipelineExpr(
 							newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 							MultiStageExpr{
@@ -481,7 +481,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum(count_over_time(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap")[5m])) by (foo)`,
 			exp: mustNewVectorAggregationExpr(newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -506,7 +506,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum(bytes_rate(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap")[5m])) by (foo)`,
 			exp: mustNewVectorAggregationExpr(newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -531,7 +531,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `topk(5,count_over_time(({foo="bar"} |= "baz" |~ "blip" != "flip" !~ "flap")[5m])) without (foo)`,
 			exp: mustNewVectorAggregationExpr(newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -558,7 +558,7 @@ func TestParse(t *testing.T) {
 			exp: mustNewVectorAggregationExpr(
 				mustNewVectorAggregationExpr(
 					newRangeAggregationExpr(
-						&logRange{
+						&LogRange{
 							left: newPipelineExpr(
 								newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 								MultiStageExpr{
@@ -586,7 +586,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `count_over_time({foo="bar"}[5m] |= "baz" |~ "blip" != "flip" !~ "flap")`,
 			exp: newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -605,7 +605,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum(count_over_time({foo="bar"}[5m] |= "baz" |~ "blip" != "flip" !~ "flap")) by (foo)`,
 			exp: mustNewVectorAggregationExpr(newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -630,7 +630,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `topk(5,count_over_time({foo="bar"}[5m] |= "baz" |~ "blip" != "flip" !~ "flap")) without (foo)`,
 			exp: mustNewVectorAggregationExpr(newRangeAggregationExpr(
-				&logRange{
+				&LogRange{
 					left: newPipelineExpr(
 						newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 						MultiStageExpr{
@@ -657,7 +657,7 @@ func TestParse(t *testing.T) {
 			exp: mustNewVectorAggregationExpr(
 				mustNewVectorAggregationExpr(
 					newRangeAggregationExpr(
-						&logRange{
+						&LogRange{
 							left: newPipelineExpr(
 								newMatcherExpr([]*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}),
 								MultiStageExpr{
@@ -718,8 +718,8 @@ func TestParse(t *testing.T) {
 					OpTypeDiv,
 					BinOpOptions{},
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -734,8 +734,8 @@ func TestParse(t *testing.T) {
 						nil,
 					),
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -751,8 +751,8 @@ func TestParse(t *testing.T) {
 					),
 				),
 				mustNewVectorAggregationExpr(newRangeAggregationExpr(
-					&logRange{
-						left: &matchersExpr{
+					&LogRange{
+						left: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 							},
@@ -781,8 +781,8 @@ func TestParse(t *testing.T) {
 					OpTypePow,
 					BinOpOptions{},
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -797,8 +797,8 @@ func TestParse(t *testing.T) {
 						nil,
 					),
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -814,8 +814,8 @@ func TestParse(t *testing.T) {
 					),
 				),
 				mustNewVectorAggregationExpr(newRangeAggregationExpr(
-					&logRange{
-						left: &matchersExpr{
+					&LogRange{
+						left: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 							},
@@ -842,8 +842,8 @@ func TestParse(t *testing.T) {
 				OpTypeAdd,
 				BinOpOptions{},
 				mustNewVectorAggregationExpr(newRangeAggregationExpr(
-					&logRange{
-						left: &matchersExpr{
+					&LogRange{
+						left: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 							},
@@ -861,8 +861,8 @@ func TestParse(t *testing.T) {
 					OpTypeDiv,
 					BinOpOptions{},
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -877,8 +877,8 @@ func TestParse(t *testing.T) {
 						nil,
 					),
 					mustNewVectorAggregationExpr(newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -905,7 +905,7 @@ func TestParse(t *testing.T) {
 				mustNewBinOpExpr(OpTypeDiv,
 					BinOpOptions{},
 					newRangeAggregationExpr(
-						&logRange{
+						&LogRange{
 							left: newPipelineExpr(
 								newMatcherExpr([]*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
@@ -916,8 +916,8 @@ func TestParse(t *testing.T) {
 							interval: 5 * time.Minute,
 						}, OpRangeTypeCount, nil, nil),
 					newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
 								},
@@ -935,7 +935,7 @@ func TestParse(t *testing.T) {
 				mustNewBinOpExpr(OpTypeDiv,
 					BinOpOptions{},
 					newRangeAggregationExpr(
-						&logRange{
+						&LogRange{
 							left: newPipelineExpr(
 								newMatcherExpr([]*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
@@ -946,8 +946,8 @@ func TestParse(t *testing.T) {
 							interval: 5 * time.Minute,
 						}, OpRangeTypeCount, nil, nil),
 					newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "namespace", "tns"),
 								},
@@ -965,8 +965,8 @@ func TestParse(t *testing.T) {
 				BinOpOptions{},
 				mustNewVectorAggregationExpr(
 					newRangeAggregationExpr(
-						&logRange{
-							left: &matchersExpr{
+						&LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -980,7 +980,7 @@ func TestParse(t *testing.T) {
 					},
 					nil,
 				),
-				&literalExpr{value: 0.5},
+				&LiteralExpr{value: 0.5},
 			),
 		},
 		{
@@ -989,8 +989,8 @@ func TestParse(t *testing.T) {
 			exp: mustNewBinOpExpr(
 				OpTypeAdd,
 				BinOpOptions{},
-				&literalExpr{value: 1},
-				mustNewBinOpExpr(OpTypeDiv, BinOpOptions{}, &literalExpr{value: -2}, &literalExpr{value: 1}),
+				&LiteralExpr{value: 1},
+				mustNewBinOpExpr(OpTypeDiv, BinOpOptions{}, &LiteralExpr{value: -2}, &LiteralExpr{value: 1}),
 			),
 		},
 		{
@@ -999,18 +999,18 @@ func TestParse(t *testing.T) {
 			exp: mustNewBinOpExpr(
 				OpTypeSub,
 				BinOpOptions{},
-				mustNewBinOpExpr(OpTypeAdd, BinOpOptions{}, &literalExpr{value: 1}, &literalExpr{value: 1}),
-				&literalExpr{value: -1},
+				mustNewBinOpExpr(OpTypeAdd, BinOpOptions{}, &LiteralExpr{value: 1}, &LiteralExpr{value: 1}),
+				&LiteralExpr{value: -1},
 			),
 		},
 		{
 			in: `{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 							log.NewAndLabelFilter(
@@ -1024,13 +1024,13 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | unpack | json | latency >= 250ms or ( status_code < 500 and status_code > 200)`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeUnpack, ""),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 							log.NewAndLabelFilter(
@@ -1044,12 +1044,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | json | (duration > 1s or status!= 200) and method!="POST"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
 							log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThan, "duration", 1*time.Second),
@@ -1063,12 +1063,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | pattern "<foo> bar <buzz>" | (duration > 1s or status!= 200) and method!="POST"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypePattern, "<foo> bar <buzz>"),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
 							log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThan, "duration", 1*time.Second),
@@ -1082,12 +1082,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | json | ( status_code < 500 and status_code > 200) or latency >= 250ms `,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewAndLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterLesserThan, "status_code", 500.0),
@@ -1101,12 +1101,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | json | ( status_code < 500 or status_code > 200) and latency >= 250ms `,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
 							log.NewOrLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterLesserThan, "status_code", 500.0),
@@ -1120,12 +1120,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | json |  status_code < 500 or status_code > 200 and latency >= 250ms `,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewNumericLabelFilter(log.LabelFilterLesserThan, "status_code", 500.0),
 							log.NewAndLabelFilter(
@@ -1140,12 +1140,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 				| foo="bar" buzz!="blip", blop=~"boop" or fuzz==5`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 							log.NewAndLabelFilter(
@@ -1154,7 +1154,7 @@ func TestParse(t *testing.T) {
 							),
 						),
 					},
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewAndLabelFilter(
 							log.NewStringLabelFilter(mustNewMatcher(labels.MatchEqual, "foo", "bar")),
 							log.NewAndLabelFilter(
@@ -1171,7 +1171,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | line_format "blip{{ .foo }}blop"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
@@ -1182,12 +1182,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 							log.NewAndLabelFilter(
@@ -1203,12 +1203,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 							log.NewAndLabelFilter(
@@ -1229,12 +1229,12 @@ func TestParse(t *testing.T) {
 			in: `count_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}"[5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1275,12 +1275,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "bar" | json |  status_code < 500 or status_code > 200 and size >= 2.5KiB `,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 					newLabelParserExpr(OpParserTypeJSON, ""),
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewOrLabelFilter(
 							log.NewNumericLabelFilter(log.LabelFilterLesserThan, "status_code", 500.0),
 							log.NewAndLabelFilter(
@@ -1296,12 +1296,12 @@ func TestParse(t *testing.T) {
 			in: `stdvar_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1327,12 +1327,12 @@ func TestParse(t *testing.T) {
 			in: `stdvar_over_time({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap duration(foo) [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1357,12 +1357,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum_over_time({namespace="tns"} |= "level=error" | json |foo>=5,bar<25ms| unwrap bytes(foo) [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "level=error"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewAndLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, "foo", 5),
 								log.NewDurationLabelFilter(log.LabelFilterLesserThan, "bar", 25*time.Millisecond),
@@ -1379,12 +1379,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum_over_time({namespace="tns"} |= "level=error" | json |foo>=5,bar<25ms| unwrap bytes(foo) [5m] offset 5m)`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "level=error"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewAndLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, "foo", 5),
 								log.NewDurationLabelFilter(log.LabelFilterLesserThan, "bar", 25*time.Millisecond),
@@ -1401,12 +1401,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum_over_time({namespace="tns"} |= "level=error" | json |foo>=5,bar<25ms| unwrap latency [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "level=error"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewAndLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, "foo", 5),
 								log.NewDurationLabelFilter(log.LabelFilterLesserThan, "bar", 25*time.Millisecond),
@@ -1423,12 +1423,12 @@ func TestParse(t *testing.T) {
 		{
 			in: `sum_over_time({namespace="tns"} |= "level=error" | json |foo==5,bar<25ms| unwrap latency [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "namespace", Value: "tns"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "level=error"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewAndLabelFilter(
 								log.NewNumericLabelFilter(log.LabelFilterEqual, "foo", 5),
 								log.NewDurationLabelFilter(log.LabelFilterLesserThan, "bar", 25*time.Millisecond),
@@ -1445,7 +1445,7 @@ func TestParse(t *testing.T) {
 		{
 			in: `stddev_over_time({app="foo"} |= "bar" | unwrap bar [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
@@ -1516,12 +1516,12 @@ func TestParse(t *testing.T) {
 			in: `max_over_time(({app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo )[5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1547,12 +1547,12 @@ func TestParse(t *testing.T) {
 			in: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo [5m])`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1578,12 +1578,12 @@ func TestParse(t *testing.T) {
 			in: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo [5m]) by (namespace,instance)`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1609,12 +1609,12 @@ func TestParse(t *testing.T) {
 			in: `quantile_over_time(0.99998,{app="foo"} |= "bar" | json | latency >= 250ms or ( status_code < 500 and status_code > 200)
 			| line_format "blip{{ .foo }}blop {{.status_code}}" | label_format foo=bar,status_code="buzz{{.bar}}" | unwrap foo | __error__ !~".+"[5m]) by (namespace,instance)`,
 			exp: newRangeAggregationExpr(
-				newLogRange(&pipelineExpr{
+				newLogRange(&PipelineExpr{
 					left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 					pipeline: MultiStageExpr{
 						newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 						newLabelParserExpr(OpParserTypeJSON, ""),
-						&labelFilterExpr{
+						&LabelFilterExpr{
 							LabelFilterer: log.NewOrLabelFilter(
 								log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 								log.NewAndLabelFilter(
@@ -1644,12 +1644,12 @@ func TestParse(t *testing.T) {
 					)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1683,12 +1683,12 @@ func TestParse(t *testing.T) {
 					)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1722,12 +1722,12 @@ func TestParse(t *testing.T) {
 				)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1761,12 +1761,12 @@ func TestParse(t *testing.T) {
 				)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1800,12 +1800,12 @@ func TestParse(t *testing.T) {
 				)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1839,12 +1839,12 @@ func TestParse(t *testing.T) {
 					)`,
 			exp: mustNewVectorAggregationExpr(
 				newRangeAggregationExpr(
-					newLogRange(&pipelineExpr{
+					newLogRange(&PipelineExpr{
 						left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 						pipeline: MultiStageExpr{
 							newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 							newLabelParserExpr(OpParserTypeJSON, ""),
-							&labelFilterExpr{
+							&LabelFilterExpr{
 								LabelFilterer: log.NewOrLabelFilter(
 									log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 									log.NewAndLabelFilter(
@@ -1887,12 +1887,12 @@ func TestParse(t *testing.T) {
 			exp: mustNewBinOpExpr(OpTypeAdd, BinOpOptions{ReturnBool: false},
 				mustNewVectorAggregationExpr(
 					newRangeAggregationExpr(
-						newLogRange(&pipelineExpr{
+						newLogRange(&PipelineExpr{
 							left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 							pipeline: MultiStageExpr{
 								newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 								newLabelParserExpr(OpParserTypeJSON, ""),
-								&labelFilterExpr{
+								&LabelFilterExpr{
 									LabelFilterer: log.NewOrLabelFilter(
 										log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 										log.NewAndLabelFilter(
@@ -1919,12 +1919,12 @@ func TestParse(t *testing.T) {
 				),
 				mustNewVectorAggregationExpr(
 					newRangeAggregationExpr(
-						newLogRange(&pipelineExpr{
+						newLogRange(&PipelineExpr{
 							left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 							pipeline: MultiStageExpr{
 								newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 								newLabelParserExpr(OpParserTypeJSON, ""),
-								&labelFilterExpr{
+								&LabelFilterExpr{
 									LabelFilterer: log.NewOrLabelFilter(
 										log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 										log.NewAndLabelFilter(
@@ -1974,12 +1974,12 @@ func TestParse(t *testing.T) {
 				mustNewBinOpExpr(OpTypeAdd, BinOpOptions{ReturnBool: false},
 					mustNewVectorAggregationExpr(
 						newRangeAggregationExpr(
-							newLogRange(&pipelineExpr{
+							newLogRange(&PipelineExpr{
 								left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 								pipeline: MultiStageExpr{
 									newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 									newLabelParserExpr(OpParserTypeJSON, ""),
-									&labelFilterExpr{
+									&LabelFilterExpr{
 										LabelFilterer: log.NewOrLabelFilter(
 											log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 											log.NewAndLabelFilter(
@@ -2006,12 +2006,12 @@ func TestParse(t *testing.T) {
 					),
 					mustNewVectorAggregationExpr(
 						newRangeAggregationExpr(
-							newLogRange(&pipelineExpr{
+							newLogRange(&PipelineExpr{
 								left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 								pipeline: MultiStageExpr{
 									newLineFilterExpr(nil, labels.MatchEqual, "bar"),
 									newLabelParserExpr(OpParserTypeJSON, ""),
-									&labelFilterExpr{
+									&LabelFilterExpr{
 										LabelFilterer: log.NewOrLabelFilter(
 											log.NewDurationLabelFilter(log.LabelFilterGreaterThanOrEqual, "latency", 250*time.Millisecond),
 											log.NewAndLabelFilter(
@@ -2043,54 +2043,54 @@ func TestParse(t *testing.T) {
 		{
 			// ensure binary ops with two literals are reduced recursively
 			in:  `1 + 1 + 1`,
-			exp: &literalExpr{value: 3},
+			exp: &LiteralExpr{value: 3},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 == 1`,
-			exp: &literalExpr{value: 1},
+			exp: &LiteralExpr{value: 1},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 != 1`,
-			exp: &literalExpr{value: 0},
+			exp: &LiteralExpr{value: 0},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 > 1`,
-			exp: &literalExpr{value: 0},
+			exp: &LiteralExpr{value: 0},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 >= 1`,
-			exp: &literalExpr{value: 1},
+			exp: &LiteralExpr{value: 1},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 < 1`,
-			exp: &literalExpr{value: 0},
+			exp: &LiteralExpr{value: 0},
 		},
 		{
 			// ensure binary ops with two literals are reduced when comparisons are used
 			in:  `1 <= 1`,
-			exp: &literalExpr{value: 1},
+			exp: &LiteralExpr{value: 1},
 		},
 		{
 			// ensure binary ops with two literals are reduced recursively when comparisons are used
 			in:  `1 >= 1 > 1`,
-			exp: &literalExpr{value: 0},
+			exp: &LiteralExpr{value: 0},
 		},
 		{
 			in:  `{foo="bar"} + {foo="bar"}`,
-			err: logqlmodel.NewParseError(`unexpected type for left leg of binary operation (+): *logql.matchersExpr`, 0, 0),
+			err: logqlmodel.NewParseError(`unexpected type for left leg of binary operation (+): *logql.MatchersExpr`, 0, 0),
 		},
 		{
 			in:  `sum(count_over_time({foo="bar"}[5m])) by (foo) - {foo="bar"}`,
-			err: logqlmodel.NewParseError(`unexpected type for right leg of binary operation (-): *logql.matchersExpr`, 0, 0),
+			err: logqlmodel.NewParseError(`unexpected type for right leg of binary operation (-): *logql.MatchersExpr`, 0, 0),
 		},
 		{
 			in:  `{foo="bar"} / sum(count_over_time({foo="bar"}[5m])) by (foo)`,
-			err: logqlmodel.NewParseError(`unexpected type for left leg of binary operation (/): *logql.matchersExpr`, 0, 0),
+			err: logqlmodel.NewParseError(`unexpected type for left leg of binary operation (/): *logql.MatchersExpr`, 0, 0),
 		},
 		{
 			in:  `sum(count_over_time({foo="bar"}[5m])) by (foo) or 1`,
@@ -2106,18 +2106,18 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `count_over_time({ foo ="bar" }[12m]) > count_over_time({ foo = "bar" }[12m])`,
-			exp: &binOpExpr{
+			exp: &BinOpExpr{
 				op: OpTypeGT,
-				SampleExpr: &rangeAggregationExpr{
-					left: &logRange{
-						left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+				SampleExpr: &RangeAggregationExpr{
+					left: &LogRange{
+						left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 						interval: 12 * time.Minute,
 					},
 					operation: "count_over_time",
 				},
-				RHS: &rangeAggregationExpr{
-					left: &logRange{
-						left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+				RHS: &RangeAggregationExpr{
+					left: &LogRange{
+						left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 						interval: 12 * time.Minute,
 					},
 					operation: "count_over_time",
@@ -2126,56 +2126,56 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `count_over_time({ foo = "bar" }[12m]) > 1`,
-			exp: &binOpExpr{
+			exp: &BinOpExpr{
 				op: OpTypeGT,
-				SampleExpr: &rangeAggregationExpr{
-					left: &logRange{
-						left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+				SampleExpr: &RangeAggregationExpr{
+					left: &LogRange{
+						left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 						interval: 12 * time.Minute,
 					},
 					operation: "count_over_time",
 				},
-				RHS: &literalExpr{value: 1},
+				RHS: &LiteralExpr{value: 1},
 			},
 		},
 		{
 			// cannot compare metric & log queries
 			in:  `count_over_time({ foo = "bar" }[12m]) > { foo = "bar" }`,
-			err: logqlmodel.NewParseError("unexpected type for right leg of binary operation (>): *logql.matchersExpr", 0, 0),
+			err: logqlmodel.NewParseError("unexpected type for right leg of binary operation (>): *logql.MatchersExpr", 0, 0),
 		},
 		{
 			in: `count_over_time({ foo = "bar" }[12m]) or count_over_time({ foo = "bar" }[12m]) > 1`,
-			exp: &binOpExpr{
+			exp: &BinOpExpr{
 				op: OpTypeOr,
-				SampleExpr: &rangeAggregationExpr{
-					left: &logRange{
-						left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+				SampleExpr: &RangeAggregationExpr{
+					left: &LogRange{
+						left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 						interval: 12 * time.Minute,
 					},
 					operation: "count_over_time",
 				},
-				RHS: &binOpExpr{
+				RHS: &BinOpExpr{
 					op: OpTypeGT,
-					SampleExpr: &rangeAggregationExpr{
-						left: &logRange{
-							left:     &matchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+					SampleExpr: &RangeAggregationExpr{
+						left: &LogRange{
+							left:     &MatchersExpr{matchers: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")}},
 							interval: 12 * time.Minute,
 						},
 						operation: "count_over_time",
 					},
-					RHS: &literalExpr{value: 1},
+					RHS: &LiteralExpr{value: 1},
 				},
 			},
 		},
 		{
 			// test associativity
 			in:  `1 > 1 < 1`,
-			exp: &literalExpr{value: 1},
+			exp: &LiteralExpr{value: 1},
 		},
 		{
 			// bool modifiers are reduced-away between two literal legs
 			in:  `1 > 1 > bool 1`,
-			exp: &literalExpr{value: 0},
+			exp: &LiteralExpr{value: 0},
 		},
 		{
 			// cannot lead with bool modifier
@@ -2202,7 +2202,7 @@ func TestParse(t *testing.T) {
 			in: `{app="foo"}
 					# |= "bar"
 					| json`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLabelParserExpr(OpParserTypeJSON, ""),
@@ -2214,7 +2214,7 @@ func TestParse(t *testing.T) {
 					#
 					|= "bar"
 					| json`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "bar"),
@@ -2228,7 +2228,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} | json #`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLabelParserExpr(OpParserTypeJSON, ""),
@@ -2245,7 +2245,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} |= "#"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newLineFilterExpr(nil, labels.MatchEqual, "#"),
@@ -2254,10 +2254,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} | bar="#"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
-					&labelFilterExpr{
+					&LabelFilterExpr{
 						LabelFilterer: log.NewStringLabelFilter(mustNewMatcher(labels.MatchEqual, "bar", "#")),
 					},
 				},
@@ -2265,7 +2265,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} | json bob="top.sub[\"index\"]"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newJSONExpressionParser([]log.JSONExpression{
@@ -2276,7 +2276,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} | json bob="top.params[0]"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newJSONExpressionParser([]log.JSONExpression{
@@ -2287,7 +2287,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in: `{app="foo"} | json response_code="response.code", api_key="request.headers[\"X-API-KEY\"]"`,
-			exp: &pipelineExpr{
+			exp: &PipelineExpr{
 				left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),
 				pipeline: MultiStageExpr{
 					newJSONExpressionParser([]log.JSONExpression{

--- a/pkg/logql/sharding.go
+++ b/pkg/logql/sharding.go
@@ -81,6 +81,8 @@ func (d DownstreamLogSelectorExpr) String() string {
 	return fmt.Sprintf("downstream<%s, shard=%s>", d.LogSelectorExpr.String(), d.shard)
 }
 
+func (d DownstreamSampleExpr) Walk(f WalkFn) { f(d) }
+
 // ConcatSampleExpr is an expr for concatenating multiple SampleExpr
 // Contract: The embedded SampleExprs within a linked list of ConcatSampleExprs must be of the
 // same structure. This makes special implementations of SampleExpr.Associative() unnecessary.
@@ -95,6 +97,11 @@ func (c ConcatSampleExpr) String() string {
 	}
 
 	return fmt.Sprintf("%s ++ %s", c.DownstreamSampleExpr.String(), c.next.String())
+}
+
+func (c ConcatSampleExpr) Walk(f WalkFn) {
+	f(c)
+	f(c.next)
 }
 
 // ConcatLogSelectorExpr is an expr for concatenating multiple LogSelectorExpr

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -22,7 +22,7 @@ func TestShardedStringer(t *testing.T) {
 						Shard: 0,
 						Of:    2,
 					},
-					LogSelectorExpr: &matchersExpr{
+					LogSelectorExpr: &MatchersExpr{
 						matchers: []*labels.Matcher{
 							mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 						},
@@ -34,7 +34,7 @@ func TestShardedStringer(t *testing.T) {
 							Shard: 1,
 							Of:    2,
 						},
-						LogSelectorExpr: &matchersExpr{
+						LogSelectorExpr: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 							},
@@ -61,10 +61,10 @@ func TestMapSampleExpr(t *testing.T) {
 		out SampleExpr
 	}{
 		{
-			in: &rangeAggregationExpr{
+			in: &RangeAggregationExpr{
 				operation: OpRangeTypeRate,
-				left: &logRange{
-					left: &matchersExpr{
+				left: &LogRange{
+					left: &MatchersExpr{
 						matchers: []*labels.Matcher{
 							mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 						},
@@ -78,10 +78,10 @@ func TestMapSampleExpr(t *testing.T) {
 						Shard: 0,
 						Of:    2,
 					},
-					SampleExpr: &rangeAggregationExpr{
+					SampleExpr: &RangeAggregationExpr{
 						operation: OpRangeTypeRate,
-						left: &logRange{
-							left: &matchersExpr{
+						left: &LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -96,10 +96,10 @@ func TestMapSampleExpr(t *testing.T) {
 							Shard: 1,
 							Of:    2,
 						},
-						SampleExpr: &rangeAggregationExpr{
+						SampleExpr: &RangeAggregationExpr{
 							operation: OpRangeTypeRate,
-							left: &logRange{
-								left: &matchersExpr{
+							left: &LogRange{
+								left: &MatchersExpr{
 									matchers: []*labels.Matcher{
 										mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 									},
@@ -222,7 +222,7 @@ func TestMapping(t *testing.T) {
 						Shard: 0,
 						Of:    2,
 					},
-					LogSelectorExpr: &matchersExpr{
+					LogSelectorExpr: &MatchersExpr{
 						matchers: []*labels.Matcher{
 							mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 						},
@@ -234,7 +234,7 @@ func TestMapping(t *testing.T) {
 							Shard: 1,
 							Of:    2,
 						},
-						LogSelectorExpr: &matchersExpr{
+						LogSelectorExpr: &MatchersExpr{
 							matchers: []*labels.Matcher{
 								mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 							},
@@ -284,10 +284,10 @@ func TestMapping(t *testing.T) {
 						Shard: 0,
 						Of:    2,
 					},
-					SampleExpr: &rangeAggregationExpr{
+					SampleExpr: &RangeAggregationExpr{
 						operation: OpRangeTypeRate,
-						left: &logRange{
-							left: &matchersExpr{
+						left: &LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -302,10 +302,10 @@ func TestMapping(t *testing.T) {
 							Shard: 1,
 							Of:    2,
 						},
-						SampleExpr: &rangeAggregationExpr{
+						SampleExpr: &RangeAggregationExpr{
 							operation: OpRangeTypeRate,
-							left: &logRange{
-								left: &matchersExpr{
+							left: &LogRange{
+								left: &MatchersExpr{
 									matchers: []*labels.Matcher{
 										mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 									},
@@ -326,10 +326,10 @@ func TestMapping(t *testing.T) {
 						Shard: 0,
 						Of:    2,
 					},
-					SampleExpr: &rangeAggregationExpr{
+					SampleExpr: &RangeAggregationExpr{
 						operation: OpRangeTypeCount,
-						left: &logRange{
-							left: &matchersExpr{
+						left: &LogRange{
+							left: &MatchersExpr{
 								matchers: []*labels.Matcher{
 									mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 								},
@@ -344,10 +344,10 @@ func TestMapping(t *testing.T) {
 							Shard: 1,
 							Of:    2,
 						},
-						SampleExpr: &rangeAggregationExpr{
+						SampleExpr: &RangeAggregationExpr{
 							operation: OpRangeTypeCount,
-							left: &logRange{
-								left: &matchersExpr{
+							left: &LogRange{
+								left: &MatchersExpr{
 									matchers: []*labels.Matcher{
 										mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 									},
@@ -362,7 +362,7 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `sum(rate({foo="bar"}[5m]))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				grouping:  &grouping{},
 				operation: OpTypeSum,
 				left: &ConcatSampleExpr{
@@ -371,13 +371,13 @@ func TestMapping(t *testing.T) {
 							Shard: 0,
 							Of:    2,
 						},
-						SampleExpr: &vectorAggregationExpr{
+						SampleExpr: &VectorAggregationExpr{
 							grouping:  &grouping{},
 							operation: OpTypeSum,
-							left: &rangeAggregationExpr{
+							left: &RangeAggregationExpr{
 								operation: OpRangeTypeRate,
-								left: &logRange{
-									left: &matchersExpr{
+								left: &LogRange{
+									left: &MatchersExpr{
 										matchers: []*labels.Matcher{
 											mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 										},
@@ -393,13 +393,13 @@ func TestMapping(t *testing.T) {
 								Shard: 1,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeSum,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -416,7 +416,7 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `topk(3, rate({foo="bar"}[5m]))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				grouping:  &grouping{},
 				params:    3,
 				operation: OpTypeTopK,
@@ -426,10 +426,10 @@ func TestMapping(t *testing.T) {
 							Shard: 0,
 							Of:    2,
 						},
-						SampleExpr: &rangeAggregationExpr{
+						SampleExpr: &RangeAggregationExpr{
 							operation: OpRangeTypeRate,
-							left: &logRange{
-								left: &matchersExpr{
+							left: &LogRange{
+								left: &MatchersExpr{
 									matchers: []*labels.Matcher{
 										mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 									},
@@ -444,10 +444,10 @@ func TestMapping(t *testing.T) {
 								Shard: 1,
 								Of:    2,
 							},
-							SampleExpr: &rangeAggregationExpr{
+							SampleExpr: &RangeAggregationExpr{
 								operation: OpRangeTypeRate,
-								left: &logRange{
-									left: &matchersExpr{
+								left: &LogRange{
+									left: &MatchersExpr{
 										matchers: []*labels.Matcher{
 											mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 										},
@@ -463,7 +463,7 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `max without (env) (rate({foo="bar"}[5m]))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				grouping: &grouping{
 					without: true,
 					groups:  []string{"env"},
@@ -475,10 +475,10 @@ func TestMapping(t *testing.T) {
 							Shard: 0,
 							Of:    2,
 						},
-						SampleExpr: &rangeAggregationExpr{
+						SampleExpr: &RangeAggregationExpr{
 							operation: OpRangeTypeRate,
-							left: &logRange{
-								left: &matchersExpr{
+							left: &LogRange{
+								left: &MatchersExpr{
 									matchers: []*labels.Matcher{
 										mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 									},
@@ -493,10 +493,10 @@ func TestMapping(t *testing.T) {
 								Shard: 1,
 								Of:    2,
 							},
-							SampleExpr: &rangeAggregationExpr{
+							SampleExpr: &RangeAggregationExpr{
 								operation: OpRangeTypeRate,
-								left: &logRange{
-									left: &matchersExpr{
+								left: &LogRange{
+									left: &MatchersExpr{
 										matchers: []*labels.Matcher{
 											mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 										},
@@ -512,7 +512,7 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `count(rate({foo="bar"}[5m]))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				operation: OpTypeSum,
 				grouping:  &grouping{},
 				left: &ConcatSampleExpr{
@@ -521,13 +521,13 @@ func TestMapping(t *testing.T) {
 							Shard: 0,
 							Of:    2,
 						},
-						SampleExpr: &vectorAggregationExpr{
+						SampleExpr: &VectorAggregationExpr{
 							grouping:  &grouping{},
 							operation: OpTypeCount,
-							left: &rangeAggregationExpr{
+							left: &RangeAggregationExpr{
 								operation: OpRangeTypeRate,
-								left: &logRange{
-									left: &matchersExpr{
+								left: &LogRange{
+									left: &MatchersExpr{
 										matchers: []*labels.Matcher{
 											mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 										},
@@ -543,13 +543,13 @@ func TestMapping(t *testing.T) {
 								Shard: 1,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeCount,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -566,9 +566,9 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `avg(rate({foo="bar"}[5m]))`,
-			expr: &binOpExpr{
+			expr: &BinOpExpr{
 				op: OpTypeDiv,
-				SampleExpr: &vectorAggregationExpr{
+				SampleExpr: &VectorAggregationExpr{
 					grouping:  &grouping{},
 					operation: OpTypeSum,
 					left: &ConcatSampleExpr{
@@ -577,13 +577,13 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeSum,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -599,13 +599,13 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping:  &grouping{},
 									operation: OpTypeSum,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},
@@ -619,7 +619,7 @@ func TestMapping(t *testing.T) {
 						},
 					},
 				},
-				RHS: &vectorAggregationExpr{
+				RHS: &VectorAggregationExpr{
 					operation: OpTypeSum,
 					grouping:  &grouping{},
 					left: &ConcatSampleExpr{
@@ -628,13 +628,13 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeCount,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -650,13 +650,13 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping:  &grouping{},
 									operation: OpTypeCount,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},
@@ -674,10 +674,10 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `1 + sum by (cluster) (rate({foo="bar"}[5m]))`,
-			expr: &binOpExpr{
+			expr: &BinOpExpr{
 				op:         OpTypeAdd,
-				SampleExpr: &literalExpr{value: 1},
-				RHS: &vectorAggregationExpr{
+				SampleExpr: &LiteralExpr{value: 1},
+				RHS: &VectorAggregationExpr{
 					grouping: &grouping{
 						groups: []string{"cluster"},
 					},
@@ -688,15 +688,15 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping: &grouping{
 									groups: []string{"cluster"},
 								},
 								operation: OpTypeSum,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -712,15 +712,15 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping: &grouping{
 										groups: []string{"cluster"},
 									},
 									operation: OpTypeSum,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},
@@ -739,10 +739,10 @@ func TestMapping(t *testing.T) {
 		// sum(max) should not shard the maxes
 		{
 			in: `sum(max(rate({foo="bar"}[5m])))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				grouping:  &grouping{},
 				operation: OpTypeSum,
-				left: &vectorAggregationExpr{
+				left: &VectorAggregationExpr{
 					grouping:  &grouping{},
 					operation: OpTypeMax,
 					left: &ConcatSampleExpr{
@@ -751,10 +751,10 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &rangeAggregationExpr{
+							SampleExpr: &RangeAggregationExpr{
 								operation: OpRangeTypeRate,
-								left: &logRange{
-									left: &matchersExpr{
+								left: &LogRange{
+									left: &MatchersExpr{
 										matchers: []*labels.Matcher{
 											mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 										},
@@ -769,10 +769,10 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &rangeAggregationExpr{
+								SampleExpr: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -790,10 +790,10 @@ func TestMapping(t *testing.T) {
 		// max(count) should shard the count, but not the max
 		{
 			in: `max(count(rate({foo="bar"}[5m])))`,
-			expr: &vectorAggregationExpr{
+			expr: &VectorAggregationExpr{
 				grouping:  &grouping{},
 				operation: OpTypeMax,
-				left: &vectorAggregationExpr{
+				left: &VectorAggregationExpr{
 					operation: OpTypeSum,
 					grouping:  &grouping{},
 					left: &ConcatSampleExpr{
@@ -802,13 +802,13 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeCount,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -824,13 +824,13 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping:  &grouping{},
 									operation: OpTypeCount,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},
@@ -848,12 +848,12 @@ func TestMapping(t *testing.T) {
 		},
 		{
 			in: `max(sum by (cluster) (rate({foo="bar"}[5m]))) / count(rate({foo="bar"}[5m]))`,
-			expr: &binOpExpr{
+			expr: &BinOpExpr{
 				op: OpTypeDiv,
-				SampleExpr: &vectorAggregationExpr{
+				SampleExpr: &VectorAggregationExpr{
 					operation: OpTypeMax,
 					grouping:  &grouping{},
-					left: &vectorAggregationExpr{
+					left: &VectorAggregationExpr{
 						grouping: &grouping{
 							groups: []string{"cluster"},
 						},
@@ -864,15 +864,15 @@ func TestMapping(t *testing.T) {
 									Shard: 0,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping: &grouping{
 										groups: []string{"cluster"},
 									},
 									operation: OpTypeSum,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},
@@ -888,15 +888,15 @@ func TestMapping(t *testing.T) {
 										Shard: 1,
 										Of:    2,
 									},
-									SampleExpr: &vectorAggregationExpr{
+									SampleExpr: &VectorAggregationExpr{
 										grouping: &grouping{
 											groups: []string{"cluster"},
 										},
 										operation: OpTypeSum,
-										left: &rangeAggregationExpr{
+										left: &RangeAggregationExpr{
 											operation: OpRangeTypeRate,
-											left: &logRange{
-												left: &matchersExpr{
+											left: &LogRange{
+												left: &MatchersExpr{
 													matchers: []*labels.Matcher{
 														mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 													},
@@ -911,7 +911,7 @@ func TestMapping(t *testing.T) {
 						},
 					},
 				},
-				RHS: &vectorAggregationExpr{
+				RHS: &VectorAggregationExpr{
 					operation: OpTypeSum,
 					grouping:  &grouping{},
 					left: &ConcatSampleExpr{
@@ -920,13 +920,13 @@ func TestMapping(t *testing.T) {
 								Shard: 0,
 								Of:    2,
 							},
-							SampleExpr: &vectorAggregationExpr{
+							SampleExpr: &VectorAggregationExpr{
 								grouping:  &grouping{},
 								operation: OpTypeCount,
-								left: &rangeAggregationExpr{
+								left: &RangeAggregationExpr{
 									operation: OpRangeTypeRate,
-									left: &logRange{
-										left: &matchersExpr{
+									left: &LogRange{
+										left: &MatchersExpr{
 											matchers: []*labels.Matcher{
 												mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 											},
@@ -942,13 +942,13 @@ func TestMapping(t *testing.T) {
 									Shard: 1,
 									Of:    2,
 								},
-								SampleExpr: &vectorAggregationExpr{
+								SampleExpr: &VectorAggregationExpr{
 									grouping:  &grouping{},
 									operation: OpTypeCount,
-									left: &rangeAggregationExpr{
+									left: &RangeAggregationExpr{
 										operation: OpRangeTypeRate,
-										left: &logRange{
-											left: &matchersExpr{
+										left: &LogRange{
+											left: &MatchersExpr{
 												matchers: []*labels.Matcher{
 													mustNewMatcher(labels.MatchEqual, "foo", "bar"),
 												},

--- a/pkg/logql/walk.go
+++ b/pkg/logql/walk.go
@@ -1,0 +1,13 @@
+package logql
+
+type WalkFn = func(e interface{})
+
+func walkAll(f WalkFn, xs ...Walkable) {
+	for _, x := range xs {
+		x.Walk(f)
+	}
+}
+
+type Walkable interface {
+	Walk(f WalkFn)
+}

--- a/pkg/logql/walk_test.go
+++ b/pkg/logql/walk_test.go
@@ -1,0 +1,91 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Walkable(t *testing.T) {
+	type table struct {
+		desc string
+		expr string
+		want int
+	}
+	tests := []table{
+		{
+			desc: "vector aggregate query",
+			expr: `sum by (cluster) (rate({job="foo"} |= "bar" | logfmt | bazz="buzz" [5m]))`,
+			want: 8,
+		},
+		{
+			desc: "bin op query",
+			expr: `(sum by(cluster)(rate({job="foo"} |= "bar" | logfmt | bazz="buzz"[5m])) / sum by(cluster)(rate({job="foo"} |= "bar" | logfmt | bazz="buzz"[5m])))`,
+			want: 16,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			expr, err := ParseExpr(test.expr)
+			require.Nil(t, err)
+
+			var cnt int
+			expr.Walk(func(_ interface{}) { cnt++ })
+			require.Equal(t, test.want, cnt)
+		})
+	}
+}
+
+func Test_AppendMatchers(t *testing.T) {
+	type table struct {
+		desc     string
+		expr     string
+		want     string
+		matchers []*labels.Matcher
+	}
+	tests := []table{
+		{
+			desc: "vector range query",
+			expr: `sum by(cluster)(rate({job="foo"} |= "bar" | logfmt | bazz="buzz"[5m]))`,
+			want: `sum by(cluster)(rate({job="foo", namespace="a"} |= "bar" | logfmt | bazz="buzz"[5m]))`,
+			matchers: []*labels.Matcher{
+				{
+					Name:  "namespace",
+					Type:  labels.MatchEqual,
+					Value: "a",
+				},
+			},
+		},
+		{
+			desc: "bin op query",
+			expr: `sum by(cluster)(rate({job="foo"} |= "bar" | logfmt | bazz="buzz"[5m])) / sum by(cluster)(rate({job="foo"} |= "bar" | logfmt | bazz="buzz"[5m]))`,
+			want: `(sum by(cluster)(rate({job="foo", namespace="a"} |= "bar" | logfmt | bazz="buzz"[5m])) / sum by(cluster)(rate({job="foo", namespace="a"} |= "bar" | logfmt | bazz="buzz"[5m])))`,
+			matchers: []*labels.Matcher{
+				{
+					Name:  "namespace",
+					Type:  labels.MatchEqual,
+					Value: "a",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			expr, err := ParseExpr(test.expr)
+			require.NoError(t, err)
+
+			expr.Walk(func(e interface{}) {
+				switch me := e.(type) {
+				case *MatchersExpr:
+					me.AppendMatchers(test.matchers)
+				default:
+					// Do nothing
+				}
+			})
+			require.Equal(t, test.want, expr.String())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The following change set provides a simple extension that enables walking the LoqQL AST for parsed and valid LogQL expressions. This helps to build third-party tooling that can inspect and manipulate LogQL queries before hitting the target Loki query-frontend/querier (e.g. [prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy/)).

Furthermore this PR changes:
- The scoping from private to public for all expressions that comprise LogQL to allow type switching when executing the walking function. 
- The `MatcherExpr` struct includes a simple `AppendMatchers` method to append new label matchers when executing the walking function.
- The LogQL optimizer's custom `walkSampleExpr` is replaced by `expr.Walk`

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-

**Checklist**
- [ ] Documentation added
- [x] Tests updated

cc @cyriltovena @owen-d 