### PR TITLE
Fix deadlock in disconnecting querier

### DIFF
--- a/pkg/lokifrontend/frontend/transport/handler_test.go
+++ b/pkg/lokifrontend/frontend/transport/handler_test.go
@@ -1,0 +1,30 @@
+package transport
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+)
+
+func TestWriteError(t *testing.T) {
+	for _, test := range []struct {
+		status int
+		err    error
+	}{
+		{http.StatusInternalServerError, errors.New("unknown")},
+		{http.StatusGatewayTimeout, context.DeadlineExceeded},
+		{StatusClientClosedRequest, context.Canceled},
+		{http.StatusBadRequest, httpgrpc.Errorf(http.StatusBadRequest, "")},
+	} {
+		t.Run(test.err.Error(), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeError(w, test.err)
+			require.Equal(t, test.status, w.Result().StatusCode)
+		})
+	}
+}

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -61,8 +61,8 @@ func TestFrontend(t *testing.T) {
 		assert.Equal(t, "Hello World", string(body))
 	}
 
-	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
-	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil)
 }
 
 func TestFrontendPropagateTrace(t *testing.T) {
@@ -111,8 +111,8 @@ func TestFrontendPropagateTrace(t *testing.T) {
 		// Query should do one call.
 		assert.Equal(t, traceID, <-observedTraceID)
 	}
-	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
-	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil)
 }
 
 func TestFrontendCheckReady(t *testing.T) {
@@ -176,9 +176,9 @@ func TestFrontendCancel(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		assert.Equal(t, int32(1), tries.Load())
 	}
-	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil)
 	tries.Store(0)
-	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil)
 }
 
 func TestFrontendMetricsCleanup(t *testing.T) {
@@ -220,15 +220,12 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 			`), "cortex_query_frontend_queue_length"))
 		}
 
-		testFrontend(t, defaultFrontendConfig(), handler, test, matchMaxConcurrency, nil, reg)
+		testFrontend(t, defaultFrontendConfig(), handler, test, matchMaxConcurrency, reg)
 	}
 }
 
-func testFrontend(t *testing.T, config Config, handler http.Handler, test func(addr string, frontend *Frontend), matchMaxConcurrency bool, l log.Logger, reg prometheus.Registerer) {
+func testFrontend(t *testing.T, config Config, handler http.Handler, test func(addr string, frontend *Frontend), matchMaxConcurrency bool, reg prometheus.Registerer) {
 	logger := log.NewNopLogger()
-	if l != nil {
-		logger = l
-	}
 
 	var workerConfig querier_worker.Config
 	flagext.DefaultValues(&workerConfig)

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -1,0 +1,303 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
+	otgrpc "github.com/opentracing-contrib/go-grpc"
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
+	"github.com/weaveworks/common/middleware"
+	"github.com/weaveworks/common/user"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/loki/pkg/lokifrontend/frontend/transport"
+	"github.com/grafana/loki/pkg/lokifrontend/frontend/v1/frontendv1pb"
+	querier_worker "github.com/grafana/loki/pkg/querier/worker"
+	"github.com/grafana/loki/pkg/scheduler/queue"
+)
+
+const (
+	query        = "/api/v1/query_range?end=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680&step=120"
+	responseBody = `{"status":"success","data":{"resultType":"Matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
+)
+
+func TestFrontend(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("Hello World"))
+		require.NoError(t, err)
+	})
+	test := func(addr string, _ *Frontend) {
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", addr), nil)
+		require.NoError(t, err)
+		err = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), "1"), req)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Hello World", string(body))
+	}
+
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+}
+
+func TestFrontendPropagateTrace(t *testing.T) {
+	closer, err := config.Configuration{}.InitGlobalTracer("test")
+	require.NoError(t, err)
+	defer closer.Close()
+
+	observedTraceID := make(chan string, 2)
+
+	handler := middleware.Tracer{}.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sp := opentracing.SpanFromContext(r.Context())
+		defer sp.Finish()
+
+		traceID := fmt.Sprintf("%v", sp.Context().(jaeger.SpanContext).TraceID())
+		observedTraceID <- traceID
+
+		_, err = w.Write([]byte(responseBody))
+		require.NoError(t, err)
+	}))
+
+	test := func(addr string, _ *Frontend) {
+		sp, ctx := opentracing.StartSpanFromContext(context.Background(), "client")
+		defer sp.Finish()
+		traceID := fmt.Sprintf("%v", sp.Context().(jaeger.SpanContext).TraceID())
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/%s", addr, query), nil)
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+		err = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(ctx, "1"), req)
+		require.NoError(t, err)
+
+		req, tr := nethttp.TraceRequest(opentracing.GlobalTracer(), req)
+		defer tr.Finish()
+
+		client := http.Client{
+			Transport: &nethttp.Transport{},
+		}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		defer resp.Body.Close()
+		_, err = ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		// Query should do one call.
+		assert.Equal(t, traceID, <-observedTraceID)
+	}
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+}
+
+func TestFrontendCheckReady(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		connectedClients int
+		msg              string
+		readyForRequests bool
+	}{
+		{"connected clients are ready", 3, "", true},
+		{"no url, no clients is not ready", 0, "not ready: number of queriers connected to query-frontend is 0", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Frontend{
+				log: log.NewNopLogger(),
+				requestQueue: queue.NewRequestQueue(5, 0,
+					prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+					prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+				),
+			}
+			for i := 0; i < tt.connectedClients; i++ {
+				f.requestQueue.RegisterQuerierConnection("test")
+			}
+			err := f.CheckReady(context.Background())
+			errMsg := ""
+
+			if err != nil {
+				errMsg = err.Error()
+			}
+
+			require.Equal(t, tt.msg, errMsg)
+		})
+	}
+}
+
+// TestFrontendCancel ensures that when client requests are cancelled,
+// the underlying query is correctly cancelled _and not retried_.
+func TestFrontendCancel(t *testing.T) {
+	var tries atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		tries.Inc()
+	})
+	test := func(addr string, _ *Frontend) {
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", addr), nil)
+		require.NoError(t, err)
+		err = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), "1"), req)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req = req.WithContext(ctx)
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err = http.DefaultClient.Do(req)
+		require.Error(t, err)
+
+		time.Sleep(100 * time.Millisecond)
+		assert.Equal(t, int32(1), tries.Load())
+	}
+	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil, nil)
+	tries.Store(0)
+	testFrontend(t, defaultFrontendConfig(), handler, test, true, nil, nil)
+}
+
+func TestFrontendMetricsCleanup(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("Hello World"))
+		require.NoError(t, err)
+	})
+
+	for _, matchMaxConcurrency := range []bool{false, true} {
+		reg := prometheus.NewPedanticRegistry()
+
+		test := func(addr string, fr *Frontend) {
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", addr), nil)
+			require.NoError(t, err)
+			err = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), "1"), req)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.StatusCode)
+			defer resp.Body.Close()
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, "Hello World", string(body))
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_query_frontend_queue_length Number of queries in the queue.
+				# TYPE cortex_query_frontend_queue_length gauge
+				cortex_query_frontend_queue_length{user="1"} 0
+			`), "cortex_query_frontend_queue_length"))
+
+			fr.cleanupInactiveUserMetrics("1")
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_query_frontend_queue_length Number of queries in the queue.
+				# TYPE cortex_query_frontend_queue_length gauge
+			`), "cortex_query_frontend_queue_length"))
+		}
+
+		testFrontend(t, defaultFrontendConfig(), handler, test, matchMaxConcurrency, nil, reg)
+	}
+}
+
+func testFrontend(t *testing.T, config Config, handler http.Handler, test func(addr string, frontend *Frontend), matchMaxConcurrency bool, l log.Logger, reg prometheus.Registerer) {
+	logger := log.NewNopLogger()
+	if l != nil {
+		logger = l
+	}
+
+	var workerConfig querier_worker.Config
+	flagext.DefaultValues(&workerConfig)
+	workerConfig.Parallelism = 1
+	workerConfig.MatchMaxConcurrency = matchMaxConcurrency
+	workerConfig.MaxConcurrentRequests = 1
+
+	// localhost:0 prevents firewall warnings on Mac OS X.
+	grpcListen, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	workerConfig.FrontendAddress = grpcListen.Addr().String()
+
+	httpListen, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	v1, err := New(config, limits{}, logger, reg)
+	require.NoError(t, err)
+	require.NotNil(t, v1)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), v1))
+	defer func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), v1))
+	}()
+
+	grpcServer := grpc.NewServer(
+		grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer())),
+	)
+	defer grpcServer.GracefulStop()
+
+	frontendv1pb.RegisterFrontendServer(grpcServer, v1)
+
+	// Default HTTP handler config.
+	handlerCfg := transport.HandlerConfig{}
+	flagext.DefaultValues(&handlerCfg)
+
+	rt := transport.AdaptGrpcRoundTripperToHTTPRoundTripper(v1)
+	r := mux.NewRouter()
+	r.PathPrefix("/").Handler(middleware.Merge(
+		middleware.AuthenticateUser,
+		middleware.Tracer{},
+	).Wrap(transport.NewHandler(handlerCfg, rt, logger, nil)))
+
+	httpServer := http.Server{
+		Handler: r,
+	}
+	defer httpServer.Shutdown(context.Background()) //nolint:errcheck
+
+	go httpServer.Serve(httpListen) //nolint:errcheck
+	go grpcServer.Serve(grpcListen) //nolint:errcheck
+
+	var worker services.Service
+	worker, err = querier_worker.NewQuerierWorker(workerConfig, nil, httpgrpc_server.NewServer(handler), logger, nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
+
+	test(httpListen.Addr().String(), v1)
+
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), worker))
+}
+
+func defaultFrontendConfig() Config {
+	config := Config{}
+	flagext.DefaultValues(&config)
+	return config
+}
+
+type limits struct {
+	queriers int
+}
+
+func (l limits) MaxQueriersPerUser(_ string) int {
+	return l.queriers
+}

--- a/pkg/lokifrontend/frontend/v1/queue_test.go
+++ b/pkg/lokifrontend/frontend/v1/queue_test.go
@@ -1,0 +1,171 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/loki/pkg/lokifrontend/frontend/v1/frontendv1pb"
+)
+
+func setupFrontend(t *testing.T, config Config) (*Frontend, error) {
+	logger := log.NewNopLogger()
+
+	frontend, err := New(config, limits{queriers: 3}, logger, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), frontend))
+	})
+	return frontend, nil
+}
+
+func testReq(ctx context.Context, reqID, user string) *request {
+	return &request{
+		originalCtx: ctx,
+		err:         make(chan error, 1),
+		request: &httpgrpc.HTTPRequest{
+			// Good enough for testing.
+			Method: user,
+			Url:    reqID,
+		},
+		response: make(chan *httpgrpc.HTTPResponse, 1),
+	}
+}
+
+func TestDequeuesExpiredRequests(t *testing.T) {
+	var config Config
+	flagext.DefaultValues(&config)
+	config.MaxOutstandingPerTenant = 10
+	userID := "1"
+
+	f, err := setupFrontend(t, config)
+	require.NoError(t, err)
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	expired, cancel := context.WithCancel(ctx)
+	cancel()
+
+	good := 0
+	for i := 0; i < config.MaxOutstandingPerTenant; i++ {
+		var err error
+		if i%5 == 0 {
+			good++
+			err = f.queueRequest(ctx, testReq(ctx, fmt.Sprintf("good-%d", i), userID))
+		} else {
+			err = f.queueRequest(ctx, testReq(expired, fmt.Sprintf("expired-%d", i), userID))
+		}
+
+		require.Nil(t, err)
+	}
+
+	// Calling Process will only return when client disconnects or context is finished.
+	// We use context timeout to stop Process call.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel2()
+
+	m := &processServerMock{ctx: ctx2, querierID: "querier"}
+	err = f.Process(m)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+
+	// Verify that only non-expired requests were forwarded to querier.
+	for _, r := range m.requests {
+		require.True(t, strings.HasPrefix(r.Url, "good-"), r.Url)
+	}
+	require.Len(t, m.requests, good)
+}
+
+func TestRoundRobinQueues(t *testing.T) {
+	var config Config
+	flagext.DefaultValues(&config)
+
+	const (
+		requests = 100
+		tenants  = 10
+	)
+
+	config.MaxOutstandingPerTenant = requests
+
+	f, err := setupFrontend(t, config)
+	require.NoError(t, err)
+
+	for i := 0; i < requests; i++ {
+		userID := fmt.Sprint(i / tenants)
+		ctx := user.InjectOrgID(context.Background(), userID)
+
+		err = f.queueRequest(ctx, testReq(ctx, fmt.Sprintf("%d", i), userID))
+		require.NoError(t, err)
+	}
+
+	// Calling Process will only return when client disconnects or context is finished.
+	// We use context timeout to stop Process call.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	m := &processServerMock{ctx: ctx, querierID: "querier"}
+	err = f.Process(m)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+
+	require.Len(t, m.requests, requests)
+	for i, r := range m.requests {
+		intUserID, err := strconv.Atoi(r.Method)
+		require.NoError(t, err)
+
+		require.Equal(t, i%tenants, intUserID)
+	}
+}
+
+// This mock behaves as connected querier worker to frontend. It will remember each request
+// that frontend sends, and reply with 200 HTTP status code.
+type processServerMock struct {
+	ctx       context.Context
+	querierID string
+
+	response *frontendv1pb.ClientToFrontend
+
+	requests []*httpgrpc.HTTPRequest
+}
+
+func (p *processServerMock) Send(client *frontendv1pb.FrontendToClient) error {
+	switch {
+	case client.GetType() == frontendv1pb.GET_ID:
+		p.response = &frontendv1pb.ClientToFrontend{ClientID: p.querierID}
+		return nil
+
+	case client.GetType() == frontendv1pb.HTTP_REQUEST:
+		p.requests = append(p.requests, client.HttpRequest)
+		p.response = &frontendv1pb.ClientToFrontend{HttpResponse: &httpgrpc.HTTPResponse{Code: 200}}
+		return nil
+
+	default:
+		return errors.New("unknown message")
+	}
+}
+
+func (p *processServerMock) Recv() (*frontendv1pb.ClientToFrontend, error) {
+	if p.response != nil {
+		m := p.response
+		p.response = nil
+		return m, nil
+	}
+	return nil, errors.New("no message")
+}
+
+func (p *processServerMock) SetHeader(_ metadata.MD) error  { return nil }
+func (p *processServerMock) SendHeader(_ metadata.MD) error { return nil }
+func (p *processServerMock) SetTrailer(md metadata.MD)      {}
+func (p *processServerMock) Context() context.Context       { return p.ctx }
+func (p *processServerMock) SendMsg(m interface{}) error    { return nil }
+func (p *processServerMock) RecvMsg(m interface{}) error    { return nil }

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -1,0 +1,274 @@
+package v2
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/querier/stats"
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/pkg/util/test"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/loki/pkg/lokifrontend/frontend/v2/frontendv2pb"
+	"github.com/grafana/loki/pkg/scheduler/schedulerpb"
+)
+
+const testFrontendWorkerConcurrency = 5
+
+func setupFrontend(t *testing.T, reg prometheus.Registerer, schedulerReplyFunc func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend) (*Frontend, *mockScheduler) {
+	l, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+
+	h, p, err := net.SplitHostPort(l.Addr().String())
+	require.NoError(t, err)
+
+	grpcPort, err := strconv.Atoi(p)
+	require.NoError(t, err)
+
+	cfg := Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.SchedulerAddress = l.Addr().String()
+	cfg.WorkerConcurrency = testFrontendWorkerConcurrency
+	cfg.Addr = h
+	cfg.Port = grpcPort
+
+	// logger := log.NewLogfmtLogger(os.Stdout)
+	logger := log.NewNopLogger()
+	f, err := NewFrontend(cfg, nil, logger, reg)
+	require.NoError(t, err)
+
+	frontendv2pb.RegisterFrontendForQuerierServer(server, f)
+
+	ms := newMockScheduler(t, f, schedulerReplyFunc)
+	schedulerpb.RegisterSchedulerForFrontendServer(server, ms)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), f))
+	t.Cleanup(func() {
+		_ = services.StopAndAwaitTerminated(context.Background(), f)
+	})
+
+	go func() {
+		_ = server.Serve(l)
+	}()
+
+	t.Cleanup(func() {
+		_ = l.Close()
+	})
+
+	// Wait for frontend to connect to scheduler.
+	test.Poll(t, 1*time.Second, 1, func() interface{} {
+		ms.mu.Lock()
+		defer ms.mu.Unlock()
+
+		return len(ms.frontendAddr)
+	})
+
+	return f, ms
+}
+
+func sendResponseWithDelay(f *Frontend, delay time.Duration, userID string, queryID uint64, resp *httpgrpc.HTTPResponse) {
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	_, _ = f.QueryResult(ctx, &frontendv2pb.QueryResultRequest{
+		QueryID:      queryID,
+		HttpResponse: resp,
+		Stats:        &stats.Stats{},
+	})
+}
+
+func TestFrontendBasicWorkflow(t *testing.T) {
+	const (
+		body   = "all fine here"
+		userID = "test"
+	)
+
+	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		// We cannot call QueryResult directly, as Frontend is not yet waiting for the response.
+		// It first needs to be told that enqueuing has succeeded.
+		go sendResponseWithDelay(f, 100*time.Millisecond, userID, msg.QueryID, &httpgrpc.HTTPResponse{
+			Code: 200,
+			Body: []byte(body),
+		})
+
+		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+	})
+
+	resp, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), &httpgrpc.HTTPRequest{})
+	require.NoError(t, err)
+	require.Equal(t, int32(200), resp.Code)
+	require.Equal(t, []byte(body), resp.Body)
+}
+
+func TestFrontendRetryEnqueue(t *testing.T) {
+	// Frontend uses worker concurrency to compute number of retries. We use one less failure.
+	failures := atomic.NewInt64(testFrontendWorkerConcurrency - 1)
+	const (
+		body   = "hello world"
+		userID = "test"
+	)
+
+	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		fail := failures.Dec()
+		if fail >= 0 {
+			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
+		}
+
+		go sendResponseWithDelay(f, 100*time.Millisecond, userID, msg.QueryID, &httpgrpc.HTTPResponse{
+			Code: 200,
+			Body: []byte(body),
+		})
+
+		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+	})
+	_, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), &httpgrpc.HTTPRequest{})
+	require.NoError(t, err)
+}
+
+func TestFrontendEnqueueFailure(t *testing.T) {
+	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
+	})
+
+	_, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), "test"), &httpgrpc.HTTPRequest{})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "failed to enqueue request"))
+}
+
+func TestFrontendCancellation(t *testing.T) {
+	f, ms := setupFrontend(t, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	resp, err := f.RoundTripGRPC(user.InjectOrgID(ctx, "test"), &httpgrpc.HTTPRequest{})
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+	require.Nil(t, resp)
+
+	// We wait a bit to make sure scheduler receives the cancellation request.
+	test.Poll(t, time.Second, 2, func() interface{} {
+		ms.mu.Lock()
+		defer ms.mu.Unlock()
+
+		return len(ms.msgs)
+	})
+
+	ms.checkWithLock(func() {
+		require.Equal(t, 2, len(ms.msgs))
+		require.True(t, ms.msgs[0].Type == schedulerpb.ENQUEUE)
+		require.True(t, ms.msgs[1].Type == schedulerpb.CANCEL)
+		require.True(t, ms.msgs[0].QueryID == ms.msgs[1].QueryID)
+	})
+}
+
+func TestFrontendFailedCancellation(t *testing.T) {
+	f, ms := setupFrontend(t, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+
+		// stop scheduler workers
+		addr := ""
+		f.schedulerWorkers.mu.Lock()
+		for k := range f.schedulerWorkers.workers {
+			addr = k
+			break
+		}
+		f.schedulerWorkers.mu.Unlock()
+
+		f.schedulerWorkers.AddressRemoved(addr)
+
+		// Wait for worker goroutines to stop.
+		time.Sleep(100 * time.Millisecond)
+
+		// Cancel request. Frontend will try to send cancellation to scheduler, but that will fail (not visible to user).
+		// Everything else should still work fine.
+		cancel()
+	}()
+
+	// send request
+	resp, err := f.RoundTripGRPC(user.InjectOrgID(ctx, "test"), &httpgrpc.HTTPRequest{})
+	require.EqualError(t, err, context.Canceled.Error())
+	require.Nil(t, resp)
+
+	ms.checkWithLock(func() {
+		require.Equal(t, 1, len(ms.msgs))
+	})
+}
+
+type mockScheduler struct {
+	t *testing.T
+	f *Frontend
+
+	replyFunc func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend
+
+	mu           sync.Mutex
+	frontendAddr map[string]int
+	msgs         []*schedulerpb.FrontendToScheduler
+}
+
+func newMockScheduler(t *testing.T, f *Frontend, replyFunc func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend) *mockScheduler {
+	return &mockScheduler{t: t, f: f, frontendAddr: map[string]int{}, replyFunc: replyFunc}
+}
+
+func (m *mockScheduler) checkWithLock(fn func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fn()
+}
+
+func (m *mockScheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_FrontendLoopServer) error {
+	init, err := frontend.Recv()
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	m.frontendAddr[init.FrontendAddress]++
+	m.mu.Unlock()
+
+	// Ack INIT from frontend.
+	if err := frontend.Send(&schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}); err != nil {
+		return err
+	}
+
+	for {
+		msg, err := frontend.Recv()
+		if err != nil {
+			return err
+		}
+
+		m.mu.Lock()
+		m.msgs = append(m.msgs, msg)
+		m.mu.Unlock()
+
+		reply := &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+		if m.replyFunc != nil {
+			reply = m.replyFunc(m.f, msg)
+		}
+
+		if err := frontend.Send(reply); err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
+
+	"github.com/grafana/loki/pkg/util/test"
 )
 
 func TestRecvFailDoesntCancelProcess(t *testing.T) {

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -1,0 +1,74 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+)
+
+func TestRecvFailDoesntCancelProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// We use random port here, hopefully without any gRPC server.
+	cc, err := grpc.DialContext(ctx, "localhost:999", grpc.WithInsecure())
+	require.NoError(t, err)
+
+	cfg := Config{}
+	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger())
+	running := atomic.NewBool(false)
+	go func() {
+		running.Store(true)
+		defer running.Store(false)
+
+		mgr.processQueriesOnSingleStream(ctx, cc, "test:12345")
+	}()
+
+	test.Poll(t, time.Second, true, func() interface{} {
+		return running.Load()
+	})
+
+	// Wait a bit, and verify that processQueriesOnSingleStream is still running, and hasn't stopped
+	// just because it cannot contact frontend.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, true, running.Load())
+
+	cancel()
+	test.Poll(t, time.Second, false, func() interface{} {
+		return running.Load()
+	})
+}
+
+func TestContextCancelStopsProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// We use random port here, hopefully without any gRPC server.
+	cc, err := grpc.DialContext(ctx, "localhost:999", grpc.WithInsecure())
+	require.NoError(t, err)
+
+	pm := newProcessorManager(ctx, &mockProcessor{}, cc, "test")
+	pm.concurrency(1)
+
+	test.Poll(t, time.Second, 1, func() interface{} {
+		return int(pm.currentProcessors.Load())
+	})
+
+	cancel()
+
+	test.Poll(t, time.Second, 0, func() interface{} {
+		return int(pm.currentProcessors.Load())
+	})
+
+	pm.stop()
+	test.Poll(t, time.Second, 0, func() interface{} {
+		return int(pm.currentProcessors.Load())
+	})
+}

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -10,16 +11,23 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/grafana/loki/pkg/util/test"
 )
+
+const bufConnSize = 1024 * 1024
 
 func TestRecvFailDoesntCancelProcess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// We use random port here, hopefully without any gRPC server.
-	cc, err := grpc.DialContext(ctx, "localhost:999", grpc.WithInsecure())
+	listener := bufconn.Listen(bufConnSize)
+	defer listener.Close()
+	cc, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithInsecure())
+
 	require.NoError(t, err)
 
 	cfg := Config{}
@@ -51,8 +59,11 @@ func TestContextCancelStopsProcess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// We use random port here, hopefully without any gRPC server.
-	cc, err := grpc.DialContext(ctx, "localhost:999", grpc.WithInsecure())
+	listener := bufconn.Listen(bufConnSize)
+	defer listener.Close()
+	cc, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithInsecure())
 	require.NoError(t, err)
 
 	pm := newProcessorManager(ctx, &mockProcessor{}, cc, "test")

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -1,0 +1,108 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestResetConcurrency(t *testing.T) {
+	tests := []struct {
+		name                string
+		parallelism         int
+		maxConcurrent       int
+		numTargets          int
+		expectedConcurrency int
+	}{
+		{
+			name:                "Test create at least one processor per target",
+			parallelism:         0,
+			maxConcurrent:       0,
+			numTargets:          2,
+			expectedConcurrency: 2,
+		},
+		{
+			name:                "Test parallelism per target",
+			parallelism:         4,
+			maxConcurrent:       0,
+			numTargets:          2,
+			expectedConcurrency: 8,
+		},
+		{
+			name:                "Test Total Parallelism with a remainder",
+			parallelism:         1,
+			maxConcurrent:       7,
+			numTargets:          4,
+			expectedConcurrency: 7,
+		},
+		{
+			name:                "Test Total Parallelism dividing evenly",
+			parallelism:         1,
+			maxConcurrent:       6,
+			numTargets:          2,
+			expectedConcurrency: 6,
+		},
+		{
+			name:                "Test Total Parallelism at least one worker per target",
+			parallelism:         1,
+			maxConcurrent:       3,
+			numTargets:          6,
+			expectedConcurrency: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Parallelism:           tt.parallelism,
+				MatchMaxConcurrency:   tt.maxConcurrent > 0,
+				MaxConcurrentRequests: tt.maxConcurrent,
+			}
+
+			w, err := newQuerierWorkerWithProcessor(cfg, log.NewNopLogger(), &mockProcessor{}, "", nil, nil)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
+
+			for i := 0; i < tt.numTargets; i++ {
+				// gRPC connections are virtual... they don't actually try to connect until they are needed.
+				// This allows us to use dummy ports, and not get any errors.
+				w.AddressAdded(fmt.Sprintf("127.0.0.1:%d", i))
+			}
+
+			test.Poll(t, 250*time.Millisecond, tt.expectedConcurrency, func() interface{} {
+				return getConcurrentProcessors(w)
+			})
+
+			require.NoError(t, services.StopAndAwaitTerminated(context.Background(), w))
+			assert.Equal(t, 0, getConcurrentProcessors(w))
+		})
+	}
+}
+
+func getConcurrentProcessors(w *querierWorker) int {
+	result := 0
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, mgr := range w.managers {
+		result += int(mgr.currentProcessors.Load())
+	}
+
+	return result
+}
+
+type mockProcessor struct{}
+
+func (m mockProcessor) processQueriesOnSingleStream(ctx context.Context, _ *grpc.ClientConn, _ string) {
+	<-ctx.Done()
+}
+
+func (m mockProcessor) notifyShutdown(_ context.Context, _ *grpc.ClientConn, _ string) {}

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -38,7 +38,7 @@ func TestResetConcurrency(t *testing.T) {
 			expectedConcurrency: 8,
 		},
 		{
-			name:                "Test Total Parallelism with a remainder",
+			name:                "Test concurrency is correct when numTargets does not divide evenly into maxConcurrent",
 			parallelism:         1,
 			maxConcurrent:       7,
 			numTargets:          4,

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/loki/pkg/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/grafana/loki/pkg/util/test"
 )
 
 func TestResetConcurrency(t *testing.T) {

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -31,7 +31,7 @@ func TestResetConcurrency(t *testing.T) {
 			expectedConcurrency: 2,
 		},
 		{
-			name:                "Test parallelism per target",
+			name:                "Test concurrency equal to parallelism * target when MatchMaxConcurrency is false",
 			parallelism:         4,
 			maxConcurrent:       0,
 			numTargets:          2,

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -1,0 +1,304 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkGetNextRequest(b *testing.B) {
+	const maxOutstandingPerTenant = 2
+	const numTenants = 50
+	const queriers = 5
+
+	queues := make([]*RequestQueue, 0, b.N)
+
+	for n := 0; n < b.N; n++ {
+		queue := NewRequestQueue(maxOutstandingPerTenant, 0,
+			prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+			prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+		)
+		queues = append(queues, queue)
+
+		for ix := 0; ix < queriers; ix++ {
+			queue.RegisterQuerierConnection(fmt.Sprintf("querier-%d", ix))
+		}
+
+		for i := 0; i < maxOutstandingPerTenant; i++ {
+			for j := 0; j < numTenants; j++ {
+				userID := strconv.Itoa(j)
+
+				err := queue.EnqueueRequest(userID, "request", 0, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		idx := FirstUser()
+		for j := 0; j < maxOutstandingPerTenant*numTenants; j++ {
+			querier := ""
+		b:
+			// Find querier with at least one request to avoid blocking in getNextRequestForQuerier.
+			for _, q := range queues[i].queues.userQueues {
+				for qid := range q.queriers {
+					querier = qid
+					break b
+				}
+			}
+
+			_, nidx, err := queues[i].GetNextRequestForQuerier(ctx, idx, querier)
+			if err != nil {
+				b.Fatal(err)
+			}
+			idx = nidx
+		}
+	}
+}
+
+func BenchmarkQueueRequest(b *testing.B) {
+	const maxOutstandingPerTenant = 2
+	const numTenants = 50
+	const queriers = 5
+
+	queues := make([]*RequestQueue, 0, b.N)
+	users := make([]string, 0, numTenants)
+	requests := make([]string, 0, numTenants)
+
+	for n := 0; n < b.N; n++ {
+		q := NewRequestQueue(maxOutstandingPerTenant, 0,
+			prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+			prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+		)
+
+		for ix := 0; ix < queriers; ix++ {
+			q.RegisterQuerierConnection(fmt.Sprintf("querier-%d", ix))
+		}
+
+		queues = append(queues, q)
+
+		for j := 0; j < numTenants; j++ {
+			requests = append(requests, fmt.Sprintf("%d-%d", n, j))
+			users = append(users, strconv.Itoa(j))
+		}
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < maxOutstandingPerTenant; i++ {
+			for j := 0; j < numTenants; j++ {
+				err := queues[n].EnqueueRequest(users[j], requests[j], 0, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+}
+
+func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBecauseQuerierHasBeenForgotten(t *testing.T) {
+	const forgetDelay = 3 * time.Second
+
+	queue := NewRequestQueue(1, forgetDelay,
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"user"}))
+
+	// Start the queue service.
+	ctx := context.Background()
+	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, queue))
+	})
+
+	// Two queriers connect.
+	queue.RegisterQuerierConnection("querier-1")
+	queue.RegisterQuerierConnection("querier-2")
+
+	// Querier-2 waits for a new request.
+	querier2wg := sync.WaitGroup{}
+	querier2wg.Add(1)
+	go func() {
+		defer querier2wg.Done()
+		_, _, err := queue.GetNextRequestForQuerier(ctx, FirstUser(), "querier-2")
+		require.NoError(t, err)
+	}()
+
+	// Querier-1 crashes (no graceful shutdown notification).
+	queue.UnregisterQuerierConnection("querier-1")
+
+	// Enqueue a request from an user which would be assigned to querier-1.
+	// NOTE: "user-1" hash falls in the querier-1 shard.
+	require.NoError(t, queue.EnqueueRequest("user-1", "request", 1, nil))
+
+	startTime := time.Now()
+	querier2wg.Wait()
+	waitTime := time.Since(startTime)
+
+	// We expect that querier-2 got the request only after querier-1 forget delay is passed.
+	assert.GreaterOrEqual(t, waitTime.Milliseconds(), forgetDelay.Milliseconds())
+}
+
+func TestContextCond(t *testing.T) {
+	t.Run("wait until broadcast", func(t *testing.T) {
+		t.Parallel()
+		mtx := &sync.Mutex{}
+		cond := contextCond{Cond: sync.NewCond(mtx)}
+
+		doneWaiting := make(chan struct{})
+
+		mtx.Lock()
+		go func() {
+			cond.Wait(context.Background())
+			mtx.Unlock()
+			close(doneWaiting)
+		}()
+
+		assertChanNotReceived(t, doneWaiting, 100*time.Millisecond, "cond.Wait returned, but it should not because we did not broadcast yet")
+
+		cond.Broadcast()
+		assertChanReceived(t, doneWaiting, 250*time.Millisecond, "cond.Wait did not return after broadcast")
+	})
+
+	t.Run("wait until context deadline", func(t *testing.T) {
+		t.Parallel()
+		mtx := &sync.Mutex{}
+		cond := contextCond{Cond: sync.NewCond(mtx)}
+		doneWaiting := make(chan struct{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mtx.Lock()
+		go func() {
+			cond.Wait(ctx)
+			mtx.Unlock()
+			close(doneWaiting)
+		}()
+
+		assertChanNotReceived(t, doneWaiting, 100*time.Millisecond, "cond.Wait returned, but it should not because we did not broadcast yet and didn't cancel the context")
+
+		cancel()
+		assertChanReceived(t, doneWaiting, 250*time.Millisecond, "cond.Wait did not return after cancelling the context")
+	})
+
+	t.Run("wait on already canceled context", func(t *testing.T) {
+		// This test represents the racy real world scenario,
+		// we don't know whether it's going to wait before the broadcast triggered by the context cancellation.
+		t.Parallel()
+		mtx := &sync.Mutex{}
+		cond := contextCond{Cond: sync.NewCond(mtx)}
+		doneWaiting := make(chan struct{})
+
+		alreadyCanceledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mtx.Lock()
+		go func() {
+			cond.Wait(alreadyCanceledContext)
+			mtx.Unlock()
+			close(doneWaiting)
+		}()
+
+		assertChanReceived(t, doneWaiting, 250*time.Millisecond, "cond.Wait did not return after cancelling the context")
+	})
+
+	t.Run("wait on already canceled context, but it takes a while to wait", func(t *testing.T) {
+		t.Parallel()
+		mtx := &sync.Mutex{}
+		cond := contextCond{
+			Cond: sync.NewCond(mtx),
+			testHookBeforeWaiting: func() {
+				// This makes the waiting goroutine so slow that out Wait(ctx) will need to broadcast once it sees it waiting.
+				time.Sleep(250 * time.Millisecond)
+			},
+		}
+		doneWaiting := make(chan struct{})
+
+		alreadyCanceledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mtx.Lock()
+		go func() {
+			cond.Wait(alreadyCanceledContext)
+			mtx.Unlock()
+			close(doneWaiting)
+		}()
+
+		assertChanReceived(t, doneWaiting, time.Second, "cond.Wait did not return after 500ms")
+	})
+
+	t.Run("lots of goroutines waiting at the same time, none of them misses it's broadcast from cancel", func(t *testing.T) {
+		t.Parallel()
+		mtx := &sync.Mutex{}
+		cond := contextCond{
+			Cond: sync.NewCond(mtx),
+			testHookBeforeWaiting: func() {
+				// Wait just a little bit to create every goroutine
+				time.Sleep(time.Millisecond)
+			},
+		}
+		const goroutines = 100
+
+		doneWaiting := make(chan struct{}, goroutines)
+		release := make(chan struct{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				<-release
+
+				mtx.Lock()
+				cond.Wait(ctx)
+				mtx.Unlock()
+
+				doneWaiting <- struct{}{}
+			}()
+		}
+		go func() {
+			<-release
+			cancel()
+		}()
+
+		close(release)
+
+		assert.Eventually(t, func() bool {
+			return len(doneWaiting) == goroutines
+		}, time.Second, 10*time.Millisecond)
+	})
+}
+
+func assertChanReceived(t *testing.T, c chan struct{}, timeout time.Duration, msg string, args ...interface{}) {
+	t.Helper()
+
+	select {
+	case <-c:
+	case <-time.After(timeout):
+		t.Fatalf(msg, args...)
+	}
+}
+
+func assertChanNotReceived(t *testing.T, c chan struct{}, wait time.Duration, msg string, args ...interface{}) {
+	t.Helper()
+
+	select {
+	case <-c:
+		t.Fatalf(msg, args...)
+	case <-time.After(wait):
+		// OK!
+	}
+}

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -282,13 +282,13 @@ func TestContextCond(t *testing.T) {
 	})
 }
 
-func assertChanReceived(t *testing.T, c chan struct{}, timeout time.Duration, msg string, args ...interface{}) {
+func assertChanReceived(t *testing.T, c chan struct{}, timeout time.Duration, msg string) {
 	t.Helper()
 
 	select {
 	case <-c:
 	case <-time.After(timeout):
-		t.Fatalf(msg, args...)
+		t.Fatalf(msg)
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -41,9 +41,7 @@ import (
 	lokihttpreq "github.com/grafana/loki/pkg/util/httpreq"
 )
 
-var (
-	errSchedulerIsNotRunning = errors.New("scheduler is not running")
-)
+var errSchedulerIsNotRunning = errors.New("scheduler is not running")
 
 const (
 	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
@@ -444,14 +442,6 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 	s.requestQueue.RegisterQuerierConnection(querierID)
 	defer s.requestQueue.UnregisterQuerierConnection(querierID)
 
-	// If the downstream connection to querier is cancelled,
-	// we need to ping the condition variable to unblock getNextRequestForQuerier.
-	// Ideally we'd have ctx aware condition variables...
-	go func() {
-		<-querier.Context().Done()
-		s.requestQueue.QuerierDisconnecting()
-	}()
-
 	lastUserIndex := queue.FirstUser()
 
 	// In stopping state scheduler is not accepting new queries, but still dispatching queries in the queues.
@@ -554,7 +544,8 @@ func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuer
 func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRequest, requestErr error) {
 	opts, err := s.cfg.GRPCClientConfig.DialOption([]grpc.UnaryClientInterceptor{
 		otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
-		middleware.ClientUserHeaderInterceptor},
+		middleware.ClientUserHeaderInterceptor,
+	},
 		nil)
 	if err != nil {
 		level.Warn(s.log).Log("msg", "failed to create gRPC options for the connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestErr)
@@ -667,7 +658,6 @@ func (s *Scheduler) running(ctx context.Context) error {
 }
 
 func (s *Scheduler) setRunState(isInSet bool) {
-
 	if isInSet {
 		if s.shouldRun.CAS(false, true) {
 			// Value was swapped, meaning this was a state change from stopped to running.
@@ -728,7 +718,6 @@ func SafeReadRing(s *Scheduler) ring.ReadRing {
 	}
 
 	return s.ring
-
 }
 
 func (s *Scheduler) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc ring.Desc, instanceExists bool, instanceID string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,308 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respsectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1457,6 +1457,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 google.golang.org/grpc/xds
 google.golang.org/grpc/xds/csds
 google.golang.org/grpc/xds/googledirectpath


### PR DESCRIPTION
There was a race condition between the broadcast triggered by the
canceled context and the condition waiting: if the broadcast happend
before the wait, wait never receives any broadcast.

I also ported back all tests missing from the code we forked.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>


