### PR TITLE
Loki: fix log level for statistics

### DIFF
--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -103,7 +103,7 @@ func StatsCollectorMiddleware() queryrange.Middleware {
 			if statistics != nil {
 				// Re-calculate the summary then log and record metrics for the current query
 				statistics.ComputeSummary(time.Since(start))
-				statistics.Log(logger)
+				statistics.Log(level.Debug(logger))
 			}
 			ctxValue := ctx.Value(ctxKey)
 			if data, ok := ctxValue.(*queryData); ok {


### PR DESCRIPTION
Stats were being logged without a level preventing them from being filtered properly by changing the log level.