### PR TITLE
fixes a badly referenced variable name in StepEvaluator code

### DIFF
--- a/pkg/logql/sharding.go
+++ b/pkg/logql/sharding.go
@@ -326,13 +326,13 @@ func (ev *DownstreamEvaluator) Iterator(
 // Contract: They must be of identical start, end, and step values.
 func ConcatEvaluator(evaluators []StepEvaluator) (StepEvaluator, error) {
 	return newStepEvaluator(
-		func() (done bool, ts int64, vec promql.Vector) {
+		func() (ok bool, ts int64, vec promql.Vector) {
 			var cur promql.Vector
 			for _, eval := range evaluators {
-				done, ts, cur = eval.Next()
+				ok, ts, cur = eval.Next()
 				vec = append(vec, cur...)
 			}
-			return done, ts, vec
+			return ok, ts, vec
 		},
 		func() (lastErr error) {
 			for _, eval := range evaluators {

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -9,7 +9,7 @@ import (
 // StepEvaluator evaluate a single step of a query.
 type StepEvaluator interface {
 	// while Next returns a promql.Value, the only acceptable types are Scalar and Vector.
-	Next() (bool, int64, promql.Vector)
+	Next() (ok bool, ts int64, vec promql.Vector)
 	// Close all resources used.
 	Close() error
 	// Reports any error


### PR DESCRIPTION
While poking around some sharding code I noticed a variable was referenced incorrectly. This didn't result in a bug, but made reading this piece of code confusing/counterintuitive. This PR fixes the variable naming and gives the interface a hint.

cc @jeschkies in case you're curious