### PR TITLE
Refactor per stream rate limit

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -132,7 +132,7 @@ func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *lo
 	if !ok {
 
 		sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(ls), fp)
-		stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+		stream = newStream(i.cfg, i.limiter, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 		i.streamsByFP[fp] = stream
 		i.streams[stream.labelsString] = stream
 		i.streamsCreatedTotal.Inc()
@@ -243,7 +243,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	fp := i.getHashForLabels(labels)
 
 	sortedLabels := i.index.Add(cortexpb.FromLabelsToLabelAdapters(labels), fp)
-	stream = newStream(i.cfg, newLocalStreamRateStrategy(i.limiter), i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
+	stream = newStream(i.cfg, i.limiter, i.instanceID, fp, sortedLabels, i.limiter.UnorderedWrites(i.instanceID), i.metrics)
 	i.streams[pushReqStream.Labels] = stream
 	i.streamsByFP[fp] = stream
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -198,7 +198,7 @@ func Test_SeriesQuery(t *testing.T) {
 	for _, testStream := range testStreams {
 		stream, err := instance.getOrCreateStream(testStream, false, recordPool.GetRecord())
 		require.NoError(t, err)
-		chunk := newStream(cfg, newLocalStreamRateStrategy(limiter), "fake", 0, nil, true, NilMetrics).NewChunk()
+		chunk := newStream(cfg, limiter, "fake", 0, nil, true, NilMetrics).NewChunk()
 		for _, entry := range testStream.Entries {
 			err = chunk.Append(&entry)
 			require.NoError(t, err)
@@ -364,7 +364,7 @@ func Benchmark_instance_addNewTailer(b *testing.B) {
 	lbs := makeRandomLabels()
 	b.Run("addTailersToNewStream", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			inst.addTailersToNewStream(newStream(nil, newLocalStreamRateStrategy(limiter), "fake", 0, lbs, true, NilMetrics))
+			inst.addTailersToNewStream(newStream(nil, limiter, "fake", 0, lbs, true, NilMetrics))
 		}
 	})
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -174,9 +174,6 @@ func (l *StreamRateLimiter) AllowN(at time.Time, n int) bool {
 		if oldLim == rate.Inf && next.Limit != oldLim {
 			l.lim = rate.NewLimiter(next.Limit, next.Burst)
 		} else {
-
-			// Need to set Burst first due to race conditions acquiring the underlocking
-			// mutex and because a zero burst allows no events unless limit == Inf.
 			if next.Burst != oldBurst {
 				l.lim.SetBurstAt(at, next.Burst)
 			}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util/limiter"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -116,7 +115,7 @@ type entryWithError struct {
 	e     error
 }
 
-func newStream(cfg *Config, limits limiter.RateLimiterStrategy, tenant string, fp model.Fingerprint, labels labels.Labels, unorderedWrites bool, metrics *ingesterMetrics) *stream {
+func newStream(cfg *Config, limits RateLimiterStrategy, tenant string, fp model.Fingerprint, labels labels.Labels, unorderedWrites bool, metrics *ingesterMetrics) *stream {
 	return &stream{
 		limiter:         NewStreamRateLimiter(limits, tenant, 10*time.Second),
 		cfg:             cfg,

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -53,7 +53,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			cfg.MaxReturnedErrors = tc.limit
 			s := newStream(
 				cfg,
-				newLocalStreamRateStrategy(limiter),
+				limiter,
 				"fake",
 				model.Fingerprint(0),
 				labels.Labels{
@@ -98,7 +98,7 @@ func TestPushDeduplication(t *testing.T) {
 
 	s := newStream(
 		defaultConfig(),
-		newLocalStreamRateStrategy(limiter),
+		limiter,
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -127,7 +127,7 @@ func TestPushRejectOldCounter(t *testing.T) {
 
 	s := newStream(
 		defaultConfig(),
-		newLocalStreamRateStrategy(limiter),
+		limiter,
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -221,7 +221,7 @@ func TestUnorderedPush(t *testing.T) {
 
 	s := newStream(
 		&cfg,
-		newLocalStreamRateStrategy(limiter),
+		limiter,
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -319,7 +319,7 @@ func TestPushRateLimit(t *testing.T) {
 
 	s := newStream(
 		defaultConfig(),
-		newLocalStreamRateStrategy(limiter),
+		limiter,
 		"fake",
 		model.Fingerprint(0),
 		labels.Labels{
@@ -360,7 +360,7 @@ func Benchmark_PushStream(b *testing.B) {
 	require.NoError(b, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
-	s := newStream(&Config{}, newLocalStreamRateStrategy(limiter), "fake", model.Fingerprint(0), ls, true, NilMetrics)
+	s := newStream(&Config{}, limiter, "fake", model.Fingerprint(0), ls, true, NilMetrics)
 	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{})
 	require.NoError(b, err)
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"golang.org/x/time/rate"
 
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/util/flagext"
@@ -430,6 +431,14 @@ func (o *Overrides) ForEachTenantLimit(callback ForEachTenantLimitCallback) {
 
 func (o *Overrides) DefaultLimits() *Limits {
 	return o.defaultLimits
+}
+
+func (o *Overrides) PerStreamRateLimit(userID string) RateLimit {
+	user := o.getOverridesForUser(userID)
+	return RateLimit{
+		Limit: rate.Limit(float64(user.MaxLocalStreamRateBytes.Val())),
+		Burst: user.MaxLocalStreamBurstRateBytes.Val(),
+	}
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/validation/rate.go
+++ b/pkg/validation/rate.go
@@ -1,0 +1,17 @@
+package validation
+
+import "golang.org/x/time/rate"
+
+// RateLimit is a colocated limit & burst config. It largely exists to
+// eliminate accidental misconfigurations due to race conditions when
+// requesting the limit & burst config sequentially, between which the
+// Limits configuration may have updated.
+type RateLimit struct {
+	Limit rate.Limit
+	Burst int
+}
+
+var Unlimited = RateLimit{
+	Limit: rate.Inf,
+	Burst: 0,
+}


### PR DESCRIPTION
This PR comes after a lot of debugging and discovering some unexpected behavior in our underlying rate limit library. Notably, it did not handle transitioning from `rate.Inf` as expected. This PR refactors and corrects to desired behavior and reduces some complexity/runtime costs by no longer depending on the per tenant rate limiter from Cortex.