### PR TITLE
[enhancement] querier cache: WriteBackCache should be off query path

### DIFF
--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -41,6 +41,11 @@ type Config struct {
 
 	// For tests to inject specific implementations.
 	Cache Cache `yaml:"-"`
+
+	// MaxAsyncConcurrency specifies the maximum number of SetAsync goroutines.
+	MaxAsyncConcurrency int `yaml:"max_async_concurrency"`
+	// MaxAsyncBufferSize specifies the queue buffer size for SetAsync operations.
+	MaxAsyncBufferSize int `yaml:"max_async_buffer_size"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -50,6 +55,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, description string, f 
 	cfg.MemcacheClient.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Redis.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Fifocache.RegisterFlagsWithPrefix(prefix, description, f)
+	f.IntVar(&cfg.MaxAsyncConcurrency, prefix+"max-async-concurrency", 16, "The maximum number of concurrent asynchronous operations can occur.")
+	f.IntVar(&cfg.MaxAsyncBufferSize, prefix+"max-async-buffer-size", 500, "The maximum number of enqueued asynchronous operations allowed.")
 	f.DurationVar(&cfg.DefaultValidity, prefix+"default-validity", time.Hour, description+"The default validity of entries for caches unless overridden.")
 	f.BoolVar(&cfg.EnableFifoCache, prefix+"cache.enable-fifocache", false, description+"Enable in-memory cache (auto-enabled for the chunks & query results cache if no other cache is configured).")
 

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -42,10 +42,10 @@ type Config struct {
 	// For tests to inject specific implementations.
 	Cache Cache `yaml:"-"`
 
-	// MaxAsyncConcurrency specifies the maximum number of SetAsync goroutines.
-	MaxAsyncConcurrency int `yaml:"max_async_concurrency"`
-	// MaxAsyncBufferSize specifies the queue buffer size for SetAsync operations.
-	MaxAsyncBufferSize int `yaml:"max_async_buffer_size"`
+	// AsyncCacheWriteBackConcurrency specifies the number of goroutines to use when asynchronously writing chunks fetched from the store to the chunk cache.
+	AsyncCacheWriteBackConcurrency int `yaml:"async_cache_write_back_concurrency"`
+	// AsyncCacheWriteBackBufferSize specifies the maximum number of fetched chunks to buffer for writing back to the chunk cache.
+	AsyncCacheWriteBackBufferSize int `yaml:"async_cache_write_back_buffer_size"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -55,8 +55,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, description string, f 
 	cfg.MemcacheClient.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Redis.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Fifocache.RegisterFlagsWithPrefix(prefix, description, f)
-	f.IntVar(&cfg.AsyncCacheWriteBackConcurrency, prefix+"max-async-concurrency", 16, "The maximum number of concurrent asynchronous operations can occur.")
-	f.IntVar(&cfg.AsyncCacheWriteBackBufferSize, prefix+"max-async-buffer-size", 500, "The maximum number of enqueued asynchronous operations allowed.")
+	f.IntVar(&cfg.AsyncCacheWriteBackConcurrency, prefix+"max-async-cache-write-back-concurrency", 16, "The maximum number of concurrent asynchronous writeback cache can occur.")
+	f.IntVar(&cfg.AsyncCacheWriteBackBufferSize, prefix+"max-async-cache-write-back-buffer-size", 500, "The maximum number of enqueued asynchronous writeback cache allowed.")
 	f.DurationVar(&cfg.DefaultValidity, prefix+"default-validity", time.Hour, description+"The default validity of entries for caches unless overridden.")
 	f.BoolVar(&cfg.EnableFifoCache, prefix+"cache.enable-fifocache", false, description+"Enable in-memory cache (auto-enabled for the chunks & query results cache if no other cache is configured).")
 

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -55,8 +55,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, description string, f 
 	cfg.MemcacheClient.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Redis.RegisterFlagsWithPrefix(prefix, description, f)
 	cfg.Fifocache.RegisterFlagsWithPrefix(prefix, description, f)
-	f.IntVar(&cfg.MaxAsyncConcurrency, prefix+"max-async-concurrency", 16, "The maximum number of concurrent asynchronous operations can occur.")
-	f.IntVar(&cfg.MaxAsyncBufferSize, prefix+"max-async-buffer-size", 500, "The maximum number of enqueued asynchronous operations allowed.")
+	f.IntVar(&cfg.AsyncCacheWriteBackConcurrency, prefix+"max-async-concurrency", 16, "The maximum number of concurrent asynchronous operations can occur.")
+	f.IntVar(&cfg.AsyncCacheWriteBackBufferSize, prefix+"max-async-buffer-size", 500, "The maximum number of enqueued asynchronous operations allowed.")
 	f.DurationVar(&cfg.DefaultValidity, prefix+"default-validity", time.Hour, description+"The default validity of entries for caches unless overridden.")
 	f.BoolVar(&cfg.EnableFifoCache, prefix+"cache.enable-fifocache", false, description+"Enable in-memory cache (auto-enabled for the chunks & query results cache if no other cache is configured).")
 

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -124,7 +124,7 @@ func testChunkFetcher(t *testing.T, c cache.Cache, keys []string, chunks []chunk
 		},
 	}
 
-	fetcher, err := chunk.NewChunkFetcher(c, false, s, nil)
+	fetcher, err := chunk.NewChunkFetcher(c, false, s, nil, 10, 100)
 	require.NoError(t, err)
 	defer fetcher.Stop()
 

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -99,7 +99,7 @@ type baseStore struct {
 }
 
 func newBaseStore(cfg StoreConfig, scfg SchemaConfig, schema BaseSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (baseStore, error) {
-	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, scfg, chunks)
+	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, scfg, chunks, cfg.ChunkCacheConfig.MaxAsyncConcurrency, cfg.ChunkCacheConfig.MaxAsyncBufferSize)
 	if err != nil {
 		return baseStore{}, err
 	}

--- a/pkg/storage/chunk/chunk_store.go
+++ b/pkg/storage/chunk/chunk_store.go
@@ -99,7 +99,7 @@ type baseStore struct {
 }
 
 func newBaseStore(cfg StoreConfig, scfg SchemaConfig, schema BaseSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (baseStore, error) {
-	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, scfg, chunks, cfg.ChunkCacheConfig.MaxAsyncConcurrency, cfg.ChunkCacheConfig.MaxAsyncBufferSize)
+	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, scfg, chunks, cfg.ChunkCacheConfig.AsyncCacheWriteBackConcurrency, cfg.ChunkCacheConfig.AsyncCacheWriteBackBufferSize)
 	if err != nil {
 		return baseStore{}, err
 	}

--- a/pkg/storage/chunk/chunk_store_utils.go
+++ b/pkg/storage/chunk/chunk_store_utils.go
@@ -27,12 +27,12 @@ var (
 		Help: "Total number of operations against cache that have been skipped.",
 	}, []string{"reason"})
 	chunkFetcherCacheQueueEnqueue = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "loki_chunk_fetcher_cache_enqueue_total",
-		Help: "Total number of chunk enqueue cache queue.",
+		Name: "loki_chunk_fetcher_cache_enqueued_total",
+		Help: "Total number of chunks enqueued to a buffer to be asynchronously written back to the chunk cache.",
 	})
 	chunkFetcherCacheQueueDequeue = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "loki_chunk_fetcher_cache_dequeue_total",
-		Help: "Total number of chunk dequeue cache queue.",
+		Name: "loki_chunk_fetcher_cache_dequeued_total",
+		Help: "Total number of chunks asynchronously dequeued from a buffer and written back to the chunk cache.",
 	})
 )
 

--- a/pkg/storage/chunk/chunk_store_utils.go
+++ b/pkg/storage/chunk/chunk_store_utils.go
@@ -163,7 +163,7 @@ func (c *Fetcher) asyncQueueProcessLoop() {
 		case fromStorage := <-c.asyncQueue:
 			cacheErr := c.writeBackCache(context.Background(), fromStorage)
 			if cacheErr != nil {
-				level.Warn(util_log.Logger).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
+				level.Warn(util_log.Logger).Log("msg", "could not write fetched chunks from storage into chunk cache", "err", cacheErr)
 			}
 		case <-c.stop:
 			return

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -210,7 +210,7 @@ func (m *mockChunkStore) GetChunkRefs(ctx context.Context, userID string, from, 
 		panic(err)
 	}
 
-	f, err := chunk.NewChunkFetcher(cache, false, m.schemas, m.client)
+	f, err := chunk.NewChunkFetcher(cache, false, m.schemas, m.client, 10, 100))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -210,7 +210,7 @@ func (m *mockChunkStore) GetChunkRefs(ctx context.Context, userID string, from, 
 		panic(err)
 	}
 
-	f, err := chunk.NewChunkFetcher(cache, false, m.schemas, m.client, 10, 100))
+	f, err := chunk.NewChunkFetcher(cache, false, m.schemas, m.client, 10, 100)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
ref issue: https://github.com/grafana/loki/issues/5072


a queue (buffered channel) configurable in size (500 keys ~ 1GB)

	`c.asyncQueue = make(chan []Chunk, c.maxAsyncBufferSize)
	maxAsyncBufferSize:  1000,`
		
Each chunk is 1Mb, and the chan length is 1000, which is approximately equal to 1Gb
