### PR TITLE
always apply replication factor common config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [4741](https://github.com/grafana/loki/pull/4741) **sandeepsukhani**: index cleanup fixes while applying retention
 * [4813](https://github.com/grafana/loki/pull/4813) **cyriltovena**: Promtail: Adds the ability to pull logs from Cloudflare.
 * [4853](https://github.com/grafana/loki/pull/4853) **sandeepsukhani**: recreate compacted boltdb files from compactor to reduce storage space usage
+* [4875](https://github.com/grafana/loki/pull/4875) **trevorwhitney**: Loki: fix bug where common replication factor wasn't always getting applied
 
 # 2.4.1 (2021/11/07)
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -101,6 +101,7 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 
 		applyFIFOCacheConfig(r)
 		applyIngesterFinalSleep(r)
+		applyIngesterReplicationFactor(r)
 		applyChunkRetain(r, &defaults)
 
 		return nil
@@ -472,6 +473,10 @@ func isMemcacheSet(cfg cortexcache.Config) bool {
 
 func applyIngesterFinalSleep(cfg *ConfigWrapper) {
 	cfg.Ingester.LifecyclerConfig.FinalSleep = 0 * time.Second
+}
+
+func applyIngesterReplicationFactor(cfg *ConfigWrapper) {
+	cfg.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor = cfg.Common.ReplicationFactor
 }
 
 // applyChunkRetain is used to set chunk retain based on having an index query cache configured

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1331,3 +1331,17 @@ storage_config:
 	})
 
 }
+
+func Test_repcliationFactor(t *testing.T) {
+	t.Run("replication factor is applied when using memberlist", func(t *testing.T) {
+		yamlContent := `---
+memberlist:
+  join_members:
+    - foo.bar.example.com
+common:
+  replication_factor: 1`
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, config.Ingester.LifecyclerConfig.RingConfig.ReplicationFactor)
+	})
+}

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1334,8 +1334,7 @@ storage_config:
 
 func Test_replicationFactor(t *testing.T) {
 	t.Run("replication factor is applied when using memberlist", func(t *testing.T) {
-		yamlContent := `---
-memberlist:
+		yamlContent := `memberlist:
   join_members:
     - foo.bar.example.com
 common:

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1332,7 +1332,7 @@ storage_config:
 
 }
 
-func Test_repcliationFactor(t *testing.T) {
+func Test_replicationFactor(t *testing.T) {
 	t.Run("replication factor is applied when using memberlist", func(t *testing.T) {
 		yamlContent := `---
 memberlist:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug with the common config where the replication factor was only getting applied if a common ring config was also provided.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
