### PR TITLE
Fix cancel issue between Query Frontend and Query Schdeduler

### DIFF
--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -224,7 +224,6 @@ enqueueAgain:
 	select {
 	case <-ctx.Done():
 		if cancelCh != nil {
-			// NOTE(kavi): I think we don't need buffer channel.
 			// Let it block until it's workers receives it, We don't want to exist RoundTripGRPC without cancelling the downstream request started by this request.
 			f.schedulerWorkers.sendRequestCancel(freq.queryID, cancelCh)
 		}

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -217,7 +217,7 @@ enqueueAgain:
 	select {
 	case <-ctx.Done():
 		if cancelCh != nil {
-			// Let it block until it's workers receives it, We don't want to exist RoundTripGRPC without cancelling the downstream request started by this request.
+			// Let it block until it's workers receives it. We don't want to exit RoundTripGRPC without cancelling the downstream request started by this request.
 			f.schedulerWorkers.sendRequestCancel(freq.queryID, cancelCh)
 		}
 		return nil, ctx.Err()

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -225,8 +225,10 @@ enqueueAgain:
 	case <-ctx.Done():
 		if cancelCh != nil {
 			// NOTE(kavi): I think we don't need buffer channel.
-			// Let it block, it worker receives it, We don't want to exist RoundTripGRPC without cancelling the frontend worker
-			cancelCh <- freq.queryID
+			// Let it block until it's workers receives it, We don't want to exist RoundTripGRPC without cancelling the downstream request started by frontend workers.
+			if f.schedulerWorkers.getWorkersCount() > 0 {
+				cancelCh <- freq.queryID
+			}
 
 			// select {
 			// case cancelCh <- freq.queryID:

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -226,9 +226,7 @@ enqueueAgain:
 		if cancelCh != nil {
 			// NOTE(kavi): I think we don't need buffer channel.
 			// Let it block until it's workers receives it, We don't want to exist RoundTripGRPC without cancelling the downstream request started by frontend workers.
-			if f.schedulerWorkers.getWorkersCount() > 0 {
-				cancelCh <- freq.queryID
-			}
+			f.schedulerWorkers.sendRequestCancel(freq.queryID, cancelCh)
 
 			// select {
 			// case cancelCh <- freq.queryID:

--- a/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -276,6 +277,7 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 			return nil
 
 		case req := <-w.requestCh:
+			fmt.Println("Got the request", req.queryID)
 			err := loop.Send(&schedulerpb.FrontendToScheduler{
 				Type:            schedulerpb.ENQUEUE,
 				QueryID:         req.queryID,
@@ -325,6 +327,7 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 			}
 
 		case reqID := <-w.cancelCh:
+			fmt.Println("Got the cancel as well", reqID)
 			err := loop.Send(&schedulerpb.FrontendToScheduler{
 				Type:    schedulerpb.CANCEL,
 				QueryID: reqID,

--- a/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
@@ -324,6 +324,7 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 					},
 				}
 			default:
+				level.Error(w.log).Log("msg", "unknown response status from the scheduler", "status", resp.Status, "queryID", req.queryID)
 				req.enqueue <- enqueueResult{status: failed}
 			}
 

--- a/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -291,7 +290,6 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 			return nil
 
 		case req := <-w.requestCh:
-			fmt.Println("Got the request", req.queryID)
 			err := loop.Send(&schedulerpb.FrontendToScheduler{
 				Type:            schedulerpb.ENQUEUE,
 				QueryID:         req.queryID,
@@ -341,7 +339,6 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 			}
 
 		case reqID := <-w.cancelCh:
-			fmt.Println("Got the cancel as well", reqID)
 			err := loop.Send(&schedulerpb.FrontendToScheduler{
 				Type:    schedulerpb.CANCEL,
 				QueryID: reqID,

--- a/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
@@ -336,6 +336,8 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 						Body: []byte("too many outstanding requests"),
 					},
 				}
+			default:
+				req.enqueue <- enqueueResult{status: failed}
 			}
 
 		case reqID := <-w.cancelCh:

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -203,7 +203,7 @@ func TestFrontendWorkerCancellation(t *testing.T) {
 
 	// We wait a bit to make sure scheduler receives the cancellation request.
 	// 2 * reqCount because for every request, should also be corresponding cancel request
-	test.Poll(t, time.Second, 2*reqCount, func() interface{} {
+	test.Poll(t, 5*time.Second, 2*reqCount, func() interface{} {
 		ms.mu.Lock()
 		defer ms.mu.Unlock()
 

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -177,7 +177,7 @@ func TestFrontendCancellation(t *testing.T) {
 }
 
 // Bug: If FrontendWorkers are busy, cancellation passed by Query frontend may not reach
-// all the frontend workers. (assumming we run multiple frontend workers)
+// all the frontend workers thus not reaching the scheduler as well.
 func TestFrontendWorkerCancellation(t *testing.T) {
 	f, ms := setupFrontend(t, nil)
 

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -176,8 +176,9 @@ func TestFrontendCancellation(t *testing.T) {
 	})
 }
 
-// Bug: If FrontendWorkers are busy, cancellation passed by Query frontend may not reach
+// If FrontendWorkers are busy, cancellation passed by Query frontend may not reach
 // all the frontend workers thus not reaching the scheduler as well.
+// Issue: https://github.com/grafana/loki/issues/5132
 func TestFrontendWorkerCancellation(t *testing.T) {
 	f, ms := setupFrontend(t, nil)
 

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -181,8 +181,6 @@ func TestFrontendCancellation(t *testing.T) {
 func TestFrontendWorkerCancellation(t *testing.T) {
 	f, ms := setupFrontend(t, nil)
 
-	// fmt.Println("workers count", f.schedulerWorkers.getWorkersCount(), "max-concurrency per worker", f.cfg.WorkerConcurrency)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -212,11 +212,6 @@ func TestFrontendWorkerCancellation(t *testing.T) {
 
 	ms.checkWithLock(func() {
 		require.Equal(t, 2*reqCount, len(ms.msgs))
-
-		// require.True(t, ms.msgs[0].Type == schedulerpb.ENQUEUE)
-		// require.True(t, ms.msgs[1].Type == schedulerpb.CANCEL)
-		// require.True(t, ms.msgs[0].QueryID == ms.msgs[1].QueryID)
-		// fmt.Println(ms.msgs[0].QueryID, ms.msgs[1].QueryID)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Query Frontend failed to send cancel signal even to Query Frontend Worker during some special cases(explained below)
And that makes querier to run till completion(even after cancellation) wasting lots of resources.

This scenario is [analogous to this simple Go program](https://go.dev/play/p/YSb64s9UF6u) (run in go-playground). The gist is `default` branch in go `select` loop takes always precedence when other branch operations are blocked (sending or receiving on the channel). In our case, we **missed the sending of cancel signal**

Now to the original issue.

The main observation is for every Querier that haven't received cancel, it's corresponding Scheduler also didn't get it.

1. single query on QF has split into 128 sub queries
2. And all of them got scheduled and picked up by the querier.
3. I added some logs in two points. Where QF send sending cancel to scheduler, And scheduler loop sends it to querier. 

Then among those 128 subqueries, only 8 of them got cancel from QF to Scheduler, remaining 120 got dropped in QF itself, never even reached the Scheduler.

The root cause is, whenever frontend worker loop is busy with service request on the main select branch ([ lisitening on w.requestCh](https://github.com/grafana/loki/blob/main/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go#L278-L334) ), and if during that time, QF [send cancel request to Scheduler via cancelCh](https://github.com/grafana/loki/blob/main/pkg/lokifrontend/frontend/v2/frontend.go#L229-L230) it will get block for sometime on the other end (coz no buffer).  **During that time, it got into default case and thus ignoring the cancel signal even before sending it to Scheduler**.

Basically we need to make sure to send cancel signal to Scheduler, no matter how busy the frontend worker to pickup cancel from the cancelCh.

**Which issue(s) this PR fixes**:
Fixes #5132 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
