### PR TITLE
Ruler: Fix remote write basic auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main
 
-* [5107](https://github.com/grafana/loki/pull5107) **chaudum** Fix bug in fluentd plugin that caused log lines containing non UTF-8 characters to be dropped.
+* [5144](https://github.com/grafana/loki/pull/5144) **dannykopping** Ruler: fix remote write basic auth credentials.
+* [5107](https://github.com/grafana/loki/pull/5107) **chaudum** Fix bug in fluentd plugin that caused log lines containing non UTF-8 characters to be dropped.
 * [5091](https://github.com/grafana/loki/pull/5091) **owen-d**: Changes `ingester.concurrent-flushes` default to 32
 * [4879](https://github.com/grafana/loki/pull/4879) **cyriltovena**: LogQL: add __line__ function to | line_format template.
 * [5081](https://github.com/grafana/loki/pull/5081) **SasSwart**: Add the option to configure memory ballast for Loki

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -73,6 +73,10 @@ func (c *RemoteWriteConfig) Clone() (*RemoteWriteConfig, error) {
 		return nil, err
 	}
 
+	// BasicAuth.Password has a type of Secret (github.com/prometheus/common/config/config.go),
+	// so when its value is marshaled it is obfuscated as "<secret>".
+	// Here we copy the original password into the cloned config.
+	n.Client.HTTPClientConfig.BasicAuth.Password = c.Client.HTTPClientConfig.BasicAuth.Password
 	return n, nil
 }
 

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -191,7 +191,7 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 
 	// HTTP client config is not currently overrideable, all tenants' configs should inherit base
 	assert.Equal(t, tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Username, "foo")
-	assert.Equal(t, tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password, promConfig.Secret("<secret>"))
+	assert.Equal(t, tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password, promConfig.Secret("bar"))
 }
 
 func TestTenantRemoteWriteHeaderOverride(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
A community member reported that a configured basic auth password was being sent via HTTP as `<secret>`. The reason for this is that value is stored in a [`Secret`](https://pkg.go.dev/github.com/prometheus/common/config#Secret) type, which - when marshaled, obfuscated the original password to `<secret>`.

Big thanks to @kingjan1999 for the report and the fix.

**Which issue(s) this PR fixes**:
Fixes #5140

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
