### PR TITLE
Loki: Bug: frontend waiting on results which would never come

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -133,6 +133,7 @@ func (in instance) For(
 	for i := 0; i < len(queries); i++ {
 		select {
 		case <-ctx.Done():
+			return nil, ctx.Err()
 		case resp := <-ch:
 			if resp.err != nil {
 				return nil, resp.err

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -131,11 +131,14 @@ func (in instance) For(
 
 	results := make([]logqlmodel.Result, len(queries))
 	for i := 0; i < len(queries); i++ {
-		resp := <-ch
-		if resp.err != nil {
-			return nil, resp.err
+		select {
+		case <-ctx.Done():
+		case resp := <-ch:
+			if resp.err != nil {
+				return nil, resp.err
+			}
+			results[resp.i] = resp.res
 		}
-		results[resp.i] = resp.res
 	}
 	return results, nil
 }


### PR DESCRIPTION
We were not also checking the context to see if it was canceled while waiting for goroutines to return with query results leading to a leak of goroutines.