### PR TITLE
fix broken boltdb-shipper test

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -48,50 +48,66 @@ func TestCompactor_RunCompaction(t *testing.T) {
 	tablesPath := filepath.Join(tempDir, "index")
 	tablesCopyPath := filepath.Join(tempDir, "index-copy")
 
-	tables := map[string]map[string]testutil.DBRecords{
+	tables := map[string]map[string]testutil.DBConfig{
 		"table1": {
 			"db1": {
-				Start:      0,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      0,
+					NumRecords: 10,
+				},
 			},
 			"db2": {
-				Start:      10,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      10,
+					NumRecords: 10,
+				},
 			},
 			"db3": {
-				Start:      20,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      20,
+					NumRecords: 10,
+				},
 			},
 			"db4": {
-				Start:      30,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      30,
+					NumRecords: 10,
+				},
 			},
 		},
 		"table2": {
 			"db1": {
-				Start:      40,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      40,
+					NumRecords: 10,
+				},
 			},
 			"db2": {
-				Start:      50,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      50,
+					NumRecords: 10,
+				},
 			},
 			"db3": {
-				Start:      60,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      60,
+					NumRecords: 10,
+				},
 			},
 			"db4": {
-				Start:      70,
-				NumRecords: 10,
+				DBRecords: testutil.DBRecords{
+					Start:      70,
+					NumRecords: 10,
+				},
 			},
 		},
 	}
 
 	for name, dbs := range tables {
-		testutil.SetupDBsAtPath(t, filepath.Join(tablesPath, name), dbs, false, nil)
+		testutil.SetupDBsAtPath(t, filepath.Join(tablesPath, name), dbs, nil)
 
 		// setup exact same copy of dbs for comparison.
-		testutil.SetupDBsAtPath(t, filepath.Join(tablesCopyPath, name), dbs, false, nil)
+		testutil.SetupDBsAtPath(t, filepath.Join(tablesCopyPath, name), dbs, nil)
 	}
 
 	compactor := setupTestCompactor(t, tempDir)

--- a/pkg/storage/stores/shipper/compactor/table_test.go
+++ b/pkg/storage/stores/shipper/compactor/table_test.go
@@ -435,15 +435,18 @@ func TestTable_CompactionFailure(t *testing.T) {
 	numDBs := 10
 	numRecordsPerDB := 100
 
-	dbsToSetup := make(map[string]testutil.DBRecords)
+	dbsToSetup := make(map[string]testutil.DBConfig)
 	for i := 0; i < numDBs; i++ {
-		dbsToSetup[fmt.Sprint(i)] = testutil.DBRecords{
-			Start:      i * numRecordsPerDB,
-			NumRecords: (i + 1) * numRecordsPerDB,
+		dbsToSetup[fmt.Sprint(i)] = testutil.DBConfig{
+			CompressFile: i%2 == 0,
+			DBRecords: testutil.DBRecords{
+				Start:      i * numRecordsPerDB,
+				NumRecords: (i + 1) * numRecordsPerDB,
+			},
 		}
 	}
 
-	testutil.SetupDBsAtPath(t, filepath.Join(objectStoragePath, tableName), dbsToSetup, true, nil)
+	testutil.SetupDBsAtPath(t, filepath.Join(objectStoragePath, tableName), dbsToSetup, nil)
 
 	// put a non-boltdb file in the table which should cause the compaction to fail in the middle because it would fail to open that file with boltdb client.
 	require.NoError(t, ioutil.WriteFile(filepath.Join(tablePathInStorage, "fail.txt"), []byte("fail the compaction"), 0666))

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -143,19 +143,22 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 
 			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
 
-			tables := map[string]map[string]testutil.DBRecords{}
+			tables := map[string]map[string]testutil.DBConfig{}
 			activeTableNumber := getActiveTableNumber()
 			for i := 0; i < 10; i++ {
-				tables[fmt.Sprintf("table_%d", activeTableNumber-int64(i))] = map[string]testutil.DBRecords{
+				tables[fmt.Sprintf("table_%d", activeTableNumber-int64(i))] = map[string]testutil.DBConfig{
 					"db": {
-						Start:      i * 10,
-						NumRecords: 10,
+						CompressFile: i%2 == 0,
+						DBRecords: testutil.DBRecords{
+							Start:      i * 10,
+							NumRecords: 10,
+						},
 					},
 				}
 			}
 
 			for name, dbs := range tables {
-				testutil.SetupDBsAtPath(t, filepath.Join(objectStoragePath, name), dbs, true, nil)
+				testutil.SetupDBsAtPath(t, filepath.Join(objectStoragePath, name), dbs, nil)
 			}
 
 			boltDBIndexClient, indexStorageClient := buildTestClients(t, tempDir)

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -56,28 +56,36 @@ func TestLoadTables(t *testing.T) {
 	testutil.AddRecordsToDB(t, filepath.Join(indexPath, "table0"), boltDBIndexClient, 0, 10, nil)
 
 	// table1 with 2 dbs
-	testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "table1"), map[string]testutil.DBRecords{
+	testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "table1"), map[string]testutil.DBConfig{
 		"db1": {
-			Start:      10,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      10,
+				NumRecords: 10,
+			},
 		},
 		"db2": {
-			Start:      20,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      20,
+				NumRecords: 10,
+			},
 		},
-	}, false, nil)
+	}, nil)
 
 	// table2 with 2 dbs
-	testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "table2"), map[string]testutil.DBRecords{
+	testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "table2"), map[string]testutil.DBConfig{
 		"db1": {
-			Start:      30,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      30,
+				NumRecords: 10,
+			},
 		},
 		"db2": {
-			Start:      40,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      40,
+				NumRecords: 10,
+			},
 		},
-	}, false, nil)
+	}, nil)
 
 	expectedTables := map[string]struct {
 		start, numRecords int

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -73,26 +73,34 @@ func TestLoadTable(t *testing.T) {
 
 	// setup some dbs with default bucket and per tenant bucket for a table at a path.
 	tablePath := filepath.Join(indexPath, "test-table")
-	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBRecords{
+	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBConfig{
 		"db1": {
-			Start:      0,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      0,
+				NumRecords: 10,
+			},
 		},
 		"db2": {
-			Start:      10,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      10,
+				NumRecords: 10,
+			},
 		},
-	}, false, nil)
-	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBRecords{
+	}, nil)
+	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBConfig{
 		"db3": {
-			Start:      20,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      20,
+				NumRecords: 10,
+			},
 		},
 		"db4": {
-			Start:      30,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      30,
+				NumRecords: 10,
+			},
 		},
-	}, false, []byte(userID))
+	}, []byte(userID))
 
 	// change a boltdb file to text file which would fail to open.
 	invalidFilePath := filepath.Join(tablePath, "invalid")
@@ -360,20 +368,26 @@ func Test_LoadBoltDBsFromDir(t *testing.T) {
 	}()
 
 	// setup some dbs with a snapshot file.
-	tablePath := testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "test-table"), map[string]testutil.DBRecords{
+	tablePath := testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "test-table"), map[string]testutil.DBConfig{
 		"db1": {
-			Start:      0,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      0,
+				NumRecords: 10,
+			},
 		},
 		"db1" + tempFileSuffix: { // a snapshot file which should be ignored.
-			Start:      0,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      0,
+				NumRecords: 10,
+			},
 		},
 		"db2": {
-			Start:      10,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      10,
+				NumRecords: 10,
+			},
 		},
-	}, false, nil)
+	}, nil)
 
 	// create a boltdb file without bucket which should get removed
 	db, err := local.OpenBoltdbFile(filepath.Join(tablePath, "no-bucket"))
@@ -424,16 +438,18 @@ func TestTable_ImmutableUploads(t *testing.T) {
 		time.Now().Truncate(ShardDBsByDuration).Unix(), // active shard, should not upload
 	}
 
-	dbs := map[string]testutil.DBRecords{}
+	dbs := map[string]testutil.DBConfig{}
 	for _, dbName := range dbNames {
-		dbs[fmt.Sprint(dbName)] = testutil.DBRecords{
-			NumRecords: 10,
+		dbs[fmt.Sprint(dbName)] = testutil.DBConfig{
+			DBRecords: testutil.DBRecords{
+				NumRecords: 10,
+			},
 		}
 	}
 
 	// setup some dbs for a table at a path.
 	tableName := "test-table"
-	tablePath := testutil.SetupDBsAtPath(t, filepath.Join(indexPath, tableName), dbs, false, nil)
+	tablePath := testutil.SetupDBsAtPath(t, filepath.Join(indexPath, tableName), dbs, nil)
 
 	table, err := LoadTable(tablePath, "test", storageClient, boltDBIndexClient, false, newMetrics(nil))
 	require.NoError(t, err)
@@ -507,26 +523,33 @@ func TestTable_MultiQueries(t *testing.T) {
 
 	// setup some dbs with default bucket and per tenant bucket for a table at a path.
 	tablePath := filepath.Join(indexPath, "test-table")
-	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBRecords{
+	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBConfig{
 		"db1": {
-			Start:      0,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				NumRecords: 10,
+			},
 		},
 		"db2": {
-			Start:      10,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      10,
+				NumRecords: 10,
+			},
 		},
-	}, false, nil)
-	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBRecords{
+	}, nil)
+	testutil.SetupDBsAtPath(t, tablePath, map[string]testutil.DBConfig{
 		"db3": {
-			Start:      20,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      20,
+				NumRecords: 10,
+			},
 		},
 		"db4": {
-			Start:      30,
-			NumRecords: 10,
+			DBRecords: testutil.DBRecords{
+				Start:      30,
+				NumRecords: 10,
+			},
 		},
-	}, false, []byte(user1))
+	}, []byte(user1))
 
 	// try loading the table.
 	table, err := LoadTable(tablePath, "test", nil, boltDBIndexClient, false, newMetrics(nil))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
`boltdb-shipper` did not initially have support for the compression of the files. When we added them, we wanted to have tests for making sure it is backwards compatible i.e it works fine with both compressed and uncompressed files. While adding tests, I added a flag in the test setup function `SetupDBsAtPath`, which would compress every other file. The mistake I did was I assumed specific files would be compressed but the test setup function iterated on a dict which is non-deterministic so the tests which relied on it are failing intermittently.

This PR fixes the test by allowing the caller to define which files to compress while setting up dbs.

**Checklist**
- [x] Tests updated
