### PR TITLE
Distributor: Truncate rather than drop log lines

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1782,8 +1782,12 @@ logs in Loki.
 [max_line_size: <string> | default = none ]
 
 # Truncate log lines when they exceed max_line_size.
-# CLI flag: -distributor.max-line-size-should-truncate
-[max_line_size_should_truncate: <boolean> | default = false ]
+# CLI flag: -distributor.max-line-size-truncate
+[max_line_size_truncate: <boolean> | default = false ]
+
+# When log lines are truncated, append this string.
+# CLI flag: -distributor.max-line-size-truncate-indicator
+[max_line_size_truncate_indicator: <string> | default = "" ]
 
 # Maximum number of log entries that will be returned for a query.
 # CLI flag: -validation.max-entries-limit

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1785,10 +1785,6 @@ logs in Loki.
 # CLI flag: -distributor.max-line-size-truncate
 [max_line_size_truncate: <boolean> | default = false ]
 
-# When log lines are truncated, append this string.
-# CLI flag: -distributor.max-line-size-truncate-indicator
-[max_line_size_truncate_indicator: <string> | default = "" ]
-
 # Maximum number of log entries that will be returned for a query.
 # CLI flag: -validation.max-entries-limit
 [max_entries_limit_per_query: <int> | default = 5000 ]

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1781,6 +1781,10 @@ logs in Loki.
 # CLI flag: -distributor.max-line-size
 [max_line_size: <string> | default = none ]
 
+# Truncate log lines when they exceed max_line_size.
+# CLI flag: -distributor.max-line-size-should-truncate
+[max_line_size_should_truncate: <boolean> | default = false ]
+
 # Maximum number of log entries that will be returned for a query.
 # CLI flag: -validation.max-entries-limit
 [max_entries_limit_per_query: <int> | default = 5000 ]

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -209,6 +209,9 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	validationContext := d.validator.getValidationContextFor(userID)
 
 	for _, stream := range req.Streams {
+		// Truncate first so subsequent steps have consistent line lengths
+		stream.Entries = d.truncateLines(validationContext, stream)
+
 		stream.Labels, err = d.parseStreamLabels(validationContext, stream.Labels, &stream)
 		if err != nil {
 			validationErr = err
@@ -220,6 +223,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 			validation.DiscardedBytes.WithLabelValues(validation.InvalidLabels, userID).Add(float64(bytes))
 			continue
 		}
+
 		n := 0
 		for _, entry := range stream.Entries {
 			if err := d.validator.ValidateEntry(validationContext, stream.Labels, entry); err != nil {
@@ -236,6 +240,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		if len(stream.Entries) == 0 {
 			continue
 		}
+
 		keys = append(keys, util.TokenFor(userID, stream.Labels))
 		streams = append(streams, streamTracker{
 			stream: stream,
@@ -298,6 +303,25 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+func (d *Distributor) truncateLines(vContext validationContext, stream logproto.Stream) []logproto.Entry {
+	if !vContext.maxLineSizeShouldTruncate {
+		return stream.Entries
+	}
+
+	n := 0
+	for _, e := range stream.Entries {
+		if maxSize := vContext.maxLineSize; maxSize != 0 && len(e.Line) > maxSize {
+			truncated := float64(len(e.Line) - maxSize)
+			stream.Entries[n].Line = e.Line[:maxSize]
+			n++
+
+			validation.TruncatedBytes.WithLabelValues(validation.LineTooLong, vContext.userID).Add(truncated)
+		}
+	}
+
+	return stream.Entries
 }
 
 // TODO taken from Cortex, see if we can refactor out an usable interface.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -313,16 +313,10 @@ func (d *Distributor) truncateLines(vContext validationContext, stream *logproto
 	var truncatedSamples, truncatedBytes int
 	for i, e := range stream.Entries {
 		if maxSize := vContext.maxLineSize; maxSize != 0 && len(e.Line) > maxSize {
-			indicator := vContext.maxLineSizeTruncateInd
-			truncateTo := maxSize - len(indicator)
-			if truncateTo <= 0 {
-				continue
-			}
-
-			stream.Entries[i].Line = e.Line[:truncateTo] + indicator
+			stream.Entries[i].Line = e.Line[:maxSize]
 
 			truncatedSamples++
-			truncatedBytes = len(e.Line) - truncateTo
+			truncatedBytes = len(e.Line) - maxSize
 		}
 	}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -139,7 +139,7 @@ func Test_TruncateLogLines(t *testing.T) {
 
 	t.Run("it truncates enough to accommodate MaxLineSizeTruncateInd if it exists", func(t *testing.T) {
 		limits, ingester := setup()
-		limits.MaxLineSizeTruncateInd = "..."
+		limits.MaxLineSizeTruncateInd = "..." //nolint:goconst
 
 		d := prepare(t, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
 		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
@@ -152,7 +152,7 @@ func Test_TruncateLogLines(t *testing.T) {
 	t.Run("it drops the log when MaxLineSize <= length of MaxLineSizeTruncateInd", func(t *testing.T) {
 		limits, ingester := setup()
 		limits.MaxLineSize = 2
-		limits.MaxLineSizeTruncateInd = "..."
+		limits.MaxLineSizeTruncateInd = "..." //nolint:goconst
 
 		d := prepare(t, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
 		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
@@ -241,7 +241,7 @@ func Benchmark_PushWithLineTruncationWithIndicator(b *testing.B) {
 	limits.IngestionRateMB = math.MaxInt32
 	limits.MaxLineSizeTruncate = true
 	limits.MaxLineSize = 50
-	limits.MaxLineSizeTruncateInd = "..."
+	limits.MaxLineSizeTruncateInd = "..." //nolint:goconst
 
 	ingester := &mockIngester{}
 	d := prepare(&testing.T{}, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -137,7 +137,7 @@ func Test_TruncateLogLines(t *testing.T) {
 		require.Len(t, ingester.pushed[0].Streams[0].Entries[0].Line, 5)
 	})
 
-	t.Run("it truncates enough to accomodate MaxLineSizeTruncateInd if it exists", func(t *testing.T) {
+	t.Run("it truncates enough to accommodate MaxLineSizeTruncateInd if it exists", func(t *testing.T) {
 		limits, ingester := setup()
 		limits.MaxLineSizeTruncateInd = "..."
 

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -4,6 +4,7 @@ import "time"
 
 // Limits is an interface for distributor limits/related configs
 type Limits interface {
+	MaxLineSizeShouldTruncate(userID string) bool
 	MaxLineSize(userID string) int
 	EnforceMetricName(userID string) bool
 	MaxLabelNamesPerSeries(userID string) int

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -4,8 +4,9 @@ import "time"
 
 // Limits is an interface for distributor limits/related configs
 type Limits interface {
-	MaxLineSizeShouldTruncate(userID string) bool
 	MaxLineSize(userID string) int
+	MaxLineSizeTruncate(userID string) bool
+	MaxLineSizeTruncateInd(userID string) string
 	EnforceMetricName(userID string) bool
 	MaxLabelNamesPerSeries(userID string) int
 	MaxLabelNameLength(userID string) int

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -6,7 +6,6 @@ import "time"
 type Limits interface {
 	MaxLineSize(userID string) int
 	MaxLineSizeTruncate(userID string) bool
-	MaxLineSizeTruncateInd(userID string) string
 	EnforceMetricName(userID string) bool
 	MaxLabelNamesPerSeries(userID string) int
 	MaxLabelNameLength(userID string) int

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -25,10 +25,11 @@ func NewValidator(l Limits) (*Validator, error) {
 }
 
 type validationContext struct {
-	rejectOldSample       bool
-	rejectOldSampleMaxAge int64
-	creationGracePeriod   int64
-	maxLineSize           int
+	rejectOldSample           bool
+	rejectOldSampleMaxAge     int64
+	creationGracePeriod       int64
+	maxLineSizeShouldTruncate bool
+	maxLineSize               int
 
 	maxLabelNamesPerSeries int
 	maxLabelNameLength     int
@@ -40,14 +41,15 @@ type validationContext struct {
 func (v Validator) getValidationContextFor(userID string) validationContext {
 	now := time.Now()
 	return validationContext{
-		userID:                 userID,
-		rejectOldSample:        v.RejectOldSamples(userID),
-		rejectOldSampleMaxAge:  now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
-		creationGracePeriod:    now.Add(v.CreationGracePeriod(userID)).UnixNano(),
-		maxLineSize:            v.MaxLineSize(userID),
-		maxLabelNamesPerSeries: v.MaxLabelNamesPerSeries(userID),
-		maxLabelNameLength:     v.MaxLabelNameLength(userID),
-		maxLabelValueLength:    v.MaxLabelValueLength(userID),
+		userID:                    userID,
+		rejectOldSample:           v.RejectOldSamples(userID),
+		rejectOldSampleMaxAge:     now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
+		creationGracePeriod:       now.Add(v.CreationGracePeriod(userID)).UnixNano(),
+		maxLineSizeShouldTruncate: v.MaxLineSizeShouldTruncate(userID),
+		maxLineSize:               v.MaxLineSize(userID),
+		maxLabelNamesPerSeries:    v.MaxLabelNamesPerSeries(userID),
+		maxLabelNameLength:        v.MaxLabelNameLength(userID),
+		maxLabelValueLength:       v.MaxLabelValueLength(userID),
 	}
 }
 

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -29,9 +29,8 @@ type validationContext struct {
 	rejectOldSampleMaxAge int64
 	creationGracePeriod   int64
 
-	maxLineSize            int
-	maxLineSizeTruncate    bool
-	maxLineSizeTruncateInd string
+	maxLineSize         int
+	maxLineSizeTruncate bool
 
 	maxLabelNamesPerSeries int
 	maxLabelNameLength     int
@@ -49,7 +48,6 @@ func (v Validator) getValidationContextFor(userID string) validationContext {
 		creationGracePeriod:    now.Add(v.CreationGracePeriod(userID)).UnixNano(),
 		maxLineSize:            v.MaxLineSize(userID),
 		maxLineSizeTruncate:    v.MaxLineSizeTruncate(userID),
-		maxLineSizeTruncateInd: v.MaxLineSizeTruncateInd(userID),
 		maxLabelNamesPerSeries: v.MaxLabelNamesPerSeries(userID),
 		maxLabelNameLength:     v.MaxLabelNameLength(userID),
 		maxLabelValueLength:    v.MaxLabelValueLength(userID),

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -25,11 +25,13 @@ func NewValidator(l Limits) (*Validator, error) {
 }
 
 type validationContext struct {
-	rejectOldSample           bool
-	rejectOldSampleMaxAge     int64
-	creationGracePeriod       int64
-	maxLineSizeShouldTruncate bool
-	maxLineSize               int
+	rejectOldSample       bool
+	rejectOldSampleMaxAge int64
+	creationGracePeriod   int64
+
+	maxLineSize            int
+	maxLineSizeTruncate    bool
+	maxLineSizeTruncateInd string
 
 	maxLabelNamesPerSeries int
 	maxLabelNameLength     int
@@ -41,15 +43,16 @@ type validationContext struct {
 func (v Validator) getValidationContextFor(userID string) validationContext {
 	now := time.Now()
 	return validationContext{
-		userID:                    userID,
-		rejectOldSample:           v.RejectOldSamples(userID),
-		rejectOldSampleMaxAge:     now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
-		creationGracePeriod:       now.Add(v.CreationGracePeriod(userID)).UnixNano(),
-		maxLineSizeShouldTruncate: v.MaxLineSizeShouldTruncate(userID),
-		maxLineSize:               v.MaxLineSize(userID),
-		maxLabelNamesPerSeries:    v.MaxLabelNamesPerSeries(userID),
-		maxLabelNameLength:        v.MaxLabelNameLength(userID),
-		maxLabelValueLength:       v.MaxLabelValueLength(userID),
+		userID:                 userID,
+		rejectOldSample:        v.RejectOldSamples(userID),
+		rejectOldSampleMaxAge:  now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
+		creationGracePeriod:    now.Add(v.CreationGracePeriod(userID)).UnixNano(),
+		maxLineSize:            v.MaxLineSize(userID),
+		maxLineSizeTruncate:    v.MaxLineSizeTruncate(userID),
+		maxLineSizeTruncateInd: v.MaxLineSizeTruncateInd(userID),
+		maxLabelNamesPerSeries: v.MaxLabelNamesPerSeries(userID),
+		maxLabelNameLength:     v.MaxLabelNameLength(userID),
+		maxLabelValueLength:    v.MaxLabelValueLength(userID),
 	}
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -28,17 +28,18 @@ const (
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type Limits struct {
 	// Distributor enforced limits.
-	IngestionRateStrategy  string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
-	IngestionRateMB        float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
-	IngestionBurstSizeMB   float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
-	MaxLabelNameLength     int              `yaml:"max_label_name_length" json:"max_label_name_length"`
-	MaxLabelValueLength    int              `yaml:"max_label_value_length" json:"max_label_value_length"`
-	MaxLabelNamesPerSeries int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
-	RejectOldSamples       bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
-	RejectOldSamplesMaxAge model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
-	CreationGracePeriod    model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
-	EnforceMetricName      bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
-	MaxLineSize            flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
+	IngestionRateStrategy     string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
+	IngestionRateMB           float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
+	IngestionBurstSizeMB      float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
+	MaxLabelNameLength        int              `yaml:"max_label_name_length" json:"max_label_name_length"`
+	MaxLabelValueLength       int              `yaml:"max_label_value_length" json:"max_label_value_length"`
+	MaxLabelNamesPerSeries    int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	RejectOldSamples          bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
+	RejectOldSamplesMaxAge    model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
+	CreationGracePeriod       model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
+	EnforceMetricName         bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
+	MaxLineSizeShouldTruncate bool             `yaml:"max_line_size_should_truncate" json:"max_line_size_should_truncate"`
+	MaxLineSize               flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
 
 	// Ingester enforced limits.
 	MaxLocalStreamsPerUser  int `yaml:"max_streams_per_user" json:"max_streams_per_user"`
@@ -88,6 +89,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-user ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 6, "Per-user allowed ingestion burst size (in sample size). Units in MB.")
 	f.Var(&l.MaxLineSize, "distributor.max-line-size", "maximum line length allowed, i.e. 100mb. Default (0) means unlimited.")
+	f.BoolVar(&l.MaxLineSizeShouldTruncate, "distributor.max-line-size-should-truncate", false, "Whether to truncate lines that exceed max_line_size")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
@@ -333,6 +335,11 @@ func (o *Overrides) MaxConcurrentTailRequests(userID string) int {
 // MaxLineSize returns the maximum size in bytes the distributor should allow.
 func (o *Overrides) MaxLineSize(userID string) int {
 	return o.getOverridesForUser(userID).MaxLineSize.Val()
+}
+
+// MaxLineSizeShouldTruncate returns whether lines longer than max should be truncated.
+func (o *Overrides) MaxLineSizeShouldTruncate(userID string) bool {
+	return o.getOverridesForUser(userID).MaxLineSizeShouldTruncate
 }
 
 // MaxEntriesLimitPerQuery returns the limit to number of entries the querier should return per query.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -28,18 +28,19 @@ const (
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type Limits struct {
 	// Distributor enforced limits.
-	IngestionRateStrategy     string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
-	IngestionRateMB           float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
-	IngestionBurstSizeMB      float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
-	MaxLabelNameLength        int              `yaml:"max_label_name_length" json:"max_label_name_length"`
-	MaxLabelValueLength       int              `yaml:"max_label_value_length" json:"max_label_value_length"`
-	MaxLabelNamesPerSeries    int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
-	RejectOldSamples          bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
-	RejectOldSamplesMaxAge    model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
-	CreationGracePeriod       model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
-	EnforceMetricName         bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
-	MaxLineSizeShouldTruncate bool             `yaml:"max_line_size_should_truncate" json:"max_line_size_should_truncate"`
-	MaxLineSize               flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
+	IngestionRateStrategy  string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
+	IngestionRateMB        float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
+	IngestionBurstSizeMB   float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
+	MaxLabelNameLength     int              `yaml:"max_label_name_length" json:"max_label_name_length"`
+	MaxLabelValueLength    int              `yaml:"max_label_value_length" json:"max_label_value_length"`
+	MaxLabelNamesPerSeries int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	RejectOldSamples       bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
+	RejectOldSamplesMaxAge model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
+	CreationGracePeriod    model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
+	EnforceMetricName      bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
+	MaxLineSize            flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
+	MaxLineSizeTruncate    bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
+	MaxLineSizeTruncateInd string           `yaml:"max_line_size_truncate_indicator" json:"max_line_size_truncate_indicator"`
 
 	// Ingester enforced limits.
 	MaxLocalStreamsPerUser  int `yaml:"max_streams_per_user" json:"max_streams_per_user"`
@@ -89,7 +90,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-user ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 6, "Per-user allowed ingestion burst size (in sample size). Units in MB.")
 	f.Var(&l.MaxLineSize, "distributor.max-line-size", "maximum line length allowed, i.e. 100mb. Default (0) means unlimited.")
-	f.BoolVar(&l.MaxLineSizeShouldTruncate, "distributor.max-line-size-should-truncate", false, "Whether to truncate lines that exceed max_line_size")
+	f.BoolVar(&l.MaxLineSizeTruncate, "distributor.max-line-size-truncate", false, "Whether to truncate lines that exceed max_line_size")
+	f.StringVar(&l.MaxLineSizeTruncateInd, "distributor.max-line-size-truncate-indicator", "", "An string appended to line that indicates it's been truncated")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
@@ -338,8 +340,13 @@ func (o *Overrides) MaxLineSize(userID string) int {
 }
 
 // MaxLineSizeShouldTruncate returns whether lines longer than max should be truncated.
-func (o *Overrides) MaxLineSizeShouldTruncate(userID string) bool {
-	return o.getOverridesForUser(userID).MaxLineSizeShouldTruncate
+func (o *Overrides) MaxLineSizeTruncate(userID string) bool {
+	return o.getOverridesForUser(userID).MaxLineSizeTruncate
+}
+
+// MaxLineSizeTruncateInd returns a string that's appended to a truncated line.
+func (o *Overrides) MaxLineSizeTruncateInd(userID string) string {
+	return o.getOverridesForUser(userID).MaxLineSizeTruncateInd
 }
 
 // MaxEntriesLimitPerQuery returns the limit to number of entries the querier should return per query.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -40,7 +40,6 @@ type Limits struct {
 	EnforceMetricName      bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
 	MaxLineSize            flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
 	MaxLineSizeTruncate    bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
-	MaxLineSizeTruncateInd string           `yaml:"max_line_size_truncate_indicator" json:"max_line_size_truncate_indicator"`
 
 	// Ingester enforced limits.
 	MaxLocalStreamsPerUser  int `yaml:"max_streams_per_user" json:"max_streams_per_user"`
@@ -91,7 +90,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 6, "Per-user allowed ingestion burst size (in sample size). Units in MB.")
 	f.Var(&l.MaxLineSize, "distributor.max-line-size", "maximum line length allowed, i.e. 100mb. Default (0) means unlimited.")
 	f.BoolVar(&l.MaxLineSizeTruncate, "distributor.max-line-size-truncate", false, "Whether to truncate lines that exceed max_line_size")
-	f.StringVar(&l.MaxLineSizeTruncateInd, "distributor.max-line-size-truncate-indicator", "", "An string appended to line that indicates it's been truncated")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
@@ -342,11 +340,6 @@ func (o *Overrides) MaxLineSize(userID string) int {
 // MaxLineSizeShouldTruncate returns whether lines longer than max should be truncated.
 func (o *Overrides) MaxLineSizeTruncate(userID string) bool {
 	return o.getOverridesForUser(userID).MaxLineSizeTruncate
-}
-
-// MaxLineSizeTruncateInd returns a string that's appended to a truncated line.
-func (o *Overrides) MaxLineSizeTruncateInd(userID string) string {
-	return o.getOverridesForUser(userID).MaxLineSizeTruncateInd
 }
 
 // MaxEntriesLimitPerQuery returns the limit to number of entries the querier should return per query.

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -44,7 +44,8 @@ reject_old_samples_max_age: 40s
 creation_grace_period: 50s
 enforce_metric_name: true
 max_line_size: 60
-max_line_size_should_truncate: true
+max_line_size_truncate: true
+max_line_size_truncate_indicator: "..."
 max_streams_per_user: 70
 max_global_streams_per_user: 80
 max_chunks_per_query: 90
@@ -77,7 +78,8 @@ per_tenant_override_period: 230s
   "creation_grace_period": "50s",
   "enforce_metric_name": true,
   "max_line_size": 60,
-  "max_line_size_should_truncate": true,
+  "max_line_size_truncate": true,
+  "max_line_size_truncate_indicator": "...",
   "max_streams_per_user": 70,
   "max_global_streams_per_user": 80,
   "max_chunks_per_query": 90,

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -44,6 +44,7 @@ reject_old_samples_max_age: 40s
 creation_grace_period: 50s
 enforce_metric_name: true
 max_line_size: 60
+max_line_size_should_truncate: true
 max_streams_per_user: 70
 max_global_streams_per_user: 80
 max_chunks_per_query: 90
@@ -76,6 +77,7 @@ per_tenant_override_period: 230s
   "creation_grace_period": "50s",
   "enforce_metric_name": true,
   "max_line_size": 60,
+  "max_line_size_should_truncate": true,
   "max_streams_per_user": 70,
   "max_global_streams_per_user": 80,
   "max_chunks_per_query": 90,

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -45,7 +45,6 @@ creation_grace_period: 50s
 enforce_metric_name: true
 max_line_size: 60
 max_line_size_truncate: true
-max_line_size_truncate_indicator: "..."
 max_streams_per_user: 70
 max_global_streams_per_user: 80
 max_chunks_per_query: 90
@@ -79,7 +78,6 @@ per_tenant_override_period: 230s
   "enforce_metric_name": true,
   "max_line_size": 60,
   "max_line_size_truncate": true,
-  "max_line_size_truncate_indicator": "...",
   "max_streams_per_user": 70,
   "max_global_streams_per_user": 80,
   "max_chunks_per_query": 90,

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -43,6 +43,16 @@ const (
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
 
+// TruncatedBytes is a metric of the total truncated bytes, by reason.
+var TruncatedBytes = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "truncated_bytes_total",
+		Help:      "The total number of bytes that were truncated.",
+	},
+	[]string{discardReasonLabel, "tenant"},
+)
+
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
 var DiscardedBytes = prometheus.NewCounterVec(
 	prometheus.CounterOpts{

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	discardReasonLabel = "reason"
+	reasonLabel                = "reason"
+	truncatedMutateReasonLabel = "truncated"
 	// InvalidLabels is a reason for discarding log lines which have labels that cannot be parsed.
 	InvalidLabels = "invalid_labels"
 	MissingLabels = "missing_labels"
@@ -43,14 +44,24 @@ const (
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
 
-// TruncatedBytes is a metric of the total truncated bytes, by reason.
+// TruncatedLines is a metric of the total number of lines mutated, by reason.
+var TruncatedLines = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "mutated_samples_total",
+		Help:      "The total number of samples that have been mutated.",
+	},
+	[]string{reasonLabel, "truncated"},
+)
+
+// TruncatedLines is a metric of the total mutated bytes, by reason.
 var TruncatedBytes = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
-		Name:      "truncated_bytes_total",
-		Help:      "The total number of bytes that were truncated.",
+		Name:      "mutated_bytes_total",
+		Help:      "The total number of bytes that have been mutated.",
 	},
-	[]string{discardReasonLabel, "tenant"},
+	[]string{reasonLabel, "truncated"},
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
@@ -60,7 +71,7 @@ var DiscardedBytes = prometheus.NewCounterVec(
 		Name:      "discarded_bytes_total",
 		Help:      "The total number of bytes that were discarded.",
 	},
-	[]string{discardReasonLabel, "tenant"},
+	[]string{reasonLabel, "tenant"},
 )
 
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
@@ -70,7 +81,7 @@ var DiscardedSamples = prometheus.NewCounterVec(
 		Name:      "discarded_samples_total",
 		Help:      "The total number of samples that were discarded.",
 	},
-	[]string{discardReasonLabel, "tenant"},
+	[]string{reasonLabel, "tenant"},
 )
 
 func init() {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -5,8 +5,7 @@ import (
 )
 
 const (
-	reasonLabel                = "reason"
-	truncatedMutateReasonLabel = "truncated"
+	reasonLabel = "reason"
 	// InvalidLabels is a reason for discarding log lines which have labels that cannot be parsed.
 	InvalidLabels = "invalid_labels"
 	MissingLabels = "missing_labels"
@@ -54,7 +53,7 @@ var TruncatedLines = prometheus.NewCounterVec(
 	[]string{reasonLabel, "truncated"},
 )
 
-// TruncatedLines is a metric of the total mutated bytes, by reason.
+// TruncatedBytes is a metric of the total mutated bytes, by reason.
 var TruncatedBytes = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -43,8 +43,8 @@ const (
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
 
-// TruncatedLines is a metric of the total number of lines mutated, by reason.
-var TruncatedLines = prometheus.NewCounterVec(
+// MutatedSamples is a metric of the total number of lines mutated, by reason.
+var MutatedSamples = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "mutated_samples_total",
@@ -53,8 +53,8 @@ var TruncatedLines = prometheus.NewCounterVec(
 	[]string{reasonLabel, "truncated"},
 )
 
-// TruncatedBytes is a metric of the total mutated bytes, by reason.
-var TruncatedBytes = prometheus.NewCounterVec(
+// MutatedBytes is a metric of the total mutated bytes, by reason.
+var MutatedBytes = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "mutated_bytes_total",


### PR DESCRIPTION
- When log lines are longer than maxLineSize, truncate them to maxLineSize rather than dropping them

**Special notes for your reviewer**:
The issue calls out adding a `_truncated_` label but I didn't do that because there doesn't seem to be a way to do it without introducing unexpected behavior: 
- If added before validation, the stream might be dropped for exceeding the max number of label names.
- If added after validation, the number of streams might be doubled for reasons that might surprise an operator. 

This change also doesn't include appending `... truncated 12345 bytes` because it has the potential to introduce strange behavior around `max_line_length`

Fixes #3747

**Checklist**
- [x] Documentation added
- [x] Tests updated

