### PR TITLE
ensures components with required SRV lookups use the correct port 

### DIFF
--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -14,6 +14,17 @@ local k = import 'ksonnet-util/kausal.libsonnet';
         containerPort.new(name='grpc', port=9095),
       ],
 
+    // We use DNS SRV record for discovering the schedulers or the frontends if schedulers are disabled.
+    // These expect port names like _grpclb on the services.
+    grpclbDefaultPorts:: [
+      containerPort.new(name='http-metrics', port=$._config.http_listen_port),
+      containerPort.new(name='grpclb', port=9095),
+    ],
+
+    // This helps ensure we create SRV records starting with _grpclb
+    grpclbServiceFor(deployment):: k.util.serviceFor(deployment, nameFormat='%(port)s'),
+
+
     readinessProbe::
       container.mixin.readinessProbe.httpGet.withPath('/ready') +
       container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +

--- a/production/ksonnet/loki/query-frontend.libsonnet
+++ b/production/ksonnet/loki/query-frontend.libsonnet
@@ -11,7 +11,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   query_frontend_container::
     container.new('query-frontend', $._images.query_frontend) +
-    container.withPorts($.util.defaultPorts) +
+    container.withPorts($.util.grpclbDefaultPorts) +
     container.withArgsMixin(k.util.mapToFlags($.query_frontend_args)) +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
@@ -43,7 +43,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local service = k.core.v1.service,
 
   query_frontend_service:
-    k.util.serviceFor($.query_frontend_deployment) +
+    $.util.grpclbServiceFor($.query_frontend_deployment,) +
     // Make sure that query frontend worker, running in the querier, do resolve
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it

--- a/production/ksonnet/loki/query-frontend.libsonnet
+++ b/production/ksonnet/loki/query-frontend.libsonnet
@@ -43,7 +43,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local service = k.core.v1.service,
 
   query_frontend_service:
-    $.util.grpclbServiceFor($.query_frontend_deployment,) +
+    $.util.grpclbServiceFor($.query_frontend_deployment) +
     // Make sure that query frontend worker, running in the querier, do resolve
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it

--- a/production/ksonnet/loki/query-scheduler.libsonnet
+++ b/production/ksonnet/loki/query-scheduler.libsonnet
@@ -35,7 +35,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local container = k.core.v1.container,
   query_scheduler_container:: if $._config.query_scheduler_enabled then
     container.new('query-scheduler', $._images.query_scheduler) +
-    container.withPorts($.util.defaultPorts) +
+    container.withPorts($.util.grpclbDefaultPorts) +
     container.withArgsMixin(k.util.mapToFlags($.query_scheduler_args)) +
     $.jaeger_mixin +
     k.util.resourcesRequests('2', '600Mi') +
@@ -58,7 +58,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   // Headless to make sure resolution gets IP address of target pods, and not service IP.
   query_scheduler_discovery_service: if !$._config.query_scheduler_enabled then {} else
-    k.util.serviceFor($.query_scheduler_deployment) +
+    $.util.grpclbServiceFor($.query_scheduler_deployment) +
     service.mixin.spec.withPublishNotReadyAddresses(true) +
     service.mixin.spec.withClusterIp('None') +
     service.mixin.metadata.withName('query-scheduler-discovery'),


### PR DESCRIPTION
The ensure we create ports & thus SRV records in k8s with the expected `_grpclb` prefix