### PR TITLE
Use http prefix path correctly in promtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main
 
-* [4828](https://github.com/grafana/loki/pull/4282) **chaudum**: Set correct `Content-Type` header in query response
+* [4832](https://github.com/grafana/loki/pull/4832) **taisho6339**: Use http prefix path correctly in Promtail
+* [4828](https://github.com/grafana/loki/pull/4828) **chaudum**: Set correct `Content-Type` header in query response
 * [4794](https://github.com/grafana/loki/pull/4794) **taisho6339**: Aggregate inotify watcher to file target manager
 * [4663](https://github.com/grafana/loki/pull/4663) **taisho6339**: Add SASL&mTLS authentication support for Kafka in Promtail
 * [4745](https://github.com/grafana/loki/pull/4745) **taisho6339**: Expose Kafka message key in labels

--- a/clients/pkg/promtail/server/server.go
+++ b/clients/pkg/promtail/server/server.go
@@ -81,7 +81,7 @@ func New(cfg Config, log log.Logger, tms *targets.TargetManagers, promtailCfg st
 	if err != nil {
 		return nil, errors.Wrapf(err, "parse external URL %q", cfg.ExternalURL)
 	}
-	cfg.PathPrefix = externalURL.Path
+	externalURL.Path += cfg.PathPrefix
 
 	healthCheckTargetFlag := true
 	if cfg.HealthCheckTarget != nil {
@@ -99,7 +99,7 @@ func New(cfg Config, log log.Logger, tms *targets.TargetManagers, promtailCfg st
 
 	serv.HTTP.Path("/").Handler(http.RedirectHandler(path.Join(serv.externalURL.Path, "/targets"), 303))
 	serv.HTTP.Path("/ready").Handler(http.HandlerFunc(serv.ready))
-	serv.HTTP.PathPrefix("/static/").Handler(http.FileServer(ui.Assets))
+	serv.HTTP.PathPrefix("/static/").Handler(http.StripPrefix(externalURL.Path, http.FileServer(ui.Assets)))
 	serv.HTTP.Path("/service-discovery").Handler(http.HandlerFunc(serv.serviceDiscovery))
 	serv.HTTP.Path("/targets").Handler(http.HandlerFunc(serv.targets))
 	serv.HTTP.Path("/config").Handler(http.HandlerFunc(serv.config))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This is bug fix for promtail.
Now, if we use http path prefix in promtail, it can't redirect to `/targets` from `/` and access to static assets correctly.
So I've fixed.

In addition I'd tested the two pattern cases, without path prefix and with it in my local workstation.

**Which issue(s) this PR fixes**:
Fixes #4765
(also https://github.com/grafana/loki/issues/1709)

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
