### PR TITLE
Docs: Remove wording like "As of version 1.6, you can..."

### DIFF
--- a/docs/sources/best-practices/_index.md
+++ b/docs/sources/best-practices/_index.md
@@ -107,20 +107,20 @@ It's also worth noting that the batching nature of the Loki push API can lead to
 
 ## Use `chunk_target_size`
 
-This was added earlier in the [Loki v1.3.0](https://grafana.com/blog/2020/01/22/loki-1.3.0-released/) release, and we've been experimenting with it for several months. We have `chunk_target_size: 1536000` in all our environments now. This instructs Loki to try to fill all chunks to a target _compressed_ size of 1.5MB. These larger chunks are more efficient for Loki to process.
+Using `chunk_target_size` instructs Loki to try to fill all chunks to a target _compressed_ size of 1.5MB. These larger chunks are more efficient for Loki to process.
 
-A couple other config variables affect how full a chunk can get. Loki has a default `max_chunk_age` of 1h and `chunk_idle_period` of 30m to limit the amount of memory used as well as the exposure of lost logs if the process crashes.
+Other configuration variables affect how full a chunk can get. Loki has a default `max_chunk_age` of 1h and `chunk_idle_period` of 30m to limit the amount of memory used as well as the exposure of lost logs if the process crashes.
 
 Depending on the compression used (we have been using snappy which has less compressibility but faster performance), you need 5-10x or 7.5-10MB of raw log data to fill a 1.5MB chunk. Remembering that a chunk is per stream, the more streams you break up your log files into, the more chunks that sit in memory, and the higher likelihood they get flushed by hitting one of those timeouts mentioned above before they are filled.
 
-Lots of small, unfilled chunks are currently kryptonite for Loki. We are always working to improve this and may consider a compactor to improve this in some situations. But, in general, the guidance should stay about the same: Try your best to fill chunks!
+Lots of small, unfilled chunks negatively affect Loki. We are always working to improve this and may consider a compactor to improve this in some situations. But, in general, the guidance should stay about the same: try your best to fill chunks.
 
 If you have an application that can log fast enough to fill these chunks quickly (much less than `max_chunk_age`), then it becomes more reasonable to use dynamic labels to break that up into separate streams.
 
 ## Use `-print-config-stderr` or `-log-config-reverse-order`
 
-Starting in version 1.6.0 Loki and Promtail have flags which will dump the entire config object to stderr, or the log file, when they start.
+Loki and Promtail have flags which will dump the entire config object to stderr or the log file when they start.
 
-`-print-config-stderr` is nice when running loki directly e.g. `./loki ` as you can get a quick output of the entire Loki config.
+`-print-config-stderr` works well when invoking Loki from the command line, as you can get a quick output of the entire Loki configuration.
 
-`-log-config-reverse-order` is the flag we run Loki with in all our environments, the config entries are reversed so that the order of configs reads correctly top to bottom when viewed in Grafana's Explore.
+`-log-config-reverse-order` is the flag we run Loki with in all our environments. The configuration entries are reversed, so that the order of the configuration reads correctly top to bottom when viewed in Grafana's Explore.

--- a/docs/sources/getting-started/grafana.md
+++ b/docs/sources/getting-started/grafana.md
@@ -3,10 +3,10 @@ title: Loki in Grafana
 ---
 # Loki in Grafana
 
-Grafana ships with built-in support for Loki for versions greater than
-[6.0](https://grafana.com/grafana/download/6.0.0). Using
-[6.3](https://grafana.com/grafana/download/6.3.0) or later is highly
-recommended to take advantage of new [LogQL]({{< relref "../logql/_index.md" >}}) functionality.
+[Grafana 6.0](https://grafana.com/grafana/download/6.0.0) and more recent
+versions have built-in support for Loki.
+Use [Grafana 6.3](https://grafana.com/grafana/download/6.3.0) or a more
+recent version to take advantage of [LogQL]({{< relref "../logql/_index.md" >}}) functionality.
 
 1. Log into your Grafana instance. If this is your first time running
    Grafana, the username and password are both defaulted to `admin`.
@@ -27,7 +27,6 @@ Read more about Grafana's Explore feature in the
 [Grafana documentation](http://docs.grafana.org/features/explore) and on how to
 search and filter for logs with Loki.
 
-> To configure the datasource via provisioning, see [Configuring Grafana via
-> Provisioning](http://docs.grafana.org/features/datasources/loki/#configure-the-datasource-with-provisioning)
-> in the Grafana documentation and make sure to adjust the URL similarly as
-> shown above.
+To configure Loki as a datasource via provisioning, see [Configuring Grafana via
+Provisioning](http://docs.grafana.org/features/datasources/loki/#configure-the-datasource-with-provisioning).
+Set the URL in the provisioning.

--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -63,11 +63,15 @@ $ kubectl port-forward loki-promtail-jrfg7 9080
 
 ## Debug output
 
-Both Loki and Promtail support a log level flag on the command-line:
+Both Loki and Promtail support a log level flag with the addition of
+a command-line option:
 
 ```bash
-$ loki -log.level=debug
-$ promtail -log.level=debug
+loki -log.level=debug
+```
+
+```bash
+promtail -log.level=debug
 ```
 
 ## Failed to create target, `ioutil.ReadDir: readdirent: not a directory`

--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -28,7 +28,7 @@ When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in t
 
 Navigate to http://localhost:3100/metrics to view the metrics and http://localhost:3100/ready for readiness.
 
-As of v1.6.0, image is configured to run by default as user loki with  UID `10001` and GID `10001`. You can use a different user, specially if you are using bind mounts, by specifying the UID with a `docker run` command and using `--user=UID` with numeric UID suited to your needs.
+The image is configured to run by default as user loki with  UID `10001` and GID `10001`. You can use a different user, specially if you are using bind mounts, by specifying the UID with a `docker run` command and using `--user=UID` with numeric UID suited to your needs.
 
 **Windows**
 

--- a/docs/sources/installation/helm.md
+++ b/docs/sources/installation/helm.md
@@ -9,9 +9,6 @@ Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-
 
 Add [Loki's chart repository](https://github.com/grafana/helm-charts) to Helm:
 
-> **PLEASE NOTE** On 2020/12/11 Loki's Helm charts were moved from their initial location within the
-Loki repo and hosted at https://grafana.github.io/loki/charts to their new location at https://github.com/grafana/helm-charts which are hosted at https://grafana.github.io/helm-charts
-
 ```bash
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
@@ -24,7 +21,7 @@ helm repo update
 
 ## Deploy Loki to your cluster
 
-### Deploy with default config
+### Deploy with default configuration
 
 ```bash
 helm upgrade --install loki grafana/loki-stack
@@ -36,7 +33,7 @@ helm upgrade --install loki grafana/loki-stack
 helm upgrade --install loki --namespace=loki grafana/loki
 ```
 
-### Deploy with custom config
+### Deploy with custom configuration
 
 ```bash
 helm upgrade --install loki grafana/loki --set "key1=val1,key2=val2,..."
@@ -87,11 +84,11 @@ output above. Then follow the [instructions for adding the Loki Data Source](../
 
 ## Run Loki behind HTTPS ingress
 
-If Loki and Promtail are deployed on different clusters you can add an Ingress
-in front of Loki. By adding a certificate you create an HTTPS endpoint. For
-extra security you can also enable Basic Authentication on the Ingress.
+If Loki and Promtail are deployed on different clusters, you can add an Ingress
+in front of Loki. By adding a certificate, you create an HTTPS endpoint. For
+extra security you can also enable Basic Authentication on Ingress.
 
-In Promtail, set the following values to communicate using HTTPS and basic authentication:
+In the Promtail configuration, set the following values to communicate using HTTPS and basic authentication:
 
 ```yaml
 loki:
@@ -127,11 +124,11 @@ spec:
 
 ## Run Promtail with syslog support
 
-In order to receive and process syslog message into Promtail, the following changes will be necessary:
+In order to receive and process syslog messages in Promtail, the following changes will be necessary:
 
 * Review the [Promtail syslog-receiver configuration documentation](/docs/clients/promtail/scraping.md#syslog-receiver)
 
-* Configure the Promtail helm chart with the syslog configuration added to the `extraScrapeConfigs` section and associated service definition to listen for syslog messages. For example:
+* Configure the Promtail Helm chart with the syslog configuration added to the `extraScrapeConfigs` section and associated service definition to listen for syslog messages. For example:
 
 ```yaml
 extraScrapeConfigs:
@@ -155,7 +152,7 @@ In order to receive and process syslog message into Promtail, the following chan
 
 * Review the [Promtail systemd-journal configuration documentation](/docs/clients/promtail/scraping.md#journal-scraping-linux-only)
 
-* Configure the Promtail helm chart with the systemd-journal configuration added to the `extraScrapeConfigs` section and volume mounts for the Promtail pods to access the log files. For example:
+* Configure the Promtail Helm chart with the systemd-journal configuration added to the `extraScrapeConfigs` section and volume mounts for the Promtail pods to access the log files. For example:
 
 ```yaml
 # Add additional scrape config

--- a/docs/sources/installation/local.md
+++ b/docs/sources/installation/local.md
@@ -15,26 +15,28 @@ In order to log events with Loki, you must download and install both Promtail an
    **Note:** Do not download LogCLI or Loki Canary at this time. [LogCLI](../../getting-started/logcli/) allows you to run Loki queries in a command line interface. [Loki Canary](../../operations/loki-canary/) is a tool to audit Loki performance.
 4. Unzip the package contents into the same directory. This is where the two programs will run.
 5. In the command line, change directory (`cd` on most systems) to the directory with Loki and Promtail. Copy and paste the commands below into your command line to download generic configuration files:
-```
-wget https://raw.githubusercontent.com/grafana/loki/master/cmd/loki/loki-local-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/main/clients/cmd/promtail/promtail-local-config.yaml
-```
+
+    ```
+    wget https://raw.githubusercontent.com/grafana/loki/master/cmd/loki/loki-local-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/main/clients/cmd/promtail/promtail-local-config.yaml
+    ```
 6. Enter the following command to start Loki:
 
-**Windows**
+    **Windows**
 
-```
-.\loki-windows-amd64.exe --config.file=loki-local-config.yaml
-```
+    ```
+    .\loki-windows-amd64.exe --config.file=loki-local-config.yaml
+    ```
 
-**Linux**
-```
-./loki-linux-amd64 -config.file=loki-local-config.yaml
-```
+    **Linux**
+    ```
+    ./loki-linux-amd64 -config.file=loki-local-config.yaml
+    ```
 
 Loki runs and displays Loki logs in your command line and on http://localhost:3100/metrics.
 
-Congratulations, Loki is installed and running! Next, you might want edit the Promtail config file to [get logs into Loki](../../getting-started/get-logs-into-loki/).
+The next step will be running an agent to send logs to Loki.
+To do so with Promtail, refer to [get logs into Loki](../../getting-started/get-logs-into-loki/).
 
 ## Release binaries - openSUSE Linux only
 


### PR DESCRIPTION
- We give readers versioned documentation (now), so they don't need to know what version a feature appeared in.
- I couldn't resist fixing some grammar, formatting, and phrasing in the sections that needed changes.



