### PR TITLE
Fix drone ECR publish.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -80,7 +80,7 @@ local lambda_promtail_ecr(app) = {
   image: 'cstyan/ecr',
   privileged: true,
   settings: {
-    repo: 'lambda-promtail',
+    repo: 'public.ecr.aws/grafana/lambda-promtail',
     registry: 'public.ecr.aws/grafana',
     dockerfile: 'tools/%s/Dockerfile' % app,
     access_key: { from_secret: ecr_key.name },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -908,7 +908,7 @@ steps:
     dry_run: true
     region: us-east-1
     registry: public.ecr.aws/grafana
-    repo: lambda-promtail
+    repo: public.ecr.aws/grafana/lambda-promtail
     secret_key:
       from_secret: ecr_secret_key
   when:
@@ -931,7 +931,7 @@ steps:
     dry_run: false
     region: us-east-1
     registry: public.ecr.aws/grafana
-    repo: lambda-promtail
+    repo: public.ecr.aws/grafana/lambda-promtail
     secret_key:
       from_secret: ecr_secret_key
   when:
@@ -984,6 +984,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: 2f519d332d5e2241a44b170461a9cf256dc8050de6d0a6caa99839a4b561aab5
+hmac: 55440faa2728a5b8abbd213c2cf198e01f00201ba7143391924da1b9aa02c350
 
 ...


### PR DESCRIPTION
Somewhere with my forked drone ECR plugin there's an issue with passing the `registry+repo` value to the base drone docker plugin as `repo` so that the `docker push` step attempts to publish the image to the correct repo (ECR instead of a docker hub repo). 

It's not immediately clear what the cause of the problem is, since I don't think I changed anything in the plugin that would cause this, but the change in this PR works as a workaround for now.

Signed-off-by: Callum Styan <callumstyan@gmail.com>