### PR TITLE
safely close nonOverlapping iterators

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -429,6 +429,9 @@ func (i *nonOverlappingIterator) Error() error {
 }
 
 func (i *nonOverlappingIterator) Close() error {
+	if i.curr != nil {
+		i.curr.Close()
+	}
 	for _, iter := range i.iterators {
 		iter.Close()
 	}

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -461,6 +461,9 @@ func (i *nonOverlappingSampleIterator) Error() error {
 }
 
 func (i *nonOverlappingSampleIterator) Close() error {
+	if i.curr != nil {
+		i.curr.Close()
+	}
 	for _, iter := range i.iterators {
 		iter.Close()
 	}


### PR DESCRIPTION
This PR safely closes the _current_ iterator in the `nonOverlapping` variants, which was incorrectly ignored previously.

Thanks to @alanhe's reporting in https://github.com/grafana/loki/issues/4156, I was able to repro this easily.

Closes #4156 