### PR TITLE
Optimize index queries and caching

### DIFF
--- a/pkg/storage/chunk/schema.go
+++ b/pkg/storage/chunk/schema.go
@@ -90,6 +90,8 @@ type IndexQuery struct {
 	// - If RangeValuePrefix is not nil, must read all keys with that prefix.
 	// - If RangeValueStart is not nil, must read all keys from there onwards.
 	// - If neither is set, must read all keys for that row.
+	// RangeValueStart should only be used for querying Chunk IDs.
+	// If this is going to change then please take care of func isChunksQuery in pkg/chunk/storage/caching_index_client.go which relies on it.
 	RangeValuePrefix []byte
 	RangeValueStart  []byte
 

--- a/pkg/storage/chunk/schema.go
+++ b/pkg/storage/chunk/schema.go
@@ -737,10 +737,10 @@ func (v9Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 	valueHash := sha256bytes(labelValue)
 	return []IndexQuery{
 		{
-			TableName:       bucket.tableName,
-			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
-			RangeValueStart: rangeValuePrefix(valueHash),
-			ValueEqual:      []byte(labelValue),
+			TableName:        bucket.tableName,
+			HashValue:        fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
+			RangeValuePrefix: rangeValuePrefix(valueHash),
+			ValueEqual:       []byte(labelValue),
 		},
 	}, nil
 }
@@ -847,10 +847,10 @@ func (s v10Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName str
 	result := make([]IndexQuery, 0, s.rowShards)
 	for i := uint32(0); i < s.rowShards; i++ {
 		result = append(result, IndexQuery{
-			TableName:       bucket.tableName,
-			HashValue:       fmt.Sprintf("%02d:%s:%s:%s", i, bucket.hashKey, metricName, labelName),
-			RangeValueStart: rangeValuePrefix(valueHash),
-			ValueEqual:      []byte(labelValue),
+			TableName:        bucket.tableName,
+			HashValue:        fmt.Sprintf("%02d:%s:%s:%s", i, bucket.hashKey, metricName, labelName),
+			RangeValuePrefix: rangeValuePrefix(valueHash),
+			ValueEqual:       []byte(labelValue),
 		})
 	}
 	return result, nil

--- a/pkg/storage/chunk/storage/bytes.go
+++ b/pkg/storage/chunk/storage/bytes.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"unsafe"
 )
 
 // Bytes exists to stop proto copying the byte array
@@ -36,4 +37,8 @@ func (bs *Bytes) Equal(other Bytes) bool {
 // Compare Bytes to other
 func (bs *Bytes) Compare(other Bytes) int {
 	return bytes.Compare(*bs, other)
+}
+
+func yoloString(buf []byte) string {
+	return *((*string)(unsafe.Pointer(&buf)))
 }

--- a/pkg/storage/chunk/storage/caching_fixtures.go
+++ b/pkg/storage/chunk/storage/caching_fixtures.go
@@ -33,7 +33,7 @@ func (f fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, 
 	indexClient = newCachingIndexClient(indexClient, cache.NewFifoCache("index-fifo", cache.FifoCacheConfig{
 		MaxSizeItems: 500,
 		Validity:     5 * time.Minute,
-	}, reg, logger), 5*time.Minute, limits, logger)
+	}, reg, logger), 5*time.Minute, limits, logger, false)
 	return indexClient, chunkClient, tableClient, schemaConfig, closer, err
 }
 

--- a/pkg/storage/chunk/storage/caching_index_client_test.go
+++ b/pkg/storage/chunk/storage/caching_index_client_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -18,15 +20,15 @@ var ctx = user.InjectOrgID(context.Background(), "1")
 
 type mockStore struct {
 	chunk.IndexClient
-	queries int
+	queries []chunk.IndexQuery
 	results ReadBatch
 }
 
 func (m *mockStore) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error {
 	for _, query := range queries {
-		m.queries++
 		callback(query, m.results)
 	}
+	m.queries = append(m.queries, queries...)
 	return nil
 }
 
@@ -43,7 +45,7 @@ func TestCachingStorageClientBasic(t *testing.T) {
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{{
 		TableName: "table",
 		HashValue: "baz",
@@ -52,14 +54,14 @@ func TestCachingStorageClientBasic(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 
 	// If we do the query to the cache again, the underlying store shouldn't see it.
 	err = client.QueryPages(ctx, queries, func(_ chunk.IndexQuery, _ chunk.ReadBatch) bool {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 }
 
 func TestTempCachingStorageClient(t *testing.T) {
@@ -75,7 +77,7 @@ func TestTempCachingStorageClient(t *testing.T) {
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
+	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo"},
 		{TableName: "table", HashValue: "bar"},
@@ -90,7 +92,7 @@ func TestTempCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, len(queries), store.queries)
+	assert.EqualValues(t, len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 
 	// If we do the query to the cache again, the underlying store shouldn't see it.
@@ -103,7 +105,7 @@ func TestTempCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, len(queries), store.queries)
+	assert.EqualValues(t, len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 
 	// If we do the query after validity, it should see the queries.
@@ -117,7 +119,7 @@ func TestTempCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 2*len(queries), store.queries)
+	assert.EqualValues(t, 2*len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 }
 
@@ -134,7 +136,7 @@ func TestPermCachingStorageClient(t *testing.T) {
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
+	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", Immutable: true},
 		{TableName: "table", HashValue: "bar", Immutable: true},
@@ -149,7 +151,7 @@ func TestPermCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, len(queries), store.queries)
+	assert.EqualValues(t, len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 
 	// If we do the query to the cache again, the underlying store shouldn't see it.
@@ -162,7 +164,7 @@ func TestPermCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, len(queries), store.queries)
+	assert.EqualValues(t, len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 
 	// If we do the query after validity, it still shouldn't see the queries.
@@ -176,7 +178,7 @@ func TestPermCachingStorageClient(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, len(queries), store.queries)
+	assert.EqualValues(t, len(queries), len(store.queries))
 	assert.EqualValues(t, len(queries), results)
 }
 
@@ -186,14 +188,14 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{{TableName: "table", HashValue: "foo"}}
 	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
 		assert.False(t, batch.Iterator().Next())
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 
 	// If we do the query to the cache again, the underlying store shouldn't see it.
 	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
@@ -201,7 +203,7 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 }
 
 func TestCachingStorageClientCollision(t *testing.T) {
@@ -225,7 +227,7 @@ func TestCachingStorageClientCollision(t *testing.T) {
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},
@@ -243,7 +245,7 @@ func TestCachingStorageClientCollision(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 	assert.EqualValues(t, store.results, results)
 
 	// If we do the query to the cache again, the underlying store shouldn't see it.
@@ -259,6 +261,202 @@ func TestCachingStorageClientCollision(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
+	assert.EqualValues(t, 1, len(store.queries))
 	assert.EqualValues(t, store.results, results)
+}
+
+type mockCache struct {
+	storedKeys []string
+	cache.Cache
+}
+
+func (m *mockCache) Store(ctx context.Context, keys []string, buf [][]byte) {
+	m.storedKeys = append(m.storedKeys, keys...)
+	m.Cache.Store(ctx, keys, buf)
+}
+
+func buildQueryKey(q chunk.IndexQuery) string {
+	ret := q.TableName + sep + q.HashValue
+
+	if len(q.RangeValuePrefix) != 0 {
+		ret += sep + yoloString(q.RangeValuePrefix)
+	}
+
+	if len(q.ValueEqual) != 0 {
+		ret += sep + yoloString(q.ValueEqual)
+	}
+
+	return ret
+}
+
+func TestCachingStorageClientStoreQueries(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		queries []chunk.IndexQuery
+
+		expectedStoreQueriesWithoutBroadQueriesDisabled []chunk.IndexQuery
+		expectedStoreQueriesWithBroadQueriesDisabled    []chunk.IndexQuery
+	}{
+		{
+			name: "TableName-HashValue queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "bar"},
+			},
+			expectedStoreQueriesWithoutBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "bar"},
+			},
+			expectedStoreQueriesWithBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "bar"},
+			},
+		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz")},
+			},
+			expectedStoreQueriesWithoutBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+			},
+			expectedStoreQueriesWithBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz")},
+			},
+		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix-ValueEqual queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz"), ValueEqual: []byte("two")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz"), ValueEqual: []byte("three")},
+			},
+			expectedStoreQueriesWithoutBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+			},
+			expectedStoreQueriesWithBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz"), ValueEqual: []byte("two")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz"), ValueEqual: []byte("three")},
+			},
+		},
+		{
+			name: "TableName-HashValue-RangeValueStart queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValueStart: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValueStart: []byte("baz")},
+			},
+			expectedStoreQueriesWithoutBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+			},
+			expectedStoreQueriesWithBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+			},
+		},
+		{
+			name: "Duplicate queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+			},
+			expectedStoreQueriesWithoutBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+			},
+			expectedStoreQueriesWithBroadQueriesDisabled: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+			},
+		},
+	} {
+		for _, disableBroadQueries := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s-%v", tc.name, disableBroadQueries), func(t *testing.T) {
+				expectedStoreQueries := tc.expectedStoreQueriesWithoutBroadQueriesDisabled
+				if disableBroadQueries {
+					expectedStoreQueries = tc.expectedStoreQueriesWithBroadQueriesDisabled
+				}
+				expectedQueryKeysInCache := make([]string, 0, len(expectedStoreQueries))
+				for _, query := range expectedStoreQueries {
+					expectedQueryKeysInCache = append(expectedQueryKeysInCache, cache.HashKey(buildQueryKey(query)))
+				}
+
+				store := &mockStore{
+					results: ReadBatch{
+						Entries: []Entry{
+							{
+								Column: []byte("bar"),
+								Value:  []byte("bar"),
+							},
+							{
+								Column: []byte("baz"),
+								Value:  []byte("baz"),
+							},
+						},
+					},
+				}
+				limits, err := defaultLimits()
+				require.NoError(t, err)
+				logger := log.NewNopLogger()
+				cache := &mockCache{
+					Cache: cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger),
+				}
+				client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, disableBroadQueries)
+				var callbackQueries []chunk.IndexQuery
+
+				err = client.QueryPages(ctx, tc.queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+					callbackQueries = append(callbackQueries, query)
+					return true
+				})
+				require.NoError(t, err)
+
+				// we do a callback per query sent not per query done to the index store. See if we got as many callbacks as the number of actual queries.
+				sort.Slice(tc.queries, func(i, j int) bool {
+					return buildQueryKey(tc.queries[i]) < buildQueryKey(tc.queries[j])
+				})
+				sort.Slice(callbackQueries, func(i, j int) bool {
+					return buildQueryKey(callbackQueries[i]) < buildQueryKey(callbackQueries[j])
+				})
+				assert.EqualValues(t, tc.queries, callbackQueries)
+
+				// sort the expected and actual queries before comparing
+				sort.Slice(expectedStoreQueries, func(i, j int) bool {
+					return buildQueryKey(expectedStoreQueries[i]) < buildQueryKey(expectedStoreQueries[j])
+				})
+				sort.Slice(store.queries, func(i, j int) bool {
+					return buildQueryKey(store.queries[i]) < buildQueryKey(store.queries[j])
+				})
+				assert.EqualValues(t, expectedStoreQueries, store.queries)
+
+				callbackQueries = callbackQueries[:]
+				// If we do the query to the cache again, the underlying store shouldn't see it.
+				err = client.QueryPages(ctx, tc.queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+					callbackQueries = append(callbackQueries, query)
+					return true
+				})
+				require.NoError(t, err)
+
+				// verify the callback queries again
+				sort.Slice(callbackQueries, func(i, j int) bool {
+					return buildQueryKey(callbackQueries[i]) < buildQueryKey(callbackQueries[j])
+				})
+				assert.EqualValues(t, tc.queries, callbackQueries)
+
+				assert.EqualValues(t, expectedStoreQueries, store.queries)
+
+				// sort the expected and actual query keys in cache before comparing
+				sort.Strings(expectedQueryKeysInCache)
+				sort.Strings(cache.storedKeys)
+				assert.EqualValues(t, expectedQueryKeysInCache, cache.storedKeys)
+			})
+
+		}
+	}
 }

--- a/pkg/storage/chunk/storage/factory.go
+++ b/pkg/storage/chunk/storage/factory.go
@@ -92,7 +92,8 @@ type Config struct {
 
 	IndexCacheValidity time.Duration `yaml:"index_cache_validity"`
 
-	IndexQueriesCacheConfig cache.Config `yaml:"index_queries_cache_config"`
+	IndexQueriesCacheConfig  cache.Config `yaml:"index_queries_cache_config"`
+	DisableBroadIndexQueries bool         `yaml:"disable_broad_index_queries"`
 
 	DeleteStoreConfig purger.DeleteStoreConfig `yaml:"delete_store"`
 
@@ -115,6 +116,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Engine, "store.engine", "chunks", "The storage engine to use: chunks or blocks.")
 	cfg.IndexQueriesCacheConfig.RegisterFlagsWithPrefix("store.index-cache-read.", "Cache config for index entry reading. ", f)
 	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Cache validity for active index entries. Should be no higher than -ingester.max-chunk-idle.")
+	f.BoolVar(&cfg.DisableBroadIndexQueries, "store.disable-broad-index-queries", false, "Disable broad index queries which results in reduced cache usage and faster query performance at the expense of somewhat higher QPS on the index store.")
 }
 
 // Validate config and returns error on failure
@@ -198,7 +200,7 @@ func NewStore(
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating index client")
 		}
-		index = newCachingIndexClient(index, indexReadCache, cfg.IndexCacheValidity, limits, logger)
+		index = newCachingIndexClient(index, indexReadCache, cfg.IndexCacheValidity, limits, logger, cfg.DisableBroadIndexQueries)
 
 		objectStoreType := s.ObjectType
 		if objectStoreType == "" {

--- a/pkg/storage/chunk/storage/index_client_test.go
+++ b/pkg/storage/chunk/storage/index_client_test.go
@@ -205,7 +205,7 @@ func TestCardinalityLimit(t *testing.T) {
 		limits, err := defaultLimits()
 		require.NoError(t, err)
 
-		client = newCachingIndexClient(client, cache.NewMockCache(), time.Minute, limits, log.NewNopLogger())
+		client = newCachingIndexClient(client, cache.NewMockCache(), time.Minute, limits, log.NewNopLogger(), false)
 		batch := client.NewWriteBatch()
 		for i := 0; i < 10; i++ {
 			batch.Add(tableName, "bar", []byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We drop some query parameters from the queries to cache all possible rows matching the HashKey, which includes just the metric name + label name for labels index entries and the metric name + series ids for chunk ids. This PR aims at the labels index query part.

In simple terms, when a query comes in for label {foo="bar"}, the caching index client will fetch and store all the index entries for label foo irrespective of the expected value from the query. While this helps with other queries looking for other label values for `foo', it is still a lot of waste of resources if the label name is present in thousands of series, and users would not search for all of them.

I have changed the code to not drop the search parameters for labels queries and keep the behaviour the as-is for the chunks queries since the chunk boundaries can vary significantly. I have also changed the GetReadMetricLabelValueQueries function used for building the labels queries to use RangeValuePrefix instead of RangeValueStart since the required entries would have a specific prefix which allows us to limit the search space.

I have tested this change with Loki in one of the large clusters, and it has reduced the CPU and memory usage for queriers and the amount of index cache required with similar or better query performance.

**Special notes for your reviewer**:
I had opened a [PR](https://github.com/cortexproject/cortex/pull/4109) in Cortex with similar changes. Re-opening this here with all the feedbacks addressed.

**Checklist**
- [x] Tests updated

