### PR TITLE
Add more tests around config parsing changes from common config PR

### DIFF
--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -172,7 +172,8 @@ func TestDefaultUnmarshal(t *testing.T) {
 
 		flags := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 		args := []string{"-config.file", file.Name()}
-		cfg.DefaultUnmarshal(&config, args, flags)
+		err = cfg.DefaultUnmarshal(&config, args, flags)
+		require.NoError(t, err)
 
 		assert.True(t, config.AuthEnabled)
 		assert.Equal(t, 80, config.Server.HTTPListenPort)

--- a/pkg/util/cfg/cfg_test.go
+++ b/pkg/util/cfg/cfg_test.go
@@ -87,7 +87,8 @@ func TestDefaultUnmarshal(t *testing.T) {
 
 		var config TestConfigWrapper
 		flags := flag.NewFlagSet(t.Name(), flag.PanicOnError)
-		DefaultUnmarshal(&config, args, flags)
+		err = DefaultUnmarshal(&config, args, flags)
+		require.NoError(t, err)
 
 		return config
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Adds a bit more testing around the new config unmarshalling methods to confirm #4419 was not a real bug. It turned out just to be a strange behavior when passing a completely empty yaml file as the config file, like:
```yaml
---
```

This was being used for tests, but is unlikely a case we need to solve for in real usage.

**Which issue(s) this PR fixes**:
Fixes #4419

**Checklist**
- [ ] Documentation added
- [x] Tests updated

