### PR TITLE
[querier] Abort a query in limitedRoundTripper if parallelism is 0

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	ErrMaxQueryParalellism = fmt.Errorf("proto: max query parallelism")
+	ErrMaxQueryParalellism = fmt.Errorf("querying is disabled, please contact your Loki operator")
 )
 
 // Limits extends the cortex limits interface with support for per tenant splitby parameters

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -28,6 +28,10 @@ const (
 	limitErrTmpl = "maximum of series (%d) reached for a single query"
 )
 
+var (
+	ErrMaxQueryParalellism = fmt.Errorf("proto: max query parallelism")
+)
+
 // Limits extends the cortex limits interface with support for per tenant splitby parameters
 type Limits interface {
 	queryrangebase.Limits
@@ -282,6 +286,9 @@ func (rt limitedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 	}
 
 	parallelism := rt.limits.MaxQueryParallelism(userid)
+	if parallelism < 1 {
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, ErrMaxQueryParalellism.Error())
+	}
 
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -238,7 +238,8 @@ func Test_MaxQueryParallelismDisable(t *testing.T) {
 
 func Test_MaxQueryLookBack(t *testing.T) {
 	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{
-		maxQueryLookback: 1 * time.Hour,
+		maxQueryLookback:    1 * time.Hour,
+		maxQueryParallelism: 1,
 	}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -117,6 +117,7 @@ func Test_shardSplitter(t *testing.T) {
 				now:  func() time.Time { return end },
 				limits: fakeLimits{
 					minShardingLookback: tc.lookback,
+					maxQueryParallelism: 1,
 				},
 			}
 
@@ -156,7 +157,7 @@ func Test_astMapper(t *testing.T) {
 		handler,
 		log.NewNopLogger(),
 		nilShardingMetrics,
-		fakeLimits{maxSeries: math.MaxInt32},
+		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
 	)
 
 	resp, err := mware.Do(context.Background(), defaultReq().WithQuery(`{food="bar"}`))
@@ -185,7 +186,7 @@ func Test_ShardingByPass(t *testing.T) {
 		handler,
 		log.NewNopLogger(),
 		nilShardingMetrics,
-		fakeLimits{maxSeries: math.MaxInt32},
+		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
 	)
 
 	_, err := mware.Do(context.Background(), defaultReq().WithQuery(`1+1`))

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -571,9 +571,6 @@ func (f fakeLimits) MaxQueryLength(string) time.Duration {
 }
 
 func (f fakeLimits) MaxQueryParallelism(string) int {
-	if f.maxQueryParallelism == 0 {
-		return 1
-	}
 	return f.maxQueryParallelism
 }
 

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -109,7 +109,7 @@ var (
 
 // those tests are mostly for testing the glue between all component and make sure they activate correctly.
 func TestMetricsTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxSeries: math.MaxInt32}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -172,7 +172,7 @@ func TestMetricsTripperware(t *testing.T) {
 }
 
 func TestLogFilterTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -221,7 +221,7 @@ func TestLogFilterTripperware(t *testing.T) {
 func TestInstantQueryTripperware(t *testing.T) {
 	testShardingConfig := testConfig
 	testShardingConfig.ShardedQueries = true
-	tpw, stopper, err := NewTripperware(testShardingConfig, util_log.Logger, fakeLimits{}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testShardingConfig, util_log.Logger, fakeLimits{maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -257,7 +257,7 @@ func TestInstantQueryTripperware(t *testing.T) {
 }
 
 func TestSeriesTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryLength: 48 * time.Hour}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryLength: 48 * time.Hour, maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -298,7 +298,7 @@ func TestSeriesTripperware(t *testing.T) {
 }
 
 func TestLabelsTripperware(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryLength: 48 * time.Hour}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryLength: 48 * time.Hour, maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}
@@ -402,7 +402,7 @@ func TestUnhandledPath(t *testing.T) {
 }
 
 func TestRegexpParamsSupport(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{}, chunk.SchemaConfig{}, nil)
+	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{maxQueryParallelism: 1}, chunk.SchemaConfig{}, nil)
 	if stopper != nil {
 		defer stopper.Stop()
 	}

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -551,7 +551,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 		}, nil
 	})
 
-	l := WithDefaultLimits(fakeLimits{}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
+	l := WithDefaultLimits(fakeLimits{maxQueryParallelism: 1}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
 	split := SplitByIntervalMiddleware(
 		l,
 		LokiCodec,
@@ -719,7 +719,7 @@ func Test_series_splitByInterval_Do(t *testing.T) {
 		}, nil
 	})
 
-	l := WithDefaultLimits(fakeLimits{}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
+	l := WithDefaultLimits(fakeLimits{maxQueryParallelism: 1}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
 	split := SplitByIntervalMiddleware(
 		l,
 		LokiCodec,
@@ -800,7 +800,7 @@ func Test_ExitEarly(t *testing.T) {
 		}, nil
 	})
 
-	l := WithDefaultLimits(fakeLimits{}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
+	l := WithDefaultLimits(fakeLimits{maxQueryParallelism: 1}, queryrangebase.Config{SplitQueriesByInterval: time.Hour})
 	split := SplitByIntervalMiddleware(
 		l,
 		LokiCodec,


### PR DESCRIPTION
Okay, I think I have this right :thinking: 

As far as I can tell, there isn't a defined limits default struct. However, we do parse the command line flags, and load those into a struct that is then passed as the defaults [here](https://github.com/grafana/loki/blob/1b5b8a31096784ac94981a0122b81e21ef6c5f78/cmd/loki/main.go#L36-L39). The default for `max_query_parallelism` is 32:
```
# Maximum number of queries that will be scheduled in parallel by the frontend.
# CLI flag: -querier.max-query-parallelism
[max_query_parallelism: <int> | default = 32]
```

We then modify that further with internally defined default Loki tenant sizes. 

So, it seems to me that there's not a possibility of the value of `max_query_parallelism` for a given Loki tenant to be `0` without that having been explicitly set in a config file.

Tl; DR, this PR modifies the `limitedRoundTripper`, which uses `max_query_paralllelism`, to abort a query early if a tenants query parallelism is less than 1. The current behaviour means that no additional Go routines would be scheduled to call the next step of the round trip chain **but** within the `limitedRoundTripper.RoundTrip` function we would not return until the context deadline (timeout) is hit within [this](https://github.com/grafana/loki/blob/1b5b8a31096784ac94981a0122b81e21ef6c5f78/pkg/querier/queryrange/limits.go#L302-L316) block.This is a less inefficient, but still not the ideal, solution to disable querying for a specific tenant ID.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
