### PR TITLE
always expose loki_build_info

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/tracing"
@@ -20,10 +19,6 @@ import (
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
-
-func init() {
-	prometheus.MustRegister(version.NewCollector("loki"))
-}
 
 func main() {
 	var config loki.ConfigWrapper

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
@@ -82,6 +83,8 @@ const (
 )
 
 func (t *Loki) initServer() (services.Service, error) {
+	prometheus.MustRegister(version.NewCollector("loki"))
+
 	// Loki handles signals on its own.
 	cortex.DisableSignalHandling(&t.Cfg.Server)
 	serv, err := server.New(t.Cfg.Server)


### PR DESCRIPTION
This moves registration of the `loki_build_info` metric from a hook in `main.go` to the `server` submodule, which enforces it's registration when used as a library as well.