### PR TITLE
Retention speedup

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	loki_storage "github.com/grafana/loki/pkg/storage"
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/storage"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
@@ -55,43 +53,6 @@ func TestIsDefaults(t *testing.T) {
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			require.Equal(t, tc.out, tc.in.IsDefaults())
-		})
-	}
-}
-
-func TestExtractIntervalFromTableName(t *testing.T) {
-	periodicTableConfig := chunk.PeriodicTableConfig{
-		Prefix: "dummy",
-		Period: 24 * time.Hour,
-	}
-
-	const millisecondsInDay = model.Time(24 * time.Hour / time.Millisecond)
-
-	calculateInterval := func(tm model.Time) (m model.Interval) {
-		m.Start = tm - tm%millisecondsInDay
-		m.End = m.Start + millisecondsInDay
-		return
-	}
-
-	for i, tc := range []struct {
-		tableName        string
-		expectedInterval model.Interval
-	}{
-		{
-			tableName:        periodicTableConfig.TableFor(model.Now()),
-			expectedInterval: calculateInterval(model.Now()),
-		},
-		{
-			tableName:        periodicTableConfig.TableFor(model.Now().Add(-24 * time.Hour)),
-			expectedInterval: calculateInterval(model.Now().Add(-24 * time.Hour)),
-		},
-		{
-			tableName:        periodicTableConfig.TableFor(model.Now().Add(-24 * time.Hour).Add(time.Minute)),
-			expectedInterval: calculateInterval(model.Now().Add(-24 * time.Hour).Add(time.Minute)),
-		},
-	} {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			require.Equal(t, tc.expectedInterval, extractIntervalFromTableName(tc.tableName))
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -214,3 +214,7 @@ func (d *DeleteRequestsManager) IntervalHasExpiredChunks(interval model.Interval
 
 	return false
 }
+
+func (d *DeleteRequestsManager) DropFromIndex(_ retention.ChunkEntry, _ model.Time, _ model.Time) bool {
+	return false
+}

--- a/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
@@ -100,11 +100,11 @@ func Test_SeriesCleaner(t *testing.T) {
 			require.NoError(t, err)
 
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				cleaner := newSeriesCleaner(tx.Bucket(bucketName), tt.config)
-				if err := cleaner.Cleanup(entryFromChunk(c2).SeriesID, entryFromChunk(c2).UserID); err != nil {
+				cleaner := newSeriesCleaner(tx.Bucket(bucketName), tt.config, tables[0].name)
+				if err := cleaner.Cleanup(entryFromChunk(c2).UserID, c2.Metric); err != nil {
 					return err
 				}
-				if err := cleaner.Cleanup(entryFromChunk(c1).SeriesID, entryFromChunk(c1).UserID); err != nil {
+				if err := cleaner.Cleanup(entryFromChunk(c1).UserID, c1.Metric); err != nil {
 					return err
 				}
 				return nil

--- a/pkg/storage/stores/shipper/compactor/retention/series_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/series_test.go
@@ -10,17 +10,17 @@ import (
 func Test_UserSeries(t *testing.T) {
 	m := newUserSeriesMap()
 
-	m.Add([]byte(`series1`), []byte(`user1`))
-	m.Add([]byte(`series1`), []byte(`user1`))
-	m.Add([]byte(`series1`), []byte(`user2`))
-	m.Add([]byte(`series2`), []byte(`user1`))
-	m.Add([]byte(`series2`), []byte(`user1`))
-	m.Add([]byte(`series2`), []byte(`user2`))
+	m.Add([]byte(`series1`), []byte(`user1`), nil)
+	m.Add([]byte(`series1`), []byte(`user1`), nil)
+	m.Add([]byte(`series1`), []byte(`user2`), nil)
+	m.Add([]byte(`series2`), []byte(`user1`), nil)
+	m.Add([]byte(`series2`), []byte(`user1`), nil)
+	m.Add([]byte(`series2`), []byte(`user2`), nil)
 
 	keys := []string{}
 
-	err := m.ForEach(func(seriesID, userID []byte) error {
-		keys = append(keys, string(seriesID)+":"+string(userID))
+	err := m.ForEach(func(info userSeriesInfo) error {
+		keys = append(keys, string(info.SeriesID())+":"+string(info.UserID()))
 		return nil
 	})
 	require.NoError(t, err)

--- a/pkg/storage/stores/shipper/compactor/retention/util.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util.go
@@ -5,7 +5,11 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
+	"time"
 	"unsafe"
+
+	"github.com/prometheus/common/model"
 )
 
 // unsafeGetString is like yolostring but with a meaningful name
@@ -44,4 +48,20 @@ func copyFile(src, dst string) (int64, error) {
 	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
+}
+
+// ExtractIntervalFromTableName gives back the time interval for which the table is expected to hold the chunks index.
+func ExtractIntervalFromTableName(tableName string) model.Interval {
+	interval := model.Interval{
+		Start: 0,
+		End:   model.Now(),
+	}
+	tableNumber, err := strconv.ParseInt(tableName[len(tableName)-5:], 10, 64)
+	if err != nil {
+		return interval
+	}
+
+	interval.Start = model.TimeFromUnix(tableNumber * 86400)
+	interval.End = interval.Start.Add(24 * time.Hour)
+	return interval
 }

--- a/pkg/storage/stores/shipper/compactor/retention/util.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strconv"
 	"time"
 	"unsafe"
@@ -15,14 +14,6 @@ import (
 // unsafeGetString is like yolostring but with a meaningful name
 func unsafeGetString(buf []byte) string {
 	return *((*string)(unsafe.Pointer(&buf)))
-}
-
-func unsafeGetBytes(s string) []byte {
-	var buf []byte
-	p := unsafe.Pointer(&buf)
-	*(*string)(p) = s
-	(*reflect.SliceHeader)(p).Cap = len(s)
-	return buf
 }
 
 func copyFile(src, dst string) (int64, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
It contains the following changes to speed up the mark phase of retention:
1. We delete a chunk only when the whole chunk is out of retention. If a chunk spans multiple tables, we will retain its entry in all those tables until the whole chunk expires, even if the table is not expected to have it based on retention config. This PR changes the approach to drop the chunk index entry early by checking the interval's end time for which a table is expected to have chunks indexed.

2. We clean up the series by iterating over the index entries to find which ones should be deleted. Because of the index format, we need to go through all the label entries(including labels for unrelated series) for the user. This PR changes the code to build the index keys using [GetCacheKeysAndLabelWriteEntries](https://github.com/grafana/loki/blob/d31f8676fd9f4dbb4f509514edbf598f2bd798ca/pkg/storage/chunk/schema.go#L165), which can be used to delete the index entries expected to be deleted efficiently.

3. When a chunk is deleted partially, we mark it for deletion. If a chunk spans multiple tables, we will mark it for deletion when the first table that indexes it is processed. If, for some reason, the compactor goes down or delays applying retention to the next tables, the compactor would fail to find the source chunk(which is needed for re-building a new chunk), which would fail the retention. This PR changes the code to mark source chunk for deletion when the table being processed is the last change that indexes it.

**Checklist**
- [x] Tests updated

