### PR TITLE
Docs: add weights to YAML metadata to order the LogQL subsections

### DIFF
--- a/docs/sources/logql/functions.md
+++ b/docs/sources/logql/functions.md
@@ -1,5 +1,6 @@
 ---
 title: Functions
+weight: 10
 ---
 
 # Functions

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -1,5 +1,6 @@
 ---
 title: Template functions
+weight: 20
 ---
 
 # Template functions


### PR DESCRIPTION
Reordering is in the left side nav panel.

