### PR TITLE
Refactor dashboard utils to include a separate function per template

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -26,6 +26,36 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ],
         },
       },
+
+      addCluster(multi=false)::
+        if multi then
+          self.addMultiTemplate('cluster', 'loki_build_info', 'cluster')
+        else
+          self.addTemplate('cluster', 'loki_build_info', 'cluster'),
+
+      addNamespace(multi=false)::
+        if multi then
+          self.addMultiTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace')
+        else
+          self.addTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace'),
+
+      addTag()::
+        self+ {
+          tags+: $._config.tags,
+          links+: [
+            {
+              asDropdown: true,
+              icon: 'external link',
+              includeVars: true,
+              keepTime: true,
+              tags: $._config.tags,
+              targetBlank: false,
+              title: 'Loki Dashboards',
+              type: 'dashboards',
+            },
+          ],
+        },
+
       addClusterSelectorTemplates(multi=true)::
         local d = self {
           tags: $._config.tags,

--- a/production/loki-mixin/dashboards/loki-chunks.libsonnet
+++ b/production/loki-mixin/dashboards/loki-chunks.libsonnet
@@ -28,7 +28,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
     } +
     $.dashboard('Loki / Chunks')
-    .addClusterSelectorTemplates(false)
+    .addCluster()
+    .addNamespace()
+    .addTag()
     .addRow(
       $.row('Active Series / Chunks')
       .addPanel(

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -6,7 +6,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       'loki-deletion.json':
         ($.dashboard('Loki / Deletion', uid='deletion'))
-        .addClusterSelectorTemplates(false)
+        .addCluster()
+        .addNamespace()
+        .addTag()
         .addRow(
           ($.row('Headlines') +
            {

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -52,10 +52,9 @@ local template = import 'grafonnet/template.libsonnet';
 
     } + lokiLogs +
     $.dashboard('Loki / Logs')
-      // TODO (callum) For this cluster the cluster template is not actually
-      // added since the json defines the template array, we just need the tags
-      // and links from this function until they're moved to a separate function.
-      .addClusterSelectorTemplates(false)
+      .addCluster()
+      .addNamespace()
+      .addTag()
       .addLog() +
     {
       panels: [

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -151,10 +151,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     } +
       $.dashboard('Loki / Operational')
-      // TODO (callum) For this cluster the cluster template is not actually
-      // added since the json defines the template array, we just need the tags
-      // and links from this function until they're moved to a separate function.
-      .addClusterSelectorTemplates(false)
-      .addLog()
+      // The queries in this dashboard don't make use of the cluster tempalte label selector
+      // but we keep it here to allow selecting a namespace specific to a certain cluster, the
+      // namespace template variable selectors query uses the cluster value.
+      .addCluster()
+      .addNamespace()
+      .addTag()
   },
 }

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -5,7 +5,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       'loki-reads-resources.json':
         ($.dashboard('Loki / Reads Resources'))
-        .addClusterSelectorTemplates(false)
+        .addCluster()
+        .addNamespace()
+        .addTag()
         .addRow(
           $.row('Gateway')
           .addPanel(

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -39,7 +39,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       querierOrIndexGatewaySelector:: selector('querierOrIndexGateway'),
     } +
     $.dashboard('Loki / Reads')
-    .addClusterSelectorTemplates(false)
+    .addCluster()
+    .addNamespace()
+    .addTag()
     .addRow(
       $.row('Frontend (cortex_gw)')
       .addPanel(

--- a/production/loki-mixin/dashboards/loki-retention.libsonnet
+++ b/production/loki-mixin/dashboards/loki-retention.libsonnet
@@ -5,7 +5,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       'loki-retention.json':
         ($.dashboard('Loki / Retention', uid='retention'))
-        .addClusterSelectorTemplates(false)
+        .addCluster()
+        .addNamespace()
+        .addTag()
         .addLog()
         .addRow(
           $.row('Ressource Usage')

--- a/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet
@@ -5,7 +5,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     {
       'loki-writes-resources.json':
         $.dashboard('Loki / Writes Resources')
-        .addClusterSelectorTemplates(false)
+        .addCluster()
+        .addNamespace()
+        .addTag()
         .addRow(
           $.row('Gateway')
           .addPanel(

--- a/production/loki-mixin/dashboards/loki-writes.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes.libsonnet
@@ -32,7 +32,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ingesterSelector:: selector('ingester'),
     } +
     $.dashboard('Loki / Writes')
-    .addClusterSelectorTemplates(false)
+    .addCluster()
+    .addNamespace()
+    .addTag()
     .addRow(
       $.row('Frontend (cortex_gw)')
       .addPanel(


### PR DESCRIPTION
Refactors dashboard utils to include a separate function per template variables and another for tag+links so we don't always have to use `addClusterSelectorTemplate` which adds cluster/namespace/tag/links all in one.

Signed-off-by: Callum Styan <callumstyan@gmail.com>