### PR TITLE
Build: Only push latest docker tag on tagged builds (not pushes to main)

### DIFF
--- a/.drone/docker-manifest.tmpl
+++ b/.drone/docker-manifest.tmpl
@@ -1,7 +1,9 @@
 image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}
 tags:
+  - main
+{{#if build.tag}}
   - latest
-  - master
+{{/if}}
 {{#if build.tags}}
 {{#each build.tags}}
   - {{this}}

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -130,7 +130,7 @@ local promtail_win() = pipeline('promtail-windows') {
   ],
 };
 
-local fluentbit() = pipeline('fluent-bit-amd64') + arch_image('amd64', 'latest,main') {
+local fluentbit() = pipeline('fluent-bit-amd64') + arch_image('amd64', 'main') {
   steps+: [
     // dry run for everything that is not tag or main
     clients_docker('amd64', 'fluent-bit') {
@@ -154,7 +154,7 @@ local fluentbit() = pipeline('fluent-bit-amd64') + arch_image('amd64', 'latest,m
   depends_on: ['check'],
 };
 
-local fluentd() = pipeline('fluentd-amd64') + arch_image('amd64', 'latest,main') {
+local fluentd() = pipeline('fluentd-amd64') + arch_image('amd64', 'main') {
   steps+: [
     // dry run for everything that is not tag or main
     clients_docker('amd64', 'fluentd') {
@@ -178,7 +178,7 @@ local fluentd() = pipeline('fluentd-amd64') + arch_image('amd64', 'latest,main')
   depends_on: ['check'],
 };
 
-local logstash() = pipeline('logstash-amd64') + arch_image('amd64', 'latest,main') {
+local logstash() = pipeline('logstash-amd64') + arch_image('amd64', 'main') {
   steps+: [
     // dry run for everything that is not tag or main
     clients_docker('amd64', 'logstash') {
@@ -395,5 +395,5 @@ local manifest(apps) = pipeline('manifest') {
     ],
   },
 ] + [promtail_win()]
-+ [lambda_promtail('latest,main')]
++ [lambda_promtail('main')]
 + [github_secret, pull_secret, docker_username_secret, docker_password_secret, ecr_key, ecr_secret_key, deploy_configuration]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -590,7 +590,7 @@ steps:
   - apk add --no-cache bash git
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
-  - echo ",latest,main" >> .tags
+  - echo ",main" >> .tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -642,7 +642,7 @@ steps:
   - apk add --no-cache bash git
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
-  - echo ",latest,main" >> .tags
+  - echo ",main" >> .tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -694,7 +694,7 @@ steps:
   - apk add --no-cache bash git
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
-  - echo ",latest,main" >> .tags
+  - echo ",main" >> .tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -847,7 +847,7 @@ steps:
   - apk add --no-cache bash git
   - git fetch origin --tags
   - echo $(./tools/image-tag)-amd64 > .tags
-  - echo ",latest,main" >> .tags
+  - echo ",main" >> .tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -936,6 +936,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: b51ec8dfc84d0be83827fc851b21b81e1091886be480d675f51485b647e58001
+hmac: 7b6eb119ab31c369dda4d65a5b26aae344e0dd4815196bfef75f93e99ebb202b
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ docker-driver: docker-driver-clean
 	docker rm -vf $$ID
 	docker rmi rootfsimage -f
 	docker plugin create $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH) clients/cmd/docker-driver
-	docker plugin create $(LOKI_DOCKER_DRIVER):latest$(PLUGIN_ARCH) clients/cmd/docker-driver
+	docker plugin create $(LOKI_DOCKER_DRIVER):main$(PLUGIN_ARCH) clients/cmd/docker-driver
 
 clients/cmd/docker-driver/docker-driver: $(APP_GO_FILES)
 	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
@@ -384,7 +384,7 @@ clients/cmd/docker-driver/docker-driver: $(APP_GO_FILES)
 
 docker-driver-push: docker-driver
 	docker plugin push $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH)
-	docker plugin push $(LOKI_DOCKER_DRIVER):latest$(PLUGIN_ARCH)
+	docker plugin push $(LOKI_DOCKER_DRIVER):main$(PLUGIN_ARCH)
 
 docker-driver-enable:
 	docker plugin enable $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH)
@@ -392,7 +392,7 @@ docker-driver-enable:
 docker-driver-clean:
 	-docker plugin disable $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH)
 	-docker plugin rm $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH)
-	-docker plugin rm $(LOKI_DOCKER_DRIVER):latest$(PLUGIN_ARCH)
+	-docker plugin rm $(LOKI_DOCKER_DRIVER):main$(PLUGIN_ARCH)
 	rm -rf clients/cmd/docker-driver/rootfs
 
 #####################
@@ -478,11 +478,10 @@ define push
 endef
 
 # push-image(app)
-# pushes the app, also as :latest and :master
+# pushes the app, also as :main
 define push-image
 	$(call push,$(1),$(IMAGE_TAG))
-	$(call push,$(1),master)
-	$(call push,$(1),latest)
+	$(call push,$(1),main)
 endef
 
 # promtail


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->


This isn't a perfect fix, as it will update the `latest` docker tag to any pushed tag, however this felt better than not automating this at all and having to do it manually.


**Which issue(s) this PR fixes**:
Fixes #4557

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
