### PR TITLE
ingester: use consistent set of instances to avoid panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [4875](https://github.com/grafana/loki/pull/4875) **trevorwhitney**: Loki: fix bug where common replication factor wasn't always getting applied
 * [4892](https://github.com/grafana/loki/pull/4892) **cristaloleg**: Loki: upgrade cristalhq/hedgedhttp from v0.6.0 to v0.7.0
 * [4902](https://github.com/grafana/loki/pull/4902) **cyriltovena**: Fixes 500 when query is outside of max_query_lookback.
-
+* [4904](https://github.com/grafana/loki/pull/4904) **bboreham**: Fixes rare race condition that could crash an ingester.
 
 # 2.4.1 (2021/11/07)
 

--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -207,7 +207,7 @@ type streamIterator struct {
 func newStreamsIterator(ing ingesterInstances) *streamIterator {
 	instances := ing.getInstances()
 	streamInstances := make([]streamInstance, len(instances))
-	for i, inst := range ing.getInstances() {
+	for i, inst := range instances {
 		inst.streamsMtx.RLock()
 		streams := make([]*stream, 0, len(inst.streams))
 		inst.streamsMtx.RUnlock()


### PR DESCRIPTION
Calling `getInstances()` twice runs the risk that the set has expanded or contracted between allocating the slice and starting to iterate.

Stack trace where it went wrong:
```
panic: runtime error: index out of range [1743] with length 1743
goroutine 514 [running]:
github.com/grafana/loki/pkg/ingester.newStreamsIterator({0x27cc280, 0xc000a73600})
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/checkpoint.go:218 +0x2ba
github.com/grafana/loki/pkg/ingester.(*ingesterSeriesIter).Iter(0x17c33cf)
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/checkpoint.go:189 +0x25
github.com/grafana/loki/pkg/ingester.(*Checkpointer).PerformCheckpoint(0xc127edff78)
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/checkpoint.go:579 +0x25f
github.com/grafana/loki/pkg/ingester.(*Checkpointer).Run(0xc127edff78)
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/checkpoint.go:618 +0x21c
github.com/grafana/loki/pkg/ingester.(*walWrapper).run(0xc0009a3810)
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/wal.go:166 +0x21c
created by github.com/grafana/loki/pkg/ingester.(*walWrapper).Start
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/ingester/wal.go:102 +0x6f
```

**Checklist**
- NA Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.

(I didn't add a test as it would be complex to synthesise delays in fetching the set to recreate the race.)