### PR TITLE
Improve case insensitive search to avoid allocations.

### DIFF
--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -183,7 +183,7 @@ func (l *containsFilter) Filter(line []byte) bool {
 	if !l.caseInsensitive {
 		return bytes.Contains(line, l.match)
 	}
-	// verify if we have to uppercase in the line and if it's only ascii chars
+	// verify if we have uppercase in the line and if it's only ascii chars
 	isASCII, hasUpper := true, false
 	for i := 0; i < len(line); i++ {
 		c := line[i]

--- a/pkg/logql/log/filter_test.go
+++ b/pkg/logql/log/filter_test.go
@@ -10,6 +10,7 @@ import (
 func Test_SimplifiedRegex(t *testing.T) {
 	fixtures := []string{
 		"foo", "foobar", "bar", "foobuzz", "buzz", "f", "  ", "fba", "foofoofoo", "b", "foob", "bfoo", "FoO",
+		"foo, 世界", allunicode(),
 	}
 	for _, test := range []struct {
 		re         string
@@ -91,6 +92,14 @@ func Test_SimplifiedRegex(t *testing.T) {
 			}
 		})
 	}
+}
+
+func allunicode() string {
+	var b []byte
+	for i := 0x00; i <= 0x10FFFF; i++ {
+		b = append(b, byte(i))
+	}
+	return string(b)
 }
 
 func Test_TrueFilter(t *testing.T) {


### PR DESCRIPTION
```
❯ benchcmp  before.txt after.txt
benchmark                                            old ns/op     new ns/op     delta
Benchmark_LineFilter/default_true_(?i)foo-16         2400          2233          -6.96%
Benchmark_LineFilter/simplified_true_(?i)foo-16      201           228           +13.13%
Benchmark_LineFilter/default_false_(?i)foo-16        2443          2376          -2.74%
Benchmark_LineFilter/simplified_false_(?i)foo-16     185           231           +24.96%

benchmark                                            old allocs     new allocs     delta
Benchmark_LineFilter/default_true_(?i)foo-16         0              0              +0.00%
Benchmark_LineFilter/simplified_true_(?i)foo-16      1              0              -100.00%
Benchmark_LineFilter/default_false_(?i)foo-16        0              0              +0.00%
Benchmark_LineFilter/simplified_false_(?i)foo-16     1              0              -100.00%

benchmark                                            old bytes     new bytes     delta
Benchmark_LineFilter/default_true_(?i)foo-16         0             0             +0.00%
Benchmark_LineFilter/simplified_true_(?i)foo-16      128           0             -100.00%
Benchmark_LineFilter/default_false_(?i)foo-16        0             0             +0.00%
Benchmark_LineFilter/simplified_false_(?i)foo-16     128           0             -100.00%
```

It's not much but for a billions line it makes a big difference.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
