### PR TITLE
Fix promtail deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [5170](https://github.com/grafana/loki/pull/5170) **chaudum** Fix deadlock in Promtail caused when targets got removed from a target group by the discovery manager.
 * [5163](https://github.com/grafana/loki/pull/5163) **chaudum** Fix regression in fluentd plugin introduced with #5107 that caused `NoMethodError` when parsing non-string values of log lines.
 * [5144](https://github.com/grafana/loki/pull/5144) **dannykopping** Ruler: fix remote write basic auth credentials.
 * [5107](https://github.com/grafana/loki/pull/5107) **chaudum** Fix bug in fluentd plugin that caused log lines containing non UTF-8 characters to be dropped.

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -321,8 +321,13 @@ func (s *targetSyncer) sync(groups []*targetgroup.Group, targetEventHandler chan
 			delete(s.targets, key)
 
 			// close related file event watcher
-			close(s.fileEventWatchers[target.path])
-			delete(s.fileEventWatchers, target.path)
+			k := target.path
+			if _, ok := s.fileEventWatchers[k]; ok {
+				close(s.fileEventWatchers[k])
+				delete(s.fileEventWatchers, k)
+			} else {
+				level.Warn(s.log).Log("msg", "failed to remove file event watcher", "path", k)
+			}
 		}
 	}
 	s.droppedTargets = dropped

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -319,6 +319,10 @@ func (s *targetSyncer) sync(groups []*targetgroup.Group, targetEventHandler chan
 			target.Stop()
 			s.metrics.targetsActive.Add(-1.)
 			delete(s.targets, key)
+
+			// close related file event watcher
+			close(s.fileEventWatchers[target.path])
+			delete(s.fileEventWatchers, target.path)
 		}
 	}
 	s.droppedTargets = dropped
@@ -376,6 +380,7 @@ func (s *targetSyncer) ready() bool {
 	}
 	return false
 }
+
 func (s *targetSyncer) stop() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -385,6 +390,7 @@ func (s *targetSyncer) stop() {
 		target.Stop()
 		delete(s.targets, key)
 	}
+
 	for key, watcher := range s.fileEventWatchers {
 		close(watcher)
 		delete(s.fileEventWatchers, key)

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -60,18 +60,17 @@ func NewTargetManagers(
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *file.Config,
 ) (*TargetManagers, error) {
-	var targetManagers []targetManager
-	targetScrapeConfigs := make(map[string][]scrapeconfig.Config, 4)
-
 	if targetConfig.Stdin {
 		level.Debug(logger).Log("msg", "configured to read from stdin")
 		stdin, err := stdin.NewStdinTargetManager(reg, logger, app, client, scrapeConfigs)
 		if err != nil {
 			return nil, err
 		}
-		targetManagers = append(targetManagers, stdin)
-		return &TargetManagers{targetManagers: targetManagers}, nil
+		return &TargetManagers{targetManagers: []targetManager{stdin}}, nil
 	}
+
+	var targetManagers []targetManager
+	targetScrapeConfigs := make(map[string][]scrapeconfig.Config, 4)
 
 	for _, cfg := range scrapeConfigs {
 		switch {

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
-	"github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/positions"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/cloudflare"

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -59,7 +59,6 @@ func NewTargetManagers(
 	client api.EntryHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *file.Config,
-	clientConfigs ...client.Config,
 ) (*TargetManagers, error) {
 	var targetManagers []targetManager
 	targetScrapeConfigs := make(map[string][]scrapeconfig.Config, 4)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a deadlock in Promtail which occurred when targets were removed from the target groups by the discovery manager.

The problem was that upon removal of a target it was removed from the targets list, but the correlating file event watcher channel was not removed from from the watchers list. This caused events to be sent to channels that were not read any more and therefore resulting in a deadlock.

**Which issue(s) this PR fixes**:
Fixes #5162

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
