### PR TITLE
Safely checks read ring for potentially nil scheduler

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -210,7 +210,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		QuerierWorkerConfig:   &t.Cfg.Worker,
 		QueryFrontendEnabled:  t.Cfg.isModuleEnabled(QueryFrontend),
 		QuerySchedulerEnabled: t.Cfg.isModuleEnabled(QueryScheduler),
-		SchedulerRing:         t.queryScheduler.SafeReadRing(),
+		SchedulerRing:         scheduler.SafeReadRing(t.queryScheduler),
 	}
 
 	var queryHandlers = map[string]http.Handler{
@@ -423,7 +423,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	}
 	roundTripper, frontendV1, frontendV2, err := frontend.InitFrontend(
 		combinedCfg,
-		t.queryScheduler.SafeReadRing(),
+		scheduler.SafeReadRing(t.queryScheduler),
 		disabledShuffleShardingLimits{},
 		t.Cfg.Server.GRPCListenPort,
 		util_log.Logger,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -637,12 +637,13 @@ func (s *Scheduler) getConnectedFrontendClientsMetric() float64 {
 // SafeReadRing does a nil check on the Scheduler before attempting to return it's ring
 // this is necessary as many callers of this function will only have a valid Scheduler
 // reference if the QueryScheduler target has been specified, which is not guaranteed
-func (s *Scheduler) SafeReadRing() ring.ReadRing {
+func SafeReadRing(s *Scheduler) ring.ReadRing {
 	if s == nil || s.ring == nil || !s.cfg.UseSchedulerRing {
 		return nil
 	}
 
 	return s.ring
+
 }
 
 func (s *Scheduler) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc ring.Desc, instanceExists bool, instanceID string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {


### PR DESCRIPTION
Previously the method signature was `(s *Scheduler) SafeReadRing()` which checks `if s == nil ||`. Notably, this _can never execute_ because calling a method on a nil pointer will panic. This fix likely prevents panics when running in microservices mode where the `scheduler` is not instantiated.

Edit: I stand corrected https://play.golang.org/p/-OfmuRO-Q8f