### PR TITLE
Cleans up redundant setting of stream.unorderedWrites=true during replay

### DIFF
--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -60,6 +60,7 @@ func NewLimiter(limits *validation.Overrides, metrics *ingesterMetrics, ring Rin
 func (l *Limiter) UnorderedWrites(userID string) bool {
 	// WAL replay should not discard previously ack'd writes,
 	// so allow out of order writes while the limiter is disabled.
+	// This allows replaying unordered WALs into ordered configurations.
 	if l.disabled {
 		return true
 	}

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -128,9 +128,6 @@ func (r *ingesterRecoverer) Series(series *Series) error {
 		stream.lastLine.content = series.LastLine
 		stream.entryCt = series.EntryCt
 		stream.highestTs = series.HighestTs
-		// Always set during replay, then reset to desired value afterward.
-		// This allows replaying unordered WALs into ordered configurations.
-		stream.unorderedWrites = true
 
 		if err != nil {
 			return err


### PR DESCRIPTION
I noticed we were specifically setting `stream.unorderedWrites=true` when recovering from checkpoints, but this is redundant since we already handle this via [`limiter.DisableForWALReplay`](https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L36-L67), which causes all streams to be created with `unorderedWrites=true` during the replay process.