### PR TITLE
replaces fallthrough statement in InitFrontend

### DIFF
--- a/pkg/lokifrontend/frontend/config.go
+++ b/pkg/lokifrontend/frontend/config.go
@@ -44,9 +44,7 @@ func InitFrontend(cfg CombinedFrontendConfig, ring ring.ReadRing, limits v1.Limi
 		// If the user has specified a downstream Prometheus, then we should use that.
 		rt, err := NewDownstreamRoundTripper(cfg.DownstreamURL, http.DefaultTransport)
 		return rt, nil, nil, err
-	case ring != nil:
-		fallthrough
-	case cfg.FrontendV2.SchedulerAddress != "":
+	case cfg.FrontendV2.SchedulerAddress != "" || ring != nil:
 		// If query-scheduler address is configured, use Frontend.
 		if cfg.FrontendV2.Addr == "" {
 			addr, err := util.GetFirstAddressOf(cfg.FrontendV2.InfNames)


### PR DESCRIPTION
This replaces the `fallthrough` usage in `InitFrontend` with an `||` clause. I think this is simpler/more understandable, especially because there is no prior logic run before the `fallthrough`. The results are equivalent, see example below:

https://play.golang.org/p/vdyYW8UMp7c