### PR TITLE
Copy `cortex/pkg/prom1` package dependency into Loki

### DIFF
--- a/pkg/prom1/storage/metric/metric.go
+++ b/pkg/prom1/storage/metric/metric.go
@@ -1,0 +1,66 @@
+// This file was taken from Prometheus (https://github.com/prometheus/prometheus).
+// The original license header is included below:
+//
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import "github.com/prometheus/common/model"
+
+// Metric wraps a model.Metric and copies it upon modification if Copied is false.
+type Metric struct {
+	Copied bool
+	Metric model.Metric
+}
+
+// Set sets a label name in the wrapped Metric to a given value and copies the
+// Metric initially, if it is not already a copy.
+func (m *Metric) Set(ln model.LabelName, lv model.LabelValue) {
+	m.Copy()
+	m.Metric[ln] = lv
+}
+
+// Del deletes a given label name from the wrapped Metric and copies the
+// Metric initially, if it is not already a copy.
+func (m *Metric) Del(ln model.LabelName) {
+	m.Copy()
+	delete(m.Metric, ln)
+}
+
+// Get the value for the given label name. An empty value is returned
+// if the label does not exist in the metric.
+func (m *Metric) Get(ln model.LabelName) model.LabelValue {
+	return m.Metric[ln]
+}
+
+// Gets behaves as Get but the returned boolean is false iff the label
+// does not exist.
+func (m *Metric) Gets(ln model.LabelName) (model.LabelValue, bool) {
+	lv, ok := m.Metric[ln]
+	return lv, ok
+}
+
+// Copy the underlying Metric if it is not already a copy.
+func (m *Metric) Copy() *Metric {
+	if !m.Copied {
+		m.Metric = m.Metric.Clone()
+		m.Copied = true
+	}
+	return m
+}
+
+// String implements fmt.Stringer.
+func (m Metric) String() string {
+	return m.Metric.String()
+}

--- a/pkg/prom1/storage/metric/metric_test.go
+++ b/pkg/prom1/storage/metric/metric_test.go
@@ -1,0 +1,73 @@
+// This file was taken from Prometheus (https://github.com/prometheus/prometheus).
+// The original license header is included below:
+//
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestMetric(t *testing.T) {
+	testMetric := model.Metric{
+		"to_delete": "test1",
+		"to_change": "test2",
+	}
+
+	scenarios := []struct {
+		fn  func(*Metric)
+		out model.Metric
+	}{
+		{
+			fn: func(cm *Metric) {
+				cm.Del("to_delete")
+			},
+			out: model.Metric{
+				"to_change": "test2",
+			},
+		},
+		{
+			fn: func(cm *Metric) {
+				cm.Set("to_change", "changed")
+			},
+			out: model.Metric{
+				"to_delete": "test1",
+				"to_change": "changed",
+			},
+		},
+	}
+
+	for i, s := range scenarios {
+		orig := testMetric.Clone()
+		cm := &Metric{
+			Metric: orig,
+			Copied: false,
+		}
+
+		s.fn(cm)
+
+		// Test that the original metric was not modified.
+		if !orig.Equal(testMetric) {
+			t.Fatalf("%d. original metric changed; expected %v, got %v", i, testMetric, orig)
+		}
+
+		// Test that the new metric has the right changes.
+		if !cm.Metric.Equal(s.out) {
+			t.Fatalf("%d. copied metric doesn't contain expected changes; expected %v, got %v", i, s.out, cm.Metric)
+		}
+	}
+}

--- a/pkg/prom1/storage/metric/sample.go
+++ b/pkg/prom1/storage/metric/sample.go
@@ -1,0 +1,25 @@
+// This file was taken from Prometheus (https://github.com/prometheus/prometheus).
+// The original license header is included below:
+//
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import "github.com/prometheus/common/model"
+
+// Interval describes the inclusive interval between two Timestamps.
+type Interval struct {
+	OldestInclusive model.Time
+	NewestInclusive model.Time
+}

--- a/pkg/querier/base/distributor_queryable.go
+++ b/pkg/querier/base/distributor_queryable.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
@@ -16,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 	"github.com/grafana/loki/pkg/querier/series"
 	"github.com/grafana/loki/pkg/tenant"
 	"github.com/grafana/loki/pkg/util/chunkcompat"

--- a/pkg/querier/base/distributor_queryable_test.go
+++ b/pkg/querier/base/distributor_queryable_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -18,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/encoding"
 	"github.com/grafana/loki/pkg/util/chunkcompat"

--- a/pkg/querier/base/querier_test.go
+++ b/pkg/querier/base/querier_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
@@ -29,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 	"github.com/grafana/loki/pkg/querier/batch"
 	"github.com/grafana/loki/pkg/querier/iterators"
 	"github.com/grafana/loki/pkg/storage/chunk"

--- a/pkg/querier/base/testutils.go
+++ b/pkg/querier/base/testutils.go
@@ -4,13 +4,14 @@ import (
 	"context"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 )
 
 type MockDistributor struct {

--- a/pkg/querier/series/series_set.go
+++ b/pkg/querier/series/series_set.go
@@ -19,11 +19,12 @@ package series
 import (
 	"sort"
 
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 )
 
 // ConcreteSeriesSet implements storage.SeriesSet.

--- a/pkg/querier/testutils.go
+++ b/pkg/querier/testutils.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 	base_querier "github.com/grafana/loki/pkg/querier/base"
 )
 

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/golang/snappy"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -18,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	errs "github.com/weaveworks/common/errors"
 
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 	prom_chunk "github.com/grafana/loki/pkg/storage/chunk/encoding"
 )
 

--- a/pkg/storage/chunk/encoding/chunk.go
+++ b/pkg/storage/chunk/encoding/chunk.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	errs "github.com/weaveworks/common/errors"
 
-	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
+	"github.com/grafana/loki/pkg/prom1/storage/metric"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
As a part of removing Loki dependency on cortex packages, we decided to copy the `prom1` package from cortex to Loki itself.
Note that we can't yet remove `cortex/pkg/prom1` as some vendored packages still using it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
