### PR TITLE
Update example for /series endpoint in _index.md

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -842,7 +842,7 @@ In microservices mode, these endpoints are exposed by the querier.
 ### Examples
 
 ``` bash
-$ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match={container_name=~"prometheus.*", component="server"}' --data-urlencode 'match={app="loki"}' | jq '.'
+$ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match[]={container_name=~"prometheus.*", component="server"}' --data-urlencode 'match[]={app="loki"}' | jq '.'
 {
   "status": "success",
   "data": [


### PR DESCRIPTION
In [documentation](https://grafana.com/docs/loki/latest/api/#series), we say that the url param for `/series` endpoint should be `match[]`, but in example we use just `match`. Although `match` works as well, we should probably use the same param. 
![image](https://user-images.githubusercontent.com/30407135/132239960-c013d050-58df-44db-b817-124c87389db1.png)


