### PR TITLE
Doc: Promtail: the label created for the message in the cri stage is …

### DIFF
--- a/docs/sources/clients/promtail/stages/cri.md
+++ b/docs/sources/clients/promtail/stages/cri.md
@@ -44,6 +44,6 @@ Given the following log line:
 
 The following key-value pairs would be created in the set of extracted data:
 
-- `output`: `message`
+- `content`: `message`
 - `stream`: `stdout`
 - `timestamp`: `2019-04-30T02:12:41.8443515`


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation of the CRI stage of promtail incorrectly states that the created label for the log content is called `output`, it is however called `content`, see https://github.com/grafana/loki/blob/v2.2.1/pkg/logentry/stages/extensions.go#L59 / https://github.com/grafana/loki/blob/6e67d1e/clients/pkg/logentry/stages/extensions.go#L59

Note: it is confusing that this is called `content` in the `cri` stage and `output` in the `docker` stage.
