### PR TITLE
Provide saner defaults for loki-operator reconciled config

### DIFF
--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -34,7 +34,7 @@ ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
   chunk_idle_period: 1h
-  chunk_retain_period: 30s
+  chunk_retain_period: 5m
   chunk_target_size: 1048576
   lifecycler:
     final_sleep: 0s
@@ -250,7 +250,7 @@ ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
   chunk_idle_period: 1h
-  chunk_retain_period: 30s
+  chunk_retain_period: 5m
   chunk_target_size: 1048576
   lifecycler:
     final_sleep: 0s

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -116,7 +116,7 @@ query_range:
       fifocache:
         max_size_bytes: 500MB
   split_queries_by_interval: 30m
-  parallelise_shardable_queries: false
+  parallelise_shardable_queries: true
 schema_config:
   configs:
     - from: "2020-10-01"
@@ -332,7 +332,7 @@ query_range:
       fifocache:
         max_size_bytes: 500MB
   split_queries_by_interval: 30m
-  parallelise_shardable_queries: false
+  parallelise_shardable_queries: true
 schema_config:
   configs:
     - from: "2020-10-01"

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -105,7 +105,7 @@ query_range:
       fifocache:
         max_size_bytes: 500MB
   split_queries_by_interval: 30m
-  parallelise_shardable_queries: false
+  parallelise_shardable_queries: true
 schema_config:
   configs:
     - from: "2020-10-01"

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -23,7 +23,7 @@ ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
   chunk_idle_period: 1h
-  chunk_retain_period: 30s
+  chunk_retain_period: 5m
   chunk_target_size: 1048576
   lifecycler:
     final_sleep: 0s


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a set of loki configuration defaults reconciled by the operator:
- `chunk_retain_period: 5m`
- `parallelise_shardable_queries: true`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
