### PR TITLE
docs: fix yaml grammar mistakes

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -435,7 +435,7 @@ The CRI stage is just a convenience wrapper for this definition:
 
 ```yaml
 - regex:
-    expression: "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$",
+    expression: "^(?s)(?P<time>\\S+?) (?P<stream>stdout|stderr) (?P<flags>\\S+?) (?P<content>.*)$"
 - labels:
     stream:
 - timestamp:


### PR DESCRIPTION
**What this PR does / why we need it**:

fix yaml grammar mistakes.
