### PR TITLE
allow applying retention at different interval than compaction with a config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release notes for 2.4.1 can be found on the [release notes page](https://grafana
 * [4687](https://github.com/grafana/loki/pull/4687) **owen-d**: overrides checks for nil tenant limits on AllByUserID
 * [4683](https://github.com/grafana/loki/pull/4683) **owen-d**: Adds replication_factor doc to common config
 * [4681](https://github.com/grafana/loki/pull/4681) **slim-bean**: Loki: check new Read target when initializing boltdb-shipper store
+* [4736](https://github.com/grafana/loki/pull/4736) **sandeepsukhani**: allow applying retention at different interval than compaction
 
 # 2.4.0 (2021/11/05)
 

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -95,7 +95,7 @@ func TestCompactor_RunCompaction(t *testing.T) {
 	}
 
 	compactor := setupTestCompactor(t, tempDir)
-	err = compactor.RunCompaction(context.Background())
+	err = compactor.RunCompaction(context.Background(), true)
 	require.NoError(t, err)
 
 	for name := range tables {

--- a/pkg/storage/stores/shipper/compactor/metrics.go
+++ b/pkg/storage/stores/shipper/compactor/metrics.go
@@ -14,6 +14,7 @@ type metrics struct {
 	compactTablesOperationTotal           *prometheus.CounterVec
 	compactTablesOperationDurationSeconds prometheus.Gauge
 	compactTablesOperationLastSuccess     prometheus.Gauge
+	applyRetentionLastSuccess             prometheus.Gauge
 	compactorRunning                      prometheus.Gauge
 }
 
@@ -33,6 +34,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Namespace: "loki_boltdb_shipper",
 			Name:      "compact_tables_operation_last_successful_run_timestamp_seconds",
 			Help:      "Unix timestamp of the last successful compaction run",
+		}),
+		applyRetentionLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "apply_retention_last_successful_run_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful retention run",
 		}),
 		compactorRunning: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki_boltdb_shipper",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When retention is enabled, we apply it with each compaction run. This causes a lot of resources to be wasted in a big Loki cluster which also causes compaction to not be able to keep up. Since applying retention is not as critical as compacting the data for better query performance, the apply retention interval can be set to a higher value than the compaction interval.

**Special notes for your reviewer**:
To keep it backwards compatible, I have allowed setting the apply retention interval to 0, which is the default. A zero value here means applying retention at the same time as compaction.
When a non-zero value is set, it should be a multiple of compaction interval because we would always apply retention when running compaction which is optimum and a pre-requisite for applying retention.

**Checklist**
- [x] Add an entry in the `CHANGELOG.md` about the changes.
