### PR TITLE
Promtail: handling tight loop in journal follow logic

### DIFF
--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -192,7 +192,7 @@ func journalTargetWithReader(
 			}
 
 			// prevent tight loop
-			time.Sleep(100*time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 

--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
@@ -182,11 +183,16 @@ func journalTargetWithReader(
 		for {
 			err := t.r.Follow(until, ioutil.Discard)
 			if err != nil {
-				if err == sdjournal.ErrExpired || err == io.EOF {
+				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
+
+				if err == sdjournal.ErrExpired || err == syscall.EBADMSG || err == io.EOF {
+					level.Error(t.logger).Log("msg", "unable to follow journal", "err", err.Error())
 					return
 				}
-				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
 			}
+
+			// prevent tight loop
+			time.Sleep(100*time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
While following the systemd journal, if an `EBADMSG` error is thrown (or indeed anything else besides for `sdjournal.ErrExpired` or `io.EOF`), then we will enter into a tight loop and consume all available CPU.

This PR handles `EBADMSG` which can occur in a corrupt journal file, and additionally adds a 100ms sleep in the loop to prevent runaway CPU usage.

**Which issue(s) this PR fixes**:
Partially addresses #4053

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

