### PR TITLE
Docs: Fix list of Ruler supported storages

### DIFF
--- a/docs/sources/rules/_index.md
+++ b/docs/sources/rules/_index.md
@@ -253,7 +253,7 @@ ruler:
 
 ## Ruler storage
 
-The Ruler supports six kinds of storage: azure, gcs, s3, swift, and local. Most kinds of storage work with the sharded Ruler configuration in an obvious way, i.e. configure all Rulers to use the same backend.
+The Ruler supports five kinds of storage: azure, gcs, s3, swift, and local. Most kinds of storage work with the sharded Ruler configuration in an obvious way, i.e. configure all Rulers to use the same backend.
 
 The local implementation reads the rule files off of the local filesystem. This is a read-only backend that does not support the creation and deletion of rules through the [Ruler API](../api/#ruler). Despite the fact that it reads the local filesystem this method can still be used in a sharded Ruler configuration if the operator takes care to load the same rules to every Ruler. For instance, this could be accomplished by mounting a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) onto every Ruler pod.
 

--- a/docs/sources/rules/_index.md
+++ b/docs/sources/rules/_index.md
@@ -253,7 +253,7 @@ ruler:
 
 ## Ruler storage
 
-The Ruler supports six kinds of storage: configdb, azure, gcs, s3, swift, and local. Most kinds of storage work with the sharded Ruler configuration in an obvious way, i.e. configure all Rulers to use the same backend.
+The Ruler supports six kinds of storage: azure, gcs, s3, swift, and local. Most kinds of storage work with the sharded Ruler configuration in an obvious way, i.e. configure all Rulers to use the same backend.
 
 The local implementation reads the rule files off of the local filesystem. This is a read-only backend that does not support the creation and deletion of rules through the [Ruler API](../api/#ruler). Despite the fact that it reads the local filesystem this method can still be used in a sharded Ruler configuration if the operator takes care to load the same rules to every Ruler. For instance, this could be accomplished by mounting a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) onto every Ruler pod.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
[initRulerStorage()](https://github.com/grafana/loki/blob/bd1fef08a8ea99e73a30c4739cfeb931353700e6/pkg/loki/modules.go#L582) rejects configurations with `configdb`, so `configdb` is clearly not supported. However, our docs lists it as a supported storage and it is potentially [misleading Loki users](https://github.com/grafana/loki/issues/4971).

**Which issue(s) this PR fixes**:
Fixes #4971

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
