### PR TITLE
Set correct `Content-Type` header in query response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [xxxx](https://github.com/grafana/loki/pull/xxxx) **chaudum**: Set correct `Content-Type` header in query response
 * [4794](https://github.com/grafana/loki/pull/4794) **taisho6339**: Aggregate inotify watcher to file target manager
 * [4663](https://github.com/grafana/loki/pull/4663) **taisho6339**: Add SASL&mTLS authentication support for Kafka in Promtail
 * [4745](https://github.com/grafana/loki/pull/4745) **taisho6339**: Expose Kafka message key in labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Main
 
-* [xxxx](https://github.com/grafana/loki/pull/xxxx) **chaudum**: Set correct `Content-Type` header in query response
+* [4828](https://github.com/grafana/loki/pull/4282) **chaudum**: Set correct `Content-Type` header in query response
 * [4794](https://github.com/grafana/loki/pull/4794) **taisho6339**: Aggregate inotify watcher to file target manager
 * [4663](https://github.com/grafana/loki/pull/4663) **taisho6339**: Add SASL&mTLS authentication support for Kafka in Promtail
 * [4745](https://github.com/grafana/loki/pull/4745) **taisho6339**: Expose Kafka message key in labels

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -52,15 +52,11 @@ func InitWorkerService(
 	authMiddleware middleware.Interface,
 ) (serve services.Service, err error) {
 
-	// Create a couple Middlewares used to handle panics, perform auth, and parse Form's in http request
-	internalMiddleware := middleware.Merge(
+	// Create a couple Middlewares used to handle panics, perform auth, parse forms in http request, and set content type in response
+	handlerMiddleware := middleware.Merge(
 		serverutil.RecoveryHTTPMiddleware,
 		authMiddleware,
 		serverutil.NewPrepopulateMiddleware(),
-	)
-	// External middleware also needs to set JSON content type headers
-	externalMiddleware := middleware.Merge(
-		internalMiddleware,
 		serverutil.ResponseJSONMiddleware(),
 	)
 
@@ -72,7 +68,7 @@ func InitWorkerService(
 	// There are some routes which are always registered on the external router, add them now and
 	// wrap them with the externalMiddleware
 	for route, handler := range alwaysExternalRoutesToHandlers {
-		externalRouter.Path(route).Methods("GET", "POST").Handler(externalMiddleware.Wrap(handler))
+		externalRouter.Path(route).Methods("GET", "POST").Handler(handlerMiddleware.Wrap(handler))
 	}
 
 	// If the querier is running standalone without the query-frontend or query-scheduler, we must register the internal
@@ -91,7 +87,7 @@ func InitWorkerService(
 
 		// Register routes externally
 		for _, route := range routes {
-			externalRouter.Path(route).Methods("GET", "POST").Handler(externalMiddleware.Wrap(internalRouter))
+			externalRouter.Path(route).Methods("GET", "POST").Handler(handlerMiddleware.Wrap(internalRouter))
 		}
 
 		//If no frontend or scheduler address has been configured, then there is no place for the
@@ -129,7 +125,7 @@ func InitWorkerService(
 			return "internalQuerier"
 		}))
 
-	internalHandler = internalMiddleware.Wrap(internalHandler)
+	internalHandler = handlerMiddleware.Wrap(internalHandler)
 
 	//Return a querier worker pointed to the internal querier HTTP handler so there is not a conflict in routes between the querier
 	//and the query frontend

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -97,6 +97,10 @@ func Test_InitQuerierService(t *testing.T) {
 		})
 
 		t.Run("wrap external handler with response json middleware", func(t *testing.T) {
+			// note: this test only assures that the content type of the reponse is
+			// set if the handler function does not override it, which happens in the
+			// actual implementation, see
+			// https://github.com/grafana/loki/blob/34a012adcfade43291de3a7670f53679ea06aefe/pkg/lokifrontend/frontend/transport/handler.go#L136-L139
 			config := WorkerServiceConfig{
 				QueryFrontendEnabled:  false,
 				QuerySchedulerEnabled: false,

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -97,7 +97,7 @@ func Test_InitQuerierService(t *testing.T) {
 		})
 
 		t.Run("wrap external handler with response json middleware", func(t *testing.T) {
-			// note: this test only assures that the content type of the reponse is
+			// note: this test only assures that the content type of the response is
 			// set if the handler function does not override it, which happens in the
 			// actual implementation, see
 			// https://github.com/grafana/loki/blob/34a012adcfade43291de3a7670f53679ea06aefe/pkg/lokifrontend/frontend/transport/handler.go#L136-L139


### PR DESCRIPTION
Because the internal query request handlers did not set the response
content type explicitly to `application/json`, and the external request
handler takes the response content type from the internal response to
set it for the resulting HTTP response, that response was also
incorrectly returning `Content-Type: text/plain`.

Setting the content type in the internal response correctly results in
the expected `Content-Type` header `application/json; charset=UTF-8`.

Fixes #4791

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

```console
$ curl -vGET http://localhost:3100/loki/api/v1/query_range --data-urlencode 'query={app="app"}' 
*   Trying 127.0.0.1:3100...
* Connected to localhost (127.0.0.1) port 3100 (#0)
> GET /loki/api/v1/query_range?query=%7Bapp%3D%22app%22%7D HTTP/1.1
> Host: localhost:3100
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=UTF-8
< Date: Thu, 25 Nov 2021 21:15:13 GMT
< Content-Length: 735
< 
```