### PR TITLE
Stream iterators account for unordered data

### DIFF
--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -20,6 +20,16 @@ import (
 	"github.com/grafana/loki/pkg/logql/log"
 )
 
+var (
+	countExtractor = func() log.StreamSampleExtractor {
+		ex, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
+		if err != nil {
+			panic(err)
+		}
+		return ex.ForStream(labels.Labels{})
+	}
+)
+
 func TestMaxReturnedStreamsErrors(t *testing.T) {
 	numLogs := 100
 
@@ -197,9 +207,10 @@ func TestUnorderedPush(t *testing.T) {
 	)
 
 	for _, x := range []struct {
-		entries []logproto.Entry
-		err     bool
-		written int
+		cutBefore bool
+		entries   []logproto.Entry
+		err       bool
+		written   int
 	}{
 		{
 			entries: []logproto.Entry{
@@ -221,7 +232,20 @@ func TestUnorderedPush(t *testing.T) {
 			err:     true,
 			written: 2, // 1 ignored
 		},
+		// force a chunk cut and then push data overlapping with previous chunk.
+		// This ultimately ensures the iterators implementation respects unordered chunks.
+		{
+			cutBefore: true,
+			entries: []logproto.Entry{
+				{Timestamp: time.Unix(11, 0), Line: "x"},
+				{Timestamp: time.Unix(7, 0), Line: "x"},
+			},
+			written: 2,
+		},
 	} {
+		if x.cutBefore {
+			_ = s.cutChunk(context.Background())
+		}
 		written, err := s.Push(context.Background(), x.entries, recordPool.GetRecord(), 0)
 		if x.err {
 			require.NotNil(t, err)
@@ -231,20 +255,32 @@ func TestUnorderedPush(t *testing.T) {
 		require.Equal(t, x.written, written)
 	}
 
+	require.Equal(t, 2, len(s.chunks))
+
 	exp := []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "x"},
 		{Timestamp: time.Unix(2, 0), Line: "x"},
 		// duplicate was allowed here b/c it wasnt written sequentially
 		{Timestamp: time.Unix(2, 0), Line: "x"},
+		{Timestamp: time.Unix(7, 0), Line: "x"},
 		{Timestamp: time.Unix(8, 0), Line: "x"},
 		{Timestamp: time.Unix(9, 0), Line: "x"},
 		{Timestamp: time.Unix(10, 0), Line: "x"},
+		{Timestamp: time.Unix(11, 0), Line: "x"},
 	}
 
-	itr, err := s.Iterator(context.Background(), nil, time.Unix(int64(0), 0), time.Unix(11, 0), logproto.FORWARD, log.NewNoopPipeline().ForStream(s.labels))
+	itr, err := s.Iterator(context.Background(), nil, time.Unix(int64(0), 0), time.Unix(12, 0), logproto.FORWARD, log.NewNoopPipeline().ForStream(s.labels))
 	require.Nil(t, err)
 	iterEq(t, exp, itr)
 
+	sItr, err := s.SampleIterator(context.Background(), nil, time.Unix(int64(0), 0), time.Unix(12, 0), countExtractor())
+	require.Nil(t, err)
+	for _, x := range exp {
+		require.Equal(t, true, sItr.Next())
+		require.Equal(t, x.Timestamp, time.Unix(0, sItr.Sample().Timestamp))
+		require.Equal(t, float64(1), sItr.Sample().Value)
+	}
+	require.Equal(t, false, sItr.Next())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {
@@ -254,7 +290,7 @@ func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {
 		require.Equal(t, exp[i].Line, got.Entry().Line)
 		i++
 	}
-	require.Equal(t, i, len(exp))
+	require.Equal(t, i, len(exp), "incorrect number of entries expected")
 }
 
 func Benchmark_PushStream(b *testing.B) {


### PR DESCRIPTION
This fixes a bug where ingester stream iterators assumed their chunks maintained increasing inter chunk order. This is not guaranteed now that unordered writes are available.

This is a followup after closing https://github.com/grafana/loki/pull/4101. Here, we take a much simpler route, adding inter-chunk ordering calculations while iterating through chunks, but importantly do not incur additional slice allocations doing so.

I spent some time attempting to build centralized logic for these calculations in order to reuse it in a few places with duplicate logic, but I was unable to find a working solution that didn't incur slice allocations which I want to avoid on this code path. I do, however, want to revisit these issues post the introduction of generics in go (or if someone sees something I did not).