### PR TITLE
Add retry with exponential backoff to `S3ObjectClient.PutObject()`

### DIFF
--- a/pkg/storage/chunk/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/aws/s3_storage_client.go
@@ -414,6 +414,9 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 			_, requestErr := a.S3.PutObjectWithContext(ctx, putObjectInput)
 			return requestErr
 		})
+		if err == nil {
+			return nil
+		}
 		retries.Wait()
 	}
 	return errors.Wrap(err, "failed to put s3 object")

--- a/pkg/storage/chunk/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/aws/s3_storage_client.go
@@ -392,6 +392,7 @@ func (a *S3ObjectClient) GetObject(ctx context.Context, objectKey string) (io.Re
 
 // PutObject into the store
 func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
+	bucket := a.bucketFromKey(objectKey)
 	retries := backoff.New(ctx, a.cfg.BackoffConfig)
 	err := ctx.Err()
 	for retries.Ongoing() {
@@ -401,7 +402,7 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 		err = instrument.CollectedRequest(ctx, "S3.PutObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			putObjectInput := &s3.PutObjectInput{
 				Body:   object,
-				Bucket: aws.String(a.bucketFromKey(objectKey)),
+				Bucket: aws.String(bucket),
 				Key:    aws.String(objectKey),
 			}
 


### PR DESCRIPTION
Signed-off-by: Jordan Rushing <jordan.rushing@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR adds [grafana/dskit](https://github.com/grafana/dskit/tree/main/backoff) retry with exponential backoff to `S3ObjectClient.PutObject()`. This is part of the [recommended request behavior](https://aws.amazon.com/premiumsupport/knowledge-center/s3-503-within-request-rate-prefix/) that AWS provides via its official documentation.

We added this to `GetObject()` in https://github.com/grafana/loki/pull/4453

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
