### PR TITLE
return empty response when whole query interval is out of lookback period

### DIFF
--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -708,6 +708,7 @@ func Test_validateQueryTimeRangeLimits(t *testing.T) {
 	}{
 		{"no change", fakeTimeLimits{1000 * time.Hour, 1000 * time.Hour}, now, now.Add(24 * time.Hour), now, now.Add(24 * time.Hour), false},
 		{"clamped to 24h", fakeTimeLimits{24 * time.Hour, 1000 * time.Hour}, now.Add(-48 * time.Hour), now, now.Add(-24 * time.Hour), now, false},
+		{"end before lookback", fakeTimeLimits{24 * time.Hour, 1000 * time.Hour}, now.Add(-72 * time.Hour), now.Add(-48 * time.Hour), time.Time{}, time.Time{}, true},
 		{"end before start", fakeTimeLimits{}, now, now.Add(-48 * time.Hour), time.Time{}, time.Time{}, true},
 		{"query too long", fakeTimeLimits{maxQueryLength: 24 * time.Hour}, now.Add(-48 * time.Hour), now, time.Time{}, time.Time{}, true},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When both start and end time are outside of the allowed query interval based on the max lookback period, we just modify the start time to bring it within the allowed range. This causes those queries to fail since we move start time ahead of the end time outside of the allowed query interval. 

**Checklist**
- [x] Tests updated