### PR TITLE
Removes split-by upstream validation

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 	"github.com/go-kit/log"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/weaveworks/common/httpgrpc"
@@ -28,6 +29,16 @@ type Config struct {
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Config.RegisterFlags(f)
+}
+
+// Validate validates the config.
+func (cfg *Config) Validate() error {
+	if cfg.CacheResults {
+		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
+			return errors.Wrap(err, "invalid ResultsCache config")
+		}
+	}
+	return nil
 }
 
 // Stopper gracefully shutdown resources created


### PR DESCRIPTION
https://github.com/grafana/loki/pull/5023 Removes the global split by configuration but we still have validation from upstream code configuration.

This PR removes the validation, while it is valid for a non multi tenant split-by in our case the validation is actually not working as we could override a tenant to a split-by zero and this means it would break his read path.

I understand this doesn't solve the problem (which we need to figure how to) but at least it really makes  the global split-by unused.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

