### PR TITLE
Add a stat panel function to dashboard-utils

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -198,4 +198,29 @@ local utils = import 'mixin-utils/utils.libsonnet';
     |||
       ignoring(%s) group_right() (label_replace(count by(%s, %s, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
     ||| % [$._config.per_instance_label, $._config.per_node_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
+
+    newStatPanel(queries, legends='', unit='percentunit', decimals=1, thresholds=[], instant=false, novalue='')::
+    super.queryPanel(queries, legends) + {
+      type: 'stat',
+      targets: [
+        target {
+          instant: instant,
+          interval: '',
+
+          // Reset defaults from queryPanel().
+          format: null,
+          intervalFactor: null,
+          step: null,
+        }
+        for target in super.targets
+      ],
+      fieldConfig: {
+        defaults: {
+          decimals: decimals,
+          noValue: novalue,
+          unit: unit,
+        },
+        overrides: [],
+      },
+    },
 }


### PR DESCRIPTION
Adds a stat panel function so we can more easily create grid layouts via loki dashboard utils.

Signed-off-by: Callum Styan <callumstyan@gmail.com>