### PR TITLE
[doc]: Add the multiline stage to stages overview

### DIFF
--- a/docs/sources/clients/promtail/stages/_index.md
+++ b/docs/sources/clients/promtail/stages/_index.md
@@ -13,6 +13,7 @@ Parsing stages:
   - [regex](regex/): Extract data using a regular expression.
   - [json](json/): Extract data by parsing the log line as JSON.
   - [replace](replace/): Replace data using a regular expression.
+  - [multiline](multiline/): Merge multiple lines into a multiline block.
 
 Transform stages:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the multiline stage to the "Stages" overview page on the docs.
The multiline stage is added under the `Parsing stages` section

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
