### PR TITLE
Handle `context` cancellation in some of the `querier` store.index-cache-read.

### DIFF
--- a/pkg/storage/chunk/series_store.go
+++ b/pkg/storage/chunk/series_store.go
@@ -145,6 +145,9 @@ func (c *seriesStore) Get(ctx context.Context, userID string, from, through mode
 }
 
 func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
 	log, ctx := spanlogger.New(ctx, "SeriesStore.GetChunkRefs")
 	defer log.Span.Finish()
 


### PR DESCRIPTION
level=error ts=2022-01-17T11:56:24.310460077Z caller=redis_cache.go:37 msg="failed to get from redis" name=chunksredis err="context canceled"

![image](https://user-images.githubusercontent.com/9583245/150050153-f5f5458b-a625-4e81-b255-8103adaee7c9.png)
![image](https://user-images.githubusercontent.com/9583245/150049959-47f5efe4-3fb4-4c74-a60c-60ff3f56e344.png)
