### PR TITLE
Retry pulling Cloudflare logs after a stream error

### DIFF
--- a/clients/pkg/promtail/targets/cloudflare/util_test.go
+++ b/clients/pkg/promtail/targets/cloudflare/util_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -25,6 +26,8 @@ func (f *fakeCloudflareClient) CallCount() int {
 type fakeLogIterator struct {
 	logs    []string
 	current string
+
+	err error
 }
 
 func (f *fakeLogIterator) Next() bool {
@@ -32,10 +35,14 @@ func (f *fakeLogIterator) Next() bool {
 		return false
 	}
 	f.current = f.logs[0]
+	if f.current == `error` {
+		f.err = errors.New("error")
+		return false
+	}
 	f.logs = f.logs[1:]
 	return true
 }
-func (f *fakeLogIterator) Err() error                         { return nil }
+func (f *fakeLogIterator) Err() error                         { return f.err }
 func (f *fakeLogIterator) Line() []byte                       { return []byte(f.current) }
 func (f *fakeLogIterator) Fields() (map[string]string, error) { return nil, nil }
 func (f *fakeLogIterator) Close() error                       { return nil }


### PR DESCRIPTION
When pulling logs from Cloudflare we were only retrying the original HTTP request but not when reading the buffer which can also fail.

This PR allows to also retry reading log line from the HTTP stream. 

Unfortunately because Cloudflare doesn't guarantee order within log line we can't resume where we left off. So I opted for retrying from the start, which is anyway what an operator would do. 
We could restart from the last read timestamp but this can lead to data loss, so I opted for possible duplication instead.

To be able to investigate duplicates, I've added a log with the amount of already read message for a given batch. If this is too much for our users, we could alternatively buffer in memory a whole batch before pushing it, but that sounds more complex and risky (memory unbounded) for now.

Fixes https://github.com/grafana/loki/issues/5157

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

