### PR TITLE
Fixes Promtail User-Agent.

### DIFF
--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -18,13 +18,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/clients/pkg/logentry/metric"
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 
 	lokiutil "github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/util/build"
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 	HostLabel    = "host"
 )
 
-var UserAgent = fmt.Sprintf("promtail/%s", version.Version)
+var UserAgent = fmt.Sprintf("promtail/%s", build.Version)
 
 type metrics struct {
 	encodedBytes     *prometheus.CounterVec


### PR DESCRIPTION
This was because promtail client was still user the old version.Version which is initialized at run-time via init.

But if we use it also at init time there's no guarantee that the version will be set.

So instead I'm using the original version variable stamped in the binary and not at runtime.

Fixes #4686

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
