### PR TITLE
Docs: Add default labels to Docker Driver for Docker Compose

### DIFF
--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -110,6 +110,7 @@ By default, the Docker driver will add the following labels to each log line:
 - `filename`: where the log is written to on disk
 - `host`: the hostname where the log has been generated
 - `swarm_stack`, `swarm_service`: added when deploying from Docker Swarm.
+- `compose_project`, `compose_service`: added when deploying with Docker Compose.
 
 Custom labels can be added using the `loki-external-labels`, `loki-pipeline-stages`,
 `loki-pipeline-stage-file`, `labels`, `env`, and `env-regex` options. See the


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Add missing default labels `compose_project` and `compose_service` for the docker driver  when deployed with Docker Compose.

Relevant code:
https://github.com/grafana/loki/blob/24b4c0eed2ca35225c88d428f62766e4fffbc67a/clients/cmd/docker-driver/config.go#L260-L268

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
