### PR TITLE
allow ingester and distributor to run on same instance

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -173,7 +173,7 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		return nil, err
 	}
 
-	// Register the distributor to receive Push requests over GRPC 
+	// Register the distributor to receive Push requests over GRPC
 	// EXCEPT when running with `-target=all` or `-target=` contains `ingester`
 	if !t.Cfg.isModuleEnabled(All) && !t.Cfg.isModuleEnabled(Ingester) {
 		logproto.RegisterPusherServer(t.Server.GRPC, t.distributor)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -173,6 +173,8 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		return nil, err
 	}
 
+	// Register the distributor to receive Push requests over GRPC 
+	// EXCEPT when running with `-target=all` or `-target=` contains `ingester`
 	if !t.Cfg.isModuleEnabled(All) && !t.Cfg.isModuleEnabled(Ingester) {
 		logproto.RegisterPusherServer(t.Server.GRPC, t.distributor)
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -173,7 +173,7 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		return nil, err
 	}
 
-	if !t.Cfg.isModuleEnabled(All) {
+	if !t.Cfg.isModuleEnabled(All) && !t.Cfg.isModuleEnabled(Ingester) {
 		logproto.RegisterPusherServer(t.Server.GRPC, t.distributor)
 	}
 


### PR DESCRIPTION
Signed-off-by: Trevor Whitney <trevorjwhitney@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When running loki with target `--target=distributor,ingester` it fails with the error `FATAL: 2021/09/17 18:48:10 [core] grpc: Server.RegisterService found duplicate service registration for "logproto.Pusher"`. This is because the guard against registering the Pusher service in the `initDistributor` code is currently only guarding against the `All` target. With our work on the "single scalable deployment", we plan on having a write path where both the distributor and ingester are enabled. This PR allows both targets to be enabled.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

