### PR TITLE
Ordering iterator optimizations

### DIFF
--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -540,14 +540,15 @@ func (o *Orderable) Bounds() (int64, int64) {
 func (o *Orderable) Empty() bool { return len(o.xs) == 0 }
 
 func (o *Orderable) Append(b Bounded) {
+	from, to := o.Bounds()
+	bFrom, bTo := b.Bounds()
+	o.maxt = max(bTo, to)
+
 	if len(o.xs) == 0 {
 		o.xs = append(o.xs, b)
 		return
 	}
 
-	from, to := o.Bounds()
-	bFrom, bTo := b.Bounds()
-	o.maxt = max(bTo, to)
 	pos := sort.Search(len(o.xs), func(i int) bool {
 		a, _ := o.xs[i].Bounds()
 		return bFrom < a

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -666,6 +666,18 @@ func TestOrderable(t *testing.T) {
 			},
 			overlap: true,
 		},
+		{
+			desc: "overlap subrange",
+			xs: []bounds{
+				{1, 5},
+				{3, 7},
+			},
+			exp: []bounds{
+				{1, 5},
+				{3, 7},
+			},
+			overlap: true,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			var o Orderable

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -366,7 +366,7 @@ func (s *stream) Bounds() (from, to time.Time) {
 	return from, to
 }
 
-// intChunk is a compatability type which implements chunkenc.Bounded
+// intChunk is a compatibility type which implements chunkenc.Bounded
 type intChunk chunkDesc
 
 func (c intChunk) Bounds() (int64, int64) {


### PR DESCRIPTION
This PR does a few things:
1) Introduces `chunkenc.Orderable`
2) Uses (1) for all previous places where we applied ordering optimizations/logic, namely (chunk cutting, chunk iterators, & stream iterators). This isolates much of the logic into a single utility.
3) Allows streams to make use of ordering optimizations for iterators and correctly fall back to unordered variants
4) Supports a new ordering optimization, where non-overlapping bounded items (blocks, chunks) can be reordered during query time regardless of their initial order, avoiding the need to use heap based iterators.

ref: https://github.com/grafana/loki/issues/1544