### PR TITLE
Docs: Fix typo in documentation `exclude_event_data` -> `exclude_user_data`

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -877,7 +877,7 @@ You can add additional labels with the `labels` property.
 [exclude_event_data: <bool> | default = false]
 
 # Allows to exclude the user data of each windows event.
-[exclude_event_data: <bool> | default = false]
+[exclude_user_data: <bool> | default = false]
 
 # Label map to add to every log line read from the windows event log
 labels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Updates documentation for the `exclude_user_data` field of a `WindowsEventsConfig` to have the proper parameter name. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
~- [ ] Tests updated~
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
