### PR TITLE
log headblock conversion error during replay cleanup

### DIFF
--- a/pkg/ingester/recovery.go
+++ b/pkg/ingester/recovery.go
@@ -241,7 +241,12 @@ func (r *ingesterRecoverer) Close() {
 			if !isAllowed && old {
 				err := s.chunks[len(s.chunks)-1].chunk.ConvertHead(headBlockType(isAllowed))
 				if err != nil {
-					return err
+					level.Warn(util_log.Logger).Log(
+						"msg", "error converting headblock",
+						"err", err.Error(),
+						"stream", s.labels.String(),
+						"component", "ingesterRecoverer",
+					)
 				}
 			}
 


### PR DESCRIPTION
While reviewing https://github.com/grafana/loki/pull/5179 I realized we're incorrectly returning an `error` here. It's not checked, but stops iterating through further streams (`forAllStreams` stops iteration upon first error).

With this PR, we'll now log this instead and continue to optimistically cleanup other streams during replay. We've likely not run into this problem prior as it's supposed to be impossible for this conversion to fail.