### PR TITLE
fix splitting of queries when step is larger than split interval

### DIFF
--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -261,6 +261,58 @@ func Test_splitMetricQuery(t *testing.T) {
 			},
 			interval: 3 * time.Hour,
 		},
+
+		// step larger than split interval
+		{
+			input: &LokiRequest{
+				StartTs: time.Unix(0, 0),
+				EndTs:   time.Unix(25*3600, 0),
+				Step:    6 * 3600 * seconds,
+			},
+			expected: []queryrange.Request{
+				&LokiRequest{
+					StartTs: time.Unix(0, 0),
+					EndTs:   time.Unix(6*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+				&LokiRequest{
+					StartTs: time.Unix(6*3600, 0),
+					EndTs:   time.Unix(12*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+				&LokiRequest{
+					StartTs: time.Unix(12*3600, 0),
+					EndTs:   time.Unix(18*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+				&LokiRequest{
+					StartTs: time.Unix(18*3600, 0),
+					EndTs:   time.Unix(24*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+				&LokiRequest{
+					StartTs: time.Unix(24*3600, 0),
+					EndTs:   time.Unix(25*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+			},
+			interval: 15 * time.Minute,
+		},
+		{
+			input: &LokiRequest{
+				StartTs: time.Unix(0, 0),
+				EndTs:   time.Unix(3*3600, 0),
+				Step:    6 * 3600 * seconds,
+			},
+			expected: []queryrange.Request{
+				&LokiRequest{
+					StartTs: time.Unix(0, 0),
+					EndTs:   time.Unix(3*3600, 0),
+					Step:    6 * 3600 * seconds,
+				},
+			},
+			interval: 15 * time.Minute,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			splits := splitMetricByTime(tc.input, tc.interval)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The query split interval code is written with the assumption of `step` always being smaller than the `split` interval. This causes the following problems when `step` is larger than the `split` interval:
1. The first split is set to the same `start` and `end` time [here](https://github.com/grafana/loki/blob/38c42a26c6955ffbe43e484894a7b0bc461e9a13/pkg/querier/queryrange/split_by_interval.go#L292-L294) since we find the next `interval` and then try to align the difference by `step` which would always be of smaller value than `step` which then makes the `end` time to be set to the `start` time.
2. We end up with a gap in query interval because the start time of the second split would be set to <previous start time> + <step> [here](https://github.com/grafana/loki/blob/38c42a26c6955ffbe43e484894a7b0bc461e9a13/pkg/querier/queryrange/split_by_interval.go#L270), but the previous query did not cover any interval due to it being set to same start and end time. 

**Checklist**
- [x] Tests updated
