### PR TITLE
[new] promtail: add readline rate limit

### DIFF
--- a/clients/cmd/promtail/promtail-local-limit-config.yaml
+++ b/clients/cmd/promtail/promtail-local-limit-config.yaml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://localhost:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*log
+
+limit_config:
+  readline_rate: 100
+  readline_burst: 200

--- a/clients/pkg/logentry/stages/pipeline.go
+++ b/clients/pkg/logentry/stages/pipeline.go
@@ -19,7 +19,7 @@ type PipelineStages = []interface{}
 type PipelineStage = map[interface{}]interface{}
 
 var rateLimiter *rate.Limiter
-var rateLimiterAsyn bool
+var rateLimiterDrop bool
 var rateLimiterDropReason = "global_rate_limiter_drop"
 
 // Pipeline pass down a log entry to each stage for mutation and/or label extraction.
@@ -108,7 +108,7 @@ func (p *Pipeline) Wrap(next api.EntryHandler) api.EntryHandler {
 		defer wg.Done()
 		for e := range pipelineOut {
 			if rateLimiter != nil {
-				if rateLimiterAsyn {
+				if rateLimiterDrop {
 					if !rateLimiter.Allow() {
 						p.dropCount.WithLabelValues(rateLimiterDropReason).Inc()
 						continue
@@ -141,7 +141,7 @@ func (p *Pipeline) Size() int {
 	return len(p.stages)
 }
 
-func SetReadLineRateLimiter(rateVal float64, burstVal int, asyn bool) {
+func SetReadLineRateLimiter(rateVal float64, burstVal int, drop bool) {
 	rateLimiter = rate.NewLimiter(rate.Limit(rateVal), burstVal)
-	rateLimiterAsyn = asyn
+	rateLimiterDrop = drop
 }

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/grafana/loki/clients/pkg/promtail/limit"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/grafana/loki/clients/pkg/promtail/client"
@@ -24,6 +25,7 @@ type Config struct {
 	PositionsConfig positions.Config      `yaml:"positions,omitempty"`
 	ScrapeConfig    []scrapeconfig.Config `yaml:"scrape_configs,omitempty"`
 	TargetConfig    file.Config           `yaml:"target_config,omitempty"`
+	LimitConfig     limit.Config          `yaml:"limit_config,omitempty"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by
@@ -33,6 +35,7 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	c.ClientConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.PositionsConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.TargetConfig.RegisterFlagsWithPrefix(prefix, f)
+	c.LimitConfig.RegisterFlagsWithPrefix(prefix, f)
 }
 
 // RegisterFlags registers flags.

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -33,12 +33,24 @@ scrape_configs:
       - localhost
       labels:
         job: varlogs
+limit_config:
+  readline_rate: 100
+  readline_burst: 200
 `
 
 func Test_Load(t *testing.T) {
 	var dst Config
 	err := yaml.Unmarshal([]byte(testFile), &dst)
 	require.Nil(t, err)
+}
+
+func Test_RateLimitLoad(t *testing.T) {
+	var dst Config
+	err := yaml.Unmarshal([]byte(testFile), &dst)
+	require.Nil(t, err)
+	config := dst.LimitConfig
+	require.Equal(t, float64(100), config.ReadlineRate)
+	require.Equal(t, 200, config.ReadlineBurst)
 }
 
 func TestConfig_Setup(t *testing.T) {

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -1,0 +1,15 @@
+package limit
+
+import (
+	"flag"
+)
+
+type Config struct {
+	ReadlineRate  float64 `yaml:"readline_rate" json:"readline_rate"`
+	ReadlineBurst int     `yaml:"readline_burst" json:"readline_burst"`
+}
+
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
+	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
+}

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -8,10 +8,12 @@ type Config struct {
 	ReadlineRate        float64 `yaml:"readline_rate" json:"readline_rate"`
 	ReadlineBurst       int     `yaml:"readline_burst" json:"readline_burst"`
 	ReadlineRateEnabled bool    `yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
+	ReadlineRateAsyn    bool    `yaml:"readline_rate_asyn,omitempty"  json:"readline_rate_asyn"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
 	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", true, "Set to false to disable readline rate limit.")
+	f.BoolVar(&cfg.ReadlineRateAsyn, prefix+"limit.readline-rate-asyn", false, "Set to true to drop log when rate limit.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -14,6 +14,6 @@ type Config struct {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
 	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
-	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", true, "Set to false to disable readline rate limit.")
+	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", false, "Set to false to disable readline rate limit.")
 	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", true, "Set to true to drop log when rate limit.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -5,11 +5,14 @@ import (
 )
 
 type Config struct {
-	ReadlineRate  float64 `yaml:"readline_rate" json:"readline_rate"`
-	ReadlineBurst int     `yaml:"readline_burst" json:"readline_burst"`
+	ReadlineRate        float64 `yaml:"readline_rate" json:"readline_rate"`
+	ReadlineBurst       int     `yaml:"readline_burst" json:"readline_burst"`
+	Enable              int     `yaml:"readline_burst" json:"readline_burst"`
+	ReadlineRateEnabled bool    `yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
 	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
+	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", true, "Set to false to disable readline rate limit.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -8,12 +8,12 @@ type Config struct {
 	ReadlineRate        float64 `yaml:"readline_rate" json:"readline_rate"`
 	ReadlineBurst       int     `yaml:"readline_burst" json:"readline_burst"`
 	ReadlineRateEnabled bool    `yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
-	ReadlineRateAsyn    bool    `yaml:"readline_rate_asyn,omitempty"  json:"readline_rate_asyn"`
+	ReadlineRateDrop    bool    `yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
 	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", true, "Set to false to disable readline rate limit.")
-	f.BoolVar(&cfg.ReadlineRateAsyn, prefix+"limit.readline-rate-asyn", false, "Set to true to drop log when rate limit.")
+	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", false, "Set to true to drop log when rate limit.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -15,5 +15,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.ReadlineRate, prefix+"limit.readline-rate", 10000, "promtail readline Rate.")
 	f.IntVar(&cfg.ReadlineBurst, prefix+"limit.readline-burst", 10000, "promtail readline Burst.")
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", true, "Set to false to disable readline rate limit.")
-	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", false, "Set to true to drop log when rate limit.")
+	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", true, "Set to true to drop log when rate limit.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -7,7 +7,6 @@ import (
 type Config struct {
 	ReadlineRate        float64 `yaml:"readline_rate" json:"readline_rate"`
 	ReadlineBurst       int     `yaml:"readline_burst" json:"readline_burst"`
-	Enable              int     `yaml:"readline_burst" json:"readline_burst"`
 	ReadlineRateEnabled bool    `yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
 }
 

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -58,7 +58,9 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 
 	cfg.Setup()
 
-	stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst)
+	if cfg.LimitConfig.ReadlineRateEnabled {
+		stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst)
+	}
 	var err error
 	if dryRun {
 		promtail.client, err = client.NewLogger(prometheus.DefaultRegisterer, promtail.logger, cfg.ClientConfigs...)

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -59,7 +59,7 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 	cfg.Setup()
 
 	if cfg.LimitConfig.ReadlineRateEnabled {
-		stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst, cfg.LimitConfig.ReadlineRateAsyn)
+		stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst, cfg.LimitConfig.ReadlineRateDrop)
 	}
 	var err error
 	if dryRun {

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -5,6 +5,7 @@ import (
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/go-kit/log"
+	"github.com/grafana/loki/clients/pkg/logentry/stages"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/clients/pkg/promtail/client"
@@ -57,6 +58,7 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 
 	cfg.Setup()
 
+	stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst)
 	var err error
 	if dryRun {
 		promtail.client, err = client.NewLogger(prometheus.DefaultRegisterer, promtail.logger, cfg.ClientConfigs...)

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -59,7 +59,7 @@ func New(cfg config.Config, dryRun bool, opts ...Option) (*Promtail, error) {
 	cfg.Setup()
 
 	if cfg.LimitConfig.ReadlineRateEnabled {
-		stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst)
+		stages.SetReadLineRateLimiter(cfg.LimitConfig.ReadlineRate, cfg.LimitConfig.ReadlineBurst, cfg.LimitConfig.ReadlineRateAsyn)
 	}
 	var err error
 	if dryRun {


### PR DESCRIPTION
refer issue : https://github.com/grafana/loki/issues/2664
it is important feature,。
In our production environment, the cpu can be reduced from 3.5 core to 0.8 core, and business monitoring begins to stabilize。

![image](https://user-images.githubusercontent.com/9583245/148036833-e63a30da-4606-4f89-b12d-a94040c06839.png)
![image](https://user-images.githubusercontent.com/9583245/148036901-1ed228c7-33d3-4767-ad00-025d899c0291.png)
![image](https://user-images.githubusercontent.com/9583245/148036982-bcdeeaac-dd8c-442b-af1a-76845dd3e61b.png)
![image](https://user-images.githubusercontent.com/9583245/148037460-2922f6c1-8ac7-47e4-a9f7-20dce37870ea.png)

