### PR TITLE
fix: Restore /config endpoint and correct handlerFunc for buildinfo

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -19,7 +19,7 @@ These endpoints are exposed by all components:
 - [`GET /ready`](#get-ready)
 - [`GET /metrics`](#get-metrics)
 - [`GET /config`](#get-config)
-- [`GET /loki/api/v1/status/buildinfo`](#get-buildinfo)
+- [`GET /loki/api/v1/status/buildinfo`](#get-lokiapiv1statusbuildinfo)
 
 These endpoints are exposed by the querier and the frontend:
 
@@ -824,11 +824,9 @@ and the current are returned. A value of `defaults` returns the default configur
 
 In microservices mode, the `/config` endpoint is exposed by all components.
 
-## `GET buildinfo`
+## `GET /loki/api/v1/status/buildinfo`
 
 `/loki/api/v1/status/buildinfo` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `buildDate`, `buildUser`, and `goVersion`.
-
-In microservices mode, the `/version` endpoint is exposed by all components.
 
 ## Series
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -261,10 +261,10 @@ func (t *Loki) Run() error {
 	t.Server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
 
 	// This adds a way to see the config and the changes compared to the defaults
-	t.Server.HTTP.Path("/loki/api/v1/status/buildinfo").HandlerFunc(configHandler(t.Cfg, newDefaultConfig()))
+	t.Server.HTTP.Path("/config").HandlerFunc(configHandler(t.Cfg, newDefaultConfig()))
 
 	// Each component serves its version.
-	t.Server.HTTP.Path("/version").HandlerFunc(versionHandler())
+	t.Server.HTTP.Path("/loki/api/v1/status/buildinfo").HandlerFunc(versionHandler())
 
 	t.Server.HTTP.Path("/debug/fgprof").Handler(fgprof.Handler())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As far as I can tell from reading the "next" documentation, the
/loki/api/v1/status/buildinfo endpoint should return the build
information. The /version endpoint is also listed further down in the
documentation but from the code prior to this change, it looks like it
should perform the same function as buildinfo endpoint so I have
removed it.

I've updated the documentation to reflect my changes.

**Special notes for your reviewer**:

~I'm just pulling the documentation image in order to check that the changed heading works as expected.~ LGTM

**Checklist**
- [x] Documentation added


