### PR TITLE
Use private network interfaces as default for ring and frontend

### DIFF
--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/opentracing/opentracing-go"
@@ -48,7 +49,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.DNSLookupPeriod, "frontend.scheduler-dns-lookup-period", 10*time.Second, "How often to resolve the scheduler-address, in order to look for new query-scheduler instances.  Also used to determine how often to poll the scheduler-ring for addresses if the scheduler-ring is configured.")
 	f.IntVar(&cfg.WorkerConcurrency, "frontend.scheduler-worker-concurrency", 5, "Number of concurrent workers forwarding queries to single query-scheduler.")
 
-	cfg.InfNames = []string{"eth0", "en0"}
+	cfg.InfNames = netutil.PrivateNetworkInterfaces()
 	f.Var((*flagext.StringSlice)(&cfg.InfNames), "frontend.instance-interface-names", "Name of network interface to read address from. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend.")
 	f.StringVar(&cfg.Addr, "frontend.instance-addr", "", "IP address to advertise to querier (via scheduler) (resolved via interfaces by default).")
 	f.IntVar(&cfg.Port, "frontend.instance-port", 0, "Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).")

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/grafana/dskit/ring"
@@ -57,7 +58,7 @@ func (cfg *RingConfig) RegisterFlagsWithPrefix(flagsPrefix, storePrefix string, 
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, flagsPrefix+"ring.zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones.")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfaces()
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), flagsPrefix+"ring.instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, flagsPrefix+"ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, flagsPrefix+"ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/vendor/github.com/cortexproject/cortex/pkg/distributor/distributor_ring.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/distributor/distributor_ring.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -46,7 +47,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeartbeatTimeout, "distributor.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled).")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfaces()
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "distributor.ring.instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, "distributor.ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, "distributor.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/vendor/github.com/cortexproject/cortex/pkg/storegateway/gateway_ring.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/storegateway/gateway_ring.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -106,7 +107,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the store-gateway ring keeps changing after this period of time, the store-gateway will start anyway.")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfaces()
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), ringFlagsPrefix+"instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, ringFlagsPrefix+"instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, ringFlagsPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/vendor/github.com/grafana/dskit/netutil/interfaces.go
+++ b/vendor/github.com/grafana/dskit/netutil/interfaces.go
@@ -1,0 +1,108 @@
+package netutil
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func ipForAddr(addr net.Addr) (net.IP, bool) {
+	switch a := addr.(type) {
+	case *net.IPAddr:
+		return a.IP, true
+	case *net.IPNet:
+		return a.IP, true
+	default:
+		return net.IPv4zero, false
+	}
+}
+
+func PrivateNetworkInterfaces() []string {
+	ifaces := []string{}
+
+	all, err := net.Interfaces()
+	if err != nil {
+		return ifaces
+	}
+
+IFACES:
+	for _, iface := range all {
+		if iface.Flags&net.FlagLoopback == 0 && iface.Flags&net.FlagUp != 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, addr := range addrs {
+				ip, ok := ipForAddr(addr)
+				if !ok {
+					continue
+				}
+				if !ip.IsPrivate() {
+					continue IFACES
+				}
+			}
+			ifaces = append(ifaces, iface.Name)
+		}
+	}
+	return ifaces
+}
+
+// FirstAddressOf returns the first IPv4 address of the supplied interface
+// names, omitting any 169.254.x.x automatic private IPs if possible.
+func FirstAddressOf(names []string, logger log.Logger) (string, error) {
+	var ipAddr net.IP
+	for _, name := range names {
+		inf, err := net.InterfaceByName(name)
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting interface", "inf", name, "err", err)
+			continue
+		}
+		addrs, err := inf.Addrs()
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
+			continue
+		}
+		if len(addrs) <= 0 {
+			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
+			continue
+		}
+		if ip := filterIPs(addrs); !ip.IsUnspecified() {
+			ipAddr = ip
+		}
+		if isAPIPA(ipAddr) || ipAddr.IsUnspecified() {
+			continue
+		}
+		return ipAddr.String(), nil
+	}
+	if ipAddr.IsUnspecified() {
+		return "", fmt.Errorf("no address found for %s", names)
+	}
+	if isAPIPA(ipAddr) {
+		level.Warn(logger).Log("msg", "using automatic private ip", "address", ipAddr)
+	}
+	return ipAddr.String(), nil
+}
+
+func isAPIPA(ip4 net.IP) bool {
+	return ip4[0] == 169 && ip4[1] == 254
+}
+
+// filterIPs attempts to return the first non automatic private IP (APIPA /
+// 169.254.x.x) if possible, only returning APIPA if available and no other
+// valid IP is found.
+func filterIPs(addrs []net.Addr) net.IP {
+	ipAddr := net.IPv4zero
+	for _, addr := range addrs {
+		if ip, ok := ipForAddr(addr); ok {
+			if ip4 := ip.To4(); ip4 != nil {
+				ipAddr = ip4
+				if isAPIPA(ip4) {
+					return ipAddr
+				}
+			}
+		}
+	}
+	return ipAddr
+}

--- a/vendor/github.com/grafana/dskit/ring/util.go
+++ b/vendor/github.com/grafana/dskit/ring/util.go
@@ -2,17 +2,14 @@ package ring
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"net"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/netutil"
 )
 
 // GenerateTokens make numTokens unique random tokens, none of which clash
@@ -55,7 +52,7 @@ func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logge
 		return configAddr, nil
 	}
 
-	addr, err := getFirstAddressOf(netInterfaces, logger)
+	addr, err := netutil.FirstAddressOf(netInterfaces, logger)
 	if err != nil {
 		return "", err
 	}
@@ -157,55 +154,4 @@ func searchToken(tokens []uint32, key uint32) int {
 		i = 0
 	}
 	return i
-}
-
-// GetFirstAddressOf returns the first IPv4 address of the supplied interface names, omitting any 169.254.x.x automatic private IPs if possible.
-func getFirstAddressOf(names []string, logger log.Logger) (string, error) {
-	var ipAddr string
-	for _, name := range names {
-		inf, err := net.InterfaceByName(name)
-		if err != nil {
-			level.Warn(logger).Log("msg", "error getting interface", "inf", name, "err", err)
-			continue
-		}
-		addrs, err := inf.Addrs()
-		if err != nil {
-			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
-			continue
-		}
-		if len(addrs) <= 0 {
-			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
-			continue
-		}
-		if ip := filterIPs(addrs); ip != "" {
-			ipAddr = ip
-		}
-		if strings.HasPrefix(ipAddr, `169.254.`) || ipAddr == "" {
-			continue
-		}
-		return ipAddr, nil
-	}
-	if ipAddr == "" {
-		return "", fmt.Errorf("No address found for %s", names)
-	}
-	if strings.HasPrefix(ipAddr, `169.254.`) {
-		level.Warn(logger).Log("msg", "using automatic private ip", "address", ipAddr)
-	}
-	return ipAddr, nil
-}
-
-// filterIPs attempts to return the first non automatic private IP (APIPA / 169.254.x.x) if possible, only returning APIPA if available and no other valid IP is found.
-func filterIPs(addrs []net.Addr) string {
-	var ipAddr string
-	for _, addr := range addrs {
-		if v, ok := addr.(*net.IPNet); ok {
-			if ip := v.IP.To4(); ip != nil {
-				ipAddr = v.IP.String()
-				if !strings.HasPrefix(ipAddr, `169.254.`) {
-					return ipAddr
-				}
-			}
-		}
-	}
-	return ipAddr
 }


### PR DESCRIPTION
_Proof of concept for using private network interfaces as default for ring configurations._

**What this PR does / why we need it**:

At the moment, the default network interfaces for the ring configurations are `eth0` and `en0`, which works for probably everyone running Loki inside Docker.
However, if you run the Loki binary directly (which is a valid first use-case for Loki), it is very likely that Loki won't start because the primary network interface has a different name.

- https://github.com/grafana/loki/issues/4948

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
