### PR TITLE
Copy `cortex/pkg/querier/astmapper` package dependency into Loki

### DIFF
--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -18,8 +18,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
 )
 

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 func Test_GetShards(t *testing.T) {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,6 +27,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/util"

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"

--- a/pkg/logql/sharding.go
+++ b/pkg/logql/sharding.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/promql"
@@ -14,6 +13,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/util"
 )
 

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -3,12 +3,13 @@ package logql
 import (
 	"fmt"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 // keys used in metrics

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 func TestShardedStringer(t *testing.T) {

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/prometheus/prometheus/model/labels"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logqlmodel"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 func NewMockQuerier(shards int, streams []logproto.Stream) MockQuerier {

--- a/pkg/querier/astmapper/astmapper.go
+++ b/pkg/querier/astmapper/astmapper.go
@@ -1,0 +1,187 @@
+package astmapper
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// ASTMapper is the exported interface for mapping between multiple AST representations
+type ASTMapper interface {
+	Map(node parser.Node) (parser.Node, error)
+}
+
+// MapperFunc is a function adapter for ASTMapper
+type MapperFunc func(node parser.Node) (parser.Node, error)
+
+// Map applies a mapperfunc as an ASTMapper
+func (fn MapperFunc) Map(node parser.Node) (parser.Node, error) {
+	return fn(node)
+}
+
+// MultiMapper can compose multiple ASTMappers
+type MultiMapper struct {
+	mappers []ASTMapper
+}
+
+// Map implements ASTMapper
+func (m *MultiMapper) Map(node parser.Node) (parser.Node, error) {
+	var result parser.Node = node
+	var err error
+
+	if len(m.mappers) == 0 {
+		return nil, errors.New("MultiMapper: No mappers registered")
+	}
+
+	for _, x := range m.mappers {
+		result, err = x.Map(result)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+
+}
+
+// Register adds ASTMappers into a multimapper.
+// Since registered functions are applied in the order they're registered, it's advised to register them
+// in decreasing priority and only operate on nodes that each function cares about, defaulting to CloneNode.
+func (m *MultiMapper) Register(xs ...ASTMapper) {
+	m.mappers = append(m.mappers, xs...)
+}
+
+// NewMultiMapper instaniates an ASTMapper from multiple ASTMappers
+func NewMultiMapper(xs ...ASTMapper) *MultiMapper {
+	m := &MultiMapper{}
+	m.Register(xs...)
+	return m
+}
+
+// CloneNode is a helper function to clone a node.
+func CloneNode(node parser.Node) (parser.Node, error) {
+	return parser.ParseExpr(node.String())
+}
+
+// NodeMapper either maps a single AST node or returns the unaltered node.
+// It also returns a bool to signal that no further recursion is necessary.
+// This is helpful because it allows mappers to only implement logic for node types they want to change.
+// It makes some mappers trivially easy to implement
+type NodeMapper interface {
+	MapNode(node parser.Node) (mapped parser.Node, finished bool, err error)
+}
+
+// NodeMapperFunc is an adapter for NodeMapper
+type NodeMapperFunc func(node parser.Node) (parser.Node, bool, error)
+
+// MapNode applies a NodeMapperFunc as a NodeMapper
+func (f NodeMapperFunc) MapNode(node parser.Node) (parser.Node, bool, error) {
+	return f(node)
+}
+
+// NewASTNodeMapper creates an ASTMapper from a NodeMapper
+func NewASTNodeMapper(mapper NodeMapper) ASTNodeMapper {
+	return ASTNodeMapper{mapper}
+}
+
+// ASTNodeMapper is an ASTMapper adapter which uses a NodeMapper internally.
+type ASTNodeMapper struct {
+	NodeMapper
+}
+
+// Map implements ASTMapper from a NodeMapper
+func (nm ASTNodeMapper) Map(node parser.Node) (parser.Node, error) {
+	node, fin, err := nm.MapNode(node)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if fin {
+		return node, nil
+	}
+
+	switch n := node.(type) {
+	case nil:
+		// nil handles cases where we check optional fields that are not set
+		return nil, nil
+
+	case parser.Expressions:
+		for i, e := range n {
+			mapped, err := nm.Map(e)
+			if err != nil {
+				return nil, err
+			}
+			n[i] = mapped.(parser.Expr)
+		}
+		return n, nil
+
+	case *parser.AggregateExpr:
+		expr, err := nm.Map(n.Expr)
+		if err != nil {
+			return nil, err
+		}
+		n.Expr = expr.(parser.Expr)
+		return n, nil
+
+	case *parser.BinaryExpr:
+		lhs, err := nm.Map(n.LHS)
+		if err != nil {
+			return nil, err
+		}
+		n.LHS = lhs.(parser.Expr)
+
+		rhs, err := nm.Map(n.RHS)
+		if err != nil {
+			return nil, err
+		}
+		n.RHS = rhs.(parser.Expr)
+		return n, nil
+
+	case *parser.Call:
+		for i, e := range n.Args {
+			mapped, err := nm.Map(e)
+			if err != nil {
+				return nil, err
+			}
+			n.Args[i] = mapped.(parser.Expr)
+		}
+		return n, nil
+
+	case *parser.SubqueryExpr:
+		mapped, err := nm.Map(n.Expr)
+		if err != nil {
+			return nil, err
+		}
+		n.Expr = mapped.(parser.Expr)
+		return n, nil
+
+	case *parser.ParenExpr:
+		mapped, err := nm.Map(n.Expr)
+		if err != nil {
+			return nil, err
+		}
+		n.Expr = mapped.(parser.Expr)
+		return n, nil
+
+	case *parser.UnaryExpr:
+		mapped, err := nm.Map(n.Expr)
+		if err != nil {
+			return nil, err
+		}
+		n.Expr = mapped.(parser.Expr)
+		return n, nil
+
+	case *parser.EvalStmt:
+		mapped, err := nm.Map(n.Expr)
+		if err != nil {
+			return nil, err
+		}
+		n.Expr = mapped.(parser.Expr)
+		return n, nil
+
+	case *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector, *parser.MatrixSelector:
+		return n, nil
+
+	default:
+		panic(errors.Errorf("nodeMapper: unhandled node type %T", node))
+	}
+}

--- a/pkg/querier/astmapper/embedded.go
+++ b/pkg/querier/astmapper/embedded.go
@@ -1,0 +1,82 @@
+package astmapper
+
+import (
+	"encoding/json"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+/*
+Design:
+
+The prometheus api package enforces a (*promql.Engine argument), making it infeasible to do lazy AST
+evaluation and substitution from within this package.
+This leaves the (storage.Queryable) interface as the remaining target for conducting application level sharding.
+
+The main idea is to analyze the AST and determine which subtrees can be parallelized. With those in hand, the queries may
+be remapped into vector or matrix selectors utilizing a reserved label containing the original query. These may then be parallelized in the storage implementation.
+*/
+
+const (
+	// QueryLabel is a reserved label containing an embedded query
+	QueryLabel = "__cortex_queries__"
+	// EmbeddedQueriesMetricName is a reserved label (metric name) denoting an embedded query
+	EmbeddedQueriesMetricName = "__embedded_queries__"
+)
+
+// EmbeddedQueries is a wrapper type for encoding queries
+type EmbeddedQueries struct {
+	Concat []string `json:"Concat"`
+}
+
+// JSONCodec is a Codec that uses JSON representations of EmbeddedQueries structs
+var JSONCodec jsonCodec
+
+type jsonCodec struct{}
+
+func (c jsonCodec) Encode(queries []string) (string, error) {
+	embedded := EmbeddedQueries{
+		Concat: queries,
+	}
+	b, err := json.Marshal(embedded)
+	return string(b), err
+}
+
+func (c jsonCodec) Decode(encoded string) (queries []string, err error) {
+	var embedded EmbeddedQueries
+	err = json.Unmarshal([]byte(encoded), &embedded)
+	if err != nil {
+		return nil, err
+	}
+
+	return embedded.Concat, nil
+}
+
+// VectorSquash reduces an AST into a single vector query which can be hijacked by a Queryable impl.
+// It always uses a VectorSelector as the substitution node.
+// This is important because logical/set binops can only be applied against vectors and not matrices.
+func VectorSquasher(nodes ...parser.Node) (parser.Expr, error) {
+
+	// concat OR legs
+	strs := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		strs = append(strs, node.String())
+	}
+
+	encoded, err := JSONCodec.Encode(strs)
+	if err != nil {
+		return nil, err
+	}
+
+	embeddedQuery, err := labels.NewMatcher(labels.MatchEqual, QueryLabel, encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser.VectorSelector{
+		Name:          EmbeddedQueriesMetricName,
+		LabelMatchers: []*labels.Matcher{embeddedQuery},
+	}, nil
+
+}

--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -1,0 +1,108 @@
+package astmapper
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+)
+
+var summableAggregates = map[parser.ItemType]struct{}{
+	parser.SUM:     {},
+	parser.MIN:     {},
+	parser.MAX:     {},
+	parser.TOPK:    {},
+	parser.BOTTOMK: {},
+	parser.COUNT:   {},
+}
+
+var nonParallelFuncs = []string{
+	"histogram_quantile",
+	"quantile_over_time",
+	"absent",
+}
+
+// CanParallelize tests if a subtree is parallelizable.
+// A subtree is parallelizable if all of its components are parallelizable.
+func CanParallelize(node parser.Node) bool {
+	switch n := node.(type) {
+	case nil:
+		// nil handles cases where we check optional fields that are not set
+		return true
+
+	case parser.Expressions:
+		for _, e := range n {
+			if !CanParallelize(e) {
+				return false
+			}
+		}
+		return true
+
+	case *parser.AggregateExpr:
+		_, ok := summableAggregates[n.Op]
+		if !ok {
+			return false
+		}
+
+		// Ensure there are no nested aggregations
+		nestedAggs, err := Predicate(n.Expr, func(node parser.Node) (bool, error) {
+			_, ok := node.(*parser.AggregateExpr)
+			return ok, nil
+		})
+
+		return err == nil && !nestedAggs && CanParallelize(n.Expr)
+
+	case *parser.BinaryExpr:
+		// since binary exprs use each side for merging, they cannot be parallelized
+		return false
+
+	case *parser.Call:
+		if n.Func == nil {
+			return false
+		}
+		if !ParallelizableFunc(*n.Func) {
+			return false
+		}
+
+		for _, e := range n.Args {
+			if !CanParallelize(e) {
+				return false
+			}
+		}
+		return true
+
+	case *parser.SubqueryExpr:
+		return CanParallelize(n.Expr)
+
+	case *parser.ParenExpr:
+		return CanParallelize(n.Expr)
+
+	case *parser.UnaryExpr:
+		// Since these are only currently supported for Scalars, should be parallel-compatible
+		return true
+
+	case *parser.EvalStmt:
+		return CanParallelize(n.Expr)
+
+	case *parser.MatrixSelector, *parser.NumberLiteral, *parser.StringLiteral, *parser.VectorSelector:
+		return true
+
+	default:
+		level.Error(util_log.Logger).Log("err", fmt.Sprintf("CanParallel: unhandled node type %T", node)) //lint:ignore faillint allow global logger for now
+		return false
+	}
+
+}
+
+// ParallelizableFunc ensures that a promql function can be part of a parallel query.
+func ParallelizableFunc(f parser.Function) bool {
+
+	for _, v := range nonParallelFuncs {
+		if v == f.Name {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -1,0 +1,314 @@
+package astmapper
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	// ShardLabel is a reserved label referencing a cortex shard
+	ShardLabel = "__cortex_shard__"
+	// ShardLabelFmt is the fmt of the ShardLabel key.
+	ShardLabelFmt = "%d_of_%d"
+)
+
+var (
+	// ShardLabelRE matches a value in ShardLabelFmt
+	ShardLabelRE = regexp.MustCompile("^[0-9]+_of_[0-9]+$")
+)
+
+type squasher = func(...parser.Node) (parser.Expr, error)
+
+type shardSummer struct {
+	shards       int
+	currentShard *int
+	squash       squasher
+
+	// Metrics.
+	shardedQueries prometheus.Counter
+}
+
+// NewShardSummer instantiates an ASTMapper which will fan out sum queries by shard
+func NewShardSummer(shards int, squasher squasher, shardedQueries prometheus.Counter) (ASTMapper, error) {
+	if squasher == nil {
+		return nil, errors.Errorf("squasher required and not passed")
+	}
+
+	return NewASTNodeMapper(&shardSummer{
+		shards:         shards,
+		squash:         squasher,
+		currentShard:   nil,
+		shardedQueries: shardedQueries,
+	}), nil
+}
+
+// CopyWithCurShard clones a shardSummer with a new current shard.
+func (summer *shardSummer) CopyWithCurShard(curshard int) *shardSummer {
+	s := *summer
+	s.currentShard = &curshard
+	return &s
+}
+
+// shardSummer expands a query AST by sharding and re-summing when possible
+func (summer *shardSummer) MapNode(node parser.Node) (parser.Node, bool, error) {
+
+	switch n := node.(type) {
+	case *parser.AggregateExpr:
+		if CanParallelize(n) && n.Op == parser.SUM {
+			result, err := summer.shardSum(n)
+			return result, true, err
+		}
+
+		return n, false, nil
+
+	case *parser.VectorSelector:
+		if summer.currentShard != nil {
+			mapped, err := shardVectorSelector(*summer.currentShard, summer.shards, n)
+			return mapped, true, err
+		}
+		return n, true, nil
+
+	case *parser.MatrixSelector:
+		if summer.currentShard != nil {
+			mapped, err := shardMatrixSelector(*summer.currentShard, summer.shards, n)
+			return mapped, true, err
+		}
+		return n, true, nil
+
+	default:
+		return n, false, nil
+	}
+}
+
+// shardSum contains the logic for how we split/stitch legs of a parallelized sum query
+func (summer *shardSummer) shardSum(expr *parser.AggregateExpr) (parser.Node, error) {
+
+	parent, subSums, err := summer.splitSum(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	combinedSums, err := summer.squash(subSums...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	parent.Expr = combinedSums
+	return parent, nil
+}
+
+// splitSum forms the parent and child legs of a parallel query
+func (summer *shardSummer) splitSum(
+	expr *parser.AggregateExpr,
+) (
+	parent *parser.AggregateExpr,
+	children []parser.Node,
+	err error,
+) {
+	parent = &parser.AggregateExpr{
+		Op:    expr.Op,
+		Param: expr.Param,
+	}
+	var mkChild func(sharded *parser.AggregateExpr) parser.Expr
+
+	if expr.Without {
+		/*
+			parallelizing a sum using without(foo) is representable naively as
+			sum without(foo) (
+			  sum without(__cortex_shard__) (rate(bar1{__cortex_shard__="0_of_2",baz="blip"}[1m])) or
+			  sum without(__cortex_shard__) (rate(bar1{__cortex_shard__="1_of_2",baz="blip"}[1m]))
+			)
+			or (more optimized):
+			sum without(__cortex_shard__) (
+			  sum without(foo) (rate(bar1{__cortex_shard__="0_of_2",baz="blip"}[1m])) or
+			  sum without(foo) (rate(bar1{__cortex_shard__="1_of_2",baz="blip"}[1m]))
+			)
+
+		*/
+		parent.Grouping = []string{ShardLabel}
+		parent.Without = true
+		mkChild = func(sharded *parser.AggregateExpr) parser.Expr {
+			sharded.Grouping = expr.Grouping
+			sharded.Without = true
+			return sharded
+		}
+	} else if len(expr.Grouping) > 0 {
+		/*
+			parallelizing a sum using by(foo) is representable as
+			sum by(foo) (
+			  sum by(foo, __cortex_shard__) (rate(bar1{__cortex_shard__="0_of_2",baz="blip"}[1m])) or
+			  sum by(foo, __cortex_shard__) (rate(bar1{__cortex_shard__="1_of_2",baz="blip"}[1m]))
+			)
+		*/
+		parent.Grouping = expr.Grouping
+		mkChild = func(sharded *parser.AggregateExpr) parser.Expr {
+			groups := make([]string, 0, len(expr.Grouping)+1)
+			groups = append(groups, expr.Grouping...)
+			groups = append(groups, ShardLabel)
+			sharded.Grouping = groups
+			return sharded
+		}
+	} else {
+		/*
+			parallelizing a non-parameterized sum is representable as
+			sum(
+			  sum without(__cortex_shard__) (rate(bar1{__cortex_shard__="0_of_2",baz="blip"}[1m])) or
+			  sum without(__cortex_shard__) (rate(bar1{__cortex_shard__="1_of_2",baz="blip"}[1m]))
+			)
+			or (more optimized):
+			sum without(__cortex_shard__) (
+			  sum by(__cortex_shard__) (rate(bar1{__cortex_shard__="0_of_2",baz="blip"}[1m])) or
+			  sum by(__cortex_shard__) (rate(bar1{__cortex_shard__="1_of_2",baz="blip"}[1m]))
+			)
+		*/
+		parent.Grouping = []string{ShardLabel}
+		parent.Without = true
+		mkChild = func(sharded *parser.AggregateExpr) parser.Expr {
+			sharded.Grouping = []string{ShardLabel}
+			return sharded
+		}
+	}
+
+	// iterate across shardFactor to create children
+	for i := 0; i < summer.shards; i++ {
+		cloned, err := CloneNode(expr.Expr)
+		if err != nil {
+			return parent, children, err
+		}
+
+		subSummer := NewASTNodeMapper(summer.CopyWithCurShard(i))
+		sharded, err := subSummer.Map(cloned)
+		if err != nil {
+			return parent, children, err
+		}
+
+		subSum := mkChild(&parser.AggregateExpr{
+			Op:   expr.Op,
+			Expr: sharded.(parser.Expr),
+		})
+
+		children = append(children,
+			subSum,
+		)
+	}
+
+	summer.recordShards(float64(summer.shards))
+
+	return parent, children, nil
+}
+
+// ShardSummer is explicitly passed a prometheus.Counter during construction
+// in order to prevent duplicate metric registerings (ShardSummers are created per request).
+//recordShards prevents calling nil interfaces (commonly used in tests).
+func (summer *shardSummer) recordShards(n float64) {
+	if summer.shardedQueries != nil {
+		summer.shardedQueries.Add(float64(summer.shards))
+	}
+}
+
+func shardVectorSelector(curshard, shards int, selector *parser.VectorSelector) (parser.Node, error) {
+	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, ShardLabel, fmt.Sprintf(ShardLabelFmt, curshard, shards))
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser.VectorSelector{
+		Name:   selector.Name,
+		Offset: selector.Offset,
+		LabelMatchers: append(
+			[]*labels.Matcher{shardMatcher},
+			selector.LabelMatchers...,
+		),
+	}, nil
+}
+
+func shardMatrixSelector(curshard, shards int, selector *parser.MatrixSelector) (parser.Node, error) {
+	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, ShardLabel, fmt.Sprintf(ShardLabelFmt, curshard, shards))
+	if err != nil {
+		return nil, err
+	}
+
+	if vs, ok := selector.VectorSelector.(*parser.VectorSelector); ok {
+		return &parser.MatrixSelector{
+			VectorSelector: &parser.VectorSelector{
+				Name:   vs.Name,
+				Offset: vs.Offset,
+				LabelMatchers: append(
+					[]*labels.Matcher{shardMatcher},
+					vs.LabelMatchers...,
+				),
+				PosRange: vs.PosRange,
+			},
+			Range:  selector.Range,
+			EndPos: selector.EndPos,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("invalid selector type: %T", selector.VectorSelector)
+}
+
+// ParseShard will extract the shard information encoded in ShardLabelFmt
+func ParseShard(input string) (parsed ShardAnnotation, err error) {
+	if !ShardLabelRE.MatchString(input) {
+		return parsed, errors.Errorf("Invalid ShardLabel value: [%s]", input)
+	}
+
+	matches := strings.Split(input, "_")
+	x, err := strconv.Atoi(matches[0])
+	if err != nil {
+		return parsed, err
+	}
+	of, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return parsed, err
+	}
+
+	if x >= of {
+		return parsed, errors.Errorf("Shards out of bounds: [%d] >= [%d]", x, of)
+	}
+	return ShardAnnotation{
+		Shard: x,
+		Of:    of,
+	}, err
+}
+
+// ShardAnnotation is a convenience struct which holds data from a parsed shard label
+type ShardAnnotation struct {
+	Shard int
+	Of    int
+}
+
+// String encodes a shardAnnotation into a label value
+func (shard ShardAnnotation) String() string {
+	return fmt.Sprintf(ShardLabelFmt, shard.Shard, shard.Of)
+}
+
+// Label generates the ShardAnnotation as a label
+func (shard ShardAnnotation) Label() labels.Label {
+	return labels.Label{
+		Name:  ShardLabel,
+		Value: shard.String(),
+	}
+}
+
+// ShardFromMatchers extracts a ShardAnnotation and the index it was pulled from in the matcher list
+func ShardFromMatchers(matchers []*labels.Matcher) (shard *ShardAnnotation, idx int, err error) {
+	for i, matcher := range matchers {
+		if matcher.Name == ShardLabel && matcher.Type == labels.MatchEqual {
+			shard, err := ParseShard(matcher.Value)
+			if err != nil {
+				return nil, i, err
+			}
+			return &shard, i, nil
+		}
+	}
+	return nil, 0, nil
+}

--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -208,7 +208,7 @@ func (summer *shardSummer) splitSum(
 // ShardSummer is explicitly passed a prometheus.Counter during construction
 // in order to prevent duplicate metric registerings (ShardSummers are created per request).
 //recordShards prevents calling nil interfaces (commonly used in tests).
-func (summer *shardSummer) recordShards(n float64) {
+func (summer *shardSummer) recordShards(_ float64) {
 	if summer.shardedQueries != nil {
 		summer.shardedQueries.Add(float64(summer.shards))
 	}

--- a/pkg/querier/astmapper/subtree_folder.go
+++ b/pkg/querier/astmapper/subtree_folder.go
@@ -1,0 +1,92 @@
+package astmapper
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+/*
+subtreeFolder is a NodeMapper which embeds an entire parser.Node in an embedded query
+if it does not contain any previously embedded queries. This allows the frontend to "zip up" entire
+subtrees of an AST that have not already been parallelized.
+
+*/
+type subtreeFolder struct{}
+
+// NewSubtreeFolder creates a subtreeFolder which can reduce an AST
+// to one embedded query if it contains no embedded queries yet
+func NewSubtreeFolder() ASTMapper {
+	return NewASTNodeMapper(&subtreeFolder{})
+}
+
+// MapNode implements NodeMapper
+func (f *subtreeFolder) MapNode(node parser.Node) (parser.Node, bool, error) {
+	switch n := node.(type) {
+	// do not attempt to fold number or string leaf nodes
+	case *parser.NumberLiteral, *parser.StringLiteral:
+		return n, true, nil
+	}
+
+	containsEmbedded, err := Predicate(node, predicate(isEmbedded))
+	if err != nil {
+		return nil, true, err
+	}
+
+	if containsEmbedded {
+		return node, false, nil
+	}
+
+	expr, err := VectorSquasher(node)
+	return expr, true, err
+}
+
+func isEmbedded(node parser.Node) (bool, error) {
+	switch n := node.(type) {
+	case *parser.VectorSelector:
+		if n.Name == EmbeddedQueriesMetricName {
+			return true, nil
+		}
+
+	case *parser.MatrixSelector:
+		return isEmbedded(n.VectorSelector)
+	}
+	return false, nil
+}
+
+type predicate = func(parser.Node) (bool, error)
+
+// Predicate is a helper which uses parser.Walk under the hood determine if any node in a subtree
+// returns true for a specified function
+func Predicate(node parser.Node, fn predicate) (bool, error) {
+	v := &visitor{
+		fn: fn,
+	}
+
+	if err := parser.Walk(v, node, nil); err != nil {
+		return false, err
+	}
+	return v.result, nil
+}
+
+type visitor struct {
+	fn     predicate
+	result bool
+}
+
+// Visit implements parser.Visitor
+func (v *visitor) Visit(node parser.Node, path []parser.Node) (parser.Visitor, error) {
+	// if the visitor has already seen a predicate success, don't overwrite
+	if v.result {
+		return nil, nil
+	}
+
+	var err error
+
+	v.result, err = v.fn(node)
+	if err != nil {
+		return nil, err
+	}
+	if v.result {
+		return nil, nil
+	}
+	return v, nil
+}

--- a/pkg/querier/astmapper/subtree_folder.go
+++ b/pkg/querier/astmapper/subtree_folder.go
@@ -26,7 +26,7 @@ func (f *subtreeFolder) MapNode(node parser.Node) (parser.Node, bool, error) {
 		return n, true, nil
 	}
 
-	containsEmbedded, err := Predicate(node, predicate(isEmbedded))
+	containsEmbedded, err := Predicate(node, isEmbedded)
 	if err != nil {
 		return nil, true, err
 	}

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
@@ -16,12 +15,12 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
 
-	"github.com/grafana/loki/pkg/tenant"
-
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logqlmodel"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/tenant"
 	"github.com/grafana/loki/pkg/util/marshal"
 )
 

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -21,6 +20,7 @@ import (
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logql/log"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
 )
 

--- a/pkg/storage/chunk/schema.go
+++ b/pkg/storage/chunk/schema.go
@@ -13,8 +13,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 const (

--- a/pkg/storage/chunk/schema_test.go
+++ b/pkg/storage/chunk/schema_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/test"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 type ByHashRangeKey []IndexEntry

--- a/pkg/storage/chunk/series_store.go
+++ b/pkg/storage/chunk/series_store.go
@@ -13,11 +13,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 )
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
@@ -15,16 +14,16 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/tenant"
-
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	chunk_local "github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/storage"
 	"github.com/grafana/loki/pkg/storage/stores/shipper"
+	"github.com/grafana/loki/pkg/tenant"
 	"github.com/grafana/loki/pkg/util"
 )
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/grafana/dskit/flagext"
 
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	chunk_local "github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/storage"

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -9,7 +9,6 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/querier/astmapper"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	loki_util "github.com/grafana/loki/pkg/util"


### PR DESCRIPTION
**What this PR does / why we need it**:
As a part of removing Loki dependency on cortex packages, we decided to copy the `querier/astmapper` package from cortex to Loki itself.
I decided to only fork this package and not whole querier because the other subpackages require code changes and the gigantique diff will make reviews a hard task. For this one I just had to copy stuff and replace `cortex/astmapper` with the new counterpart. 

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
