### PR TITLE
Jsonnet: Let compactor access the runtime_config

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -68,6 +68,7 @@
     statefulSet.mixin.spec.withServiceName('compactor') +
     $.config_hash_mixin +
     k.util.configVolumeMount('loki', '/etc/loki/config') +
+    k.util.configVolumeMount('overrides', '/etc/loki/overrides') +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile
   else {},


### PR DESCRIPTION
**What this PR does / why we need it**:

Let compactor access the runtime_config (overrides.yaml) by mounting the configmap. This fixes the problem that compactor fails to start (crash) due to no access to the runtime config.

**Which issue(s) this PR fixes**:
No issue filed.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
