### PR TITLE
Docs: revise incendiary language added in PR 4507

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -277,7 +277,7 @@ external_labels:
 # A comma-separated list of labels to include in the stream lag metric `promtail_stream_lag_seconds`.
 # The default value is "filename". A "host" label is always included.
 # The stream lag metric indicates which streams are falling behind on writes to Loki;
-# be mindful about not using too many labels here as it can explode cardinality.
+# be mindful about using too many labels, as it can increase cardinality.
 [stream_lag_labels: <string> | default = "filename"]
 ```
 


### PR DESCRIPTION
Language added in in https://github.com/grafana/loki/pull/4507 used the word "explode." While accurate, I think it is more appropriate to use phrasing that doesn't trigger images of death or destruction. This PR revises that word usage, and simplifies the phrasing. 