### PR TITLE
Test: Fix test in compactor/retention/expiration_test.go on slow machines

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
@@ -73,7 +73,7 @@ func Test_expirationChecker_Expired(t *testing.T) {
 		want bool
 	}{
 		{"expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), true},
-		{"just expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-1*time.Hour+(10*time.Microsecond))), false},
+		{"just expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-1*time.Hour+(10*time.Millisecond))), false},
 		{"not expired tenant", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-30*time.Minute)), false},
 		{"not expired tenant by far", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-72*time.Hour), model.Now().Add(-3*time.Hour)), false},
 		{"expired stream override", newChunkEntry("2", `{foo="bar"}`, model.Now().Add(-12*time.Hour), model.Now().Add(-10*time.Hour)), true},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The `"just expired tenant"` test requires the corresponding `e.Expired` to be called within 0.01ms with previous code, and which fails on low performance devices.
https://github.com/grafana/loki/blob/ff47d7419a889ac94e43c08c534a58f9d448bf8e/pkg/storage/stores/shipper/compactor/retention/expiration_test.go#L70-L88

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Checklist**
- [ ] Documentation added - not needed
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
