### PR TITLE
loki-mixin: Add grafonnet-lib as dependency

### DIFF
--- a/production/loki-mixin/jsonnetfile.json
+++ b/production/loki-mixin/jsonnetfile.json
@@ -19,6 +19,16 @@
                 }
             },
             "version": "master"
+        },
+        {
+            "name": "grafonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib",
+                    "subdir": "grafonnet"
+              }
+            },
+            "version": "master"
         }
     ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Building the Loki mixin currently fails, because of a missing dependency. This causes a bad user experience for people that try to generate the manifests (compare docs on https://monitoring.mixins.dev). 

**Which issue(s) this PR fixes**:
Fixes #4805

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
