### PR TITLE
Fix operator images actions for bundle and calculator

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -88,7 +88,7 @@ jobs:
        uses: docker/build-push-action@v2
        with:
          context: ./operator
-         file: bundle.Dockerfile
+         file: ./operator/bundle.Dockerfile
          push: true
          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 
@@ -127,6 +127,6 @@ jobs:
        uses: docker/build-push-action@v2
        with:
          context: ./operator
-         file: calculator.Dockerfile
+         file: ./operator/calculator.Dockerfile
          push: true
          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a correct configuration for operator image GH action jobs that use a custom dockerfile, i.e. operator bundle and storage-size-calculator. It prependes the `./operator` directory path to access the corresponding `bundle.Dockerfile` and `calculator.Dockerfile`.
