### PR TITLE
Ignore missing stream while querying from ingester

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -37,11 +37,6 @@ const (
 	queryBatchSampleSize = 512
 )
 
-// Errors returned on Query.
-var (
-	ErrStreamMissing = errors.New("Stream missing")
-)
-
 var (
 	memoryStreams = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "loki",
@@ -571,7 +566,9 @@ outer:
 	for _, streamID := range ids {
 		stream, ok := i.streams.LoadByFP(streamID)
 		if !ok {
-			return ErrStreamMissing
+			// If a stream is missing here, it has already been flushed
+			// and is supposed to be picked up from storage by querier
+			continue
 		}
 		for _, filter := range filters {
 			if !filter.Matches(stream.labels.Get(filter.Name)) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Ignore missing stream while querying in ingester. This means the stream has been removed while querying, and it's supposed to be picked up from storage by querier.
https://github.com/grafana/loki/issues/5228#issuecomment-1021484947

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/5228#issuecomment-1021196762

**Special notes for your reviewer**:
Please keep the issue open for original problem.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
