### PR TITLE
index cleanup fixes while applying retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [4736](https://github.com/grafana/loki/pull/4736) **sandeepsukhani**: allow applying retention at different interval than compaction
 * [4744](https://github.com/grafana/loki/pull/4744) **cyriltovena**: Promtail: Adds GELF UDP support.
+* [4741](https://github.com/grafana/loki/pull/4741) **sandeepsukhani**: index cleanup fixes while applying retention
 
 # 2.4.1 (2021/11/07)
 

--- a/pkg/storage/stores/shipper/compactor/retention/iterator.go
+++ b/pkg/storage/stores/shipper/compactor/retention/iterator.go
@@ -125,6 +125,13 @@ func newSeriesCleaner(bucket *bbolt.Bucket, config chunk.PeriodConfig, tableName
 }
 
 func (s *seriesCleaner) Cleanup(userID []byte, lbls labels.Labels) error {
+	// We need to add metric name label as well if it is missing since the series ids are calculated including that.
+	if lbls.Get(labels.MetricName) == "" {
+		lbls = append(lbls, labels.Label{
+			Name:  labels.MetricName,
+			Value: logMetricName,
+		})
+	}
 	_, indexEntries, err := s.schema.GetCacheKeysAndLabelWriteEntries(s.tableInterval.Start, s.tableInterval.End, string(userID), logMetricName, lbls, "")
 	if err != nil {
 		return err

--- a/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/iterator_test.go
@@ -85,7 +85,7 @@ func Test_SeriesCleaner(t *testing.T) {
 
 			tables := store.indexTables()
 			require.Len(t, tables, 1)
-			// remove c2 chunk
+			// remove c1, c2 chunk
 			err := tables[0].DB.Update(func(tx *bbolt.Tx) error {
 				it, err := newChunkIndexIterator(tx.Bucket(bucketName), tt.config)
 				require.NoError(t, err)
@@ -104,13 +104,16 @@ func Test_SeriesCleaner(t *testing.T) {
 				if err := cleaner.Cleanup(entryFromChunk(c2).UserID, c2.Metric); err != nil {
 					return err
 				}
-				return cleaner.Cleanup(entryFromChunk(c1).UserID, c1.Metric)
+
+				// remove series for c1 without __name__ label, which should work just fine
+				return cleaner.Cleanup(entryFromChunk(c1).UserID, c1.Metric.WithoutLabels(labels.MetricName))
 			})
 			require.NoError(t, err)
 
 			err = tables[0].DB.View(func(tx *bbolt.Tx) error {
 				return tx.Bucket(bucketName).ForEach(func(k, _ []byte) error {
-					expectedDeleteSeries := entryFromChunk(c2).SeriesID
+					c1SeriesID := entryFromChunk(c1).SeriesID
+					c2SeriesID := entryFromChunk(c2).SeriesID
 					series, ok, err := parseLabelIndexSeriesID(decodeKey(k))
 					if !ok {
 						return nil
@@ -118,8 +121,11 @@ func Test_SeriesCleaner(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					if string(expectedDeleteSeries) == string(series) {
-						require.Fail(t, "series should be deleted", expectedDeleteSeries)
+
+					if string(c1SeriesID) == string(series) {
+						require.Fail(t, "series for c1 should be deleted", c1SeriesID)
+					} else if string(c2SeriesID) == string(series) {
+						require.Fail(t, "series for c2 should be deleted", c2SeriesID)
 					}
 
 					return nil

--- a/pkg/storage/stores/shipper/compactor/retention/util.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util.go
@@ -53,6 +53,7 @@ func ExtractIntervalFromTableName(tableName string) model.Interval {
 	}
 
 	interval.Start = model.TimeFromUnix(tableNumber * 86400)
-	interval.End = interval.Start.Add(24 * time.Hour)
+	// subtract a millisecond here so that interval only covers a single table since adding 24 hours ends up covering the start time of next table as well.
+	interval.End = interval.Start.Add(24*time.Hour) - 1
 	return interval
 }

--- a/pkg/storage/stores/shipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util_test.go
@@ -274,7 +274,7 @@ func TestExtractIntervalFromTableName(t *testing.T) {
 
 	calculateInterval := func(tm model.Time) (m model.Interval) {
 		m.Start = tm - tm%millisecondsInDay
-		m.End = m.Start + millisecondsInDay
+		m.End = m.Start + millisecondsInDay - 1
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR includes two fixes:
1. Add a metric name if missing in labels used for calculating index entries for the series clean up since it is used while building the series IDs. The test did not catch this because the test data included the metric name label. Without the metric name, wrong series IDs were calculated, which caused labels entries not to get cleaned up.
2. While calculating table interval from table name, we calculate the start time first and then add 24h to it. The problem with this is it would end up covering the start time of next days table. This is fixed by subtracting a millisecond from the end time of the interval after adding 24h to the start time. There was no harm caused by the overlap with the next day, I am just fixing it to avoid index entries being calculated unnecessarily for the next day as well.

**Checklist**
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
