### PR TITLE
Automation: Use dependabot to keep go modules dependancies up to date.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

**What this PR does / why we need it**:

Configure dependabot to keep go modules up to date.

