### PR TITLE
Improves memchunk benchmark to account for block size.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -44,9 +44,7 @@ const (
 	defaultBlockSize = 256 * 1024
 )
 
-var (
-	HeadBlockFmts = []HeadBlockFmt{OrderedHeadBlockFmt, UnorderedHeadBlockFmt}
-)
+var HeadBlockFmts = []HeadBlockFmt{OrderedHeadBlockFmt, UnorderedHeadBlockFmt}
 
 type HeadBlockFmt byte
 
@@ -725,7 +723,6 @@ func (c *MemChunk) reorder() error {
 }
 
 func (c *MemChunk) ConvertHead(desired HeadBlockFmt) error {
-
 	if c.head != nil && c.head.Format() != desired {
 		newH, err := c.head.Convert(desired)
 		if err != nil {
@@ -856,7 +853,6 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 		return iter.NewNonOverlappingIterator(blockItrs, ""), nil
 	}
 	return iter.NewHeapIterator(ctx, blockItrs, direction), nil
-
 }
 
 // Iterator implements Chunk.
@@ -932,7 +928,6 @@ func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
 		// The alternative here could be going over all the blocks and using the size of the largest block as target block size but I(Sandeep) feel that it is not worth the complexity.
 		// For target chunk size I am using compressed size of original chunk since the newChunk should anyways be lower in size than that.
 		newChunk = NewMemChunk(c.Encoding(), c.headFmt, defaultBlockSize, c.CompressedSize())
-
 	}
 
 	for itr.Next() {
@@ -1114,7 +1109,6 @@ type bufferedIterator struct {
 
 	err error
 
-	decBuf   []byte // The buffer for decoding the lengths.
 	buf      []byte // The buffer for a single entry.
 	currLine []byte // the current line, this is the same as the buffer but sliced the the line size.
 	currTs   int64
@@ -1131,7 +1125,6 @@ func newBufferedIterator(ctx context.Context, pool ReaderPool, b []byte) *buffer
 		reader:    nil, // will be initialized later
 		bufReader: nil, // will be initialized later
 		pool:      pool,
-		decBuf:    make([]byte, binary.MaxVarintLen64),
 	}
 }
 
@@ -1233,7 +1226,6 @@ func (si *bufferedIterator) close() {
 		si.buf = nil
 	}
 	si.origBytes = nil
-	si.decBuf = nil
 }
 
 func newEntryIterator(ctx context.Context, pool ReaderPool, b []byte, pipeline log.StreamPipeline) iter.EntryIterator {

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,6 +43,7 @@ var testEncoding = []Encoding{
 var (
 	testBlockSize  = 256 * 1024
 	testTargetSize = 1500 * 1024
+	testBlockSizes = []int{64 * 1024, 256 * 1024, 512 * 1024}
 	countExtractor = func() log.StreamSampleExtractor {
 		ex, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
 		if err != nil {
@@ -496,21 +498,40 @@ func TestMemChunk_AppendOutOfOrder(t *testing.T) {
 }
 
 func TestChunkSize(t *testing.T) {
-	for _, f := range HeadBlockFmts {
-		for _, enc := range testEncoding {
-			t.Run(enc.String(), func(t *testing.T) {
-				t.Parallel()
-				c := NewMemChunk(enc, f, testBlockSize, testTargetSize)
-				inserted := fillChunk(c)
-				b, err := c.Bytes()
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Log("Chunk size", humanize.Bytes(uint64(len(b))))
-				t.Log("characters ", humanize.Bytes(uint64(inserted)))
-				t.Log("Ratio", float64(inserted)/float64(len(b)))
-			})
+	type res struct {
+		name           string
+		size           uint64
+		compressedSize uint64
+		ratio          float64
+	}
+	var result []res
+	for _, bs := range testBlockSizes {
+		for _, f := range HeadBlockFmts {
+			for _, enc := range testEncoding {
+				name := fmt.Sprintf("%s_%s", enc.String(), humanize.Bytes(uint64(bs)))
+				t.Run(name, func(t *testing.T) {
+					c := NewMemChunk(enc, f, bs, testTargetSize)
+					inserted := fillChunk(c)
+					b, err := c.Bytes()
+					if err != nil {
+						t.Fatal(err)
+					}
+					result = append(result, res{
+						name:           name,
+						size:           uint64(inserted),
+						compressedSize: uint64(len(b)),
+						ratio:          float64(inserted) / float64(len(b)),
+					})
+				})
+			}
 		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ratio > result[j].ratio
+	})
+	fmt.Printf("%s\t%s\t%s\t%s\n", "name", "uncompressed", "compressed", "ratio")
+	for _, r := range result {
+		fmt.Printf("%s\t%s\t%s\t%f\n", r.name, humanize.Bytes(r.size), humanize.Bytes(r.compressedSize), r.ratio)
 	}
 }
 
@@ -635,7 +656,6 @@ func BenchmarkWrite(b *testing.B) {
 	i := int64(0)
 
 	for _, f := range HeadBlockFmts {
-
 		for _, enc := range testEncoding {
 			b.Run(fmt.Sprintf("%v-%v", f, enc), func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
@@ -663,78 +683,102 @@ func (nomatchPipeline) ProcessString(line string) (string, log.LabelsResult, boo
 }
 
 func BenchmarkRead(b *testing.B) {
-	for _, enc := range testEncoding {
-		b.Run(enc.String(), func(b *testing.B) {
-			chunks, size := generateData(enc, 5)
-			b.ResetTimer()
-			bytesRead := uint64(0)
-			now := time.Now()
-			for n := 0; n < b.N; n++ {
-				for _, c := range chunks {
-					// use forward iterator for benchmark -- backward iterator does extra allocations by keeping entries in memory
-					iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.FORWARD, nomatchPipeline{})
-					if err != nil {
-						panic(err)
+	type res struct {
+		name  string
+		speed float64
+	}
+	result := []res{}
+	for _, bs := range testBlockSizes {
+		for _, enc := range testEncoding {
+			name := fmt.Sprintf("%s_%s", enc.String(), humanize.Bytes(uint64(bs)))
+			b.Run(name, func(b *testing.B) {
+				chunks, size := generateData(enc, 5, bs, testTargetSize)
+				b.ResetTimer()
+				bytesRead := uint64(0)
+				now := time.Now()
+				for n := 0; n < b.N; n++ {
+					for _, c := range chunks {
+						// use forward iterator for benchmark -- backward iterator does extra allocations by keeping entries in memory
+						iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.FORWARD, nomatchPipeline{})
+						if err != nil {
+							panic(err)
+						}
+						for iterator.Next() {
+							_ = iterator.Entry()
+						}
+						if err := iterator.Close(); err != nil {
+							b.Fatal(err)
+						}
 					}
-					for iterator.Next() {
-						_ = iterator.Entry()
-					}
-					if err := iterator.Close(); err != nil {
-						b.Fatal(err)
-					}
+					bytesRead += size
 				}
-				bytesRead += size
-			}
-			b.Log("bytes per second ", humanize.Bytes(uint64(float64(bytesRead)/time.Since(now).Seconds())))
-			b.Log("n=", b.N)
-		})
+				result = append(result, res{
+					name:  name,
+					speed: float64(bytesRead) / time.Since(now).Seconds(),
+				})
+			})
 
-		b.Run(enc.String()+"_sample", func(b *testing.B) {
-			chunks, size := generateData(enc, 5)
-			b.ResetTimer()
-			bytesRead := uint64(0)
-			now := time.Now()
-			for n := 0; n < b.N; n++ {
-				for _, c := range chunks {
-					iterator := c.SampleIterator(context.Background(), time.Unix(0, 0), time.Now(), countExtractor)
-					for iterator.Next() {
-						_ = iterator.Sample()
+			name = fmt.Sprintf("sample_%s_%s", enc.String(), humanize.Bytes(uint64(bs)))
+
+			b.Run(name, func(b *testing.B) {
+				chunks, size := generateData(enc, 5, bs, testTargetSize)
+				b.ResetTimer()
+				bytesRead := uint64(0)
+				now := time.Now()
+				for n := 0; n < b.N; n++ {
+					for _, c := range chunks {
+						iterator := c.SampleIterator(context.Background(), time.Unix(0, 0), time.Now(), countExtractor)
+						for iterator.Next() {
+							_ = iterator.Sample()
+						}
+						if err := iterator.Close(); err != nil {
+							b.Fatal(err)
+						}
 					}
-					if err := iterator.Close(); err != nil {
-						b.Fatal(err)
-					}
+					bytesRead += size
 				}
-				bytesRead += size
-			}
-			b.Log("bytes per second ", humanize.Bytes(uint64(float64(bytesRead)/time.Since(now).Seconds())))
-			b.Log("n=", b.N)
-		})
+				result = append(result, res{
+					name:  name,
+					speed: float64(bytesRead) / time.Since(now).Seconds(),
+				})
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].speed > result[j].speed
+	})
+	for _, r := range result {
+		fmt.Printf("%s: %.2f MB/s\n", r.name, r.speed/1024/1024)
 	}
 }
 
 func BenchmarkBackwardIterator(b *testing.B) {
-	b.ReportAllocs()
-	c := NewMemChunk(EncSnappy, DefaultHeadBlockFmt, testBlockSize, testTargetSize)
-	_ = fillChunk(c)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.BACKWARD, noopStreamPipeline)
-		if err != nil {
-			panic(err)
-		}
-		for iterator.Next() {
-			_ = iterator.Entry()
-		}
-		if err := iterator.Close(); err != nil {
-			b.Fatal(err)
-		}
+	for _, bs := range testBlockSizes {
+		b.Run(humanize.Bytes(uint64(bs)), func(b *testing.B) {
+			b.ReportAllocs()
+			c := NewMemChunk(EncSnappy, DefaultHeadBlockFmt, bs, testTargetSize)
+			_ = fillChunk(c)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				iterator, err := c.Iterator(context.Background(), time.Unix(0, 0), time.Now(), logproto.BACKWARD, noopStreamPipeline)
+				if err != nil {
+					panic(err)
+				}
+				for iterator.Next() {
+					_ = iterator.Entry()
+				}
+				if err := iterator.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
 func TestGenerateDataSize(t *testing.T) {
 	for _, enc := range testEncoding {
 		t.Run(enc.String(), func(t *testing.T) {
-			chunks, size := generateData(enc, 50)
+			chunks, size := generateData(enc, 50, testBlockSize, testTargetSize)
 
 			bytesRead := uint64(0)
 			for _, c := range chunks {

--- a/pkg/chunkenc/util_test.go
+++ b/pkg/chunkenc/util_test.go
@@ -15,14 +15,14 @@ func logprotoEntry(ts int64, line string) *logproto.Entry {
 	}
 }
 
-func generateData(enc Encoding, chunksCount int) ([]Chunk, uint64) {
+func generateData(enc Encoding, chunksCount, blockSize, targetSize int) ([]Chunk, uint64) {
 	chunks := []Chunk{}
 	i := int64(0)
 	size := uint64(0)
 
 	for n := 0; n < chunksCount; n++ {
 		entry := logprotoEntry(0, testdata.LogString(0))
-		c := NewMemChunk(enc, DefaultHeadBlockFmt, testBlockSize, testTargetSize)
+		c := NewMemChunk(enc, DefaultHeadBlockFmt, blockSize, targetSize)
 		for c.SpaceFor(entry) {
 			size += uint64(len(entry.Line))
 			_ = c.Append(entry)


### PR DESCRIPTION
No major code change except some cleanup.

```
none_524 kB: 3952.20 MB/s
none_262 kB: 3818.19 MB/s
none_262 kB: 3588.39 MB/s
none_524 kB: 3528.82 MB/s
none_66 kB: 3347.10 MB/s
none_66 kB: 3306.29 MB/s
none_524 kB: 3052.64 MB/s
none_262 kB: 2932.31 MB/s
lz4-1M_66 kB: 2567.87 MB/s
lz4_262 kB: 2467.42 MB/s
none_66 kB: 2453.80 MB/s
lz4-256k_524 kB: 2398.77 MB/s
lz4-1M_262 kB: 2295.78 MB/s
lz4-256k_524 kB: 2289.92 MB/s
lz4-256k_262 kB: 2281.90 MB/s
lz4-1M_524 kB: 2213.51 MB/s
lz4-256k_66 kB: 2187.04 MB/s
lz4_524 kB: 2183.28 MB/s
lz4_524 kB: 2177.57 MB/s
lz4-1M_66 kB: 2148.51 MB/s
lz4_66 kB: 2145.61 MB/s
lz4-1M_262 kB: 2120.39 MB/s
sample_none_66 kB: 2104.96 MB/s
lz4-64k_66 kB: 2098.88 MB/s
lz4-64k_524 kB: 2077.25 MB/s
lz4-64k_524 kB: 2073.97 MB/s
lz4-256k_66 kB: 2070.37 MB/s
lz4_262 kB: 2052.62 MB/s
lz4-256k_262 kB: 2030.32 MB/s
lz4_66 kB: 2013.14 MB/s
lz4-64k_262 kB: 2009.75 MB/s
lz4_262 kB: 1998.54 MB/s
lz4-64k_66 kB: 1992.59 MB/s
lz4-64k_262 kB: 1942.55 MB/s
lz4-1M_524 kB: 1914.17 MB/s
lz4-256k_262 kB: 1865.59 MB/s
snappy_524 kB: 1859.09 MB/s
```

Interesting to see lz4 beating snappy now.

I'm guessing this is due to the an upgrade of the vendor code.

As for size lz4 has a compression ratio of 13 vs 9 for snappy.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

