### PR TITLE
Loki: query scheduler should send shutdown to frontends when ReplicationSet changes

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,100 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestScheduler_setRunState(t *testing.T) {
+
+	// This test is a bit crude, the method is not the most directly testable but
+	// this covers us to make sure we don't accidentally change the behavior of
+	// the little bit of logic which runs/stops the scheduler and makes sure we
+	// send a shutdown message to disconnect frontends.
+
+	// To avoid a lot more complicated test setup of calling NewScheduler instead
+	// we make a Scheduler with the things required to avoid nil pointers
+	s := Scheduler{
+		log: util_log.Logger,
+		schedulerRunning: promauto.With(prometheus.DefaultRegisterer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_query_scheduler_running",
+			Help: "Value will be 1 if the scheduler is in the ReplicationSet and actively receiving/processing requests",
+		}),
+	}
+	mock := &mockSchedulerForFrontendFrontendLoopServer{}
+	s.connectedFrontends = map[string]*connectedFrontend{
+		"127.0.0.1:9095": {
+			connections: 0,
+			frontend:    mock,
+			ctx:         nil,
+			cancel:      nil,
+		},
+	}
+
+	// not_running, shouldRun == false
+	assert.False(t, s.shouldRun.Load())
+
+	// not_running -> running, shouldRun == true
+	s.setRunState(true)
+	assert.True(t, s.shouldRun.Load())
+
+	// running -> running, shouldRun == true
+	s.setRunState(true)
+	assert.True(t, s.shouldRun.Load())
+
+	// running -> not_running, shouldRun == false, shutdown message sent
+	s.setRunState(false)
+	assert.False(t, s.shouldRun.Load())
+	assert.Equal(t, schedulerpb.SHUTTING_DOWN, mock.msg.Status)
+	mock.msg = nil
+
+	// not_running -> not_running, shouldRun == false, no shutdown message sent
+	s.setRunState(false)
+	assert.Nil(t, mock.msg)
+
+}
+
+type mockSchedulerForFrontendFrontendLoopServer struct {
+	msg *schedulerpb.SchedulerToFrontend
+}
+
+func (m *mockSchedulerForFrontendFrontendLoopServer) Send(frontend *schedulerpb.SchedulerToFrontend) error {
+	m.msg = frontend
+	return nil
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) Recv() (*schedulerpb.FrontendToScheduler, error) {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) SetHeader(md metadata.MD) error {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) SendHeader(md metadata.MD) error {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) SetTrailer(md metadata.MD) {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) Context() context.Context {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) SendMsg(msg interface{}) error {
+	panic("implement me")
+}
+
+func (m mockSchedulerForFrontendFrontendLoopServer) RecvMsg(msg interface{}) error {
+	panic("implement me")
+}

--- a/pkg/util/ring.go
+++ b/pkg/util/ring.go
@@ -1,6 +1,10 @@
 package util
 
-import "hash/fnv"
+import (
+	"hash/fnv"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+)
 
 // TokenFor generates a token used for finding ingesters from ring
 func TokenFor(userID, labels string) uint32 {
@@ -8,4 +12,22 @@ func TokenFor(userID, labels string) uint32 {
 	_, _ = h.Write([]byte(userID))
 	_, _ = h.Write([]byte(labels))
 	return h.Sum32()
+}
+
+// IsInReplicationSet will query the provided ring for the provided key
+// and see if the provided address is in the resulting ReplicationSet
+func IsInReplicationSet(r *ring.Ring, ringKey uint32, address string) (bool, error) {
+	bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
+	rs, err := r.Get(ringKey, ring.WriteNoExtend, bufDescs, bufHosts, bufZones)
+	if err != nil {
+		return false, err
+	}
+
+	addrs := rs.GetAddresses()
+	for _, a := range addrs {
+		if a == address {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/util/ring.go
+++ b/pkg/util/ring.go
@@ -18,7 +18,7 @@ func TokenFor(userID, labels string) uint32 {
 // and see if the provided address is in the resulting ReplicationSet
 func IsInReplicationSet(r *ring.Ring, ringKey uint32, address string) (bool, error) {
 	bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
-	rs, err := r.Get(ringKey, ring.WriteNoExtend, bufDescs, bufHosts, bufZones)
+	rs, err := r.Get(ringKey, ring.Write, bufDescs, bufHosts, bufZones)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR attempts to improve a race when adding/removing instances into the scheduler ring where messages could end up stuck in a schedulers queue with no queriers coming back to process them.

Currently when an elected scheduler is no longer "elected" everyone finds out about this through the ring, but the schedulers themselves do nothing and technically stay active, the frontend and queriers poll the ring and when they find out about the scheduler change, disconnect from the old and connect to the new.

The distributed nature of this creates the possibility that all the queriers find out about a scheduler change and disconnect from the scheduler while the frontend still stays connected. The frontend could then be stuck waiting for inflight queries to process (which will never happen because all the queriers have moved on) ultimately leading to a timeout or failure of the query.

To mitigate this we make sure that as soon as the scheduler knows it's not in the ReplicationSet of who should act as a scheduler it should send a shutdown message to connected frontends so they will cancel requests and retry them in other schedulers.
>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
