### PR TITLE
Add count to 'loki_ingester_memory_chunks' when recovery from wal

### DIFF
--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -135,6 +135,7 @@ func (r *ingesterRecoverer) Series(series *Series) error {
 		if err != nil {
 			return err
 		}
+		memoryChunks.Add(float64(len(series.Chunks)))
 		r.ing.metrics.recoveredChunksTotal.Add(float64(len(series.Chunks)))
 		r.ing.metrics.recoveredEntriesTotal.Add(float64(entriesAdded))
 		r.ing.replayController.Add(int64(bytesAdded))

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -310,7 +310,10 @@ func (s *stream) Push(
 				}
 			}()
 		}
+	}
 
+	if len(s.chunks) != prevNumChunks {
+		memoryChunks.Add(float64(len(s.chunks) - prevNumChunks))
 	}
 
 	if len(failedEntriesWithError) > 0 {
@@ -345,9 +348,6 @@ func (s *stream) Push(
 		return bytesAdded, httpgrpc.Errorf(statusCode, buf.String())
 	}
 
-	if len(s.chunks) != prevNumChunks {
-		memoryChunks.Add(float64(len(s.chunks) - prevNumChunks))
-	}
 	return bytesAdded, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

"loki_ingester_memory_chunks" isn't incremented when WAL recovery is executed so I've fixed.

**Which issue(s) this PR fixes**:
Fixes #4004 
