### PR TITLE
Support Redis Cluster Configuration Endpoint

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1757,7 +1757,7 @@ memcached_client:
   [consistent_hash: <bool>]
 
 redis:
-  # Redis Server endpoint to use for caching. A comma-separated list of endpoints
+  # Redis Server or Cluster configuration endpoint to use for caching. A comma-separated list of endpoints
   # for Redis Cluster or Redis Sentinel. If empty, no redis will be used.
   # CLI flag: -<prefix>.redis.endpoint
   [endpoint: <string>]

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -113,7 +114,11 @@ func New(cfg Config, reg prometheus.Registerer, logger log.Logger) (Cache, error
 			cfg.Redis.Expiration = cfg.DefaultValidity
 		}
 		cacheName := cfg.Prefix + "redis"
-		cache := NewRedisCache(cacheName, NewRedisClient(&cfg.Redis), logger)
+		client, err := NewRedisClient(&cfg.Redis)
+		if err != nil {
+			return nil, fmt.Errorf("redis client setup failed: %w", err)
+		}
+		cache := NewRedisCache(cacheName, client, logger)
 		caches = append(caches, NewBackground(cacheName, cfg.Background, Instrument(cacheName, cache, reg), reg))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The go-redis options requires multiple redis addresses for a cluster.
In some scenarios like AWS ElastiCache, a single configuration endpoint is used to resolve all cluster nodes.

This change adds an extra step to resolve all nodes and pass them to go-redis.
It removes the need to specify multiple cluster nodes in the configuration.

Signed-off-by: Siavash Safi <siavash.safi@gmail.com>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
No tests were added for this scenario since it requires patching the Go resolver during runtime.
But let me know if you have a suggestion.
Same change for Cortex https://github.com/cortexproject/cortex/pull/4590

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
