### PR TITLE
Enrich WAL folder creation error message

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -208,7 +208,15 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 
 	if cfg.WAL.Enabled {
 		if err := os.MkdirAll(cfg.WAL.Dir, os.ModePerm); err != nil {
-			return nil, fmt.Errorf("error creating WAL folder at '%s': %w", cfg.WAL.Dir, err)
+			path := cfg.WAL.Dir
+      
+			// Best effort try to make path absolute for easier debugging.
+			path, _ = filepath.Abs(cfg.WAL.Dir)
+			if path == "" {
+				path = cfg.WAL.Dir
+			}
+      
+			return nil, fmt.Errorf("creating WAL folder at %q: %w", path, err)
 		}
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -208,14 +209,12 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 
 	if cfg.WAL.Enabled {
 		if err := os.MkdirAll(cfg.WAL.Dir, os.ModePerm); err != nil {
-			path := cfg.WAL.Dir
-      
 			// Best effort try to make path absolute for easier debugging.
-			path, _ = filepath.Abs(cfg.WAL.Dir)
+			path, _ := filepath.Abs(cfg.WAL.Dir)
 			if path == "" {
 				path = cfg.WAL.Dir
 			}
-      
+
 			return nil, fmt.Errorf("creating WAL folder at %q: %w", path, err)
 		}
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -208,7 +208,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 
 	if cfg.WAL.Enabled {
 		if err := os.MkdirAll(cfg.WAL.Dir, os.ModePerm); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error creating WAL folder at '%s': %w", cfg.WAL.Dir, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enrich WAL folder creation error message, by explicitly saying that it failed to create WAL folder and by saying what is the directory that is being used.

**Which issue(s) this PR fixes**:
- [4704](https://github.com/grafana/loki/issues/4704)

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
