### PR TITLE
Fix race condition in Query Scheduler ring with frontend/worker

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -465,6 +465,18 @@ func (t *Loki) setupModuleManager() error {
 		deps[All] = append(deps[All], Compactor)
 	}
 
+	// If the query scheduler and querier are running together, make sure the scheduler goes
+	// first to initialize the ring that will also be used by the querier
+	if (t.Cfg.isModuleEnabled(Querier) && t.Cfg.isModuleEnabled(QueryScheduler)) || t.Cfg.isModuleEnabled(Read) || t.Cfg.isModuleEnabled(All) {
+		deps[Querier] = append(deps[Querier], QueryScheduler)
+	}
+
+	// If the query scheduler and query frontend are running together, make sure the scheduler goes
+	// first to initialize the ring that will also be used by the query frontend
+	if (t.Cfg.isModuleEnabled(QueryFrontend) && t.Cfg.isModuleEnabled(QueryScheduler)) || t.Cfg.isModuleEnabled(Read) || t.Cfg.isModuleEnabled(All) {
+		deps[QueryFrontend] = append(deps[QueryFrontend], QueryScheduler)
+	}
+
 	for mod, targets := range deps {
 		if err := mm.AddDependency(mod, targets...); err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When the query frontend and/or query worker targets are enabled on the same instance as the query scheduler (which happens in both the `All` and `Read` targets), the fronted and worker require the scheduler's initialization sequence to run before their own so that the scheduler ring will be populated. The Frontend and Worker rely on this ring in the scenario where a fronted or scheduler address has not been specified, which is also usually true in single-binary (`All` target) or simple scalable deployment (`Read` target) deployments.
