### PR TITLE
Fix duplicate registry.MustRegister call in Promtail Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [4865](https://github.com/grafana/loki/pull/4865) **taisho6339**: Fix duplicate registry.MustRegister call in Promtail Kafka
 * [4845](https://github.com/grafana/loki/pull/4845) **chaudum** Return error responses consistently as JSON
 * [4826](https://github.com/grafana/loki/pull/4826) **cyriltovena**: Adds the ability to hedge storage requests.
 * [4828](https://github.com/grafana/loki/pull/4282) **chaudum**: Set correct `Content-Type` header in query response

--- a/clients/pkg/promtail/targets/kafka/target_syncer.go
+++ b/clients/pkg/promtail/targets/kafka/target_syncer.go
@@ -10,13 +10,14 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/util"
 )
@@ -28,10 +29,11 @@ type TopicManager interface {
 }
 
 type TargetSyncer struct {
-	logger log.Logger
-	cfg    scrapeconfig.Config
-	reg    prometheus.Registerer
-	client api.EntryHandler
+	logger   log.Logger
+	cfg      scrapeconfig.Config
+	pipeline *stages.Pipeline
+	reg      prometheus.Registerer
+	client   api.EntryHandler
 
 	topicManager TopicManager
 	consumer
@@ -86,8 +88,11 @@ func NewSyncer(
 	if err != nil {
 		return nil, fmt.Errorf("error creating topic manager: %w", err)
 	}
+	pipeline, err := stages.NewPipeline(log.With(logger, "component", "kafka_pipeline"), cfg.PipelineStages, &cfg.JobName, reg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating pipeline: %w", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
-
 	t := &TargetSyncer{
 		logger:       logger,
 		ctx:          ctx,
@@ -96,6 +101,7 @@ func NewSyncer(
 		cfg:          cfg,
 		reg:          reg,
 		client:       pushClient,
+		pipeline:     pipeline,
 		close: func() error {
 			if err := group.Close(); err != nil {
 				level.Warn(logger).Log("msg", "error while closing consumer group", "err", err)
@@ -280,19 +286,13 @@ func (ts *TargetSyncer) NewTarget(session sarama.ConsumerGroupSession, claim sar
 			},
 		}, nil
 	}
-
-	pipeline, err := stages.NewPipeline(log.With(ts.logger, "component", "kafka_pipeline"), ts.cfg.PipelineStages, &ts.cfg.JobName, ts.reg)
-	if err != nil {
-		return nil, err
-	}
-
 	t := NewTarget(
 		session,
 		claim,
 		discoveredLabels,
 		labelOut,
 		ts.cfg.RelabelConfigs,
-		pipeline.Wrap(ts.client),
+		ts.pipeline.Wrap(ts.client),
 		ts.cfg.KafkaConfig.UseIncomingTimestamp,
 	)
 

--- a/clients/pkg/promtail/targets/kafka/target_syncer_test.go
+++ b/clients/pkg/promtail/targets/kafka/target_syncer_test.go
@@ -6,18 +6,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/clients/pkg/logentry/stages"
+
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/config"
 
 	"github.com/Shopify/sarama"
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/clients/pkg/promtail/client/fake"
-	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/clients/pkg/promtail/client/fake"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 )
 
 func Test_TopicDiscovery(t *testing.T) {
@@ -102,6 +105,9 @@ func Test_NewTarget(t *testing.T) {
 			},
 		},
 	}
+	pipeline, err := stages.NewPipeline(ts.logger, ts.cfg.PipelineStages, &ts.cfg.JobName, ts.reg)
+	require.NoError(t, err)
+	ts.pipeline = pipeline
 	tg, err := ts.NewTarget(&testSession{}, newTestClaim("foo", 10, 1))
 
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

registry.MustRegister is called every newPipeline and newPipeline is called in every newTarget in target_syncer.go.
Therefore MustRegister is called in duplicate and it causes the metrics collection error.
I've moved the newPipeline to newTargetsyncer to fix it.

**Which issue(s) this PR fixes**:
Fixes #4865 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
