### PR TITLE
Enhance logging on timeout tailing logs on canary

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -344,17 +344,15 @@ func (r *Reader) run() {
 
 		// Set a read timeout of 10x the interval we expect to see messages
 		// Ignore the error as it will get caught when we call ReadJSON
-		_ = r.conn.SetReadDeadline(time.Now().Add(10 * r.interval))
+		timeoutInterval := 10 * r.interval
+		_ = r.conn.SetReadDeadline(time.Now().Add(timeoutInterval))
 		// I assume this is a blocking call that either reads from the websocket connection
 		// or times out based on the above SetReadDeadline call.
 		err := unmarshal.ReadTailResponseJSON(tailResponse, r.conn)
 		if err != nil {
-			var reason string
-			netErr, ok := err.(net.Error)
-			if ok && netErr.Timeout() {
-				reason = "timeout tailing new logs"
-			} else {
-				reason = "error reading websocket"
+			reason := "error reading websocket"
+			if e, ok := err.(net.Error); ok && e.Timeout() {
+				reason = fmt.Sprintf("timeout tailing new logs (timeout period: %.2fs)", timeoutInterval.Seconds())
 			}
 
 			fmt.Fprintf(r.w, "%s, will retry in 10 seconds: %s\n", reason, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When the Loki canary opens a WebSockets stream to tail logs, it sets a deadline. This deadline can expire if the ingester doesn't get a new log for the query within that deadline. The problem is that the error message logged on the canary is misleading as it states:
```
error reading websocket [...]
``` 

This is not true as there was no error reading from WebSockets but rather a timeout error. In this PR, we change the error handling to print a timeout message if the tailing times out, or the `error reading websocket [...]` message if the operation does not timeout but there is any other error.

**Which issue(s) this PR fixes**:
Fixes #4821

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
