### PR TITLE
Improve error message for stream rate limit.

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -316,14 +316,14 @@ func (s *stream) Push(
 	if len(failedEntriesWithError) > 0 {
 		lastEntryWithErr := failedEntriesWithError[len(failedEntriesWithError)-1]
 		_, ok := lastEntryWithErr.e.(*validation.ErrStreamRateLimit)
-		if lastEntryWithErr.e != chunkenc.ErrOutOfOrder && ok {
+		if lastEntryWithErr.e != chunkenc.ErrOutOfOrder && !ok {
 			return bytesAdded, lastEntryWithErr.e
 		}
 		var statusCode int
 		if lastEntryWithErr.e == chunkenc.ErrOutOfOrder {
 			statusCode = http.StatusBadRequest
 		}
-		if _, ok := lastEntryWithErr.e.(*validation.ErrStreamRateLimit); ok {
+		if ok {
 			statusCode = http.StatusTooManyRequests
 		}
 		// Return a http status 4xx request response with all failed entries.

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -52,19 +52,6 @@ var (
 	ErrEntriesExist = errors.New("duplicate push - entries already exist")
 )
 
-type ErrStreamRateLimit struct {
-	rateLimit float64
-	labels    string
-	bytes     int
-}
-
-func (e *ErrStreamRateLimit) Error() string {
-	return fmt.Sprintf("Per stream rate limit exceeded (limit: %f bytes/sec) while attempting to ingest for stream '%s'  totaling '%d' bytes, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased",
-		e.rateLimit,
-		e.labels,
-		e.bytes)
-}
-
 func init() {
 	prometheus.MustRegister(chunksCreatedTotal)
 	prometheus.MustRegister(samplesPerChunk)
@@ -252,7 +239,7 @@ func (s *stream) Push(
 		// Check if this this should be rate limited.
 		now := time.Now()
 		if !s.limiter.AllowN(now, len(entries[i].Line)) {
-			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], &ErrStreamRateLimit{float64(s.limiter.lim.Limit()), s.labelsString, len(entries[i].Line)}})
+			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], &validation.ErrStreamRateLimit{RateLimit: float64(s.limiter.lim.Limit()), Labels: s.labelsString, Bytes: len(entries[i].Line)}})
 			rateLimitedSamples++
 			rateLimitedBytes += len(entries[i].Line)
 			continue
@@ -327,7 +314,7 @@ func (s *stream) Push(
 
 	if len(failedEntriesWithError) > 0 {
 		lastEntryWithErr := failedEntriesWithError[len(failedEntriesWithError)-1]
-		_, ok := lastEntryWithErr.e.(*ErrStreamRateLimit)
+		_, ok := lastEntryWithErr.e.(*validation.ErrStreamRateLimit)
 		if lastEntryWithErr.e != chunkenc.ErrOutOfOrder && ok {
 			return bytesAdded, lastEntryWithErr.e
 		}
@@ -335,7 +322,7 @@ func (s *stream) Push(
 		if lastEntryWithErr.e == chunkenc.ErrOutOfOrder {
 			statusCode = http.StatusBadRequest
 		}
-		if _, ok := lastEntryWithErr.e.(*ErrStreamRateLimit); ok {
+		if _, ok := lastEntryWithErr.e.(*validation.ErrStreamRateLimit); ok {
 			statusCode = http.StatusTooManyRequests
 		}
 		// Return a http status 4xx request response with all failed entries.

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -219,8 +219,8 @@ func (s *stream) Push(
 	}()
 
 	// This call uses a mutex under the hood, cache the result since we're checking the limit
-	// on each entry in the push (hot path) and we only use this value when logging entries that
-	// passed the rate limit.
+	// on each entry in the push (hot path) and we only use this value when logging entries
+	// over the rate limit.
 	limit := s.limiter.lim.Limit()
 
 	// Don't fail on the first append error - if samples are sent out of order,

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/util/flagext"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -239,7 +240,7 @@ func (s *stream) Push(
 		// Check if this this should be rate limited.
 		now := time.Now()
 		if !s.limiter.AllowN(now, len(entries[i].Line)) {
-			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], &validation.ErrStreamRateLimit{RateLimit: float64(s.limiter.lim.Limit()), Labels: s.labelsString, Bytes: len(entries[i].Line)}})
+			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], &validation.ErrStreamRateLimit{RateLimit: flagext.ByteSize(s.limiter.lim.Limit()), Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[i].Line))}})
 			rateLimitedSamples++
 			rateLimitedBytes += len(entries[i].Line)
 			continue

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -335,7 +335,7 @@ func TestPushRateLimit(t *testing.T) {
 	}
 	// Counter should be 2 now since the first line will be deduped.
 	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0)
-	require.Equal(t, (&ErrStreamRateLimit{float64(l.MaxLocalStreamRateBytes), s.labelsString, len(entries[1].Line)}).Error(), err.Error())
+	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: float64(l.MaxLocalStreamRateBytes), Labels: s.labelsString, Bytes: len(entries[1].Line)}).Error(), err.Error())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -336,7 +336,7 @@ func TestPushRateLimit(t *testing.T) {
 	}
 	// Counter should be 2 now since the first line will be deduped.
 	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0)
-	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: flagext.ByteSize(l.MaxLocalStreamRateBytes), Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error(), err.Error())
+	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: l.MaxLocalStreamRateBytes, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error(), err.Error())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -336,7 +336,7 @@ func TestPushRateLimit(t *testing.T) {
 	}
 	// Counter should be 2 now since the first line will be deduped.
 	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0)
-	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: l.MaxLocalStreamRateBytes, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error(), err.Error())
+	require.Contains(t, err.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
+	"github.com/grafana/loki/pkg/util/flagext"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -335,7 +336,7 @@ func TestPushRateLimit(t *testing.T) {
 	}
 	// Counter should be 2 now since the first line will be deduped.
 	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0)
-	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: float64(l.MaxLocalStreamRateBytes), Labels: s.labelsString, Bytes: len(entries[1].Line)}).Error(), err.Error())
+	require.Equal(t, (&validation.ErrStreamRateLimit{RateLimit: flagext.ByteSize(l.MaxLocalStreamRateBytes), Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error(), err.Error())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -329,13 +329,13 @@ func TestPushRateLimit(t *testing.T) {
 		NilMetrics,
 	)
 
-	// Counter should be 2 now since the first line will be deduped.
-	_, err = s.Push(context.Background(), []logproto.Entry{
+	entries := []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaaa"},
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},
-	}, recordPool.GetRecord(), 0)
-	require.Contains(t, err.Error(), ErrStreamRateLimit.Error())
-	require.Contains(t, err.Error(), "total ignored: 1 out of 2")
+	}
+	// Counter should be 2 now since the first line will be deduped.
+	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0)
+	require.Equal(t, (&ErrStreamRateLimit{float64(l.MaxLocalStreamRateBytes), s.labelsString, len(entries[1].Line)}).Error(), err.Error())
 }
 
 func iterEq(t *testing.T, exp []logproto.Entry, got iter.EntryIterator) {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,6 +48,19 @@ const (
 	DuplicateLabelNames         = "duplicate_label_names"
 	DuplicateLabelNamesErrorMsg = "stream '%s' has duplicate label name: '%s'"
 )
+
+type ErrStreamRateLimit struct {
+	RateLimit float64
+	Labels    string
+	Bytes     int
+}
+
+func (e *ErrStreamRateLimit) Error() string {
+	return fmt.Sprintf("Per stream rate limit exceeded (limit: %f bytes/sec) while attempting to ingest for stream '%s'  totaling '%d' bytes, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased",
+		e.RateLimit,
+		e.Labels,
+		e.Bytes)
+}
 
 // MutatedSamples is a metric of the total number of lines mutated, by reason.
 var MutatedSamples = prometheus.NewCounterVec(

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 
+	"github.com/grafana/loki/pkg/util/flagext"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -50,16 +51,16 @@ const (
 )
 
 type ErrStreamRateLimit struct {
-	RateLimit float64
+	RateLimit flagext.ByteSize
 	Labels    string
-	Bytes     int
+	Bytes     flagext.ByteSize
 }
 
 func (e *ErrStreamRateLimit) Error() string {
-	return fmt.Sprintf("Per stream rate limit exceeded (limit: %f bytes/sec) while attempting to ingest for stream '%s'  totaling '%d' bytes, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased",
-		e.RateLimit,
+	return fmt.Sprintf("Per stream rate limit exceeded (limit: %s/sec) while attempting to ingest for stream '%s' totaling %s, consider splitting a stream via additional labels or contact your Loki administrator to see if the limt can be increased",
+		e.RateLimit.String(),
 		e.Labels,
-		e.Bytes)
+		e.Bytes.String())
 }
 
 // MutatedSamples is a metric of the total number of lines mutated, by reason.

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -3,8 +3,9 @@ package validation
 import (
 	"fmt"
 
-	"github.com/grafana/loki/pkg/util/flagext"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 const (


### PR DESCRIPTION
Logs the rate limit, stream labels, and bytes for that push in the error/error message.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

