### PR TITLE
loki-build-image: Upgrade golangci-lint and Go

### DIFF
--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache curl && \
 FROM alpine as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.32.2
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1
 
 FROM alpine:edge as docker
 RUN apk add --no-cache docker-cli

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.16.2 as drone
+FROM golang:1.16.6 as drone
 RUN GO111MODULE=on go get github.com/drone/drone-cli/drone@1fad337d74ca0ecf420993d9d2d7229a1c99f054
 
 # Install faillint used to lint go imports in CI.
@@ -34,10 +34,10 @@ RUN GO111MODULE=on go get github.com/drone/drone-cli/drone@1fad337d74ca0ecf42099
 # Error:
 #	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.16.2 as faillint
+FROM golang:1.16.6 as faillint
 RUN GO111MODULE=on go get github.com/fatih/faillint@v1.5.0
 
-FROM golang:1.16.2-buster
+FROM golang:1.16.6-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \


### PR DESCRIPTION
**What this PR does / why we need it**:
In loki-build-image Dockerfile, upgrade golangci-lint and Go.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Would like to see whether Loki will work with latest golangci-lint, fails for me locally.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

