### PR TITLE
Remove instance level streams lock

### DIFF
--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -207,10 +207,8 @@ type streamIterator struct {
 func newStreamsIterator(ing ingesterInstances) *streamIterator {
 	instances := ing.getInstances()
 	streamInstances := make([]streamInstance, len(instances))
-	for i, inst := range instances {
-		inst.streamsMtx.RLock()
-		streams := make([]*stream, 0, len(inst.streams))
-		inst.streamsMtx.RUnlock()
+	for i, inst := range ing.getInstances() {
+		streams := make([]*stream, 0, inst.streams.Len())
 		_ = inst.forAllStreams(context.Background(), func(s *stream) error {
 			streams = append(streams, s)
 			return nil

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -170,16 +170,13 @@ func (i *Ingester) sweepUsers(immediate, mayRemoveStreams bool) {
 }
 
 func (i *Ingester) sweepInstance(instance *instance, immediate, mayRemoveStreams bool) {
-	instance.streamsMtx.Lock()
-	defer instance.streamsMtx.Unlock()
-
-	for _, stream := range instance.streams {
-		i.sweepStream(instance, stream, immediate)
-		i.removeFlushedChunks(instance, stream, mayRemoveStreams)
-	}
+	instance.streams.ForEach(func(s *stream) (bool, error) {
+		i.sweepStream(instance, s, immediate)
+		i.removeFlushedChunks(instance, s, mayRemoveStreams)
+		return true, nil
+	})
 }
 
-// must hold streamsMtx
 func (i *Ingester) sweepStream(instance *instance, stream *stream, immediate bool) {
 	stream.chunkMtx.RLock()
 	defer stream.chunkMtx.RUnlock()
@@ -253,9 +250,7 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 }
 
 func (i *Ingester) collectChunksToFlush(instance *instance, fp model.Fingerprint, immediate bool) ([]*chunkDesc, labels.Labels, *sync.RWMutex) {
-	instance.streamsMtx.Lock()
-	stream, ok := instance.streamsByFP[fp]
-	instance.streamsMtx.Unlock()
+	stream, ok := instance.streams.LoadByFP(fp)
 
 	if !ok {
 		return nil, nil, nil
@@ -304,7 +299,6 @@ func (i *Ingester) shouldFlushChunk(chunk *chunkDesc) (bool, string) {
 	return false, ""
 }
 
-// must hold streamsMtx
 func (i *Ingester) removeFlushedChunks(instance *instance, stream *stream, mayRemoveStream bool) {
 	now := time.Now()
 

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -170,7 +170,7 @@ func (i *Ingester) sweepUsers(immediate, mayRemoveStreams bool) {
 }
 
 func (i *Ingester) sweepInstance(instance *instance, immediate, mayRemoveStreams bool) {
-	instance.streams.ForEach(func(s *stream) (bool, error) {
+	_ = instance.streams.ForEach(func(s *stream) (bool, error) {
 		i.sweepStream(instance, s, immediate)
 		i.removeFlushedChunks(instance, s, mayRemoveStreams)
 		return true, nil

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -143,7 +143,7 @@ func TestSyncPeriod(t *testing.T) {
 	require.NoError(t, err)
 
 	// let's verify results
-	s, err := inst.getOrCreateStream(pr.Streams[0], false, recordPool.GetRecord())
+	s, err := inst.getOrCreateStream(pr.Streams[0], recordPool.GetRecord())
 	require.NoError(t, err)
 
 	// make sure each chunk spans max 'sync period' time
@@ -181,7 +181,7 @@ func setupTestStreams(t *testing.T) (*instance, time.Time, int) {
 	}
 
 	for _, testStream := range testStreams {
-		stream, err := instance.getOrCreateStream(testStream, false, recordPool.GetRecord())
+		stream, err := instance.getOrCreateStream(testStream, recordPool.GetRecord())
 		require.NoError(t, err)
 		chunk := newStream(cfg, limiter, "fake", 0, nil, true, NilMetrics).NewChunk()
 		for _, entry := range testStream.Entries {

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -118,7 +118,7 @@ func (r *ingesterRecoverer) Series(series *Series) error {
 		// TODO(owen-d): create another fn to avoid unnecessary label type conversions.
 		stream, err := inst.getOrCreateStream(logproto.Stream{
 			Labels: cortexpb.FromLabelAdaptersToLabels(series.Labels).String(),
-		}, true, nil)
+		}, nil)
 
 		if err != nil {
 			return err
@@ -167,7 +167,6 @@ func (r *ingesterRecoverer) SetStream(userID string, series record.RefSeries) er
 		logproto.Stream{
 			Labels: series.Labels.String(),
 		},
-		true,
 		nil,
 	)
 	if err != nil {

--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -194,7 +194,7 @@ func (r *ingesterRecoverer) Push(userID string, entries RefEntries) error {
 		}
 
 		// ignore out of order errors here (it's possible for a checkpoint to already have data from the wal segments)
-		bytesAdded, err := s.(*stream).Push(context.Background(), entries.Entries, nil, entries.Counter)
+		bytesAdded, err := s.(*stream).Push(context.Background(), entries.Entries, nil, entries.Counter, true)
 		r.ing.replayController.Add(int64(bytesAdded))
 		if err != nil && err == ErrEntriesExist {
 			r.ing.metrics.duplicateEntriesTotal.Add(float64(len(entries.Entries)))

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -24,7 +24,7 @@ func (f *replayFlusher) Flush() {
 
 	for _, instance := range instances {
 
-		instance.streams.ForEach(func(s *stream) (bool, error) {
+		_ = instance.streams.ForEach(func(s *stream) (bool, error) {
 			f.i.removeFlushedChunks(instance, s, false)
 			return true, nil
 		})

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -23,13 +23,12 @@ func (f *replayFlusher) Flush() {
 	instances := f.i.getInstances()
 
 	for _, instance := range instances {
-		instance.streamsMtx.Lock()
 
-		for _, stream := range instance.streams {
-			f.i.removeFlushedChunks(instance, stream, false)
-		}
+		instance.streams.ForEach(func(s *stream) (bool, error) {
+			f.i.removeFlushedChunks(instance, s, false)
+			return true, nil
+		})
 
-		instance.streamsMtx.Unlock()
 	}
 
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -176,9 +176,14 @@ func (s *stream) Push(
 	// with a counter value less than or equal to it's own.
 	// It is set to zero and thus bypassed outside of WAL replays.
 	counter int64,
+	// Lock chunkMtx while pushing.
+	// If this is false, chunkMtx must be held outside Push.
+	lockChunk bool,
 ) (int, error) {
-	s.chunkMtx.Lock()
-	defer s.chunkMtx.Unlock()
+	if lockChunk {
+		s.chunkMtx.Lock()
+		defer s.chunkMtx.Unlock()
+	}
 
 	isReplay := counter > 0
 	if isReplay && counter <= s.entryCt {

--- a/pkg/ingester/streams_map.go
+++ b/pkg/ingester/streams_map.go
@@ -1,0 +1,100 @@
+package ingester
+
+import (
+	"sync"
+
+	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
+)
+
+type streamsMap struct {
+	consistencyMtx sync.Mutex
+	streams        *sync.Map // map[string]*stream
+	streamsByFP    *sync.Map // map[model.Fingerprint]*stream
+	streamsCounter *atomic.Int64
+}
+
+func newStreamsMap() *streamsMap {
+	return &streamsMap{
+		consistencyMtx: sync.Mutex{},
+		streams:        &sync.Map{},
+		streamsByFP:    &sync.Map{},
+		streamsCounter: atomic.NewInt64(0),
+	}
+}
+
+func (m *streamsMap) Load(key string) (*stream, bool) {
+	return m.load(m.streams, key)
+}
+
+func (m *streamsMap) LoadByFP(fp model.Fingerprint) (*stream, bool) {
+	return m.load(m.streamsByFP, fp)
+}
+
+func (m *streamsMap) LoadOrStoreNew(key string, newStreamFn func() (*stream, error)) (*stream, bool, error) {
+	return m.loadOrStoreNew(m.streams, key, newStreamFn)
+}
+
+func (m *streamsMap) LoadOrStoreNewByFP(fp model.Fingerprint, newStreamFn func() (*stream, error)) (*stream, bool, error) {
+	return m.loadOrStoreNew(m.streamsByFP, fp, newStreamFn)
+}
+
+func (m *streamsMap) Delete(s *stream) bool {
+	m.consistencyMtx.Lock()
+	defer m.consistencyMtx.Unlock()
+	_, loaded := m.streams.LoadAndDelete(s.labelsString)
+	if loaded {
+		m.streamsByFP.Delete(s.fp)
+		m.streamsCounter.Dec()
+		return true
+	}
+	return false
+}
+
+func (m *streamsMap) ForEach(fn func(s *stream) (bool, error)) error {
+	var c bool
+	var err error
+	m.streams.Range(func(key, value interface{}) bool {
+		c, err = fn(value.(*stream))
+		return c
+	})
+	return err
+}
+
+func (m *streamsMap) Len() int {
+	return int(m.streamsCounter.Load())
+}
+
+func (m *streamsMap) load(mp *sync.Map, key interface{}) (*stream, bool) {
+	if v, ok := mp.Load(key); ok {
+		return v.(*stream), true
+	} else {
+		return nil, false
+	}
+}
+
+func (m *streamsMap) loadOrStoreNew(mp *sync.Map, key interface{}, newStreamFn func() (*stream, error)) (*stream, bool, error) {
+	if s, ok := m.load(mp, key); ok {
+		return s, true, nil
+	} else {
+		m.consistencyMtx.Lock()
+		defer m.consistencyMtx.Unlock()
+		// Double check
+		if s, ok := m.load(mp, key); ok {
+			return s, true, nil
+		} else {
+			s, err := newStreamFn()
+			if err != nil {
+				return nil, false, err
+			}
+			if labelsString, ok := key.(string); ok {
+				m.streams.Store(labelsString, s)
+			} else {
+				m.streams.Store(s.labelsString, s)
+			}
+			m.streamsByFP.Store(s.fp, s)
+			m.streamsCounter.Inc()
+			return s, false, nil
+		}
+	}
+}

--- a/pkg/ingester/streams_map_test.go
+++ b/pkg/ingester/streams_map_test.go
@@ -1,0 +1,93 @@
+package ingester
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/validation"
+)
+
+func TestStreamsMap(t *testing.T) {
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(t, err)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
+
+	ss := []*stream{
+		newStream(
+			defaultConfig(),
+			limiter,
+			"fake",
+			model.Fingerprint(1),
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+			},
+			true,
+			NilMetrics,
+		),
+		newStream(
+			defaultConfig(),
+			limiter,
+			"fake",
+			model.Fingerprint(2),
+			labels.Labels{
+				{Name: "bar", Value: "foo"},
+			},
+			true,
+			NilMetrics,
+		),
+	}
+	var s *stream
+	var loaded bool
+
+	streams := newStreamsMap()
+
+	require.Equal(t, 0, streams.Len())
+	s, loaded = streams.Load(ss[0].labelsString)
+	require.Nil(t, s)
+	require.False(t, loaded)
+	s, loaded = streams.LoadByFP(ss[1].fp)
+	require.Nil(t, s)
+	require.False(t, loaded)
+
+	s, loaded, err = streams.LoadOrStoreNew(ss[0].labelsString, func() (*stream, error) {
+		return ss[0], nil
+	})
+	require.Equal(t, s, ss[0])
+	require.False(t, loaded)
+	require.Nil(t, err)
+
+	s, loaded, err = streams.LoadOrStoreNewByFP(ss[1].fp, func() (*stream, error) {
+		return ss[1], nil
+	})
+	require.Equal(t, s, ss[1])
+	require.False(t, loaded)
+	require.Nil(t, err)
+
+	require.Equal(t, len(ss), streams.Len())
+
+	for _, st := range ss {
+		s, loaded = streams.Load(st.labelsString)
+		require.Equal(t, st, s)
+		require.True(t, loaded)
+
+		s, loaded = streams.LoadByFP(st.fp)
+		require.Equal(t, st, s)
+		require.True(t, loaded)
+	}
+
+	for _, st := range ss {
+		deleted := streams.Delete(st)
+		require.True(t, deleted)
+
+		s, loaded = streams.Load(st.labelsString)
+		require.Nil(t, s)
+		require.False(t, loaded)
+
+		s, loaded = streams.LoadByFP(st.fp)
+		require.Nil(t, s)
+		require.False(t, loaded)
+	}
+}

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -70,7 +70,7 @@ func TestTransferOut(t *testing.T) {
 		lines := []string{}
 
 		// Get all the lines back and make sure the blocks transferred successfully
-		ing2.instances["test"].streams.ForEach(func(s *stream) (bool, error) {
+		_ = ing2.instances["test"].streams.ForEach(func(s *stream) (bool, error) {
 			it, err := s.Iterator(
 				context.TODO(),
 				nil,

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -55,7 +55,7 @@ func TestTransferOut(t *testing.T) {
 
 	assert.Len(t, ing.instances, 1)
 	if assert.Contains(t, ing.instances, "test") {
-		assert.Len(t, ing.instances["test"].streams, 2)
+		assert.Equal(t, ing.instances["test"].streams.Len(), 2)
 	}
 
 	// Create a new ingester and transfer data to it
@@ -65,31 +65,31 @@ func TestTransferOut(t *testing.T) {
 
 	assert.Len(t, ing2.instances, 1)
 	if assert.Contains(t, ing2.instances, "test") {
-		assert.Len(t, ing2.instances["test"].streams, 2)
+		assert.Equal(t, ing2.instances["test"].streams.Len(), 2)
 
 		lines := []string{}
 
 		// Get all the lines back and make sure the blocks transferred successfully
-		ing2.instances["test"].streamsMtx.RLock()
-		for _, stream := range ing2.instances["test"].streams {
-			it, err := stream.Iterator(
+		ing2.instances["test"].streams.ForEach(func(s *stream) (bool, error) {
+			it, err := s.Iterator(
 				context.TODO(),
 				nil,
 				time.Unix(0, 0),
 				time.Unix(10, 0),
 				logproto.FORWARD,
-				log.NewNoopPipeline().ForStream(stream.labels),
+				log.NewNoopPipeline().ForStream(s.labels),
 			)
 			if !assert.NoError(t, err) {
-				continue
+				return true, nil
 			}
 
 			for it.Next() {
 				entry := it.Entry()
 				lines = append(lines, entry.Line)
 			}
-		}
-		ing2.instances["test"].streamsMtx.RUnlock()
+			return true, nil
+		})
+
 		sort.Strings(lines)
 
 		assert.Equal(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Remove instance level `streams`/`streamsByFP` lock inside ingester, `Push` GRPC calls can run parallel to others with different streams.

This PR introduces a new struct `streamsMap` to replace `streamsMtx`, `streams`, `streamsByFP` inside ingester's `instance`. Instead of locking `streams`/`streamsByFP` while reading/writing, this struct provides `Load`/`LoadByFP` which is basically lock-free to read from internal `sync.Map`. Writing to `streamsMap` is locked internally to keep consistency of two `sync.Map`s.

Significantly improve concurrent capacity and process speed of ingester's `Push` GRPC API, as well as distributor's `/loki/api/v1/push` HTTP API. 

**Which issue(s) this PR fixes**:

Fixes #5177

**Special notes for your reviewer**:

This PR was tested based on Loki `2.4.1`, due to our production environment baseline version is Loki `2.4.1`, there is no related commits since `2.4.1` on `main` branch until now.

This PR has been tested over several clusters, charts bellow are from the same cluster mentioned in #5177

![loki_qps](https://user-images.githubusercontent.com/6872198/150059320-751fb8f2-90fa-49f0-a4c9-da55e0b3034e.png)

Total QPS has less spikes with this PR. POST 500 rate also dropped from 1%(QPS≈60) to 0.005%(QPS≈0.3)

![throughput_per_tenant](https://user-images.githubusercontent.com/6872198/150059364-e5579c9c-c8f4-4556-b0ee-912adfc0471a.png)

Distributor throughput is also smoother than before.

![grpc_duration](https://user-images.githubusercontent.com/6872198/150059394-bf1674ed-b140-4c86-bfcb-52bbd4549307.png)

Push GRPC API request duration now has a more stable and satisfying value.

![post_duration](https://user-images.githubusercontent.com/6872198/150059412-21c64563-caf6-4d1b-bee9-cc43c208cbbd.png)

Push HTTP POST API has similar performance improvement.

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
