### PR TITLE
Backport #4968: temporary fix for the ruler joining the ingester ring (#4968)

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -186,6 +186,11 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc util.RingConfig, mergeWit
 		r.Ruler.Ring.InstanceID = rc.InstanceID
 		r.Ruler.Ring.InstanceInterfaceNames = rc.InstanceInterfaceNames
 		r.Ruler.Ring.KVStore = rc.KVStore
+
+		// TODO(tjw): temporary fix until dskit is updated: https://github.com/grafana/dskit/pull/101
+		// The ruler's default ring key is "ring", so if if registers under the same common prefix
+		// as the ingester, queriers will try to query it, resulting in failed queries.
+		r.Ruler.Ring.KVStore.Prefix = "/rulers"
 	}
 
 	// Query Scheduler


### PR DESCRIPTION
Backports #4968 to 2.4 release branch in preparation for 2.4.2