### PR TITLE
Doc: Fix typo in documentation, exclude_event_data -> exclude_user_data

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -877,7 +877,7 @@ You can add additional labels with the `labels` property.
 [exclude_event_data: <bool> | default = false]
 
 # Allows to exclude the user data of each windows event.
-[exclude_event_data: <bool> | default = false]
+[exclude_user_data: <bool> | default = false]
 
 # Label map to add to every log line read from the windows event log
 labels:


### PR DESCRIPTION
What this PR does / why we need it:

Updates documentation for the exclude_user_data field of a WindowsEventsConfig to have the proper parameter name.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Checklist

- [x] Documentation added
~- [ ] Tests updated~
- [ ] Add an entry in the CHANGELOG.md about the changes.