### PR TITLE
Updating drone signature

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -973,6 +973,6 @@ get:
 
 ---
 kind: signature
-hmac: b9ca51f266b7895bd1ea53ca40721d65915472fde3dc25fb662968282bc8acd5
+hmac: b70be41d1a7f91c11af945a34bdbdc7a4f7613cf830c13f5438dba0bf33a1ec5
 
 ...


### PR DESCRIPTION
It doesn't seem like https://github.com/grafana/loki/pull/4069 worked out; re-ran `drone sign` and committed the result.