### PR TITLE
Config: Change default RejectOldSamplesMaxAge from 14d to 7d

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -126,7 +126,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
 	f.BoolVar(&l.RejectOldSamples, "validation.reject-old-samples", true, "Reject old samples.")
 
-	_ = l.RejectOldSamplesMaxAge.Set("14d")
+	_ = l.RejectOldSamplesMaxAge.Set("7d")
 	f.Var(&l.RejectOldSamplesMaxAge, "validation.reject-old-samples.max-age", "Maximum accepted sample age before rejecting.")
 	_ = l.CreationGracePeriod.Set("10m")
 	f.Var(&l.CreationGracePeriod, "validation.create-grace-period", "Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time.")


### PR DESCRIPTION
**What this PR does / why we need it**:
In [PR 4415](https://github.com/grafana/loki/pull/4415) I was supposed to change `RejectOldSamplesMaxAge` default value from 14d to 7d (it is even listed in the upgrading guide). However, I overlooked it and merged it with the previous value.

**Checklist**
- [X] Documentation added (docs are already correct)
- [x] Tests updated

