### PR TITLE
fix flaky retention tests

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -462,7 +462,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "no chunk and series deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, now.Add(-30*time.Minute), now),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -482,7 +482,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "only one chunk in store which gets deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, now.Add(-30*time.Minute), now),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -502,14 +502,14 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "only one chunk in store which gets partially deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, now.Add(-30*time.Minute), now),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
 					nonDeletedIntervals: []model.Interval{{
-						Start: now.Add(-15 * time.Minute),
-						End:   now,
+						Start: todaysTableInterval.Start,
+						End:   todaysTableInterval.Start.Add(15 * time.Minute),
 					}},
 				},
 			},
@@ -526,8 +526,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one of two chunks deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, now.Add(-30*time.Minute), now),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, now.Add(-30*time.Minute), now),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -550,8 +550,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 		{
 			name: "one of two chunks partially deleted",
 			chunks: []chunk.Chunk{
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, now.Add(-30*time.Minute), now),
-				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, now.Add(-30*time.Minute), now),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "1"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
+				createChunk(t, userID, labels.Labels{labels.Label{Name: "foo", Value: "2"}}, todaysTableInterval.Start, todaysTableInterval.Start.Add(30*time.Minute)),
 			},
 			expiry: []chunkExpiry{
 				{
@@ -560,8 +560,8 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				{
 					isExpired: true,
 					nonDeletedIntervals: []model.Interval{{
-						Start: now.Add(-15 * time.Minute),
-						End:   now,
+						Start: todaysTableInterval.Start,
+						End:   todaysTableInterval.Start.Add(15 * time.Minute),
 					}},
 				},
 			},

--- a/pkg/storage/stores/shipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func dayFromTime(t model.Time) chunk.DayTime {
-	parsed, err := time.Parse("2006-01-02", t.Time().Format("2006-01-02"))
+	parsed, err := time.Parse("2006-01-02", t.Time().In(time.UTC).Format("2006-01-02"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR fixes 2 flaky tests:
* In `TestMarkForDelete_SeriesCleanup` test, we use `now` as a reference time for building chunks that could unintentionally lead to overlapping chunks based on the timezone. This PR fixes it by using interval for today's table as a reference for building chunks.
* In `Test_schemaPeriodForTable`, we build schema using [dayFromTime](https://github.com/grafana/loki/blob/979a532732967e199ac4e7def0bae16168191837/pkg/storage/stores/shipper/compactor/retention/util_test.go#L31) which internally uses [time.Format](https://pkg.go.dev/time#Time.Format) function. Now since `time.Format` builds string representation of time WRT local timezone while rest of the test code uses epoch which is in UTC, the test fails sometimes based on when the test runs.
