### PR TITLE
Promtail: fix TargetManager.run() not exit after stop is called

### DIFF
--- a/clients/pkg/promtail/targets/docker/targetmanager.go
+++ b/clients/pkg/promtail/targets/docker/targetmanager.go
@@ -30,6 +30,7 @@ type TargetManager struct {
 	logger     log.Logger
 	positions  positions.Positions
 	cancel     context.CancelFunc
+	done       chan struct{}
 	manager    *discovery.Manager
 	pushClient api.EntryHandler
 	groups     map[string]*targetGroup
@@ -47,6 +48,7 @@ func NewTargetManager(
 		metrics:    metrics,
 		logger:     logger,
 		cancel:     cancel,
+		done:       make(chan struct{}),
 		positions:  positions,
 		manager:    discovery.NewManager(ctx, log.With(logger, "component", "docker_discovery")),
 		pushClient: pushClient,
@@ -87,22 +89,28 @@ func NewTargetManager(
 		}
 	}
 
-	go tm.run()
+	go tm.run(ctx)
 	go util.LogError("running target manager", tm.manager.Run)
 
 	return tm, tm.manager.ApplyConfig(configs)
 }
 
 // run listens on the service discovery and adds new targets.
-func (tm *TargetManager) run() {
-	for targetGroups := range tm.manager.SyncCh() {
-		for jobName, groups := range targetGroups {
-			tg, ok := tm.groups[jobName]
-			if !ok {
-				level.Debug(tm.logger).Log("msg", "unknown target for job", "job", jobName)
-				continue
+func (tm *TargetManager) run(ctx context.Context) {
+	defer close(tm.done)
+	for {
+		select {
+		case targetGroups := <-tm.manager.SyncCh():
+			for jobName, groups := range targetGroups {
+				tg, ok := tm.groups[jobName]
+				if !ok {
+					level.Debug(tm.logger).Log("msg", "unknown target for job", "job", jobName)
+					continue
+				}
+				tg.sync(groups)
 			}
-			tg.sync(groups)
+		case <-ctx.Done():
+			return
 		}
 	}
 }
@@ -119,6 +127,7 @@ func (tm *TargetManager) Ready() bool {
 
 func (tm *TargetManager) Stop() {
 	tm.cancel()
+	<-tm.done
 	for _, s := range tm.groups {
 		s.Stop()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR fix a possible goroutine leak in promtail:
* `FileTargetManager.run()`will not exit after `FileTargetManager.stop()` is called.


`manager.SyncCh()` in `run()` is a read-only channel copy of `manager.syncCh`, and there is no `close(ch)` operation in manager's whole lifecycle. See code search below:
![image](https://user-images.githubusercontent.com/41042306/151162437-851bb032-0214-4416-8ea7-36e7c3711f3c.png)



So it would be stuck in `range ch` operation. 

By passing the `context`related to `TargetManager.cancelfunc` , which is also passed to the `manager` above to control its lifecycle,  the problem is fixed and tested in our own project.


**Which issue(s) this PR fixes**:
Fixes #5237 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.



