### PR TITLE
Correcting documentation example for `/api/prom/query`

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -640,7 +640,7 @@ See [statistics](#Statistics) for information about the statistics returned by L
 ### Examples
 
 ```bash
-$ curl -G -s  "http://localhost:3100/api/prom/query" --data-urlencode '{foo="bar"}' | jq
+$ curl -G -s "http://localhost:3100/api/prom/query" --data-urlencode 'query={foo="bar"}' | jq
 {
   "streams": [
     {


### PR DESCRIPTION
Reimplementing change (#4298) from @jacobsakran
I merged their change before the CLA was signed. We reverted that in #4299 and now I'm reopening.
