### PR TITLE
docs:  (logs-deletion.md) URL Encode curl command

### DIFF
--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -40,10 +40,10 @@ Query parameters:
 
 A 204 response indicates success.
 
-Sample form of a cURL command:
+URL encode the `match[]` parameter. This sample form of a cURL command URL encodes `match[]={foo="bar"}`:
 ```
 curl -X POST \
-  '<compactor_addr>/loki/api/admin/delete?match[]={foo="bar"}&start=1591616227&end=1591619692' \
+  '<compactor_addr>/loki/api/admin/delete?match%5B%5D=%7Bfoo=%22bar%22%7D&start=1591616227&end=1591619692' \
   -H 'x-scope-orgid: <tenant-id>'
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

What: Update the `cURL` command example to URL encode
the `match` query param

Why: The current `cURL` command throws this error:

```
$ curl -X POST \                                                                                                                                        
  'http://localhost:3100/loki/api/admin/delete?match[]={foo="bar"}&start=1591616227&end=1591619692' \                                                    
  -H 'x-scope-orgid: fake'
1:4: parse error: unexpected "="
```

**Checklist**
- [x] Documentation added
- [ ] Tests updated

