### PR TITLE
doc: Update URL for LokiLogger.jl (Julia client)

### DIFF
--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -70,4 +70,4 @@ when using or writing a third-party client.
 - [Serilog-Sinks-Loki](https://github.com/JosephWoodward/Serilog-Sinks-Loki) (C#)
 - [loki-logback-appender](https://github.com/loki4j/loki-logback-appender) (Java)
 - [Log4j2 appender for Loki](https://github.com/tkowalcz/tjahzi) (Java)
-- [LokiLogger.jl](https://github.com/fredrikekre/LokiLogger.jl) (Julia)
+- [LokiLogger.jl](https://github.com/JuliaLogging/LokiLogger.jl) (Julia)


### PR DESCRIPTION
I transferred my package to the [JuliaLogging](https://github.com/JuliaLogging) GitHub organization. The old URL redirects to the new one, but seems best to update it here too.