### PR TITLE
Allow to run local boltdb queries with logcli.

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/loki/pkg/loki"
 	"github.com/grafana/loki/pkg/storage"
 	chunk_storage "github.com/grafana/loki/pkg/storage/chunk/storage"
+	"github.com/grafana/loki/pkg/storage/stores/shipper"
 	"github.com/grafana/loki/pkg/util/cfg"
 	"github.com/grafana/loki/pkg/util/marshal"
 	"github.com/grafana/loki/pkg/validation"
@@ -188,7 +189,8 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 	if err != nil {
 		return err
 	}
-
+	storage.RegisterCustomIndexClients(&conf.StorageConfig, prometheus.DefaultRegisterer)
+	conf.StorageConfig.BoltDBShipperConfig.Mode = shipper.ModeReadOnly
 	chunkStore, err := chunk_storage.NewStore(conf.StorageConfig.Config, conf.ChunkStoreConfig.StoreConfig, conf.SchemaConfig.SchemaConfig, limits, prometheus.DefaultRegisterer, nil, util_log.Logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
Debugging local queries is life saving, but currently doesn't work for boltdb.
This fixes it. Do note that downloading index can be slow for the first time.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


