### PR TITLE
Add support for `X-Query-Tags`

### DIFF
--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -91,8 +91,7 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 
 	queryTags, _ := ctx.Value(serverutil.QueryTagsHTTPHeader).(string) // it's ok to be empty.
 
-	logValues := make([]interface{}, 0)
-	logValues = append(logValues, tagsToKeyValues(queryTags)...)
+	logValues := make([]interface{}, 0, 20)
 
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.
@@ -108,6 +107,8 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 		"throughput", strings.Replace(humanize.Bytes(uint64(stats.Summary.BytesProcessedPerSecond)), " ", "", 1),
 		"total_bytes", strings.Replace(humanize.Bytes(uint64(stats.Summary.TotalBytesProcessed)), " ", "", 1),
 	}...)
+
+	logValues = append(logValues, tagsToKeyValues(queryTags)...)
 
 	// we also log queries, useful for troubleshooting slow queries.
 	level.Info(logger).Log(

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -88,6 +88,8 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 		returnedLines = int(result.(logqlmodel.Streams).Lines())
 	}
 
+	queryTags, _ := ctx.Value("X-Query-Tags").(string) // it's ok to be empty.
+
 	// we also log queries, useful for troubleshooting slow queries.
 	level.Info(logger).Log(
 		"latency", latencyType, // this can be used to filter log lines.
@@ -98,6 +100,7 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 		"step", p.Step(),
 		"duration", time.Duration(int64(stats.Summary.ExecTime*float64(time.Second))),
 		"status", status,
+		"query_tags", queryTags,
 		"limit", p.Limit(),
 		"returned_lines", returnedLines,
 		"throughput", strings.Replace(humanize.Bytes(uint64(stats.Summary.BytesProcessedPerSecond)), " ", "", 1),

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	serverutil "github.com/grafana/loki/pkg/util/server"
 )
 
 const (
@@ -25,7 +26,6 @@ const (
 	latencyTypeFast = "fast"
 
 	slowQueryThresholdSecond = float64(10)
-	QueryTagsHTTPHeader      = "X-Query-Tags"
 )
 
 var (
@@ -89,7 +89,7 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 		returnedLines = int(result.(logqlmodel.Streams).Lines())
 	}
 
-	queryTags, _ := ctx.Value(QueryTagsHTTPHeader).(string) // it's ok to be empty.
+	queryTags, _ := ctx.Value(serverutil.QueryTagsHTTPHeader).(string) // it's ok to be empty.
 
 	logValues := make([]interface{}, 0)
 	logValues = append(logValues, tagsToKeyValues(queryTags)...)

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -144,9 +144,10 @@ func QueryType(query string) (string, error) {
 	}
 }
 
-// `Source=foo,Feature=beta` -> []interface{}{"source", "foo", "feature", "beta"}
+// tagsToKeyValues converts QueryTags to form that is easy to log.
+// e.g: `Source=foo,Feature=beta` -> []interface{}{"source", "foo", "feature", "beta"}
 // so that we could log nicely!
-// NOTE: if values is not in canonical form e.g: `X-Query-Tag: abc` -> []interface{}{"abc"}
+// If queryTags is not in canonical form then its completely ignored (e.g: `key1=value1,key2=value`)
 func tagsToKeyValues(queryTags string) []interface{} {
 	toks := strings.FieldsFunc(queryTags, func(r rune) bool {
 		return r == ','
@@ -158,6 +159,10 @@ func tagsToKeyValues(queryTags string) []interface{} {
 		val := strings.FieldsFunc(tok, func(r rune) bool {
 			return r == '='
 		})
+
+		if len(val) != 2 {
+			continue
+		}
 		vals = append(vals, val...)
 	}
 

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -82,7 +82,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s source=logvolhist feature=beta latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
+			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB source=logvolhist feature=beta\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	serverutil "github.com/grafana/loki/pkg/util/server"
 )
 
 func TestQueryType(t *testing.T) {
@@ -62,7 +63,7 @@ func TestLogSlowQuery(t *testing.T) {
 	ctx := opentracing.ContextWithSpan(user.InjectOrgID(context.Background(), "foo"), sp)
 	now := time.Now()
 
-	ctx = context.WithValue(ctx, QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
+	ctx = context.WithValue(ctx, serverutil.QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
 
 	RecordMetrics(ctx, LiteralParams{
 		qs:        `{foo="bar"} |= "buzz"`,

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log"
 	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go"
 	"github.com/weaveworks/common/user"
@@ -86,4 +87,48 @@ func TestLogSlowQuery(t *testing.T) {
 		),
 		buf.String())
 	util_log.Logger = log.NewNopLogger()
+}
+
+func Test_testToKeyValues(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		exp  []interface{}
+	}{
+		{
+			name: "canonical-form",
+			in:   "Source=logvolhist",
+			exp: []interface{}{
+				"source",
+				"logvolhist",
+			},
+		},
+		{
+			name: "canonical-form-multiple-values",
+			in:   "Source=logvolhist,Feature=beta",
+			exp: []interface{}{
+				"source",
+				"logvolhist",
+				"feature",
+				"beta",
+			},
+		},
+		{
+			name: "empty",
+			in:   "",
+			exp:  []interface{}{},
+		},
+		{
+			name: "non-canonical form",
+			in:   "abc",
+			exp:  []interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tagsToKeyValues(c.in)
+			assert.Equal(t, c.exp, got)
+		})
+	}
 }

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -62,7 +62,7 @@ func TestLogSlowQuery(t *testing.T) {
 	ctx := opentracing.ContextWithSpan(user.InjectOrgID(context.Background(), "foo"), sp)
 	now := time.Now()
 
-	ctx = context.WithValue(ctx, "X-Query-Tags", "Source=logvolhist")
+	ctx = context.WithValue(ctx, QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
 
 	RecordMetrics(ctx, LiteralParams{
 		qs:        `{foo="bar"} |= "buzz"`,
@@ -80,7 +80,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 query_tags=\"Source=logvolhist\" limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
+			"level=info org_id=foo traceID=%s source=logvolhist feature=beta latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -61,6 +61,9 @@ func TestLogSlowQuery(t *testing.T) {
 	sp := opentracing.StartSpan("")
 	ctx := opentracing.ContextWithSpan(user.InjectOrgID(context.Background(), "foo"), sp)
 	now := time.Now()
+
+	ctx = context.WithValue(ctx, "X-Query-Tags", "Source=logvolhist")
+
 	RecordMetrics(ctx, LiteralParams{
 		qs:        `{foo="bar"} |= "buzz"`,
 		direction: logproto.BACKWARD,
@@ -77,7 +80,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
+			"level=info org_id=foo traceID=%s latency=slow query=\"{foo=\\\"bar\\\"} |= \\\"buzz\\\"\" query_type=filter range_type=range length=1h0m0s step=1m0s duration=25.25s status=200 query_tags=\"Source=logvolhist\" limit=1000 returned_lines=10 throughput=100kB total_bytes=100kB\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -489,21 +489,21 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	}
 
 	frontendHandler = middleware.Merge(
+		serverutil.ExtractQueryTagsMiddleware(),
 		serverutil.RecoveryHTTPMiddleware,
 		t.HTTPAuthMiddleware,
 		queryrange.StatsHTTPMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
 		serverutil.ResponseJSONMiddleware(),
-		serverutil.ExtractQueryTagsMiddleware(),
 	).Wrap(frontendHandler)
 
 	var defaultHandler http.Handler
 	// If this process also acts as a Querier we don't do any proxying of tail requests
 	if t.Cfg.Frontend.TailProxyURL != "" && !t.isModuleActive(Querier) {
 		httpMiddleware := middleware.Merge(
+			serverutil.ExtractQueryTagsMiddleware(),
 			t.HTTPAuthMiddleware,
 			queryrange.StatsHTTPMiddleware,
-			serverutil.ExtractQueryTagsMiddleware(),
 		)
 		tailURL, err := url.Parse(t.Cfg.Frontend.TailProxyURL)
 		if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -494,6 +494,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 		queryrange.StatsHTTPMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
 		serverutil.ResponseJSONMiddleware(),
+		serverutil.ExtractQueryTagsMiddleware(),
 	).Wrap(frontendHandler)
 
 	var defaultHandler http.Handler
@@ -502,6 +503,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 		httpMiddleware := middleware.Merge(
 			t.HTTPAuthMiddleware,
 			queryrange.StatsHTTPMiddleware,
+			serverutil.ExtractQueryTagsMiddleware(),
 		)
 		tailURL, err := url.Parse(t.Cfg.Frontend.TailProxyURL)
 		if err != nil {

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -54,6 +54,7 @@ func InitWorkerService(
 
 	// Create a couple Middlewares used to handle panics, perform auth, parse forms in http request, and set content type in response
 	handlerMiddleware := middleware.Merge(
+		serverutil.ExtractQueryTagsMiddleware(),
 		serverutil.RecoveryHTTPMiddleware,
 		authMiddleware,
 		serverutil.NewPrepopulateMiddleware(),

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -50,6 +50,7 @@ func ExtractQueryTagsMiddleware() middleware.Interface {
 				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
 				req = req.WithContext(ctx)
 			}
+			next.ServeHTTP(w, req)
 		})
 	})
 }

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -8,6 +8,10 @@ import (
 	"github.com/weaveworks/common/middleware"
 )
 
+const (
+	QueryTagsHTTPHeader = "X-Query-Tags"
+)
+
 // NewPrepopulateMiddleware creates a middleware which will parse incoming http forms.
 // This is important because some endpoints can POST x-www-form-urlencoded bodies instead of GET w/ query strings.
 func NewPrepopulateMiddleware() middleware.Interface {
@@ -37,12 +41,11 @@ func ExtractQueryTagsMiddleware() middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
-			tagsKey := "X-Query-Tags"
-			tags := req.Header.Get(tagsKey)
+			tags := req.Header.Get(QueryTagsHTTPHeader)
 			if tags != "" {
-				ctx = context.WithValue(ctx, tagsKey, tags)
+				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
+				req = req.WithContext(ctx)
 			}
-			req = req.WithContext(ctx)
 		})
 	})
 }

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -8,8 +8,12 @@ import (
 	"github.com/weaveworks/common/middleware"
 )
 
-const (
-	QueryTagsHTTPHeader = "X-Query-Tags"
+// NOTE(kavi): Why new type?
+// Our linter won't allow to use basic types like string to be used as key in context.
+type ctxKey string
+
+var (
+	QueryTagsHTTPHeader ctxKey = "X-Query-Tags"
 )
 
 // NewPrepopulateMiddleware creates a middleware which will parse incoming http forms.
@@ -41,7 +45,7 @@ func ExtractQueryTagsMiddleware() middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
-			tags := req.Header.Get(QueryTagsHTTPHeader)
+			tags := req.Header.Get(string(QueryTagsHTTPHeader))
 			if tags != "" {
 				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
 				req = req.WithContext(ctx)

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/weaveworks/common/httpgrpc"
@@ -28,6 +29,20 @@ func ResponseJSONMiddleware() middleware.Interface {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 			next.ServeHTTP(w, req)
+		})
+	})
+}
+
+func ExtractQueryTagsMiddleware() middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			tagsKey := "X-Query-Tags"
+			tags := req.Header.Get(tagsKey)
+			if tags != "" {
+				ctx = context.WithValue(ctx, tagsKey, tags)
+			}
+			req = req.WithContext(ctx)
 		})
 	})
 }

--- a/pkg/util/server/middleware_test.go
+++ b/pkg/util/server/middleware_test.go
@@ -35,12 +35,12 @@ func TestQueryTags(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "http://testing.com", nil)
-			req.Header.Set("X-Query-Tags", tc.headerValue)
+			req.Header.Set(QueryTagsHTTPHeader, tc.headerValue)
 
 			w := httptest.NewRecorder()
 			checked := false
 			mware := ExtractQueryTagsMiddleware().Wrap(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				require.Equal(t, tc.headerValue, req.Context().Value("X-Query-Tags").(string))
+				require.Equal(t, tc.headerValue, req.Context().Value(QueryTagsHTTPHeader).(string))
 				checked = true
 			}))
 

--- a/pkg/util/server/middleware_test.go
+++ b/pkg/util/server/middleware_test.go
@@ -14,33 +14,35 @@ import (
 
 func TestQueryTags(t *testing.T) {
 	for _, tc := range []struct {
-		desc        string
-		method      string
-		headerValue string
-		body        io.Reader
-		error       bool
+		desc  string
+		in    string
+		exp   string
+		error bool
 	}{
 		{
-			desc:        "single-value",
-			method:      "GET",
-			headerValue: `Source=logvolhist`,
-			body:        nil,
+			desc: "single-value",
+			in:   `Source=logvolhist`,
+			exp:  `Source=logvolhist`,
 		},
 		{
-			desc:        "multiple-values",
-			method:      "POST",
-			headerValue: `Source=logvolhist,Statate=beta`,
-			body:        nil,
+			desc: "multiple-values",
+			in:   `Source=logvolhist,Statate=beta`,
+			exp:  `Source=logvolhist,Statate=beta`,
+		},
+		{
+			desc: "remove-invalid-chars",
+			in:   `Source=log+volhi\\st,Statate=be$ta`,
+			exp:  `Source=logvolhist,Statate=beta`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, "http://testing.com", nil)
-			req.Header.Set(string(QueryTagsHTTPHeader), tc.headerValue)
+			req := httptest.NewRequest("GET", "http://testing.com", nil)
+			req.Header.Set(string(QueryTagsHTTPHeader), tc.in)
 
 			w := httptest.NewRecorder()
 			checked := false
 			mware := ExtractQueryTagsMiddleware().Wrap(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				require.Equal(t, tc.headerValue, req.Context().Value(QueryTagsHTTPHeader).(string))
+				require.Equal(t, tc.exp, req.Context().Value(QueryTagsHTTPHeader).(string))
 				checked = true
 			}))
 

--- a/pkg/util/server/middleware_test.go
+++ b/pkg/util/server/middleware_test.go
@@ -35,7 +35,7 @@ func TestQueryTags(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "http://testing.com", nil)
-			req.Header.Set(QueryTagsHTTPHeader, tc.headerValue)
+			req.Header.Set(string(QueryTagsHTTPHeader), tc.headerValue)
 
 			w := httptest.NewRecorder()
 			checked := false


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

1. Now client can send any metadata about query via `X-Query-Tags` HTTP header
2. Also record `X-Query-Tags` in `metrics.go` for instant and range queries.

**Which issue(s) this PR fixes**:
Fixes: NA

**Special notes for your reviewer**:

Some context and rationale are discussed in https://github.com/grafana/loki/pull/4796#issuecomment-975547927
and [internal discussion](https://raintank-corp.slack.com/archives/C029V4SSS9L/p1637589440378600)

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
