### PR TITLE
Auto-expire old items from FIFO cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [5262](https://github.com/grafana/loki/pull/5262) **MichelHollands**: Remove the labelFilter field
 * [4911](https://github.com/grafana/loki/pull/4911) **jeschkies**: Support Docker service discovery in Promtail.
 * [5107](https://github.com/grafana/loki/pull/5107) **chaudum** Fix bug in fluentd plugin that caused log lines containing non UTF-8 characters to be dropped.
+* [5148](https://github.com/grafana/loki/pull/5148) **chaudum** Add periodic task to prune old expired items from the FIFO cache to free up memory.
 * [5187](https://github.com/grafana/loki/pull/5187) **aknuds1** Rename metric `cortex_experimental_features_in_use_total` to `loki_experimental_features_in_use_total` and metric `log_messages_total` to `loki_log_messages_total`.
 * [5170](https://github.com/grafana/loki/pull/5170) **chaudum** Fix deadlock in Promtail caused when targets got removed from a target group by the discovery manager.
 * [5163](https://github.com/grafana/loki/pull/5163) **chaudum** Fix regression in fluentd plugin introduced with #5107 that caused `NoMethodError` when parsing non-string values of log lines.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1900,10 +1900,15 @@ fifocache:
   # CLI flag: -<prefix>.fifocache.max-size-items
   [max_size_items: <int> | default = 0]
 
-  # The expiry duration for the cache.
+  # The expiry duration for the cache; deprecated in favour of `-<prefix>.fifocache.ttl`.
   # The default value of 0 disables expiration.
   # CLI flag: -<prefix>.fifocache.duration
   [validity: <duration>]
+
+  # The time to live for items in the cache before they get purged.
+  # The value of 0 disables auto-expiration.
+  # CLI flag: -<prefix>.fifocache.ttl
+  [ttl: <duration> | default = 1h]
 ```
 
 ## schema_config

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1900,12 +1900,12 @@ fifocache:
   # CLI flag: -<prefix>.fifocache.max-size-items
   [max_size_items: <int> | default = 0]
 
-  # The expiry duration for the cache; deprecated in favour of `-<prefix>.fifocache.ttl`.
+  # Deprecated: The expiry duration for the cache. Use `-<prefix>.fifocache.ttl`.
   # The default value of 0 disables expiration.
   # CLI flag: -<prefix>.fifocache.duration
   [validity: <duration>]
 
-  # The time to live for items in the cache before they get purged.
+  # The time for items to live in the cache before those items are purged.
   # The value of 0 disables auto-expiration.
   # CLI flag: -<prefix>.fifocache.ttl
   [ttl: <duration> | default = 1h]

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -129,7 +129,6 @@ func NewReader(writer io.Writer,
 			fmt.Fprintf(rd.w, "shutting down reader\n")
 			rd.shuttingDown = true
 			_ = rd.conn.Close()
-			rd.conn = nil
 		}
 	}()
 

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -129,6 +129,7 @@ func NewReader(writer io.Writer,
 			fmt.Fprintf(rd.w, "shutting down reader\n")
 			rd.shuttingDown = true
 			_ = rd.conn.Close()
+			rd.conn = nil
 		}
 	}()
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -483,7 +483,7 @@ func applyFIFOCacheConfig(r *ConfigWrapper) {
 		// The query results fifocache is still in Cortex so we couldn't change the flag defaults
 		// so instead we will override them here.
 		r.QueryRange.ResultsCacheConfig.CacheConfig.Fifocache.MaxSizeBytes = "1GB"
-		r.QueryRange.ResultsCacheConfig.CacheConfig.Fifocache.Validity = 1 * time.Hour
+		r.QueryRange.ResultsCacheConfig.CacheConfig.Fifocache.TTL = 1 * time.Hour
 	}
 }
 

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -41,7 +41,7 @@ var (
 				EnableFifoCache: true,
 				Fifocache: cache.FifoCacheConfig{
 					MaxSizeItems: 1024,
-					Validity:     24 * time.Hour,
+					TTL:          24 * time.Hour,
 				},
 			},
 		},

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -91,8 +91,8 @@ func New(cfg Config, reg prometheus.Registerer, logger log.Logger) (Cache, error
 	caches := []Cache{}
 
 	if cfg.EnableFifoCache {
-		if cfg.Fifocache.Validity == 0 && cfg.DefaultValidity != 0 {
-			cfg.Fifocache.Validity = cfg.DefaultValidity
+		if cfg.Fifocache.TTL == 0 && cfg.DefaultValidity != 0 {
+			cfg.Fifocache.TTL = cfg.DefaultValidity
 		}
 
 		if cache := NewFifoCache(cfg.Prefix+"fifocache", cfg.Fifocache, reg, logger); cache != nil {

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -199,7 +199,7 @@ func TestMemcache(t *testing.T) {
 }
 
 func TestFifoCache(t *testing.T) {
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 1e3, Validity: 1 * time.Hour},
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 1e3, TTL: 1 * time.Hour},
 		nil, log.NewNopLogger())
 	testCache(t, cache)
 }

--- a/pkg/storage/chunk/cache/fifo_cache.go
+++ b/pkg/storage/chunk/cache/fifo_cache.go
@@ -33,18 +33,22 @@ const (
 type FifoCacheConfig struct {
 	MaxSizeBytes string        `yaml:"max_size_bytes"`
 	MaxSizeItems int           `yaml:"max_size_items"`
-	Validity     time.Duration `yaml:"validity"`
+	TTL          time.Duration `yaml:"ttl"`
 
-	DeprecatedSize int `yaml:"size"`
+	DeprecatedValidity time.Duration `yaml:"validity"`
+	DeprecatedSize     int           `yaml:"size"`
+
+	PurgeInterval time.Duration
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
 func (cfg *FifoCacheConfig) RegisterFlagsWithPrefix(prefix, description string, f *flag.FlagSet) {
 	f.StringVar(&cfg.MaxSizeBytes, prefix+"fifocache.max-size-bytes", "1GB", description+"Maximum memory size of the cache in bytes. A unit suffix (KB, MB, GB) may be applied.")
 	f.IntVar(&cfg.MaxSizeItems, prefix+"fifocache.max-size-items", 0, description+"Maximum number of entries in the cache.")
-	f.DurationVar(&cfg.Validity, prefix+"fifocache.duration", time.Hour, description+"The expiry duration for the cache.")
+	f.DurationVar(&cfg.TTL, prefix+"fifocache.ttl", time.Hour, description+"The time to live for items in the cache before they get purged.")
 
-	f.IntVar(&cfg.DeprecatedSize, prefix+"fifocache.size", 0, "Deprecated (use max-size-items or max-size-bytes instead): "+description+"The number of entries to cache. ")
+	f.DurationVar(&cfg.DeprecatedValidity, prefix+"fifocache.duration", 0, "Deprecated (use ttl instead): "+description+"The expiry duration for the cache.")
+	f.IntVar(&cfg.DeprecatedSize, prefix+"fifocache.size", 0, "Deprecated (use max-size-items or max-size-bytes instead): "+description+"The number of entries to cache.")
 }
 
 func (cfg *FifoCacheConfig) Validate() error {
@@ -74,12 +78,15 @@ type FifoCache struct {
 	entries map[string]*list.Element
 	lru     *list.List
 
+	done chan struct{}
+
 	entriesAdded    prometheus.Counter
 	entriesAddedNew prometheus.Counter
 	entriesEvicted  prometheus.Counter
 	entriesCurrent  prometheus.Gauge
 	totalGets       prometheus.Counter
 	totalMisses     prometheus.Counter
+	staleGets       prometheus.Counter
 	memoryBytes     prometheus.Gauge
 }
 
@@ -105,11 +112,26 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 		level.Warn(logger).Log("msg", "neither fifocache.max-size-bytes nor fifocache.max-size-items is set", "cache", name)
 		return nil
 	}
-	return &FifoCache{
+
+	if cfg.DeprecatedValidity > 0 {
+		flagext.DeprecatedFlagsUsed.Inc()
+		level.Warn(logger).Log("msg", "running with DEPRECATED flag fifocache.interval, use fifocache.ttl instead", "cache", name)
+		cfg.TTL = cfg.DeprecatedValidity
+	}
+
+	// Set a default interval for the ticker
+	// This can be overwritten to a smaller value in tests
+	if cfg.PurgeInterval == 0 {
+		cfg.PurgeInterval = 1 * time.Minute
+	}
+
+	cache := &FifoCache{
 		maxSizeItems: cfg.MaxSizeItems,
 		maxSizeBytes: maxSizeBytes,
 		entries:      make(map[string]*list.Element),
 		lru:          list.New(),
+
+		done: make(chan struct{}),
 
 		entriesAdded: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace:   "querier",
@@ -159,6 +181,14 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 			ConstLabels: prometheus.Labels{"cache": name},
 		}),
 
+		staleGets: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "stale_gets_total",
+			Help:        "The total number of Get calls that had an entry which expired (deprecated)",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
+
 		memoryBytes: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace:   "querier",
 			Subsystem:   "cache",
@@ -166,6 +196,43 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 			Help:        "The current cache size in bytes",
 			ConstLabels: prometheus.Labels{"cache": name},
 		}),
+	}
+
+	if cfg.TTL > 0 {
+		go cache.runPruneJob(cfg.PurgeInterval, cfg.TTL)
+	}
+
+	return cache
+}
+
+func (c *FifoCache) runPruneJob(interval, ttl time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			c.pruneExpiredItems(ttl)
+		}
+	}
+}
+
+// pruneExpiredItems prunes items in the cache that exceeded their ttl
+func (c *FifoCache) pruneExpiredItems(ttl time.Duration) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for k, v := range c.entries {
+		entry := v.Value.(*cacheEntry)
+		if time.Since(entry.updated) > ttl {
+			_ = c.lru.Remove(v).(*cacheEntry)
+			delete(c.entries, k)
+			c.currSizeBytes -= sizeOf(entry)
+			c.entriesCurrent.Dec()
+			c.entriesEvicted.Inc()
+		}
 	}
 }
 
@@ -202,6 +269,8 @@ func (c *FifoCache) Store(ctx context.Context, keys []string, values [][]byte) e
 func (c *FifoCache) Stop() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	close(c.done)
 
 	c.entriesEvicted.Add(float64(c.lru.Len()))
 

--- a/pkg/storage/chunk/storage/caching_fixtures.go
+++ b/pkg/storage/chunk/storage/caching_fixtures.go
@@ -30,7 +30,7 @@ func (f fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, 
 	logger := log.NewNopLogger()
 	indexClient = newCachingIndexClient(indexClient, cache.NewFifoCache("index-fifo", cache.FifoCacheConfig{
 		MaxSizeItems: 500,
-		Validity:     5 * time.Minute,
+		TTL:          5 * time.Minute,
 	}, reg, logger), 5*time.Minute, limits, logger, false)
 	return indexClient, chunkClient, tableClient, schemaConfig, closer, err
 }

--- a/pkg/storage/chunk/storage/caching_index_client_test.go
+++ b/pkg/storage/chunk/storage/caching_index_client_test.go
@@ -44,7 +44,7 @@ func TestCachingStorageClientBasic(t *testing.T) {
 	limits, err := defaultLimits()
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{{
 		TableName: "table",
@@ -76,7 +76,7 @@ func TestTempCachingStorageClient(t *testing.T) {
 	limits, err := defaultLimits()
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo"},
@@ -135,7 +135,7 @@ func TestPermCachingStorageClient(t *testing.T) {
 	limits, err := defaultLimits()
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", Immutable: true},
@@ -187,7 +187,7 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 	limits, err := defaultLimits()
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{{TableName: "table", HashValue: "foo"}}
 	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
@@ -226,7 +226,7 @@ func TestCachingStorageClientCollision(t *testing.T) {
 	limits, err := defaultLimits()
 	require.NoError(t, err)
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, false)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
@@ -406,7 +406,7 @@ func TestCachingStorageClientStoreQueries(t *testing.T) {
 				require.NoError(t, err)
 				logger := log.NewNopLogger()
 				cache := &mockCache{
-					Cache: cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger),
+					Cache: cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, TTL: 10 * time.Second}, nil, logger),
 				}
 				client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger, disableBroadQueries)
 				var callbackQueries []chunk.IndexQuery


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Addresses the problem of the FIFO cache where items become stale due to the validity setting but are never purged, as described in https://github.com/grafana/loki/issues/4921

**Which issue(s) this PR fixes**:
Fixes #4921

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
