### PR TITLE
Link Kubernetes service discovery configuration.

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -76,7 +76,7 @@ relabel_configs:
     target_label: '__host__'
 ```
 
-See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery config](../configuration/#kubernetes_sd_config).
+See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery configuration](../configuration/#kubernetes_sd_config).
 
 ## Journal Scraping (Linux Only)
 

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -76,7 +76,7 @@ relabel_configs:
     target_label: '__host__'
 ```
 
-See [Relabeling](#relabeling) for more information.
+See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery config](../configuration/#kubernetes_sd_config).
 
 ## Journal Scraping (Linux Only)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have two sections on the Kubernetes service discovery in Promtail. This change links from `scraping/#kubernetes-discovery` to `configuration/#kubernetes_sd_config`.

**Checklist**
- [x] Documentation added

