### PR TITLE
Querier worker/inflight metrics

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -268,7 +268,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	}
 
 	return querier.InitWorkerService(
-		querierWorkerServiceConfig, queryHandlers, alwaysExternalHandlers, t.Server.HTTP, t.Server.HTTPServer.Handler, t.HTTPAuthMiddleware,
+		querierWorkerServiceConfig, prometheus.DefaultRegisterer, queryHandlers, alwaysExternalHandlers, t.Server.HTTP, t.Server.HTTPServer.Handler, t.HTTPAuthMiddleware,
 	)
 }
 

--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -1,0 +1,25 @@
+package worker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Metrics struct {
+	frontendClientRequestDuration *prometheus.HistogramVec
+	frontendClientsGauge          prometheus.Gauge
+}
+
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	return &Metrics{
+		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "loki_querier_query_frontend_request_duration_seconds",
+			Help:    "Time spend doing requests to frontend.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+		}, []string{"operation", "status_code"}),
+		frontendClientsGauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_querier_query_frontend_clients",
+			Help: "The current number of clients connected to query-frontend.",
+		}),
+	}
+}

--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -6,12 +6,17 @@ import (
 )
 
 type Metrics struct {
+	inflightRequests              prometheus.Gauge
 	frontendClientRequestDuration *prometheus.HistogramVec
 	frontendClientsGauge          prometheus.Gauge
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	return &Metrics{
+		inflightRequests: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_querier_worker_inflight_queries",
+			Help: "Number of queries being processed by the querier workers",
+		}),
 		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",

--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -6,13 +6,18 @@ import (
 )
 
 type Metrics struct {
+	concurrentWorkers             prometheus.Gauge
 	inflightRequests              prometheus.Gauge
 	frontendClientRequestDuration *prometheus.HistogramVec
 	frontendClientsGauge          prometheus.Gauge
 }
 
-func NewMetrics(r prometheus.Registerer) *Metrics {
+func NewMetrics(conf Config, r prometheus.Registerer) *Metrics {
 	return &Metrics{
+		concurrentWorkers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_querier_worker_concurrency",
+			Help: "Number of concurrent querier workers",
+		}),
 		inflightRequests: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_querier_worker_inflight_queries",
 			Help: "Number of queries being processed by the querier workers",

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/dskit/services"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
@@ -30,7 +29,7 @@ import (
 	"github.com/grafana/loki/pkg/tenant"
 )
 
-func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, reg prometheus.Registerer) (*schedulerProcessor, []services.Service) {
+func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, metrics *Metrics) (*schedulerProcessor, []services.Service) {
 	p := &schedulerProcessor{
 		log:            log,
 		handler:        handler,
@@ -38,7 +37,7 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 		querierID:      cfg.QuerierID,
 		grpcConfig:     cfg.GRPCClientConfig,
 
-		metrics: NewMetrics(reg),
+		metrics: metrics,
 	}
 
 	poolConfig := client.PoolConfig{

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -131,12 +131,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
 			sp.metrics.inflightRequests.Inc()
-			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "type", "enqueue")
+			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
 			sp.metrics.inflightRequests.Dec()
-			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "type", "dequeue", "duration", time.Since(start))
+			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.
 			if err := c.Send(&schedulerpb.QuerierToScheduler{}); err != nil {

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -68,7 +68,7 @@ func TestResetConcurrency(t *testing.T) {
 				MaxConcurrentRequests: tt.maxConcurrent,
 			}
 
-			w, err := newQuerierWorkerWithProcessor(cfg, log.NewNopLogger(), &mockProcessor{}, "", nil, nil)
+			w, err := newQuerierWorkerWithProcessor(cfg, NewMetrics(cfg, nil), log.NewNopLogger(), &mockProcessor{}, "", nil, nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
 

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -46,6 +46,7 @@ type WorkerServiceConfig struct {
 //
 func InitWorkerService(
 	cfg WorkerServiceConfig,
+	reg prometheus.Registerer,
 	queryRoutesToHandlers map[string]http.Handler,
 	alwaysExternalRoutesToHandlers map[string]http.Handler,
 	externalRouter *mux.Router,
@@ -105,7 +106,8 @@ func InitWorkerService(
 			cfg.SchedulerRing,
 			httpgrpc_server.NewServer(externalHandler),
 			util_log.Logger,
-			prometheus.DefaultRegisterer)
+			reg,
+		)
 	}
 
 	// Since we must be running a querier with either a frontend and/or scheduler at this point, if no scheduler ring, frontend, or scheduler address
@@ -136,7 +138,8 @@ func InitWorkerService(
 		cfg.SchedulerRing,
 		httpgrpc_server.NewServer(internalHandler),
 		util_log.Logger,
-		prometheus.DefaultRegisterer)
+		reg,
+	)
 }
 
 func querierRunningStandalone(cfg WorkerServiceConfig) bool {

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -38,6 +38,7 @@ func Test_InitQuerierService(t *testing.T) {
 
 		querierWorkerService, err := InitWorkerService(
 			config,
+			nil,
 			mockQueryHandlers,
 			alwaysExternalHandlers,
 			externalRouter,


### PR DESCRIPTION
This adds a few new metrics. I've chosen not to thread them through the frontend processor as well as the scheduler processor because (1) these metrics previously didn't exist there and (2) we're largely moving towards scheduler usage even in the single binary.

I've also changed the prefixes from `cortex_` -> `loki_` after grepping and finding these unused.

These metrics and log lines will allow us to determine current read path saturation via
```promql
loki_querier_worker_inflight_queries
/
loki_querier_worker_concurrency
```
and will also enable tenant-partitioned log metrics via the `enqueue` and `dequeue` lines.