### PR TITLE
Create contingency with v13 schema that generates keys from v11 but can parse v11 and v12

### DIFF
--- a/pkg/storage/chunk/schema.go
+++ b/pkg/storage/chunk/schema.go
@@ -970,3 +970,7 @@ func (v11Entries) GetLabelNamesForSeries(bucket Bucket, seriesID []byte) ([]Inde
 type v12Entries struct {
 	v11Entries
 }
+
+type v13Entries struct {
+	v12Entries
+}


### PR DESCRIPTION
Signed-off-by: Jordan Rushing <jordan.rushing@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR creates schema v13 which generates chunk external keys with the format used prior to schema v12. Chunks are able to parse both key types.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
