### PR TITLE
Feature: Add tenant_folders option to filesystem store

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -39,6 +39,7 @@ storage_config:
     shared_store: filesystem
   filesystem:
     directory: /tmp/loki/chunks
+    tenant_folders: true
 
 compactor:
   working_directory: /tmp/loki/boltdb-shipper-compactor

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1429,6 +1429,9 @@ filesystem:
   # Directory to store chunks in.
   # CLI flag: -local.chunk-directory
   directory: <string>
+  # Store chunks in per-tenant folders.
+  # CLI flag: -local.chunk-tenant-folders
+  [tenant_folders: <boolean> | default = false]
 
 # Configures storing index in an Object Store(GCS/S3/Azure/Swift/Filesystem) in the form of boltdb files.
 # Required fields only required when boltdb-shipper is defined in config.

--- a/docs/sources/operations/storage/filesystem.md
+++ b/docs/sources/operations/storage/filesystem.md
@@ -14,9 +14,9 @@ storage_config:
 ```
 
 By default all chunks are stored in the given directory.
-Enable the `tenant_folders` option to separate chunks of tenants into their own folders.
+Set `tenant_folders` to true to separate chunks of tenants into their own folders.
 
-If loki is run in single-tenant mode, the synthesized tenant name `fake` is used for all chunks.
+If Loki is run in single-tenant mode, the synthesized tenant name `fake` is used for all chunks.
 
 See [multi-tenancy](../../multi-tenancy/) for more information.
 

--- a/docs/sources/operations/storage/filesystem.md
+++ b/docs/sources/operations/storage/filesystem.md
@@ -13,9 +13,10 @@ storage_config:
     directory: /tmp/loki/
 ```
 
-A folder is created for every tenant all the chunks for one tenant are stored in that directory.
+By default all chunks are stored in the given directory.
+Enable the `tenant_folders` option to separate chunks of tenants into their own folders.
 
-If loki is run in single-tenant mode, all the chunks are put in a folder named `fake` which is the synthesized tenant name used for single tenant mode.
+If loki is run in single-tenant mode, the synthesized tenant name `fake` is used for all chunks.
 
 See [multi-tenancy](../../multi-tenancy/) for more information.
 

--- a/pkg/storage/chunk/aws/fixtures.go
+++ b/pkg/storage/chunk/aws/fixtures.go
@@ -44,7 +44,7 @@ var Fixtures = []testutils.Fixture{
 				schemaCfg:               schemaConfig,
 				metrics:                 newMetrics(nil),
 			}
-			object := objectclient.NewClient(&S3ObjectClient{S3: newMockS3()}, nil)
+			object := objectclient.NewClient(&S3ObjectClient{S3: newMockS3()})
 			return index, object, table, schemaConfig, testutils.CloserFunc(func() error {
 				table.Stop()
 				index.Stop()

--- a/pkg/storage/chunk/gcp/fixtures.go
+++ b/pkg/storage/chunk/gcp/fixtures.go
@@ -78,7 +78,7 @@ func (f *fixture) Clients() (
 	}
 
 	if f.gcsObjectClient {
-		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{BucketName: "chunks"}, f.gcssrv.Client()), nil)
+		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{BucketName: "chunks"}, f.gcssrv.Client()))
 	} else {
 		cClient = newBigtableObjectClient(Config{}, schemaConfig, client)
 	}

--- a/pkg/storage/chunk/local/fixtures.go
+++ b/pkg/storage/chunk/local/fixtures.go
@@ -43,7 +43,7 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	chunkClient = objectclient.NewClient(oClient, objectclient.Base64Encoder)
+	chunkClient = objectclient.NewClient(oClient)
 
 	tableClient, err = NewTableClient(f.dirname)
 	if err != nil {

--- a/pkg/storage/chunk/local/fs_object_client.go
+++ b/pkg/storage/chunk/local/fs_object_client.go
@@ -65,9 +65,8 @@ func (FSObjectClient) Stop() {}
 func (f *FSObjectClient) KeyEncoder() objectclient.KeyEncoder {
 	if f.cfg.TenantFolders {
 		return objectclient.TenantBase64Encoder
-	} else {
-		return objectclient.Base64Encoder
 	}
+	return objectclient.Base64Encoder
 }
 
 // GetObject from the store

--- a/pkg/storage/chunk/local/fs_object_client.go
+++ b/pkg/storage/chunk/local/fs_object_client.go
@@ -62,9 +62,9 @@ func NewFSObjectClient(cfg FSConfig) (*FSObjectClient, error) {
 // Stop implements ObjectClient
 func (FSObjectClient) Stop() {}
 
-func (f *FSObjectClient) KeyEncoder() objectclient.KeyEncoder {
+func (f *FSObjectClient) KeyEncoder() chunk.KeyEncoder {
 	if f.cfg.TenantFolders {
-		return objectclient.TenantBase64Encoder
+		return objectclient.SlashBase64Encoder
 	}
 	return objectclient.Base64Encoder
 }

--- a/pkg/storage/chunk/local/fs_object_client.go
+++ b/pkg/storage/chunk/local/fs_object_client.go
@@ -16,8 +16,8 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/chunk/util"
 	"github.com/grafana/loki/pkg/storage/chunk/objectclient"
+	"github.com/grafana/loki/pkg/storage/chunk/util"
 )
 
 // FSConfig is the config for a FSObjectClient.

--- a/pkg/storage/chunk/local/fs_object_client_test.go
+++ b/pkg/storage/chunk/local/fs_object_client_test.go
@@ -16,14 +16,15 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/util"
 )
 
-func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
+func testFSObjectClient_DeleteChunksBefore(t *testing.T, tenantFolders bool) {
 	deleteFilesOlderThan := 10 * time.Minute
 
 	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
 	require.NoError(t, err)
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
-		Directory: fsChunksDir,
+		Directory:     fsChunksDir,
+		TenantFolders: tenantFolders,
 	})
 	require.NoError(t, err)
 
@@ -63,12 +64,18 @@ func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
 	require.Equal(t, 1, len(files), "Number of files should be 1 after enforcing retention")
 }
 
-func TestFSObjectClient_List(t *testing.T) {
+func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
+	testFSObjectClient_DeleteChunksBefore(t, false)
+	testFSObjectClient_DeleteChunksBefore(t, true)
+}
+
+func testFSObjectClient_List(t *testing.T, tenantFolders bool) {
 	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-objects")
 	require.NoError(t, err)
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
-		Directory: fsObjectsDir,
+		Directory:     fsObjectsDir,
+		TenantFolders: tenantFolders,
 	})
 	require.NoError(t, err)
 
@@ -165,12 +172,18 @@ func TestFSObjectClient_List(t *testing.T) {
 	require.Empty(t, commonPrefixes)
 }
 
-func TestFSObjectClient_DeleteObject(t *testing.T) {
+func TestFSObjectClient_List(t *testing.T) {
+	testFSObjectClient_List(t, false)
+	testFSObjectClient_List(t, true)
+}
+
+func testFSObjectClient_DeleteObject(t *testing.T, tenantFolders bool) {
 	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-delete-object")
 	require.NoError(t, err)
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
-		Directory: fsObjectsDir,
+		Directory:     fsObjectsDir,
+		TenantFolders: tenantFolders,
 	})
 	require.NoError(t, err)
 
@@ -214,4 +227,9 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, commonPrefixes, 0)
 	require.Len(t, files, len(foldersWithFiles["folder2/"]))*/
+}
+
+func TestFSObjectClient_DeleteObject(t *testing.T) {
+	testFSObjectClient_DeleteObject(t, false)
+	testFSObjectClient_DeleteObject(t, true)
 }

--- a/pkg/storage/chunk/local/fs_object_client_test.go
+++ b/pkg/storage/chunk/local/fs_object_client_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/util"
 )
 
-func testFSObjectClient_DeleteChunksBefore(t *testing.T, tenantFolders bool) {
+func deleteChunksBefore(t *testing.T, tenantFolders bool) {
 	deleteFilesOlderThan := 10 * time.Minute
 
 	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
@@ -65,11 +65,11 @@ func testFSObjectClient_DeleteChunksBefore(t *testing.T, tenantFolders bool) {
 }
 
 func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
-	testFSObjectClient_DeleteChunksBefore(t, false)
-	testFSObjectClient_DeleteChunksBefore(t, true)
+	deleteChunksBefore(t, false)
+	deleteChunksBefore(t, true)
 }
 
-func testFSObjectClient_List(t *testing.T, tenantFolders bool) {
+func list(t *testing.T, tenantFolders bool) {
 	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-objects")
 	require.NoError(t, err)
 
@@ -173,11 +173,11 @@ func testFSObjectClient_List(t *testing.T, tenantFolders bool) {
 }
 
 func TestFSObjectClient_List(t *testing.T) {
-	testFSObjectClient_List(t, false)
-	testFSObjectClient_List(t, true)
+	list(t, false)
+	list(t, true)
 }
 
-func testFSObjectClient_DeleteObject(t *testing.T, tenantFolders bool) {
+func deleteObject(t *testing.T, tenantFolders bool) {
 	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-delete-object")
 	require.NoError(t, err)
 
@@ -230,6 +230,6 @@ func testFSObjectClient_DeleteObject(t *testing.T, tenantFolders bool) {
 }
 
 func TestFSObjectClient_DeleteObject(t *testing.T) {
-	testFSObjectClient_DeleteObject(t, false)
-	testFSObjectClient_DeleteObject(t, true)
+	deleteObject(t, false)
+	deleteObject(t, true)
 }

--- a/pkg/storage/chunk/objectclient/client.go
+++ b/pkg/storage/chunk/objectclient/client.go
@@ -45,7 +45,7 @@ type Client struct {
 
 // NewClient wraps the provided ObjectClient with a chunk.Client implementation
 func NewClient(store chunk.ObjectClient) *Client {
-	var encoder KeyEncoder = nil
+	var encoder KeyEncoder
 	// check if store provides a KeyEncoder
 	var ok bool
 	method := reflect.ValueOf(&store).MethodByName("KeyEncoder")

--- a/pkg/storage/chunk/objectclient/client.go
+++ b/pkg/storage/chunk/objectclient/client.go
@@ -33,9 +33,8 @@ var TenantBase64Encoder = func(key string) string {
 			base64.URLEncoding.EncodeToString(data[:i]),
 			base64.URLEncoding.EncodeToString(data[i+1:]),
 		}, "/")
-	} else {
-		return base64.URLEncoding.EncodeToString(data)
 	}
+	return base64.URLEncoding.EncodeToString(data)
 }
 
 // Client is used to store chunks in object store backends

--- a/pkg/storage/chunk/storage/factory.go
+++ b/pkg/storage/chunk/storage/factory.go
@@ -298,7 +298,7 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, regis
 		if err != nil {
 			return nil, err
 		}
-		return objectclient.NewClient(store, objectclient.Base64Encoder), nil
+		return objectclient.NewClient(store), nil
 	case StorageTypeGrpc:
 		return grpc.NewStorageClient(cfg.GrpcConfig, schemaCfg)
 	default:
@@ -310,7 +310,7 @@ func newChunkClientFromStore(store chunk.ObjectClient, err error) (chunk.Client,
 	if err != nil {
 		return nil, err
 	}
-	return objectclient.NewClient(store, nil), nil
+	return objectclient.NewClient(store), nil
 }
 
 // NewTableClient makes a new table client based on the configuration.

--- a/pkg/storage/chunk/storage_client.go
+++ b/pkg/storage/chunk/storage_client.go
@@ -79,6 +79,17 @@ type ObjectClient interface {
 	Stop()
 }
 
+// KeyEncoder is used to encode chunk keys before writing/retrieving chunks
+// from the underlying ObjectClient
+type KeyEncoder func(string) string
+
+// EncoderObjectClient is a specialization of the ObjectClient interface that implements encoding schemes for object keys
+type EncoderObjectClient interface {
+	ObjectClient
+	// Returns the KeyEncoder function as defined/required by the ObjectClient
+	KeyEncoder() KeyEncoder
+}
+
 // StorageObject represents an object being stored in an Object Store
 type StorageObject struct {
 	Key        string

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	loki_storage "github.com/grafana/loki/pkg/storage"
-	"github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/objectclient"
 	"github.com/grafana/loki/pkg/storage/chunk/storage"
 	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
@@ -109,12 +108,7 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig loki_storage
 	c.metrics = newMetrics(r)
 
 	if c.cfg.RetentionEnabled {
-		var encoder objectclient.KeyEncoder
-		if _, ok := objectClient.(*local.FSObjectClient); ok {
-			encoder = objectclient.Base64Encoder
-		}
-
-		chunkClient := objectclient.NewClient(objectClient, encoder)
+		chunkClient := objectclient.NewClient(objectClient)
 
 		retentionWorkDir := filepath.Join(c.cfg.WorkingDirectory, "retention")
 		c.sweeper, err = retention.NewSweeper(retentionWorkDir, chunkClient, c.cfg.RetentionDeleteWorkCount, c.cfg.RetentionDeleteDelay, r)

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -363,7 +363,7 @@ func TestChunkRewriter(t *testing.T) {
 			require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{tt.chunk}))
 			store.Stop()
 
-			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir), objectclient.Base64Encoder)
+			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir))
 			for _, indexTable := range store.indexTables() {
 				err := indexTable.DB.Update(func(tx *bbolt.Tx) error {
 					bucket := tx.Bucket(bucketName)
@@ -618,7 +618,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			tables := store.indexTables()
 			require.Len(t, tables, len(tc.expectedDeletedSeries))
 
-			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir), objectclient.Base64Encoder)
+			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir))
 
 			for i, table := range tables {
 				seriesCleanRecorder := newSeriesCleanRecorder()

--- a/pkg/storage/stores/shipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util_test.go
@@ -125,6 +125,14 @@ type testObjectClient struct {
 	path string
 }
 
+func (c *testObjectClient) KeyEncoder() chunk.KeyEncoder {
+	var encoder chunk.KeyEncoder
+	if encoderClient, ok := c.ObjectClient.(chunk.EncoderObjectClient); ok {
+		encoder = encoderClient.KeyEncoder()
+	}
+	return encoder
+}
+
 func newTestObjectClient(path string) chunk.ObjectClient {
 	c, err := chunk_storage.NewObjectClient("filesystem", chunk_storage.Config{
 		FSConfig: local.FSConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Currently the docs for filesystem chunk storage state that chunks for each tenant will be stored in their own folder, but the `Base64Encoder` function that is used to encode chunk keys prevents this from happening.
Simply fixing the encoder function would break existing deployments, so instead this PR adds a Boolean option `tenant_folders` to the filesystem store that defaults to `false`.
Enabling this option means the new `TenantBase64Encoder` function is used, which is aware of the structure of chunk keys and preserves the tenant folder prefix.

**Which issue(s) this PR fixes**:
Fixes #4291

**Special notes for your reviewer**:
This is my first time working with the Loki source, but it seems like the more sensible solution would be to let the stores themselves handle how keys are encoded. Filesystem seems to be the only store to do any kind of encoding anyway. That would mean touching more of the code though, so I opted not do that. However, that meant I had to use the reflect package during client creation to avoid a circular import, which feels nasty.

**Checklist**
- [X] Documentation added
- [x] Tests updated