### PR TITLE
removes wal from ingester config

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -5,9 +5,6 @@ server:
   grpc_listen_port: 9096
 
 ingester:
-  wal:
-    enabled: true
-    dir: /tmp/wal
   lifecycler:
     address: 127.0.0.1
     ring:


### PR DESCRIPTION
Seems that this is a legacy configuration in the local-config.yaml:
```shell
ingester:
  wal:
    enabled: true
    dir: /tmp/wal
```
```shell
failed parsing config: /etc/loki/local-config.yaml: yaml: unmarshal errors:
  line 8: field wal not found in type ingester.Config
```

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Allows Loki to run.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

