### PR TITLE
Instrument s3 client DeleteObject requests.

### DIFF
--- a/pkg/storage/chunk/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/aws/s3_storage_client.go
@@ -337,15 +337,15 @@ func (a *S3ObjectClient) Stop() {}
 
 // DeleteObject deletes the specified objectKey from the appropriate S3 bucket
 func (a *S3ObjectClient) DeleteObject(ctx context.Context, objectKey string) error {
-	_, err := a.S3.DeleteObject(&s3.DeleteObjectInput{
-		Bucket: aws.String(a.bucketFromKey(objectKey)),
-		Key:    aws.String(objectKey),
-	})
-	if err != nil {
-		return err
-	}
+	return instrument.CollectedRequest(ctx, "S3.DeleteObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		deleteObjectInput := &s3.DeleteObjectInput{
+			Bucket: aws.String(a.bucketFromKey(objectKey)),
+			Key:    aws.String(objectKey),
+		}
 
-	return nil
+		_, err := a.S3.DeleteObjectWithContext(ctx, deleteObjectInput)
+		return err
+	})
 }
 
 // bucketFromKey maps a key to a bucket name


### PR DESCRIPTION
Not sure if we're missing historical context for any reason why these requests were not instrumented, but while working on an S3 experiment @JordanRushing and I noticed that the s3 client `DeleteObject` requests are not metrics instrumented.

Signed-off-by: Callum Styan <callumstyan@gmail.com>