### PR TITLE
Fixes a bug in the block cache code.

### DIFF
--- a/pkg/iter/cache_test.go
+++ b/pkg/iter/cache_test.go
@@ -31,7 +31,7 @@ func Test_CachedIterator(t *testing.T) {
 		require.Equal(t, true, c.Next())
 		require.Equal(t, stream.Entries[2], c.Entry())
 		require.Equal(t, false, c.Next())
-		require.Equal(t, nil, c.Error())
+		require.NoError(t, c.Error())
 		require.Equal(t, stream.Entries[2], c.Entry())
 		require.Equal(t, false, c.Next())
 	}
@@ -95,7 +95,7 @@ func Test_CachedIteratorResetNotExhausted(t *testing.T) {
 	require.Equal(t, true, c.Next())
 	require.Equal(t, stream.Entries[2], c.Entry())
 	require.Equal(t, false, c.Next())
-	require.Equal(t, nil, c.Error())
+	require.NoError(t, c.Error())
 	require.Equal(t, stream.Entries[2], c.Entry())
 	require.Equal(t, false, c.Next())
 
@@ -149,7 +149,7 @@ func Test_CachedSampleIterator(t *testing.T) {
 		require.Equal(t, true, c.Next())
 		require.Equal(t, series.Samples[2], c.Sample())
 		require.Equal(t, false, c.Next())
-		require.Equal(t, nil, c.Error())
+		require.NoError(t, c.Error())
 		require.Equal(t, series.Samples[2], c.Sample())
 		require.Equal(t, false, c.Next())
 	}
@@ -185,7 +185,7 @@ func Test_CachedSampleIteratorResetNotExhausted(t *testing.T) {
 	require.Equal(t, true, c.Next())
 	require.Equal(t, series.Samples[2], c.Sample())
 	require.Equal(t, false, c.Next())
-	require.Equal(t, nil, c.Error())
+	require.NoError(t, c.Error())
 	require.Equal(t, series.Samples[2], c.Sample())
 	require.Equal(t, false, c.Next())
 

--- a/pkg/iter/cache_test.go
+++ b/pkg/iter/cache_test.go
@@ -45,7 +45,6 @@ func Test_CachedIterator(t *testing.T) {
 }
 
 func Test_EmptyCachedIterator(t *testing.T) {
-
 	c := NewCachedIterator(NoopIterator, 0)
 
 	require.Equal(t, "", c.Labels())
@@ -61,11 +60,9 @@ func Test_EmptyCachedIterator(t *testing.T) {
 	require.Equal(t, false, c.Next())
 	require.Equal(t, "", c.Labels())
 	require.Equal(t, logproto.Entry{}, c.Entry())
-
 }
 
 func Test_ErrorCachedIterator(t *testing.T) {
-
 	c := NewCachedIterator(&errorIter{}, 0)
 
 	require.Equal(t, false, c.Next())
@@ -73,6 +70,62 @@ func Test_ErrorCachedIterator(t *testing.T) {
 	require.Equal(t, logproto.Entry{}, c.Entry())
 	require.Equal(t, errors.New("error"), c.Error())
 	require.Equal(t, errors.New("close"), c.Close())
+}
+
+func Test_CachedIteratorResetNotExhausted(t *testing.T) {
+	stream := logproto.Stream{
+		Labels: `{foo="bar"}`,
+		Entries: []logproto.Entry{
+			{Timestamp: time.Unix(0, 1), Line: "1"},
+			{Timestamp: time.Unix(0, 2), Line: "2"},
+			{Timestamp: time.Unix(0, 3), Line: "3"},
+		},
+	}
+	c := NewCachedIterator(NewStreamIterator(stream), 3)
+
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[0], c.Entry())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[1], c.Entry())
+	c.Reset()
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[0], c.Entry())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[1], c.Entry())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[2], c.Entry())
+	require.Equal(t, false, c.Next())
+	require.Equal(t, nil, c.Error())
+	require.Equal(t, stream.Entries[2], c.Entry())
+	require.Equal(t, false, c.Next())
+
+	// Close the iterator reset it to the beginning.
+	require.Equal(t, nil, c.Close())
+}
+
+func Test_CachedIteratorResetExhausted(t *testing.T) {
+	stream := logproto.Stream{
+		Labels: `{foo="bar"}`,
+		Entries: []logproto.Entry{
+			{Timestamp: time.Unix(0, 1), Line: "1"},
+			{Timestamp: time.Unix(0, 2), Line: "2"},
+		},
+	}
+	c := NewCachedIterator(NewStreamIterator(stream), 3)
+
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[0], c.Entry())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[1], c.Entry())
+	c.Reset()
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[0], c.Entry())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, stream.Entries[1], c.Entry())
+	require.Equal(t, false, c.Next())
+
+	// Close the iterator reset it to the beginning.
+	require.Equal(t, nil, c.Close())
 }
 
 func Test_CachedSampleIterator(t *testing.T) {
@@ -109,8 +162,63 @@ func Test_CachedSampleIterator(t *testing.T) {
 	assert()
 }
 
-func Test_EmptyCachedSampleIterator(t *testing.T) {
+func Test_CachedSampleIteratorResetNotExhausted(t *testing.T) {
+	series := logproto.Series{
+		Labels: `{foo="bar"}`,
+		Samples: []logproto.Sample{
+			{Timestamp: time.Unix(0, 1).UnixNano(), Hash: 1, Value: 1.},
+			{Timestamp: time.Unix(0, 2).UnixNano(), Hash: 2, Value: 2.},
+			{Timestamp: time.Unix(0, 3).UnixNano(), Hash: 3, Value: 3.},
+		},
+	}
+	c := NewCachedSampleIterator(NewSeriesIterator(series), 3)
 
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[0], c.Sample())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[1], c.Sample())
+	c.Reset()
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[0], c.Sample())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[1], c.Sample())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[2], c.Sample())
+	require.Equal(t, false, c.Next())
+	require.Equal(t, nil, c.Error())
+	require.Equal(t, series.Samples[2], c.Sample())
+	require.Equal(t, false, c.Next())
+
+	// Close the iterator reset it to the beginning.
+	require.Equal(t, nil, c.Close())
+}
+
+func Test_CachedSampleIteratorResetExhausted(t *testing.T) {
+	series := logproto.Series{
+		Labels: `{foo="bar"}`,
+		Samples: []logproto.Sample{
+			{Timestamp: time.Unix(0, 1).UnixNano(), Hash: 1, Value: 1.},
+			{Timestamp: time.Unix(0, 2).UnixNano(), Hash: 2, Value: 2.},
+		},
+	}
+	c := NewCachedSampleIterator(NewSeriesIterator(series), 3)
+
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[0], c.Sample())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[1], c.Sample())
+	c.Reset()
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[0], c.Sample())
+	require.Equal(t, true, c.Next())
+	require.Equal(t, series.Samples[1], c.Sample())
+	require.Equal(t, false, c.Next())
+
+	// Close the iterator reset it to the beginning.
+	require.Equal(t, nil, c.Close())
+}
+
+func Test_EmptyCachedSampleIterator(t *testing.T) {
 	c := NewCachedSampleIterator(NoopIterator, 0)
 
 	require.Equal(t, "", c.Labels())
@@ -126,11 +234,9 @@ func Test_EmptyCachedSampleIterator(t *testing.T) {
 	require.Equal(t, false, c.Next())
 	require.Equal(t, "", c.Labels())
 	require.Equal(t, logproto.Sample{}, c.Sample())
-
 }
 
 func Test_ErrorCachedSampleIterator(t *testing.T) {
-
 	c := NewCachedSampleIterator(&errorIter{}, 0)
 
 	require.Equal(t, false, c.Next())

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -71,7 +71,7 @@ func (c *LazyChunk) Iterator(
 		if nextChunk != nil {
 			if cache, ok := c.overlappingBlocks[b.Offset()]; ok {
 				delete(c.overlappingBlocks, b.Offset())
-				if err := cache.Base().Close(); err != nil {
+				if err := cache.Wrapped().Close(); err != nil {
 					level.Warn(util_log.Logger).Log(
 						"msg", "failed to close cache block iterator",
 						"err", err,
@@ -152,7 +152,7 @@ func (c *LazyChunk) SampleIterator(
 		if nextChunk != nil {
 			if cache, ok := c.overlappingSampleBlocks[b.Offset()]; ok {
 				delete(c.overlappingSampleBlocks, b.Offset())
-				if err := cache.Base().Close(); err != nil {
+				if err := cache.Wrapped().Close(); err != nil {
 					level.Warn(util_log.Logger).Log(
 						"msg", "failed to close cache block sample iterator",
 						"err", err,

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -67,7 +67,10 @@ func (c *LazyChunk) Iterator(
 			continue
 		}
 		if nextChunk != nil {
-			delete(c.overlappingBlocks, b.Offset())
+			if cache, ok := c.overlappingBlocks[b.Offset()]; ok {
+				delete(c.overlappingBlocks, b.Offset())
+				cache.Base().Close()
+			}
 		}
 		// non-overlapping block with the next chunk are not cached.
 		its = append(its, b.Iterator(ctx, pipeline))
@@ -140,7 +143,10 @@ func (c *LazyChunk) SampleIterator(
 			continue
 		}
 		if nextChunk != nil {
-			delete(c.overlappingSampleBlocks, b.Offset())
+			if cache, ok := c.overlappingSampleBlocks[b.Offset()]; ok {
+				delete(c.overlappingSampleBlocks, b.Offset())
+				cache.Base().Close()
+			}
 		}
 		// non-overlapping block with the next chunk are not cached.
 		its = append(its, b.SampleIterator(ctx, extractor))

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/storage/chunk"
 
 	"github.com/grafana/loki/pkg/chunkenc"
@@ -69,7 +71,12 @@ func (c *LazyChunk) Iterator(
 		if nextChunk != nil {
 			if cache, ok := c.overlappingBlocks[b.Offset()]; ok {
 				delete(c.overlappingBlocks, b.Offset())
-				cache.Base().Close()
+				if err := cache.Base().Close(); err != nil {
+					level.Warn(util_log.Logger).Log(
+						"msg", "failed to close cache block iterator",
+						"err", err,
+					)
+				}
 			}
 		}
 		// non-overlapping block with the next chunk are not cached.
@@ -145,7 +152,12 @@ func (c *LazyChunk) SampleIterator(
 		if nextChunk != nil {
 			if cache, ok := c.overlappingSampleBlocks[b.Offset()]; ok {
 				delete(c.overlappingSampleBlocks, b.Offset())
-				cache.Base().Close()
+				if err := cache.Base().Close(); err != nil {
+					level.Warn(util_log.Logger).Log(
+						"msg", "failed to close cache block sample iterator",
+						"err", err,
+					)
+				}
 			}
 		}
 		// non-overlapping block with the next chunk are not cached.

--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -7,12 +7,12 @@ import (
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/storage/chunk"
 
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
+	"github.com/grafana/loki/pkg/storage/chunk"
 )
 
 // LazyChunk loads the chunk when it is accessed.


### PR DESCRIPTION
Because chunks can overlap and that can causes multiple processing of the same chunk within batches, we decided to cache the
evaluation of it.

However there was a bug here causing incorrect query result, specially for metric queries. The bug would occur when we would only partially consume a block (overlapping block between multiple batches) and then try to replay it. 
In which case it wouldn't actually replay it but keep consuming the underlaying iterator.

I guess I assumed that blocks would only be fully consumed, but that's not correct for metric queries (forward). I added new tests that were failing with the previous code to ensure we're good now.

This took us 2 days to figure out, thank @dannykopping  for helping along.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


