### PR TITLE
Docs: correctly represent product name

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,10 +1,10 @@
 ---
-title: Loki Documentation
+title: Grafana Loki
 aliases:
   - /docs/loki/
 ---
 
-# Loki Documentation
+# Grafana Loki Documentation
 
 <p align="center"> <img src="logo_and_name.png" alt="Loki Logo"> <br>
   <small>Like Prometheus, but for logs!</small> </p>

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -3,9 +3,9 @@ title: HTTP API
 weight: 900
 ---
 
-# Loki HTTP API
+# Grafana Loki HTTP API
 
-Loki exposes an HTTP API for pushing, querying, and tailing log data.
+Grafana Loki exposes an HTTP API for pushing, querying, and tailing log data.
 Note that [authenticating](../operations/authentication/) against the API is
 out of scope for Loki.
 

--- a/docs/sources/best-practices/_index.md
+++ b/docs/sources/best-practices/_index.md
@@ -2,9 +2,9 @@
 title: Best practices
 weight: 400
 ---
-# Loki label best practices
+# Grafana Loki label best practices
 
-Loki is under active development, and we are constantly working to improve performance. But here are some of the most current best practices for labels that will give you the best experience with Loki.
+Grafana Loki is under active development, and we are constantly working to improve performance. But here are some of the most current best practices for labels that will give you the best experience with Loki.
 
 ## Static labels are good
 

--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -2,9 +2,9 @@
 title: Clients
 weight: 600
 ---
-# Loki clients
+# Grafana Loki clients
 
-Loki supports the following official clients for sending logs:
+Grafana Loki supports the following official clients for sending logs:
 
 - [Promtail](promtail/)
 - [Docker Driver](docker-driver/)

--- a/docs/sources/clients/aws/_index.md
+++ b/docs/sources/clients/aws/_index.md
@@ -1,8 +1,9 @@
 ---
 title: AWS
+weight: 30
 ---
 
-Sending logs from AWS services to Loki is a little different depending on what AWS service you are using:
+Sending logs from AWS services to Grafana Loki is a little different depending on what AWS service you are using:
 
 * [Elastic Compute Cloud (EC2)](ec2/)
 * [Elastic Container Service (ECS)](ecs/)

--- a/docs/sources/clients/aws/ec2/_index.md
+++ b/docs/sources/clients/aws/ec2/_index.md
@@ -3,7 +3,7 @@ title: EC2
 ---
 # Running Promtail on AWS EC2
 
-In this tutorial we're going to setup [Promtail](../../promtail/) on an AWS EC2 instance and configure it to sends all its logs to a Loki instance.
+In this tutorial we're going to setup [Promtail](../../promtail/) on an AWS EC2 instance and configure it to sends all its logs to a Grafana Loki instance.
 
 <!-- TOC -->
 

--- a/docs/sources/clients/aws/ecs/_index.md
+++ b/docs/sources/clients/aws/ecs/_index.md
@@ -3,7 +3,7 @@ title: ECS
 ---
 # Sending Logs From AWS Elastic Container Service (ECS)
 
-[ECS][ECS] is the fully managed container orchestration service by Amazon. Combined with [Fargate][Fargate] you can run your container workload without the need to provision your own compute resources. In this tutorial we will see how you can leverage [Firelens][Firelens] an AWS log router to forward all your logs and your workload metadata to a Loki instance.
+[ECS][ECS] is the fully managed container orchestration service by Amazon. Combined with [Fargate][Fargate] you can run your container workload without the need to provision your own compute resources. In this tutorial we will see how you can leverage [Firelens][Firelens] an AWS log router to forward all your logs and your workload metadata to a Grafana Loki instance.
 
 After this tutorial you will able to query all your logs in one place using Grafana.
 

--- a/docs/sources/clients/aws/eks/_index.md
+++ b/docs/sources/clients/aws/eks/_index.md
@@ -25,7 +25,7 @@ Before we start you'll need:
 
 - The [AWS CLI][aws cli] configured (run `aws configure`).
 - [kubectl][kubectl] and [eksctl][eksctl] installed.
-- A Grafana instance with a Loki data source already configured, you can use [GrafanaCloud][GrafanaCloud] free trial.
+- A Grafana instance with a Grafana Loki data source already configured, you can use [GrafanaCloud][GrafanaCloud] free trial.
 
 For the sake of simplicity we'll use a [GrafanaCloud][GrafanaCloud] Loki and Grafana instances, you can get an free account for this tutorial on our [website][GrafanaCloud], but all the steps are the same if you're running your own Open Source version of Loki and Grafana instances.
 

--- a/docs/sources/clients/docker-driver/_index.md
+++ b/docs/sources/clients/docker-driver/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Docker driver
+weight: 40
 ---
 # Docker Driver Client
 
-Loki officially supports a Docker plugin that will read logs from Docker
+Grafana Loki officially supports a Docker plugin that will read logs from Docker
 containers and ship them to Loki. The plugin can be configured to send the logs
 to a private Loki instance or [Grafana Cloud](https://grafana.com/oss/loki).
 

--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -8,7 +8,7 @@ each container will use the default driver unless configured otherwise.
 
 ## Installation
 
-Before configuring the plugin, [install or upgrade the Loki Docker Driver Client](../../docker-driver/)
+Before configuring the plugin, [install or upgrade the Grafana Loki Docker Driver Client](../../docker-driver/)
 
 ## Change the logging driver for a container
 

--- a/docs/sources/clients/fluentbit/_index.md
+++ b/docs/sources/clients/fluentbit/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Fluentbit
+weight: 50
 ---
 # Fluentbit Loki Output Plugin
 
-[Fluent Bit](https://fluentbit.io/) is a Fast and Lightweight Data Forwarder, it can be configured with the [Loki output plugin](https://fluentbit.io/documentation/0.12/output/) to ship logs to Loki. You can define which log files you want to collect using the [`Tail`](https://fluentbit.io/documentation/0.12/input/tail.html) or [`Stdin`](https://docs.fluentbit.io/manual/pipeline/inputs/standard-input) [input plugin](https://fluentbit.io/documentation/0.12/getting_started/input.html). Additionally Fluent Bit supports multiple `Filter` and `Parser` plugins (`Kubernetes`, `JSON`, etc..) to structure and alter log lines.
+[Fluent Bit](https://fluentbit.io/) is a Fast and Lightweight Data Forwarder, it can be configured with the [Grafana Loki output plugin](https://fluentbit.io/documentation/0.12/output/) to ship logs to Loki. You can define which log files you want to collect using the [`Tail`](https://fluentbit.io/documentation/0.12/input/tail.html) or [`Stdin`](https://docs.fluentbit.io/manual/pipeline/inputs/standard-input) [input plugin](https://fluentbit.io/documentation/0.12/getting_started/input.html). Additionally Fluent Bit supports multiple `Filter` and `Parser` plugins (`Kubernetes`, `JSON`, etc..) to structure and alter log lines.
 
 ## Usage
 

--- a/docs/sources/clients/fluentd/_index.md
+++ b/docs/sources/clients/fluentd/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Fluentd
+weight: 60
 ---
 # Fluentd Loki Output Plugin
 
-Loki has a [Fluentd](https://www.fluentd.org/) output plugin called
+Grafana Loki has a [Fluentd](https://www.fluentd.org/) output plugin called
 `fluent-plugin-grafana-loki` that enables shipping logs to a private Loki
 instance or [Grafana Cloud](https://grafana.com/products/cloud/).
 

--- a/docs/sources/clients/lambda-promtail/_index.md
+++ b/docs/sources/clients/lambda-promtail/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Lambda Promtail
+weight: 20
 ---
 # Lambda Promtail
 
-Loki includes an [AWS SAM](https://aws.amazon.com/serverless/sam/) package template for shipping Cloudwatch logs to Loki via a [set of Promtails](https://github.com/grafana/loki/tree/master/tools/lambda-promtail). This is done via an intermediary [lambda function](https://aws.amazon.com/lambda/) which processes cloudwatch events and propagates them to a Promtail instance (or set of instances behind a load balancer) via the push-api [scrape config](../promtail/configuration#loki_push_api_config).
+Grafana Loki includes an [AWS SAM](https://aws.amazon.com/serverless/sam/) package template for shipping Cloudwatch logs to Loki via a [set of Promtails](https://github.com/grafana/loki/tree/master/tools/lambda-promtail). This is done via an intermediary [lambda function](https://aws.amazon.com/lambda/) which processes cloudwatch events and propagates them to a Promtail instance (or set of instances behind a load balancer) via the push-api [scrape config](../promtail/configuration#loki_push_api_config).
 
 ## Uses
 

--- a/docs/sources/clients/logstash/_index.md
+++ b/docs/sources/clients/logstash/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Logstash
+weight: 70
 ---
 # Logstash
 
-Loki has a [Logstash](https://www.elastic.co/logstash) output plugin called
+Grafana Loki has a [Logstash](https://www.elastic.co/logstash) output plugin called
 `logstash-output-loki` that enables shipping logs to a Loki
 instance or [Grafana Cloud](https://grafana.com/products/cloud/).
 

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Promtail
+weight: 10
 ---
 # Promtail
 
-Promtail is an agent which ships the contents of local logs to a private Loki
+Promtail is an agent which ships the contents of local logs to a private Grafana Loki
 instance or [Grafana Cloud](https://grafana.com/oss/loki). It is usually
 deployed to every machine that has applications needed to be monitored.
 

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -80,7 +80,7 @@ Where default_value is the value to use if the environment variable is undefined
 [server: <server_config>]
 
 # Describes how Promtail connects to multiple instances
-# of Loki, sending logs to each.
+# of Grafana Loki, sending logs to each.
 # WARNING: If one of the remote Loki servers fails to respond or responds
 # with any error which is retryable, this will impact sending logs to any
 # other configured remote Loki servers.  Sending is done on a single thread!

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -3,7 +3,7 @@ title: Cloud setup GCP Logs
 ---
 # Cloud setup GCP logs
 
-This document explain how one can setup Google Cloud Platform to forward its cloud resource logs from a particular GCP project into Google Pubsub topic so that is available for Loki Promtail to consume.
+This document explain how one can setup Google Cloud Platform to forward its cloud resource logs from a particular GCP project into Google Pubsub topic so that is available for Promtail to consume.
 
 This document assumes, that reader have `gcloud` installed and have required permissions(as mentioned in #[Roles and Permission] section)
 
@@ -46,7 +46,7 @@ For more information on adding `log-filter` refer this [document](https://cloud.
 
 We cover more advanced `log-filter` [below](#Advanced-Log-filter)
 
-## Create Pubsub subscription for Loki
+## Create Pubsub subscription for Grafana Loki
 
 We create subscription for the pubsub topic we create above and Promtail uses this subscription to consume log messages.
 
@@ -94,7 +94,7 @@ gcloud pubsub subscriptions seek projects/my-project/subscriptions/cloud-logs --
 
 ## Advanced log filter
 
-So far we've covered admitting GCS bucket logs into Loki, but often one may need to add multiple cloud resource logs and may also need to exclude unnecessary logs. The following is a more complex example.
+So far we've covered admitting GCS bucket logs into Grafana Loki, but often one may need to add multiple cloud resource logs and may also need to exclude unnecessary logs. The following is a more complex example.
 
 We use the `log-filter` option to include logs and the `exclusion` option to exclude them.
 

--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -33,7 +33,7 @@ something with that extracted data. The most common action stage will be a
 A common stage will also be the [match](../stages/match/) stage to selectively
 apply stages or drop entries based on a [LogQL stream selector and filter expressions](../../../logql/).
 
-Note that pipelines can not currently be used to deduplicate logs; Loki will
+Note that pipelines can not currently be used to deduplicate logs; Grafana Loki will
 receive the same log line multiple times if, for example:
 
 1. Two scrape configs read from the same file

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -33,7 +33,7 @@ There are different types of labels present in Promtail:
 - Labels starting with `__` (two underscores) are internal labels. They usually
   come from dynamic sources like service discovery. Once relabeling is done,
   they are removed from the label set. To persist internal labels so they're
-  sent to Loki, rename them so they don't start with `__`. See
+  sent to Grafana Loki, rename them so they don't start with `__`. See
   [Relabeling](#relabeling) for more information.
 
 - Labels starting with `__meta_kubernetes_pod_label_*` are "meta labels" which

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2,9 +2,9 @@
 title: Configuration
 weight: 500
 ---
-# Configuring Loki
+# Configuring Grafana Loki
 
-Loki is configured in a YAML file (usually referred to as `loki.yaml` )
+Grafana Loki is configured in a YAML file (usually referred to as `loki.yaml` )
 which contains information on the Loki server and its individual components,
 depending on which mode Loki is launched in.
 

--- a/docs/sources/configuration/examples.md
+++ b/docs/sources/configuration/examples.md
@@ -1,9 +1,9 @@
 ---
 title: Examples
 ---
-# Loki Configuration Examples
+# Grafana Loki Configuration Examples
 
-## Complete Local config
+## Complete Local configuration
 
 ```yaml
 auth_enabled: false

--- a/docs/sources/configuration/query-frontend.md
+++ b/docs/sources/configuration/query-frontend.md
@@ -9,7 +9,7 @@ This aims to be a general purpose example; there are a number of substitutions t
 
 ## Use case
 
-It's a common occurrence to start running Loki as a single binary while trying it out in order to simplify deployments and defer learning the (initially unnecessary) nitty gritty details. As we become more comfortable with its paradigms and begin migrating towards a more production ready deployment there are a number of things to be aware of. A common bottleneck is on the read path: queries that executed effortlessly on small data sets may churn to a halt on larger ones. Sometimes we can solve this with more queriers. However, that doesn't help when our queries are too large for a single querier to execute. Then we need the query frontend.
+It's a common occurrence to start running Grafana Loki as a single binary while trying it out in order to simplify deployments and defer learning the (initially unnecessary) nitty gritty details. As we become more comfortable with its paradigms and begin migrating towards a more production ready deployment there are a number of things to be aware of. A common bottleneck is on the read path: queries that executed effortlessly on small data sets may churn to a halt on larger ones. Sometimes we can solve this with more queriers. However, that doesn't help when our queries are too large for a single querier to execute. Then we need the query frontend.
 
 ### Parallelization
 

--- a/docs/sources/fundamentals/architecture/_index.md
+++ b/docs/sources/fundamentals/architecture/_index.md
@@ -4,12 +4,12 @@ weight: 200
 aliases:
     - /docs/loki/latest/architecture/
 ---
-# Loki's Architecture
+# Grafana Loki's Architecture
 
 ## Multi-tenancy
 
 All data, both in memory and in long-term storage, may be partitioned by a
-tenant ID, pulled from the `X-Scope-OrgID` HTTP header in the request when Loki
+tenant ID, pulled from the `X-Scope-OrgID` HTTP header in the request when Grafana Loki
 is running in multi-tenant mode. When Loki is **not** in multi-tenant mode, the
 header is ignored and the tenant ID is set to "fake", which will appear in the
 index and in stored chunks.

--- a/docs/sources/fundamentals/architecture/distributor.md
+++ b/docs/sources/fundamentals/architecture/distributor.md
@@ -8,7 +8,7 @@ Distributors are stateless and communicate with ingesters via [gRPC](https://grp
 
 ## Where does it live?
 
-The distributor is the first component on Loki's write path downstream from any gateways providing auth or load balancing. It's responsible for validating, preprocessing, and applying a subset of rate limiting to incoming data before sending it to the ingester component. It is important that a load balancer sits in front of the distributor in order to properly balance traffic to them.
+The distributor is the first component on Grafana Loki's write path downstream from any gateways providing auth or load balancing. It's responsible for validating, preprocessing, and applying a subset of rate limiting to incoming data before sending it to the ingester component. It is important that a load balancer sits in front of the distributor in order to properly balance traffic to them.
 
 ## What does it do?
 

--- a/docs/sources/fundamentals/labels.md
+++ b/docs/sources/fundamentals/labels.md
@@ -8,7 +8,7 @@ aliases:
 
 Labels are key value pairs and can be defined as anything! We like to refer to them as metadata to describe a log stream. If you are familiar with Prometheus, there are a few labels you are used to seeing like `job` and `instance`, and I will use those in the coming examples.
 
-The scrape configs we provide with Loki define these labels, too. If you are using Prometheus, having consistent labels between Loki and Prometheus is one of Loki's superpowers, making it incredibly [easy to correlate your application metrics with your log data](https://grafana.com/blog/2019/05/06/how-loki-correlates-metrics-and-logs-and-saves-you-money/).
+The scrape configs we provide with Grafana Loki define these labels, too. If you are using Prometheus, having consistent labels between Loki and Prometheus is one of Loki's superpowers, making it incredibly [easy to correlate your application metrics with your log data](https://grafana.com/blog/2019/05/06/how-loki-correlates-metrics-and-logs-and-saves-you-money/).
 
 ## How Loki uses labels
 

--- a/docs/sources/fundamentals/overview/comparisons.md
+++ b/docs/sources/fundamentals/overview/comparisons.md
@@ -3,7 +3,7 @@ title: Comparisons
 ---
 # Loki compared to other log systems
 
-## Loki / Promtail / Grafana vs EFK
+## Grafana Loki / Promtail / Grafana vs EFK
 
 The EFK (Elasticsearch, Fluentd, Kibana) stack is used to ingest, visualize, and
 query for logs from various sources.
@@ -13,7 +13,7 @@ keys for each object and the contents of each key are indexed. Data can then be
 queried using a JSON object to define a query (called the Query DSL) or through
 the Lucene query language.
 
-In comparison, Loki in single-binary mode can store data on-disk, but in
+In comparison, Grafana Loki in single-binary mode can store data on-disk, but in
 horizontally-scalable mode data is stored in a cloud storage system such as S3,
 GCS, or Cassandra. Logs are stored in plaintext form tagged with a set of label
 names and values, where only the label pairs are indexed. This tradeoff makes it

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -2,7 +2,7 @@
 title: Getting started
 weight: 300
 ---
-# Getting started with Loki
+# Getting started with Grafana Loki
 
 > **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 

--- a/docs/sources/getting-started/get-logs-into-loki.md
+++ b/docs/sources/getting-started/get-logs-into-loki.md
@@ -1,9 +1,10 @@
 ---
 title: Get logs into Loki
+weight: 10
 ---
-# Get logs into Loki
+# Get logs into Grafana Loki
 
-After you [install and run Loki](../../installation/local/), you probably want to get logs from other applications into it.
+After you [install and run Grafana Loki](../../installation/local/), you probably want to get logs from other applications into it.
 
 To get application logs into Loki, you need to edit the [Promtail]({{< relref "../clients/promtail" >}}) configuration file.
 

--- a/docs/sources/getting-started/grafana.md
+++ b/docs/sources/getting-started/grafana.md
@@ -1,10 +1,11 @@
 ---
 title: Loki in Grafana
+weight: 30
 ---
 # Loki in Grafana
 
 [Grafana 6.0](https://grafana.com/grafana/download/6.0.0) and more recent
-versions have built-in support for Loki.
+versions have built-in support for Grafana Loki.
 Use [Grafana 6.3](https://grafana.com/grafana/download/6.3.0) or a more
 recent version to take advantage of [LogQL]({{< relref "../logql/_index.md" >}}) functionality.
 

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -1,9 +1,10 @@
 ---
 title: LogCLI
+weight: 20
 ---
-# LogCLI, Loki's command-line interface
+# LogCLI, Grafana Loki's command-line interface
 
-LogCLI is the command-line interface to Loki.
+LogCLI is the command-line interface to Grafana Loki.
 It facilitates running [LogQL]({{< relref "../logql/_index.md" >}})
 queries against a Loki instance.
 

--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -1,11 +1,12 @@
 ---
 title: Troubleshooting
+weight: 40
 ---
-# Troubleshooting Loki
+# Troubleshooting Grafana Loki
 
 ## "Loki: Bad Gateway. 502"
 
-This error can appear in Grafana when Loki is added as a
+This error can appear in Grafana when Grafana Loki is added as a
 datasource, indicating that Grafana in unable to connect to Loki. There may
 one of many root causes:
 

--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -2,9 +2,9 @@
 title: Docker
 weight: 30
 ---
-# Install Loki with Docker or Docker Compose
+# Install Grafana Loki with Docker or Docker Compose
 
-You can install Loki and Promtail with Docker or Docker Compose if you are evaluating, testing, or developing Loki.
+You can install Grafana Loki and Promtail with Docker or Docker Compose if you are evaluating, testing, or developing Loki.
 For production, we recommend installing with Tanka or Helm.
 
 The configuration acquired with these installation instructions run Loki as a single binary.

--- a/docs/sources/installation/helm.md
+++ b/docs/sources/installation/helm.md
@@ -2,9 +2,9 @@
 title: Helm
 weight: 20
 ---
-# Install Loki with Helm
+# Install Grafana Loki with Helm
 
-The Helm installation runs the Loki cluster as a single binary.
+The Helm installation runs the Grafana Loki cluster as a single binary.
 
 ## Prerequisites
 

--- a/docs/sources/installation/install-from-source.md
+++ b/docs/sources/installation/install-from-source.md
@@ -4,7 +4,7 @@ weight: 50
 ---
 # Build from source
 
-Clone the Loki repository and use the provided `Makefile`
+Clone the Grafana Loki repository and use the provided `Makefile`
 to build Loki from source.
 
 ## Prerequisites

--- a/docs/sources/installation/local.md
+++ b/docs/sources/installation/local.md
@@ -2,9 +2,9 @@
 title: Local
 weight: 40
 ---
-# Install and run Loki locally
+# Install and run Grafana Loki locally
 
-In order to log events with Loki, download and install both Promtail and Loki.
+In order to log events with Grafana Loki, download and install both Promtail and Loki.
 - Loki is the logging engine.
 - Promtail sends logs to Loki.
 

--- a/docs/sources/installation/tanka.md
+++ b/docs/sources/installation/tanka.md
@@ -2,11 +2,11 @@
 title: Tanka
 weight: 10
 ---
-# Install Loki with Tanka
+# Install Grafana Loki with Tanka
 
 [Tanka](https://tanka.dev) is a reimplementation of
 [Ksonnet](https://ksonnet.io) that Grafana Labs created after Ksonnet was
-deprecated. Tanka is used by Grafana Labs to run Loki in production.
+deprecated. Tanka is used by Grafana Labs to run Grafana Loki in production.
 
 The Tanka installation runs the Loki cluster in microservices mode.
 

--- a/docs/sources/logql/_index.md
+++ b/docs/sources/logql/_index.md
@@ -4,7 +4,7 @@ weight: 700
 ---
 # LogQL: Log query language
 
-LogQL is Loki's PromQL-inspired query language.
+LogQL is Grafana Loki's PromQL-inspired query language.
 Queries act as if they are a distributed `grep` to aggregate log sources.
 LogQL uses labels and operators for filtering.
 

--- a/docs/sources/logql/log_queries.md
+++ b/docs/sources/logql/log_queries.md
@@ -49,7 +49,7 @@ A stream may contain other pairs of labels and values,
 but only the specified pairs within the stream selector are used to determine
 which streams will be included within the query results.
 
-The same rules that apply for [Prometheus Label Selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) apply for Loki log stream selectors.
+The same rules that apply for [Prometheus Label Selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) apply for Grafana Loki log stream selectors.
 
 The `=` operator after the label name is a **label matching operator**.
 The following label matching operators are supported:

--- a/docs/sources/logql/metric_queries.md
+++ b/docs/sources/logql/metric_queries.md
@@ -16,7 +16,7 @@ All labels, including extracted ones, will be available for aggregations and gen
 ## Range Vector aggregation
 
 LogQL shares the [range vector](https://prometheus.io/docs/prometheus/latest/querying/basics/#range-vector-selectors) concept of Prometheus.
-In Loki, the selected range of samples is a range of selected log or label values.
+In Grafana Loki, the selected range of samples is a range of selected log or label values.
 
 The aggregation is applied over a time duration.
 Loki defines [Time Durations](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-durations) with the same syntax as Prometheus.

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -40,7 +40,7 @@ Examples:
 `{{ToUpper "This is a string" | ToLower}}`
 ```
 
-> **Note:** In Loki 2.1 you can also use respectively [`lower`](#lower) and [`upper`](#upper) shortcut, e.g `{{.request_method | lower }}`.
+> **Note:** In Grafana Loki 2.1 you can also use respectively [`lower`](#lower) and [`upper`](#upper) shortcut, e.g `{{.request_method | lower }}`.
 
 ## Replace string
 

--- a/docs/sources/maintaining/_index.md
+++ b/docs/sources/maintaining/_index.md
@@ -2,6 +2,6 @@
 title: Maintaining
 weight: 1200
 ---
-# Loki Maintainers Guide
+# Grafana Loki Maintainers' Guide
 
-This section details information for maintainers of Loki.
+This section details information for maintainers of Grafana Loki.

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -3,7 +3,7 @@ title: Releasing Loki Build Image
 ---
 # Releasing `loki-build-image`
 
-The [`loki-build-image`](https://github.com/grafana/loki/tree/master/loki-build-image) is the Docker image used to run tests and build Loki binaries in CI.
+The [`loki-build-image`](https://github.com/grafana/loki/tree/master/loki-build-image) is the Docker image used to run tests and build Grafana Loki binaries in CI.
 
 ## How To Perform a Release
 

--- a/docs/sources/maintaining/release.md
+++ b/docs/sources/maintaining/release.md
@@ -1,9 +1,9 @@
 ---
 title: Releasing Loki
 ---
-# Releasing Loki
+# Releasing Grafana Loki
 
-This document is a series of instructions for core Loki maintainers to be able
+This document is a series of instructions for core Grafana Loki maintainers to be able
 to publish a new Loki release.
 
 ## Prerequisites

--- a/docs/sources/operations/authentication.md
+++ b/docs/sources/operations/authentication.md
@@ -2,9 +2,9 @@
 title: Authentication
 weight: 10
 ---
-# Authentication with Loki
+# Authentication with Grafana Loki
 
-Loki does not come with any included authentication layer. Operators are
+Grafana Loki does not come with any included authentication layer. Operators are
 expected to run an authenticating reverse proxy in front of your services, such
 as NGINX using basic auth or an OAuth2 proxy.
 

--- a/docs/sources/operations/loki-canary.md
+++ b/docs/sources/operations/loki-canary.md
@@ -7,7 +7,7 @@ weight: 60
 ![canary](../canary.png)
 
 Loki Canary is a standalone app that audits the log-capturing performance of
-a Loki cluster.
+a Grafana Loki cluster.
 
 Loki Canary generates artificial log lines.
 These log lines are sent to the Loki cluster.

--- a/docs/sources/operations/multi-tenancy.md
+++ b/docs/sources/operations/multi-tenancy.md
@@ -2,9 +2,9 @@
 title: Multi-tenancy
 weight: 50
 ---
-# Loki Multi-Tenancy
+# Grafana Loki Multi-Tenancy
 
-Loki is a multi-tenant system; requests and data for tenant A are isolated from
+Grafana Loki is a multi-tenant system; requests and data for tenant A are isolated from
 tenant B. Requests to the Loki API should include an HTTP header
 (`X-Scope-OrgID`) that identifies the tenant for the request.
 

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -2,9 +2,9 @@
 title: Observability
 weight: 20
 ---
-# Observing Loki
+# Observing Grafana Loki
 
-Both Loki and Promtail expose a `/metrics` endpoint that expose Prometheus
+Both Grafana Loki and Promtail expose a `/metrics` endpoint that expose Prometheus
 metrics. You will need a local Prometheus and add Loki and Promtail as targets.
 See [configuring
 Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration)

--- a/docs/sources/operations/scalability.md
+++ b/docs/sources/operations/scalability.md
@@ -2,10 +2,10 @@
 title: Scalability
 weight: 30
 ---
-# Scaling with Loki
+# Scaling with Grafana Loki
 
 See [Loki: Prometheus-inspired, open source logging for cloud natives](https://grafana.com/blog/2018/12/12/loki-prometheus-inspired-open-source-logging-for-cloud-natives/)
-for a discussion about Loki's scalability.
+for a discussion about Grafana Loki's scalability.
 
 When scaling Loki, operators should consider running several Loki processes
 partitioned by role (ingester, distributor, querier) rather than a single Loki

--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -2,11 +2,11 @@
 title: Storage
 weight: 40
 ---
-# Loki Storage
+# Grafana Loki Storage
 
 [High level storage overview here]({{< relref "../../storage/_index.md" >}})
 
-Loki needs to store two different types of data: **chunks** and **indexes**.
+Grafana Loki needs to store two different types of data: **chunks** and **indexes**.
 
 Loki receives logs in separate streams, where each stream is uniquely identified
 by its tenant ID and its set of labels. As log entries from a stream arrive,

--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -3,7 +3,7 @@ title: Single Store (boltdb-shipper)
 ---
 # Single Store Loki (boltdb-shipper index type)
 
-BoltDB Shipper lets you run Loki without any dependency on NoSQL stores for storing index.
+BoltDB Shipper lets you run Grafana Loki without any dependency on NoSQL stores for storing index.
 It locally stores the index in BoltDB files instead and keeps shipping those files to a shared object store i.e the same object store which is being used for storing chunks.
 It also keeps syncing BoltDB files from shared object store to a configured local directory for getting index entries created by other services of same Loki cluster.
 This helps run Loki with one less dependency and also saves costs in storage since object stores are likely to be much cheaper compared to cost of a hosted NoSQL store or running a self hosted instance of Cassandra.

--- a/docs/sources/operations/storage/filesystem.md
+++ b/docs/sources/operations/storage/filesystem.md
@@ -3,7 +3,7 @@ title: Filesystem
 ---
 # Filesystem Object Store
 
-The filesystem object store is the easiest to get started with Loki but there are some pros/cons to this approach.
+The filesystem object store is the easiest to get started with Grafana Loki but there are some pros/cons to this approach.
 
 Very simply it stores all the objects (chunks) in the specified directory:
 
@@ -15,7 +15,7 @@ storage_config:
 
 A folder is created for every tenant all the chunks for one tenant are stored in that directory.
 
-If loki is run in single-tenant mode, all the chunks are put in a folder named `fake` which is the synthesized tenant name used for single tenant mode.
+If Loki is run in single-tenant mode, all the chunks are put in a folder named `fake` which is the synthesized tenant name used for single tenant mode.
 
 See [multi-tenancy](../../multi-tenancy/) for more information.
 

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -6,7 +6,7 @@ weight: 60
 
 <span style="background-color:#f3f973;">Log entry deletion is experimental. It is only supported for the BoltDB Shipper index store.</span>
 
-Loki supports the deletion of log entries from specified streams.
+Grafana Loki supports the deletion of log entries from specified streams.
 Log entries that fall within a specified time window are those that will be deleted.
 
 The Compactor component exposes REST endpoints that process delete requests.

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -1,9 +1,9 @@
 ---
 title: Retention
 ---
-# Loki Storage Retention
+# Grafana Loki Storage Retention
 
-Retention in Loki is achieved either through the [Table Manager](#table-manager) or the [Compactor](#Compactor).
+Retention in Grafana Loki is achieved either through the [Table Manager](#table-manager) or the [Compactor](#Compactor).
 
 
 Retention through the [Table Manager](../table-manager/) is achieved by relying on the object store TTL feature, and will work for both [boltdb-shipper](../boltdb-shipper) store and chunk/index store. However retention through the [Compactor](../boltdb-shipper#compactor) is supported only with the [boltdb-shipper](../boltdb-shipper) store.

--- a/docs/sources/operations/storage/table-manager.md
+++ b/docs/sources/operations/storage/table-manager.md
@@ -3,7 +3,7 @@ title: Table manager
 ---
 # Table Manager
 
-Loki supports storing indexes and chunks in table-based data storages. When
+Grafana Loki supports storing indexes and chunks in table-based data storages. When
 such a storage type is used, multiple tables are created over the time: each
 table - also called periodic table - contains the data for a specific time
 range.

--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -6,7 +6,7 @@ title: Write Ahead Log
 
 Ingesters temporarily store data in memory. In the event of a crash, there could be data loss. The WAL helps fill this gap in reliability.
 
-The WAL in Loki records incoming data and stores it on the local file system in order to guarantee persistence of acknowledged data in the event of a process crash. Upon restart, Loki will "replay" all of the data in the log before registering itself as ready for subsequent writes. This allows Loki to maintain the performance & cost benefits of buffering data in memory _and_ durability benefits (it won't lose data once a write has been acknowledged).
+The WAL in Grafana Loki records incoming data and stores it on the local file system in order to guarantee persistence of acknowledged data in the event of a process crash. Upon restart, Loki will "replay" all of the data in the log before registering itself as ready for subsequent writes. This allows Loki to maintain the performance & cost benefits of buffering data in memory _and_ durability benefits (it won't lose data once a write has been acknowledged).
 
 This section will use Kubernetes as a reference deployment paradigm in the examples.
 

--- a/docs/sources/rules/_index.md
+++ b/docs/sources/rules/_index.md
@@ -7,7 +7,7 @@ weight: 700
 
 # Rules and the Ruler
 
-Loki includes a component called the Ruler, adapted from our upstream project, Cortex. The Ruler is responsible for continually evaluating a set of configurable queries and performing an action based on the result.
+Grafana Loki includes a component called the Ruler, adapted from our upstream project, Cortex. The Ruler is responsible for continually evaluating a set of configurable queries and performing an action based on the result.
 
 This example configuration sources rules from a local disk.
 

--- a/docs/sources/storage/_index.md
+++ b/docs/sources/storage/_index.md
@@ -4,7 +4,7 @@ weight: 1010
 ---
 # Storage
 
-Unlike other logging systems, Loki is built around the idea of only indexing
+Unlike other logging systems, Grafana Loki is built around the idea of only indexing
 metadata about your logs: labels (just like Prometheus labels). Log data itself
 is then compressed and stored in chunks in object stores such as S3 or GCS, or
 even locally on the filesystem. A small index and highly compressed chunks

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -3,9 +3,9 @@ title: Upgrading
 weight: 250
 ---
 
-# Upgrading Loki
+# Upgrading Grafana Loki
 
-Every attempt is made to keep Loki backwards compatible, such that upgrades should be low risk and low friction.
+Every attempt is made to keep Grafana Loki backwards compatible, such that upgrades should be low risk and low friction.
 
 Unfortunately Loki is software and software is hard and sometimes we are forced to make decisions between ease of use and ease of maintenance.
 


### PR DESCRIPTION
The product name is Grafana Loki.  The first use of the product name on
each web page should be the full product name.  After that, within each
page, it is fine to use just Loki.

This PR also set up some frontmatter with weights where it was missing
on a few files, and it corrects where "Loki" was not capitalized.


