### PR TITLE
adds instrumentation to azure object client

### DIFF
--- a/pkg/storage/chunk/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/azure/blob_storage_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/mattn/go-ieproxy"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/instrument"
 
 	cortex_azure "github.com/cortexproject/cortex/pkg/chunk/azure"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -35,6 +36,19 @@ const (
 	azureGermanCloud  = "AzureGermanCloud"
 	azureUSGovernment = "AzureUSGovernment"
 )
+
+var requestDuration = instrument.NewHistogramCollector(prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "loki",
+	Name:      "azure_blob_request_duration_seconds",
+	Help:      "Time spent doing azure blob requests.",
+	// Latency seems to range from a few ms to a few secs and is
+	// important.  So use 6 buckets from 5ms to 5s.
+	Buckets: prometheus.ExponentialBuckets(0.005, 4, 6),
+}, []string{"operation", "status_code"}))
+
+func init() {
+	requestDuration.Register()
+}
 
 var (
 	supportedEnvironments = []string{azureGlobal, azureChinaCloud, azureGermanCloud, azureUSGovernment}
@@ -179,7 +193,13 @@ func (b *BlobStorage) GetObject(ctx context.Context, objectKey string) (io.ReadC
 		ctx, cancel = context.WithTimeout(ctx, b.cfg.RequestTimeout)
 	}
 
-	rc, err := b.getObject(ctx, objectKey)
+	var rc io.ReadCloser
+	err := instrument.CollectedRequest(ctx, "azure.GetObject", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		rc, err = b.getObject(ctx, objectKey)
+		return err
+	})
+
 	if err != nil {
 		// cancel the context if there is an error.
 		cancel()
@@ -205,17 +225,19 @@ func (b *BlobStorage) getObject(ctx context.Context, objectKey string) (rc io.Re
 }
 
 func (b *BlobStorage) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
-	blockBlobURL, err := b.getBlobURL(objectKey, false)
-	if err != nil {
+	return instrument.CollectedRequest(ctx, "azure.PutObject", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		blockBlobURL, err := b.getBlobURL(objectKey, false)
+		if err != nil {
+			return err
+		}
+
+		bufferSize := b.cfg.UploadBufferSize
+		maxBuffers := b.cfg.UploadBufferCount
+		_, err = azblob.UploadStreamToBlockBlob(ctx, object, blockBlobURL,
+			azblob.UploadStreamToBlockBlobOptions{BufferSize: bufferSize, MaxBuffers: maxBuffers})
+
 		return err
-	}
-
-	bufferSize := b.cfg.UploadBufferSize
-	maxBuffers := b.cfg.UploadBufferCount
-	_, err = azblob.UploadStreamToBlockBlob(ctx, object, blockBlobURL,
-		azblob.UploadStreamToBlockBlobOptions{BufferSize: bufferSize, MaxBuffers: maxBuffers})
-
-	return err
+	})
 }
 
 func (b *BlobStorage) getBlobURL(blobID string, hedging bool) (azblob.BlockBlobURL, error) {
@@ -349,38 +371,49 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]chu
 			return nil, nil, ctx.Err()
 		}
 
-		listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
+		err := instrument.CollectedRequest(ctx, "azure.List", requestDuration, instrument.ErrorCode, func(context.Context) error {
+			listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
+			if err != nil {
+				return err
+			}
+
+			marker = listBlob.NextMarker
+
+			// Process the blobs returned in this result segment (if the segment is empty, the loop body won't execute)
+			for _, blobInfo := range listBlob.Segment.BlobItems {
+				storageObjects = append(storageObjects, chunk.StorageObject{
+					Key:        blobInfo.Name,
+					ModifiedAt: blobInfo.Properties.LastModified,
+				})
+			}
+
+			// Process the BlobPrefixes so called commonPrefixes or synthetic directories in the listed synthetic directory
+			for _, blobPrefix := range listBlob.Segment.BlobPrefixes {
+				commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(blobPrefix.Name))
+			}
+
+			return nil
+
+		})
 		if err != nil {
 			return nil, nil, err
 		}
 
-		marker = listBlob.NextMarker
-
-		// Process the blobs returned in this result segment (if the segment is empty, the loop body won't execute)
-		for _, blobInfo := range listBlob.Segment.BlobItems {
-			storageObjects = append(storageObjects, chunk.StorageObject{
-				Key:        blobInfo.Name,
-				ModifiedAt: blobInfo.Properties.LastModified,
-			})
-		}
-
-		// Process the BlobPrefixes so called commonPrefixes or synthetic directories in the listed synthetic directory
-		for _, blobPrefix := range listBlob.Segment.BlobPrefixes {
-			commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(blobPrefix.Name))
-		}
 	}
 
 	return storageObjects, commonPrefixes, nil
 }
 
 func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
-	blockBlobURL, err := b.getBlobURL(blobID, false)
-	if err != nil {
-		return err
-	}
+	return instrument.CollectedRequest(ctx, "azure.DeleteObject", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		blockBlobURL, err := b.getBlobURL(blobID, false)
+		if err != nil {
+			return err
+		}
 
-	_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
-	return err
+		_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
+		return err
+	})
 }
 
 // Validate the config.

--- a/pkg/storage/chunk/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/azure/blob_storage_client.go
@@ -371,7 +371,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]chu
 			return nil, nil, ctx.Err()
 		}
 
-		err := instrument.CollectedRequest(ctx, "azure.List", requestDuration, instrument.ErrorCode, func(context.Context) error {
+		err := instrument.CollectedRequest(ctx, "azure.List", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
 			if err != nil {
 				return err


### PR DESCRIPTION
Eventually, I'd like to make a higher order utility for instrumented object clients, but the plumbing seemed a bit tedious. Instead, I've just added azure specific instrumentation here.