### PR TITLE
Improve LogQL format stages requireLabel

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -224,7 +224,6 @@ func NewLabelsFormatter(fmts []LabelFmt) (*LabelsFormatter, error) {
 		return nil, err
 	}
 	formats := make([]labelFormatter, 0, len(fmts))
-	var names []string
 
 	for _, fm := range fmts {
 		toAdd := labelFormatter{LabelFmt: fm}
@@ -234,13 +233,8 @@ func NewLabelsFormatter(fmts []LabelFmt) (*LabelsFormatter, error) {
 				return nil, fmt.Errorf("invalid template for label '%s': %s", fm.Name, err)
 			}
 			toAdd.tmpl = t
-			names = uniqueString(append(names, listNodeFields([]parse.Node{t.Root})...))
 		}
 		formats = append(formats, toAdd)
-	}
-	namesMap := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		namesMap[n] = struct{}{}
 	}
 	return &LabelsFormatter{
 		formats: formats,


### PR DESCRIPTION
This only includes required labels.

```
➜ go test -benchmem -run=^$  -bench ^Benchmark_Pipeline ./pkg/logql/log -v -count 5  > after.txt && benchstat before.txt after.txt
name                                 old time/op    new time/op    delta
_Pipeline/pipeline_bytes-16            13.8µs ± 6%    11.5µs ± 1%  -16.42%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16           13.9µs ± 2%    11.5µs ± 2%  -17.27%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16      14.0µs ± 4%    11.6µs ± 0%  -17.45%  (p=0.016 n=5+4)
_Pipeline/line_extractor_string-16     13.5µs ± 0%    11.5µs ± 0%  -14.67%  (p=0.008 n=5+5)
_Pipeline/label_extractor_bytes-16     13.7µs ± 1%    11.7µs ± 1%  -14.69%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16    14.1µs ±11%    11.6µs ± 0%  -17.89%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
_Pipeline/pipeline_bytes-16            9.51kB ± 0%    7.50kB ± 0%  -21.19%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16           9.51kB ± 0%    7.50kB ± 0%  -21.19%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16      9.51kB ± 0%    7.50kB ± 0%  -21.19%  (p=0.008 n=5+5)
_Pipeline/line_extractor_string-16     9.51kB ± 0%    7.50kB ± 0%     ~     (p=0.079 n=4+5)
_Pipeline/label_extractor_bytes-16     9.51kB ± 0%    7.50kB ± 0%  -21.18%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16    9.51kB ± 0%    7.50kB ± 0%  -21.18%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
_Pipeline/pipeline_bytes-16              46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16             46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16        46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
_Pipeline/line_extractor_string-16       46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
_Pipeline/label_extractor_bytes-16       46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16      46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.008 n=5+5)
```

Also fixes the text/template parsing it was buggy.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
