### PR TITLE
cmd/logcli: add --follow flag as an alias for --tail

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -73,6 +73,7 @@ If you are querying metrics and just want the most recent data point
 the "instant-query" command instead.`)
 	rangeQuery = newQuery(false, queryCmd)
 	tail       = queryCmd.Flag("tail", "Tail the logs").Short('t').Default("false").Bool()
+	follow     = queryCmd.Flag("follow", "Alias for --tail").Short('f').Default("false").Bool()
 	delayFor   = queryCmd.Flag("delay-for", "Delay in tailing by number of seconds to accumulate logs for re-ordering").Default("0").Int()
 
 	instantQueryCmd = app.Command("instant-query", `Run an instant LogQL query.
@@ -155,7 +156,7 @@ func main() {
 			log.Fatalf("Unable to create log output: %s", err)
 		}
 
-		if *tail {
+		if *tail || *follow {
 			rangeQuery.TailQuery(time.Duration(*delayFor)*time.Second, queryClient, out)
 		} else {
 			rangeQuery.DoQuery(queryClient, out, *statistics)

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -316,6 +316,7 @@ Flags:
                            from a given Loki configuration file.
       --colored-output     Show output with colored labels
   -t, --tail               Tail the logs
+  -f, --follow             Alias for --tail
       --delay-for=0        Delay in tailing by number of seconds to accumulate
                            logs for re-ordering
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When using 'logcli query --tail', '--tail' behaves similar to the 'tail'
command, which uses '--follow' flag, if you want to continuously
follow the appended data to the file.

I believe '--follow' flag is more natural for system administrators to
use rather than '--tail' if one wants to "follow" the incoming logs, so
this commit adds one, as an alias for '--tail'.

**Which issue(s) this PR fixes**:
Fixes #3570

**Special notes for your reviewer**:

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

**Checklist**
- [x] Documentation added
- [ ] Tests updated

