### PR TITLE
Provide saner default for loki-operator managed chunk_target_size

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Main
+
+- [4975](https://github.com/grafana/loki/pull/4975) **periklis**: Provide saner default for loki-operator managed chunk_target_size

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -35,7 +35,7 @@ ingester:
   chunk_encoding: snappy
   chunk_idle_period: 1h
   chunk_retain_period: 5m
-  chunk_target_size: 1048576
+  chunk_target_size: 2097152
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
@@ -251,7 +251,7 @@ ingester:
   chunk_encoding: snappy
   chunk_idle_period: 1h
   chunk_retain_period: 5m
-  chunk_target_size: 1048576
+  chunk_target_size: 2097152
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -24,7 +24,7 @@ ingester:
   chunk_encoding: snappy
   chunk_idle_period: 1h
   chunk_retain_period: 5m
-  chunk_target_size: 1048576
+  chunk_target_size: 2097152
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a saner default for `chunk_target_size`, effectively doubling the original value from `1048576` to `2097152` as suggested here: https://github.com/grafana/loki/pull/4881#discussion_r770301044

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
