### PR TITLE
Compactor improvements

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -40,6 +40,7 @@ type Config struct {
 	RetentionDeleteDelay      time.Duration `yaml:"retention_delete_delay"`
 	RetentionDeleteWorkCount  int           `yaml:"retention_delete_worker_count"`
 	DeleteRequestCancelPeriod time.Duration `yaml:"delete_request_cancel_period"`
+	MaxCompactionParallelism  int           `yaml:"max_compaction_parallelism"`
 }
 
 // RegisterFlags registers flags.
@@ -52,6 +53,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.RetentionEnabled, "boltdb.shipper.compactor.retention-enabled", false, "(Experimental) Activate custom (per-stream,per-tenant) retention.")
 	f.IntVar(&cfg.RetentionDeleteWorkCount, "boltdb.shipper.compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
 	f.DurationVar(&cfg.DeleteRequestCancelPeriod, "boltdb.shipper.compactor.delete-request-cancel-period", 24*time.Hour, "Allow cancellation of delete request until duration after they are created. Data would be deleted only after delete requests have been older than this duration. Ideally this should be set to at least 24h.")
+	f.IntVar(&cfg.MaxCompactionParallelism, "boltdb.shipper.compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
 }
 
 func (cfg *Config) IsDefaults() bool {
@@ -61,6 +63,9 @@ func (cfg *Config) IsDefaults() bool {
 }
 
 func (cfg *Config) Validate() error {
+	if cfg.MaxCompactionParallelism < 1 {
+		return errors.New("max compaction parallelism must be >= 1")
+	}
 	return shipper_util.ValidateSharedStoreKeyPrefix(cfg.SharedStoreKeyPrefix)
 }
 
@@ -246,23 +251,62 @@ func (c *Compactor) RunCompaction(ctx context.Context) error {
 		tables[i] = strings.TrimSuffix(string(dir), delimiter)
 	}
 
-	for _, tableName := range tables {
-		if tableName == deletion.DeleteRequestsTableName {
-			// we do not want to compact or apply retention on delete requests table
-			continue
+	compactTablesChan := make(chan string)
+	errChan := make(chan error)
+
+	for i := 0; i < c.cfg.MaxCompactionParallelism; i++ {
+		go func() {
+			var err error
+			defer func() {
+				errChan <- err
+			}()
+
+			for {
+				select {
+				case tableName, ok := <-compactTablesChan:
+					if !ok {
+						return
+					}
+
+					err = c.CompactTable(ctx, tableName)
+					if err != nil {
+						return
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	go func() {
+		for _, tableName := range tables {
+			if tableName == deletion.DeleteRequestsTableName {
+				// we do not want to compact or apply retention on delete requests table
+				continue
+			}
+
+			select {
+			case compactTablesChan <- tableName:
+			case <-ctx.Done():
+				return
+			}
 		}
-		if err := c.CompactTable(ctx, tableName); err != nil {
+
+		close(compactTablesChan)
+	}()
+
+	var firstErr error
+	// read all the errors
+	for i := 0; i < c.cfg.MaxCompactionParallelism; i++ {
+		err := <-errChan
+		if err != nil && firstErr == nil {
 			status = statusFailure
-		}
-		// check if context was cancelled before going for next table.
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
+			firstErr = err
 		}
 	}
 
-	return nil
+	return firstErr
 }
 
 type expirationChecker struct {

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -268,10 +268,12 @@ func (c *Compactor) RunCompaction(ctx context.Context) error {
 						return
 					}
 
+					level.Info(util_log.Logger).Log("msg", "compacting table", "table-name", tableName)
 					err = c.CompactTable(ctx, tableName)
 					if err != nil {
 						return
 					}
+					level.Info(util_log.Logger).Log("msg", "finished compacting table", "table-name", tableName)
 				case <-ctx.Done():
 					return
 				}

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -50,6 +50,7 @@ func TestIsDefaults(t *testing.T) {
 			RetentionDeleteDelay:      2 * time.Hour,
 			RetentionDeleteWorkCount:  150,
 			DeleteRequestCancelPeriod: 24 * time.Hour,
+			MaxCompactionParallelism:  1,
 		}, true},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/pkg/storage/stores/shipper/compactor/table_test.go
+++ b/pkg/storage/stores/shipper/compactor/table_test.go
@@ -24,51 +24,75 @@ const (
 )
 
 func TestTable_Compaction(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-compaction")
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name              string
+		withCompactedFile bool
+	}{
+		{
+			name:              "without compacted file",
+			withCompactedFile: false,
+		},
+		{
+			name:              "with compacted file",
+			withCompactedFile: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", fmt.Sprintf("table-compaction-%v", tc.withCompactedFile))
+			require.NoError(t, err)
 
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+			defer func() {
+				require.NoError(t, os.RemoveAll(tempDir))
+			}()
 
-	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
-	tablePathInStorage := filepath.Join(objectStoragePath, tableName)
-	tableWorkingDirectory := filepath.Join(tempDir, workingDirName, tableName)
+			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+			tablePathInStorage := filepath.Join(objectStoragePath, tableName)
+			tableWorkingDirectory := filepath.Join(tempDir, workingDirName, tableName)
 
-	// setup some dbs
-	numDBs := compactMinDBs * 2
-	numRecordsPerDB := 100
+			// setup some dbs
+			numDBs := compactMinDBs * 2
+			numRecordsPerDB := 100
 
-	dbsToSetup := make(map[string]testutil.DBRecords)
-	for i := 0; i < numDBs; i++ {
-		dbsToSetup[fmt.Sprint(i)] = testutil.DBRecords{
-			Start:      i * numRecordsPerDB,
-			NumRecords: (i + 1) * numRecordsPerDB,
-		}
+			dbsToSetup := make(map[string]testutil.DBRecords)
+			for i := 0; i < numDBs; i++ {
+				dbsToSetup[fmt.Sprint(i)] = testutil.DBRecords{
+					Start:      i * numRecordsPerDB,
+					NumRecords: (i + 1) * numRecordsPerDB,
+				}
+			}
+
+			if tc.withCompactedFile {
+				// add a compacted file with some overlap with previously created dbs
+				dbsToSetup[fmt.Sprintf("%s-0", uploaderName)] = testutil.DBRecords{
+					Start:      (numDBs / 2) * numRecordsPerDB,
+					NumRecords: (numDBs + 10) * numRecordsPerDB,
+				}
+			}
+
+			testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, dbsToSetup, true)
+
+			// setup exact same copy of dbs for comparison.
+			testutil.SetupDBTablesAtPath(t, "test-copy", objectStoragePath, dbsToSetup, false)
+
+			// do the compaction
+			objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
+			require.NoError(t, err)
+
+			table, err := newTable(context.Background(), tableWorkingDirectory, objectClient, false, nil)
+			require.NoError(t, err)
+
+			require.NoError(t, table.compact(false))
+
+			// verify that we have only 1 file left in storage after compaction.
+			files, err := ioutil.ReadDir(tablePathInStorage)
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+			require.True(t, strings.HasSuffix(files[0].Name(), ".gz"))
+
+			// verify we have all the kvs in compacted db which were there in source dbs.
+			compareCompactedDB(t, filepath.Join(tablePathInStorage, files[0].Name()), filepath.Join(objectStoragePath, "test-copy"))
+		})
 	}
-
-	testutil.SetupDBTablesAtPath(t, tableName, objectStoragePath, dbsToSetup, true)
-
-	// setup exact same copy of dbs for comparison.
-	testutil.SetupDBTablesAtPath(t, "test-copy", objectStoragePath, dbsToSetup, false)
-
-	// do the compaction
-	objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
-	require.NoError(t, err)
-
-	table, err := newTable(context.Background(), tableWorkingDirectory, objectClient, false, nil)
-	require.NoError(t, err)
-
-	require.NoError(t, table.compact(false))
-
-	// verify that we have only 1 file left in storage after compaction.
-	files, err := ioutil.ReadDir(tablePathInStorage)
-	require.NoError(t, err)
-	require.Len(t, files, 1)
-	require.True(t, strings.HasSuffix(files[0].Name(), ".gz"))
-
-	// verify we have all the kvs in compacted db which were there in source dbs.
-	compareCompactedDB(t, filepath.Join(tablePathInStorage, files[0].Name()), filepath.Join(objectStoragePath, "test-copy"))
 }
 
 type TableMarkerFunc func(ctx context.Context, tableName string, db *bbolt.DB) (bool, int64, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
A couple of improvements:
1. During compaction, we create an empty file and merge the index from all the files into it. This wastes a lot of resources in a big cluster that has large index files. This PR changes it to use compacted file built from the last compaction as seed file and then copies index from all the other files into it. If there is no compacted file then it uses whatever files appear first in the list of files to compact. This should significantly reduce compaction time in a large cluster.
2. Allows configuring compactor to compact multiple tables at a time.

**Checklist**
- [x] Tests updated

