### PR TITLE
Documentation: Add compactor to simple-scalable-deployment text

### DIFF
--- a/docs/sources/fundamentals/architecture/_index.md
+++ b/docs/sources/fundamentals/architecture/_index.md
@@ -69,7 +69,8 @@ Consider the microservices mode approach for very large Loki installations.
 ![simple scalable deployment mode diagram](simple-scalable.png)
 
 In this mode the component microservices of Loki are bundled into two targets:
-`-target=read` and `-target=write`.
+`-target=read` and `-target=write`. The BoltDB [compactor](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/#compactor) 
+service will also run as part of the read path when using either `-target=all` or `-target=read`.
 
 There are advantages to separating the read and write paths:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documentation failed to mention that the compact is run as part of the simple-scalable-deployment.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
 It would best if this is also added to the diagrams, but the source for the diagrams isn't available in the repository.

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
