### PR TITLE
compactor depends on memberlist for memberlist ring option

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -450,7 +450,7 @@ func (t *Loki) setupModuleManager() error {
 		QueryScheduler:           {Server, Overrides, MemberlistKV},
 		Ruler:                    {Ring, Server, Store, RulerStorage, IngesterQuerier, Overrides, TenantConfigs},
 		TableManager:             {Server},
-		Compactor:                {Server, Overrides},
+		Compactor:                {Server, Overrides, MemberlistKV},
 		IndexGateway:             {Server},
 		IngesterQuerier:          {Ring},
 		All:                      {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler, Compactor},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

We seem to have introduced a race condition when using memberlist for the compactor ring:
```
│ level=info ts=2021-11-03T23:26:34.317080539Z caller=main.go:94 msg="Starting Loki" version="(version=k70-07ea1ed, branch=k70, revision=07ea1ed99)"          ││ level=info ts=2021-11-03T23:26:34.317342925Z caller=server.go:260 http=[::]:3100 grpc=[::]:9095 msg="server listening on addresses"                         ││ panic: runtime error: invalid memory address or nil pointer dereference                                                                                     ││ [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xed5498]                                                                                      ││ goroutine 1 [running]:                                                                                                                                      ││ github.com/grafana/dskit/kv/memberlist.(*KVInitService).GetMemberlistKV(0x0)                                                                                ││     /src/loki/vendor/github.com/grafana/dskit/kv/memberlist/kv_init_service.go:57 +0x18                                                                     ││ github.com/grafana/dskit/kv.createClient({_, _}, {_, _}, {{{0x22456a8, 0xe}, {0x0, 0x0}, 0x4a817c800, 0x0, ...}, ...}, ...)                                 ││     /src/loki/vendor/github.com/grafana/dskit/kv/client.go:146 +0x4b2                                                                                       ││ github.com/grafana/dskit/kv.NewClient({{0x223da05, 0xa}, {0x223f2b3, 0xb}, {{{0x22456a8, 0xe}, {0x0, 0x0}, 0x4a817c800, 0x0, ...}, ...}, ...}, ...)         ││     /src/loki/vendor/github.com/grafana/dskit/kv/client.go:123 +0x11e                                                                                       ││ github.com/grafana/loki/pkg/storage/stores/shipper/compactor.NewCompactor({{0xc000501c10, 0xf}, {0x2231d26, 0x3}, {0x2235bc8, 0x6}, 0x8bb2c97000, 0x0, 0x68 ││     /src/loki/pkg/storage/stores/shipper/compactor/compactor.go:125 +0x33a                                                                                  ││ github.com/grafana/loki/pkg/loki.(*Loki).initCompactor(0xc000343500)                                                                                        ││     /src/loki/pkg/loki/modules.go:668 +0x1df                                                                                                                ││ github.com/grafana/dskit/modules.(*Manager).initModule(0xc00012d710, {0x7ffd92f27d0d, 0x1}, 0xc000245c50, 0xc00091cc18)                                     ││     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:106 +0x22c                                                                                 ││ github.com/grafana/dskit/modules.(*Manager).InitModuleServices(0xc000434a50, {0xc0007e6bb0, 0x1, 0x40ac5d})                                                 ││     /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:78 +0x10c                                                                                  ││ github.com/grafana/loki/pkg/loki.(*Loki).Run(0xc000343500)                                                                                                  ││     /src/loki/pkg/loki/loki.go:284 +0x4b                                                                                                                    ││ main.main()                                                                                                                                                 ││     /src/loki/cmd/loki/main.go:96 +0xd70
```

This PR add `MemberlistKV` as a dependency of `Compactor` which should fix this.