### PR TITLE
Loki: Set querier worker max concurrent regardless of run configuration.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -212,6 +212,8 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	if t.Cfg.Ingester.QueryStoreMaxLookBackPeriod != 0 {
 		t.Cfg.Querier.IngesterQueryStoreMaxLookback = t.Cfg.Ingester.QueryStoreMaxLookBackPeriod
 	}
+	// Querier worker's max concurrent requests must be the same as the querier setting
+	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.MaxConcurrent
 
 	var err error
 	t.Querier, err = querier.New(t.Cfg.Querier, t.Store, t.ingesterQuerier, t.overrides)

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -131,9 +131,6 @@ func InitWorkerService(
 
 	internalHandler = internalMiddleware.Wrap(internalHandler)
 
-	//Querier worker's max concurrent requests must be the same as the querier setting
-	(*cfg.QuerierWorkerConfig).MaxConcurrentRequests = cfg.QuerierMaxConcurrent
-
 	//Return a querier worker pointed to the internal querier HTTP handler so there is not a conflict in routes between the querier
 	//and the query frontend
 	return querier_worker.NewQuerierWorker(

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -224,18 +224,6 @@ func Test_InitQuerierService(t *testing.T) {
 			}
 		})
 
-		t.Run("set the worker's max concurrent request to the same as the max concurrent setting for the querier", func(t *testing.T) {
-			for _, config := range nonStandaloneTargetPermutations {
-				workerConfig := querier_worker.Config{}
-				config.QuerierWorkerConfig = &workerConfig
-				config.QuerierMaxConcurrent = 42
-
-				testContext(config, nil)
-
-				assert.Equal(t, 42, workerConfig.MaxConcurrentRequests)
-			}
-		})
-
 		t.Run("always return a query worker service", func(t *testing.T) {
 			for _, config := range nonStandaloneTargetPermutations {
 				workerConfig := querier_worker.Config{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Be sure to set MaxConcurrentRequests when initializing the querier.

**Which issue(s) this PR fixes**:
Fixes #4760

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
