### PR TITLE
Docs: Move `min_sharding_lookback` to the right place

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -378,13 +378,6 @@ The `query_range` block configures query splitting and caching in the Loki query
 # CLI flag: -querier.split-queries-by-interval
 [split_queries_by_interval: <duration> | default = 0s]
 
-# Limit queries that can be sharded.
-# Queries within the time range of now and now minus this sharding lookback
-# are not sharded. The default value of 0s disables the lookback, causing
-# sharding of all queries at all times.
-# CLI flag: -frontend.min-sharding-lookback
-[min_sharding_lookback: <duration> | default = 0s]
-
 # Deprecated: Split queries by day and execute in parallel.
 # Use -querier.split-queries-by-interval instead.
 # CLI flag: -querier.split-queries-by-day
@@ -2160,6 +2153,13 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # Retry upon receiving a 429 status code from the remote-write storage.
 # This is experimental and might change in the future.
 [ruler_remote_write_queue_retry_on_ratelimit: <bool>]
+
+# Limit queries that can be sharded.
+# Queries within the time range of now and now minus this sharding lookback
+# are not sharded. The default value of 0s disables the lookback, causing
+# sharding of all queries at all times.
+# CLI flag: -frontend.min-sharding-lookback
+[min_sharding_lookback: <duration> | default = 0s]
 ```
 
 ### grpc_client_config


### PR DESCRIPTION
**What this PR does / why we need it**:
Move `min_sharding_lookback` to the right place, as it is part of the `limits` section instead of `query_range`. I considered changing the CLI flag from `frontend.min_sharding_lookback` to something else but that would be a breaking change so I think it is actually a bad idea.

**Which issue(s) this PR fixes**:
Fixes #4953

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
