### PR TITLE
fix:  Support version 2.x to be imported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/loki
+module github.com/grafana/loki/v2
 
 go 1.15
 


### PR DESCRIPTION
When I need to import the v2.3.0 version of loki in the project， it will happen :` require github.com/grafana/loki: version "v2.3.0" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2`

