### PR TITLE
add virtual targets read/write/async

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -418,7 +418,12 @@ func (t *Loki) setupModuleManager() error {
 		Compactor:                {Server, Overrides},
 		IndexGateway:             {Server},
 		IngesterQuerier:          {Ring},
-		All:                      {QueryFrontend, Querier, Ingester, Distributor, TableManager, Ruler},
+
+		// Virtual Targets
+		All:   {QueryFrontend, Querier, Ingester, Distributor, TableManager, Ruler},
+		Read:  {QueryFrontend, QueryScheduler, Querier},
+		Write: {Ingester, Distributor},
+		Async: {Ruler, TableManager, Compactor},
 	}
 
 	// Add IngesterQuerier as a dependency for store when target is either ingester or querier.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -78,7 +78,12 @@ const (
 	Compactor                string = "compactor"
 	IndexGateway             string = "index-gateway"
 	QueryScheduler           string = "query-scheduler"
-	All                      string = "all"
+
+	// Virtual Targets
+	All   string = "all"
+	Read  string = "read"
+	Write string = "write"
+	Async string = "async"
 )
 
 func (t *Loki) initServer() (services.Service, error) {
@@ -209,7 +214,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		QuerySchedulerEnabled: t.Cfg.isModuleEnabled(QueryScheduler),
 	}
 
-	var queryHandlers = map[string]http.Handler{
+	queryHandlers := map[string]http.Handler{
 		"/loki/api/v1/query_range":         http.HandlerFunc(t.Querier.RangeQueryHandler),
 		"/loki/api/v1/query":               http.HandlerFunc(t.Querier.InstantQueryHandler),
 		"/loki/api/v1/label":               http.HandlerFunc(t.Querier.LabelHandler),


### PR DESCRIPTION
Add virtual targets named read/write/async. Each of them represents one component in a typical 3 binary deployment, where `read` contains all services that are part of the read path, `write` contains all services that are part of the write path, and `async` contains all services that act as asynchronous background jobs.

These are aliases to improve the ease of use when a user wants to create a 3 component deployment.