### PR TITLE
default ingester final sleep to 0 unless otherwise specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [4594](https://github.com/grafana/loki/pull/4594) **owen-d**: Configures unordered_writes=true by default
 * [4574](https://github.com/grafana/loki/pull/4574) **slim-bean**: Loki: Add a ring to the compactor used to control concurrency when not running standalone
 * [4603](https://github.com/grafana/loki/pull/4603) **garrettlish**: Add date time sprig template functions in logql label/line formatter
+* [4608](https://github.com/grafana/loki/pull/4608) **trevorwhitney**: Change default value of ingester lifecycler's `final_sleep` from `30s` to `0s`
 
 # 2.3.0 (2021/08/06)
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1033,7 +1033,7 @@ lifecycler:
 
   # Duration to sleep before exiting to ensure metrics are scraped.
   # CLI flag: -ingester.final-sleep
-  [final_sleep: <duration> | default = 30s]
+  [final_sleep: <duration> | default = 0s]
 
 # Number of times to try and transfer chunks when leaving before
 # falling back to flushing to the store. Zero = no transfers are done.

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -19,6 +19,12 @@ If possible try to stay current and do sequential updates. If you want to skip v
 
 ### Loki
 
+
+#### Ingester Lifecycler `final_sleep` now defaults to `0s`
+* [4608](https://github.com/grafana/loki/pull/4608) **trevorwhitney**: Change default value of ingester lifecycler's `final_sleep` from `30s` to `0s`
+
+This changes the default value for the `final_sleep` property of the ingester's lifecycler from `30s` to `0s`
+
 #### Ingester WAL now defaults to on, and chunk transfers are disabled by default
 
 * [4543](https://github.com/grafana/loki/pull/4543) **trevorwhitney**: Change more default values and improve application of common storage config

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	cortexcache "github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/grafana/dskit/flagext"
@@ -91,6 +92,7 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 		}
 
 		applyFIFOCacheConfig(r)
+		applyIngesterFinalSleep(r)
 
 		return nil
 	}
@@ -368,4 +370,8 @@ func isRedisSet(cfg cortexcache.Config) bool {
 // loki/pkg/storage/chunk/cache and cortex/pkg/chunk/cache at the same time.
 func isMemcacheSet(cfg cortexcache.Config) bool {
 	return cfg.MemcacheClient.Addresses != "" || cfg.MemcacheClient.Host != ""
+}
+
+func applyIngesterFinalSleep(cfg *ConfigWrapper) {
+	cfg.Ingester.LifecyclerConfig.FinalSleep = 0 * time.Second
 }

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -745,6 +745,27 @@ schema_config:
 		assert.Equal(t, "/opt/loki/boltdb-shipper-active", config.StorageConfig.BoltDBShipperConfig.ActiveIndexDirectory)
 		assert.Equal(t, "/opt/loki/boltdb-shipper-cache", config.StorageConfig.BoltDBShipperConfig.CacheLocation)
 	})
+
+	t.Run("ingester final sleep config", func(t *testing.T) {
+		t.Run("defaults to 0s", func(t *testing.T) {
+			config, _ := testContext(emptyConfigString, nil)
+
+			assert.Equal(t, 0*time.Second, config.Ingester.LifecyclerConfig.FinalSleep)
+		})
+
+		t.Run("honors values from config file and command line", func(t *testing.T) {
+			config, _ := testContext(emptyConfigString, []string{"--ingester.final-sleep", "5s"})
+			assert.Equal(t, 5*time.Second, config.Ingester.LifecyclerConfig.FinalSleep)
+
+			const finalSleepConfig = `---
+ingester:
+  lifecycler:
+    final_sleep: 12s`
+
+			config, _ = testContext(finalSleepConfig, nil)
+			assert.Equal(t, 12*time.Second, config.Ingester.LifecyclerConfig.FinalSleep)
+		})
+	})
 }
 
 func TestDefaultFIFOCacheBehavior(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This changes the default value for the ingester lifecycler's final sleep from 30s to 0s. With the default value, loki appears to hang when shutting down. This feature is designed to allow one last metric scrape to occur before shutdown, but as that is heavily dependent on scrape intervals in various environments, this default value is probably not sensible for everyone. Furthermore, for users who don't even know this value exists, it may be surprising to them why Loki "hangs" on shut-down.

`0s` seems like a better default, as it won't delay the Loki shutdown, and the property is still available for users to set per their environment / scrape interval.

**Which issue(s) this PR fixes**:
Fixes #4605 

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
