### PR TITLE
Make `ParseExternalKey` from the `chunk` package allocations free.

### DIFF
--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1522,6 +1522,7 @@ var entry logproto.Entry
 func Benchmark_store_OverlappingChunks(b *testing.B) {
 	b.ReportAllocs()
 	st := &store{
+		chunkMetrics: NilMetrics,
 		cfg: Config{
 			MaxChunkBatchSize: 50,
 		},

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -378,3 +378,10 @@ func TestChunk_Slice(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_ParseExternalKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := ParseExternalKey("fake", "fake/57f628c7f6d57aad:162c699f000:162c69a07eb:eb242d99")
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
```
~/go/src/github.com/grafana/loki main* ⇣
❯ benchcmp  before.txt after.txt2
benchmark                         old ns/op     new ns/op     delta
Benchmark_ParseExternalKey-16     569           415           -27.03%

benchmark                         old allocs     new allocs     delta
Benchmark_ParseExternalKey-16     2              0              -100.00%

benchmark                         old bytes     new bytes     delta
Benchmark_ParseExternalKey-16     96            0             -100.00%
```

This is a very hot function in Loki being used for every chunk reference we get from the index.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
