### PR TITLE
dont try to use the scheduler ring when a downstream url is configured

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -69,10 +69,11 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 			return errors.New("dst is not a Loki ConfigWrapper")
 		}
 
-		// If nobody has defined any frontend address or scheduler address
+		// If nobody has defined any frontend address, scheduler address, or downstream url
 		// we can default to using the query scheduler ring for scheduler discovery.
 		if r.Worker.FrontendAddress == "" &&
 			r.Worker.SchedulerAddress == "" &&
+			r.Frontend.DownstreamURL == "" &&
 			r.Frontend.FrontendV2.SchedulerAddress == "" {
 			r.QueryScheduler.UseSchedulerRing = true
 		}


### PR DESCRIPTION
I can't see this being a reasonable configuration people would use, but when the scheduler is enabled `(all, read, scheduler)` targets, avoid using the scheduler ring when a downstream address is present in the frontend config, which would avoid any schedulers anyway.