### PR TITLE
Authc/z: Enable grpc_client_config to allow mTLS

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -61,8 +61,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // New returns a new ingester client.
 func New(cfg Config, addr string) (HealthAndIngesterClient, error) {
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
 		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
+	}
+
+	if !cfg.GRPCClientConfig.TLSEnabled {
+		opts = append(opts, grpc.WithInsecure())
 	}
 
 	dialOpts, err := cfg.GRPCClientConfig.DialOption(instrumentation(&cfg))

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -64,10 +64,6 @@ func New(cfg Config, addr string) (HealthAndIngesterClient, error) {
 		grpc.WithDefaultCallOptions(cfg.GRPCClientConfig.CallOptions()...),
 	}
 
-	if !cfg.GRPCClientConfig.TLSEnabled {
-		opts = append(opts, grpc.WithInsecure())
-	}
-
 	dialOpts, err := cfg.GRPCClientConfig.DialOption(instrumentation(&cfg))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Loki can be protected by mTLS. However, if you configure grpc_tls_config, internal grpc clients (e.g. distributor/querier to ingester) fails to connect because the client cert option is not supported.
The fix allows it.

**Which issue(s) this PR fixes**:
Fixes #3252 

**Special notes for your reviewer**:
This has been tested with the following Loki config.

```
server:
  http_listen_port: 13101
  grpc_listen_port: 18931
  log_level: debug
  http_tls_config:
    key_file: /path/to/key.pem
    cert_file: /path/to/cert.pem
    client_ca_file: /path/to/ca.pem
    client_auth_type: VerifyClientCertIfGiven
  grpc_tls_config:
    key_file: /path/to/key.pem
    cert_file: /path/to/cert.pem
    client_ca_file: /path/to/ca.pem
    client_auth_type: VerifyClientCertIfGiven

ingester_client:
  grpc_client_config:
    tls_enabled: true
    tls_cert_path: path/to/cert.pem
    tls_key_path:  path/to/key.pem
    tls_ca_path: path/to/ca.pem
...
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

