### PR TITLE
WIP: Implement a common ring config

### DIFF
--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -8,13 +8,15 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/gcp"
 	"github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/openstack"
+	"github.com/grafana/loki/pkg/util"
 )
 
 // Config holds common config that can be shared between multiple other config sections
 type Config struct {
-	PathPrefix    string  `yaml:"path_prefix"`
-	Storage       Storage `yaml:"storage"`
-	PersistTokens bool    `yaml:"persist_tokens"`
+	PathPrefix    string          `yaml:"path_prefix"`
+	Storage       Storage         `yaml:"storage"`
+	PersistTokens bool            `yaml:"persist_tokens"`
+	Ring          util.RingConfig `yaml:"ring"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -82,6 +82,27 @@ func (cfg *RingConfig) ToLifecyclerConfig(numTokens int) (ring.BasicLifecyclerCo
 	}, nil
 }
 
+func (cfg *RingConfig) ToCortexLifecyclerConfig() (ring.LifecyclerConfig, error) {
+	// TODO(dylanguedes): Make sure no important config is missed.
+	return ring.LifecyclerConfig{
+		RingConfig:      ring.Config{KVStore: cfg.KVStore},
+		NumTokens:       128, // default ingester num tokens
+		HeartbeatPeriod: cfg.HeartbeatPeriod,
+		ObservePeriod:   cfg.ObservePeriod,
+
+		//     MinReadyDuration: cfg.MinReady
+		InfNames: cfg.InstanceInterfaceNames,
+		// FinalSleep: ,
+		TokensFilePath: cfg.TokensFilePath,
+		Zone:           cfg.InstanceZone,
+		//     UnregisterOnShutdown: cfg
+
+		Addr: cfg.InstanceAddr,
+		Port: cfg.InstancePort,
+		ID:   cfg.InstanceID,
+	}, nil
+}
+
 func (cfg *RingConfig) ToRingConfig(replicationFactor int) ring.Config {
 	rc := ring.Config{}
 	flagext.DefaultValues(&rc)


### PR DESCRIPTION
**What this PR does / why we need it**:
## General Idea
This PR creates a new subsection in the `common` config named `ring`, that will be reused internally to configure other rings.
The previous behavior was the following:
*For every ring, check if an explicit config is given. If it is, use it. If it isn't, reuse whatever is set for the Ingester ring.*

The new behavior, implemented by this PR, is the following:
For every ring, check if an explicit config is given:
- If it is given, use it
- If it isn't given, check if a common ring (ring under common section) is given. If it is, use it
- If a common ring isn't given, just reuse whatever is set for the Ingester ring.

## Technical Decisions
- Since the LifecyclerConfig (from Cortex) is the ring config with the most configurations, I decided to use it in the `reuseConfig...` function instead of others. If you think this looks weird just let me know
- I'm applying the token paths in a separate function after all this new behavior to isolate things
- There's a caveat in reusing the common config and appending a loopback interface when appropriate: if we call `appendLoopbackInterface` before time, the check `reflect.DeepEqual(config.Ingester.LifecyclerConfig, defaults.ingester.LifecyclerConfig)` will fail when it shouldn't. Because of this, I have to first check if the Ingester config was set or not, and only then I can invoke `appendLoopbackInterface`.

**Which issue(s) this PR fixes**:
Fixes #<issue number> (I'll create an issue later)

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
