### PR TITLE
[new feature] logql: extrapolate unwrapped rate function

### DIFF
--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -1292,11 +1292,11 @@ func TestEngine_RangeQuery(t *testing.T) {
 			promql.Matrix{
 				promql.Series{
 					Metric: labels.Labels{{Name: "app", Value: "bar"}},
-					Points: []promql.Point{{T: 60 * 1000, V: 0.4}, {T: 90 * 1000, V: 0.4}, {T: 120 * 1000, V: 0.4}, {T: 150 * 1000, V: 0.4}, {T: 180 * 1000, V: 0.4}},
+					Points: []promql.Point{{T: 60 * 1000, V: 0.0}, {T: 90 * 1000, V: 0.0}, {T: 120 * 1000, V: 0.0}, {T: 150 * 1000, V: 0.0}, {T: 180 * 1000, V: 0.0}},
 				},
 				promql.Series{
 					Metric: labels.Labels{{Name: "app", Value: "foo"}},
-					Points: []promql.Point{{T: 60 * 1000, V: 0.2}, {T: 90 * 1000, V: 0.2}, {T: 120 * 1000, V: 0.2}, {T: 150 * 1000, V: 0.2}, {T: 180 * 1000, V: 0.2}},
+					Points: []promql.Point{{T: 60 * 1000, V: 0.0}, {T: 90 * 1000, V: 0.0}, {T: 120 * 1000, V: 0.0}, {T: 150 * 1000, V: 0.0}, {T: 180 * 1000, V: 0.0}},
 				},
 			},
 		},

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -49,12 +49,12 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 			`rate({app="foo"} | unwrap foo [30s])`, time.Unix(60, 0), logproto.FORWARD, 10,
 			[][]logproto.Series{
 				// 30s range the lower bound of the range is not inclusive only 15 samples will make it 60 included
-				{newSeries(testSize, offset(46, constantValue(2)), `{app="foo"}`)},
+				{newSeries(testSize, offset(46, incValue(10)), `{app="foo"}`)},
 			},
 			[]SelectSampleParams{
 				{&logproto.SampleQueryRequest{Start: time.Unix(30, 0), End: time.Unix(60, 0), Selector: `rate({app="foo"} | unwrap foo[30s])`}},
 			},
-			promql.Vector{promql.Sample{Point: promql.Point{T: 60 * 1000, V: 0.0}, Metric: labels.Labels{labels.Label{Name: "app", Value: "foo"}}}},
+			promql.Vector{promql.Sample{Point: promql.Point{T: 60 * 1000, V: 0.46666766666666665}, Metric: labels.Labels{labels.Label{Name: "app", Value: "foo"}}}},
 		},
 	} {
 		test := test
@@ -2498,6 +2498,23 @@ func constantValue(t int64) generator {
 				Timestamp: time.Unix(i, 0).UnixNano(),
 				Hash:      uint64(i),
 				Value:     float64(t),
+			},
+		}
+	}
+}
+
+// nolint
+func incValue(val int64) generator {
+	return func(i int64) logData {
+		return logData{
+			Entry: logproto.Entry{
+				Timestamp: time.Unix(i, 0),
+				Line:      fmt.Sprintf("%d", i),
+			},
+			Sample: logproto.Sample{
+				Timestamp: time.Unix(i, 0).UnixNano(),
+				Hash:      uint64(i),
+				Value:     float64(val + i),
 			},
 		}
 	}

--- a/pkg/logql/functions.go
+++ b/pkg/logql/functions.go
@@ -132,6 +132,7 @@ func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.
 	}
 }
 
+// extrapolatedRate function is taken from prometheus code promql/functions.go:59
 // extrapolatedRate is a utility function for rate/increase/delta.
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // extrapolates if the first/last sample is close to the boundary, and returns

--- a/pkg/logql/functions.go
+++ b/pkg/logql/functions.go
@@ -92,7 +92,7 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 func (r RangeAggregationExpr) aggregator() (RangeVectorAggregator, error) {
 	switch r.Operation {
 	case OpRangeTypeRate:
-		return rateLogs(r.Left.Interval, r.Left.Unwrap != nil), nil
+		return rateLogs(r.Left.Interval, r.Left.Unwrap != nil, r.Left.Offset), nil
 	case OpRangeTypeCount:
 		return countOverTime, nil
 	case OpRangeTypeBytesRate:
@@ -123,17 +123,90 @@ func (r RangeAggregationExpr) aggregator() (RangeVectorAggregator, error) {
 }
 
 // rateLogs calculates the per-second rate of log lines.
-func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.Point) float64 {
+func rateLogs(selRange time.Duration, computeValues bool, sefOffset time.Duration) func(samples []promql.Point) float64 {
 	return func(samples []promql.Point) float64 {
 		if !computeValues {
 			return float64(len(samples)) / selRange.Seconds()
 		}
-		var total float64
-		for _, p := range samples {
-			total += p.V
-		}
-		return total / selRange.Seconds()
+		return extrapolatedRate(samples, selRange, sefOffset, true, true)
 	}
+}
+
+// extrapolatedRate is a utility function for rate/increase/delta.
+// It calculates the rate (allowing for counter resets if isCounter is true),
+// extrapolates if the first/last sample is close to the boundary, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extrapolatedRate(samples []promql.Point, selRange time.Duration, sefOffset time.Duration, isCounter, isRate bool) float64 {
+	// No sense in trying to compute a rate without at least two points. Drop
+	// this Vector element.
+	if len(samples) < 2 {
+		return 0
+	}
+	timeStandar := samples[0].T
+	var (
+		rangeStart = timeStandar - durationMilliseconds(selRange+sefOffset)
+		rangeEnd   = timeStandar - durationMilliseconds(sefOffset)
+	)
+
+	resultValue := samples[len(samples)-1].V - samples[0].V
+	if isCounter {
+		var lastValue float64
+		for _, sample := range samples {
+			if sample.V < lastValue {
+				resultValue += lastValue
+			}
+			lastValue = sample.V
+		}
+	}
+
+	// Duration between first/last samples and boundary of range.
+	durationToStart := float64(samples[0].T-rangeStart) / 1000
+	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1000
+
+	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1000
+	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
+
+	if isCounter && resultValue > 0 && samples[0].V >= 0 {
+		// Counters cannot be negative. If we have any slope at
+		// all (i.e. resultValue went up), we can extrapolate
+		// the zero point of the counter. If the duration to the
+		// zero point is shorter than the durationToStart, we
+		// take the zero point as the start of the series,
+		// thereby avoiding extrapolation to negative counter
+		// values.
+		durationToZero := sampledInterval * (samples[0].V / resultValue)
+		if durationToZero < durationToStart {
+			durationToStart = durationToZero
+		}
+	}
+
+	// If the first/last samples are close to the boundaries of the range,
+	// extrapolate the result. This is as we expect that another sample
+	// will exist given the spacing between samples we've seen thus far,
+	// with an allowance for noise.
+	extrapolationThreshold := averageDurationBetweenSamples * 1.1
+	extrapolateToInterval := sampledInterval
+
+	if durationToStart < extrapolationThreshold {
+		extrapolateToInterval += durationToStart
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	if durationToEnd < extrapolationThreshold {
+		extrapolateToInterval += durationToEnd
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	resultValue = resultValue * (extrapolateToInterval / sampledInterval)
+	if isRate {
+		resultValue = resultValue / selRange.Seconds()
+	}
+
+	return resultValue
+}
+
+func durationMilliseconds(d time.Duration) int64 {
+	return int64(d / (time.Millisecond / time.Nanosecond))
 }
 
 // rateLogBytes calculates the per-second rate of log bytes.


### PR DESCRIPTION
ref issue:https://github.com/grafana/loki/issues/1136
doc: https://grafana.com/docs/loki/latest/logql/metric_queries/ 
rate function doc:  rate(unwrapped-range): calculates per second rate of all values in the specified interval.

logql: rate({_source="vector-internal-metrics" }|json|name="component_received_event_bytes_total"|tags_component_id="service_metrics"|unwrap counter_value [1m])


![image](https://user-images.githubusercontent.com/9583245/147637156-d23f3988-f77c-4843-9bab-e1f2844c19af.png)

![image](https://user-images.githubusercontent.com/9583245/147637234-316c3f12-6886-4da3-9697-88bb9c55193d.png)
![image](https://user-images.githubusercontent.com/9583245/147643393-0a248940-96f8-4fa4-a087-71bfc15d8359.png)


qps = 20,000 /s