### PR TITLE
remove empty streams after wal replay

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -327,11 +327,7 @@ func (i *Ingester) removeFlushedChunks(instance *instance, stream *stream, mayRe
 	i.replayController.Sub(int64(subtracted))
 
 	if mayRemoveStream && len(stream.chunks) == 0 {
-		delete(instance.streamsByFP, stream.fp)
-		delete(instance.streams, stream.labelsString)
-		instance.index.Delete(stream.labels, stream.fp)
-		instance.streamsRemovedTotal.Inc()
-		memoryStreams.WithLabelValues(instance.instanceID).Dec()
+		instance.removeStream(stream)
 	}
 }
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -273,6 +273,15 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, lock bool, r
 	return stream, nil
 }
 
+// removeStream removes a stream from the instance. The streamsMtx must be held.
+func (i *instance) removeStream(s *stream) {
+	delete(i.streamsByFP, s.fp)
+	delete(i.streams, s.labelsString)
+	i.index.Delete(s.labels, s.fp)
+	i.streamsRemovedTotal.Inc()
+	memoryStreams.WithLabelValues(i.instanceID).Dec()
+}
+
 func (i *instance) getHashForLabels(ls labels.Labels) model.Fingerprint {
 	var fp uint64
 	fp, i.buf = ls.HashWithoutLabels(i.buf, []string(nil)...)


### PR DESCRIPTION
Refactors stream removal into it's own function and removes empty streams after WAL replay completes in order to not interfere with tenant stream limits during rollout.