### PR TITLE
add date time sprig template functions in logql label/line formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [4570](https://github.com/grafana/loki/pull/4570) **DylanGuedes**: Loki: Append loopback to ingester net interface default list
 * [4594](https://github.com/grafana/loki/pull/4594) **owen-d**: Configures unordered_writes=true by default
 * [4574](https://github.com/grafana/loki/pull/4574) **slim-bean**: Loki: Add a ring to the compactor used to control concurrency when not running standalone
+* [4603](https://github.com/grafana/loki/pull/4603) **garrettlish**: Add date time sprig template functions in logql label/line formatter
 
 # 2.3.0 (2021/08/06)
 

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -631,7 +631,7 @@ Example of a query to print a newline per queries stored as a json array in the 
 
 ## date
 
-`date` returns a textual representation of the time value formatted according to layout.
+`date` returns a textual representation of the time value formatted according to the provided [golang datetime layout](https://pkg.go.dev/time#pkg-constants). 
 
 ```template
 { date "2006-01-02" now }}

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -612,3 +612,40 @@ Example of a query to print a newline per queries stored as a json array in the 
 ```logql
 {job="cortex/querier"} |= "finish in prometheus" | logfmt | line_format "{{ range $q := fromJson .queries }} {{ $q.query }} {{ end }}"
 ```
+
+## now
+
+`now` returns the current local time.
+
+```template
+{{ now }}
+```
+
+## toDate
+
+`toDate` parses a formatted string and returns the time value it represents.
+
+```template
+{{ toDate "2006-01-02" "2021-11-02" }}
+```
+
+## date
+
+`date` returns a textual representation of the time value formatted according to layout.
+
+```template
+{ date "2006-01-02" now }}
+```
+
+## unixEpoch
+
+`unixEpoch` returns the number of seconds elapsed since January 1, 1970 UTC.
+
+```template
+{ unixEpoch now }}
+```
+
+Example of a query to filter cortex querier jobs which create time is 1 day before:
+```logql
+{job="cortex/querier"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff="{{sub .nowEpoch .createDateEpoch}}" | dateTimeDiff > 86400
+```

--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -76,6 +76,10 @@ var (
 		"floor",
 		"round",
 		"fromJson",
+		"date",
+		"toDate",
+		"now",
+		"unixEpoch",
 	}
 )
 

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -206,6 +206,27 @@ func Test_lineFormatter_Format(t *testing.T) {
 			[]byte("12"),
 			labels.Labels{{Name: "foo", Value: "2.5"}},
 		},
+		{
+			"datetime",
+			newMustLineFormatter("{{ sub (unixEpoch (toDate \"2006-01-02\" \"2021-11-02\")) (unixEpoch (toDate \"2006-01-02\" \"2021-11-01\")) }}"),
+			labels.Labels{},
+			[]byte("86400"),
+			labels.Labels{},
+		},
+		{
+			"dateformat",
+			newMustLineFormatter("{{ date \"2006-01-02\" (toDate \"2006-01-02\" \"2021-11-02\") }}"),
+			labels.Labels{},
+			[]byte("2021-11-02"),
+			labels.Labels{},
+		},
+		{
+			"now",
+			newMustLineFormatter("{{ div (unixEpoch now) (unixEpoch now) }}"),
+			labels.Labels{},
+			[]byte("1"),
+			labels.Labels{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce date time sprig template functions in logql label/line formatter, it allows us to get current time, format date time and parse date time with specified layout.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/4511, we will be able to filter test jobs which create time is 1 day before as the following:
```
{job="test"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff="{{sub .nowEpoch .createDateEpoch}}" | dateTimeDiff > 86400
```

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Documentation added
- [x] Tests updated

