### PR TITLE
loki: Move VerifyConfig after PrintConfig and LogConfig

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -53,11 +53,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if config.VerifyConfig {
-		level.Info(util_log.Logger).Log("msg", "config is valid")
-		os.Exit(0)
-	}
-
 	if config.PrintConfig {
 		err := logutil.PrintConfig(os.Stderr, &config)
 		if err != nil {
@@ -70,6 +65,11 @@ func main() {
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "failed to log config object", "err", err.Error())
 		}
+	}
+
+	if config.VerifyConfig {
+		level.Info(util_log.Logger).Log("msg", "config is valid")
+		os.Exit(0)
 	}
 
 	if config.Tracing.Enabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

Move VerifyConfig after PrintConfig and LogConfig so that config can be dumped and the program can exit instead of starting loki.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Thanks!

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
