### PR TITLE
Group memcached queries by container

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -3946,21 +3946,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le))",
+              "expr": "histogram_quantile(.99, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le, container))",
               "intervalFactor": 1,
-              "legendFormat": ".99-{{method}}-{{name}}",
+              "legendFormat": "{{container}}: .99-{{method}}-{{name}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(.9, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le))",
+              "expr": "histogram_quantile(.9, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le, container))",
               "hide": false,
-              "legendFormat": ".9-{{method}}-{{name}}",
+              "legendFormat": "{{container}}: .9-{{method}}-{{name}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(.5, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le))",
+              "expr": "histogram_quantile(.5, sum(rate(cortex_memcache_request_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (method, name, le, container))",
               "hide": false,
-              "legendFormat": ".5-{{method}}-{{name}}",
+              "legendFormat": "{{container}}: .5-{{method}}-{{name}}",
               "refId": "C"
             }
           ],
@@ -4049,9 +4049,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cortex_memcache_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (status_code, method, name)",
+              "expr": "sum(rate(cortex_memcache_request_duration_seconds_count{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (status_code, method, name, container)",
               "intervalFactor": 1,
-              "legendFormat": "{{status_code}}-{{method}}-{{name}}",
+              "legendFormat": "{{container}}: {{status_code}}-{{method}}-{{name}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Modifies _Loki Operational_ dashboard to group by container in Memcached row, so we can attribute used methods to components.

For example, we have an entry for `200-Memcache.Put-chunks`, but multiple components use the querier code which ultimately makes this call (`ingester` and `ruler`, for example). With this change, all entries in the panel will be prefixed with the component name.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

