### PR TITLE
Jsonnet: Add Grafana Enterprise Logs library

### DIFF
--- a/production/ksonnet/enterprise-logs/.gitignore
+++ b/production/ksonnet/enterprise-logs/.gitignore
@@ -1,0 +1,3 @@
+.eval
+lib
+vendor

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -39,3 +39,12 @@ test/jsonnetfile.json: test/jsonnetfile.jsonnet variables.mk jsonnetfile.json
 test/jsonnetfile.lock.json test/vendor: ## Update the locked dependency versions used in testing.
 test/jsonnetfile.lock.json test/vendor: test/jsonnetfile.json
 	cd $(@D); jb update
+
+.PHONY: k3d-cluster-create
+k3d-cluster-create: ## Create a development k3d cluster.
+	./scripts/k3d-cluster create
+
+.PHONY: k3d-cluster-create
+k3d-cluster-delete: ## Delete a development k3d cluster.
+k3d-cluster-delete:
+	./scripts/k3d-cluster delete

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -17,14 +17,18 @@ jsonnetfile.lock.json: ## Update the locked dependency versions for the library.
 jsonnetfile.lock.json: jsonnetfile.json
 	jb update
 
-test/.eval: ## Evaluate the library Jsonnet.
+test: ## Evaluate the library Jsonnet.
+test: test/.eval
+	:
+
+test/.eval: # Cache testing results.
 test/.eval: test/eval.jsonnet main.libsonnet test/lib/k.libsonnet test/vendor
 	cd $(@D); tmp=$$(mktemp); if tk eval $(<F) | tee $${tmp}; then mv $${tmp} $(@F); fi
 
 test/lib:
 	mkdir -p $@
 
-test/lib/k.libsonnet: ## Install implicit k.libsonnet dependency used in testing.
+test/lib/k.libsonnet: # Install implicit k.libsonnet dependency used in testing.
 test/lib/k.libsonnet: test/lib
 	printf "(import 'github.com/jsonnet-libs/k8s-libsonnet/%s/main.libsonnet')" $(K8S_VERSION) > $@
 

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -1,3 +1,5 @@
+include variables.mk
+
 .ONESHELL:
 .DELETE_ON_ERROR:
 export SHELL     := bash
@@ -11,25 +13,29 @@ help: ## Display this help.
 help:
 	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/% ]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-jsonnetfile.lock.json: ## Update the locked dependency versions.
+jsonnetfile.lock.json: ## Update the locked dependency versions for the library.
 jsonnetfile.lock.json: jsonnetfile.json
 	jb update
 
-vendor: ## Vendor dependencies.
-vendor: jsonnetfile.json
-	jb install
+test/.eval: ## Evaluate the library Jsonnet.
+test/.eval: test/eval.jsonnet main.libsonnet test/lib/k.libsonnet vendor test/vendor
+	cd $(@D); tmp=$$(mktemp); if tk eval $(<F) | tee $${tmp}; then mv $${tmp} $(@F); fi
 
-lib:
+test/lib:
 	mkdir -p $@
 
-lib/k.libsonnet: ## Install implicit k.libsonnet dependency.
-lib/k.libsonnet: jsonnetfile.json | lib
-	lib="github.com/jsonnet-libs/k8s-libsonnet"
-	version=$$(jq --arg repo https://$${lib}.git -r -M \
-								'.dependencies[] | select(.source.git.remote == $$repo) | .source.git.subdir' \
-								jsonnetfile.json)
-	printf "(import '%s/%s/main.libsonnet')" $${lib} $${version} > $@
+test/lib/k.libsonnet: ## Install implicit k.libsonnet dependency used in testing.
+test/lib/k.libsonnet: test/lib
+	printf "(import 'github.com/jsonnet-libs/k8s-libsonnet/%s/main.libsonnet')" $(K8S_VERSION) > $@
 
-.eval: ## Evaluate the library Jsonnet.
-.eval: eval.jsonnet main.libsonnet lib/k.libsonnet vendor
-	tmp=$$(mktemp); if tk eval $< | tee $${tmp}; then mv $${tmp} $@; fi
+test/jsonnetfile.json: ## Update the jsonnetfile used in testing.
+test/jsonnetfile.json: test/jsonnetfile.jsonnet variables.mk jsonnetfile.json
+	jsonnet --tla-str k8sVersion=$(K8S_VERSION) $< > $@
+
+test/jsonnetfile.lock.json: ## Update the locked dependency versions used in testing.
+test/jsonnetfile.lock.json: test/jsonnetfile.json
+	cd $(@D); jb update
+
+test/vendor: ## Vendor dependencies used in testing.
+test/vendor: test/jsonnetfile.lock.json
+	cd $(@D); jb install

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -32,10 +32,6 @@ test/jsonnetfile.json: ## Update the jsonnetfile used in testing.
 test/jsonnetfile.json: test/jsonnetfile.jsonnet variables.mk jsonnetfile.json
 	jsonnet --tla-str k8sVersion=$(K8S_VERSION) $< > $@
 
-test/jsonnetfile.lock.json: ## Update the locked dependency versions used in testing.
-test/jsonnetfile.lock.json: test/jsonnetfile.json
+test/jsonnetfile.lock.json test/vendor: ## Update the locked dependency versions used in testing.
+test/jsonnetfile.lock.json test/vendor: test/jsonnetfile.json
 	cd $(@D); jb update
-
-test/vendor: ## Vendor dependencies used in testing.
-test/vendor: test/jsonnetfile.lock.json
-	cd $(@D); jb install

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -18,7 +18,7 @@ jsonnetfile.lock.json: jsonnetfile.json
 	jb update
 
 test/.eval: ## Evaluate the library Jsonnet.
-test/.eval: test/eval.jsonnet main.libsonnet test/lib/k.libsonnet vendor test/vendor
+test/.eval: test/eval.jsonnet main.libsonnet test/lib/k.libsonnet test/vendor
 	cd $(@D); tmp=$$(mktemp); if tk eval $(<F) | tee $${tmp}; then mv $${tmp} $(@F); fi
 
 test/lib:

--- a/production/ksonnet/enterprise-logs/Makefile
+++ b/production/ksonnet/enterprise-logs/Makefile
@@ -1,0 +1,35 @@
+.ONESHELL:
+.DELETE_ON_ERROR:
+export SHELL     := bash
+export SHELLOPTS := pipefail:errexit
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rule
+
+# Adapted from https://suva.sh/posts/well-documented-makefiles/
+.PHONY: help
+help: ## Display this help.
+help:
+	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/% ]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+jsonnetfile.lock.json: ## Update the locked dependency versions.
+jsonnetfile.lock.json: jsonnetfile.json
+	jb update
+
+vendor: ## Vendor dependencies.
+vendor: jsonnetfile.json
+	jb install
+
+lib:
+	mkdir -p $@
+
+lib/k.libsonnet: ## Install implicit k.libsonnet dependency.
+lib/k.libsonnet: jsonnetfile.json | lib
+	lib="github.com/jsonnet-libs/k8s-libsonnet"
+	version=$$(jq --arg repo https://$${lib}.git -r -M \
+								'.dependencies[] | select(.source.git.remote == $$repo) | .source.git.subdir' \
+								jsonnetfile.json)
+	printf "(import '%s/%s/main.libsonnet')" $${lib} $${version} > $@
+
+.eval: ## Evaluate the library Jsonnet.
+.eval: eval.jsonnet main.libsonnet lib/k.libsonnet vendor
+	tmp=$$(mktemp); if tk eval $< | tee $${tmp}; then mv $${tmp} $@; fi

--- a/production/ksonnet/enterprise-logs/eval.jsonnet
+++ b/production/ksonnet/enterprise-logs/eval.jsonnet
@@ -1,0 +1,12 @@
+(import 'main.libsonnet') {
+  _config+:: {
+    boltdb_shipper_shared_store: self.storage_backend,
+    gcs_bucket_name: 'test-gcs-bucket-name',
+    storage_backend: 'gcs',
+
+    namespace: 'test-namespace',
+    commonArgs+: {
+      'cluster-name': 'test-cluster-name',
+    },
+  },
+}

--- a/production/ksonnet/enterprise-logs/jsonnetfile.json
+++ b/production/ksonnet/enterprise-logs/jsonnetfile.json
@@ -14,7 +14,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "ksonnet-util",
+          "subdir": "ksonnet-util"
         }
       },
       "version": "master"

--- a/production/ksonnet/enterprise-logs/jsonnetfile.json
+++ b/production/ksonnet/enterprise-logs/jsonnetfile.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/loki"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.18"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/production/ksonnet/enterprise-logs/jsonnetfile.json
+++ b/production/ksonnet/enterprise-logs/jsonnetfile.json
@@ -13,11 +13,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
-          "subdir": "1.18"
+          "remote": "https://github.com/grafana/jsonnet-libs",
+          "subdir": "ksonnet-util",
         }
       },
-      "version": "main"
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/production/ksonnet/enterprise-logs/jsonnetfile.lock.json
+++ b/production/ksonnet/enterprise-logs/jsonnetfile.lock.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "consul"
+        }
+      },
+      "version": "00795013f5975f518a0a3de99253f9d5590271c8",
+      "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "jaeger-agent-mixin"
+        }
+      },
+      "version": "00795013f5975f518a0a3de99253f9d5590271c8",
+      "sum": "DsdBoqgx5kE3zc6fMYnfiGjW2+9Mx2OXFieWm1oFHgY="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "00795013f5975f518a0a3de99253f9d5590271c8",
+      "sum": "OxgtIWL4hjvG0xkMwUzZ7Yjs52zUhLhaVQpwHCbqf8A="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "memcached"
+        }
+      },
+      "version": "00795013f5975f518a0a3de99253f9d5590271c8",
+      "sum": "dTOeEux3t9bYSqP2L/uCuLo/wUDpCKH4w+4OD9fePUk="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/loki"
+        }
+      },
+      "version": "9ea59f2062016d91398387ee2231e2e840af6a06",
+      "sum": "i27fS9sssvYd9Ywyq6uoB52EUWTaOPxo9DczCBVBuaM="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.18"
+        }
+      },
+      "version": "91008dbd2ea5734288467d6dcafef7c285c3f7e6",
+      "sum": "x881PM+6ARMsa9OSJcxO6L+4GOBy91clZipjeYbbzpw="
+    }
+  ],
+  "legacyImports": false
+}

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -72,7 +72,6 @@ loki {
     + deployment.spec.selector.withMatchLabelsMixin({ name: 'admin-api' })
     + deployment.spec.template.metadata.withLabelsMixin({ name: 'admin-api', gossip_ring_member: 'true' })
     + deployment.spec.template.spec.withTerminationGracePeriodSeconds(15)
-    // Mount filesystems as the "loki" user id.
     + deployment.spec.template.spec.securityContext.withFsGroup(10001)
     + util.configVolumeMount('loki', '/etc/loki/config')
     + util.secretVolumeMount('gel-license', '/etc/gel-license/'),
@@ -107,7 +106,6 @@ loki {
   gateway_deployment:
     deployment.new(name='gateway', replicas=3, containers=[self.gateway_container])
     + deployment.spec.template.spec.withTerminationGracePeriodSeconds(15)
-    // Mount filesystems as the "loki" user id.
     + deployment.spec.template.spec.securityContext.withFsGroup(10001)
     + util.configVolumeMount('loki', '/etc/loki/config')
     + util.secretVolumeMount('gel-license', '/etc/gel-license/'),
@@ -144,7 +142,6 @@ loki {
       'kubectl create secret generic gel-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="self.base64 <(echo :self.cat /shared/admin-token)))"',
     ])
     + container.withVolumeMounts([{ mountPath: '/shared', name: 'shared' }])
-    // Run as "loki" user.
     + container.securityContext.withRunAsUser(10001),
 
   tokengen_job:

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -49,6 +49,14 @@ loki {
         join_members: ['gossip-ring'],
       },
     },
+
+    ingester_pvc_size: '50Gi',
+    stateful_ingesters: true,
+
+    querier_pvc_size: '50Gi',
+    stateful_queriers: true,
+
+    compactor_pvc_size: '50Gi',
   },
 
   _images+:: {
@@ -78,6 +86,7 @@ loki {
   admin_api_service:
     util.serviceFor(self.admin_api_deployment),
 
+  compactor_data_pvc+: { spec+: { storageClassName:: null } },
   // Remove consul in favor of memberlist.
   consul_config_map:: {},
   consul_deployment:: null,
@@ -113,9 +122,11 @@ loki {
   gateway_service:
     util.serviceFor(self.gateway_deployment),
 
+  ingester_data_pvc+: { spec+: { storageClassName:: null } },
   ingester_statefulset+:
     statefulSet.spec.template.metadata.withLabelsMixin({ gossip_ring_member: 'true' }),
 
+  querier_data_pvc+: { spec+: { storageClassName:: null } },
   querier_statefulset+:
     statefulSet.spec.template.metadata.withLabelsMixin({ gossip_ring_member: 'true' }),
 

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -52,6 +52,10 @@ loki {
         },
       },
       memberlist: {
+        retransmit_factor: 2,
+        gossip_interval: '5s',
+        stream_timeout: '5s',
+        abort_if_cluster_join_fails: false,
         bind_port: 7946,
         join_members: ['gossip-ring'],
       },

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -10,7 +10,6 @@ local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet'
       pvc = k.core.v1.persistentVolumeClaim,
       service = k.core.v1.service,
       serviceAccount = k.core.v1.serviceAccount,
-      servicePort = k.core.v1.servicePort,
       subject = k.rbac.v1.subject,
       statefulSet = k.apps.v1.statefulSet;
 local loki = import 'github.com/grafana/loki/production/ksonnet/loki/loki.libsonnet';
@@ -213,10 +212,7 @@ loki {
     service.new(
       name='gossip-ring',
       selector={ gossip_ring_member: 'true' },
-      ports=[
-        servicePort.newNamed('gossip-ring', 7946, 7946)
-        + servicePort.withProtocol('TCP'),
-      ],
+      ports=[{ name: 'gossip-ring', port: 7946, protocol: 'TCP', targetPort: 7946 }],
     )
     + service.spec.withClusterIp('None')
     + service.spec.withPublishNotReadyAddresses(true),

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -1,4 +1,5 @@
 // TODO(jdb): Use cluster_dns_suffix to configure absolute domain names so as to avoid excessive lookups.
+// TODO(jdb): Introduce utility functions for mapping over all containers, all microservices (modules), all apps, etc..
 local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet',
       clusterRole = k.rbac.v1.clusterRole,
       clusterRoleBinding = k.rbac.v1.clusterRoleBinding,

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -172,7 +172,7 @@ loki {
       'kubectl create secret generic gel-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="self.base64 <(echo :self.cat /shared/admin-token)))"',
     ])
     + container.withVolumeMounts([{ mountPath: '/shared', name: 'shared' }]),
-  tokengen_job:
+  tokengen_job::
     job.new('tokengen')
     + job.spec.withCompletions(1)
     + job.spec.withParallelism(1)

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -52,7 +52,7 @@ loki {
   },
 
   _images+:: {
-    loki: 'grafana/enterprise-metrics:v1.1.0',
+    loki: 'grafana/enterprise-logs:v1.1.0',
     kubectl: 'bitnami/kubectl',
   },
 

--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -1,0 +1,199 @@
+// TODO(jdb): Use cluster_dns_suffix to configure absolute domain names so as to avoid excessive lookups.
+local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet',
+      clusterRole = k.rbac.v1.clusterRole,
+      clusterRoleBinding = k.rbac.v1.clusterRoleBinding,
+      container = k.core.v1.container,
+      configMap = k.core.v1.configMap,
+      deployment = k.apps.v1.deployment,
+      job = k.batch.v1.job,
+      policyRule = k.rbac.v1.policyRule,
+      pvc = k.core.v1.persistentVolumeClaim,
+      service = k.core.v1.service,
+      serviceAccount = k.core.v1.serviceAccount,
+      servicePort = k.core.v1.servicePort,
+      subject = k.rbac.v1.subject,
+      statefulSet = k.apps.v1.statefulSet;
+local loki = import 'github.com/grafana/loki/production/ksonnet/loki/loki.libsonnet';
+local util = (import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet').withK(k);
+
+loki {
+  _config+:: {
+    commonArgs+:: {
+      'auth.enabled': 'true',
+      'auth.type': 'enterprise',
+      'cluster-name':
+        if self['auth.type'] == 'enterprise' then
+          error 'must set _config.commonArgs.cluster-name'
+        else null,
+    },
+
+    loki+: {
+      distributor+: {
+        ring: {
+          kvstore: {
+            store: 'memberlist',
+          },
+        },
+      },
+      ingester+: {
+        lifecycler+: {
+          ring: {
+            kvstore: {
+              store: 'memberlist',
+            },
+          },
+        },
+      },
+      memberlist: {
+        bind_port: 7946,
+        join_members: ['gossip-ring'],
+      },
+    },
+  },
+
+  _images+:: {
+    loki: 'grafana/enterprise-metrics:v1.1.0',
+    kubectl: 'bitnami/kubectl',
+  },
+
+  admin_api_args:: self._config.commonArgs {
+    'bootstrap.license.path': '/etc/gel-license/license.jwt',
+    target: 'admin-api',
+  },
+  admin_api_container::
+    container.new(name='admin-api', image=self._images.loki)
+    + container.withArgs(util.mapToFlags(self.admin_api_args))
+    + container.withPorts(loki.util.defaultPorts)
+    + container.resources.withLimits({ cpu: '2', memory: '4Gi' })
+    + container.resources.withRequests({ cpu: '500m', memory: '1Gi' })
+    + loki.util.readinessProbe,
+  admin_api_deployment:
+    deployment.new(name='admin-api', replicas=3, containers=[self.admin_api_container])
+    + deployment.spec.selector.withMatchLabelsMixin({ name: 'admin-api' })
+    + deployment.spec.template.metadata.withLabelsMixin({ name: 'admin-api', gossip_ring_member: 'true' })
+    + deployment.spec.template.spec.withTerminationGracePeriodSeconds(15)
+    // Mount filesystems as the "loki" user id.
+    + deployment.spec.template.spec.securityContext.withFsGroup(10001)
+    + util.configVolumeMount('loki', '/etc/loki/config')
+    + util.secretVolumeMount('gel-license', '/etc/gel-license/'),
+  admin_api_service:
+    util.serviceFor(self.admin_api_deployment),
+
+  // Remove consul in favor of memberlist.
+  consul_config_map:: {},
+  consul_deployment:: null,
+  consul_service:: null,
+
+  distributor_deployment+:
+    deployment.spec.template.metadata.withLabelsMixin({ gossip_ring_member: 'true' }),
+
+  gateway_args:: self._config.commonArgs {
+    'bootstrap.license.path': '/etc/gel-license/license.jwt',
+    'gateway.proxy.admin-api.url': 'http://admin-api:%s' % $._config.http_listen_port,
+    'gateway.proxy.compactor.url': 'http://compactor:%s' % $._config.http_listen_port,
+    'gateway.proxy.distributor.url': 'dns:///distributor:9095',
+    'gateway.proxy.ingester.url': 'http://ingester:%s' % $._config.http_listen_port,
+    'gateway.proxy.query-frontend.url': 'http://query-frontend:%s' % $._config.http_listen_port,
+    'gateway.proxy.ruler.url': 'http://ruler:%s' % $._config.http_listen_port,
+    target: 'gateway',
+  },
+  gateway_container::
+    container.new(name='gateway', image=self._images.loki)
+    + container.withArgs(util.mapToFlags(self.gateway_args))
+    + container.withPorts(loki.util.defaultPorts)
+    + container.resources.withLimits({ cpu: '2', memory: '4Gi' })
+    + container.resources.withRequests({ cpu: '500m', memory: '1Gi' })
+    + loki.util.readinessProbe,
+  gateway_deployment:
+    deployment.new(name='gateway', replicas=3, containers=[self.gateway_container])
+    + deployment.spec.template.spec.withTerminationGracePeriodSeconds(15)
+    // Mount filesystems as the "loki" user id.
+    + deployment.spec.template.spec.securityContext.withFsGroup(10001)
+    + util.configVolumeMount('loki', '/etc/loki/config')
+    + util.secretVolumeMount('gel-license', '/etc/gel-license/'),
+
+  gateway_service:
+    util.serviceFor(self.gateway_deployment),
+
+  ingester_statefulset+:
+    statefulSet.spec.template.metadata.withLabelsMixin({ gossip_ring_member: 'true' }),
+
+  querier_statefulset+:
+    statefulSet.spec.template.metadata.withLabelsMixin({ gossip_ring_member: 'true' }),
+
+  tokengen_args:: self._config.commonArgs {
+    target: 'tokengen',
+    'tokengen.token-file': '/shared/admin-token',
+  },
+  tokengen_container::
+    container.new('tokengen', self._images.loki)
+    + container.withPorts(loki.util.defaultPorts)
+    + container.withArgs(util.mapToFlags(self.tokengen_args))
+    + container.withVolumeMounts([
+      { mountPath: '/etc/loki/config', name: 'config' },
+      { mountPath: '/shared', name: 'shared' },
+    ])
+    + container.resources.withLimits({ memory: '4Gi' })
+    + container.resources.withRequests({ cpu: '500m', memory: '500Mi' }),
+
+  tokengen_create_secret_container::
+    container.new('create-secret', self._images.kubectl)
+    + container.withCommand([
+      '/bin/bash',
+      '-euc',
+      'kubectl create secret generic gel-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="self.base64 <(echo :self.cat /shared/admin-token)))"',
+    ])
+    + container.withVolumeMounts([{ mountPath: '/shared', name: 'shared' }])
+    // Run as "loki" user.
+    + container.securityContext.withRunAsUser(10001),
+
+  tokengen_job:
+    job.new('tokengen')
+    + job.spec.withCompletions(1)
+    + job.spec.withParallelism(1)
+    + job.spec.template.spec.withContainers([self.tokengen_create_secret_container])
+    + job.spec.template.spec.withInitContainers([self.tokengen_container])
+    + job.spec.template.spec.withRestartPolicy('Never')
+    + job.spec.template.spec.withServiceAccount('tokengen')
+    + job.spec.template.spec.withServiceAccountName('tokengen')
+    + job.spec.template.spec.withVolumes([
+      { name: 'config', configMap: { name: 'loki' } },
+      { name: 'shared', emptyDir: {} },
+    ]),
+
+  tokengen_service_account:
+    serviceAccount.new('tokengen'),
+
+  tokengen_cluster_role:
+    clusterRole.new('tokengen')
+    + clusterRole.withRules([
+      policyRule.withApiGroups([''])
+      + policyRule.withResources(['secrets'])
+      + policyRule.withVerbs(['create']),
+    ]),
+
+  tokengen_cluster_role_binding:
+    clusterRoleBinding.new()
+    + clusterRoleBinding.metadata.withName('tokengen')
+    + clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
+    + clusterRoleBinding.roleRef.withKind('ClusterRole')
+    + clusterRoleBinding.roleRef.withName('tokengen')
+    + clusterRoleBinding.withSubjects([
+      subject.new()
+      + subject.withName('tokengen')
+      + subject.withKind('ServiceAccount')
+      + { namespace: $._config.namespace },
+    ]),
+
+  gossip_ring_service:
+    service.new(
+      name='gossip-ring',
+      selector={ gossip_ring_member: 'true' },
+      ports=[
+        servicePort.newNamed('gossip-ring', 7946, 7946)
+        + servicePort.withProtocol('TCP'),
+      ],
+    )
+    + service.spec.withClusterIp('None')
+    + service.spec.withPublishNotReadyAddresses(true),
+}

--- a/production/ksonnet/enterprise-logs/scripts/k3d-cluster
+++ b/production/ksonnet/enterprise-logs/scripts/k3d-cluster
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  cat <<EOF
+Create or delete a dev k3d cluster
+
+Usage:
+  $0 create
+  $0 delete
+EOF
+fi
+
+CLUSTER_NAME=enterprise-logs
+
+case $1 in
+  create)
+    shift
+    # Make creation idempotent.
+    if k3d cluster list "${CLUSTER_NAME}" &>/dev/null; then
+      exit 0
+    fi
+    k3d cluster create "${CLUSTER_NAME}"
+
+    echo -n 'creating'
+    set +e
+    while ! k3d kubeconfig get "${CLUSTER_NAME}" &>/dev/null; do
+      sleep 1
+      echo -n '.'
+    done
+    set -e
+    echo 'done'
+
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+    kubectl patch storageclass local-path -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+    kubectl config use-context k3d-"${CLUSTER_NAME}"
+    sleep 10 # Lazy sleep instead of checking for readiness of API server to handle all resources.
+    ;;
+  delete)
+    k3d cluster delete "${CLUSTER_NAME}"
+    shift
+    ;;
+esac

--- a/production/ksonnet/enterprise-logs/test/eval.jsonnet
+++ b/production/ksonnet/enterprise-logs/test/eval.jsonnet
@@ -1,4 +1,4 @@
-(import 'main.libsonnet') {
+(import '../main.libsonnet') {
   _config+:: {
     boltdb_shipper_shared_store: self.storage_backend,
     gcs_bucket_name: 'test-gcs-bucket-name',

--- a/production/ksonnet/enterprise-logs/test/jsonnetfile.json
+++ b/production/ksonnet/enterprise-logs/test/jsonnetfile.json
@@ -1,0 +1,33 @@
+{
+   "dependencies": [
+      {
+         "source": {
+            "git": {
+               "remote": "https://github.com/grafana/loki.git",
+               "subdir": "production/ksonnet/loki"
+            }
+         },
+         "version": "main"
+      },
+      {
+         "source": {
+            "git": {
+               "remote": "https://github.com/grafana/jsonnet-libs",
+               "subdir": "ksonnet-util"
+            }
+         },
+         "version": "master"
+      },
+      {
+         "source": {
+            "git": {
+               "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+               "subdir": "1.18"
+            }
+         },
+         "version": "main"
+      }
+   ],
+   "legacyImports": true,
+   "version": 1
+}

--- a/production/ksonnet/enterprise-logs/test/jsonnetfile.jsonnet
+++ b/production/ksonnet/enterprise-logs/test/jsonnetfile.jsonnet
@@ -1,0 +1,12 @@
+function(k8sVersion)
+  (import '../jsonnetfile.json') + {
+    dependencies+: [{
+      source: {
+        git: {
+          remote: 'https://github.com/jsonnet-libs/k8s-libsonnet.git',
+          subdir: k8sVersion,
+        },
+      },
+      version: 'main',
+    }],
+  }

--- a/production/ksonnet/enterprise-logs/test/jsonnetfile.lock.json
+++ b/production/ksonnet/enterprise-logs/test/jsonnetfile.lock.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "consul"
+        }
+      },
+      "version": "7e3954ca9459cad6508ce3675876dbe4f4b33a8f",
+      "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "jaeger-agent-mixin"
+        }
+      },
+      "version": "7e3954ca9459cad6508ce3675876dbe4f4b33a8f",
+      "sum": "DsdBoqgx5kE3zc6fMYnfiGjW2+9Mx2OXFieWm1oFHgY="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "7e3954ca9459cad6508ce3675876dbe4f4b33a8f",
+      "sum": "OxgtIWL4hjvG0xkMwUzZ7Yjs52zUhLhaVQpwHCbqf8A="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "memcached"
+        }
+      },
+      "version": "7e3954ca9459cad6508ce3675876dbe4f4b33a8f",
+      "sum": "dTOeEux3t9bYSqP2L/uCuLo/wUDpCKH4w+4OD9fePUk="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/loki"
+        }
+      },
+      "version": "43b9b224ea5561fb37c004a054b7a3fc391662cd",
+      "sum": "ihooLlOemtJlNiFzAPYM06ug4kLKtOMTJ0SWRXWNCuA="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.18"
+        }
+      },
+      "version": "91008dbd2ea5734288467d6dcafef7c285c3f7e6",
+      "sum": "x881PM+6ARMsa9OSJcxO6L+4GOBy91clZipjeYbbzpw="
+    }
+  ],
+  "legacyImports": false
+}

--- a/production/ksonnet/enterprise-logs/test/jsonnetfile.lock.json
+++ b/production/ksonnet/enterprise-logs/test/jsonnetfile.lock.json
@@ -48,7 +48,7 @@
           "subdir": "production/ksonnet/loki"
         }
       },
-      "version": "43b9b224ea5561fb37c004a054b7a3fc391662cd",
+      "version": "cd79adc8ab0c80c55a0f39b43322839c6ffb05d8",
       "sum": "ihooLlOemtJlNiFzAPYM06ug4kLKtOMTJ0SWRXWNCuA="
     },
     {

--- a/production/ksonnet/enterprise-logs/variables.mk
+++ b/production/ksonnet/enterprise-logs/variables.mk
@@ -1,0 +1,2 @@
+## Version of Kubernetes used in testing.
+K8S_VERSION = 1.18


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR adds a Grafana Enterprise Logs Jsonnet library that extends the OSS Loki library. 

**Special notes for your reviewer**:
- This PR includes rudimentary testing that can be performed with `$ make test`, this essentially only proves that Tanka is able to evaluate the Jsonnet.
- This has been evaluated against a working dev cluster and produces minimal (and desirable) diffs over what is currently deployed internally.
- Documentation is separate and will be released in the [GEL setup docs](https://grafana.com/docs/enterprise-logs/latest/setup/)
- There are some TODOs noted at the top of the library file. These represent task that I would ideally like to contribute to the OSS Loki chart and inherit.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

