### PR TITLE
Remove split-queries-by-interval validation

### DIFF
--- a/pkg/querier/queryrange/queryrangebase/roundtrip.go
+++ b/pkg/querier/queryrange/queryrangebase/roundtrip.go
@@ -76,9 +76,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // Validate validates the config.
 func (cfg *Config) Validate() error {
 	if cfg.CacheResults {
-		if cfg.SplitQueriesByInterval <= 0 {
-			return errors.New("querier.cache-results may only be enabled in conjunction with querier.split-queries-by-interval. Please set the latter")
-		}
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid ResultsCache config")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

- Removes `split-queries-by-interval` validation when `query_range.cache-results` is enabled.
- This issue was introduced by #5023.
- This causes the loki components to always stay in error state. The error on the pods would be:
`level=error ts=2022-01-10T16:54:10.516711991Z caller=main.go:51 msg="validating config" err="invalid queryrange config: querier.cache-results may only be enabled in conjunction with querier.split-queries-by-interval. Please set the latter"`

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
