### PR TITLE
Cleanup/unordered writes ingester config

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -724,6 +724,20 @@ func (c *MemChunk) reorder() error {
 	return nil
 }
 
+func (c *MemChunk) ConvertHead(desired HeadBlockFmt) error {
+
+	if c.head != nil && c.head.Format() != desired {
+		newH, err := c.head.Convert(desired)
+		if err != nil {
+			return err
+		}
+
+		c.head = newH
+	}
+	c.headFmt = desired
+	return nil
+}
+
 // cut a new block and add it to finished blocks.
 func (c *MemChunk) cut() error {
 	if c.head.IsEmpty() {

--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -100,10 +100,10 @@ func fromWireChunks(conf *Config, wireChunks []Chunk) ([]chunkDesc, error) {
 			lastUpdated: c.LastUpdated,
 		}
 
-		hbType := chunkenc.OrderedHeadBlockFmt
-		if conf.UnorderedWrites {
-			hbType = chunkenc.UnorderedHeadBlockFmt
-		}
+		// Always use Unordered headblocks during replay
+		// to ensure Loki can effectively replay an unordered-friendly
+		// WAL into a new configuration that disables unordered writes.
+		hbType := chunkenc.UnorderedHeadBlockFmt
 		mc, err := chunkenc.MemchunkFromCheckpoint(c.Data, c.Head, hbType, conf.BlockSize, conf.TargetChunkSize)
 		if err != nil {
 			return nil, err

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -291,7 +291,6 @@ func defaultIngesterTestConfig(t testing.TB) Config {
 	cfg.LifecyclerConfig.MinReadyDuration = 0
 	cfg.BlockSize = 256 * 1024
 	cfg.TargetChunkSize = 1500 * 1024
-	cfg.UnorderedWrites = true
 	return cfg
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -228,7 +228,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 
 	// Now that the lifecycler has been created, we can create the limiter
 	// which depends on it.
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
+	i.limiter = NewLimiter(limits, metrics, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor)
 
 	i.Service = services.NewBasicService(i.starting, i.running, i.stopping)
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -82,8 +82,6 @@ type Config struct {
 
 	ChunkFilterer storage.RequestChunkFilterer `yaml:"-"`
 
-	UnorderedWrites bool `yaml:"unordered_writes_enabled"`
-
 	IndexShards int `yaml:"index_shards"`
 }
 
@@ -107,7 +105,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", time.Hour, "Maximum chunk age before flushing.")
 	f.DurationVar(&cfg.QueryStoreMaxLookBackPeriod, "ingester.query-store-max-look-back-period", 0, "How far back should an ingester be allowed to query the store for data, for use only with boltdb-shipper index and filesystem object store. -1 for infinite.")
 	f.BoolVar(&cfg.AutoForgetUnhealthy, "ingester.autoforget-unhealthy", false, "Enable to remove unhealthy ingesters from the ring after `ring.kvstore.heartbeat_timeout`")
-	f.BoolVar(&cfg.UnorderedWrites, "ingester.unordered-writes-enabled", false, "(Experimental) Allow out of order writes.")
 	f.IntVar(&cfg.IndexShards, "ingester.index-shards", index.DefaultIndexShards, "Shard factor used in the ingesters for the in process reverse index. This MUST be evenly divisible by ALL schema shard factors or Loki will not start.")
 }
 
@@ -328,9 +325,9 @@ func (i *Ingester) starting(ctx context.Context) error {
 			i.cfg.RetainPeriod = old
 		}()
 
-		// Disable the in process stream limit checks while replaying the WAL
-		i.limiter.Disable()
-		defer i.limiter.Enable()
+		// Disable the in process stream limit checks while replaying the WAL.
+		// It is re-enabled in the recover's Close() method.
+		i.limiter.DisableForWALReplay()
 
 		recoverer := newIngesterRecoverer(i)
 		defer recoverer.Close()
@@ -381,6 +378,8 @@ func (i *Ingester) starting(ctx context.Context) error {
 			"errors", segmentRecoveryErr != nil,
 		)
 
+		level.Info(util_log.Logger).Log("msg", "closing recoverer")
+		recoverer.Close()
 		elapsed := time.Since(start)
 		i.metrics.walReplayDuration.Set(elapsed.Seconds())
 		level.Info(util_log.Logger).Log("msg", "recovery finished", "time", elapsed.String())

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -243,7 +243,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	fp := i.getHashForLabels(labels)
 
 	sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(labels), fp)
-	stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.limiter.limits.UnorderedWrites(i.instanceID), i.metrics)
+	stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 	i.streams[pushReqStream.Labels] = stream
 	i.streamsByFP[fp] = stream
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -132,7 +132,7 @@ func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *lo
 	if !ok {
 
 		sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(ls), fp)
-		stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.limiter.limits.UnorderedWrites(i.instanceID), i.metrics)
+		stream = newStream(i.cfg, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 		i.streamsByFP[fp] = stream
 		i.streams[stream.labelsString] = stream
 		i.streamsCreatedTotal.Inc()

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -39,7 +39,7 @@ var NilMetrics = newIngesterMetrics(nil)
 func TestLabelsCollisions(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
 	require.NoError(t, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	i := newInstance(defaultConfig(), "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, nil, &OnceSwitch{}, nil)
 
@@ -66,7 +66,7 @@ func TestLabelsCollisions(t *testing.T) {
 func TestConcurrentPushes(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
 	require.NoError(t, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	inst := newInstance(defaultConfig(), "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 
@@ -117,7 +117,7 @@ func TestConcurrentPushes(t *testing.T) {
 func TestSyncPeriod(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
 	require.NoError(t, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	const (
 		syncPeriod = 1 * time.Minute
@@ -159,7 +159,7 @@ func TestSyncPeriod(t *testing.T) {
 func Test_SeriesQuery(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
 	require.NoError(t, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	// just some random values
 	cfg := defaultConfig()
@@ -274,7 +274,7 @@ func makeRandomLabels() labels.Labels {
 func Benchmark_PushInstance(b *testing.B) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 1000}, nil)
 	require.NoError(b, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	i := newInstance(&Config{}, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil)
 	ctx := context.Background()
@@ -314,7 +314,7 @@ func Benchmark_PushInstance(b *testing.B) {
 func Benchmark_instance_addNewTailer(b *testing.B) {
 	limits, err := validation.NewOverrides(validation.Limits{MaxLocalStreamsPerUser: 100000}, nil)
 	require.NoError(b, err)
-	limiter := NewLimiter(limits, &ringCountMock{count: 1}, 1)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	ctx := context.Background()
 
@@ -368,7 +368,7 @@ func Test_Iterator(t *testing.T) {
 	defaultLimits := defaultLimitsTestConfig()
 	overrides, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
-	instance := newInstance(&ingesterConfig, "fake", NewLimiter(overrides, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+	instance := newInstance(&ingesterConfig, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
 	ctx := context.TODO()
 	direction := logproto.BACKWARD
 	limit := uint32(2)
@@ -450,7 +450,7 @@ func Test_ChunkFilter(t *testing.T) {
 	overrides, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
 	instance := newInstance(
-		&ingesterConfig, "fake", NewLimiter(overrides, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, &testFilter{})
+		&ingesterConfig, "fake", NewLimiter(overrides, NilMetrics, &ringCountMock{count: 1}, 1), loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, &testFilter{})
 	ctx := context.TODO()
 	direction := logproto.BACKWARD
 	limit := uint32(2)

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -24,6 +24,7 @@ type Limiter struct {
 	limits            *validation.Overrides
 	ring              RingCount
 	replicationFactor int
+	metrics           *ingesterMetrics
 
 	mtx      sync.RWMutex
 	disabled bool
@@ -33,20 +34,23 @@ func (l *Limiter) DisableForWALReplay() {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 	l.disabled = true
+	l.metrics.limiterEnabled.Set(0)
 }
 
 func (l *Limiter) Enable() {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 	l.disabled = false
+	l.metrics.limiterEnabled.Set(1)
 }
 
 // NewLimiter makes a new limiter
-func NewLimiter(limits *validation.Overrides, ring RingCount, replicationFactor int) *Limiter {
+func NewLimiter(limits *validation.Overrides, metrics *ingesterMetrics, ring RingCount, replicationFactor int) *Limiter {
 	return &Limiter{
 		limits:            limits,
 		ring:              ring,
 		replicationFactor: replicationFactor,
+		metrics:           metrics,
 	}
 }
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -108,7 +108,7 @@ func TestLimiter_AssertMaxStreamsPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor)
+			limiter := NewLimiter(limits, NilMetrics, ring, testData.ringReplicationFactor)
 			actual := limiter.AssertMaxStreamsPerUser("test", testData.streams)
 
 			assert.Equal(t, testData.expected, actual)
@@ -155,7 +155,7 @@ func TestLimiter_minNonZero(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			limiter := NewLimiter(nil, nil, 0)
+			limiter := NewLimiter(nil, NilMetrics, nil, 0)
 			assert.Equal(t, testData.expected, limiter.minNonZero(testData.first, testData.second))
 		})
 	}

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -27,6 +27,8 @@ type ingesterMetrics struct {
 	recoveryBytesInUse    prometheus.Gauge
 	recoveryIsFlushing    prometheus.Gauge
 
+	limiterEnabled prometheus.Gauge
+
 	autoForgetUnhealthyIngestersTotal prometheus.Counter
 }
 
@@ -118,6 +120,10 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 		recoveryIsFlushing: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_ingester_wal_replay_flushing",
 			Help: "Whether the wal replay is in a flushing phase due to backpressure",
+		}),
+		limiterEnabled: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingester_limiter_enabled",
+			Help: "Whether the ingester's limiter is enabled",
 		}),
 		autoForgetUnhealthyIngestersTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_autoforget_unhealthy_ingesters_total",

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -227,7 +227,7 @@ func (r *ingesterRecoverer) Close() {
 			// configuration disables them, convert all streams/head blocks
 			// to ensure unordered writes are disabled after the replay,
 			// but without dropping any previously accepted data.
-			isAllowed := r.ing.limiter.limits.UnorderedWrites(s.tenant)
+			isAllowed := r.ing.limiter.UnorderedWrites(s.tenant)
 			old := s.unorderedWrites
 			s.unorderedWrites = isAllowed
 

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -99,6 +99,7 @@ type ingesterRecoverer struct {
 }
 
 func newIngesterRecoverer(i *Ingester) *ingesterRecoverer {
+
 	return &ingesterRecoverer{
 		ing:  i,
 		done: make(chan struct{}),
@@ -127,6 +128,9 @@ func (r *ingesterRecoverer) Series(series *Series) error {
 		stream.lastLine.content = series.LastLine
 		stream.entryCt = series.EntryCt
 		stream.highestTs = series.HighestTs
+		// Always set during replay, then reset to desired value afterward.
+		// This allows replaying unordered WALs into ordered configurations.
+		stream.unorderedWrites = true
 
 		if err != nil {
 			return err
@@ -202,14 +206,46 @@ func (r *ingesterRecoverer) Push(userID string, entries RefEntries) error {
 }
 
 func (r *ingesterRecoverer) Close() {
-	// reset all the incrementing stream counters after a successful WAL replay.
+	// Ensure this is only run once.
+	select {
+	case <-r.done:
+		return
+	default:
+	}
+
+	close(r.done)
+
+	// Enable the limiter here to accurately reflect tenant limits after recovery.
+	r.ing.limiter.Enable()
+
 	for _, inst := range r.ing.getInstances() {
 		inst.forAllStreams(context.Background(), func(s *stream) error {
+			// reset all the incrementing stream counters after a successful WAL replay.
 			s.resetCounter()
+
+			// If we've replayed a WAL with unordered writes, but the new
+			// configuration disables them, convert all streams/head blocks
+			// to ensure unordered writes are disabled after the replay,
+			// but without dropping any previously accepted data.
+			isAllowed := r.ing.limiter.limits.UnorderedWrites(s.tenant)
+			old := s.unorderedWrites
+			s.unorderedWrites = isAllowed
+
+			if !isAllowed && old {
+
+				s.chunkMtx.Lock()
+				defer s.chunkMtx.Unlock()
+				if len(s.chunks) > 0 {
+					err := s.chunks[len(s.chunks)-1].chunk.ConvertHead(headBlockType(isAllowed))
+					if err != nil {
+						return err
+					}
+				}
+			}
+
 			return nil
 		})
 	}
-	close(r.done)
 }
 
 func (r *ingesterRecoverer) Done() <-chan struct{} {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -161,11 +161,7 @@ func (s *stream) setChunks(chunks []Chunk) (bytesAdded, entriesAdded int, err er
 }
 
 func (s *stream) NewChunk() *chunkenc.MemChunk {
-	hbType := chunkenc.OrderedHeadBlockFmt
-	if s.unorderedWrites {
-		hbType = chunkenc.UnorderedHeadBlockFmt
-	}
-	return chunkenc.NewMemChunk(s.cfg.parsedEncoding, hbType, s.cfg.BlockSize, s.cfg.TargetChunkSize)
+	return chunkenc.NewMemChunk(s.cfg.parsedEncoding, headBlockType(s.unorderedWrites), s.cfg.BlockSize, s.cfg.TargetChunkSize)
 }
 
 func (s *stream) Push(
@@ -479,4 +475,11 @@ func (s *stream) addTailer(t *tailer) {
 
 func (s *stream) resetCounter() {
 	s.entryCt = 0
+}
+
+func headBlockType(unorderedWrites bool) chunkenc.HeadBlockFmt {
+	if unorderedWrites {
+		return chunkenc.UnorderedHeadBlockFmt
+	}
+	return chunkenc.OrderedHeadBlockFmt
 }

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -30,7 +30,6 @@ func TestTransferOut(t *testing.T) {
 	f := newTestIngesterFactory(t)
 
 	ing := f.getIngester(time.Duration(0), t)
-	ing.cfg.UnorderedWrites = false // enforce ordered writes on old testware (transfers are deprecated).
 
 	// Push some data into our original ingester
 	ctx := user.InjectOrgID(context.Background(), "test")


### PR DESCRIPTION
This PR does a few things:
1) Finishes removing the `ingester.unordered-writes-enabled` config. This has been entirely replaced by the per tenant limit configuration.
2) Always replays WALs with unordered writes enabled. This primarily safeguards against dropping samples due to `out_of_order` errors when replaying a WAL after moving from `unordered_writes: true` -> `unordered_writes: false`. It does this by ensuring all the internals accept unordered writes during WAL replay and switches any differences at the end.
3) Adds a new metric, `loki_ingester_limiter_enabled`, which reports when it's enabled/disabled. This should help debugging as it overrides some of the embedded overrides, particularly to disable them during WAL replay.