### PR TITLE
    Add missing `Inc()` to correctly increment the `dropStage.dropCount` metric on valid dropped log line; update related docs

### DIFF
--- a/clients/pkg/logentry/stages/drop.go
+++ b/clients/pkg/logentry/stages/drop.go
@@ -110,7 +110,7 @@ func (m *dropStage) Run(in chan Entry) chan Entry {
 				out <- e
 				continue
 			}
-			m.dropCount.WithLabelValues(*m.cfg.DropReason)
+			m.dropCount.WithLabelValues(*m.cfg.DropReason).Inc()
 		}
 	}()
 	return out

--- a/docs/sources/clients/promtail/stages/drop.md
+++ b/docs/sources/clients/promtail/stages/drop.md
@@ -137,7 +137,7 @@ However it would _not_ drop this log line:
 
 In this example the current time is 2020-08-12T12:00:00Z and `older_than` is 24h. All log lines which have a timestamp older than 2020-08-11T12:00:00Z will be dropped.
 
-All lines dropped by this drop stage would also increment the `logentry_drop_lines_total` metric with a label `reason="line_too_old"`
+All lines dropped by this drop stage would also increment the `logentry_dropped_lines_total` metric with a label `reason="line_too_old"`
 
 #### Dropping long log lines
 
@@ -151,7 +151,7 @@ Given the pipeline:
 
 Would drop any log line longer than 8kb bytes, this is useful when Loki would reject a line for being too long.
 
-All lines dropped by this drop stage would also increment the `logentry_drop_lines_total` metric with a label `reason="line_too_long"`
+All lines dropped by this drop stage would also increment the `logentry_dropped_lines_total` metric with a label `reason="line_too_long"`
 
 ### Complex drops
 

--- a/docs/sources/clients/promtail/stages/match.md
+++ b/docs/sources/clients/promtail/stages/match.md
@@ -104,7 +104,7 @@ label of `app` whose value is `pokey`. This does **not** match in our case, so
 the nested `json` stage is not ran.
 
 The fifth stage will drop any entries from the application `promtail` that matches
-the regex `.*noisy error`. and will also increment the `logentry_drop_lines_total` 
+the regex `.*noisy error`. and will also increment the `logentry_dropped_lines_total` 
 metric with a label `reason="promtail_noisy_error"`
 
 The final `output` stage changes the contents of the log line to be the value of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When dropping a log line we are not currently incrementing the associated `dropStage.dropCount` metric.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/loki/issues/4158

**Special notes for your reviewer**:
N/A

**Checklist**
- [✅] Documentation added
- [N/A] Tests updated

