### PR TITLE
bumps per stream default rate limits

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -23,8 +23,8 @@ const (
 
 	bytesInMB = 1048576
 
-	defaultPerStreamRateLimit  = 1 << 20 // 1MB
-	defaultPerStreamBurstLimit = 2 * defaultPerStreamRateLimit
+	defaultPerStreamRateLimit  = 3 << 20 // 3MB
+	defaultPerStreamBurstLimit = 5 * defaultPerStreamRateLimit
 )
 
 // Limits describe all the limits for users; can be used to describe global default


### PR DESCRIPTION
After some testing, this seems a more reasonable balance between protecting ingesters and good defaults out of the box
