### PR TITLE
Update logstash dependency in logstash-output-loki plugin

### DIFF
--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -1,8 +1,8 @@
-FROM logstash:7.9.3
+FROM logstash:7.16.1
 
 USER logstash
-ENV PATH /usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/vendor/bundle/jruby/2.5.0/bin:$PATH
-ENV LOGSTASH_PATH="/usr/share/logstash"
+ENV PATH /usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/vendor/bundle/jruby/2.5.0/bin:/usr/share/logstash/jdk/bin:$PATH
+ENV LOGSTASH_PATH /usr/share/logstash
 ENV GEM_PATH /usr/share/logstash/vendor/bundle/jruby/2.5.0
 ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/2.5.0
 
@@ -11,8 +11,9 @@ RUN gem install bundler:2.1.4
 COPY --chown=logstash:logstash ./clients/cmd/logstash/ /home/logstash/
 WORKDIR /home/logstash/
 
-
-RUN bundle install --path=/usr/share/logstash/vendor/bundle && \
+RUN bundle config set --local path /usr/share/logstash/vendor/bundle && \
+    bundle install && \
+    bundle update && \
     bundle exec rake vendor && \
     bundle exec rspec
 

--- a/clients/cmd/logstash/README.md
+++ b/clients/cmd/logstash/README.md
@@ -29,8 +29,11 @@ export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
 ```
 
-Then install bundler
-`gem install bundler:2.1.4`
+Then install bundler:
+
+```bash
+gem install bundler:2.1.4
+```
 
 Follow those instructions to [install logstash](https://www.elastic.co/guide/en/logstash/current/installing-logstash.html) before moving to the next section.
 
@@ -41,36 +44,45 @@ Follow those instructions to [install logstash](https://www.elastic.co/guide/en/
 ```bash
 git clone git@github.com:elastic/logstash.git
 cd logstash
-git checkout tags/v7.6.2
-export LOGSTASH_PATH=`pwd`
-export GEM_PATH=$LOGSTASH_PATH/vendor/bundle/jruby/2.5.0
-export GEM_HOME=$LOGSTASH_PATH/vendor/bundle/jruby/2.5.0
+git checkout tags/v7.16.1
+export LOGSTASH_PATH="$(pwd)"
+export GEM_PATH="$LOGSTASH_PATH/vendor/bundle/jruby/2.5.0"
+export GEM_HOME="$LOGSTASH_PATH/vendor/bundle/jruby/2.5.0"
 ./gradlew assemble
 cd ..
+ruby -S bundle config set --local path "$LOGSTASH_PATH/vendor/bundle"
 ruby -S bundle install
 ruby -S bundle exec rake vendor
 ```
 
 ### Build the plugin
 
-`gem build logstash-output-loki.gemspec`
+```bash
+gem build logstash-output-loki.gemspec
+```
 
 ### Test
 
-`ruby -S bundle exec rspec`
+```bash
+ruby -S bundle exec rspec
+```
 
 Alternatively if you don't want to install JRuby. Enter inside logstash-loki container.
 
 ```bash
 docker build -t logstash-loki ./
-docker run -v  `pwd`/spec:/home/logstash/spec -it --rm --entrypoint /bin/sh logstash-loki
+docker run -v  $(pwd)/spec:/home/logstash/spec -it --rm --entrypoint /bin/sh logstash-loki
 bundle exec rspec
 ```
 
 ## Install plugin to local logstash
 
-`bin/logstash-plugin install --no-verify --local logstash-output-loki-1.0.0.gem`
+```bash
+bin/logstash-plugin install --no-verify --local logstash-output-loki-1.0.0.gem
+```
 
 ## Send sample event and check plugin is working
 
-`bin/logstash -f loki.conf`
+```bash
+bin/logstash -f loki.conf
+```

--- a/clients/cmd/logstash/logstash-output-loki.gemspec
+++ b/clients/cmd/logstash/logstash-output-loki.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   # Gem dependencies
   #
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain", "3.0.6"
+  s.add_runtime_dependency "logstash-codec-plain", "3.1.0"
   s.add_development_dependency 'logstash-devutils', "2.0.2"
 end


### PR DESCRIPTION
Use `logstash:7.16.1` as base image for the `grafana/logstash-output-loki` Docker image.
This logstash version uses `log4j` 2.15.0 which mitigates CVE-2021-44228.

- https://www.elastic.co/guide/en/logstash/current/logstash-7-16-1.html
- https://nvd.nist.gov/vuln/detail/CVE-2021-44228

Closes #4463

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>