### PR TITLE
[ingester/stream]: Add a byte stream rate limit.

### DIFF
--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -453,7 +453,7 @@ func Test_SeriesIterator(t *testing.T) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := 0; i < 3; i++ {
-		inst := newInstance(defaultConfig(), fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+		inst := newInstance(defaultConfig(), &validation.Overrides{}, fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream1}}))
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream2}}))
 		instances = append(instances, inst)
@@ -503,7 +503,7 @@ func Benchmark_SeriesIterator(b *testing.B) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := range instances {
-		inst := newInstance(defaultConfig(), fmt.Sprintf("instance %d", i), limiter, nil, noopWAL{}, NilMetrics, nil, nil)
+		inst := newInstance(defaultConfig(), &validation.Overrides{}, fmt.Sprintf("instance %d", i), limiter, nil, noopWAL{}, NilMetrics, nil, nil)
 
 		require.NoError(b,
 			inst.Push(context.Background(), &logproto.PushRequest{

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -443,11 +443,12 @@ var (
 
 func Test_SeriesIterator(t *testing.T) {
 	var instances []*instance
-
 	limits, err := validation.NewOverrides(validation.Limits{
-		MaxLocalStreamsPerUser: 1000,
-		IngestionRateMB:        1e4,
-		IngestionBurstSizeMB:   1e4,
+		MaxLocalStreamsPerUser:       1000,
+		IngestionRateMB:              1e4,
+		IngestionBurstSizeMB:         1e4,
+		MaxLocalStreamRateBytes:      defaultLimitsTestConfig().MaxLocalStreamRateBytes,
+		MaxLocalStreamBurstRateBytes: defaultLimitsTestConfig().MaxLocalStreamBurstRateBytes,
 	}, nil)
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -453,7 +453,7 @@ func Test_SeriesIterator(t *testing.T) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := 0; i < 3; i++ {
-		inst := newInstance(defaultConfig(), &validation.Overrides{}, fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+		inst := newInstance(defaultConfig(), fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream1}}))
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream2}}))
 		instances = append(instances, inst)
@@ -503,7 +503,7 @@ func Benchmark_SeriesIterator(b *testing.B) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := range instances {
-		inst := newInstance(defaultConfig(), &validation.Overrides{}, fmt.Sprintf("instance %d", i), limiter, nil, noopWAL{}, NilMetrics, nil, nil)
+		inst := newInstance(defaultConfig(), fmt.Sprintf("instance %d", i), limiter, nil, noopWAL{}, NilMetrics, nil, nil)
 
 		require.NoError(b,
 			inst.Push(context.Background(), &logproto.PushRequest{

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -137,6 +137,7 @@ type Ingester struct {
 	cfg           Config
 	clientConfig  client.Config
 	tenantConfigs *runtime.TenantConfigs
+	limits        *validation.Overrides
 
 	shutdownMtx  sync.Mutex // Allows processes to grab a lock and prevent a shutdown
 	instancesMtx sync.RWMutex
@@ -195,6 +196,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 		cfg:                   cfg,
 		clientConfig:          clientConfig,
 		tenantConfigs:         configs,
+		limits:                limits,
 		instances:             map[string]*instance{},
 		store:                 store,
 		periodicConfigs:       store.GetSchemaConfigs(),
@@ -514,7 +516,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) *instance {
 	defer i.instancesMtx.Unlock()
 	inst, ok = i.instances[instanceID]
 	if !ok {
-		inst = newInstance(&i.cfg, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
+		inst = newInstance(&i.cfg, i.limits, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
 		i.instances[instanceID] = inst
 	}
 	return inst

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -514,7 +514,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) *instance {
 	defer i.instancesMtx.Unlock()
 	inst, ok = i.instances[instanceID]
 	if !ok {
-		inst = newInstance(&i.cfg, i.limiter.limits, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
+		inst = newInstance(&i.cfg, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
 		i.instances[instanceID] = inst
 	}
 	return inst

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -137,7 +137,6 @@ type Ingester struct {
 	cfg           Config
 	clientConfig  client.Config
 	tenantConfigs *runtime.TenantConfigs
-	limits        *validation.Overrides
 
 	shutdownMtx  sync.Mutex // Allows processes to grab a lock and prevent a shutdown
 	instancesMtx sync.RWMutex
@@ -196,7 +195,6 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 		cfg:                   cfg,
 		clientConfig:          clientConfig,
 		tenantConfigs:         configs,
-		limits:                limits,
 		instances:             map[string]*instance{},
 		store:                 store,
 		periodicConfigs:       store.GetSchemaConfigs(),
@@ -516,7 +514,7 @@ func (i *Ingester) getOrCreateInstance(instanceID string) *instance {
 	defer i.instancesMtx.Unlock()
 	inst, ok = i.instances[instanceID]
 	if !ok {
-		inst = newInstance(&i.cfg, i.limits, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
+		inst = newInstance(&i.cfg, i.limiter.limits, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
 		i.instances[instanceID] = inst
 	}
 	return inst

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -63,7 +63,6 @@ var (
 
 type instance struct {
 	cfg        *Config
-	limits     *validation.Overrides
 	streamsMtx sync.RWMutex
 
 	buf         []byte // buffer used to compute fps.
@@ -95,10 +94,9 @@ type instance struct {
 	chunkFilter storage.RequestChunkFilterer
 }
 
-func newInstance(cfg *Config, limits *validation.Overrides, instanceID string, limiter *Limiter, configs *runtime.TenantConfigs, wal WAL, metrics *ingesterMetrics, flushOnShutdownSwitch *OnceSwitch, chunkFilter storage.RequestChunkFilterer) *instance {
+func newInstance(cfg *Config, instanceID string, limiter *Limiter, configs *runtime.TenantConfigs, wal WAL, metrics *ingesterMetrics, flushOnShutdownSwitch *OnceSwitch, chunkFilter storage.RequestChunkFilterer) *instance {
 	i := &instance{
 		cfg:         cfg,
-		limits:      limits,
 		streams:     map[string]*stream{},
 		streamsByFP: map[model.Fingerprint]*stream{},
 		buf:         make([]byte, 0, 1024),
@@ -134,7 +132,7 @@ func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *lo
 	if !ok {
 
 		sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(ls), fp)
-		stream = newStream(i.cfg, i.limits, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+		stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter.limits), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 		i.streamsByFP[fp] = stream
 		i.streams[stream.labelsString] = stream
 		i.streamsCreatedTotal.Inc()
@@ -245,7 +243,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	fp := i.getHashForLabels(labels)
 
 	sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(labels), fp)
-	stream = newStream(i.cfg, i.limits, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+	stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter.limits), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 	i.streams[pushReqStream.Labels] = stream
 	i.streamsByFP[fp] = stream
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -132,7 +132,7 @@ func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *lo
 	if !ok {
 
 		sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(ls), fp)
-		stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter.limits), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+		stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 		i.streamsByFP[fp] = stream
 		i.streams[stream.labelsString] = stream
 		i.streamsCreatedTotal.Inc()
@@ -243,7 +243,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	fp := i.getHashForLabels(labels)
 
 	sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(labels), fp)
-	stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter.limits), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+	stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 	i.streams[pushReqStream.Labels] = stream
 	i.streamsByFP[fp] = stream
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -41,7 +41,7 @@ func TestLabelsCollisions(t *testing.T) {
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
-	i := newInstance(defaultConfig(), "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, nil, &OnceSwitch{}, nil)
+	i := newInstance(defaultConfig(), &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, nil, &OnceSwitch{}, nil)
 
 	// avoid entries from the future.
 	tt := time.Now().Add(-5 * time.Minute)
@@ -68,7 +68,7 @@ func TestConcurrentPushes(t *testing.T) {
 	require.NoError(t, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
-	inst := newInstance(defaultConfig(), "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
+	inst := newInstance(defaultConfig(), &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 
 	const (
 		concurrent          = 10
@@ -126,7 +126,7 @@ func TestSyncPeriod(t *testing.T) {
 		minUtil    = 0.20
 	)
 
-	inst := newInstance(defaultConfig(), "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
+	inst := newInstance(defaultConfig(), &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 	lbls := makeRandomLabels()
 
 	tt := time.Now()
@@ -166,7 +166,7 @@ func Test_SeriesQuery(t *testing.T) {
 	cfg.SyncPeriod = 1 * time.Minute
 	cfg.SyncMinUtilization = 0.20
 
-	instance := newInstance(cfg, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
+	instance := newInstance(cfg, &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 
 	currentTime := time.Now()
 
@@ -178,7 +178,7 @@ func Test_SeriesQuery(t *testing.T) {
 	for _, testStream := range testStreams {
 		stream, err := instance.getOrCreateStream(testStream, false, recordPool.GetRecord())
 		require.NoError(t, err)
-		chunk := newStream(cfg, "fake", 0, nil, true, NilMetrics).NewChunk()
+		chunk := newStream(cfg, &validation.Overrides{}, "fake", 0, nil, true, NilMetrics).NewChunk()
 		for _, entry := range testStream.Entries {
 			err = chunk.Append(&entry)
 			require.NoError(t, err)
@@ -276,7 +276,7 @@ func Benchmark_PushInstance(b *testing.B) {
 	require.NoError(b, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
-	i := newInstance(&Config{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
+	i := newInstance(&Config{}, &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 	ctx := context.Background()
 
 	for n := 0; n < b.N; n++ {
@@ -318,7 +318,7 @@ func Benchmark_instance_addNewTailer(b *testing.B) {
 
 	ctx := context.Background()
 
-	inst := newInstance(&Config{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
+	inst := newInstance(&Config{}, &validation.Overrides{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 	t, err := newTailer("foo", `{namespace="foo",pod="bar",instance=~"10.*"}`, nil)
 	require.NoError(b, err)
 	for i := 0; i < 10000; i++ {
@@ -334,7 +334,7 @@ func Benchmark_instance_addNewTailer(b *testing.B) {
 	lbs := makeRandomLabels()
 	b.Run("addTailersToNewStream", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			inst.addTailersToNewStream(newStream(nil, "fake", 0, lbs, true, NilMetrics))
+			inst.addTailersToNewStream(newStream(nil, &validation.Overrides{}, "fake", 0, lbs, true, NilMetrics))
 		}
 	})
 }
@@ -368,7 +368,7 @@ func Test_Iterator(t *testing.T) {
 	defaultLimits := defaultLimitsTestConfig()
 	overrides, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
-	instance := newInstance(&ingesterConfig, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+	instance := newInstance(&ingesterConfig, &validation.Overrides{}, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
 	ctx := context.TODO()
 	direction := logproto.BACKWARD
 	limit := uint32(2)
@@ -450,7 +450,7 @@ func Test_ChunkFilter(t *testing.T) {
 	overrides, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
 	instance := newInstance(
-		&ingesterConfig, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, &testFilter{})
+		&ingesterConfig, &validation.Overrides{}, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, &testFilter{})
 	ctx := context.TODO()
 	direction := logproto.BACKWARD
 	limit := uint32(2)

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -141,7 +141,7 @@ func newLocalStreamRateStrategy(l *Limiter) cortex_limiter.RateLimiterStrategy {
 
 func (s *localStrategy) Limit(userID string) float64 {
 	if s.limiter.disabled {
-		return float64(rate.Inf) // or 0 if that's what we're supposed to do
+		return float64(rate.Inf)
 	}
 	return float64(s.limiter.limits.MaxLocalStreamRateBytes(userID))
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/cortexproject/cortex/pkg/util/limiter"
+
 	"github.com/grafana/loki/pkg/validation"
 )
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -138,7 +138,7 @@ func newLocalStreamRateStrategy(limits *validation.Overrides) limiter.RateLimite
 }
 
 func (s *localStrategy) Limit(userID string) float64 {
-	return s.limits.MaxLocalStreamRateMB(userID)
+	return float64(s.limits.MaxLocalStreamRateMB(userID))
 }
 
 func (s *localStrategy) Burst(userID string) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -138,9 +138,9 @@ func newLocalStreamRateStrategy(limits *validation.Overrides) limiter.RateLimite
 }
 
 func (s *localStrategy) Limit(userID string) float64 {
-	return float64(s.limits.MaxLocalStreamRateMB(userID))
+	return float64(s.limits.MaxLocalStreamRateBytes(userID))
 }
 
 func (s *localStrategy) Burst(userID string) int {
-	return s.limits.MaxLocalStreamBurstRateMB(userID)
+	return s.limits.MaxLocalStreamBurstRateBytes(userID)
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/cortexproject/cortex/pkg/util/limiter"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -124,4 +125,22 @@ func (l *Limiter) minNonZero(first, second int) int {
 	}
 
 	return first
+}
+
+type localStrategy struct {
+	limits *validation.Overrides
+}
+
+func newLocalStreamRateStrategy(limits *validation.Overrides) limiter.RateLimiterStrategy {
+	return &localStrategy{
+		limits: limits,
+	}
+}
+
+func (s *localStrategy) Limit(userID string) float64 {
+	return s.limits.MaxLocalStreamRateMB(userID)
+}
+
+func (s *localStrategy) Burst(userID string) int {
+	return s.limits.MaxLocalStreamBurstRateMB(userID)
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -319,7 +319,7 @@ func (s *stream) Push(
 		if lastEntryWithErr.e == ErrStreamRateLimit {
 			statusCode = http.StatusTooManyRequests
 		}
-		// return a http status 4xx request response with all failed entries
+		// Return a http status 4xx request response with all failed entries.
 		buf := bytes.Buffer{}
 		streamName := s.labelsString
 

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -117,9 +117,9 @@ type entryWithError struct {
 	e     error
 }
 
-func newStream(cfg *Config, limits *validation.Overrides, tenant string, fp model.Fingerprint, labels labels.Labels, unorderedWrites bool, metrics *ingesterMetrics) *stream {
+func newStream(cfg *Config, limits limiter.RateLimiterStrategy, tenant string, fp model.Fingerprint, labels labels.Labels, unorderedWrites bool, metrics *ingesterMetrics) *stream {
 	return &stream{
-		limiter:         limiter.NewRateLimiter(newLocalStreamRateStrategy(limits), 10*time.Second),
+		limiter:         limiter.NewRateLimiter(limits, 10*time.Second),
 		cfg:             cfg,
 		fp:              fp,
 		labels:          labels,

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -309,11 +309,9 @@ func (s *stream) Push(
 
 	if len(failedEntriesWithError) > 0 {
 		lastEntryWithErr := failedEntriesWithError[len(failedEntriesWithError)-1]
-		if lastEntryWithErr.e != chunkenc.ErrOutOfOrder || lastEntryWithErr.e != ErrStreamRateLimit {
+		if lastEntryWithErr.e != chunkenc.ErrOutOfOrder && lastEntryWithErr.e != ErrStreamRateLimit {
 			return bytesAdded, lastEntryWithErr.e
-
 		}
-
 		var statusCode int
 		if lastEntryWithErr.e == chunkenc.ErrOutOfOrder {
 			statusCode = http.StatusBadRequest

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -52,7 +52,6 @@ var (
 var (
 	ErrEntriesExist    = errors.New("duplicate push - entries already exist")
 	ErrStreamRateLimit = errors.New("stream rate limit exceeded")
-	StreamRateLimitMsg = "stream rate limit of %s exceeded"
 )
 
 func init() {
@@ -232,7 +231,6 @@ func (s *stream) Push(
 		if chunk.closed || !chunk.chunk.SpaceFor(&entries[i]) || s.cutChunkForSynchronization(entries[i].Timestamp, s.highestTs, chunk, s.cfg.SyncPeriod, s.cfg.SyncMinUtilization) {
 			chunk = s.cutChunk(ctx)
 		}
-
 		// Check if this this should be rate limited.
 		now := time.Now()
 		if !s.limiter.AllowN(now, s.tenant, len(entries[i].Line)) {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -294,8 +294,8 @@ func TestUnorderedPush(t *testing.T) {
 
 func TestPushRateLimit(t *testing.T) {
 	l := validation.Limits{
-		MaxLocalStreamRateMB:      1000,
-		MaxLocalStreamBurstRateMB: 2000,
+		MaxLocalStreamRateBytes:      1000,
+		MaxLocalStreamBurstRateBytes: 2000,
 	}
 	limits, err := validation.NewOverrides(l, nil)
 	require.NoError(t, err)

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -329,7 +329,7 @@ func TestPushRateLimit(t *testing.T) {
 		NilMetrics,
 	)
 
-	// counter should be 2 now since the first line will be deduped
+	// Counter should be 2 now since the first line will be deduped.
 	_, err = s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaaa"},
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -49,7 +49,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			cfg.MaxReturnedErrors = tc.limit
 			s := newStream(
 				cfg,
-				&validation.Overrides{},
+				newLocalStreamRateStrategy(&validation.Overrides{}),
 				"fake",
 				model.Fingerprint(0),
 				labels.Labels{
@@ -90,7 +90,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 func TestPushDeduplication(t *testing.T) {
 	s := newStream(
 		defaultConfig(),
-		&validation.Overrides{},
+		newLocalStreamRateStrategy(&validation.Overrides{}),
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -115,7 +115,7 @@ func TestPushDeduplication(t *testing.T) {
 func TestPushRejectOldCounter(t *testing.T) {
 	s := newStream(
 		defaultConfig(),
-		&validation.Overrides{},
+		newLocalStreamRateStrategy(&validation.Overrides{}),
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -205,7 +205,7 @@ func TestUnorderedPush(t *testing.T) {
 	cfg.MaxChunkAge = 10 * time.Second
 	s := newStream(
 		&cfg,
-		&validation.Overrides{},
+		newLocalStreamRateStrategy(&validation.Overrides{}),
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -305,7 +305,7 @@ func TestPushRateLimit(t *testing.T) {
 
 	s := newStream(
 		defaultConfig(),
-		limits,
+		newLocalStreamRateStrategy(limits),
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -357,7 +357,7 @@ func Benchmark_PushStream(b *testing.B) {
 		labels.Label{Name: "job", Value: "loki-dev/ingester"},
 		labels.Label{Name: "container", Value: "ingester"},
 	}
-	s := newStream(&Config{}, &validation.Overrides{}, "fake", model.Fingerprint(0), ls, true, NilMetrics)
+	s := newStream(&Config{}, newLocalStreamRateStrategy(&validation.Overrides{}), "fake", model.Fingerprint(0), ls, true, NilMetrics)
 	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{})
 	require.NoError(b, err)
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -116,7 +116,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	_ = l.MaxLocalStreamRateBytes.Set(strconv.Itoa(defaultPerStreamRateLimit))
 	f.Var(&l.MaxLocalStreamRateBytes, "ingester.max-stream-rate-bytes", "Maximum bytes per second rate per active stream.")
 	_ = l.MaxLocalStreamBurstRateBytes.Set(strconv.Itoa(defaultPerStreamBurstLimit))
-	f.Var(&l.MaxLocalStreamBurstRateBytes, "ingester.max-stream-rate-bytes", "Maximum burst bytes per second rate per active stream.")
+	f.Var(&l.MaxLocalStreamBurstRateBytes, "ingester.max-stream-burst-bytes", "Maximum burst bytes per second rate per active stream.")
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -42,9 +42,11 @@ type Limits struct {
 	MaxLineSizeTruncate    bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
 
 	// Ingester enforced limits.
-	MaxLocalStreamsPerUser  int  `yaml:"max_streams_per_user" json:"max_streams_per_user"`
-	MaxGlobalStreamsPerUser int  `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
-	UnorderedWrites         bool `yaml:"unordered_writes" json:"unordered_writes"`
+	MaxLocalStreamsPerUser    int     `yaml:"max_streams_per_user" json:"max_streams_per_user"`
+	MaxGlobalStreamsPerUser   int     `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
+	UnorderedWrites           bool    `yaml:"unordered_writes" json:"unordered_writes"`
+	MaxLocalStreamRateMB      float64 `yaml:"max_stream_rate_mb" json:"max_stream_rate_mb"`
+	MaxLocalStreamBurstRateMB float64 `yaml:"max_stream_burst_rate_mb" json:"max_stream_burst_rate_mb"`
 
 	// Querier enforced limits.
 	MaxChunksPerQuery          int            `yaml:"max_chunks_per_query" json:"max_chunks_per_query"`
@@ -107,6 +109,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalStreamsPerUser, "ingester.max-streams-per-user", 10e3, "Maximum number of active streams per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalStreamsPerUser, "ingester.max-global-streams-per-user", 0, "Maximum number of active streams per user, across the cluster. 0 to disable.")
 	f.BoolVar(&l.UnorderedWrites, "ingester.unordered-writes", false, "(Experimental) Allow out of order writes.")
+	f.Float64Var(&l.MaxLocalStreamRateMB, "ingester.max-stream-rate-mb", 10e6, "Maximum bytes per second rate per active stream.")
+	f.Float64Var(&l.MaxLocalStreamBurstRateMB, "ingester.max-stream-rate-mb", 20e6, "Maximum burst bytes per second rate per active stream.")
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
 
@@ -404,6 +408,14 @@ func (o *Overrides) StreamRetention(userID string) []StreamRetention {
 
 func (o *Overrides) UnorderedWrites(userID string) bool {
 	return o.getOverridesForUser(userID).UnorderedWrites
+}
+
+func (o *Overrides) MaxLocalStreamRateMB(userID string) float64 {
+	return o.getOverridesForUser(userID).MaxLocalStreamRateMB
+}
+
+func (o *Overrides) MaxLocalStreamBurstRateMB(userID string) int {
+	return int(o.getOverridesForUser(userID).MaxLocalStreamRateMB)
 }
 
 func (o *Overrides) ForEachTenantLimit(callback ForEachTenantLimitCallback) {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -49,8 +49,8 @@ type Limits struct {
 	MaxLocalStreamsPerUser       int              `yaml:"max_streams_per_user" json:"max_streams_per_user"`
 	MaxGlobalStreamsPerUser      int              `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
 	UnorderedWrites              bool             `yaml:"unordered_writes" json:"unordered_writes"`
-	MaxLocalStreamRateBytes      flagext.ByteSize `yaml:"max_stream_rate_mb" json:"max_stream_rate_bytes"`
-	MaxLocalStreamBurstRateBytes flagext.ByteSize `yaml:"max_stream_burst_rate_mb" json:"max_stream_burst_rate_bytes"`
+	MaxLocalStreamRateBytes      flagext.ByteSize `yaml:"max_stream_rate_bytes" json:"max_stream_rate_bytes"`
+	MaxLocalStreamBurstRateBytes flagext.ByteSize `yaml:"max_stream_burst_rate_bytes" json:"max_stream_burst_rate_bytes"`
 
 	// Querier enforced limits.
 	MaxChunksPerQuery          int            `yaml:"max_chunks_per_query" json:"max_chunks_per_query"`

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -23,11 +23,10 @@ const (
 	// because the limit of active streams has been reached.
 	StreamLimit         = "stream_limit"
 	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
-	//StreamRateLimit is a reason for discarding lines when the streams own rate limit is hit
+	// StreamRateLimit is a reason for discarding lines when the streams own rate limit is hit
 	// rather than the overall ingestion rate limit.
-	StreamRateLimit         = "per_stream_rate_limt"
-	StreamRateLimitErrorMsg = "Per stream rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased"
-	OutOfOrder              = "out_of_order"
+	StreamRateLimit = "per_stream_rate_limt"
+	OutOfOrder      = "out_of_order"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
 	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
 	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -23,7 +23,11 @@ const (
 	// because the limit of active streams has been reached.
 	StreamLimit         = "stream_limit"
 	StreamLimitErrorMsg = "Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased"
-	OutOfOrder          = "out_of_order"
+	//StreamRateLimit is a reason for discarding lines when the streams own rate limit is hit
+	// rather than the overall ingestion rate limit.
+	StreamRateLimit         = "per_stream_rate_limt"
+	StreamRateLimitErrorMsg = "Per stream rate limit exceeded (limit: %d bytes/sec) while attempting to ingest '%d' lines totaling '%d' bytes, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased"
+	OutOfOrder              = "out_of_order"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
 	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
 	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"


### PR DESCRIPTION
Adds a limiter to the stream struct.

Signed-off-by: Callum Styan <callumstyan@gmail.com>