### PR TITLE
Fix docs typo: IP Matching section "=f" becomes "="

### DIFF
--- a/docs/sources/logql/ip.md
+++ b/docs/sources/logql/ip.md
@@ -67,6 +67,6 @@ When specifying label filter expressions, only the  `=` and `!=` operations are 
     ```logql
     {job_name="myapp"}
 		| logfmt
-		| addr =f ip("192.168.4.5/16")
+		| addr = ip("192.168.4.5/16")
 		| addr != ip("192.168.4.2")
     ```


### PR DESCRIPTION
Tiny commit to fix a docs typo.

