### PR TITLE
Add a test to verify goroutine leak in compression pools.

### DIFF
--- a/pkg/chunkenc/pool_test.go
+++ b/pkg/chunkenc/pool_test.go
@@ -50,11 +50,10 @@ func TestPool(t *testing.T) {
 
 	wg.Wait()
 
-	runtime.GC()
-	time.Sleep(20 * time.Millisecond)
-	runtime.GC()
-
-	if !assert.LessOrEqual(t, runtime.NumGoroutine(), 100) {
+	if !assert.Eventually(t, func() bool {
+		runtime.GC()
+		return runtime.NumGoroutine() <= 50
+	}, 5*time.Second, 10*time.Millisecond) {
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	}
 }

--- a/pkg/chunkenc/pool_test.go
+++ b/pkg/chunkenc/pool_test.go
@@ -18,7 +18,7 @@ func TestPool(t *testing.T) {
 	var wg sync.WaitGroup
 	for _, enc := range supportedEncoding {
 		enc := enc
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 200; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -54,7 +54,7 @@ func TestPool(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	runtime.GC()
 
-	if !assert.LessOrEqual(t, runtime.NumGoroutine(), 2) {
+	if !assert.LessOrEqual(t, runtime.NumGoroutine(), 100) {
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 	}
 }


### PR DESCRIPTION
I thought zstd has a leak for the writer, but it did not.

This also fixes a request from @kavirajk when I added the finalizer on the zstd reader.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

