### PR TITLE
WIP: Make log query results cacheable

### DIFF
--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -283,7 +283,6 @@ func Test_splitByInterval_Do(t *testing.T) {
 					{
 						Labels: `{foo="bar", level="debug"}`,
 						Entries: []logproto.Entry{
-
 							{Timestamp: time.Unix(0, r.(*LokiRequest).StartTs.UnixNano()), Line: fmt.Sprintf("%d", r.(*LokiRequest).StartTs.UnixNano())},
 						},
 					},
@@ -423,6 +422,198 @@ func Test_splitByInterval_Do(t *testing.T) {
 							Entries: []logproto.Entry{
 								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds())},
 								{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds())},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := split.Do(ctx, tt.req)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, res)
+		})
+	}
+}
+
+func Test_splitByInterval_Do_aligned(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "1")
+	data := []logproto.Entry{
+		{Timestamp: time.Unix(0, 0), Line: fmt.Sprintf("%d", 0)},
+		{Timestamp: time.Unix(0, time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds()-1)},
+		{Timestamp: time.Unix(0, time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds())},
+		{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds()-1)},
+		{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds())},
+		{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds()-1)},
+		{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds())},
+		{Timestamp: time.Unix(0, 4*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 4*time.Hour.Nanoseconds()-1)},
+	}
+
+	next := queryrange.HandlerFunc(func(_ context.Context, r queryrange.Request) (queryrange.Response, error) {
+		var entries []logproto.Entry
+		for _, e := range data {
+			if e.Timestamp.UnixNano()/int64(time.Millisecond) >= r.GetStart() && e.Timestamp.UnixNano()/int64(time.Millisecond) < r.GetEnd() {
+				entries = append(entries, e)
+			}
+		}
+		return &LokiResponse{
+			Status:    loghttp.QueryStatusSuccess,
+			Direction: r.(*LokiRequest).Direction,
+			Limit:     r.(*LokiRequest).Limit,
+			Version:   uint32(loghttp.VersionV1),
+			Data: LokiData{
+				ResultType: loghttp.ResultTypeStream,
+				Result: []logproto.Stream{
+					{
+						Labels:  `{foo="bar", level="debug"}`,
+						Entries: entries,
+					},
+				},
+			},
+		}, nil
+	})
+
+	l := WithDefaultLimits(fakeLimits{}, queryrange.Config{SplitQueriesByInterval: time.Hour})
+	split := SplitByIntervalMiddleware(
+		l,
+		LokiCodec,
+		splitByTime,
+		nilMetrics,
+	).Wrap(next)
+
+	tests := []struct {
+		name string
+		req  *LokiRequest
+		want *LokiResponse
+	}{
+		{
+			"backward",
+			&LokiRequest{
+				StartTs:   time.Unix(0, (5 * time.Minute).Nanoseconds()),
+				EndTs:     time.Unix(0, (4 * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     1000,
+				Step:      1,
+				Direction: logproto.BACKWARD,
+				Path:      "/api/prom/query_range",
+			},
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.BACKWARD,
+				Limit:     1000,
+				Version:   1,
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels: `{foo="bar", level="debug"}`,
+							Entries: []logproto.Entry{ // Apparently the function we're testing doesn't sort the entries
+								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 4*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 4*time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds()-1)},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"forward",
+			&LokiRequest{
+				StartTs:   time.Unix(0, (5 * time.Minute).Nanoseconds()),
+				EndTs:     time.Unix(0, (4 * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     1000,
+				Step:      1,
+				Direction: logproto.FORWARD,
+				Path:      "/api/prom/query_range",
+			},
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.FORWARD,
+				Limit:     1000,
+				Version:   1,
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels: `{foo="bar", level="debug"}`,
+							Entries: []logproto.Entry{ // Apparently the function we're testing doesn't sort the entries
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, 2*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 2*time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 4*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 4*time.Hour.Nanoseconds()-1)},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			"forward limited",
+			&LokiRequest{
+				StartTs:   time.Unix(0, (5 * time.Minute).Nanoseconds()),
+				EndTs:     time.Unix(0, (4 * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     2,
+				Step:      1,
+				Direction: logproto.FORWARD,
+				Path:      "/api/prom/query_range",
+			},
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.FORWARD,
+				Limit:     2,
+				Version:   1,
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels: `{foo="bar", level="debug"}`,
+							Entries: []logproto.Entry{
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds()-1)},
+								{Timestamp: time.Unix(0, time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", time.Hour.Nanoseconds())},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"backward limited",
+			&LokiRequest{
+				StartTs:   time.Unix(0, (5 * time.Minute).Nanoseconds()),
+				EndTs:     time.Unix(0, (4 * time.Hour).Nanoseconds()),
+				Query:     "",
+				Limit:     2,
+				Step:      1,
+				Direction: logproto.BACKWARD,
+				Path:      "/api/prom/query_range",
+			},
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.BACKWARD,
+				Limit:     2,
+				Version:   1,
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result: []logproto.Stream{
+						{
+							Labels: `{foo="bar", level="debug"}`,
+							Entries: []logproto.Entry{
+								{Timestamp: time.Unix(0, 3*time.Hour.Nanoseconds()), Line: fmt.Sprintf("%d", 3*time.Hour.Nanoseconds())},
+								{Timestamp: time.Unix(0, 4*time.Hour.Nanoseconds()-1), Line: fmt.Sprintf("%d", 4*time.Hour.Nanoseconds()-1)},
 							},
 						},
 					},


### PR DESCRIPTION
This PR aligns a queries time range to multiples of the split-by interval prior to splitting so that each intervals query result can be cached. Note that the first and last interval are later changed again to use the original start and end time of the query so that we're not.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

