### PR TITLE
Minor dashboard fixes

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'grafana-builder/grafana.libsonnet') {
   // Override the dashboard constructor to add:
   // - default tags,
-  // - some links that propagate the selectred cluster.
+  // - some links that propagate the selected cluster.
   dashboard(title, uid='')::
     super.dashboard(title, uid) + {
       addRowIf(condition, row)::

--- a/production/loki-mixin/dashboards/loki-chunks.libsonnet
+++ b/production/loki-mixin/dashboards/loki-chunks.libsonnet
@@ -1,7 +1,6 @@
-local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
-{
+(import 'dashboard-utils.libsonnet') {
   grafanaDashboards+: {
     local dashboards = self,
 
@@ -54,16 +53,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
       ],
     } +
-    g.dashboard('Loki / Chunks')
+    $.dashboard('Loki / Chunks')
+    .addClusterSelectorTemplates(false)
     .addRow(
-      g.row('Active Series / Chunks')
+      $.row('Active Series / Chunks')
       .addPanel(
-        g.panel('Series') +
-        g.queryPanel('sum(loki_ingester_memory_chunks{%s})' % dashboards['loki-chunks.json'].ingesterSelector, 'series'),
+        $.panel('Series') +
+        $.queryPanel('sum(loki_ingester_memory_chunks{%s})' % dashboards['loki-chunks.json'].ingesterSelector, 'series'),
       )
       .addPanel(
-        g.panel('Chunks per series') +
-        g.queryPanel(
+        $.panel('Chunks per series') +
+        $.queryPanel(
           'sum(loki_ingester_memory_chunks{%s}) / sum(loki_ingester_memory_streams{%s})' % [
             dashboards['loki-chunks.json'].ingesterSelector,
             dashboards['loki-chunks.json'].ingesterSelectorOnly,
@@ -73,27 +73,27 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Flush Stats')
+      $.row('Flush Stats')
       .addPanel(
-        g.panel('Utilization') +
-        g.latencyPanel('loki_ingester_chunk_utilization', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector, multiplier='1') +
-        { yaxes: g.yaxes('percentunit') },
+        $.panel('Utilization') +
+        $.latencyPanel('loki_ingester_chunk_utilization', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector, multiplier='1') +
+        { yaxes: $.yaxes('percentunit') },
       )
       .addPanel(
-        g.panel('Age') +
-        g.latencyPanel('loki_ingester_chunk_age_seconds', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector),
+        $.panel('Age') +
+        $.latencyPanel('loki_ingester_chunk_age_seconds', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector),
       ),
     )
     .addRow(
-      g.row('Flush Stats')
+      $.row('Flush Stats')
       .addPanel(
-        g.panel('Size') +
-        g.latencyPanel('loki_ingester_chunk_entries', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector, multiplier='1') +
-        { yaxes: g.yaxes('short') },
+        $.panel('Size') +
+        $.latencyPanel('loki_ingester_chunk_entries', '{%s}' % dashboards['loki-chunks.json'].ingesterSelector, multiplier='1') +
+        { yaxes: $.yaxes('short') },
       )
       .addPanel(
-        g.panel('Entries') +
-        g.queryPanel(
+        $.panel('Entries') +
+        $.queryPanel(
           'sum(rate(loki_chunk_store_index_entries_per_chunk_sum{%s}[5m])) / sum(rate(loki_chunk_store_index_entries_per_chunk_count{%s}[5m]))' % [
             dashboards['loki-chunks.json'].ingesterSelector,
             dashboards['loki-chunks.json'].ingesterSelector,
@@ -103,21 +103,21 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ),
     )
     .addRow(
-      g.row('Flush Stats')
+      $.row('Flush Stats')
       .addPanel(
-        g.panel('Queue Length') +
-        g.queryPanel('cortex_ingester_flush_queue_length{%s}' % dashboards['loki-chunks.json'].ingesterSelector, '{{pod}}'),
+        $.panel('Queue Length') +
+        $.queryPanel('cortex_ingester_flush_queue_length{%s}' % dashboards['loki-chunks.json'].ingesterSelector, '{{pod}}'),
       )
       .addPanel(
-        g.panel('Flush Rate') +
-        g.qpsPanel('loki_ingester_chunk_age_seconds_count{%s}' % dashboards['loki-chunks.json'].ingesterSelector,),
+        $.panel('Flush Rate') +
+        $.qpsPanel('loki_ingester_chunk_age_seconds_count{%s}' % dashboards['loki-chunks.json'].ingesterSelector,),
       ),
     )
     .addRow(
-      g.row('Duration')
+      $.row('Duration')
       .addPanel(
-        g.panel('Chunk Duration hours (end-start)') +
-        g.queryPanel(
+        $.panel('Chunk Duration hours (end-start)') +
+        $.queryPanel(
           [
             'histogram_quantile(0.5, sum(rate(loki_ingester_chunk_bounds_hours_bucket{%s}[5m])) by (le))' % dashboards['loki-chunks.json'].ingesterSelector,
             'histogram_quantile(0.99, sum(rate(loki_ingester_chunk_bounds_hours_bucket{%s}[5m])) by (le))' % dashboards['loki-chunks.json'].ingesterSelector,

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -1,7 +1,6 @@
-local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
-{
+(import 'dashboard-utils.libsonnet') {
   grafanaDashboards+: {
     local dashboards = self,
 
@@ -66,15 +65,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
       ],
     } +
-    g.dashboard('Loki / Reads')
+    $.dashboard('Loki / Reads')
+    .addClusterSelectorTemplates(false)
     .addRow(
-      g.row('Frontend (cortex_gw)')
+      $.row('Frontend (cortex_gw)')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].cortexGwSelector, http_routes])
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].cortexGwSelector, http_routes])
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-reads.json'].matchers.cortexgateway + [utils.selector.re('route', http_routes)],
@@ -84,13 +84,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Frontend (query-frontend)')
+      $.row('Frontend (query-frontend)')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].queryFrontendSelector, http_routes])
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].queryFrontendSelector, http_routes])
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-reads.json'].matchers.queryFrontend + [utils.selector.re('route', http_routes)],
@@ -100,13 +100,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Querier')
+      $.row('Querier')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].querierSelector, http_routes])
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].querierSelector, http_routes])
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-reads.json'].matchers.querier + [utils.selector.re('route', http_routes)],
@@ -116,13 +116,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Ingester')
+      $.row('Ingester')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].ingesterSelector, grpc_routes])
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['loki-reads.json'].ingesterSelector, grpc_routes])
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-reads.json'].matchers.ingester + [utils.selector.re('route', grpc_routes)],
@@ -132,13 +132,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('BigTable')
+      $.row('BigTable')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/ReadRows"}' % dashboards['loki-reads.json'].querierSelector)
+        $.panel('QPS') +
+        $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/ReadRows"}' % dashboards['loki-reads.json'].querierSelector)
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'cortex_bigtable_request_duration_seconds',
           dashboards['loki-reads.json'].matchers.querier + [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/ReadRows')]
@@ -146,14 +146,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('BoltDB Shipper')
+      $.row('BoltDB Shipper')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
+        $.panel('QPS') +
+        $.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
       )
       .addPanel(
-        g.panel('Latency') +
-        g.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
+        $.panel('Latency') +
+        $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="QUERY"}' % dashboards['loki-reads.json'].querierOrIndexGatewaySelector)
       )
     ){
       templating+: {

--- a/production/loki-mixin/dashboards/loki-retention.libsonnet
+++ b/production/loki-mixin/dashboards/loki-retention.libsonnet
@@ -1,4 +1,3 @@
-local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
@@ -76,8 +75,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         .addRow(
           $.row('')
           .addPanel(
+            $.panel('Sweeper Lag') +
             $.queryPanel(['time() - (loki_boltdb_shipper_retention_sweeper_marker_file_processing_current_time{%s} > 0)' % $.namespaceMatcher()], ['lag']) + {
-              yaxes: g.yaxes({ format: 's', min: null }),
+              yaxes: $.yaxes({ format: 's', min: null }),
             },
           )
           .addPanel(

--- a/production/loki-mixin/dashboards/loki-writes.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes.libsonnet
@@ -1,7 +1,6 @@
-local g = import 'grafana-builder/grafana.libsonnet';
 local utils = import 'mixin-utils/utils.libsonnet';
 
-{
+(import 'dashboard-utils.libsonnet') {
   grafanaDashboards+: {
     local dashboards = self,
 
@@ -59,15 +58,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
       ],
     } +
-    g.dashboard('Loki / Writes')
+    $.dashboard('Loki / Writes')
+    .addClusterSelectorTemplates(false)
     .addRow(
-      g.row('Frontend (cortex_gw)')
+      $.row('Frontend (cortex_gw)')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route=~"api_prom_push|loki_api_v1_push"}' % dashboards['loki-writes.json'].cortexGwSelector)
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route=~"api_prom_push|loki_api_v1_push"}' % dashboards['loki-writes.json'].cortexGwSelector)
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-writes.json'].matchers.cortexgateway + [utils.selector.re('route', 'api_prom_push|loki_api_v1_push')],
@@ -76,13 +76,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Distributor')
+      $.row('Distributor')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s}' % std.rstripChars(dashboards['loki-writes.json'].distributorSelector, ','))
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s}' % std.rstripChars(dashboards['loki-writes.json'].distributorSelector, ','))
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-writes.json'].matchers.distributor,
@@ -91,13 +91,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('Ingester')
+      $.row('Ingester')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterSelector)
+        $.panel('QPS') +
+        $.qpsPanel('loki_request_duration_seconds_count{%s route="/logproto.Pusher/Push"}' % dashboards['loki-writes.json'].ingesterSelector)
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'loki_request_duration_seconds',
           dashboards['loki-writes.json'].matchers.ingester + [utils.selector.eq('route', '/logproto.Pusher/Push')],
@@ -106,13 +106,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('BigTable')
+      $.row('BigTable')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/MutateRows"}' % dashboards['loki-writes.json'].ingesterSelector)
+        $.panel('QPS') +
+        $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s operation="/google.bigtable.v2.Bigtable/MutateRows"}' % dashboards['loki-writes.json'].ingesterSelector)
       )
       .addPanel(
-        g.panel('Latency') +
+        $.panel('Latency') +
         utils.latencyRecordingRulePanel(
           'cortex_bigtable_request_duration_seconds',
           dashboards['loki-writes.json'].clusterMatchers + dashboards['loki-writes.json'].matchers.ingester + [utils.selector.eq('operation', '/google.bigtable.v2.Bigtable/MutateRows')]
@@ -120,14 +120,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      g.row('BoltDB Shipper')
+      $.row('BoltDB Shipper')
       .addPanel(
-        g.panel('QPS') +
-        g.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
+        $.panel('QPS') +
+        $.qpsPanel('loki_boltdb_shipper_request_duration_seconds_count{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
       )
       .addPanel(
-        g.panel('Latency') +
-        g.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
+        $.panel('Latency') +
+        $.latencyPanel('loki_boltdb_shipper_request_duration_seconds', '{%s operation="WRITE"}' % dashboards['loki-writes.json'].ingesterSelector)
       )
     ){
       templating+: {


### PR DESCRIPTION
Fix to retention dashboard (seems like query panel without a `panel(...)` line to set the name throws an error, plus add links + selector copying dropdown to other dashboards (top right of dashboard, links to other dashboards and copies over cluster selectors, etc.).


