### PR TITLE
Update docker.md

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -22,9 +22,9 @@ Copy and paste the commands below into your command line.
 
 ```bash
 wget https://raw.githubusercontent.com/grafana/loki/v2.4.2/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.4.2 -config.file=/mnt/config/loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.4.2 -config.file=/mnt/config/loki-config.yaml
 wget https://raw.githubusercontent.com/grafana/loki/v2.4.2/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.4.2 -config.file=/mnt/config/promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.4.2 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.


### PR DESCRIPTION
Create the containers in detached mode and name the promtail container "promtail".
Without this fix the first container must be stopped before the second one is started since they are running in foreground.
The promtail container didn't have any "--name" flag so docker assigns a random name to it.

