### PR TITLE
Add distributor ring page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [4938](https://github.com/grafana/loki/pull/4938) **DylanGuedes**: Implement ring status page for the distributor
 * [5023](https://github.com/grafana/loki/pull/5023) **ssncferreira**: Move `querier.split-queries-by-interval` to a per-tenant configuration
 * [4993](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix parent of wal and wal_cleaner in loki ruler config docs
 * [4933](https://github.com/grafana/loki/pull/4933) **jeschkies**: Support matchers in series label values query.

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -56,6 +56,7 @@ These endpoints are exposed by the querier and the frontend:
 While these endpoints are exposed by just the distributor:
 
 - [`POST /loki/api/v1/push`](#post-lokiapiv1push)
+- [`GET /distributor/ring`](#get-distributorring)
 
 And these endpoints are exposed by just the ingester:
 
@@ -81,6 +82,9 @@ These endpoints are exposed by the ruler:
 - [`DELETE /api/prom/rules/{namespace}`](#delete-namespace)
 - [`GET /prometheus/api/v1/rules`](#list-rules)
 - [`GET /prometheus/api/v1/alerts`](#list-alerts)
+
+These endpoints are exposed by the compactor:
+- [`GET /compactor/ring`](#get-compactorring)
 
 A [list of clients](../clients) can be found in the clients documentation.
 
@@ -798,6 +802,14 @@ This is helpful for scaling down WAL-enabled ingesters where we want to ensure o
 but instead flushed to our chunk backend.
 
 In microservices mode, the `/ingester/flush_shutdown` endpoint is exposed by the ingester.
+
+### `GET /distributor/ring`
+
+Displays a web page with the distributor hash ring status, including the state, healthy and last heartbeat time of each distributor.
+
+### `GET /compactor/ring`
+
+Displays a web page with the compactor hash ring status, including the state, healthy and last heartbeat time of each compactor.
 
 ## `GET /metrics`
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/limiter"
 	"github.com/grafana/dskit/ring"
 	ring_client "github.com/grafana/dskit/ring/client"
@@ -22,13 +23,12 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/pkg/distributor/clientpool"
-	"github.com/grafana/loki/pkg/tenant"
-
 	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/compactor/retention"
+	"github.com/grafana/loki/pkg/tenant"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/validation"
 )
@@ -63,7 +63,10 @@ type Distributor struct {
 
 	// The global rate limiter requires a distributors ring to count
 	// the number of healthy instances.
-	distributorsRing *ring.Lifecycler
+	distributorsRing       *ring.Ring
+	distributorsLifecycler *ring.Lifecycler
+
+	rateLimitStrat RateLimitStrat
 
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
@@ -94,19 +97,35 @@ func New(cfg Config, clientCfg client.Config, configs *runtime.TenantConfigs, in
 
 	// Create the configured ingestion rate limit strategy (local or global).
 	var ingestionRateStrategy limiter.RateLimiterStrategy
-	var distributorsRing *ring.Lifecycler
+	var distributorsLifecycler *ring.Lifecycler
+	var distributorsRing *ring.Ring
+	rateLimitStrat := LocalRateLimitStrat
 
 	var servs []services.Service
-
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {
-		var err error
-		distributorsRing, err = ring.NewLifecycler(cfg.DistributorRing.ToLifecyclerConfig(), nil, "distributor", ring.DistributorRingKey, false, util_log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", registerer))
+		rateLimitStrat = GlobalRateLimitStrat
+		ringStore, err := kv.NewClient(
+			cfg.DistributorRing.KVStore,
+			ring.GetCodec(),
+			kv.RegistererWithKVName(prometheus.WrapRegistererWithPrefix("loki_", registerer), "distributor"),
+			util_log.Logger)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "create distributor KV store client")
 		}
 
-		servs = append(servs, distributorsRing)
-		ingestionRateStrategy = newGlobalIngestionRateStrategy(overrides, distributorsRing)
+		distributorsLifecycler, err = ring.NewLifecycler(cfg.DistributorRing.ToLifecyclerConfig(), nil, "distributor", ring.DistributorRingKey, false, util_log.Logger, prometheus.WrapRegistererWithPrefix("cortex_", registerer))
+		if err != nil {
+			return nil, errors.Wrap(err, "create distributor lifecycler")
+		}
+
+		distributorsRing, err = ring.NewWithStoreClientAndStrategy(cfg.DistributorRing.ToRingConfig(),
+			"distributor", "distributor", ringStore, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), prometheus.WrapRegistererWithPrefix("cortex_", registerer), util_log.Logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "create distributor ring client")
+		}
+
+		servs = append(servs, distributorsLifecycler, distributorsRing)
+		ingestionRateStrategy = newGlobalIngestionRateStrategy(overrides, distributorsLifecycler)
 	} else {
 		ingestionRateStrategy = newLocalIngestionRateStrategy(overrides)
 	}
@@ -116,16 +135,18 @@ func New(cfg Config, clientCfg client.Config, configs *runtime.TenantConfigs, in
 		return nil, err
 	}
 	d := Distributor{
-		cfg:                  cfg,
-		clientCfg:            clientCfg,
-		tenantConfigs:        configs,
-		tenantsRetention:     retention.NewTenantsRetention(overrides),
-		ingestersRing:        ingestersRing,
-		distributorsRing:     distributorsRing,
-		validator:            validator,
-		pool:                 clientpool.NewPool(clientCfg.PoolConfig, ingestersRing, factory, util_log.Logger),
-		ingestionRateLimiter: limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
-		labelCache:           labelCache,
+		cfg:                    cfg,
+		clientCfg:              clientCfg,
+		tenantConfigs:          configs,
+		tenantsRetention:       retention.NewTenantsRetention(overrides),
+		ingestersRing:          ingestersRing,
+		distributorsRing:       distributorsRing,
+		distributorsLifecycler: distributorsLifecycler,
+		validator:              validator,
+		pool:                   clientpool.NewPool(clientCfg.PoolConfig, ingestersRing, factory, util_log.Logger),
+		ingestionRateLimiter:   limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
+		labelCache:             labelCache,
+		rateLimitStrat:         rateLimitStrat,
 		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",
 			Name:      "distributor_ingester_appends_total",

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -66,7 +66,7 @@ type Distributor struct {
 	distributorsRing       *ring.Ring
 	distributorsLifecycler *ring.Lifecycler
 
-	rateLimitStrat RateLimitStrat
+	rateLimitStrat string
 
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
@@ -99,11 +99,11 @@ func New(cfg Config, clientCfg client.Config, configs *runtime.TenantConfigs, in
 	var ingestionRateStrategy limiter.RateLimiterStrategy
 	var distributorsLifecycler *ring.Lifecycler
 	var distributorsRing *ring.Ring
-	rateLimitStrat := LocalRateLimitStrat
+	rateLimitStrat := validation.LocalIngestionRateStrategy
 
 	var servs []services.Service
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {
-		rateLimitStrat = GlobalRateLimitStrat
+		rateLimitStrat = validation.GlobalIngestionRateStrategy
 		ringStore, err := kv.NewClient(
 			cfg.DistributorRing.KVStore,
 			ring.GetCodec(),

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -339,6 +339,7 @@ func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory
 	distributorConfig.DistributorRing.HeartbeatPeriod = 100 * time.Millisecond
 	distributorConfig.DistributorRing.InstanceID = strconv.Itoa(rand.Int())
 	distributorConfig.DistributorRing.KVStore.Mock = kvStore
+	distributorConfig.DistributorRing.KVStore.Store = "inmemory"
 	distributorConfig.DistributorRing.InstanceInterfaceNames = []string{loopbackName}
 	distributorConfig.factory = factory
 	if factory == nil {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -287,7 +287,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			// updates to the expected size
 			if distributors[0].distributorsRing != nil {
 				test.Poll(t, time.Second, testData.distributors, func() interface{} {
-					return distributors[0].distributorsRing.HealthyInstancesCount()
+					return distributors[0].distributorsLifecycler.HealthyInstancesCount()
 				})
 			}
 

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -4,10 +4,11 @@ import (
 	"net/http"
 	"strings"
 
-	cortex_util "github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log/level"
 	"github.com/weaveworks/common/httpgrpc"
+
+	"github.com/grafana/loki/pkg/util"
 
 	"github.com/grafana/loki/pkg/loghttp/push"
 	"github.com/grafana/loki/pkg/tenant"
@@ -99,5 +100,5 @@ func (d *Distributor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					<p>Not running with Global Rating Limit - ring not being used by the Distributor.</p>
 				</body>
 			</html>`
-	cortex_util.WriteHTMLResponse(w, noRingPage)
+	util.WriteHTMLResponse(w, noRingPage)
 }

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/loki/pkg/loghttp/push"
 	"github.com/grafana/loki/pkg/tenant"
 	serverutil "github.com/grafana/loki/pkg/util/server"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 // PushHandler reads a snappy-compressed proto from the HTTP body.
@@ -81,7 +82,7 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 // If the rate limiting strategy is local instead of global, no ring is used by
 // the distributor and as such, no ring status is returned from this function.
 func (d *Distributor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if d.rateLimitStrat == GlobalRateLimitStrat {
+	if d.rateLimitStrat == validation.GlobalIngestionRateStrategy {
 		d.distributorsRing.ServeHTTP(w, r)
 		return
 	}

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -1,1 +1,58 @@
 package distributor
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/pkg/validation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistributorRingHandler(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+
+	runServer := func() *httptest.Server {
+		d := prepare(t, limits, nil, nil)
+		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
+
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			d.ServeHTTP(w, r)
+		}))
+	}
+
+	t.Run("renders ring status for global rate limiting", func(t *testing.T) {
+		limits.IngestionRateStrategy = validation.GlobalIngestionRateStrategy
+		svr := runServer()
+		defer svr.Close()
+
+		resp, err := svr.Client().Get(svr.URL)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "<th>Instance ID</th>")
+		require.NotContains(t, string(body), "Not running with Global Rating Limit - ring not being used by the Distributor")
+	})
+
+	t.Run("doesn't return ring status for local rate limiting", func(t *testing.T) {
+		limits.IngestionRateStrategy = validation.LocalIngestionRateStrategy
+		svr := runServer()
+		defer svr.Close()
+
+		resp, err := svr.Client().Get(svr.URL)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "Not running with Global Rating Limit - ring not being used by the Distributor")
+		require.NotContains(t, string(body), "<th>Instance ID</th>")
+	})
+}

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/loki/pkg/validation"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/validation"
 )
 
 func TestDistributorRingHandler(t *testing.T) {

--- a/pkg/distributor/ingestion_rate_strategy.go
+++ b/pkg/distributor/ingestion_rate_strategy.go
@@ -6,30 +6,6 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 )
 
-// RateLimitStrat represents a rate limiting strategy to be followed by the distributor
-// regarding when to discard received input.
-//
-// As of now, only two strategies are supported: local, where the ingestion rate limit should is
-// applied individually to each distributor instance, and global, where the ingestion rate limit
-// is shared across the cluster. The ingestion rate strategy cannot be overridden on a per-tenant basis.
-type RateLimitStrat int64
-
-const (
-	// GlobalRateLimitStrat represents a ingestion rate limiting strategy that enforces the rate
-	// limiting globally, configuring a per-distributor local rate limiter as "ingestion_rate / N",
-	// where N is the number of distributor replicas (it's automatically adjusted if the
-	// number of replicas change).
-	//
-	// The global strategy requires the distributors to form their own ring, which
-	// is used to keep track of the current number of healthy distributor replicas.
-	GlobalRateLimitStrat RateLimitStrat = iota
-
-	// LocalRateLimitStrat represents a ingestion rate limiting strategy that enforces the limit
-	// on a per distributor basis. The actual effective rate limit will be N times higher, where
-	// N is the number of distributor replicas.
-	LocalRateLimitStrat
-)
-
 // ReadLifecycler represents the read interface to the lifecycler.
 type ReadLifecycler interface {
 	HealthyInstancesCount() int

--- a/pkg/distributor/ingestion_rate_strategy.go
+++ b/pkg/distributor/ingestion_rate_strategy.go
@@ -6,6 +6,30 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 )
 
+// RateLimitStrat represents a rate limiting strategy to be followed by the distributor
+// regarding when to discard received input.
+//
+// As of now, only two strategies are supported: local, where the ingestion rate limit should is
+// applied individually to each distributor instance, and global, where the ingestion rate limit
+// is shared across the cluster. The ingestion rate strategy cannot be overridden on a per-tenant basis.
+type RateLimitStrat int64
+
+const (
+	// GlobalRateLimitStrat represents a ingestion rate limiting strategy that enforces the rate
+	// limiting globally, configuring a per-distributor local rate limiter as "ingestion_rate / N",
+	// where N is the number of distributor replicas (it's automatically adjusted if the
+	// number of replicas change).
+	//
+	// The global strategy requires the distributors to form their own ring, which
+	// is used to keep track of the current number of healthy distributor replicas.
+	GlobalRateLimitStrat RateLimitStrat = iota
+
+	// LocalRateLimitStrat represents a ingestion rate limiting strategy that enforces the limit
+	// on a per distributor basis. The actual effective rate limit will be N times higher, where
+	// N is the number of distributor replicas.
+	LocalRateLimitStrat
+)
+
 // ReadLifecycler represents the read interface to the lifecycler.
 type ReadLifecycler interface {
 	HealthyInstancesCount() int

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -205,6 +205,8 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		t.HTTPAuthMiddleware,
 	).Wrap(http.HandlerFunc(t.distributor.PushHandler))
 
+	t.Server.HTTP.Path("/distributor/ring").Methods("GET").Handler(t.distributor)
+
 	t.Server.HTTP.Path("/api/prom/push").Methods("POST").Handler(pushHandler)
 	t.Server.HTTP.Path("/loki/api/v1/push").Methods("POST").Handler(pushHandler)
 	return t.distributor, nil

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,11 @@
+package util
+
+import "net/http"
+
+// Sends message as text/html response with 200 status code.
+func WriteHTMLResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/html")
+
+	// Ignore inactionable errors.
+	_, _ = w.Write([]byte(message))
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -19,10 +19,19 @@ import (
 )
 
 const (
-	// Local ingestion rate strategy
+	// LocalRateLimitStrat represents a ingestion rate limiting strategy that enforces the limit
+	// on a per distributor basis.
+	//
+	// The actual effective rate limit will be N times higher, where N is the number of distributor replicas.
 	LocalIngestionRateStrategy = "local"
 
-	// Global ingestion rate strategy
+	// GlobalRateLimitStrat represents a ingestion rate limiting strategy that enforces the rate
+	// limiting globally, configuring a per-distributor local rate limiter as "ingestion_rate / N",
+	// where N is the number of distributor replicas (it's automatically adjusted if the
+	// number of replicas change).
+	//
+	// The global strategy requires the distributors to form their own ring, which
+	// is used to keep track of the current number of healthy distributor replicas.
 	GlobalIngestionRateStrategy = "global"
 
 	bytesInMB = 1048576


### PR DESCRIPTION
**What this PR does / why we need it**:
- Inside the distributor implementation, rename `distributorsRing` to `distributorsLifecycler` to avoid mislead
- Add a ring instance to the distributor
- Implement a /distributor/ring page, served by the new ring instance

**Which issue(s) this PR fixes**:
Fixes #4937

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
