### PR TITLE
Fixes the pattern parser validation.

### DIFF
--- a/pkg/logql/log/pattern/pattern_test.go
+++ b/pkg/logql/log/pattern/pattern_test.go
@@ -150,9 +150,11 @@ func Test_Error(t *testing.T) {
 		{"<_>", ErrNoCapture},
 		{"foo <_> bar <_>", ErrNoCapture},
 		{"foo bar buzz", ErrNoCapture},
-		{"<f><f>", fmt.Errorf("found consecutive capture: %w", ErrInvalidExpr)},
-		{"<f> f<d><b>", fmt.Errorf("found consecutive capture: %w", ErrInvalidExpr)},
+		{"<f><f>", fmt.Errorf("found consecutive capture '<f><f>': %w", ErrInvalidExpr)},
+		{"<f> f<d><b>", fmt.Errorf("found consecutive capture '<d><b>': %w", ErrInvalidExpr)},
 		{"<f> f<f>", fmt.Errorf("duplicate capture name (f): %w", ErrInvalidExpr)},
+		{`f<f><_>`, fmt.Errorf("found consecutive capture '<f><_>': %w", ErrInvalidExpr)},
+		{`<f>f<f><_>`, fmt.Errorf("found consecutive capture '<f><_>': %w", ErrInvalidExpr)},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := New(tt.name)


### PR DESCRIPTION
We should never have 2 consecutive capture, since when we do we can't figure which data goes where.
The previous validation was validating two nodes at the time and moving to the next two nodes so in the end it wasn't validating properly.

I've also took the opportunity to improve the error message to make it easier to spot the problem.

:facepalm:

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
