### PR TITLE
Add metrics for gcplog scrape.

### DIFF
--- a/clients/pkg/promtail/targets/gcplog/metrics.go
+++ b/clients/pkg/promtail/targets/gcplog/metrics.go
@@ -32,7 +32,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	m.gcplogTargetLastSuccessScrape = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "promtail",
 		Name:      "gcplog_target_last_success_scrape",
-		Help:      "Timestamp of the specific target's last successfull poll",
+		Help:      "Timestamp of the specific target's last successful poll",
 	}, []string{"project", "target"})
 
 	reg.MustRegister(m.gcplogEntries, m.gcplogErrors)

--- a/clients/pkg/promtail/targets/gcplog/metrics.go
+++ b/clients/pkg/promtail/targets/gcplog/metrics.go
@@ -7,8 +7,9 @@ type Metrics struct {
 	// reg is the Registerer used to create this set of metrics.
 	reg prometheus.Registerer
 
-	gcplogEntries *prometheus.CounterVec
-	gcplogErrors  *prometheus.CounterVec
+	gcplogEntries                 *prometheus.CounterVec
+	gcplogErrors                  *prometheus.CounterVec
+	gcplogTargetLastSuccessScrape *prometheus.GaugeVec
 }
 
 // NewMetrics creates a new set of metrics. Metrics will be registered to reg.
@@ -27,6 +28,12 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Name:      "gcplog_target_parsing_errors_total",
 		Help:      "Total number of parsing errors while receiving gcplog messages",
 	}, []string{"project"})
+
+	m.gcplogTargetLastSuccessScrape = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "promtail",
+		Name:      "gcplog_target_last_success_scrape",
+		Help:      "Timestamp of the specific target's last successfull poll",
+	}, []string{"project", "target"})
 
 	reg.MustRegister(m.gcplogEntries, m.gcplogErrors)
 	return &m

--- a/clients/pkg/promtail/targets/gcplog/target.go
+++ b/clients/pkg/promtail/targets/gcplog/target.go
@@ -139,7 +139,7 @@ func (t *GcplogTarget) Type() target.TargetType {
 
 func (t *GcplogTarget) Ready() bool {
 	// Return true just like all other targets.
-	// Rationale is gcplog scraping shouldn't stop because of some some transient timeout errors.
+	// Rationale is gcplog scraping shouldn't stop because of some transient timeout errors.
 	// This transient failure can cause promtail readyness probe to fail which may prevent pod from starting.
 	// We have metrics now to track if scraping failed (`gcplog_target_last_success_scrape`).
 	return true

--- a/clients/pkg/promtail/targets/gcplog/target.go
+++ b/clients/pkg/promtail/targets/gcplog/target.go
@@ -108,9 +108,9 @@ func (t *GcplogTarget) run() error {
 			t.msgs <- m
 		})
 		if err != nil {
-			// TODO(kavi): Add proper error propagation maybe?
-			level.Error(t.logger).Log("error", err)
+			level.Error(t.logger).Log("msg", "failed to receive pubsub messages", "error", err)
 			t.metrics.gcplogErrors.WithLabelValues(t.config.ProjectID).Inc()
+			t.metrics.gcplogTargetLastSuccessScrape.WithLabelValues(t.config.ProjectID, t.config.Subscription).SetToCurrentTime()
 		}
 	}()
 
@@ -138,7 +138,11 @@ func (t *GcplogTarget) Type() target.TargetType {
 }
 
 func (t *GcplogTarget) Ready() bool {
-	return t.ctx.Err() == nil
+	// Return true just like all other targets.
+	// Rationale is gcplog scraping shouldn't stop because of some some transient timeout errors.
+	// This transient failure can cause promtail readyness probe to fail which may prevent pod from starting.
+	// We have metrics now to track if scraping failed (`gcplog_target_last_success_scrape`).
+	return true
 }
 
 func (t *GcplogTarget) DiscoveredLabels() model.LabelSet {


### PR DESCRIPTION
Also fix the Ready() method of target

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
- gcplog's `ready()` method always return (just like every other scrape target). Rationale is gcplog scraping shouldn't stop because of some some transient timeout errors.
- This transient failure can cause promtail readyness probe to fail which may prevent pod from starting.
- We have metrics now to track if scraping failed (`gcplog_target_last_success_scrape`).

**Which issue(s) this PR fixes**:
Fixes NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

