### PR TITLE
Publish CI logs to Loki dev.

### DIFF
--- a/promtail.yaml
+++ b/promtail.yaml
@@ -1,0 +1,16 @@
+server:
+  disable: true
+client:
+  url: https://loki-bigtable-dev-us-central-0.grafana.net
+  basic_auth:
+    username: ${GRAFANA_USER}
+    password: ${GRAFANA_PUBLISHER_KEY}
+
+scrape_configs:
+  - job_name: ci-karsten
+    static_configs:
+    - labels:
+        job: ci
+        build: ${DRONE_BUILD_NUMBER}
+        pr: ${DRONE_PULL_REQUEST}
+        commit: ${DRONE_COMMIT}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will publish all logs from the `check` pipeline to our development instance of Loki. This will enable us to analyze our tests and their performance.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

