### PR TITLE
Ruler: Adding group_key label to recording_rules_samples_queue_capacity metric

### DIFF
--- a/pkg/ruler/appender.go
+++ b/pkg/ruler/appender.go
@@ -168,7 +168,7 @@ func (a *RemoteWriteAppender) WithQueueCapacity(capacity int) error {
 		return err
 	}
 
-	a.metrics.samplesQueueCapacity.WithLabelValues(a.userID).Set(float64(capacity))
+	a.metrics.samplesQueueCapacity.WithLabelValues(a.userID, a.groupKey).Set(float64(capacity))
 	return nil
 }
 

--- a/pkg/ruler/remote_write.go
+++ b/pkg/ruler/remote_write.go
@@ -133,11 +133,11 @@ func newRemoteWriteMetrics(r prometheus.Registerer) *remoteWriteMetrics {
 			Name:      "recording_rules_samples_queued_current",
 			Help:      "Number of samples queued to be remote-written.",
 		}, []string{"tenant", "group_key"}),
+		// even though capacity can only be set per tenant, it's convenient to have a metric per rulegroup for calculations
 		samplesQueueCapacity: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "recording_rules_samples_queue_capacity",
 			Help:      "Number of samples that can be queued before eviction of oldest samples occurs.",
-		// even though capacity can only be set per tenant, it's convenient to have a metric per rulegroup for calculations
 		}, []string{"tenant", "group_key"}),
 		remoteWriteErrors: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",

--- a/pkg/ruler/remote_write.go
+++ b/pkg/ruler/remote_write.go
@@ -137,7 +137,8 @@ func newRemoteWriteMetrics(r prometheus.Registerer) *remoteWriteMetrics {
 			Namespace: "loki",
 			Name:      "recording_rules_samples_queue_capacity",
 			Help:      "Number of samples that can be queued before eviction of oldest samples occurs.",
-		}, []string{"tenant"}),
+		// even though capacity can only be set per tenant, it's convenient to have a metric per rulegroup for calculations
+		}, []string{"tenant", "group_key"}),
 		remoteWriteErrors: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",
 			Name:      "recording_rules_remote_write_errors",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds a `group_key` label to the `recording_rules_samples_queue_capacity` metric, in order to make queries simpler.
Attempting to determine what the total used capacity of a queue is difficult if we can't match the `recording_rules_samples_queued_current` and `recording_rules_samples_queue_capacity` metrics on tenant and rule group key. We need to start doing ugly things like `ignoring (group_key)` to get around this currently.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Initially this wasn't added because queue capacity (`ruler_remote_write_queue_capacity`) can only be set on a per-tenant basis. The ruler maintains a separate queue for each rule group, and each rule group inherits this capacity.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

