### PR TITLE
[Promtail] resolve issue with promtail not scraping target if only path changed in a simpler way that dont need mutex to sync threads

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -118,14 +118,6 @@ func (t *FileTarget) Stop() {
 	t.handler.Stop()
 }
 
-// UpdatePath updates the filetarget path
-// returns true if the path was changed
-func (t *FileTarget) UpdatePath(path string) bool {
-	curPath := t.path
-	t.path = path
-	return curPath != path
-}
-
 // Type implements a Target
 func (t *FileTarget) Type() target.TargetType {
 	return target.FileTargetType

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -243,16 +243,12 @@ func (s *targetSyncer) sync(groups []*targetgroup.Group) {
 				}
 			}
 
-			key := labels.String()
+			key := fmt.Sprintf("%s:%s", path, labels.String())
 			targets[key] = struct{}{}
-			if tgt, ok := s.targets[key]; ok {
-				if tgt.UpdatePath(string(path)) {
-					level.Debug(s.log).Log("msg", "updating target, path changed", "labels", labels.String())
-				} else {
-					dropped = append(dropped, target.NewDroppedTarget("ignoring target, already exists", discoveredLabels))
-					level.Debug(s.log).Log("msg", "ignoring target, already exists", "labels", labels.String())
-					s.metrics.failedTargets.WithLabelValues("exists").Inc()
-				}
+			if _, ok := s.targets[key]; ok {
+				dropped = append(dropped, target.NewDroppedTarget("ignoring target, already exists", discoveredLabels))
+				level.Debug(s.log).Log("msg", "ignoring target, already exists", "labels", labels.String())
+				s.metrics.failedTargets.WithLabelValues("exists").Inc()
 				continue
 			}
 


### PR DESCRIPTION
resolve issue with promtail not scraping target if only path changed in a simpler way that dont need mutex to sync threads

Signed-off-by: Roger Steneteg <rsteneteg@ea.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`. 
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Resolves an issue in a better way, that don't require sharing variables between theads that would require a mutex to synchronize goroutines.

**Which issue(s) this PR fixes**:
Fixes #4581 #4460

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

