### PR TITLE
uses ring.Write instead of ring.WriteNoExtend for compactor ring checks

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -292,7 +292,7 @@ func (c *Compactor) loop(ctx context.Context) error {
 			return nil
 		case <-syncTicker.C:
 			bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
-			rs, err := c.ring.Get(ringKeyOfLeader, ring.WriteNoExtend, bufDescs, bufHosts, bufZones)
+			rs, err := c.ring.Get(ringKeyOfLeader, ring.Write, bufDescs, bufHosts, bufZones)
 			if err != nil {
 				level.Error(util_log.Logger).Log("msg", "error asking ring for who should run the compactor, will check again", "err", err)
 				continue


### PR DESCRIPTION
`ring.WriteNoExtend` won't keep iterating the ring until an active node is picked, so I think we should use `ring.Write` here instead. This is the same idea from https://github.com/grafana/loki/pull/4607