### PR TITLE
Provide optional matchers to `LabelValuesForMetricName`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [4933](https://github.com/grafana/loki/pull/4933) **jeschkies**: Support matchers in series label values query.
 * [4926](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix comment in Loki module loading for accuracy
 * [4920](https://github.com/grafana/loki/pull/4920) **chaudum**: Add `-list-targets` command line flag to list all available run targets
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -302,7 +302,7 @@ func (s *mockStore) GetChunkRefs(ctx context.Context, userID string, from, throu
 	return nil, nil, nil
 }
 
-func (s *mockStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (s *mockStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	return []string{"val1", "val2"}, nil
 }
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -245,7 +245,7 @@ func (s *storeMock) PutOne(ctx context.Context, from, through model.Time, chunk 
 	return errors.New("storeMock.PutOne() has not been mocked")
 }
 
-func (s *storeMock) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (s *storeMock) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	args := s.Called(ctx, userID, from, through, metricName, labelName)
 	return args.Get(0).([]string), args.Error(1)
 }

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -251,58 +251,10 @@ func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string,
 			result.Add(string(labelValue))
 		}
 		return result.Strings(), nil
-	} else {
-
-		// Otherwise get chunks which include other matchers
-		seriesIDsSet := make(map[string]struct{}, 0)
-		var initialized bool
-		for _, matcher := range matchers {
-			incoming, err := c.lookupIdsByMetricNameMatcher(ctx, from, through, userID, metricName, matcher, nil)
-			if err != nil {
-				return nil, err
-			}
-			if !initialized {
-				for _, i := range incoming {
-					seriesIDsSet[i] = struct{}{}
-				}
-				initialized = true
-			} else {
-				// Intersect incoming and current set.
-				for _, i := range incoming {
-					_, ok := seriesIDsSet[i]		
-					if !ok {
-						delete(seriesIDsSet, i)
-					}
-				}
-			}
-		}
-		contains := func(id string) bool {
-			_, ok := seriesIDsSet[id]
-			return ok
-		}
-
-		// Fetch label values for label name that are part of the filtered chunks
-		var result UniqueStrings
-		queries, err := c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
-		if err != nil {
-			return nil, err
-		}
-		entries, err := c.lookupEntriesByQueries(ctx, queries)
-		if err != nil {
-			return nil, err
-		}
-		for _, entry := range entries {
-			seriesID, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
-			if err != nil {
-				return nil, err
-			}
-			if contains(seriesID) {
-				result.Add(string(labelValue))
-			}
-		}
-
-		return result.Strings(), nil
 	}
+
+	return nil, errors.New("Unimplemented: Matchers are not supported by chunk store.")
+
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -541,7 +541,7 @@ func (c *baseStore) parseIndexEntries(_ context.Context, entries []IndexEntry, m
 
 	result := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		seriesID, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		chunkKey, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -555,14 +555,14 @@ func (c *baseStore) parseIndexEntries(_ context.Context, entries []IndexEntry, m
 
 			// If its in the set, then add it to set, we don't need to run
 			// matcher on it again.
-			result = append(result, seriesID)
+			result = append(result, chunkKey)
 			continue
 		}
 
 		if matcher != nil && !matcher.Matches(string(labelValue)) {
 			continue
 		}
-		result = append(result, seriesID)
+		result = append(result, chunkKey)
 	}
 	// Return ids sorted and deduped because they will be merged with other sets.
 	sort.Strings(result)

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -253,7 +253,7 @@ func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string,
 		return result.Strings(), nil
 	}
 
-	return nil, errors.New("Unimplemented: Matchers are not supported by chunk store.")
+	return nil, errors.New("unimplemented: Matchers are not supported by chunk store")
 
 }
 

--- a/pkg/storage/chunk/chunk_store_test.go
+++ b/pkg/storage/chunk/chunk_store_test.go
@@ -218,6 +218,7 @@ func TestChunkStore_Get(t *testing.T) {
 						return
 					}
 					require.NoError(t, err)
+
 					if !reflect.DeepEqual(tc.expect, chunks1) {
 						t.Fatalf("%s: wrong chunks - %s", tc.query, test.Diff(tc.expect, chunks1))
 					}

--- a/pkg/storage/chunk/chunk_store_test.go
+++ b/pkg/storage/chunk/chunk_store_test.go
@@ -320,6 +320,14 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 			[]string{"not-secret"},
 			[]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")},
 		},
+		{
+			`foo`, `bar`,
+			[]string{"baz"},
+			[]*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "env", "prod"),
+				labels.MustNewMatcher(labels.MatchEqual, "toms", "code"),
+			},
+		},
 	} {
 		for _, schema := range schemas {
 			for _, storeCase := range stores {

--- a/pkg/storage/chunk/chunk_store_test.go
+++ b/pkg/storage/chunk/chunk_store_test.go
@@ -251,15 +251,11 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 		{Name: "bar", Value: "baz"},
 		{Name: "flip", Value: "flop"},
 		{Name: "toms", Value: "code"},
-		{Name: "env", Value: "dev"},
-		{Name: "class", Value: "not-secret"},
 	}
 	fooMetric2 := labels.Labels{
 		{Name: labels.MetricName, Value: "foo"},
 		{Name: "bar", Value: "beep"},
 		{Name: "toms", Value: "code"},
-		{Name: "env", Value: "prod"},
-		{Name: "class", Value: "secret"},
 	}
 	fooMetric3 := labels.Labels{
 		{Name: labels.MetricName, Value: "foo"},
@@ -288,45 +284,26 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 	for _, tc := range []struct {
 		metricName, labelName string
 		expect                []string
-		matchers              []*labels.Matcher
 	}{
 		{
 			`foo`, `bar`,
 			[]string{"baz", "beep", "bop"},
-			[]*labels.Matcher{},
 		},
 		{
 			`bar`, `toms`,
 			[]string{"code"},
-			[]*labels.Matcher{},
 		},
 		{
 			`bar`, `bar`,
 			[]string{"baz"},
-			[]*labels.Matcher{},
 		},
 		{
 			`foo`, `foo`,
 			nil,
-			[]*labels.Matcher{},
 		},
 		{
 			`foo`, `flip`,
 			[]string{"flap", "flop"},
-			[]*labels.Matcher{},
-		},
-		{
-			`foo`, `class`,
-			[]string{"not-secret"},
-			[]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")},
-		},
-		{
-			`foo`, `bar`,
-			[]string{"baz"},
-			[]*labels.Matcher{
-				labels.MustNewMatcher(labels.MatchNotEqual, "env", "prod"),
-				labels.MustNewMatcher(labels.MatchEqual, "toms", "code"),
-			},
 		},
 	} {
 		for _, schema := range schemas {
@@ -348,7 +325,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 					}
 
 					// Query with ordinary time-range
-					labelValues1, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName, tc.labelName, tc.matchers...)
+					labelValues1, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName, tc.labelName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelValues1) {
@@ -356,7 +333,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 					}
 
 					// Pushing end of time-range into future should yield exact same resultset
-					labelValues2, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName, tc.matchers...)
+					labelValues2, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelValues2) {

--- a/pkg/storage/chunk/composite_store.go
+++ b/pkg/storage/chunk/composite_store.go
@@ -30,7 +30,7 @@ type Store interface {
 	// GetChunkRefs returns the un-loaded chunks and the fetchers to be used to load them. You can load each slice of chunks ([]Chunk),
 	// using the corresponding Fetcher (fetchers[i].FetchChunks(ctx, chunks[i], ...)
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error)
-	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error)
+	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
 	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
 	GetChunkFetcher(tm model.Time) *Fetcher
 
@@ -127,10 +127,10 @@ func (c compositeStore) Get(ctx context.Context, userID string, from, through mo
 }
 
 // LabelValuesForMetricName retrieves all label values for a single label name and metric name.
-func (c compositeStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (c compositeStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	var result UniqueStrings
 	err := c.forStores(ctx, userID, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
-		labelValues, err := store.LabelValuesForMetricName(innerCtx, userID, from, through, metricName, labelName)
+		labelValues, err := store.LabelValuesForMetricName(innerCtx, userID, from, through, metricName, labelName, matchers...)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/chunk/composite_store_test.go
+++ b/pkg/storage/chunk/composite_store_test.go
@@ -26,7 +26,7 @@ func (m mockStore) PutOne(ctx context.Context, from, through model.Time, chunk C
 func (m mockStore) Get(tx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
 	return nil, nil
 }
-func (m mockStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (m mockStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 
@@ -184,7 +184,7 @@ type mockStoreLabel struct {
 	values []string
 }
 
-func (m mockStoreLabel) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (m mockStoreLabel) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	return m.values, nil
 }
 

--- a/pkg/storage/chunk/inmemory_storage_client.go
+++ b/pkg/storage/chunk/inmemory_storage_client.go
@@ -186,7 +186,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	for _, req := range mockBatch.inserts {
 		table, ok := m.tables[req.tableName]
 		if !ok {
-			return fmt.Errorf("table not found")
+			return fmt.Errorf("table not found: %s", req.tableName)
 		}
 
 		// Check for duplicate writes by RangeKey in same batch
@@ -223,7 +223,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	for _, req := range mockBatch.deletes {
 		table, ok := m.tables[req.tableName]
 		if !ok {
-			return fmt.Errorf("table not found")
+			return fmt.Errorf("table not found: %s", req.tableName)
 		}
 
 		items := table.items[req.hashValue]
@@ -274,7 +274,7 @@ func (m *MockStorage) query(ctx context.Context, query IndexQuery, callback func
 
 	table, ok := m.tables[query.TableName]
 	if !ok {
-		return fmt.Errorf("table not found")
+		return fmt.Errorf("table not found: %s", query.TableName)
 	}
 
 	items, ok := table.items[query.HashValue]

--- a/pkg/storage/chunk/schema_caching_test.go
+++ b/pkg/storage/chunk/schema_caching_test.go
@@ -24,6 +24,7 @@ func TestCachingSchema(t *testing.T) {
 	baseTime = baseTime.Add(30*24*time.Hour - 1)
 
 	mtime.NowForce(baseTime)
+	defer mtime.NowReset()
 
 	for i, tc := range []struct {
 		from, through time.Time

--- a/pkg/storage/chunk/schema_util.go
+++ b/pkg/storage/chunk/schema_util.go
@@ -186,7 +186,7 @@ var componentsPool = sync.Pool{
 	},
 }
 
-// parseChunkTimeRangeValue returns the chunkID and labelValue for chunk time
+// parseChunkTimeRangeValue returns the chunkID (seriesID since v9) and labelValue for chunk time
 // range values.
 func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
 	chunkID string, labelValue model.LabelValue, err error,

--- a/pkg/storage/chunk/series_store.go
+++ b/pkg/storage/chunk/series_store.go
@@ -257,7 +257,6 @@ func (c *seriesStore) LabelValuesForMetricName(ctx context.Context, userID strin
 	}
 
 	// Fetch label values for label name that are part of the filtered chunks
-	var result UniqueStrings
 	queries, err := c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
 	if err != nil {
 		return nil, err
@@ -266,6 +265,8 @@ func (c *seriesStore) LabelValuesForMetricName(ctx context.Context, userID strin
 	if err != nil {
 		return nil, err
 	}
+
+	result := NewUniqueStrings(len(entries))
 	for _, entry := range entries {
 		seriesID, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {

--- a/pkg/storage/chunk/series_store.go
+++ b/pkg/storage/chunk/series_store.go
@@ -240,7 +240,6 @@ func (c *seriesStore) LabelValuesForMetricName(ctx context.Context, userID strin
 	} else if shortcut {
 		return nil, nil
 	}
-	level.Debug(log).Log("metric", metricName)
 
 	// Otherwise get series which include other matchers
 	seriesIDs, err := c.lookupSeriesByMetricNameMatchers(ctx, from, through, userID, metricName, matchers)

--- a/pkg/storage/chunk/series_store.go
+++ b/pkg/storage/chunk/series_store.go
@@ -226,6 +226,48 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string
 
 	return labelNames, nil
 }
+func (c *seriesStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) == 0 {
+		return c.baseStore.LabelValuesForMetricName(ctx, userID, from, through, metricName, labelName, matchers...)
+	}
+
+	// Otherwise get series which include other matchers
+	seriesIDs, err := c.lookupSeriesByMetricNameMatchers(ctx, from, through, userID, metricName, matchers)
+	if err != nil {
+		return nil, err
+	}
+	seriesIDsSet := make(map[string]struct{}, len(seriesIDs))
+	for _, i := range seriesIDs {
+		seriesIDsSet[i] = struct{}{}
+	}
+
+	contains := func(id string) bool {
+		_, ok := seriesIDsSet[id]
+		return ok
+	}
+
+	// Fetch label values for label name that are part of the filtered chunks
+	var result UniqueStrings
+	queries, err := c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := c.lookupEntriesByQueries(ctx, queries)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		seriesID, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		if err != nil {
+			return nil, err
+		}
+		if contains(seriesID) {
+			result.Add(string(labelValue))
+		}
+	}
+
+	return result.Strings(), nil
+}
 
 func (c *seriesStore) lookupLabelNamesByChunks(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupLabelNamesByChunks")

--- a/pkg/storage/chunk/series_store_test.go
+++ b/pkg/storage/chunk/series_store_test.go
@@ -3,14 +3,12 @@ package chunk
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/test"
 )
 
 func TestSeriesStore_LabelValuesForMetricName(t *testing.T) {
@@ -73,18 +71,12 @@ func TestSeriesStore_LabelValuesForMetricName(t *testing.T) {
 					// Query with ordinary time-range
 					labelValues1, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName, tc.labelName, tc.matchers...)
 					require.NoError(t, err)
-
-					if !reflect.DeepEqual(tc.expect, labelValues1) {
-						t.Fatalf("%s/%s: wrong label values - %s", tc.metricName, tc.labelName, test.Diff(tc.expect, labelValues1))
-					}
+					require.ElementsMatch(t, tc.expect, labelValues1)
 
 					// Pushing end of time-range into future should yield exact same resultset
 					labelValues2, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName, tc.matchers...)
 					require.NoError(t, err)
-
-					if !reflect.DeepEqual(tc.expect, labelValues2) {
-						t.Fatalf("%s/%s: wrong label values - %s", tc.metricName, tc.labelName, test.Diff(tc.expect, labelValues2))
-					}
+					require.ElementsMatch(t, tc.expect, labelValues2)
 				})
 			}
 		}

--- a/pkg/storage/chunk/series_store_test.go
+++ b/pkg/storage/chunk/series_store_test.go
@@ -1,0 +1,92 @@
+package chunk
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/test"
+)
+
+func TestSeriesStore_LabelValuesForMetricName(t *testing.T) {
+	ctx := context.Background()
+	now := model.Now()
+
+	fooMetric1 := labels.Labels{
+		{Name: labels.MetricName, Value: "foo"},
+		{Name: "bar", Value: "baz"},
+		{Name: "flip", Value: "flop"},
+		{Name: "toms", Value: "code"},
+		{Name: "env", Value: "dev"},
+		{Name: "class", Value: "not-secret"},
+	}
+	fooMetric2 := labels.Labels{
+		{Name: labels.MetricName, Value: "foo"},
+		{Name: "bar", Value: "beep"},
+		{Name: "toms", Value: "code"},
+		{Name: "env", Value: "prod"},
+		{Name: "class", Value: "secret"},
+	}
+
+	fooChunk1 := dummyChunkFor(now, fooMetric1)
+	fooChunk2 := dummyChunkFor(now, fooMetric2)
+
+	for _, tc := range []struct {
+		metricName, labelName string
+		expect                []string
+		matchers              []*labels.Matcher
+	}{
+		{
+			`foo`, `class`,
+			[]string{"not-secret"},
+			[]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")},
+		},
+		{
+			`foo`, `bar`,
+			[]string{"baz"},
+			[]*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "env", "prod"),
+				labels.MustNewMatcher(labels.MatchEqual, "toms", "code"),
+			},
+		},
+	} {
+		for _, schema := range seriesStoreSchemas {
+			for _, storeCase := range stores {
+				t.Run(fmt.Sprintf("%s / %s / %s / %s", tc.metricName, tc.labelName, schema, storeCase.name), func(t *testing.T) {
+					t.Log("========= Running labelValues with metricName", tc.metricName, "with labelName", tc.labelName, "with schema", schema)
+					storeCfg := storeCase.configFn()
+					store := newTestChunkStoreConfig(t, schema, storeCfg)
+					defer store.Stop()
+
+					if err := store.Put(ctx, []Chunk{
+						fooChunk1,
+						fooChunk2,
+					}); err != nil {
+						t.Fatal(err)
+					}
+
+					// Query with ordinary time-range
+					labelValues1, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName, tc.labelName, tc.matchers...)
+					require.NoError(t, err)
+
+					if !reflect.DeepEqual(tc.expect, labelValues1) {
+						t.Fatalf("%s/%s: wrong label values - %s", tc.metricName, tc.labelName, test.Diff(tc.expect, labelValues1))
+					}
+
+					// Pushing end of time-range into future should yield exact same resultset
+					labelValues2, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName, tc.matchers...)
+					require.NoError(t, err)
+
+					if !reflect.DeepEqual(tc.expect, labelValues2) {
+						t.Fatalf("%s/%s: wrong label values - %s", tc.metricName, tc.labelName, test.Diff(tc.expect, labelValues2))
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/storage/chunk/strings.go
+++ b/pkg/storage/chunk/strings.go
@@ -67,6 +67,11 @@ type UniqueStrings struct {
 	result []string
 }
 
+// NewUniqueStrings returns a UniqueStrings instance with a pre-allocated result buffer.
+func NewUniqueStrings(sizeHint int) UniqueStrings {
+	return UniqueStrings{result: make([]string, 0, sizeHint)}
+}
+
 // Add adds a new string, dropping duplicates.
 func (us *UniqueStrings) Add(strings ...string) {
 	for _, s := range strings {

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -169,7 +169,7 @@ func (m *mockChunkStore) PutOne(ctx context.Context, from, through model.Time, c
 	return nil
 }
 
-func (m *mockChunkStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (m *mockChunkStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases we want to fetch label values from a limited set of series. This can be done by passing label matchers for the series to the `LabelValuesForMetricName` method. The matchers are applied first to filter out all chunk ids that matcher all of them. Then we fetch all label values and filter out those that are part of the chunks.

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
