### PR TITLE
Remove temporary ruler ring key fix

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -218,11 +218,6 @@ func applyConfigToRings(r, defaults *ConfigWrapper, rc util.RingConfig, mergeWit
 		r.Ruler.Ring.InstanceID = rc.InstanceID
 		r.Ruler.Ring.InstanceInterfaceNames = rc.InstanceInterfaceNames
 		r.Ruler.Ring.KVStore = rc.KVStore
-
-		// TODO(tjw): temporary fix until dskit is updated: https://github.com/grafana/dskit/pull/101
-		// The ruler's default ring key is "ring", so if if registers under the same common prefix
-		// as the ingester, queriers will try to query it, resulting in failed queries.
-		r.Ruler.Ring.KVStore.Prefix = "/rulers"
 	}
 
 	// Query Scheduler

--- a/pkg/ruler/base/ruler.go
+++ b/pkg/ruler/base/ruler.go
@@ -50,7 +50,7 @@ var (
 
 const (
 	// ringKey is the key under which we store the rulers ring in the KVStore.
-	ringKey = "ring"
+	ringKey = "rulers"
 
 	// Number of concurrent group list and group loads operations.
 	loadRulesConcurrency  = 10


### PR DESCRIPTION
Ring keys have been moved out of dskit into their respective projects.

**What this PR does / why we need it**:

Removes a temporary fix that was waiting on https://github.com/grafana/dskit/pull/101
