### PR TITLE
Ruler: disable the WAL cleaner by default

### DIFF
--- a/pkg/ruler/storage/cleaner/cleaner.go
+++ b/pkg/ruler/storage/cleaner/cleaner.go
@@ -20,7 +20,7 @@ import (
 // Default settings for the WAL cleaner.
 const (
 	DefaultCleanupAge    = 12 * time.Hour
-	DefaultCleanupPeriod = 30 * time.Minute
+	DefaultCleanupPeriod = 0
 )
 
 // lastModifiedFunc gets the last modified time of the most recent segment of a WAL


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables the WAL cleaner by default as this might be wanted by everyone.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
If the cleanup period is `0`, the ticker is not started:
https://github.com/grafana/loki/blob/main/pkg/ruler/storage/cleaner/cleaner.go#L175-L179

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

