### PR TITLE
Discard/ooo

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -132,7 +132,7 @@ func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *lo
 	if !ok {
 
 		sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(ls), fp)
-		stream = newStream(i.cfg, fp, sortedLabels, i.metrics)
+		stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.metrics)
 		i.streamsByFP[fp] = stream
 		i.streams[stream.labelsString] = stream
 		i.streamsCreatedTotal.Inc()
@@ -243,7 +243,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	fp := i.getHashForLabels(labels)
 
 	sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(labels), fp)
-	stream = newStream(i.cfg, fp, sortedLabels, i.metrics)
+	stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.metrics)
 	i.streams[pushReqStream.Labels] = stream
 	i.streamsByFP[fp] = stream
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -177,7 +177,7 @@ func Test_SeriesQuery(t *testing.T) {
 	for _, testStream := range testStreams {
 		stream, err := instance.getOrCreateStream(testStream, false, recordPool.GetRecord())
 		require.NoError(t, err)
-		chunk := newStream(cfg, 0, nil, NilMetrics).NewChunk()
+		chunk := newStream(cfg, "fake", 0, nil, NilMetrics).NewChunk()
 		for _, entry := range testStream.Entries {
 			err = chunk.Append(&entry)
 			require.NoError(t, err)
@@ -333,7 +333,7 @@ func Benchmark_instance_addNewTailer(b *testing.B) {
 	lbs := makeRandomLabels()
 	b.Run("addTailersToNewStream", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			inst.addTailersToNewStream(newStream(nil, 0, lbs, NilMetrics))
+			inst.addTailersToNewStream(newStream(nil, "fake", 0, lbs, NilMetrics))
 		}
 	})
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -63,7 +63,8 @@ type line struct {
 }
 
 type stream struct {
-	cfg *Config
+	cfg    *Config
+	tenant string
 	// Newest chunk at chunks[n-1].
 	// Not thread-safe; assume accesses to this are locked by caller.
 	chunks   []chunkDesc
@@ -109,7 +110,7 @@ type entryWithError struct {
 	e     error
 }
 
-func newStream(cfg *Config, fp model.Fingerprint, labels labels.Labels, metrics *ingesterMetrics) *stream {
+func newStream(cfg *Config, tenant string, fp model.Fingerprint, labels labels.Labels, metrics *ingesterMetrics) *stream {
 	return &stream{
 		cfg:          cfg,
 		fp:           fp,
@@ -117,6 +118,7 @@ func newStream(cfg *Config, fp model.Fingerprint, labels labels.Labels, metrics 
 		labelsString: labels.String(),
 		tailers:      map[uint32]*tailer{},
 		metrics:      metrics,
+		tenant:       tenant,
 	}
 }
 

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -38,6 +38,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			cfg.MaxReturnedErrors = tc.limit
 			s := newStream(
 				cfg,
+				"fake",
 				model.Fingerprint(0),
 				labels.Labels{
 					{Name: "foo", Value: "bar"},
@@ -76,6 +77,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 func TestPushDeduplication(t *testing.T) {
 	s := newStream(
 		defaultConfig(),
+		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
 			{Name: "foo", Value: "bar"},
@@ -98,6 +100,7 @@ func TestPushDeduplication(t *testing.T) {
 func TestPushRejectOldCounter(t *testing.T) {
 	s := newStream(
 		defaultConfig(),
+		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
 			{Name: "foo", Value: "bar"},
@@ -185,6 +188,7 @@ func TestUnorderedPush(t *testing.T) {
 	cfg.MaxChunkAge = 10 * time.Second
 	s := newStream(
 		&cfg,
+		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
 			{Name: "foo", Value: "bar"},
@@ -260,7 +264,7 @@ func Benchmark_PushStream(b *testing.B) {
 		labels.Label{Name: "job", Value: "loki-dev/ingester"},
 		labels.Label{Name: "container", Value: "ingester"},
 	}
-	s := newStream(&Config{}, model.Fingerprint(0), ls, NilMetrics)
+	s := newStream(&Config{}, "fake", model.Fingerprint(0), ls, NilMetrics)
 	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{})
 	require.NoError(b, err)
 

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -23,6 +23,7 @@ const (
 	// because the limit of active streams has been reached.
 	StreamLimit         = "stream_limit"
 	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
+	OutOfOrder          = "out_of_order"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
 	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
 	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"


### PR DESCRIPTION
Exposes out of order metrics for ingester pushes

ref: https://github.com/grafana/loki/issues/1544