### PR TITLE
Feature: allow querier and query frontend targets to run on same process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/ncw/swift v1.0.52
 	github.com/oklog/ulid v1.3.1
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
+	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
 	// github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pierrec/lz4/v4 v4.1.7

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/fluent/fluent-bit-go v0.0.0-20190925192703-ea13c021720c
 	github.com/fsouza/fake-gcs-server v1.7.0
 	github.com/go-kit/kit v0.11.0
+	github.com/go-kit/log v0.1.0
 	github.com/go-logfmt/logfmt v0.5.0
 	github.com/go-redis/redis/v8 v8.9.0
 	github.com/gocql/gocql v0.0.0-20200526081602-cd04bd7f22a7

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -411,7 +411,7 @@ func (t *Loki) setupModuleManager() error {
 		Compactor:                {Server, Overrides},
 		IndexGateway:             {Server},
 		IngesterQuerier:          {Ring},
-		All:                      {Querier, Ingester, Distributor, TableManager, Ruler},
+		All:                      {QueryFrontend, Querier, Ingester, Distributor, TableManager, Ruler},
 	}
 
 	// Add IngesterQuerier as a dependency for store when target is either ingester or querier.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -215,13 +215,13 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		"/api/prom/tail":                http.HandlerFunc(t.Querier.TailHandler),
 		"/api/prom/series":              http.HandlerFunc(t.Querier.SeriesHandler),
 	}
-	return querier.InitQuerierWorkerService(
+	return querier.InitWorkerService(
 		querierWorkerServiceConfig, queryHandlers, t.Server.HTTP, t.Server.HTTPServer.Handler, t.HTTPAuthMiddleware,
 	)
 }
 
-func generateQuerierServiceConfig(t *Loki) querier.QuerierWorkerServiceConfig {
-	return querier.QuerierWorkerServiceConfig{
+func generateQuerierServiceConfig(t *Loki) querier.WorkerServiceConfig {
+	return querier.WorkerServiceConfig{
 		AllEnabled:            t.Cfg.isModuleEnabled(All),
 		GrpcListenPort:        t.Cfg.Server.GRPCListenPort,
 		QuerierMaxConcurrent:  t.Cfg.Querier.MaxConcurrent,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -198,7 +198,14 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		return nil, err
 	}
 
-	querierWorkerServiceConfig := generateQuerierServiceConfig(t)
+	querierWorkerServiceConfig := querier.WorkerServiceConfig{
+		AllEnabled:            t.Cfg.isModuleEnabled(All),
+		GrpcListenPort:        t.Cfg.Server.GRPCListenPort,
+		QuerierMaxConcurrent:  t.Cfg.Querier.MaxConcurrent,
+		QuerierWorkerConfig:   &t.Cfg.Worker,
+		QueryFrontendEnabled:  t.Cfg.isModuleEnabled(QueryFrontend),
+		QuerySchedulerEnabled: t.Cfg.isModuleEnabled(QueryScheduler),
+	}
 
 	var queryHandlers = map[string]http.Handler{
 		"/loki/api/v1/query_range":         http.HandlerFunc(t.Querier.RangeQueryHandler),

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -227,17 +227,6 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	)
 }
 
-func generateQuerierServiceConfig(t *Loki) querier.WorkerServiceConfig {
-	return querier.WorkerServiceConfig{
-		AllEnabled:            t.Cfg.isModuleEnabled(All),
-		GrpcListenPort:        t.Cfg.Server.GRPCListenPort,
-		QuerierMaxConcurrent:  t.Cfg.Querier.MaxConcurrent,
-		QuerierWorkerConfig:   &t.Cfg.Worker,
-		QueryFrontendEnabled:  t.Cfg.isModuleEnabled(QueryFrontend),
-		QuerySchedulerEnabled: t.Cfg.isModuleEnabled(QueryScheduler),
-	}
-}
-
 func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.runtimeConfig)
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -6,9 +6,9 @@ import (
 
 	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/grafana/dskit/services"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/services"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,7 +18,7 @@ import (
 	serverutil "github.com/grafana/loki/pkg/util/server"
 )
 
-type QuerierWorkerServiceConfig struct {
+type WorkerServiceConfig struct {
 	AllEnabled            bool
 	GrpcListenPort        int
 	QuerierMaxConcurrent  int
@@ -27,9 +27,9 @@ type QuerierWorkerServiceConfig struct {
 	QuerySchedulerEnabled bool
 }
 
-// InitQuerierWorkerService takes a config object, a map of routes to handlers, an external http router and external
-// http handler, and an auth middleware wrapper. This function creates an internal HTTP router that responds to all 
-// the provided query routes/handlers. This router can either be registered with the external Loki HTTP server, or 
+// InitWorkerService takes a config object, a map of routes to handlers, an external http router and external
+// http handler, and an auth middleware wrapper. This function creates an internal HTTP router that responds to all
+// the provided query routes/handlers. This router can either be registered with the external Loki HTTP server, or
 // be used internally by a querier worker so that it does not conflict with the routes registered by the Query Frontend module.
 //
 // 1. Query-Frontend Enabled: If Loki has an All or QueryFrontend target, the internal
@@ -40,8 +40,8 @@ type QuerierWorkerServiceConfig struct {
 //    HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
 //    as a http.Handler to the frontend worker.
 //
-func InitQuerierWorkerService(
-	cfg QuerierWorkerServiceConfig,
+func InitWorkerService(
+	cfg WorkerServiceConfig,
 	queryRoutesToHandlers map[string]http.Handler,
 	externalRouter *mux.Router,
 	externalHandler http.Handler,
@@ -61,7 +61,7 @@ func InitQuerierWorkerService(
 		// First, register the internal querier handler with the external HTTP server
 		routes := make([]string, len(queryRoutesToHandlers))
 		var idx = 0
-		for route, _ := range queryRoutesToHandlers {
+		for route := range queryRoutesToHandlers {
 			routes[idx] = route
 			idx++
 		}
@@ -105,7 +105,7 @@ func InitQuerierWorkerService(
 	httpMiddleware := middleware.Merge(
 		authMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
-  )
+	)
 
 	internalHandler = httpMiddleware.Wrap(internalHandler)
 
@@ -131,6 +131,6 @@ func registerRoutesExternally(routes []string, externalRouter *mux.Router, inter
 	}
 }
 
-func querierRunningStandalone(cfg QuerierWorkerServiceConfig) bool {
+func querierRunningStandalone(cfg WorkerServiceConfig) bool {
 	return !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
 }

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -58,6 +58,7 @@ func InitWorkerService(
 	// external Loki Server HTTP handler to the frontend worker to ensure requests it processes use the default
 	// middleware instrumentation.
 	if querierRunningStandalone(cfg) {
+
 		// First, register the internal querier handler with the external HTTP server
 		routes := make([]string, len(queryRoutesToHandlers))
 		var idx = 0
@@ -132,5 +133,14 @@ func registerRoutesExternally(routes []string, externalRouter *mux.Router, inter
 }
 
 func querierRunningStandalone(cfg WorkerServiceConfig) bool {
-	return !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
+	runningStandalone := !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
+	level.Debug(util_log.Logger).Log(
+		"msg", "determing if querier is running as standalone target",
+		"runningStandalone", runningStandalone,
+		"queryFrontendEnabled", cfg.QueryFrontendEnabled,
+		"queryScheduleEnabled", cfg.QuerySchedulerEnabled,
+		"allEnabled", cfg.AllEnabled,
+	)
+
+	return runningStandalone
 }

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -1,0 +1,136 @@
+package querier
+
+import (
+	"fmt"
+	"net/http"
+
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/grafana/dskit/services"
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
+	"github.com/weaveworks/common/middleware"
+
+	serverutil "github.com/grafana/loki/pkg/util/server"
+)
+
+type QuerierWorkerServiceConfig struct {
+	AllEnabled            bool
+	GrpcListenPort        int
+	QuerierMaxConcurrent  int
+	QuerierWorkerConfig   *querier_worker.Config
+	QueryFrontendEnabled  bool
+	QuerySchedulerEnabled bool
+}
+
+// InitQuerierWorkerService takes a config object, a map of routes to handlers, an external http router and external
+// http handler, and an auth middleware wrapper. This function creates an internal HTTP router that responds to all 
+// the provided query routes/handlers. This router can either be registered with the external Loki HTTP server, or 
+// be used internally by a querier worker so that it does not conflict with the routes registered by the Query Frontend module.
+//
+// 1. Query-Frontend Enabled: If Loki has an All or QueryFrontend target, the internal
+//    HTTP router is wrapped with Tenant ID parsing middleware and passed to the frontend
+//    worker.
+//
+// 2. Querier Standalone: The querier will register the internal HTTP router with the external
+//    HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
+//    as a http.Handler to the frontend worker.
+//
+func InitQuerierWorkerService(
+	cfg QuerierWorkerServiceConfig,
+	queryRoutesToHandlers map[string]http.Handler,
+	externalRouter *mux.Router,
+	externalHandler http.Handler,
+	authMiddleware middleware.Interface,
+) (serve services.Service, err error) {
+
+	internalRouter := mux.NewRouter()
+	for route, handler := range queryRoutesToHandlers {
+		internalRouter.Handle(route, handler)
+	}
+
+	// If the querier is running standalone without the query-frontend or query-scheduler, we must register the internal
+	// HTTP handler externally (as it's the only handler that needs to register on querier routes) and provide the
+	// external Loki Server HTTP handler to the frontend worker to ensure requests it processes use the default
+	// middleware instrumentation.
+	if querierRunningStandalone(cfg) {
+		// First, register the internal querier handler with the external HTTP server
+		routes := make([]string, len(queryRoutesToHandlers))
+		var idx = 0
+		for route, _ := range queryRoutesToHandlers {
+			routes[idx] = route
+			idx++
+		}
+
+		registerRoutesExternally(routes, externalRouter, internalRouter, authMiddleware)
+
+		//If no frontend or scheduler address has been configured, then there is no place for the
+		//querier worker to request work from, so no need to start a worker service
+		if (*cfg.QuerierWorkerConfig).FrontendAddress == "" && (*cfg.QuerierWorkerConfig).SchedulerAddress == "" {
+			return nil, nil
+		}
+
+		// If a frontend or scheduler address has been configured, return a querier worker service that uses
+		// the external Loki Server HTTP server, which has now has the internal handler's routes registered with it
+		return querier_worker.NewQuerierWorker(
+			*(cfg.QuerierWorkerConfig), httpgrpc_server.NewServer(externalHandler), util_log.Logger, prometheus.DefaultRegisterer)
+	}
+
+	// Since we must be running a querier with either a frontend and/or scheduler at this point, if no frontend or scheduler address
+	// is configured, Loki will default to using the frontend on localhost on it's own GRPC listening port.
+	if (*cfg.QuerierWorkerConfig).FrontendAddress == "" && (*cfg.QuerierWorkerConfig).SchedulerAddress == "" {
+		address := fmt.Sprintf("127.0.0.1:%d", cfg.GrpcListenPort)
+		level.Warn(util_log.Logger).Log(
+			"msg", "Worker address is empty, attempting automatic worker configuration.  If queries are unresponsive consider configuring the worker explicitly.",
+			"address", address)
+		cfg.QuerierWorkerConfig.FrontendAddress = address
+	}
+
+	// Add a middleware to extract the trace context and add a header.
+	var internalHandler http.Handler
+	internalHandler = nethttp.MiddlewareFunc(
+		opentracing.GlobalTracer(),
+		internalRouter.ServeHTTP,
+		nethttp.OperationNameFunc(func(r *http.Request) string {
+			return "internalQuerier"
+		}))
+
+	// If queries are processed using the external HTTP Server, we need wrap the internal querier with
+	// HTTP router with middleware to parse the tenant ID from the HTTP header and inject it into the
+	// request context, as well as make sure any x-www-url-formencoded params are correctly parsed
+	httpMiddleware := middleware.Merge(
+		authMiddleware,
+		serverutil.NewPrepopulateMiddleware(),
+  )
+
+	internalHandler = httpMiddleware.Wrap(internalHandler)
+
+	//Querier worker's max concurrent requests must be the same as the querier setting
+	(*cfg.QuerierWorkerConfig).MaxConcurrentRequests = cfg.QuerierMaxConcurrent
+
+	//Return a querier worker pointed to the internal querier HTTP handler so there is not a conflict in routes between the querier
+	//and the query frontend
+	return querier_worker.NewQuerierWorker(
+		*(cfg.QuerierWorkerConfig), httpgrpc_server.NewServer(internalHandler), util_log.Logger, prometheus.DefaultRegisterer)
+}
+
+func registerRoutesExternally(routes []string, externalRouter *mux.Router, internalHandler http.Handler, authMiddleware middleware.Interface) {
+	httpMiddleware := middleware.Merge(
+		serverutil.RecoveryHTTPMiddleware,
+		authMiddleware,
+		serverutil.NewPrepopulateMiddleware(),
+		serverutil.ResponseJSONMiddleware(),
+	)
+
+	for _, route := range routes {
+		externalRouter.Handle(route, httpMiddleware.Wrap(internalHandler))
+	}
+}
+
+func querierRunningStandalone(cfg QuerierWorkerServiceConfig) bool {
+	return !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
+}

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -135,7 +135,7 @@ func registerRoutesExternally(routes []string, externalRouter *mux.Router, inter
 func querierRunningStandalone(cfg WorkerServiceConfig) bool {
 	runningStandalone := !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
 	level.Debug(util_log.Logger).Log(
-		"msg", "determing if querier is running as standalone target",
+		"msg", "determining if querier is running as standalone target",
 		"runningStandalone", runningStandalone,
 		"queryFrontendEnabled", cfg.QueryFrontendEnabled,
 		"queryScheduleEnabled", cfg.QuerySchedulerEnabled,

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -1,0 +1,217 @@
+package querier
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
+	"github.com/grafana/dskit/services"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/middleware"
+)
+
+func Test_InitQuerierService(t *testing.T) {
+	requestedAuthenticated := false
+	noopWrapper := middleware.Func(func(next http.Handler) http.Handler {
+		requestedAuthenticated = true
+		return next
+	})
+
+	var mockQueryHandlers = map[string]http.Handler{
+		"/loki/api/v1/query": http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.Write([]byte("test handler"))
+		}),
+	}
+
+	testContext := func(config QuerierWorkerServiceConfig) (*mux.Router, services.Service) {
+		requestedAuthenticated = false
+		externalRouter := mux.NewRouter()
+		querierWorkerService, err := InitQuerierWorkerService(config, mockQueryHandlers, externalRouter, http.HandlerFunc(externalRouter.ServeHTTP), noopWrapper)
+		require.NoError(t, err)
+
+		return externalRouter, querierWorkerService
+	}
+
+	t.Run("when querier is configured to run standalone, without a query frontend", func(t *testing.T) {
+		t.Run("register the internal query handlers externally", func(t *testing.T) {
+			config := QuerierWorkerServiceConfig{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &querier_worker.Config{},
+			}
+
+			externalRouter, _ := testContext(config)
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/loki/api/v1/query", nil)
+			externalRouter.ServeHTTP(recorder, request)
+			assert.Equal(t, 200, recorder.Code)
+			assert.Equal(t, "test handler", recorder.Body.String())
+		})
+
+		t.Run("wrap external handler with auth middleware", func(t *testing.T) {
+			config := QuerierWorkerServiceConfig{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &querier_worker.Config{},
+			}
+
+			externalRouter, _ := testContext(config)
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/loki/api/v1/query", nil)
+			externalRouter.ServeHTTP(recorder, request)
+			assert.True(t, requestedAuthenticated)
+		})
+
+		t.Run("wrap external handler with response json middleware", func(t *testing.T) {
+			config := QuerierWorkerServiceConfig{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &querier_worker.Config{},
+			}
+
+			externalRouter, _ := testContext(config)
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/loki/api/v1/query", nil)
+			externalRouter.ServeHTTP(recorder, request)
+
+      contentTypeHeader := recorder.Header().Get("Content-Type")
+      assert.Equal(t, "application/json; charset=UTF-8", contentTypeHeader)
+		})
+
+		t.Run("do not create a querier worker service if neither frontend address nor scheduler address has been configured", func(t *testing.T) {
+			config := QuerierWorkerServiceConfig{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &querier_worker.Config{},
+			}
+
+			_, workerService := testContext(config)
+			assert.Nil(t, workerService)
+		})
+
+		t.Run("return a querier worker service if frontend or scheduler address has been configured", func(t *testing.T) {
+			withFrontendConfig := QuerierWorkerServiceConfig{
+				QuerierWorkerConfig: &querier_worker.Config{
+					FrontendAddress: "http://example.com",
+				},
+			}
+			withSchedulerConfig := QuerierWorkerServiceConfig{
+				QuerierWorkerConfig: &querier_worker.Config{
+					SchedulerAddress: "http://example.com",
+				},
+			}
+
+			for _, config := range []QuerierWorkerServiceConfig{
+				withFrontendConfig,
+				withSchedulerConfig,
+			} {
+				_, workerService := testContext(config)
+				assert.NotNil(t, workerService)
+			}
+		})
+	})
+
+	t.Run("when query frontend, scheduler, or all target is enabled", func(t *testing.T) {
+		defaultWorkerConfig := querier_worker.Config{}
+		nonStandaloneTargetPermutations := []QuerierWorkerServiceConfig{
+			{
+				QueryFrontendEnabled:  true,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: true,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            true,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  true,
+				QuerySchedulerEnabled: true,
+				AllEnabled:            false,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  true,
+				QuerySchedulerEnabled: false,
+				AllEnabled:            true,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  false,
+				QuerySchedulerEnabled: true,
+				AllEnabled:            true,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+			{
+				QueryFrontendEnabled:  true,
+				QuerySchedulerEnabled: true,
+				AllEnabled:            true,
+				QuerierWorkerConfig:   &defaultWorkerConfig,
+			},
+		}
+
+		t.Run("do not register the internal query handler externally", func(t *testing.T) {
+			for _, config := range nonStandaloneTargetPermutations {
+				externalRouter, _ := testContext(config)
+				recorder := httptest.NewRecorder()
+				request := httptest.NewRequest("GET", "/loki/api/v1/query", nil)
+				externalRouter.ServeHTTP(recorder, request)
+				assert.Equal(t, 404, recorder.Code)
+			}
+		})
+
+		t.Run("use localhost as the worker address if none is set", func(t *testing.T) {
+			for _, config := range nonStandaloneTargetPermutations {
+				workerConfig := querier_worker.Config{}
+				config.QuerierWorkerConfig = &workerConfig
+				config.GrpcListenPort = 1234
+
+				testContext(config)
+
+				assert.Equal(t, "127.0.0.1:1234", workerConfig.FrontendAddress)
+			}
+		})
+
+		t.Run("set the worker's max concurrent request to the same as the max concurrent setting for the querier", func(t *testing.T) {
+			for _, config := range nonStandaloneTargetPermutations {
+				workerConfig := querier_worker.Config{}
+				config.QuerierWorkerConfig = &workerConfig
+				config.QuerierMaxConcurrent = 42
+
+				testContext(config)
+
+				assert.Equal(t, 42, workerConfig.MaxConcurrentRequests)
+			}
+		})
+
+		t.Run("always return a query worker service", func(t *testing.T) {
+			for _, config := range nonStandaloneTargetPermutations {
+				workerConfig := querier_worker.Config{}
+				config.QuerierWorkerConfig = &workerConfig
+				config.GrpcListenPort = 1234
+
+				_, querierWorkerService := testContext(config)
+
+				assert.NotNil(t, querierWorkerService)
+			}
+		})
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -765,6 +765,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 ## explicit
 github.com/opentracing-contrib/go-grpc
 # github.com/opentracing-contrib/go-stdlib v1.0.0
+## explicit
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.2.0
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -417,6 +417,7 @@ github.com/fsouza/fake-gcs-server/internal/backend
 github.com/go-kit/kit/log
 github.com/go-kit/kit/log/level
 # github.com/go-kit/log v0.1.0
+## explicit
 github.com/go-kit/log
 github.com/go-kit/log/level
 # github.com/go-logfmt/logfmt v0.5.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR allows both the Query and QueryFrontend targets to be enabled in the same loki process, as well as adding QueryFrontend to the "all" target. It follows a similar pattern as was done in cortex, where a query worker service is enabled with an internal router to handle query endpoints. Those endpoints are either a) exposed externally if the querier is running standalone, b) used internally by the query worker if the querier is running alongside the query frontend (since the query fronted will register those same routes externally).

**Which issue(s) this PR fixes**:
Fixes #4218 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

