### PR TITLE
Add new "merge" pipeline stage

### DIFF
--- a/clients/pkg/logentry/stages/merge.go
+++ b/clients/pkg/logentry/stages/merge.go
@@ -1,0 +1,92 @@
+package stages
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	// ErrEmptyMergeStageConfig is returned if config is empty
+	ErrEmptyMergeStageConfig = errors.New("merge stage config cannot be empty")
+	// ErrEmptyMergeStageConfig is returned if no source list is specified
+	ErrMergeSourcesRequired = errors.New("merge sources are required")
+	// ErrEmptyMergeStageConfig is returned if target is unspecified
+	ErrMergeTargetRequired = errors.New("merge target is required")
+)
+
+// MergeConfig represents a Merge Stage configuration
+type MergeConfig struct {
+	Sources []string `mapstructure:"sources"`
+	Target  string   `mapstructure:"target"`
+}
+
+func validateMergeConfig(c *MergeConfig) error {
+	if c == nil {
+		return ErrEmptyMergeStageConfig
+	}
+	if len(c.Sources) == 0 {
+		return ErrMergeSourcesRequired
+	}
+	if c.Target == "" {
+		return ErrMergeTargetRequired
+	}
+
+	return nil
+}
+
+func newMergeStage(logger log.Logger, configs interface{}) (Stage, error) {
+	cfg := &MergeConfig{}
+	err := mapstructure.Decode(configs, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateMergeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return toStage(&mergeStage{
+		cfg:    *cfg,
+		logger: log.With(logger, "component", "stage", "type", "merge"),
+	}), nil
+}
+
+type mergeStage struct {
+	cfg    MergeConfig
+	logger log.Logger
+}
+
+// Process implements Stage
+func (m *mergeStage) Process(labels model.LabelSet, extracted map[string]interface{}, t *time.Time, entry *string) {
+	result := make(map[string]interface{})
+	for _, s := range m.cfg.Sources {
+		if e, found := extracted[s]; found {
+			switch te := e.(type) {
+			case map[string]interface{}:
+				// Maps are squashed
+				for k, v := range te {
+					result[k] = v
+				}
+			default:
+				// Anything else is copied
+				result[s] = te
+			}
+		} else {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "extracted data did not contain merge source", "source", s)
+			}
+		}
+	}
+	extracted[m.cfg.Target] = result
+}
+
+// Name implements Stage
+func (m *mergeStage) Name() string {
+	return StageTypeMerge
+}

--- a/clients/pkg/logentry/stages/merge_test.go
+++ b/clients/pkg/logentry/stages/merge_test.go
@@ -1,0 +1,192 @@
+package stages
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ww "github.com/weaveworks/common/server"
+)
+
+func Test_MergeStage_Process(t *testing.T) {
+	// Enable debug logging
+	cfg := &ww.Config{}
+	require.Nil(t, cfg.LogLevel.Set("debug"))
+	util_log.InitLogger(cfg)
+	Debug = true
+
+	tests := []struct {
+		name                string
+		config              *MergeConfig
+		previousExtractions map[string]interface{}
+		expectedExtraction  interface{}
+	}{
+		{
+			name: "merge multiple maps",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"hello",
+					"foo",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"hello": map[string]interface{}{"world": "!"},
+				"foo":   map[string]interface{}{"bar": "baz"},
+			},
+			expectedExtraction: map[string]interface{}{"world": "!", "bar": "baz"},
+		},
+		{
+			name: "merge map and slice",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"hello",
+					"foo",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"hello": map[string]interface{}{"world": "!"},
+				"foo":   []interface{}{"bar", "baz"},
+			},
+			expectedExtraction: map[string]interface{}{
+				"world": "!",
+				"foo":   []interface{}{"bar", "baz"},
+			},
+		},
+		{
+			name: "merge map and string",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"hello",
+					"foo",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"hello": map[string]interface{}{"world": "!"},
+				"foo":   "bar",
+			},
+			expectedExtraction: map[string]interface{}{
+				"world": "!",
+				"foo":   "bar",
+			},
+		},
+		{
+			name: "merge string and string",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"hello",
+					"foo",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"hello": "world",
+				"foo":   "bar",
+			},
+			expectedExtraction: map[string]interface{}{
+				"hello": "world",
+				"foo":   "bar",
+			},
+		},
+		{
+			name: "merge with missing key returns rest of sources merged",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"hello",
+					"missing",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"hello": map[string]interface{}{"world": "!"},
+			},
+			expectedExtraction: map[string]interface{}{
+				"world": "!",
+			},
+		},
+		{
+			name: "merge more than two",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"one",
+					"two",
+					"three",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"one":   map[string]interface{}{"A": "B"},
+				"two":   map[string]interface{}{"C": "D"},
+				"three": map[string]interface{}{"E": "F"},
+			},
+			expectedExtraction: map[string]interface{}{
+				"A": "B",
+				"C": "D",
+				"E": "F",
+			},
+		},
+		{
+			name: "maps with overlapping keys has last-write-wins",
+			config: &MergeConfig{
+				Target: "test",
+				Sources: []string{
+					"one",
+					"two",
+					"three",
+				},
+			},
+			previousExtractions: map[string]interface{}{
+				"one":   map[string]interface{}{"A": "B"},
+				"two":   map[string]interface{}{"A": "D", "C": "E"},
+				"three": map[string]interface{}{"A": "F"},
+			},
+			expectedExtraction: map[string]interface{}{
+				"A": "F",
+				"C": "E",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			st, err := newMergeStage(util_log.Logger, test.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := processEntries(st, newEntry(test.previousExtractions, nil, "", time.Now()))[0]
+			assert.Equal(t, test.expectedExtraction, out.Extracted[test.config.Target])
+		})
+	}
+}
+
+func Test_MergeWithMissingKey_Output(t *testing.T) {
+	var buf bytes.Buffer
+	w := log.NewSyncWriter(&buf)
+	logger := log.NewLogfmtLogger(w)
+	missingKey := "missing"
+	cfg := &MergeConfig{
+		Target: "test",
+		Sources: []string{
+			"hello",
+			missingKey,
+		},
+	}
+	st, err := newMergeStage(logger, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	Debug = true
+	_ = processEntries(st, newEntry(map[string]interface{}{"hello": "world"}, nil, "", time.Now()))
+	expectedLog := fmt.Sprintf(`level=debug component=stage type=merge msg="extracted data did not contain merge source" source=%s`, missingKey)
+	if !(strings.Contains(buf.String(), expectedLog)) {
+		t.Errorf("\nexpected: %s\n+actual: %s", expectedLog, buf.String())
+	}
+}

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -34,6 +34,7 @@ const (
 	StageTypeMultiline  = "multiline"
 	StageTypePack       = "pack"
 	StageTypeLabelAllow = "labelallow"
+	StageTypeMerge      = "merge"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -194,6 +195,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeLabelAllow:
 		s, err = newLabelAllowStage(cfg)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeMerge:
+		s, err = newMergeStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Following discussions on Slack, this PR introduces a new pipeline stage which merges multiple previously extracted fields into a single one. Maps are merged (with last-write-wins semantics for overlapping keys), while non-maps are copied including the field name into the resulting map.

Main motivation for this is to make it easier to combine fields in order to use them with the `output` stage. Currently, this requires doing text manipulation to concatenate the fields, which is rather brittle, especially if the fields are json.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Docs not yet created, pending discussion if this is actually a good idea :)

**Checklist**
- [ ] Documentation added
- [x] Tests updated

