### PR TITLE
Set loki-image-cross with build platform amd64 for arm64 architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,10 +504,14 @@ promtail-push: promtail-image-cross
 	$(call push-image,promtail)
 
 # loki
+# Set docker platform linux/amd64 for arm64 processors architecture
+ifeq ($(shell uname -p),arm)
+BUILD_PLATFORM=--platform=linux/amd64
+endif
 loki-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile .
 loki-image-cross:
-	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
+	$(SUDO) $(BUILD_OCI) $(BUILD_PLATFORM) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
 
 loki-debug-image: OCI_PLATFORMS=
 loki-debug-image:

--- a/Makefile
+++ b/Makefile
@@ -504,14 +504,13 @@ promtail-push: promtail-image-cross
 	$(call push-image,promtail)
 
 # loki
-# Set docker platform linux/amd64 for arm64 processors architecture
-ifeq ($(shell uname -p),arm)
-BUILD_PLATFORM=--platform=linux/amd64
-endif
+BUILD_PLATFORM ?= amd64
 loki-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile .
 loki-image-cross:
-	$(SUDO) $(BUILD_OCI) $(BUILD_PLATFORM) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
+	@echo "make loki-image-cross builds a docker image for a different processor architecture than the one from the host machine (default is linux/amd64)."
+	@echo "If you want to build for a different architecture set BUILD_PLATFORM. For arm64 (Raspberry Pi or Apple Silicon), run 'BUILD_PLATFORM=arm64 make loki-image-cross'"
+	$(SUDO) $(BUILD_OCI) --platform=linux/$(BUILD_PLATFORM) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
 
 loki-debug-image: OCI_PLATFORMS=
 loki-debug-image:

--- a/Makefile
+++ b/Makefile
@@ -504,13 +504,13 @@ promtail-push: promtail-image-cross
 	$(call push-image,promtail)
 
 # loki
-BUILD_PLATFORM ?= amd64
+TARGET_PLATFORM ?= amd64
 loki-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile .
 loki-image-cross:
-	@echo "make loki-image-cross builds a docker image for a different processor architecture than the one from the host machine (default is linux/amd64)."
-	@echo "If you want to build for a different architecture set BUILD_PLATFORM. For arm64 (Raspberry Pi or Apple Silicon), run 'BUILD_PLATFORM=arm64 make loki-image-cross'"
-	$(SUDO) $(BUILD_OCI) --platform=linux/$(BUILD_PLATFORM) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
+	@echo "make loki-image-cross builds a docker image for a specific processor architecture (TARGET_PLATFORM). This is useful when the intended target platform is different than the platform where the image is built on. The default target platform is linux/amd64."
+	@echo "If you want to build for a different architecture set TARGET_PLATFORM. For arm64 (Raspberry Pi or Apple Silicon), run 'TARGET_PLATFORM=arm64 make loki-image-cross'"
+	$(SUDO) $(BUILD_OCI) --platform=linux/$(TARGET_PLATFORM) -t $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) -f cmd/loki/Dockerfile.cross .
 
 loki-debug-image: OCI_PLATFORMS=
 loki-debug-image:

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -3,14 +3,15 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
 FROM golang:1.17.2-alpine as goenv
-RUN go env GOARCH > /goarch && \
+RUN go env GOOS > /goos && \
+    go env GOARCH > /goarch && \
     go env GOARM > /goarm
 
 FROM --platform=linux/amd64 $BUILD_IMAGE as build
-COPY --from=goenv /goarch /goarm /
+COPY --from=goenv /goos /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
+RUN make clean && GOOS=$(cat /goos) GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
 FROM alpine:3.13
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In arm64 processor architecture (Apple's M1 chip), when building a loki docker image using `make loki-image-cross` the resultant image is defined with a `linux/arm64` architecture. Therefore, when deploying such an image in a `linux/amd64` environment, the following error occurs:
```
standard_init_linux.go:228: exec user process caused: exec format error
```

Use case: build docker image on `linux/arm64` architecture (local machine) to be deployed on `linux/amd64` architecture (e.g., dev environment).

The current PR updates `make loki-image-cross` to generate loki docker images with `linux/amd64` architecture when the docker image is built on `linux/arm64` processor architectures.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
