### PR TITLE
Use 127.0.0.1 as frontend address for all/read modes

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -461,10 +461,10 @@ func (t *Loki) initQueryFrontendTripperware() (_ services.Service, err error) {
 }
 
 func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
-  //Use localhost as the frontend for single binary and simple scalable modes if not otherwise set
-  if (t.Cfg.isModuleEnabled(All) || t.Cfg.isModuleEnabled(Read)) && t.Cfg.Frontend.FrontendV2.Addr == "" {
-    t.Cfg.Frontend.FrontendV2.Addr = "127.0.0.1"
-  }
+	//Use localhost as the frontend for single binary and simple scalable modes if not otherwise set
+	if (t.Cfg.isModuleEnabled(All) || t.Cfg.isModuleEnabled(Read)) && t.Cfg.Frontend.FrontendV2.Addr == "" {
+		t.Cfg.Frontend.FrontendV2.Addr = "127.0.0.1"
+	}
 
 	level.Debug(util_log.Logger).Log("msg", "initializing query frontend", "config", fmt.Sprintf("%+v", t.Cfg.Frontend))
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -461,6 +461,11 @@ func (t *Loki) initQueryFrontendTripperware() (_ services.Service, err error) {
 }
 
 func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
+  //Use localhost as the frontend for single binary and simple scalable modes if not otherwise set
+  if (t.Cfg.isModuleEnabled(All) || t.Cfg.isModuleEnabled(Read)) && t.Cfg.Frontend.FrontendV2.Addr == "" {
+    t.Cfg.Frontend.FrontendV2.Addr = "127.0.0.1"
+  }
+
 	level.Debug(util_log.Logger).Log("msg", "initializing query frontend", "config", fmt.Sprintf("%+v", t.Cfg.Frontend))
 
 	combinedCfg := frontend.CombinedFrontendConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Default the frontend address to 127.0.0.1 in `read` and `all` targets if not set. This avoids the need to find an IP using the network interface, which shouldn't be necessary for these modes.

**Which issue(s) this PR fixes**:
Fixes #4699 

**Special notes for your reviewer**:

I'm not 100% sure this will work. In both of these modes the query scheduler ring is enabled. If queriers on other nodes handle the query, and the frontend address is advertised as `127.0.0.1`, won't it respond to the frontend on the same instance, and not necessarily the frontend that is handling the request? The only way this could work then is if the scheduler is modifying the query request to populate the correct frontend address?

Maybe @cyriltovena @owen-d or @slim-bean might know the answer to this?

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
