### PR TITLE
loki-mixin: use centralized configuration for dashboard matchers / selectors

### DIFF
--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -3,10 +3,25 @@
     // Tags for dashboards.
     tags: ['loki'],
 
+    singleBinary: false,
+
     // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',
 
     // The label used to differentiate between different nodes (i.e. servers).
     per_node_label: 'instance',
+
+    // These are used by the dashboards and allow for the simultaneous display of
+    // microservice and single binary loki clusters.
+    job_names: {
+      gateway: '(gateway|loki-gw|loki-gw-internal)',
+      query_frontend: '(query-frontend.*|loki$)',  // Match also custom query-frontend deployments.
+      querier: '(querier.*|loki$)',  // Match also custom querier deployments.
+      ingester: '(ingester.*|loki$)',  // Match also custom and per-zone ingester deployments.
+      distributor: '(distributor.*|loki$)',
+      index_gateway: '(index-gateway.*|querier.*|loki$)',
+      ruler: '(ruler|loki$)',
+      compactor: 'compactor.*',  // Match also custom compactor deployments.
+    },
   },
 }

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -47,15 +47,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
           d.addMultiTemplate('cluster', 'loki_build_info', 'cluster')
           .addMultiTemplate('namespace', 'loki_build_info', 'namespace')
         else
-          d.addTemplate('cluster', 'loki_build_info', 'cluster')
-          .addTemplate('namespace', 'loki_build_info', 'namespace'),
+          d.addTemplate('namespace', 'loki_build_info', 'namespace'),
     },
+
+  jobSelector(job)::
+    if $._config.singleBinary
+    then [utils.selector.noop('cluster'), utils.selector.re('job', '$job')]
+    else [utils.selector.re('cluster', '$cluster'), utils.selector.re('job', '($namespace)/%s' % job)],
 
   jobMatcher(job)::
     'cluster=~"$cluster", job=~"($namespace)/%s"' % job,
 
   namespaceMatcher()::
     'cluster=~"$cluster", namespace=~"$namespace"',
+
   logPanel(title, selector, datasource='$logs'):: {
     title: title,
     type: 'logs',
@@ -116,6 +121,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
       datasource: '$datasource',
     },
+
   containerCPUUsagePanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -14,7 +14,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('Frontend (cortex_gw)')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.gateway), http_routes])
+          $.qpsPanel('loki_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.gateway), http_routes])
         )
         .addPanel(
           $.panel('Latency') +
@@ -29,7 +29,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('Frontend (query-frontend)')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.query_frontend), http_routes])
+          $.qpsPanel('loki_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.query_frontend), http_routes])
         )
         .addPanel(
           $.panel('Latency') +
@@ -44,7 +44,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('Querier')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.querier), http_routes])
+          $.qpsPanel('loki_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.querier), http_routes])
         )
         .addPanel(
           $.panel('Latency') +
@@ -59,7 +59,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('Ingester')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.ingester), grpc_routes])
+          $.qpsPanel('loki_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.ingester), grpc_routes])
         )
         .addPanel(
           $.panel('Latency') +
@@ -74,7 +74,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('BigTable')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
+          $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
         )
         .addPanel(
           $.panel('Latency') +
@@ -88,11 +88,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.row('BoltDB Shipper')
         .addPanel(
           $.panel('QPS') +
-          $.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
+          $.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s, operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
         )
         .addPanel(
           $.panel('Latency') +
-          $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
+          $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s, operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
         )
       ),
   },

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -1,4 +1,3 @@
-local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
 {
@@ -8,187 +7,93 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local http_routes = 'loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values',
     local grpc_routes = '/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs',
 
-    'loki-reads.json': {
-      local cfg = self,
-
-      showMultiCluster:: true,
-      clusterLabel:: 'cluster',
-      clusterMatchers::
-        if cfg.showMultiCluster then
-          [utils.selector.re(cfg.clusterLabel, '$cluster')]
-        else
-          [],
-
-      namespaceType:: 'query',
-      namespaceQuery::
-        if cfg.showMultiCluster then
-          'kube_pod_container_info{cluster="$cluster", image=~".*loki.*"}'
-        else
-          'kube_pod_container_info{image=~".*loki.*"}',
-
-      assert (cfg.namespaceType == 'custom' || cfg.namespaceType == 'query') : "Only types 'query' and 'custom' are allowed for dashboard variable 'namespace'",
-
-      matchers:: {
-        cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw')],
-        queryFrontend: [utils.selector.re('job', '($namespace)/query-frontend')],
-        querier: [utils.selector.re('job', '($namespace)/querier')],
-        ingester: [utils.selector.re('job', '($namespace)/ingester')],
-        querierOrIndexGateway: [utils.selector.re('job', '($namespace)/(querier|index-gateway)')],
-      },
-
-      local selector(matcherId) =
-        local ms = (cfg.clusterMatchers + cfg.matchers[matcherId]);
-        if std.length(ms) > 0 then
-          std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
-        else '',
-
-      cortexGwSelector:: selector('cortexgateway'),
-      queryFrontendSelector:: selector('queryFrontend'),
-      querierSelector:: selector('querier'),
-      ingesterSelector:: selector('ingester'),
-      querierOrIndexGatewaySelector:: selector('querierOrIndexGateway'),
-
-      templateLabels:: (
-        if cfg.showMultiCluster then [
-          {
-            variable:: 'cluster',
-            label:: cfg.clusterLabel,
-            query:: 'kube_pod_container_info{image=~".*loki.*"}',
-            type:: 'query',
-          },
-        ] else []
-      ) + [
-        {
-          variable:: 'namespace',
-          label:: 'namespace',
-          query:: cfg.namespaceQuery,
-          type:: cfg.namespaceType,
-        },
-      ],
-    } +
-    g.dashboard('Loki / Reads')
-    .addRow(
-      g.row('Frontend (cortex_gw)')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].cortexGwSelector, http_routes])
-      )
-      .addPanel(
-        g.panel('Latency') +
-        utils.latencyRecordingRulePanel(
-          'loki_request_duration_seconds',
-          dashboards['loki-reads.json'].matchers.cortexgateway + [utils.selector.re('route', http_routes)],
-          extra_selectors=dashboards['loki-reads.json'].clusterMatchers,
-          sum_by=['route']
+    'loki-reads.json':
+      ($.dashboard('Loki / Reads'))
+      .addClusterSelectorTemplates()
+      .addRow(
+        $.row('Frontend (cortex_gw)')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.gateway), http_routes])
+        )
+        .addPanel(
+          $.panel('Latency') +
+          utils.latencyRecordingRulePanel(
+            'loki_request_duration_seconds',
+            $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', http_routes)],
+            sum_by=['route']
+          )
         )
       )
-    )
-    .addRow(
-      g.row('Frontend (query-frontend)')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].queryFrontendSelector, http_routes])
-      )
-      .addPanel(
-        g.panel('Latency') +
-        utils.latencyRecordingRulePanel(
-          'loki_request_duration_seconds',
-          dashboards['loki-reads.json'].matchers.queryFrontend + [utils.selector.re('route', http_routes)],
-          extra_selectors=dashboards['loki-reads.json'].clusterMatchers,
-          sum_by=['route']
+      .addRow(
+        $.row('Frontend (query-frontend)')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.query_frontend), http_routes])
+        )
+        .addPanel(
+          $.panel('Latency') +
+          utils.latencyRecordingRulePanel(
+            'loki_request_duration_seconds',
+            $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', http_routes)],
+            sum_by=['route']
+          )
         )
       )
-    )
-    .addRow(
-      g.row('Querier')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].querierSelector, http_routes])
-      )
-      .addPanel(
-        g.panel('Latency') +
-        utils.latencyRecordingRulePanel(
-          'loki_request_duration_seconds',
-          dashboards['loki-reads.json'].matchers.querier + [utils.selector.re('route', http_routes)],
-          extra_selectors=dashboards['loki-reads.json'].clusterMatchers,
-          sum_by=['route']
+      .addRow(
+        $.row('Querier')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.querier), http_routes])
+        )
+        .addPanel(
+          $.panel('Latency') +
+          utils.latencyRecordingRulePanel(
+            'loki_request_duration_seconds',
+            $.jobSelector($._config.job_names.querier) + [utils.selector.re('route', http_routes)],
+            sum_by=['route']
+          )
         )
       )
-    )
-    .addRow(
-      g.row('Ingester')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].ingesterSelector, grpc_routes])
-      )
-      .addPanel(
-        g.panel('Latency') +
-        utils.latencyRecordingRulePanel(
-          'loki_request_duration_seconds',
-          dashboards['loki-reads.json'].matchers.ingester + [utils.selector.re('route', grpc_routes)],
-          extra_selectors=dashboards['loki-reads.json'].clusterMatchers,
-          sum_by=['route']
+      .addRow(
+        $.row('Ingester')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [$.jobMatcher($._config.job_names.ingester), grpc_routes])
+        )
+        .addPanel(
+          $.panel('Latency') +
+          utils.latencyRecordingRulePanel(
+            'loki_request_duration_seconds',
+            $.jobSelector($._config.job_names.ingester) + [utils.selector.re('route', grpc_routes)],
+            sum_by=['route']
+          )
         )
       )
-    )
-    .addRow(
-      g.row('BigTable')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/ReadRows"}' % dashboards['loki-reads.json'].querierSelector)
-      )
-      .addPanel(
-        g.panel('Latency') +
-        utils.latencyRecordingRulePanel(
-          'cortex_bigtable_request_duration_seconds',
-          dashboards['loki-reads.json'].matchers.querier + [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/ReadRows')]
+      .addRow(
+        $.row('BigTable')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
+        )
+        .addPanel(
+          $.panel('Latency') +
+          utils.latencyRecordingRulePanel(
+            'cortex_bigtable_request_duration_seconds',
+            $.jobSelector($._config.job_names.querier) + [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/ReadRows')]
+          )
         )
       )
-    )
-    .addRow(
-      g.row('BoltDB Shipper')
-      .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
-      )
-      .addPanel(
-        g.panel('Latency') +
-        g.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
-      )
-    ){
-      templating+: {
-        list+: [
-          {
-            allValue: null,
-            current:
-              if l.type == 'custom' then {
-                text: l.query,
-                value: l.query,
-              } else {},
-            datasource: '$datasource',
-            hide: 0,
-            includeAll: false,
-            label: l.variable,
-            multi: false,
-            name: l.variable,
-            options: [],
-            query:
-              if l.type == 'query' then
-                'label_values(%s, %s)' % [l.query, l.label]
-              else
-                l.query,
-            refresh: 1,
-            regex: '',
-            sort: 2,
-            tagValuesQuery: '',
-            tags: [],
-            tagsQuery: '',
-            type: l.type,
-            useTags: false,
-          }
-          for l in dashboards['loki-reads.json'].templateLabels
-        ],
-      },
-    },
+      .addRow(
+        $.row('BoltDB Shipper')
+        .addPanel(
+          $.panel('QPS') +
+          $.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
+        )
+        .addPanel(
+          $.panel('Latency') +
+          $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="QUERY"}' % $.jobMatcher($._config.job_names.index_gateway))
+        )
+      ),
   },
 }

--- a/production/loki-mixin/jsonnetfile.lock.json
+++ b/production/loki-mixin/jsonnetfile.lock.json
@@ -8,7 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "master"
+      "version": "ff22d1d6698573e7cb76228198edfa2b2f632dcc",
+      "sum": "GRf2GvwEU4jhXV+JOonXSZ4wdDv8mnHBPCQ6TUVd+g8="
     },
     {
       "source": {
@@ -17,8 +18,9 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "master"
+      "version": "ff22d1d6698573e7cb76228198edfa2b2f632dcc",
+      "sum": "v6fuqqQp9rHZbsxN9o79QzOpUlwYZEJ84DxTCZMCYeU="
     }
   ],
-  "legacyImports": true
+  "legacyImports": false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The dashboards have some boilerplate configuration copied at the top of each dashboard that means overwritting a selector, label, or otherwise must be done for each dashboard individually (at least thats what it looks like with my limited jsonnet experience). The PR adds 'job_names' and uses some of the unused functions in `dashboard-utils.libsonnet` to centralize the configuration and make it feel like cortex-mixin / tempo-mixin.

This PR is very much a work-in-progress, but since this is such a large change I am looking for feedback to see if this is something y'all are interested in.

Dashboards updated:
- [ ] loki-logs.json
- [ ] loki-deletion.json
- [ ] loki-chunks.json
- [ ] loki-operational.json
- [ ] loki-reads-resources.json
- [X] loki-reads.json
- [ ] loki-retention.json
- [ ] loki-writes-resource.json
- [ ] loki-writes.json

