### PR TITLE
Loki: Implement common net interface/instance addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Main
 
+* [4950](https://github.com/grafana/loki/pull/4950) **DylanGuedes**: Implement common instance addr/net interface
 * [4949](https://github.com/grafana/loki/pull/4949) **ssncferreira**: Add query `queueTime` metric to statistics and metrics.go
 * [4938](https://github.com/grafana/loki/pull/4938) **DylanGuedes**: Implement ring status page for the distributor
 * [5023](https://github.com/grafana/loki/pull/5023) **ssncferreira**: Move `querier.split-queries-by-interval` to a per-tenant configuration
 * [4993](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix parent of wal and wal_cleaner in loki ruler config docs
 * [4933](https://github.com/grafana/loki/pull/4933) **jeschkies**: Support matchers in series label values query.
+* [4944](https://github.com/grafana/loki/pull/4944) **kavirajk**: Move cortex/pkg/tenant dependency to Loki
 * [4926](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix comment in Loki module loading for accuracy
 * [4920](https://github.com/grafana/loki/pull/4920) **chaudum**: Add `-list-targets` command line flag to list all available run targets
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * [5023](https://github.com/grafana/loki/pull/5023) **ssncferreira**: Move `querier.split-queries-by-interval` to a per-tenant configuration
 * [4993](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix parent of wal and wal_cleaner in loki ruler config docs
 * [4933](https://github.com/grafana/loki/pull/4933) **jeschkies**: Support matchers in series label values query.
-* [4944](https://github.com/grafana/loki/pull/4944) **kavirajk**: Move cortex/pkg/tenant dependency to Loki
 * [4926](https://github.com/grafana/loki/pull/4926) **thejosephstevens**: Fix comment in Loki module loading for accuracy
 * [4920](https://github.com/grafana/loki/pull/4920) **chaudum**: Add `-list-targets` command line flag to list all available run targets
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2371,6 +2371,19 @@ This way, one doesn't have to replicate configuration in multiple places.
 # and path_prefix is empty.
 [persist_tokens: <boolean>: default = false]
 
+# A common list of net interfaces used internally to look for addresses.
+# If a more specific "instance_interface_names" is set, this is ignored.
+# If "instance_interface_names" under the common ring section is configured,
+# this common "instance_interface_names" is only applied to the frontend, but not for
+# ring related components (ex: distributor, ruler, etc).
+[instance_interface_names: <list of string>]
+
+# A common address used by Loki components to advertise their address.
+# If a more specific "instance_addr" is set, this is ignored.
+# If "instance_addr" under the common ring section is configured, this common "instance_addr"
+# is only applied to the frontend, but not for ring related components (ex: distributor, ruler, etc).
+[instance_addr: <string>]
+
 # A common ring configuration to be used by all Loki rings.
 # If a common ring is given, its values are used to define any undefined ring values.
 # For instance, you can expect the `heartbeat_period` defined in the common section

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -31,7 +31,9 @@ type Config struct {
 
 	// InstanceAddr represents a common ip used by instances to advertise their address.
 	//
-	// For instance, the different Loki rings will use this
+	// For instance, the different Loki rings will have this stored in its key-value store to be later retrieved by other components.
+	// You can check this during Loki execution under ring status pages (ex: `/ring` will output the address of the different ingester
+	// instances).
 	InstanceAddr string `yaml:"instance_addr"`
 }
 

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"flag"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/loki/pkg/storage/chunk/aws"
 	"github.com/grafana/loki/pkg/storage/chunk/azure"
 	"github.com/grafana/loki/pkg/storage/chunk/gcp"
@@ -11,13 +12,26 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
-// Config holds common config that can be shared between multiple other config sections
+// Config holds common config that can be shared between multiple other config sections.
+//
+// Values defined under this common configuration are supersede if a more specific value is defined.
 type Config struct {
 	PathPrefix        string          `yaml:"path_prefix"`
 	Storage           Storage         `yaml:"storage"`
 	PersistTokens     bool            `yaml:"persist_tokens"`
 	ReplicationFactor int             `yaml:"replication_factor"`
 	Ring              util.RingConfig `yaml:"ring"`
+
+	// InstanceInterfaceNames represents a common list of net interfaces used to look for host addresses.
+	//
+	// Internally, addresses will be resolved in the order that this is configured.
+	// By default, the list of used interfaces are, in order: "eth0", "en0", and your loopback net interface (probably "lo").
+	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
+
+	// InstanceAddr represents a common ip used by instances to advertise their address.
+	//
+	// For instance, the different Loki rings will use this
+	InstanceAddr string `yaml:"instance_addr"`
 }
 
 func (c *Config) RegisterFlags(_ *flag.FlagSet) {
@@ -25,6 +39,11 @@ func (c *Config) RegisterFlags(_ *flag.FlagSet) {
 	throwaway.IntVar(&c.ReplicationFactor, "common.replication-factor", 3, "How many ingesters incoming data should be replicated to.")
 	c.Storage.RegisterFlagsWithPrefix("common.storage", throwaway)
 	c.Ring.RegisterFlagsWithPrefix("", "collectors/", throwaway)
+
+	// instance related flags.
+	c.InstanceInterfaceNames = []string{"eth0", "en0"}
+	throwaway.StringVar(&c.InstanceAddr, "common.instance-addr", "127.0.0.1", "Default advertised address to be used by Loki components.")
+	throwaway.Var((*flagext.StringSlice)(&c.InstanceInterfaceNames), "common.instance-interface-names", "List of network interfaces to read address from.")
 }
 
 type Storage struct {

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/grafana/dskit/flagext"
+
 	"github.com/grafana/loki/pkg/storage/chunk/aws"
 	"github.com/grafana/loki/pkg/storage/chunk/azure"
 	"github.com/grafana/loki/pkg/storage/chunk/gcp"

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -43,7 +43,7 @@ func (c *Config) RegisterFlags(_ *flag.FlagSet) {
 
 	// instance related flags.
 	c.InstanceInterfaceNames = []string{"eth0", "en0"}
-	throwaway.StringVar(&c.InstanceAddr, "common.instance-addr", "127.0.0.1", "Default advertised address to be used by Loki components.")
+	throwaway.StringVar(&c.InstanceAddr, "common.instance-addr", "", "Default advertised address to be used by Loki components.")
 	throwaway.Var((*flagext.StringSlice)(&c.InstanceInterfaceNames), "common.instance-interface-names", "List of network interfaces to read address from.")
 }
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -85,6 +85,8 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 
 		applyPathPrefixDefaults(r, &defaults)
 
+		applyInstanceConfigs(r, &defaults)
+
 		applyDynamicRingConfigs(r, &defaults)
 
 		appendLoopbackInterface(r, &defaults)
@@ -107,6 +109,35 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 		applyChunkRetain(r, &defaults)
 
 		return nil
+	}
+}
+
+// applyInstanceConfigs apply to Loki components instance-related configurations under the common
+// config section.
+//
+// The list of components making usage of these instance-related configurations are: compactor's ring,
+// ruler's ring, distributor's ring, ingester's ring, query scheduler's ring, and the query frontend.
+//
+// The list of implement common configurations are:
+// - "instance-addr", the address advertised to be used by other components.
+// - "instance-interface-names", a list of net interfaces used when looking for addresses.
+func applyInstanceConfigs(r, defaults *ConfigWrapper) {
+	if !reflect.DeepEqual(r.Common.InstanceAddr, defaults.Common.InstanceAddr) {
+		r.Ingester.LifecyclerConfig.Addr = r.Common.InstanceAddr
+		r.CompactorConfig.CompactorRing.InstanceAddr = r.Common.InstanceAddr
+		r.Distributor.DistributorRing.InstanceAddr = r.Common.InstanceAddr
+		r.Ruler.Ring.InstanceAddr = r.Common.InstanceAddr
+		r.QueryScheduler.SchedulerRing.InstanceAddr = r.Common.InstanceAddr
+		r.Frontend.FrontendV2.Addr = r.Common.InstanceAddr
+	}
+
+	if !reflect.DeepEqual(r.Common.InstanceInterfaceNames, defaults.Common.InstanceInterfaceNames) {
+		r.Ingester.LifecyclerConfig.InfNames = r.Common.InstanceInterfaceNames
+		r.CompactorConfig.CompactorRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		r.Distributor.DistributorRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		r.Ruler.Ring.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		r.QueryScheduler.SchedulerRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		r.Frontend.FrontendV2.InfNames = r.Common.InstanceInterfaceNames
 	}
 }
 

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -45,7 +45,7 @@ type Config struct {
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.SchedulerAddress, "frontend.scheduler-address", "", "DNS hostname used for finding query-schedulers.")
-	f.DurationVar(&cfg.DNSLookupPeriod, "frontend.scheduler-dns-lookup-period", 10*time.Second, "How often to resolve the scheduler-address, in order to look for new query-scheduler instances.  Also used to determine how often to poll the scheduler-ring for addresses if the scheduler-ring is configured.")
+	f.DurationVar(&cfg.DNSLookupPeriod, "frontend.scheduler-dns-lookup-period", 10*time.Second, "How often to resolve the scheduler-address, in order to look for new query-scheduler instances. Also used to determine how often to poll the scheduler-ring for addresses if the scheduler-ring is configured.")
 	f.IntVar(&cfg.WorkerConcurrency, "frontend.scheduler-worker-concurrency", 5, "Number of concurrent workers forwarding queries to single query-scheduler.")
 
 	cfg.InfNames = []string{"eth0", "en0"}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add two new common configurations:
  - `instance_interface_names`, a common net interface used by components internally to look for addresses. The list order matters, as components internally iterate over the list until they find a valid address. If the common ring section specifies an `instance_interface_names`, this configuration is only applied to the frontend but not to other components.
  -  `instance_addr`, a common instance address used by components to advertise their address. Again, if the common ring section specifies an `instance_addr`, this configuration is only applied to the frontend (since it is not a ring) but not to other components.

**Which issue(s) this PR fixes**:
Fixes #4897 

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
