### PR TITLE
Add copyright notice

### DIFF
--- a/docs/sources/copyright/_index.md
+++ b/docs/sources/copyright/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Copyright notice"
+aliases = ["/docs/loki/next/copyright-notice"]
++++
+
+# Copyright notice
+
+Copyright &#169; 2021 Raintank, Inc. dba Grafana Labs. All Rights Reserved


### PR DESCRIPTION
This PR adds a copyright notice to the docs. I've already handled the addition for previous versions of Loki in the /website repo. Change was requested by Fiona.
