### PR TITLE
Feature: add virtual read and write targets

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -423,7 +423,10 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(Compactor, t.initCompactor)
 	mm.RegisterModule(IndexGateway, t.initIndexGateway)
 	mm.RegisterModule(QueryScheduler, t.initQueryScheduler)
+
 	mm.RegisterModule(All, nil)
+	mm.RegisterModule(Read, nil)
+	mm.RegisterModule(Write, nil)
 
 	// Add dependencies
 	deps := map[string][]string{
@@ -443,6 +446,8 @@ func (t *Loki) setupModuleManager() error {
 		IndexGateway:             {Server},
 		IngesterQuerier:          {Ring},
 		All:                      {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler},
+		Read:                     {QueryScheduler, QueryFrontend, Querier, Ruler},
+		Write:                    {Ingester, Distributor},
 	}
 
 	// Add IngesterQuerier as a dependency for store when target is either ingester or querier.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -80,6 +80,8 @@ const (
 	IndexGateway             string = "index-gateway"
 	QueryScheduler           string = "query-scheduler"
 	All                      string = "all"
+	Read                     string = "read"
+	Write                    string = "write"
 )
 
 func (t *Loki) initServer() (services.Service, error) {
@@ -178,7 +180,7 @@ func (t *Loki) initDistributor() (services.Service, error) {
 
 	// Register the distributor to receive Push requests over GRPC
 	// EXCEPT when running with `-target=all` or `-target=` contains `ingester`
-	if !t.Cfg.isModuleEnabled(All) && !t.Cfg.isModuleEnabled(Ingester) {
+	if !t.Cfg.isModuleEnabled(All) && !t.Cfg.isModuleEnabled(Write) && !t.Cfg.isModuleEnabled(Ingester) {
 		logproto.RegisterPusherServer(t.Server.GRPC, t.distributor)
 	}
 
@@ -205,6 +207,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 
 	querierWorkerServiceConfig := querier.WorkerServiceConfig{
 		AllEnabled:            t.Cfg.isModuleEnabled(All),
+		ReadEnabled:           t.Cfg.isModuleEnabled(Read),
 		GrpcListenPort:        t.Cfg.Server.GRPCListenPort,
 		QuerierMaxConcurrent:  t.Cfg.Querier.MaxConcurrent,
 		QuerierWorkerConfig:   &t.Cfg.Worker,

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -21,6 +21,7 @@ import (
 
 type WorkerServiceConfig struct {
 	AllEnabled            bool
+	ReadEnabled           bool
 	GrpcListenPort        int
 	QuerierMaxConcurrent  int
 	QuerierWorkerConfig   *querier_worker.Config
@@ -144,12 +145,13 @@ func registerRoutesExternally(routes []string, externalRouter *mux.Router, inter
 }
 
 func querierRunningStandalone(cfg WorkerServiceConfig) bool {
-	runningStandalone := !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.AllEnabled
+	runningStandalone := !cfg.QueryFrontendEnabled && !cfg.QuerySchedulerEnabled && !cfg.ReadEnabled && !cfg.AllEnabled
 	level.Debug(util_log.Logger).Log(
 		"msg", "determining if querier is running as standalone target",
 		"runningStandalone", runningStandalone,
 		"queryFrontendEnabled", cfg.QueryFrontendEnabled,
 		"queryScheduleEnabled", cfg.QuerySchedulerEnabled,
+		"readEnabled", cfg.ReadEnabled,
 		"allEnabled", cfg.AllEnabled,
 	)
 


### PR DESCRIPTION
Co-Authored-By: Mauro Stettler <mauro.stettler@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Replaces #4397, adds virtual target of read and write to loki. These are needed to support the new "single scalable deployment" deployment strategy, offering users a deployment topology that is easier to deploy/understand than micro-services, while also being more resilient and scalable than single binary.

This adds a couple extra lines of code that were needed on top of #4397, and since @replay is off, I'm taking the the torch on this one.

**Checklist**
- [ ] Documentation added
- [x] ~Tests updated~ N/A

