### PR TITLE
Remove common-labels

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -46,9 +46,8 @@ The output of the log can be specified with the "-o" flag, for
 example, "-o raw" for the raw output format.
 
 The "query" command will output extra information about the query
-and its results, such as the API URL, set of common labels, and set
-of excluded labels. This extra information can be suppressed with the
---quiet flag.
+and its results, such as the API URL, and set of excluded labels.
+This extra information can be suppressed with the --quiet flag.
 
 By default we look over the last hour of data; use --since to modify
 or provide specific start and end times with --from and --to respectively.

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -156,8 +156,8 @@ Commands:
     raw" for the raw output format.
 
     The "query" command will output extra information about the query and its
-    results, such as the API URL, and set of excluded labels.
-    This extra information can be suppressed with the --quiet flag.
+    results, such as the API URL and a set of excluded labels.
+    This extra information can be suppressed with the `--quiet` flag.
 
     By default we look over the last hour of data; use --since to modify or
     provide specific start and end times with --from and --to respectively.
@@ -235,7 +235,7 @@ The output of the log can be specified with the "-o" flag, for example, "-o raw"
 for the raw output format.
 
 The "query" command will output extra information about the query and its
-results, such as the API URL, and set of excluded labels.
+results, such as the API URL and a set of excluded labels.
 This extra information can be suppressed with the --quiet flag.
 
 By default we look over the last hour of data; use --since to modify or provide

--- a/docs/sources/getting-started/logcli.md
+++ b/docs/sources/getting-started/logcli.md
@@ -55,9 +55,8 @@ cortex-ops/cortex-gw
 
 $ logcli query '{job="cortex-ops/consul"}'
 https://logs-dev-ops-tools1.grafana.net/api/prom/query?query=%7Bjob%3D%22cortex-ops%2Fconsul%22%7D&limit=30&start=1529928228&end=1529931828&direction=backward&regexp=
-Common labels: {job="cortex-ops/consul", namespace="cortex-ops"}
-2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Snapshot to 475409 complete
-2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169
+2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w", job="cortex-ops/consul", namespace="cortex-ops"} 2018/06/25 12:52:09 [INFO] raft: Snapshot to 475409 complete
+2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w", job="cortex-ops/consul", namespace="cortex-ops"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169
 ...
 
 $ logcli series -q --match='{namespace="loki",container_name="loki"}'
@@ -157,8 +156,8 @@ Commands:
     raw" for the raw output format.
 
     The "query" command will output extra information about the query and its
-    results, such as the API URL, set of common labels, and set of excluded
-    labels. This extra information can be suppressed with the --quiet flag.
+    results, such as the API URL, and set of excluded labels.
+    This extra information can be suppressed with the --quiet flag.
 
     By default we look over the last hour of data; use --since to modify or
     provide specific start and end times with --from and --to respectively.
@@ -236,7 +235,7 @@ The output of the log can be specified with the "-o" flag, for example, "-o raw"
 for the raw output format.
 
 The "query" command will output extra information about the query and its
-results, such as the API URL, set of common labels, and set of excluded labels.
+results, such as the API URL, and set of excluded labels.
 This extra information can be suppressed with the --quiet flag.
 
 By default we look over the last hour of data; use --since to modify or provide

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -259,17 +259,6 @@ func (q *Query) isInstant() bool {
 }
 
 func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastEntry []*loghttp.Entry) (int, []*loghttp.Entry) {
-	common := commonLabels(streams)
-
-	// Remove the labels we want to show from common
-	if len(q.ShowLabelsKey) > 0 {
-		common = matchLabels(false, common, q.ShowLabelsKey)
-	}
-
-	if len(common) > 0 && !q.Quiet {
-		log.Println("Common labels:", color.RedString(common.String()))
-	}
-
 	if len(q.IgnoreLabelsKey) > 0 && !q.Quiet {
 		log.Println("Ignoring labels key:", color.RedString(strings.Join(q.IgnoreLabelsKey, ",")))
 	}
@@ -278,12 +267,11 @@ func (q *Query) printStream(streams loghttp.Streams, out output.LogOutput, lastE
 		log.Println("Print only labels key:", color.RedString(strings.Join(q.ShowLabelsKey, ",")))
 	}
 
-	// Remove ignored and common labels from the cached labels and
+	// Remove ignored labels from the cached labels and
 	// calculate the max labels length
 	maxLabelsLen := q.FixedLabelsLen
 	for i, s := range streams {
-		// Remove common labels
-		ls := subtract(s.Labels, common)
+		ls := s.Labels
 
 		if len(q.ShowLabelsKey) > 0 {
 			ls = matchLabels(true, ls, q.ShowLabelsKey)

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -3,8 +3,6 @@ package query
 import (
 	"bytes"
 	"context"
-	"log"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -18,74 +16,6 @@ import (
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/util/marshal"
 )
-
-func Test_subtract(t *testing.T) {
-	type args struct {
-		a loghttp.LabelSet
-		b loghttp.LabelSet
-	}
-	tests := []struct {
-		name string
-		args args
-		want loghttp.LabelSet
-	}{
-		{
-			"Subtract labels source > target",
-			args{
-				mustParseLabels(`{foo="bar", bar="foo"}`),
-				mustParseLabels(`{bar="foo", foo="foo", baz="baz"}`),
-			},
-			mustParseLabels(`{foo="bar"}`),
-		},
-		{
-			"Subtract labels source < target",
-			args{
-				mustParseLabels(`{foo="bar", bar="foo"}`),
-				mustParseLabels(`{bar="foo"}`),
-			},
-			mustParseLabels(`{foo="bar"}`),
-		},
-		{
-			"Subtract labels source < target no sub",
-			args{
-				mustParseLabels(`{foo="bar", bar="foo"}`),
-				mustParseLabels(`{fo="bar"}`),
-			},
-			mustParseLabels(`{bar="foo", foo="bar"}`),
-		},
-		{
-			"Subtract labels source = target no sub",
-			args{
-				mustParseLabels(`{foo="bar"}`),
-				mustParseLabels(`{fiz="buz"}`),
-			},
-			mustParseLabels(`{foo="bar"}`),
-		},
-		{
-			"Subtract labels source > target no sub",
-			args{
-				mustParseLabels(`{foo="bar"}`),
-				mustParseLabels(`{fiz="buz", foo="baz"}`),
-			},
-			mustParseLabels(`{foo="bar"}`),
-		},
-		{
-			"Subtract labels source > target no sub",
-			args{
-				mustParseLabels(`{a="b", foo="bar", baz="baz", fizz="fizz"}`),
-				mustParseLabels(`{foo="bar", baz="baz", buzz="buzz", fizz="fizz"}`),
-			},
-			mustParseLabels(`{a="b"}`),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := subtract(tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("subtract() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_batch(t *testing.T) {
 	tests := []struct {
@@ -420,16 +350,6 @@ func Test_batch(t *testing.T) {
 			assert.Equal(t, tt.expectedCalls, tc.queryRangeCalls)
 		})
 	}
-}
-
-func mustParseLabels(s string) loghttp.LabelSet {
-	l, err := marshal.NewLabelSet(s)
-
-	if err != nil {
-		log.Fatalf("Failed to parse %s", s)
-	}
-
-	return l
 }
 
 type testQueryClient struct {

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -19,69 +19,6 @@ import (
 	"github.com/grafana/loki/pkg/util/marshal"
 )
 
-func Test_commonLabels(t *testing.T) {
-	type args struct {
-		lss []loghttp.LabelSet
-	}
-	tests := []struct {
-		name string
-		args args
-		want loghttp.LabelSet
-	}{
-		{
-			"Extract common labels source > target",
-			args{
-				[]loghttp.LabelSet{mustParseLabels(`{foo="bar", bar="foo"}`), mustParseLabels(`{bar="foo", foo="foo", baz="baz"}`)},
-			},
-			mustParseLabels(`{bar="foo"}`),
-		},
-		{
-			"Extract common labels source > target",
-			args{
-				[]loghttp.LabelSet{mustParseLabels(`{foo="bar", bar="foo"}`), mustParseLabels(`{bar="foo", foo="bar", baz="baz"}`)},
-			},
-			mustParseLabels(`{foo="bar", bar="foo"}`),
-		},
-		{
-			"Extract common labels source < target",
-			args{
-				[]loghttp.LabelSet{mustParseLabels(`{foo="bar", bar="foo"}`), mustParseLabels(`{bar="foo"}`)},
-			},
-			mustParseLabels(`{bar="foo"}`),
-		},
-		{
-			"Extract common labels source < target no common",
-			args{
-				[]loghttp.LabelSet{mustParseLabels(`{foo="bar", bar="foo"}`), mustParseLabels(`{fo="bar"}`)},
-			},
-			loghttp.LabelSet{},
-		},
-		{
-			"Extract common labels source = target no common",
-			args{
-				[]loghttp.LabelSet{mustParseLabels(`{foo="bar"}`), mustParseLabels(`{fooo="bar"}`)},
-			},
-			loghttp.LabelSet{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var streams []loghttp.Stream
-
-			for _, lss := range tt.args.lss {
-				streams = append(streams, loghttp.Stream{
-					Entries: nil,
-					Labels:  lss,
-				})
-			}
-
-			if got := commonLabels(streams); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("commonLabels() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_subtract(t *testing.T) {
 	type args struct {
 		a loghttp.LabelSet

--- a/pkg/logcli/query/utils.go
+++ b/pkg/logcli/query/utils.go
@@ -4,33 +4,6 @@ import (
 	"github.com/grafana/loki/pkg/loghttp"
 )
 
-// return commonLabels labels between given labels set
-func commonLabels(streams loghttp.Streams) loghttp.LabelSet {
-	if len(streams) == 0 {
-		return nil
-	}
-
-	result := streams[0].Labels
-	for i := 1; i < len(streams); i++ {
-		result = intersect(result, streams[i].Labels)
-	}
-	return result
-}
-
-// intersect two labels set
-func intersect(a, b loghttp.LabelSet) loghttp.LabelSet {
-	set := loghttp.LabelSet{}
-
-	for ka, va := range a {
-		if vb, ok := b[ka]; ok {
-			if vb == va {
-				set[ka] = va
-			}
-		}
-	}
-	return set
-}
-
 // subtract labels set b from labels set a
 func subtract(a, b loghttp.LabelSet) loghttp.LabelSet {
 	set := loghttp.LabelSet{}

--- a/pkg/logcli/query/utils.go
+++ b/pkg/logcli/query/utils.go
@@ -4,21 +4,6 @@ import (
 	"github.com/grafana/loki/pkg/loghttp"
 )
 
-// subtract labels set b from labels set a
-func subtract(a, b loghttp.LabelSet) loghttp.LabelSet {
-	set := loghttp.LabelSet{}
-
-	for ka, va := range a {
-		if vb, ok := b[ka]; ok {
-			if vb == va {
-				continue
-			}
-		}
-		set[ka] = va
-	}
-	return set
-}
-
 func matchLabels(on bool, l loghttp.LabelSet, names []string) loghttp.LabelSet {
 	ret := loghttp.LabelSet{}
 


### PR DESCRIPTION
Fixes #3581

This common-labels functionality made the CLI tool harder to use when
piping the output into other programs. The common labels would be printed
on STDERR, while the rest of the labels and log-lines were emitted on
STDOUT.
I don't think we need this functionality any more, now that we have the
`--exclude-label` option.

**Checklist**
- [x] Documentation ~~added~~ removed and updated
- [x] Tests updated

