### PR TITLE
Skip middleware for unsupported type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [4924](https://github.com/grafana/loki/pull/4924) **DylanGuedes**: Skip middleware for unsupported type
 * [4920](https://github.com/grafana/loki/pull/4920) **chaudum**: Add `-list-targets` command line flag to list all available run targets
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging
 * [4865](https://github.com/grafana/loki/pull/4865) **taisho6339**: Fix duplicate registry.MustRegister call in Promtail Kafka

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -789,9 +789,41 @@ func paramsFromRequest(req queryrange.Request) (logql.Params, error) {
 		return &paramsInstantWrapper{
 			LokiInstantRequest: r,
 		}, nil
+	case *LokiLabelNamesRequest:
+		return &paramsLabelNamesWrapper{
+			LokiLabelNamesRequest: r,
+		}, nil
 	default:
-		return nil, fmt.Errorf("expected *LokiRequest or *LokiInstantRequest, got (%T)", r)
+		return nil, fmt.Errorf("expected *LokiRequest, *LokiLabelNamesRequest, or *LokiInstantRequest, got (%T)", r)
 	}
+}
+
+type paramsLabelNamesWrapper struct {
+	*LokiLabelNamesRequest
+}
+
+func (p paramsLabelNamesWrapper) Query() string {
+	return p.GetQuery()
+}
+
+func (p paramsLabelNamesWrapper) Start() time.Time {
+	return p.GetStartTs()
+}
+
+func (p paramsLabelNamesWrapper) End() time.Time {
+	return p.GetEndTs()
+}
+
+func (p paramsLabelNamesWrapper) Step() time.Duration {
+	return time.Duration(p.GetStep() * 1e6)
+}
+func (p paramsLabelNamesWrapper) Interval() time.Duration { return 0 }
+func (p paramsLabelNamesWrapper) Direction() logproto.Direction {
+	return p.Direction()
+}
+func (p paramsLabelNamesWrapper) Limit() uint32 { return 0 } // no limit.
+func (p paramsLabelNamesWrapper) Shards() []string {
+	return p.Shards()
 }
 
 type paramsRangeWrapper struct {

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -819,11 +819,11 @@ func (p paramsLabelNamesWrapper) Step() time.Duration {
 }
 func (p paramsLabelNamesWrapper) Interval() time.Duration { return 0 }
 func (p paramsLabelNamesWrapper) Direction() logproto.Direction {
-	return p.Direction()
+	return logproto.FORWARD
 }
 func (p paramsLabelNamesWrapper) Limit() uint32 { return 0 } // no limit.
 func (p paramsLabelNamesWrapper) Shards() []string {
-	return p.Shards()
+	return []string{}
 }
 
 type paramsRangeWrapper struct {

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -100,11 +100,15 @@ func StatsCollectorMiddleware() queryrange.Middleware {
 					level.Warn(logger).Log("msg", fmt.Sprintf("cannot compute stats, unexpected type: %T", resp))
 				}
 			}
-			if statistics != nil {
-				// Re-calculate the summary then log and record metrics for the current query
-				statistics.ComputeSummary(time.Since(start))
-				statistics.Log(level.Debug(logger))
+
+			// type doesn't support statistics, skipping stats collection.
+			if statistics == nil {
+				return resp, err
 			}
+
+			statistics.ComputeSummary(time.Since(start))
+			statistics.Log(level.Debug(logger))
+
 			ctxValue := ctx.Value(ctxKey)
 			if data, ok := ctxValue.(*queryData); ok {
 				data.recorded = true

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -101,13 +101,10 @@ func StatsCollectorMiddleware() queryrange.Middleware {
 				}
 			}
 
-			// type doesn't support statistics, skipping stats collection.
-			if statistics == nil {
-				return resp, err
+			if statistics != nil {
+				statistics.ComputeSummary(time.Since(start))
+				statistics.Log(level.Debug(logger))
 			}
-
-			statistics.ComputeSummary(time.Since(start))
-			statistics.Log(level.Debug(logger))
 
 			ctxValue := ctx.Value(ctxKey)
 			if data, ok := ctxValue.(*queryData); ok {

--- a/pkg/querier/queryrange/stats_test.go
+++ b/pkg/querier/queryrange/stats_test.go
@@ -23,12 +23,14 @@ func TestStatsCollectorMiddleware(t *testing.T) {
 		now  = time.Now()
 	)
 	ctx := context.WithValue(context.Background(), ctxKey, data)
+
 	_, _ = StatsCollectorMiddleware().Wrap(queryrange.HandlerFunc(func(ctx context.Context, r queryrange.Request) (queryrange.Response, error) {
 		return nil, nil
 	})).Do(ctx, &LokiRequest{
 		Query:   "foo",
 		StartTs: now,
 	})
+
 	require.Equal(t, "foo", data.params.Query())
 	require.Equal(t, true, data.recorded)
 	require.Equal(t, now, data.params.Start())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips the stats middleware for the unsupported type `LokiLabelNamesResponse`, used by Grafana to check the data source connection

**Which issue(s) this PR fixes**:
Fixes #4923

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
