### PR TITLE
Docs/configuration: fix incorrect env-subst syntax

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -56,7 +56,7 @@ References to undefined variables are replaced by empty strings unless you speci
 To specify a default value, use:
 
 ```
-${VAR:default_value}
+${VAR:-default_value}
 ```
 
 Where default_value is the value to use if the environment variable is undefined.


### PR DESCRIPTION
Signed-off-by: Marks Polakovs <marks.polakovs@couchbase.com>

**What this PR does / why we need it**:

The docs currently state that the syntax for default values if `config.expand-env=true` is `${VAR:default}`. However, Loki uses https://github.com/drone/envsubst, where the correct syntax is `${VAR:-n}` - `${VAR:foo}` is the syntax to "offset $VAR n characters from start"

**Checklist**
- [x] Documentation added
- [n/a] Tests updated
- [n/a] Add an entry in the `CHANGELOG.md` about the changes.
