### PR TITLE
Correcting documentation example for `/api/prom/query`

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -640,7 +640,7 @@ See [statistics](#Statistics) for information about the statistics returned by L
 ### Examples
 
 ```bash
-$ curl -G -s  "http://localhost:3100/api/prom/query" --data-urlencode '{foo="bar"}' | jq
+$ curl -G -s  "http://localhost:3100/api/prom/query" --data-urlencode 'query={foo="bar"}' | jq
 {
   "streams": [
     {


### PR DESCRIPTION
The command: curl -G -s "http://localhost:3100/api/prom/query" --data-urlencode '{foo="bar"}' | jq
gives the message: parse error: Invalid numeric literal at line 1, column 6
Instead, the command: curl -G -s  "http://localhost:3100/api/prom/query" --data-urlencode 'query={foo="bar"}' | jq, works

<!--  Thanks for sending a pull request!  Before submitting:
1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

