### PR TITLE
Remove unnecessary ticker in the tail loop

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -75,17 +75,11 @@ func (t *tailer) loop() {
 	var err error
 	var ok bool
 
-	ticker := time.NewTicker(3 * time.Second)
-	defer ticker.Stop()
-
 	for {
 		select {
-		case <-ticker.C:
-			err := t.conn.Context().Err()
-			if err != nil {
-				t.close()
-				return
-			}
+		case <-t.conn.Context().Done():
+			t.close()
+			return
 		case <-t.closeChan:
 			return
 		case stream, ok = <-t.sendChan:


### PR DESCRIPTION
I don't think the ticker was required in the first place, the behaviour is the same.

This should help in cluster where there's a lot of tailers since ticker can be expensive at scale (waking up many goroutine at the same time).

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

