### PR TITLE
Promtial: output timestamp with nanosecond precision in dry-run mode

### DIFF
--- a/clients/pkg/promtail/client/logger.go
+++ b/clients/pkg/promtail/client/logger.go
@@ -74,7 +74,7 @@ func (l *logger) Chan() chan<- api.Entry {
 
 func (l *logger) run() {
 	for e := range l.entries {
-		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05-0700")))
+		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05.999999999-0700")))
 		fmt.Fprint(l.Writer, "\t")
 		fmt.Fprint(l.Writer, yellow.Sprint(e.Labels.String()))
 		fmt.Fprint(l.Writer, "\t")


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Promtail only logs the entry timestamp with second precision in dry-run mode; this should be nanosecond to match what Loki can support. Without this, users who are correctly parsing their timestamps with nanosecond precision will become confused when the dry-run output only shows second precision.

**Which issue(s) this PR fixes**:
Fixes #3955

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

