### PR TITLE
[WIP] promtail: Allow inspect messages to be correlated via id 

### DIFF
--- a/clients/pkg/logentry/stages/inspector.go
+++ b/clients/pkg/logentry/stages/inspector.go
@@ -63,7 +63,7 @@ func (i inspector) inspect(stageName string, before *Entry, after Entry) {
 		diff = i.formatter.red.Sprintf("none")
 	}
 
-	fmt.Fprintf(i.writer, "[inspect: %s stage]: %s\n", i.formatter.bold.Sprintf("%s", stageName), diff)
+	fmt.Fprintf(i.writer, "[%s inspect: %s stage]: %s\n", after.Id, i.formatter.bold.Sprintf("%s", stageName), diff)
 }
 
 // diffReporter is a simple custom reporter that only records differences

--- a/clients/pkg/logentry/stages/multiline.go
+++ b/clients/pkg/logentry/stages/multiline.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+	"encoding/hex"
+	"crypto/md5"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -219,6 +221,11 @@ func (m *multilineStage) flush(out chan Entry, s *multilineState) {
 			},
 		},
 	}
+
+	// Regenerate the id for the line
+	sum := md5.Sum([]byte(collapsed.Line))
+	collapsed.Id = hex.EncodeToString(sum[:])
+
 	s.buffer.Reset()
 	s.currentLines = 0
 

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -96,7 +96,7 @@ func (s stageProcessor) Run(in chan Entry) chan Entry {
 func toStage(p Processor) Stage {
 	return &stageProcessor{
 		Processor: p,
-		inspector: newInspector(os.Stderr, runtime.GOOS == "windows"),
+		inspector: newInspector(os.Stdout, runtime.GOOS == "windows"),
 	}
 }
 

--- a/clients/pkg/promtail/api/types.go
+++ b/clients/pkg/promtail/api/types.go
@@ -10,6 +10,7 @@ import (
 
 // Entry is a log entry with labels.
 type Entry struct {
+	Id string `json:"id"`
 	Labels model.LabelSet
 	logproto.Entry
 }

--- a/clients/pkg/promtail/client/logger.go
+++ b/clients/pkg/promtail/client/logger.go
@@ -76,6 +76,8 @@ func (l *logger) run() {
 	for e := range l.entries {
 		fmt.Fprint(l.Writer, blue.Sprint(e.Timestamp.Format("2006-01-02T15:04:05.999999999-0700")))
 		fmt.Fprint(l.Writer, "\t")
+		fmt.Fprint(l.Writer, e.Id + " ")
+		fmt.Fprint(l.Writer, "\t")
 		fmt.Fprint(l.Writer, yellow.Sprint(e.Labels.String()))
 		fmt.Fprint(l.Writer, "\t")
 		fmt.Fprint(l.Writer, e.Line)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Currently inspect output is interleaved between multiple tail instances and mixes inbetween stdout, this means debugging with dry-run is nearly impossible because the printed loglines cannot be correlated.

This adds, if enabled, a label InspectId to every log line. This label is printed before each inspect statement, and also printed by the --dry-run functionality. 

**Which issue(s) this PR fixes**:
Fixes #4280

**Special notes for your reviewer**:


**Checklist**
- [ ] Documentation added
- [ ] Tests updated

