### PR TITLE
Document the common config section

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -535,7 +535,7 @@ storage:
   [swift: <swift_storage_config>]
 
   # Configures backend rule storage for a local filesystem directory.
-  [local: <filesystem_storage_config>]
+  [local: <local_storage_config>]
 
 # Remote-write configuration to send rule samples to a Prometheus remote-write endpoint.
 remote_write:
@@ -2322,7 +2322,7 @@ If any specific configs for an object storage client have been provided elsewher
 [swift: <swift_storage_config>]
 
 # Configures a (local) filesystem as the common storage.
-[filesystem: <filesystem_storage_config>]
+[filesystem: <local_storage_config>]
 ```
 
 ## Runtime Configuration file


### PR DESCRIPTION
**What this PR does / why we need it**:
- Documents the `common` Loki config section.
- Adds a bunch of missing periods (from same config section)

**Which issue(s) this PR fixes**:
Fixes #4412 

**Special notes for your reviewer**:
PR #4473 will introduce the `object_storage` subsection to `common`. `path_prefix` already exists (although it isn't documented yet)

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

