### PR TITLE
introduces "entry too far behind" instrumentation for unordered writes

### DIFF
--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -17,10 +17,15 @@ import (
 var (
 	ErrChunkFull       = errors.New("chunk full")
 	ErrOutOfOrder      = errors.New("entry out of order")
+	ErrTooFarBehind    = errors.New("entry too far behind")
 	ErrInvalidSize     = errors.New("invalid size")
 	ErrInvalidFlag     = errors.New("invalid flag")
 	ErrInvalidChecksum = errors.New("invalid chunk checksum")
 )
+
+func IsOutOfOrderErr(err error) bool {
+	return err == ErrOutOfOrder || err == ErrTooFarBehind
+}
 
 // Encoding is the identifier for a chunk encoding.
 type Encoding byte

--- a/pkg/chunkenc/interface_test.go
+++ b/pkg/chunkenc/interface_test.go
@@ -1,6 +1,10 @@
 package chunkenc
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestParseEncoding(t *testing.T) {
 	tests := []struct {
@@ -22,5 +26,11 @@ func TestParseEncoding(t *testing.T) {
 				t.Errorf("ParseEncoding() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsOutOfOrderErr(t *testing.T) {
+	for _, err := range []error{ErrOutOfOrder, ErrTooFarBehind} {
+		require.Equal(t, true, IsOutOfOrderErr(err))
 	}
 }

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -77,7 +77,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			var expected bytes.Buffer
 			for i := 0; i < tc.expectErrs; i++ {
 				fmt.Fprintf(&expected,
-					"entry with timestamp %s ignored, reason: 'entry out of order' for stream: {foo=\"bar\"},\n",
+					"entry with timestamp %s ignored, reason: 'entry too far behind' for stream: {foo=\"bar\"},\n",
 					time.Unix(int64(i), 0).String(),
 				)
 			}

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -31,6 +31,7 @@ const (
 	// rather than the overall ingestion rate limit.
 	StreamRateLimit = "per_stream_rate_limit"
 	OutOfOrder      = "out_of_order"
+	TooFarBehind    = "too_far_behind"
 	// GreaterThanMaxSampleAge is a reason for discarding log lines which are older than the current time - `reject_old_samples_max_age`
 	GreaterThanMaxSampleAge         = "greater_than_max_sample_age"
 	GreaterThanMaxSampleAgeErrorMsg = "entry for stream '%s' has timestamp too old: %v"


### PR DESCRIPTION
This distinguishes between `out of order` errors (when running with `unordered_writes: false`) and `too far behind` ( `unordered_writes: true`), for both metrics & errors.

ref https://github.com/grafana/loki/issues/1544