### PR TITLE
Refactor NewMemcachedClient constructor to return a concrete type instead of interface

### DIFF
--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -159,7 +159,7 @@ func testCache(t *testing.T, cache cache.Cache) {
 
 func TestMemcache(t *testing.T) {
 	t.Run("Unbatched", func(t *testing.T) {
-		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache(),
+		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcachedBasicClient(),
 			"test", nil, log.NewNopLogger())
 		testCache(t, cache)
 	})
@@ -168,7 +168,7 @@ func TestMemcache(t *testing.T) {
 		cache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 3,
-		}, newMockMemcache(), "test", nil, log.NewNopLogger())
+		}, newMockMemcachedBasicClient(), "test", nil, log.NewNopLogger())
 		testCache(t, cache)
 	})
 }

--- a/pkg/storage/chunk/cache/memcached.go
+++ b/pkg/storage/chunk/cache/memcached.go
@@ -38,7 +38,7 @@ func (cfg *MemcachedConfig) RegisterFlagsWithPrefix(prefix, description string, 
 // Memcached type caches chunks in memcached
 type Memcached struct {
 	cfg      MemcachedConfig
-	memcache MemcachedClient
+	memcache MemcachedBasicClient
 	name     string
 
 	requestDuration *instr.HistogramCollector
@@ -50,7 +50,7 @@ type Memcached struct {
 }
 
 // NewMemcached makes a new Memcached.
-func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg prometheus.Registerer, logger log.Logger) *Memcached {
+func NewMemcached(cfg MemcachedConfig, client MemcachedBasicClient, name string, reg prometheus.Registerer, logger log.Logger) *Memcached {
 	c := &Memcached{
 		cfg:      cfg,
 		memcache: client,

--- a/pkg/storage/chunk/cache/memcached_test.go
+++ b/pkg/storage/chunk/cache/memcached_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
-		client := newMockMemcache()
+		client := newMockMemcachedBasicClient()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
 			"test", nil, log.NewNopLogger())
 
@@ -24,7 +24,7 @@ func TestMemcached(t *testing.T) {
 	})
 
 	t.Run("batched", func(t *testing.T) {
-		client := newMockMemcache()
+		client := newMockMemcachedBasicClient()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
@@ -69,15 +69,15 @@ func testMemcache(t *testing.T, memcache *cache.Memcached) {
 	}
 }
 
-// mockMemcache whose calls fail 1/3rd of the time.
+// mockMemcachedBasicClient whose calls fail 1/3rd of the time.
 type mockMemcacheFailing struct {
-	*mockMemcache
+	*mockMemcachedBasicClient
 	calls atomic.Uint64
 }
 
-func newMockMemcacheFailing() *mockMemcacheFailing {
+func newMockMemcachedBasicClientFailing() *mockMemcacheFailing {
 	return &mockMemcacheFailing{
-		mockMemcache: newMockMemcache(),
+		mockMemcachedBasicClient: newMockMemcachedBasicClient(),
 	}
 }
 
@@ -87,12 +87,12 @@ func (c *mockMemcacheFailing) GetMulti(keys []string) (map[string]*memcache.Item
 		return nil, errors.New("fail")
 	}
 
-	return c.mockMemcache.GetMulti(keys)
+	return c.mockMemcachedBasicClient.GetMulti(keys)
 }
 
 func TestMemcacheFailure(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
-		client := newMockMemcacheFailing()
+		client := newMockMemcachedBasicClientFailing()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
 			"test", nil, log.NewNopLogger())
 
@@ -100,7 +100,7 @@ func TestMemcacheFailure(t *testing.T) {
 	})
 
 	t.Run("batched", func(t *testing.T) {
-		client := newMockMemcacheFailing()
+		client := newMockMemcachedBasicClientFailing()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously NewMemcachedClient was returning the MemcachedClient
interface that only had a subset of cache methods. This was
limiting the use of the constructor to a single type of use.

The changes introduced in this PR are simply:

- Rename the MemcachedClient interface into MemcachedBasicClient
- Rename memcachedClient type to MemcachedClient
- Now the constructor returns the type instead of the interface
- Also MemcachedClient now does not anonymously export memcache.Client
  methods and sync.Mutex methods

This enables the the constructor to be used for other purposes where the
caller may want to use other available methods in the memcached client
like Add, Delete, CompareAndSwap etcetera.

**Which issue(s) this PR fixes**:
There is no issue related to this

**Checklist**
- [ ] Documentation added (Despite of the changes in the implementation, the rest of the code can keep using the client as they were before so I don't know if any more documentation should be added)
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes. (Is this required?)
