### PR TITLE
improve default config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [4942](https://github.com/grafana/loki/pull/4942) **cyriltovena**: Allow to disable HTTP/2 for GCS.
 * [4876](https://github.com/grafana/loki/pull/4876) **trevorwhitney**: Docs: add simple, scalable example using docker-compose
 * [4857](https://github.com/grafana/loki/pull/4857) **jordanrushing**: New schema v12 changes chunk key structure
+* [5077](https://github.com/grafana/loki/pull/5077) **trevorwhitney**: Change some default values for better out-of-the-box performance
 
 # 2.4.1 (2021/11/07)
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -276,11 +276,11 @@ The `querier` block configures the Loki Querier.
 # Maximum lookback beyond which queries are not sent to ingester.
 # 0 means all queries are sent to ingester.
 # CLI flag: -querier.query-ingesters-within
-[query_ingesters_within: <duration> | default = 0s]
+[query_ingesters_within: <duration> | default = 2h]
 
 # The maximum number of concurrent queries allowed.
 # CLI flag: -querier.max-concurrent
-[max_concurrent: <int> | default = 20]
+[max_concurrent: <int> | default = 10]
 
 # Only query the store, do not attempt to query any ingesters,
 # useful for running a standalone querier pool opearting only against stored data.
@@ -378,7 +378,7 @@ The `query_range` block configures query splitting and caching in the Loki query
 
 # Mutate incoming queries to align their start and end with their step.
 # CLI flag: -querier.align-querier-with-step
-[align_queries_with_step: <boolean> | default = false]
+[align_queries_with_step: <boolean> | default = true]
 
 results_cache:
   # The CLI flags prefix for this block config is: frontend
@@ -396,7 +396,7 @@ results_cache:
 # Perform query parallelisations based on storage sharding configuration and
 # query ASTs. This feature is supported only by the chunks storage engine.
 # CLI flag: -querier.parallelise-shardable-queries
-[parallelise_shardable_queries: <boolean> | default = false]
+[parallelise_shardable_queries: <boolean> | default = true]
 ```
 
 ## ruler
@@ -1009,7 +1009,7 @@ lifecycler:
 # Number of times to try and transfer chunks when leaving before
 # falling back to flushing to the store. Zero = no transfers are done.
 # CLI flag: -ingester.max-transfer-retries
-[max_transfer_retries: <int> | default = 10]
+[max_transfer_retries: <int> | default = 0]
 
 # How many flushes can happen concurrently from each stream.
 # CLI flag: -ingester.concurrent-flushes
@@ -1073,7 +1073,7 @@ lifecycler:
 # The maximum duration of a timeseries chunk in memory. If a timeseries runs for longer than this,
 # the current chunk will be flushed to the store and a new chunk created.
 # CLI flag: -ingester.max-chunk-age
-[max_chunk_age: <duration> | default = 1h]
+[max_chunk_age: <duration> | default = 2h]
 
 # How far in the past an ingester is allowed to query the store for data.
 # This is only useful for running multiple Loki binaries with a shared ring
@@ -2167,7 +2167,7 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # to avoid queriers downloading and processing the same chunks. This also
 # determines how cache keys are chosen when result caching is enabled
 # CLI flag: -querier.split-queries-by-interval
-[split_queries_by_interval: <duration> | default = 0s]
+[split_queries_by_interval: <duration> | default = 30m]
 ```
 
 ### grpc_client_config

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -396,7 +396,7 @@ results_cache:
 # Perform query parallelisations based on storage sharding configuration and
 # query ASTs. This feature is supported only by the chunks storage engine.
 # CLI flag: -querier.parallelise-shardable-queries
-[parallelise_shardable_queries: <boolean> | default = false]
+[parallelise_shardable_queries: <boolean> | default = true]
 ```
 
 ## ruler

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -378,7 +378,7 @@ The `query_range` block configures query splitting and caching in the Loki query
 
 # Mutate incoming queries to align their start and end with their step.
 # CLI flag: -querier.align-querier-with-step
-[align_queries_with_step: <boolean> | default = true]
+[align_queries_with_step: <boolean> | default = false]
 
 results_cache:
   # The CLI flags prefix for this block config is: frontend
@@ -396,7 +396,7 @@ results_cache:
 # Perform query parallelisations based on storage sharding configuration and
 # query ASTs. This feature is supported only by the chunks storage engine.
 # CLI flag: -querier.parallelise-shardable-queries
-[parallelise_shardable_queries: <boolean> | default = true]
+[parallelise_shardable_queries: <boolean> | default = false]
 ```
 
 ## ruler

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1009,7 +1009,7 @@ lifecycler:
 # Number of times to try and transfer chunks when leaving before
 # falling back to flushing to the store. Zero = no transfers are done.
 # CLI flag: -ingester.max-transfer-retries
-[max_transfer_retries: <int> | default = 0]
+[max_transfer_retries: <int> | default = 10]
 
 # How many flushes can happen concurrently from each stream.
 # CLI flag: -ingester.concurrent-flushes

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -276,7 +276,7 @@ The `querier` block configures the Loki Querier.
 # Maximum lookback beyond which queries are not sent to ingester.
 # 0 means all queries are sent to ingester.
 # CLI flag: -querier.query-ingesters-within
-[query_ingesters_within: <duration> | default = 2h]
+[query_ingesters_within: <duration> | default = 3h]
 
 # The maximum number of concurrent queries allowed.
 # CLI flag: -querier.max-concurrent

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -49,6 +49,13 @@ The response body has the following schema:
 }
 ```
 
+#### Changes to default configuration values
+
+* `split_queries_by_interval` under the Query Range config now defaults to `30m`, it was `0s`.
+* `max_chunk_age` for the Ingester now defaults to `2h` instead of `1h`.
+* `query_ingesters_within` under the Queier config now defaults to `3h`, it was previously set to 0, meaning always query ingesters.
+* `max_concurrent` under the Querier config now defaults to `10` instead of `20`, since is should be the same as the Frontend Worker's `parallelism` setting (which is `10`).
+
 ### Promtail
 
 #### `gcplog` labels have changed

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -51,6 +51,7 @@ The response body has the following schema:
 
 #### Changes to default configuration values
 
+* `parallelise_shardable_queries` under the Query Range config now defaults to `true`, it was `false`.
 * `split_queries_by_interval` under the Query Range config now defaults to `30m`, it was `0s`.
 * `max_chunk_age` for the Ingester now defaults to `2h` instead of `1h`.
 * `query_ingesters_within` under the Queier config now defaults to `3h`, it was previously set to 0, meaning always query ingesters.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -106,7 +106,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.SyncPeriod, "ingester.sync-period", 0, "How often to cut chunks to synchronize ingesters.")
 	f.Float64Var(&cfg.SyncMinUtilization, "ingester.sync-min-utilization", 0, "Minimum utilization of chunk when doing synchronization.")
 	f.IntVar(&cfg.MaxReturnedErrors, "ingester.max-ignored-stream-errors", 10, "Maximum number of ignored stream errors to return. 0 to return all errors.")
-	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", time.Hour, "Maximum chunk age before flushing.")
+	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 2*time.Hour, "Maximum chunk age before flushing.")
 	f.DurationVar(&cfg.QueryStoreMaxLookBackPeriod, "ingester.query-store-max-look-back-period", 0, "How far back should an ingester be allowed to query the store for data, for use only with boltdb-shipper index and filesystem object store. -1 for infinite.")
 	f.BoolVar(&cfg.AutoForgetUnhealthy, "ingester.autoforget-unhealthy", false, "Enable to remove unhealthy ingesters from the ring after `ring.kvstore.heartbeat_timeout`")
 	f.IntVar(&cfg.IndexShards, "ingester.index-shards", index.DefaultIndexShards, "Shard factor used in the ingesters for the in process reverse index. This MUST be evenly divisible by ALL schema shard factors or Loki will not start.")

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -147,12 +147,6 @@ func (c *Config) registerQueryRangeFlagsWithChangedDefaultValues(fs *flag.FlagSe
 		switch f.Name {
 		case "querier.split-queries-by-interval":
 			_ = f.Value.Set("30m")
-
-		case "querier.align-querier-with-step":
-			_ = f.Value.Set("true")
-
-		case "querier.parallelise-shardable-queries":
-			_ = f.Value.Set("true")
 		}
 
 		fs.Var(f.Value, f.Name, f.Usage)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -136,7 +136,8 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 
 func (c *Config) registerQueryRangeFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	throwaway := flag.NewFlagSet("throwaway", flag.PanicOnError)
-
+	// NB: We can remove this after removing Loki's dependency on Cortex and bringing in the queryrange.Config.
+	// That will let us change the defaults there rather than include wrapper functions like this one.
 	// Register to throwaway flags first. Default values are remembered during registration and cannot be changed,
 	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
 	c.QueryRange.RegisterFlags(throwaway)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -147,6 +147,9 @@ func (c *Config) registerQueryRangeFlagsWithChangedDefaultValues(fs *flag.FlagSe
 		switch f.Name {
 		case "querier.split-queries-by-interval":
 			_ = f.Value.Set("30m")
+
+		case "querier.parallelise-shardable-queries":
+			_ = f.Value.Set("true")
 		}
 
 		fs.Var(f.Value, f.Name, f.Usage)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -105,7 +105,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Frontend.RegisterFlags(f)
 	c.Ruler.RegisterFlags(f)
 	c.Worker.RegisterFlags(f)
-	c.QueryRange.RegisterFlags(f)
+	c.registerQueryRangeFlagsWithChangedDefaultValues(f)
 	c.RuntimeConfig.RegisterFlags(f)
 	c.MemberlistKV.RegisterFlags(f)
 	c.Tracing.RegisterFlags(f)
@@ -127,6 +127,30 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 			_ = f.Value.Set("10s")
 
 		case "server.grpc.keepalive.ping-without-stream-allowed":
+			_ = f.Value.Set("true")
+		}
+
+		fs.Var(f.Value, f.Name, f.Usage)
+	})
+}
+
+func (c *Config) registerQueryRangeFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
+	throwaway := flag.NewFlagSet("throwaway", flag.PanicOnError)
+
+	// Register to throwaway flags first. Default values are remembered during registration and cannot be changed,
+	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
+	c.QueryRange.RegisterFlags(throwaway)
+
+	throwaway.VisitAll(func(f *flag.Flag) {
+		// Ignore errors when setting new values. We have a test to verify that it works.
+		switch f.Name {
+		case "querier.split-queries-by-interval":
+			_ = f.Value.Set("30m")
+
+		case "querier.align-querier-with-step":
+			_ = f.Value.Set("true")
+
+		case "querier.parallelise-shardable-queries":
 			_ = f.Value.Set("true")
 		}
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -57,7 +57,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.TailMaxDuration, "querier.tail-max-duration", 1*time.Hour, "Limit the duration for which live tailing request would be served")
 	f.DurationVar(&cfg.QueryTimeout, "querier.query-timeout", 1*time.Minute, "Timeout when querying backends (ingesters or storage) during the execution of a query request")
 	f.DurationVar(&cfg.ExtraQueryDelay, "querier.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
-	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 2*time.Hour, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
+	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 3*time.Hour, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
 	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 10, "The maximum number of concurrent queries.")
 	f.BoolVar(&cfg.QueryStoreOnly, "querier.query-store-only", false, "Queriers should only query the store and not try to query any ingesters")
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -57,8 +57,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.TailMaxDuration, "querier.tail-max-duration", 1*time.Hour, "Limit the duration for which live tailing request would be served")
 	f.DurationVar(&cfg.QueryTimeout, "querier.query-timeout", 1*time.Minute, "Timeout when querying backends (ingesters or storage) during the execution of a query request")
 	f.DurationVar(&cfg.ExtraQueryDelay, "querier.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
-	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
-	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The maximum number of concurrent queries.")
+	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 2*time.Hour, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
+	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 10, "The maximum number of concurrent queries.")
 	f.BoolVar(&cfg.QueryStoreOnly, "querier.query-store-only", false, "Queriers should only query the store and not try to query any ingesters")
 }
 

--- a/vendor/github.com/cortexproject/cortex/pkg/querier/queryrange/roundtrip.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/querier/queryrange/roundtrip.go
@@ -67,10 +67,10 @@ type Config struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRetries, "querier.max-retries-per-request", 5, "Maximum number of retries for a single request; beyond this, the downstream error is returned.")
-	f.DurationVar(&cfg.SplitQueriesByInterval, "querier.split-queries-by-interval", 30*time.Minute, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled")
-	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", true, "Mutate incoming queries to align their start and end with their step.")
+	f.DurationVar(&cfg.SplitQueriesByInterval, "querier.split-queries-by-interval", 0, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled")
+	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step.")
 	f.BoolVar(&cfg.CacheResults, "querier.cache-results", false, "Cache query results.")
-	f.BoolVar(&cfg.ShardedQueries, "querier.parallelise-shardable-queries", true, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the chunks storage engine.")
+	f.BoolVar(&cfg.ShardedQueries, "querier.parallelise-shardable-queries", false, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the chunks storage engine.")
 	f.Var(&cfg.ForwardHeaders, "frontend.forward-headers-list", "List of headers forwarded by the query Frontend to downstream querier.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }

--- a/vendor/github.com/cortexproject/cortex/pkg/querier/queryrange/roundtrip.go
+++ b/vendor/github.com/cortexproject/cortex/pkg/querier/queryrange/roundtrip.go
@@ -67,10 +67,10 @@ type Config struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRetries, "querier.max-retries-per-request", 5, "Maximum number of retries for a single request; beyond this, the downstream error is returned.")
-	f.DurationVar(&cfg.SplitQueriesByInterval, "querier.split-queries-by-interval", 0, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled")
-	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step.")
+	f.DurationVar(&cfg.SplitQueriesByInterval, "querier.split-queries-by-interval", 30*time.Minute, "Split queries by an interval and execute in parallel, 0 disables it. You should use an a multiple of 24 hours (same as the storage bucketing scheme), to avoid queriers downloading and processing the same chunks. This also determines how cache keys are chosen when result caching is enabled")
+	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", true, "Mutate incoming queries to align their start and end with their step.")
 	f.BoolVar(&cfg.CacheResults, "querier.cache-results", false, "Cache query results.")
-	f.BoolVar(&cfg.ShardedQueries, "querier.parallelise-shardable-queries", false, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the chunks storage engine.")
+	f.BoolVar(&cfg.ShardedQueries, "querier.parallelise-shardable-queries", true, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the chunks storage engine.")
 	f.Var(&cfg.ForwardHeaders, "frontend.forward-headers-list", "List of headers forwarded by the query Frontend to downstream querier.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Default `parallelise_shardable_queries` to `true` (was `false`)
Default  `split_queries_by_interval` to `30m` (was `0s`)
~Default `align_queries_with_step` to `true` (was `fasle`)~ (kept the previous default due to the result of this change on queries with very large steps)

Default `query_ingesters_within` and `max_chunk_age` ~both to `2h`~ to `3h` and `2h` respectively (the addtional hour provides a buffer on top of `max_chunk_age`). Previously, `max_chunk_age` was set to `1h` and `query_ingesters_within` was set to `0`, meaning always query ingesters. An ingester with no data for a query will return quickly, so the performance improvement by defaulting `query_ingesters_within` to `2h` is minimal, and it does introduce complexity, since now if the `max_chunk_age` is increased, you could end up with un-queryable data on the ingester. I'm open to reverting this one based on feedback?

Default `max_concurrent` to the default value of `parallelism`, which is `10` (was `20`, but should be the same as `parallelism`).

** Update **

After discussion, this PR contains of the subset of the changes above. Updates were made inline above using ~strikethrough~

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
