### PR TITLE
Jsonnet: Update license path argument name

### DIFF
--- a/production/ksonnet/enterprise-logs/main.libsonnet
+++ b/production/ksonnet/enterprise-logs/main.libsonnet
@@ -76,7 +76,7 @@ loki {
   },
 
   admin_api_args:: self._config.commonArgs {
-    'bootstrap.license.path': '/etc/gel-license/license.jwt',
+    'license.path': '/etc/gel-license/license.jwt',
     target: 'admin-api',
   },
   admin_api_container::
@@ -110,7 +110,7 @@ loki {
     + util.withNonRootSecurityContext(uid=10001),
 
   gateway_args:: self._config.commonArgs {
-    'bootstrap.license.path': '/etc/gel-license/license.jwt',
+    'license.path': '/etc/gel-license/license.jwt',
     'gateway.proxy.admin-api.url': 'http://admin-api:%s' % $._config.http_listen_port,
     'gateway.proxy.compactor.url': 'http://compactor:%s' % $._config.http_listen_port,
     'gateway.proxy.distributor.url': 'dns:///distributor:9095',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The argument name for the license path has changed. It used to be `bootstrap.license.path` but has been updated to `license.path` (per the GEM documentation, wherein GEL likely inherits the same code). Without this change, the Jsonnet will deploy a GEL cluster that fails to find the license, causing the admin-api to fail to start and the gateway to also be unlicensed.

**Which issue(s) this PR fixes**:
Fixes #4258 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

