### PR TITLE
fluentd: Fix bug that caused lines to be dropped when containing non utf-8 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [5107](https://github.com/grafana/loki/pull5107) **chaudum** Fix bug in fluentd plugin that caused log lines containing non UTF-8 characters to be dropped.
 * [5091](https://github.com/grafana/loki/pull/5091) **owen-d**: Changes `ingester.concurrent-flushes` default to 32
 * [4879](https://github.com/grafana/loki/pull/4879) **cyriltovena**: LogQL: add __line__ function to | line_format template.
 * [5081](https://github.com/grafana/loki/pull/5081) **SasSwart**: Add the option to configure memory ballast for Loki

--- a/Makefile
+++ b/Makefile
@@ -425,9 +425,10 @@ fluent-bit-test:
 # fluentd plugin #
 ##################
 fluentd-plugin:
-	gem install bundler --version 1.16.2
+	gem install bundler --version 2.3.4
 	bundle config silence_root_warning true
-	bundle install --gemfile=clients/cmd/fluentd/Gemfile --path=clients/cmd/fluentd/vendor/bundle
+	bundle config set --local path clients/cmd/fluentd/vendor/bundle
+	bundle install --gemfile=clients/cmd/fluentd/Gemfile
 
 fluentd-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/fluent-plugin-loki:$(IMAGE_TAG) -f clients/cmd/fluentd/Dockerfile .
@@ -435,9 +436,9 @@ fluentd-image:
 fluentd-push:
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/fluent-plugin-loki:$(IMAGE_TAG)
 
-fluentd-test: LOKI_URL ?= http://localhost:3100/loki/api/
+fluentd-test: LOKI_URL ?= http://loki:3100
 fluentd-test:
-	LOKI_URL="$(LOKI_URL)" docker-compose -f clients/cmd/fluentd/docker/docker-compose.yml up --build $(IMAGE_PREFIX)/fluent-plugin-loki:$(IMAGE_TAG)
+	LOKI_URL="$(LOKI_URL)" docker-compose -f clients/cmd/fluentd/docker/docker-compose.yml up --build
 
 ##################
 # logstash plugin #

--- a/clients/cmd/fluentd/.gitignore
+++ b/clients/cmd/fluentd/.gitignore
@@ -1,3 +1,9 @@
-/coverage/
-/.rspec_status
-/Gemfile.lock
+Gemfile.lock
+.rspec_status
+# rbenv
+.ruby-version
+# bundler
+.bundle/
+vendor/
+# simplecov
+coverage/

--- a/clients/cmd/fluentd/.rubocop.yml
+++ b/clients/cmd/fluentd/.rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  NewCops: disable
   Exclude:
     - 'bin/**'
     - 'test/**/*.rb'

--- a/clients/cmd/fluentd/Dockerfile
+++ b/clients/cmd/fluentd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6 as build
+FROM ruby:2.7.5 as build
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/clients/cmd/fluentd/README.md
+++ b/clients/cmd/fluentd/README.md
@@ -6,14 +6,17 @@ See [docs/client/fluentd/README.md](../../docs/sources/clients/fluentd/_index.md
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `fluent-plugin-grafana-loki.gemspec`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `ruby -S bundle exec rake install`. To release a new version, update the version number in `fluent-plugin-grafana-loki.gemspec`, and then run `ruby -S bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
-To create the gem: `gem build fluent-plugin-grafana-loki.gemspec`
+To create the gem: `ruby -S gem build fluent-plugin-grafana-loki.gemspec`
 
 Useful additions:
-  `gem install rubocop`
+
+```bash
+ruby -S gem install rubocop
+```
 
 ## Testing
 

--- a/clients/cmd/fluentd/bin/setup
+++ b/clients/cmd/fluentd/bin/setup
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
 
-gem install bundler
-bundle install
+set -euo pipefail
+
+ruby --version
+echo ""
+ruby -S gem install bundler --version 2.3.4
+ruby -S bundle config set --local path $(pwd)/vendor/bundle
+ruby -S bundle install

--- a/clients/cmd/fluentd/bin/test
+++ b/clients/cmd/fluentd/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ruby -S bundle exec rspec

--- a/clients/cmd/fluentd/docker/docker-compose.yml
+++ b/clients/cmd/fluentd/docker/docker-compose.yml
@@ -1,15 +1,28 @@
 version: '3'
 services:
+  loki:
+    build:
+      context: ../../../../
+      dockerfile: ./cmd/loki/Dockerfile
+    image: grafana/loki:main
+    ports:
+      - 3100
+    volumes:
+    - ./fluentd.conf:/fluentd/etc/fluent.conf
+
   # Receive forwarded logs and send to /fluentd/logs/data.log and loki
   fluentd:
     build:
-      context: ../../../..
-      dockerfile: ../Dockerfile
-    image: fluentd:loki
+      context: ../../../../
+      dockerfile: ./clients/cmd/fluentd/Dockerfile
+    image: grafana/fluent-plugin-loki:main
     volumes:
     - ./fluentd.conf:/fluentd/etc/fluent.conf
     environment:
       - LOKI_URL
+    depends_on:
+    - loki
+
   # Read /var/log/syslog and send it to fluentd
   fluentbit:
     image: fluent/fluent-bit:1.0
@@ -20,3 +33,4 @@ services:
     - /var/log/syslog:/var/log/syslog:ro
     depends_on:
     - fluentd
+    - loki

--- a/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.16'
+  spec.version = '1.2.17'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 

--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -278,8 +278,8 @@ module Fluent
           when :key_value
             formatted_labels = []
             record.each do |k, v|
-              # Remove non UTF-8 characters by force-encoding the string and replacing said chars with empty string
-              v = v.encode('utf-8', invalid: :replace, replace: '')
+              # Remove non UTF-8 characters by force-encoding the string
+              v = v.encode('utf-8', invalid: :replace)
               # Escape double quotes and backslashes by prefixing them with a backslash
               v = v.to_s.gsub(%r{(["\\])}, '\\\\\1')
               if v.include?(' ') || v.include?('=')

--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -278,6 +278,8 @@ module Fluent
           when :key_value
             formatted_labels = []
             record.each do |k, v|
+              # Remove non UTF-8 characters by force-encoding the string and replacing said chars with empty string
+              v = v.encode('utf-8', invalid: :replace, replace: '')
               # Escape double quotes and backslashes by prefixing them with a backslash
               v = v.to_s.gsub(%r{(["\\])}, '\\\\\1')
               if v.include?(' ') || v.include?('=')
@@ -292,7 +294,6 @@ module Fluent
         line
       end
 
-      #
       # convert a line to loki line with labels
       def line_to_loki(record)
         chunk_labels = {}

--- a/clients/cmd/fluentd/spec/gems/fluent/plugin/data/non_utf8.log
+++ b/clients/cmd/fluentd/spec/gems/fluent/plugin/data/non_utf8.log
@@ -1,0 +1,1 @@
+Á rest of line

--- a/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
+++ b/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(payload[0]['stream'].empty?).to eq true
     expect(payload[0]['values'].count).to eq 1
     expect(payload[0]['values'][0][0]).to eq '1546270458000000000'
-    expect(payload[0]['values'][0][1]).to eq 'message=" rest of line" stream=stdout'
+    expect(payload[0]['values'][0][1]).to eq 'message="� rest of line" stream=stdout'
   end
 
   it 'formats record hash as key_value' do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When a log line in hash format contains non UTF-8 characters fluentd
would drop the complete line because it failed to convert the line in
key-value format.

By forcing UTF-8 encoding and replacing non UTF-8 characters with empty
strings the log line will not be dropped but only contain the valid
UTF-8 characters.

**Which issue(s) this PR fixes**:

Fixes #5099

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
