### PR TITLE
Clarify error message when no valid target scrape config is defined for `promtail` job

### DIFF
--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -1,6 +1,8 @@
 package targets
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -80,7 +82,7 @@ func NewTargetManagers(
 			targetScrapeConfigs[WindowsEventsConfigs] = append(targetScrapeConfigs[WindowsEventsConfigs], cfg)
 
 		default:
-			return nil, errors.New("unknown scrape config")
+			return nil, fmt.Errorf("no valid target scrape config defined for %q", cfg.JobName)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with master
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
I was recently trying to understand why I was getting this error message:

`unable to create logs instance: unknown scrape config` when using the Grafana Agent with this config:

```yaml
...loki:
  configs:
      ...
      name: default
      scrape_configs:
        - job_name: my-job-name
          pipeline_stages:
            - multiline:
                firstline: '^\d{4}-\d{2}-\d{2}\s\d{1,2}\:\d{2}\:\d{2}\.\d{3}'
...
```

The problem here is not that the scrape config is unknown, but rather that there is no target scrape config defined for this particular job.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
[Slack thread](https://raintank-corp.slack.com/archives/C01LEA0NMFT/p1634821129011200) with one of our Solutions Engineers

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

