### PR TITLE
fix finding tables which would have out of retention data

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/expiration.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kit/log/level"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We optimise applying retention by skipping tables that would not have any out of retention data. The code was incorrectly skipping some tables because it was using the highest retention period as a reference instead of the smallest. All the tables older than or overlapping with the smallest retention period would possibly have some data to be deleted. This PR fixes the code.

**Checklist**
- [x] Tests updated

