### PR TITLE
Loki: Revert distributor defaulting to `inmemory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Main
 * [4400](https://github.com/grafana/loki/pull/4400) **trevorwhitney**: Config: automatically apply memberlist config too all rings when provided
 * [4435](https://github.com/grafana/loki/pull/4435) **trevorwhitney**: Change default values for two GRPC settings so querier can connect to frontend/scheduler
-* [4440](https://github.com/grafana/loki/pull/4440) **DylanGuedes**: Config: Override distributor's default ring KV store
 * [4443](https://github.com/grafana/loki/pull/4443) **DylanGuedes**: Loki: Change how push API checks for contentType
 * [4415](https://github.com/grafana/loki/pull/4415) **DylanGuedes**: Change default limits to common values
 * [4473](https://github.com/grafana/loki/pull/4473) **trevorwhitney**: Config: add object storage configuration to common config

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -52,21 +52,6 @@ ingester:
     enabled: true
 ```
 
-#### Distributor now stores ring in memory by default instead of Consul
-
-PR [4440](https://github.com/grafana/loki/pull/4440) **DylanGuedes**: Config: Override distributor's default ring KV store
-
-This change sets `inmemory` as the new default storage for the Distributor ring (previously `consul`).
-The motivation is making the Distributor easier to run with default configs, by not requiring Consul anymore.
-In any case, if you prefer to use Consul as the ring storage, you can set it by using the following config:
-
-```yaml
-distributor:
-  ring:
-    kvstore:
-      store: consul
-```
-
 #### Memberlist config now automatically applies to all non-configured rings
 PR [4400](https://github.com/grafana/loki/pull/4400) **trevorwhitney**: Config: automatically apply memberlist config too all rings when provided
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -44,25 +44,8 @@ type Config struct {
 }
 
 // RegisterFlags registers distributor-related flags.
-//
-// Since they are registered through an external library, we override some of them to set
-// different default values.
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
-	throwaway := flag.NewFlagSet("throwaway", flag.PanicOnError)
-
-	cfg.DistributorRing.RegisterFlags(throwaway)
-
-	// Register to throwaway flags first. Default values are remembered during registration and cannot be changed,
-	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
-	throwaway.VisitAll(func(f *flag.Flag) {
-		// Ignore errors when setting new values. We have a test to verify that it works.
-		switch f.Name {
-		case "distributor.ring.store":
-			_ = f.Value.Set("inmemory")
-		}
-
-		fs.Var(f.Value, f.Name, f.Usage)
-	})
+	cfg.DistributorRing.RegisterFlags(fs)
 }
 
 // Distributor coordinates replicates and distribution of log streams.

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -42,12 +42,7 @@ func TestFlagDefaults(t *testing.T) {
 		gotFlags[splittedLine] = nextLine
 	}
 
-	flagToCheck := "-distributor.ring.store"
-	require.Contains(t, gotFlags, flagToCheck)
-	require.Equal(t, c.Distributor.DistributorRing.KVStore.Store, "inmemory")
-	require.Contains(t, gotFlags[flagToCheck], "(default \"inmemory\")")
-
-	flagToCheck = "-server.grpc.keepalive.min-time-between-pings"
+	flagToCheck := "-server.grpc.keepalive.min-time-between-pings"
 	require.Contains(t, gotFlags, flagToCheck)
 	require.Equal(t, c.Server.GRPCServerMinTimeBetweenPings, 10*time.Second)
 	require.Contains(t, gotFlags[flagToCheck], "(default 10s)")


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reverts [PR 4440](https://github.com/grafana/loki/pull/4440/files), which modified the distributor ring to `inmemory` (instead of consul). This is inconsistent with other rings default behavior and is also not retrocompatible with previous versions.
    - That change was required at that time because, by changing the default rate limiting to `global`, a ring was necessary, and, since by default the ring KV was `consul`, the project couldn't run with the default configs. That's not the case anymore: right now we are defaulting to reusing the ingester config, which users already have properly configured otherwise they wouldn't be able to run the project anyway.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
