### PR TITLE
WAL replay discard metrics

### DIFF
--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -1,9 +1,10 @@
 package ingester
 
 import (
-	"github.com/grafana/loki/pkg/validation"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/pkg/validation"
 )
 
 type ingesterMetrics struct {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -184,6 +184,13 @@ func (s *stream) Push(
 	defer s.chunkMtx.Unlock()
 
 	if counter > 0 && counter <= s.entryCt {
+		var byteCt int
+		for _, e := range entries {
+			byteCt += len(e.Line)
+		}
+
+		s.metrics.walReplaySamplesDropped.WithLabelValues(duplicateReason).Add(float64(len(entries)))
+		s.metrics.walReplayBytesDropped.WithLabelValues(duplicateReason).Add(float64(byteCt))
 		return 0, ErrEntriesExist
 	}
 

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	reasonLabel = "reason"
+	ReasonLabel = "reason"
 	// InvalidLabels is a reason for discarding log lines which have labels that cannot be parsed.
 	InvalidLabels = "invalid_labels"
 	MissingLabels = "missing_labels"
@@ -54,7 +54,7 @@ var MutatedSamples = prometheus.NewCounterVec(
 		Name:      "mutated_samples_total",
 		Help:      "The total number of samples that have been mutated.",
 	},
-	[]string{reasonLabel, "truncated"},
+	[]string{ReasonLabel, "truncated"},
 )
 
 // MutatedBytes is a metric of the total mutated bytes, by reason.
@@ -64,7 +64,7 @@ var MutatedBytes = prometheus.NewCounterVec(
 		Name:      "mutated_bytes_total",
 		Help:      "The total number of bytes that have been mutated.",
 	},
-	[]string{reasonLabel, "truncated"},
+	[]string{ReasonLabel, "truncated"},
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
@@ -74,7 +74,7 @@ var DiscardedBytes = prometheus.NewCounterVec(
 		Name:      "discarded_bytes_total",
 		Help:      "The total number of bytes that were discarded.",
 	},
-	[]string{reasonLabel, "tenant"},
+	[]string{ReasonLabel, "tenant"},
 )
 
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
@@ -84,7 +84,7 @@ var DiscardedSamples = prometheus.NewCounterVec(
 		Name:      "discarded_samples_total",
 		Help:      "The total number of samples that were discarded.",
 	},
-	[]string{reasonLabel, "tenant"},
+	[]string{ReasonLabel, "tenant"},
 )
 
 func init() {


### PR DESCRIPTION
As the WAL replays segments on top of checkpoints, it's common to confront duplicate data. This PR adds metrics for how much data is discarded this way during a replay.