### PR TITLE
add a method to check whether error is due to a missing object in storage while reading or deleting the object

### DIFF
--- a/pkg/storage/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/storage/chunk/aws/dynamodb_storage_client.go
@@ -570,6 +570,10 @@ func (a dynamoDBStorageClient) DeleteChunk(ctx context.Context, userID, chunkID 
 	return a.BatchWrite(ctx, dynamoDBWrites)
 }
 
+func (a dynamoDBStorageClient) IsChunkNotFoundErr(_ error) bool {
+	return false
+}
+
 func (a dynamoDBStorageClient) writesForChunks(chunks []chunk.Chunk) (dynamoDBWriteBatch, error) {
 	dynamoDBWrites := dynamoDBWriteBatch{}
 

--- a/pkg/storage/chunk/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/azure/blob_storage_client.go
@@ -138,9 +138,6 @@ func (b *BlobStorage) getObject(ctx context.Context, objectKey string) (rc io.Re
 	// Request access to the blob
 	downloadResponse, err := blockBlobURL.Download(ctx, 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
 	if err != nil {
-		if isObjNotFoundErr(err) {
-			return nil, chunk.ErrStorageObjectNotFound
-		}
 		return nil, err
 	}
 
@@ -250,9 +247,6 @@ func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
 	}
 
 	_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
-	if err != nil && isObjNotFoundErr(err) {
-		return chunk.ErrStorageObjectNotFound
-	}
 	return err
 }
 
@@ -272,8 +266,8 @@ func (b *BlobStorage) selectContainerURLFmt() string {
 	return endpoints[b.cfg.Environment].containerURLFmt
 }
 
-// isObjNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
-func isObjNotFoundErr(err error) bool {
+// IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
+func (b *BlobStorage) IsObjectNotFoundErr(err error) bool {
 	var e azblob.StorageError
 	if errors.As(err, &e) && e.ServiceCode() == azblob.ServiceCodeBlobNotFound {
 		return true

--- a/pkg/storage/chunk/cassandra/storage_client.go
+++ b/pkg/storage/chunk/cassandra/storage_client.go
@@ -546,6 +546,10 @@ func (s *ObjectClient) DeleteChunk(ctx context.Context, userID, chunkID string) 
 	return nil
 }
 
+func (s *ObjectClient) IsChunkNotFoundErr(_ error) bool {
+	return false
+}
+
 // Stop implement chunk.ObjectClient.
 func (s *ObjectClient) Stop() {
 	s.readSession.Close()

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -636,7 +636,7 @@ func (c *baseStore) deleteChunk(ctx context.Context,
 
 	err = c.chunks.DeleteChunk(ctx, userID, chunkID)
 	if err != nil {
-		if err == ErrStorageObjectNotFound {
+		if c.chunks.IsChunkNotFoundErr(err) {
 			return nil
 		}
 		return errors.Wrapf(err, "when deleting chunk from storage with chunkID=%s", chunkID)
@@ -657,7 +657,7 @@ func (c *baseStore) reboundChunk(ctx context.Context, userID, chunkID string, pa
 
 	chunks, err := c.fetcher.FetchChunks(ctx, []Chunk{chunk}, []string{chunkID})
 	if err != nil {
-		if err == ErrStorageObjectNotFound {
+		if c.fetcher.IsChunkNotFoundErr(err) {
 			return nil
 		}
 		return errors.Wrap(err, "when fetching chunk from storage for slicing")

--- a/pkg/storage/chunk/chunk_store_utils.go
+++ b/pkg/storage/chunk/chunk_store_utils.go
@@ -252,3 +252,7 @@ func (c *Fetcher) processCacheResponse(ctx context.Context, chunks []Chunk, keys
 	}
 	return found, missing, err
 }
+
+func (c *Fetcher) IsChunkNotFoundErr(err error) bool {
+	return c.storage.IsChunkNotFoundErr(err)
+}

--- a/pkg/storage/chunk/gcp/bigtable_object_client.go
+++ b/pkg/storage/chunk/gcp/bigtable_object_client.go
@@ -181,3 +181,7 @@ func (s *bigtableObjectClient) DeleteChunk(ctx context.Context, userID, chunkID 
 
 	return s.client.Open(tableName).Apply(ctx, chunkID, mut)
 }
+
+func (s *bigtableObjectClient) IsChunkNotFoundErr(_ error) bool {
+	return false
+}

--- a/pkg/storage/chunk/grpc/storage_client.go
+++ b/pkg/storage/chunk/grpc/storage_client.go
@@ -74,6 +74,10 @@ func (s *StorageClient) DeleteChunk(ctx context.Context, userID, chunkID string)
 	return nil
 }
 
+func (s *StorageClient) IsChunkNotFoundErr(_ error) bool {
+	return false
+}
+
 func (s *StorageClient) GetChunks(ctx context.Context, input []chunk.Chunk) ([]chunk.Chunk, error) {
 	req := &GetChunksRequest{}
 	req.Chunks = []*Chunk{}

--- a/pkg/storage/chunk/objectclient/client.go
+++ b/pkg/storage/chunk/objectclient/client.go
@@ -117,3 +117,7 @@ func (o *Client) DeleteChunk(ctx context.Context, userID, chunkID string) error 
 	}
 	return o.store.DeleteObject(ctx, key)
 }
+
+func (o *Client) IsChunkNotFoundErr(err error) bool {
+	return o.store.IsObjectNotFoundErr(err)
+}

--- a/pkg/storage/chunk/storage/metrics.go
+++ b/pkg/storage/chunk/storage/metrics.go
@@ -108,3 +108,7 @@ func (c metricsChunkClient) GetChunks(ctx context.Context, chunks []chunk.Chunk)
 func (c metricsChunkClient) DeleteChunk(ctx context.Context, userID, chunkID string) error {
 	return c.client.DeleteChunk(ctx, userID, chunkID)
 }
+
+func (c metricsChunkClient) IsChunkNotFoundErr(err error) bool {
+	return c.client.IsChunkNotFoundErr(err)
+}

--- a/pkg/storage/chunk/storage_client.go
+++ b/pkg/storage/chunk/storage_client.go
@@ -8,8 +8,6 @@ import (
 )
 
 var (
-	// ErrStorageObjectNotFound when object storage does not have requested object
-	ErrStorageObjectNotFound = errors.New("object not found in storage")
 	// ErrMethodNotImplemented when any of the storage clients do not implement a method
 	ErrMethodNotImplemented = errors.New("method is not implemented")
 )
@@ -33,6 +31,7 @@ type Client interface {
 	PutChunks(ctx context.Context, chunks []Chunk) error
 	GetChunks(ctx context.Context, chunks []Chunk) ([]Chunk, error)
 	DeleteChunk(ctx context.Context, userID, chunkID string) error
+	IsChunkNotFoundErr(err error) bool
 }
 
 // ObjectAndIndexClient allows optimisations where the same client handles both
@@ -76,6 +75,7 @@ type ObjectClient interface {
 	// Keys of returned storage objects have given prefix.
 	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
+	IsObjectNotFoundErr(err error) bool
 	Stop()
 }
 

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table.go
@@ -65,7 +65,7 @@ func (t *deleteRequestsTable) init() error {
 	_, err := os.Stat(t.dbPath)
 	if err != nil {
 		err = shipper_util.GetFileFromStorage(context.Background(), t.objectClient, objectPathInStorage, t.dbPath, true)
-		if err != nil && !errors.Is(err, chunk.ErrStorageObjectNotFound) {
+		if err != nil && !t.objectClient.IsObjectNotFoundErr(err) {
 			return err
 		}
 	}

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -175,6 +175,7 @@ func markforDelete(ctx context.Context, marker MarkerStorageWriter, chunkIt Chun
 
 type ChunkClient interface {
 	DeleteChunk(ctx context.Context, userID, chunkID string) error
+	IsChunkNotFoundErr(err error) bool
 }
 
 type Sweeper struct {
@@ -210,7 +211,7 @@ func (s *Sweeper) Start() {
 		}
 
 		err = s.chunkClient.DeleteChunk(ctx, unsafeGetString(userID), chunkIDString)
-		if err == chunk.ErrStorageObjectNotFound {
+		if s.chunkClient.IsChunkNotFoundErr(err) {
 			status = statusNotFound
 			level.Debug(util_log.Logger).Log("msg", "delete on not found chunk", "chunkID", chunkIDString)
 			return nil

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -41,6 +41,10 @@ func (m *mockChunkClient) DeleteChunk(_ context.Context, _, chunkID string) erro
 	return nil
 }
 
+func (m *mockChunkClient) IsChunkNotFoundErr(err error) bool {
+	return false
+}
+
 func (m *mockChunkClient) getDeletedChunkIds() []string {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/pkg/storage/stores/util/object_client.go
+++ b/pkg/storage/stores/util/object_client.go
@@ -42,6 +42,10 @@ func (p PrefixedObjectClient) DeleteObject(ctx context.Context, objectKey string
 	return p.downstreamClient.DeleteObject(ctx, p.prefix+objectKey)
 }
 
+func (p PrefixedObjectClient) IsObjectNotFoundErr(err error) bool {
+	return p.downstreamClient.IsObjectNotFoundErr(err)
+}
+
 func (p PrefixedObjectClient) Stop() {
 	p.downstreamClient.Stop()
 }

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -245,6 +245,10 @@ func (m mockChunkStoreClient) DeleteChunk(ctx context.Context, userID, chunkID s
 	return nil
 }
 
+func (m mockChunkStoreClient) IsChunkNotFoundErr(_ error) bool {
+	return false
+}
+
 var streamsFixture = []*logproto.Stream{
 	{
 		Labels: "{foo=\"bar\"}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We return `chunk.ErrStorageObjectNotFound` when `GetObject` or `DeleteObject` fails due to a missing object. `GetObject` returns a reader of the object and if the file gets deleted in the middle of the download operation, it can cause the download to fail with an error set by the underlying storage client which would be different than `chunk.ErrStorageObjectNotFound`.

This PR adds a new method `IsObjectNotFoundErr` to `ObjectClient` interface and `IsChunkNotFoundErr` to `Client` interface to help consumers find if the error was due to a missing object. The former is used for raw object operations while the latter is used for treating objects as chunks in the storage.

