### PR TITLE
[enhancement] querier : Add "query_memory_only" to make loki have option to rely only on memory availability like google monarch.

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -154,6 +154,9 @@ func (c *Config) Validate() error {
 	if err := c.QueryRange.Validate(); err != nil {
 		return errors.Wrap(err, "invalid queryrange config")
 	}
+	if err := c.Querier.Validate(); err != nil {
+		return errors.Wrap(err, "invalid querier config")
+	}
 	if err := c.TableManager.Validate(); err != nil {
 		return errors.Wrap(err, "invalid tablemanager config")
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -50,7 +50,7 @@ type Config struct {
 	Engine                        logql.EngineOpts `yaml:"engine,omitempty"`
 	MaxConcurrent                 int              `yaml:"max_concurrent"`
 	QueryStoreOnly                bool             `yaml:"query_store_only"`
-	QueryMemoryOnly               bool             `yaml:"query_memory_only"`
+	QueryIngesterOnly               bool             `yaml:"query_ingester_only"`
 }
 
 // RegisterFlags register flags.


### PR DESCRIPTION
**What this PR does / why we need it**:
    Add "query_memory_only" to make loki have option to rely only on memory availability like google monarch.

1: momery + store mode
![image](https://user-images.githubusercontent.com/9583245/148887456-d6f5e52c-0ecb-4f41-866b-239eae2ad342.png)
2: momery mode
![image](https://user-images.githubusercontent.com/9583245/148887636-1880160b-a6a6-4673-9724-b317f391e19e.png)
**Which issue(s) this PR fixes**:
Fixes nil
**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/9583245/148888942-9e94cad2-7110-434d-90e3-a0f947e2d22a.png)
<Monarch: Google’s Planet-Scale In-Memory
Time Series Database>
 https://www.vldb.org/pvldb/vol13/p3181-adams.pdf
**Why is important**
Last week, due to the 1.5-hour unavailability of the s3 service in our area, the loki cluster operator by me was also completely unavailable for 1.5 hours, which had a very negative impact on my work。
In order to solve this problem, I checked After some information on how other companies solve this problem, I found that google's monarch has an in-memory mode that allows monitoring to be available when storage is unavailable. So I think this mode can help loki operators like me.

ref unavailable loki snapshot：
![image](https://user-images.githubusercontent.com/9583245/148888041-a674408f-ab7b-4262-83d4-51fbd9f8c8b0.png)

![image](https://user-images.githubusercontent.com/9583245/148887985-211109e4-2764-41c0-a8ce-bebdf6546a04.png)

![image](https://user-images.githubusercontent.com/9583245/148887687-863d3014-b6cf-4a70-9ba7-6a9e8af8ff31.png)

![image](https://user-images.githubusercontent.com/9583245/148887809-7e3f1703-39c2-40cb-b0a9-8389205c270a.png)

![image](https://user-images.githubusercontent.com/9583245/148887883-9ebade3b-65eb-4386-a069-3cf8fff0659e.png)


If there are similar option, when s3 is unavailable, I can adjust the querier to memory mode to downgrade the service of loki, wait for s3 to become available, and then restore to a fully available loki, so that the failure will not be too serious.
Hope similar failures don't happen to other loki operators like me.
