### PR TITLE
overrides checks for nil tenant limits on AllByUserID

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -251,7 +251,12 @@ func NewOverrides(defaults Limits, tenantLimits TenantLimits) (*Overrides, error
 	}, nil
 }
 
-func (o *Overrides) AllByUserID() map[string]*Limits { return o.tenantLimits.AllByUserID() }
+func (o *Overrides) AllByUserID() map[string]*Limits {
+	if o.tenantLimits != nil {
+		return o.tenantLimits.AllByUserID()
+	}
+	return nil
+}
 
 // IngestionRateStrategy returns whether the ingestion rate limit should be individually applied
 // to each distributor instance (local) or evenly shared across the cluster (global).


### PR DESCRIPTION
This protects against the case where `TenantLimits` can be nil, which I thought was impossible, but upon closer a closer look at [`modules.go`](https://github.com/grafana/loki/blob/main/pkg/loki/modules.go#L145-L157), when there's no load path, it never gets instantiated. I confirmed locally using the config provided in #4684 that it failed before and succeeded after this fix.

Closes #4684