### PR TITLE
promtail: update promtail base image to debian:bullseye-slim

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,23 +1,23 @@
-FROM golang:1.17.2-buster as build
+FROM golang:1.17.2-bullseye as build
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS
 COPY . /src/loki
 WORKDIR /src/loki
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t buster-backports -qy libsystemd-dev
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 RUN make clean && (if [ "${TOUCH_PROTOS}" ]; then make touch-protos; fi) && make BUILD_IN_CONTAINER=false promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 # tzdata required for the timestamp stage to work
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && \
   apt-get install -qy \
   tzdata ca-certificates
-RUN apt-get install -t buster-backports -qy libsystemd-dev && \
+RUN apt-get install -t bullseye-backports -qy libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Update the base image of promtail to keep the image secure.
From `debian:buster-slim` to `debian:bullseye-slim`
**Which issue(s) this PR fixes**:
Fixes #4140

**Special notes for your reviewer**:
docker scan report before the update:
```
Package manager:   deb
Project name:      docker-image|grafana/promtail
Docker image:      grafana/promtail:update-promtail-base-image-517ba7c
Platform:          linux/amd64
Base image:        debian:10.11-slim

Tested 89 dependencies for known vulnerabilities, found 62 vulnerabilities.

Base Image         Vulnerabilities  Severity
debian:10.11-slim  60               2 critical, 8 high, 6 medium, 44 low

Recommendations for base image upgrade:

Major upgrades
Base Image      Vulnerabilities  Severity
debian:11-slim  35               1 critical, 0 high, 1 medium, 33 low
```

docker scan report after the update:
```
Package manager:   deb
Project name:      docker-image|grafana/promtail
Docker image:      grafana/promtail:update-promtail-base-image-517ba7c-WIP
Platform:          linux/amd64
Base image:        debian:11.1-slim

Tested 100 dependencies for known vulnerabilities, found 35 vulnerabilities.

According to our scan, you are currently using the most secure version of the selected base image
```



**Checklist**
- [ ] Documentation added
- [ ] Tests updated

