### PR TITLE
doc: fix typo on loki-external-labels for docker client labels

### DIFF
--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -115,7 +115,7 @@ Custom labels can be added using the `loki-external-labels`, `loki-pipeline-stag
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the
 next section for all supported options.
 
-`loki-external-labels` have the default value of `container_name={{.Name}}`. If you have custom value for `loki-external-labels` then that will replace the default value, meaning you won't have `container_name` label unless you explcity add it (e.g: `loki-external-lables: "job=docker,container_name={{.Name}}"`.
+`loki-external-labels` have the default value of `container_name={{.Name}}`. If you have custom value for `loki-external-labels` then that will replace the default value, meaning you won't have `container_name` label unless you explcity add it (e.g: `loki-external-labels: "job=docker,container_name={{.Name}}"`.
 
 ## Pipeline stages
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

There is a typo on loki-external-labels for [docker client labels documentation](https://grafana.com/docs/loki/latest/clients/docker-driver/configuration/), which give this error : 

```
ERROR: for xx  Cannot start service vigil: failed to initialize logging driver: error creating logger: error creating loki logger: loki: wrong log-opt: 'loki-external-lables' - 
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

