### PR TITLE
Docs: SSD mode read target runs the compactor

### DIFF
--- a/docs/sources/fundamentals/architecture/deployment-modes.md
+++ b/docs/sources/fundamentals/architecture/deployment-modes.md
@@ -58,6 +58,8 @@ Consider the microservices mode approach for very large Loki installations.
 
 In this mode the component microservices of Loki are bundled into two targets:
 `-target=read` and `-target=write`.
+The BoltDB [compactor](../../../operations/storage/boltdb-shipper/#compactor) 
+service will run as part of the read target.
 
 There are advantages to separating the read and write paths:
 


### PR DESCRIPTION
This PR brings the work of @zswanson from PR https://github.com/grafana/loki/pull/4877. Since 4877 was created, the file organization changed, such that the information added by 4877 has been relocated.

This PR updates Zach's wording and does not mention target=all, since the subsection is about the simple scalable deployment mode, and target=all specifies a single binary.

This PR also corrects the link to be relative.