### PR TITLE
CI: Fixing linter deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,14 +58,14 @@ linters:
     - revive
     - gosimple
     - ineffassign
-    - megacheck
+    - staticcheck
     - misspell
     - structcheck
     - unconvert
     - unparam
     - varcheck
     - govet
-    - unused # new from here.
+    - unused
     - typecheck
 
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters:
     - goconst
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosimple
     - ineffassign
     - megacheck
@@ -66,7 +66,6 @@ linters:
     - varcheck
     - govet
     - unused # new from here.
-    - interfacer
     - typecheck
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,8 @@ publish: dist
 # Lint #
 ########
 
+# To run this efficiently on your workstation, use:
+# docker run --rm --tty -i -v $(pwd)/.cache:/go/cache -v $(pwd)/.pkg:/go/pkg -v $(pwd):/src/loki grafana/loki-build-image:0.17.0 lint
 lint:
 	GO111MODULE=on GOGC=10 golangci-lint run -v $(GOLANGCI_ARG)
 	faillint -paths "sync/atomic=go.uber.org/atomic" ./...

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ publish: dist
 # Lint #
 ########
 
-# To run this efficiently on your workstation, use:
+# To run this efficiently on your workstation, run this from the root dir:
 # docker run --rm --tty -i -v $(pwd)/.cache:/go/cache -v $(pwd)/.pkg:/go/pkg -v $(pwd):/src/loki grafana/loki-build-image:0.17.0 lint
 lint:
 	GO111MODULE=on GOGC=10 golangci-lint run -v $(GOLANGCI_ARG)

--- a/clients/cmd/docker-driver/loki.go
+++ b/clients/cmd/docker-driver/loki.go
@@ -44,7 +44,7 @@ func New(logCtx logger.Info, logger log.Logger) (logger.Logger, error) {
 		return nil, err
 	}
 	var handler api.EntryHandler = c
-	var stop func() = func() {}
+	var stop = func() {}
 	if len(cfg.pipeline.PipelineStages) != 0 {
 		pipeline, err := stages.NewPipeline(logger, cfg.pipeline.PipelineStages, &jobName, prometheus.DefaultRegisterer)
 		if err != nil {

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -44,7 +44,7 @@ func (cfg *Config) RegisterFlags(flags *flag.FlagSet) {
 }
 
 // FileTarget describes a particular set of logs.
-// nolint:golint
+// nolint:revive
 type FileTarget struct {
 	metrics *Metrics
 	logger  log.Logger

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -33,7 +33,7 @@ const (
 )
 
 // FileTargetManager manages a set of targets.
-// nolint:golint
+// nolint:revive
 type FileTargetManager struct {
 	log     log.Logger
 	quit    context.CancelFunc

--- a/clients/pkg/promtail/targets/gcplog/formatter.go
+++ b/clients/pkg/promtail/targets/gcplog/formatter.go
@@ -31,7 +31,7 @@ func init() {
 // LogEntry that will be written to the pubsub topic.
 // According to the following spec.
 // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
-// nolint: golint
+// nolint:revive
 type GCPLogEntry struct {
 	LogName  string `json:"logName"`
 	Resource struct {

--- a/clients/pkg/promtail/targets/gcplog/target.go
+++ b/clients/pkg/promtail/targets/gcplog/target.go
@@ -17,7 +17,7 @@ import (
 
 // GcplogTarget represents the target specific to GCP project.
 // It collects logs from GCP and push it to Loki.
-// nolint:golint
+// nolint:revive
 type GcplogTarget struct {
 	metrics       *Metrics
 	logger        log.Logger
@@ -41,7 +41,7 @@ type GcplogTarget struct {
 // and push it Loki via given `api.EntryHandler.`
 // It starts the `run` loop to consume log entries that can be
 // stopped via `target.Stop()`
-// nolint:golint,govet
+// nolint:revive,govet
 func NewGcplogTarget(
 	metrics *Metrics,
 	logger log.Logger,
@@ -66,7 +66,7 @@ func NewGcplogTarget(
 	return target, nil
 }
 
-// nolint: golint
+// nolint:revive
 func newGcplogTarget(
 	metrics *Metrics,
 	logger log.Logger,

--- a/clients/pkg/promtail/targets/gcplog/targetmanager.go
+++ b/clients/pkg/promtail/targets/gcplog/targetmanager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 )
 
-// nolint: golint
+// nolint:revive
 type GcplogTargetManager struct {
 	logger  log.Logger
 	targets map[string]*GcplogTarget

--- a/clients/pkg/promtail/targets/journal/journaltargetmanager.go
+++ b/clients/pkg/promtail/targets/journal/journaltargetmanager.go
@@ -15,7 +15,7 @@ import (
 )
 
 // JournalTargetManager manages a series of JournalTargets.
-// nolint:golint
+// nolint:revive
 type JournalTargetManager struct{}
 
 // NewJournalTargetManager returns nil as JournalTargets are not supported

--- a/clients/pkg/promtail/targets/stdin/stdin_target_manager.go
+++ b/clients/pkg/promtail/targets/stdin/stdin_target_manager.go
@@ -52,7 +52,7 @@ type Shutdownable interface {
 	Shutdown()
 }
 
-// nolint:golint
+// nolint:revive
 type StdinTargetManager struct {
 	*readerTarget
 	app Shutdownable

--- a/clients/pkg/promtail/targets/syslog/syslogtarget.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget.go
@@ -33,7 +33,7 @@ var (
 )
 
 // SyslogTarget listens to syslog messages.
-// nolint:golint
+// nolint:revive
 type SyslogTarget struct {
 	metrics       *Metrics
 	logger        log.Logger

--- a/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtargetmanager.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SyslogTargetManager manages a series of SyslogTargets.
-// nolint:golint
+// nolint:revive
 type SyslogTargetManager struct {
 	logger  log.Logger
 	targets map[string]*SyslogTarget

--- a/clients/pkg/promtail/targets/target/target.go
+++ b/clients/pkg/promtail/targets/target/target.go
@@ -5,7 +5,7 @@ import (
 )
 
 // TargetType is the type of target
-// nolint:golint
+// nolint:revive
 type TargetType string
 
 const (

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -102,7 +102,7 @@ func (h *splitByInterval) Process(
 	}
 
 	// don't spawn unnecessary goroutines
-	var p int = parallelism
+	var p = parallelism
 	if len(input) < parallelism {
 		p = len(input)
 	}

--- a/pkg/storage/chunk/aws/dynamodb_table_client.go
+++ b/pkg/storage/chunk/aws/dynamodb_table_client.go
@@ -199,7 +199,7 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc
 }
 
 func (d dynamoTableClient) DeleteTable(ctx context.Context, name string) error {
-	if err := d.backoffAndRetry(ctx, func(ctx context.Context) error {
+	return d.backoffAndRetry(ctx, func(ctx context.Context) error {
 		return instrument.CollectedRequest(ctx, "DynamoDB.DeleteTable", d.metrics.dynamoRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			input := &dynamodb.DeleteTableInput{TableName: aws.String(name)}
 			_, err := d.DynamoDB.DeleteTableWithContext(ctx, input)
@@ -209,11 +209,7 @@ func (d dynamoTableClient) DeleteTable(ctx context.Context, name string) error {
 
 			return nil
 		})
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -82,10 +82,7 @@ func (cfg *StoreConfig) Validate(logger log.Logger) error {
 	if err := cfg.ChunkCacheConfig.Validate(); err != nil {
 		return err
 	}
-	if err := cfg.WriteDedupeCacheConfig.Validate(); err != nil {
-		return err
-	}
-	return nil
+	return cfg.WriteDedupeCacheConfig.Validate()
 }
 
 type baseStore struct {

--- a/pkg/storage/chunk/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/gcp/gcs_object_client.go
@@ -112,11 +112,7 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 		_ = writer.Close()
 		return err
 	}
-	if err := writer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return writer.Close()
 }
 
 // List implements chunk.ObjectClient.

--- a/pkg/storage/chunk/purger/purger.go
+++ b/pkg/storage/chunk/purger/purger.go
@@ -357,7 +357,7 @@ func (p *Purger) executePlan(userID, requestID string, planNo int, logger log.Lo
 				return err
 			}
 
-			var partiallyDeletedInterval *model.Interval = nil
+			var partiallyDeletedInterval *model.Interval
 			if chunkDetails.PartiallyDeletedInterval != nil {
 				partiallyDeletedInterval = &model.Interval{
 					Start: model.Time(chunkDetails.PartiallyDeletedInterval.StartTimestampMs),

--- a/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
@@ -104,10 +104,7 @@ func Test_SeriesCleaner(t *testing.T) {
 				if err := cleaner.Cleanup(entryFromChunk(c2).UserID, c2.Metric); err != nil {
 					return err
 				}
-				if err := cleaner.Cleanup(entryFromChunk(c1).UserID, c1.Metric); err != nil {
-					return err
-				}
-				return nil
+				return cleaner.Cleanup(entryFromChunk(c1).UserID, c1.Metric)
 			})
 			require.NoError(t, err)
 

--- a/pkg/storage/stores/shipper/compactor/retention/marker.go
+++ b/pkg/storage/stores/shipper/compactor/retention/marker.go
@@ -303,7 +303,7 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 			}
 		}()
 	}
-	if err := dbView.View(func(tx *bbolt.Tx) error {
+	return dbView.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(chunkBucket)
 		if b == nil {
 			return nil
@@ -323,10 +323,7 @@ func (r *markerProcessor) processPath(path string, deleteFunc func(ctx context.C
 
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func processKey(ctx context.Context, key *keyPair, db *bbolt.DB, deleteFunc func(ctx context.Context, chunkId []byte) error) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
- replaced deprecated `golint` with `[revive](https://github.com/mgechev/revive#installation)` (https://github.com/golangci/golangci-lint/pull/1965)
- removed `interfacer` (https://github.com/golangci/golangci-lint/pull/1755)
- replaced deprecated `megacheck` with `staticcheck` (https://pkg.go.dev/github.com/aspenteam/go-tools/cmd/megacheck)

**Which issue(s) this PR fixes**:
Partially addresses #1002

**Special notes for your reviewer**:
I did not include the `prealloc` linter as suggested by Marco yet as I didn't want to complicate this PR with the requisite changes it would introduce to get CI passing. This should be done in a subsequent PR.

I did implement changes to make `revive` pass, as it's a little more strict that `golint` and the suggestions it came up with were all reasonable.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

