### PR TITLE
Fixes an edge case in the batch chunk iterator.

### DIFF
--- a/pkg/storage/lazy_chunk.go
+++ b/pkg/storage/lazy_chunk.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -135,7 +134,6 @@ func (c *LazyChunk) SampleIterator(
 	for _, b := range blocks {
 		// if we have already processed and cache block let's use it.
 		if cache, ok := c.overlappingSampleBlocks[b.Offset()]; ok {
-			fmt.Println("overlaping cache")
 			cache.Reset()
 			its = append(its, cache)
 			continue


### PR DESCRIPTION
When batching, if the from reach the end we should discard batch.

Unless the original start and end is equal which is the only case where the end become inclusive.

I was digging another bug and stumble on duplicate for this particular edge case.

