### PR TITLE
Runtime config: do not validate nil limits

### DIFF
--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -24,6 +24,10 @@ type runtimeConfigValues struct {
 
 func (r runtimeConfigValues) validate() error {
 	for t, c := range r.TenantLimits {
+		if c == nil {
+			continue
+		}
+
 		if err := c.Validate(); err != nil {
 			return fmt.Errorf("invalid override for tenant %s: %w", t, err)
 		}

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/runtimeconfig"
 	"gopkg.in/yaml.v2"
@@ -25,6 +27,7 @@ type runtimeConfigValues struct {
 func (r runtimeConfigValues) validate() error {
 	for t, c := range r.TenantLimits {
 		if c == nil {
+			level.Warn(util_log.Logger).Log("msg", "skipping empty tenant limit definition", "tenant", t)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Fixes a panic which occurs when an overrides file has an entry defined for a tenant without any limits:

```yaml
overrides:
  "54321":
    max_query_series: 10000
  "12345":
```

`12345` in the example above will be unmarshaled to a `nil` value, and cause a panic.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

