### PR TITLE
removes deprecated duplicate per stream rate limit fields

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -48,13 +48,11 @@ type Limits struct {
 	MaxLineSizeTruncate    bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
 
 	// Ingester enforced limits.
-	MaxLocalStreamsPerUser       int              `yaml:"max_streams_per_user" json:"max_streams_per_user"`
-	MaxGlobalStreamsPerUser      int              `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
-	UnorderedWrites              bool             `yaml:"unordered_writes" json:"unordered_writes"`
-	MaxLocalStreamRateBytes      flagext.ByteSize `yaml:"max_stream_rate_bytes" json:"max_stream_rate_bytes"`
-	MaxLocalStreamBurstRateBytes flagext.ByteSize `yaml:"max_stream_burst_rate_bytes" json:"max_stream_burst_rate_bytes"`
-	PerStreamRateLimit           flagext.ByteSize `yaml:"per_stream_rate_limit" json:"per_stream_rate_limit"`
-	PerStreamRateLimitBurst      flagext.ByteSize `yaml:"per_stream_rate_limit_burst" json:"per_stream_rate_limit_burst"`
+	MaxLocalStreamsPerUser  int              `yaml:"max_streams_per_user" json:"max_streams_per_user"`
+	MaxGlobalStreamsPerUser int              `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user"`
+	UnorderedWrites         bool             `yaml:"unordered_writes" json:"unordered_writes"`
+	PerStreamRateLimit      flagext.ByteSize `yaml:"per_stream_rate_limit" json:"per_stream_rate_limit"`
+	PerStreamRateLimitBurst flagext.ByteSize `yaml:"per_stream_rate_limit_burst" json:"per_stream_rate_limit_burst"`
 
 	// Querier enforced limits.
 	MaxChunksPerQuery          int            `yaml:"max_chunks_per_query" json:"max_chunks_per_query"`
@@ -135,12 +133,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalStreamsPerUser, "ingester.max-streams-per-user", 10e3, "Maximum number of active streams per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalStreamsPerUser, "ingester.max-global-streams-per-user", 0, "Maximum number of active streams per user, across the cluster. 0 to disable.")
 	f.BoolVar(&l.UnorderedWrites, "ingester.unordered-writes", false, "(Experimental) Allow out of order writes.")
-
-	// Deprecated
-	_ = l.MaxLocalStreamRateBytes.Set(strconv.Itoa(defaultPerStreamRateLimit))
-	f.Var(&l.MaxLocalStreamRateBytes, "ingester.max-stream-rate-bytes", "Maximum bytes per second rate per active stream (deprecated in favor of ingester.per-stream-rate-limit).")
-	_ = l.MaxLocalStreamBurstRateBytes.Set(strconv.Itoa(defaultPerStreamBurstLimit))
-	f.Var(&l.MaxLocalStreamBurstRateBytes, "ingester.max-stream-burst-bytes", "Maximum burst bytes per second rate per active stream (deprecated in favor of ingester.per-stream-rate-limit-burst).")
 
 	_ = l.PerStreamRateLimit.Set(strconv.Itoa(defaultPerStreamRateLimit))
 	f.Var(&l.PerStreamRateLimit, "ingester.per-stream-rate-limit", "Maximum byte rate per second per stream, also expressible in human readable forms (1MB, 256KB, etc).")
@@ -516,18 +508,8 @@ func (o *Overrides) PerStreamRateLimit(userID string) RateLimit {
 	user := o.getOverridesForUser(userID)
 
 	return RateLimit{
-		Limit: rate.Limit(float64(
-			firstNonDefault(
-				defaultPerStreamRateLimit,
-				user.PerStreamRateLimit.Val(),
-				user.MaxLocalStreamRateBytes.Val(),
-			),
-		)),
-		Burst: firstNonDefault(
-			defaultPerStreamBurstLimit,
-			user.PerStreamRateLimitBurst.Val(),
-			user.MaxLocalStreamBurstRateBytes.Val(),
-		),
+		Limit: rate.Limit(float64(user.PerStreamRateLimit.Val())),
+		Burst: user.PerStreamRateLimitBurst.Val(),
 	}
 }
 
@@ -539,13 +521,4 @@ func (o *Overrides) getOverridesForUser(userID string) *Limits {
 		}
 	}
 	return o.defaultLimits
-}
-
-func firstNonDefault(def int, xs ...int) int {
-	for _, x := range xs {
-		if x != def {
-			return x
-		}
-	}
-	return def
 }


### PR DESCRIPTION
Followup to https://github.com/grafana/loki/pull/4236