### PR TITLE
Docs: Remove ListObjects S3 permission

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -50,7 +50,6 @@ The following are supported for the chunks:
 
 When using S3 as object storage, the following permissions are needed:
 
-- `s3:ListObjects`
 - `s3:ListBucket`
 - `s3:PutObject`
 - `s3:GetObject`


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

On this documentation page "s3:ListObjects" is incorrectly listed as an S3 permission.

ListObjects is not an S3 IAM [Action](https://docs.aws.amazon.com/AmazonS3/latest/userguide/list_amazons3.html), it is only an [API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#:~:text=to%20perform%20the-,s3:listbucket,-action.%20The%20bucket) which uses the s3:ListBucket IAM Action.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Documentation added