### PR TITLE
Refactor pkg/util/server to avoid cortexpb import in downstream projects vendoring logql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,10 @@ lint:
 	GO111MODULE=on GOGC=10 golangci-lint run -v $(GOLANGCI_ARG)
 	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
 
+	# Ensure packages imported by downstream projects (eg. GEM) don't depend on other packages
+	# vendoring Cortex's cortexpb (to avoid conflicting imports in downstream projects).
+	faillint -paths "github.com/grafana/loki/pkg/util/server/...,github.com/grafana/loki/pkg/storage/...,github.com/cortexproject/cortex/pkg/cortexpb" ./pkg/logql/...
+
 ########
 # Test #
 ########

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
-	serverutil "github.com/grafana/loki/pkg/util/server"
+	"github.com/grafana/loki/pkg/util/httpreq"
 )
 
 const (
@@ -89,7 +89,7 @@ func RecordMetrics(ctx context.Context, p Params, status string, stats stats.Res
 		returnedLines = int(result.(logqlmodel.Streams).Lines())
 	}
 
-	queryTags, _ := ctx.Value(serverutil.QueryTagsHTTPHeader).(string) // it's ok to be empty.
+	queryTags, _ := ctx.Value(httpreq.QueryTagsHTTPHeader).(string) // it's ok to be empty.
 
 	logValues := make([]interface{}, 0, 20)
 

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
-	serverutil "github.com/grafana/loki/pkg/util/server"
+	"github.com/grafana/loki/pkg/util/httpreq"
 )
 
 func TestQueryType(t *testing.T) {
@@ -64,7 +64,7 @@ func TestLogSlowQuery(t *testing.T) {
 	ctx := opentracing.ContextWithSpan(user.InjectOrgID(context.Background(), "foo"), sp)
 	now := time.Now()
 
-	ctx = context.WithValue(ctx, serverutil.QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
+	ctx = context.WithValue(ctx, httpreq.QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
 
 	RecordMetrics(ctx, LiteralParams{
 		qs:        `{foo="bar"} |= "buzz"`,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -51,6 +51,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway/indexgatewaypb"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/uploads"
+	"github.com/grafana/loki/pkg/util/httpreq"
 	serverutil "github.com/grafana/loki/pkg/util/server"
 	"github.com/grafana/loki/pkg/validation"
 )
@@ -489,7 +490,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	}
 
 	frontendHandler = middleware.Merge(
-		serverutil.ExtractQueryTagsMiddleware(),
+		httpreq.ExtractQueryTagsMiddleware(),
 		serverutil.RecoveryHTTPMiddleware,
 		t.HTTPAuthMiddleware,
 		queryrange.StatsHTTPMiddleware,
@@ -501,7 +502,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	// If this process also acts as a Querier we don't do any proxying of tail requests
 	if t.Cfg.Frontend.TailProxyURL != "" && !t.isModuleActive(Querier) {
 		httpMiddleware := middleware.Merge(
-			serverutil.ExtractQueryTagsMiddleware(),
+			httpreq.ExtractQueryTagsMiddleware(),
 			t.HTTPAuthMiddleware,
 			queryrange.StatsHTTPMiddleware,
 		)

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -26,9 +26,9 @@ import (
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/util/httpreq"
 	"github.com/grafana/loki/pkg/util/marshal"
 	marshal_legacy "github.com/grafana/loki/pkg/util/marshal/legacy"
-	serverutil "github.com/grafana/loki/pkg/util/server"
 )
 
 var LokiCodec = &Codec{}
@@ -261,7 +261,7 @@ func (Codec) EncodeRequest(ctx context.Context, r queryrange.Request) (*http.Req
 	header := make(http.Header)
 	queryTags := getQueryTags(ctx)
 	if queryTags != "" {
-		header.Set(string(serverutil.QueryTagsHTTPHeader), queryTags)
+		header.Set(string(httpreq.QueryTagsHTTPHeader), queryTags)
 	}
 
 	switch request := r.(type) {
@@ -866,6 +866,6 @@ func httpResponseHeadersToPromResponseHeaders(httpHeaders http.Header) []queryra
 }
 
 func getQueryTags(ctx context.Context) string {
-	v, _ := ctx.Value(serverutil.QueryTagsHTTPHeader).(string) // it's ok to be empty
+	v, _ := ctx.Value(httpreq.QueryTagsHTTPHeader).(string) // it's ok to be empty
 	return v
 }

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/weaveworks/common/middleware"
 
 	querier_worker "github.com/grafana/loki/pkg/querier/worker"
+	"github.com/grafana/loki/pkg/util/httpreq"
 	serverutil "github.com/grafana/loki/pkg/util/server"
 )
 
@@ -54,7 +55,7 @@ func InitWorkerService(
 
 	// Create a couple Middlewares used to handle panics, perform auth, parse forms in http request, and set content type in response
 	handlerMiddleware := middleware.Merge(
-		serverutil.ExtractQueryTagsMiddleware(),
+		httpreq.ExtractQueryTagsMiddleware(),
 		serverutil.RecoveryHTTPMiddleware,
 		authMiddleware,
 		serverutil.NewPrepopulateMiddleware(),

--- a/pkg/util/httpreq/tags.go
+++ b/pkg/util/httpreq/tags.go
@@ -1,0 +1,35 @@
+package httpreq
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+
+	"github.com/weaveworks/common/middleware"
+)
+
+// NOTE(kavi): Why new type?
+// Our linter won't allow to use basic types like string to be used as key in context.
+type ctxKey string
+
+var (
+	QueryTagsHTTPHeader ctxKey = "X-Query-Tags"
+	safeQueryTags              = regexp.MustCompile("[^a-zA-Z0-9-=, ]+") // only alpha-numeric, ' ', ',', '=' and `-`
+
+)
+
+func ExtractQueryTagsMiddleware() middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			tags := req.Header.Get(string(QueryTagsHTTPHeader))
+			tags = safeQueryTags.ReplaceAllString(tags, "")
+
+			if tags != "" {
+				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
+				req = req.WithContext(ctx)
+			}
+			next.ServeHTTP(w, req)
+		})
+	})
+}

--- a/pkg/util/httpreq/tags_test.go
+++ b/pkg/util/httpreq/tags_test.go
@@ -1,0 +1,51 @@
+package httpreq
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryTags(t *testing.T) {
+	for _, tc := range []struct {
+		desc  string
+		in    string
+		exp   string
+		error bool
+	}{
+		{
+			desc: "single-value",
+			in:   `Source=logvolhist`,
+			exp:  `Source=logvolhist`,
+		},
+		{
+			desc: "multiple-values",
+			in:   `Source=logvolhist,Statate=beta`,
+			exp:  `Source=logvolhist,Statate=beta`,
+		},
+		{
+			desc: "remove-invalid-chars",
+			in:   `Source=log+volhi\\st,Statate=be$ta`,
+			exp:  `Source=logvolhist,Statate=beta`,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "http://testing.com", nil)
+			req.Header.Set(string(QueryTagsHTTPHeader), tc.in)
+
+			w := httptest.NewRecorder()
+			checked := false
+			mware := ExtractQueryTagsMiddleware().Wrap(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				require.Equal(t, tc.exp, req.Context().Value(QueryTagsHTTPHeader).(string))
+				checked = true
+			}))
+
+			mware.ServeHTTP(w, req)
+
+			assert.True(t, true, checked)
+		})
+	}
+}

--- a/pkg/util/server/middleware.go
+++ b/pkg/util/server/middleware.go
@@ -1,22 +1,10 @@
 package server
 
 import (
-	"context"
 	"net/http"
-	"regexp"
 
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
-)
-
-// NOTE(kavi): Why new type?
-// Our linter won't allow to use basic types like string to be used as key in context.
-type ctxKey string
-
-var (
-	QueryTagsHTTPHeader ctxKey = "X-Query-Tags"
-	safeQueryTags              = regexp.MustCompile("[^a-zA-Z0-9-=, ]+") // only alpha-numeric, ' ', ',', '=' and `-`
-
 )
 
 // NewPrepopulateMiddleware creates a middleware which will parse incoming http forms.
@@ -39,22 +27,6 @@ func ResponseJSONMiddleware() middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-			next.ServeHTTP(w, req)
-		})
-	})
-}
-
-func ExtractQueryTagsMiddleware() middleware.Interface {
-	return middleware.Func(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ctx := req.Context()
-			tags := req.Header.Get(string(QueryTagsHTTPHeader))
-			tags = safeQueryTags.ReplaceAllString(tags, "")
-
-			if tags != "" {
-				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
-				req = req.WithContext(ctx)
-			}
 			next.ServeHTTP(w, req)
 		})
 	})

--- a/pkg/util/server/middleware_test.go
+++ b/pkg/util/server/middleware_test.go
@@ -8,50 +8,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQueryTags(t *testing.T) {
-	for _, tc := range []struct {
-		desc  string
-		in    string
-		exp   string
-		error bool
-	}{
-		{
-			desc: "single-value",
-			in:   `Source=logvolhist`,
-			exp:  `Source=logvolhist`,
-		},
-		{
-			desc: "multiple-values",
-			in:   `Source=logvolhist,Statate=beta`,
-			exp:  `Source=logvolhist,Statate=beta`,
-		},
-		{
-			desc: "remove-invalid-chars",
-			in:   `Source=log+volhi\\st,Statate=be$ta`,
-			exp:  `Source=logvolhist,Statate=beta`,
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://testing.com", nil)
-			req.Header.Set(string(QueryTagsHTTPHeader), tc.in)
-
-			w := httptest.NewRecorder()
-			checked := false
-			mware := ExtractQueryTagsMiddleware().Wrap(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				require.Equal(t, tc.exp, req.Context().Value(QueryTagsHTTPHeader).(string))
-				checked = true
-			}))
-
-			mware.ServeHTTP(w, req)
-
-			assert.True(t, true, checked)
-		})
-	}
-}
 
 func TestPrepopulate(t *testing.T) {
 	success := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR #4814 introduced a cascading dependency from `pkg/logql` to `cortexpb` (from Cortex project). This is causing a conflict in a downstream project (GEM). More details here:
https://github.com/grafana/loki/pull/4814#issuecomment-979936641

In this PR I'm proposing an option to avoid the `cortexpb` cascading dependency for projects importing `logql` (I've tested this change and works from GEM perspective). Not sure if the refactoring I've done in the PR is acceptable for Loki project; if not, please share an alternative suggestion on how to solve. Thanks!

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
