### PR TITLE
Disable chunk transfers in jsonnet lib

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -203,7 +203,6 @@
       ingester: {
         chunk_idle_period: '15m',
         chunk_block_size: 262144,
-        max_transfer_retries: 60,
 
         lifecycler: {
           ring: {


### PR DESCRIPTION
Since the WAL is now enabled by default and incompatible with chunk
transfer, the latter needs to be disabled (setting to `0`).

The default of `max_transfer_retries` is `0` and therefore the setting
can be removed.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>