### PR TITLE
docs: fix link to Promtail documentation

### DIFF
--- a/production/README.md
+++ b/production/README.md
@@ -8,7 +8,7 @@ Currently there are five ways to try out Loki, in order from easier to hardest:
 - [Build Loki from source](#build-and-run-from-source)
 - [Get inspired by our production setup](#get-inspired-by-our-production-setup)
 
-For the various ways to run `promtail`, the tailing agent, see our [Promtail documentation](../docs/clients/promtail/README.md).
+For the various ways to run `promtail`, the tailing agent, see our [Promtail documentation](https://grafana.com/docs/loki/latest/clients/promtail/installation/).
 
 ## Grafana Cloud: Hosted Logs
 

--- a/production/README.md
+++ b/production/README.md
@@ -8,7 +8,7 @@ Currently there are five ways to try out Loki, in order from easier to hardest:
 - [Build Loki from source](#build-and-run-from-source)
 - [Get inspired by our production setup](#get-inspired-by-our-production-setup)
 
-For the various ways to run `promtail`, the tailing agent, see our [Promtail documentation](https://grafana.com/docs/loki/latest/clients/promtail/installation/).
+For the various ways to run `promtail`, the tailing agent, see our [Promtail documentation](../docs/sources/clients/promtail/installation.md).
 
 ## Grafana Cloud: Hosted Logs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**: 

The current link to Promtail installation documentation in the file leads to 404 error. I observed that the `../docs/clients/` folder was refactored into `../docs/sources/clients` at same time in past. However, the `loki/docs/sources/clients/promtail/installation.md` file is not very convenient if we talk about UX. So, I've replaced the wrong link with the one to rendered beautiful documentation

