### PR TITLE
Logstash: Add config option which allows seting up an allowlist for labels to be mapped to Loki

### DIFF
--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -8,7 +8,7 @@ ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/2.5.0
 
 RUN gem install bundler:2.1.4
 
-COPY --chown=logstash:logstash ./ /home/logstash/
+COPY --chown=logstash:logstash ./clients/cmd/logstash/ /home/logstash/
 WORKDIR /home/logstash/
 
 RUN bundle config set --local path /usr/share/logstash/vendor/bundle && \

--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -8,7 +8,7 @@ ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/2.5.0
 
 RUN gem install bundler:2.1.4
 
-COPY --chown=logstash:logstash ./clients/cmd/logstash/ /home/logstash/
+COPY --chown=logstash:logstash ./ /home/logstash/
 WORKDIR /home/logstash/
 
 RUN bundle config set --local path /usr/share/logstash/vendor/bundle && \

--- a/clients/cmd/logstash/lib/logstash/outputs/loki.rb
+++ b/clients/cmd/logstash/lib/logstash/outputs/loki.rb
@@ -47,6 +47,9 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
   ## 'Backoff configuration. Initial backoff time between retries. Default 1s'
   config :min_delay, :validate => :number, :default => 1, :required => false
 
+  ## 'An array of fields to map to labels, if defined only fields in this list will be mapped.'
+  config :include_fields, :validate => :array, :default => [], :required => false
+
   ## 'Backoff configuration. Maximum backoff time between retries. Default 300s'
   config :max_delay, :validate => :number, :default => 300, :required => false
 
@@ -198,7 +201,7 @@ class LogStash::Outputs::Loki < LogStash::Outputs::Base
   ## Receives logstash events
   public
   def receive(event)
-    @entries << Entry.new(event, @message_field)
+    @entries << Entry.new(event, @message_field, @include_fields)
   end
 
   def close

--- a/clients/cmd/logstash/lib/logstash/outputs/loki/entry.rb
+++ b/clients/cmd/logstash/lib/logstash/outputs/loki/entry.rb
@@ -5,7 +5,7 @@ module Loki
     class Entry
         include Loki
         attr_reader :labels, :entry
-        def initialize(event,message_field)
+        def initialize(event,message_field,include_fields)
             @entry = {
                 "ts" => to_ns(event.get("@timestamp")),
                 "line" => event.get(message_field).to_s
@@ -18,6 +18,7 @@ module Loki
             event.to_hash.each { |key,value|
                 next if key.start_with?('@')
                 next if value.is_a?(Hash)
+                next if include_fields.length() > 0 and not include_fields.include?(key)
                 @labels[key] = value.to_s
             }
         end

--- a/clients/cmd/logstash/logstash-output-loki.gemspec
+++ b/clients/cmd/logstash/logstash-output-loki.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name    = 'logstash-output-loki'
-  s.version = '1.0.4'
+  s.version = '1.1.0'
   s.authors = ['Aditya C S','Cyril Tovena']
   s.email   = ['aditya.gnu@gmail.com','cyril.tovena@grafana.com']
 

--- a/clients/cmd/logstash/loki.conf
+++ b/clients/cmd/logstash/loki.conf
@@ -12,6 +12,9 @@ output {
 
     #message_field => "message" #default message
 
+    # If include_fields is set, only fields in this list will be sent to Loki as labels.
+    #include_fields => ["service","host","app","env"] #default empty array, all labels included.
+
     #batch_wait => 1 ## in seconds #default 1 second
 
     #batch_size => 102400 #bytes #default 102400 bytes

--- a/clients/cmd/logstash/spec/outputs/loki/entry_spec.rb
+++ b/clients/cmd/logstash/spec/outputs/loki/entry_spec.rb
@@ -27,8 +27,15 @@ describe Loki::Entry do
       }
 
       it 'labels extracted should not contains object and metadata or timestamp' do
-        entry = Entry.new(event,"message")
+        entry = Entry.new(event,"message", [])
         expect(entry.labels).to eql({ 'agent' => 'filebeat', 'host' => '172.0.0.1', 'foo'=>'5'})
+        expect(entry.entry['ts']).to eql to_ns(event.get("@timestamp"))
+        expect(entry.entry['line']).to eql 'hello'
+      end
+
+      it 'labels extracted should only contain allowlisted labels' do
+        entry = Entry.new(event, "message", %w[agent foo])
+        expect(entry.labels).to eql({ 'agent' => 'filebeat', 'foo'=>'5'})
         expect(entry.entry['ts']).to eql to_ns(event.get("@timestamp"))
         expect(entry.entry['line']).to eql 'hello'
       end
@@ -36,9 +43,9 @@ describe Loki::Entry do
 
   context 'test batch generation with label order' do
     let (:entries)  {[
-        Entry.new(LogStash::Event.new({"message"=>"foobuzz","buzz"=>"bar","cluster"=>"us-central1","@timestamp"=>Time.at(1)}),"message"),
-        Entry.new(LogStash::Event.new({"log"=>"foobar","bar"=>"bar","@timestamp"=>Time.at(2)}),"log"),
-        Entry.new(LogStash::Event.new({"cluster"=>"us-central1","message"=>"foobuzz","buzz"=>"bar","@timestamp"=>Time.at(3)}),"message"),
+        Entry.new(LogStash::Event.new({"message"=>"foobuzz","buzz"=>"bar","cluster"=>"us-central1","@timestamp"=>Time.at(1)}),"message", []),
+        Entry.new(LogStash::Event.new({"log"=>"foobar","bar"=>"bar","@timestamp"=>Time.at(2)}),"log", []),
+        Entry.new(LogStash::Event.new({"cluster"=>"us-central1","message"=>"foobuzz","buzz"=>"bar","@timestamp"=>Time.at(3)}),"message", []),
 
     ]}
     let (:expected) {

--- a/docs/sources/clients/logstash/_index.md
+++ b/docs/sources/clients/logstash/_index.md
@@ -57,6 +57,8 @@ output {
     [tenant_id => string | default = nil | required=false]
 
     [message_field => string | default = "message" | required=false]
+    
+    [include_fields => array | default = [] | required=false]
 
     [batch_wait => number | default = 1(s) | required=false]
 
@@ -105,6 +107,8 @@ Contains a `message` and `@timestamp` fields, which are respectively used to for
 
 All other fields (except nested fields) will form the label set (key value pairs) attached to the log line. [This means you're responsible for mutating and dropping high cardinality labels](https://grafana.com/blog/2020/04/21/how-labels-in-loki-can-make-log-queries-faster-and-easier/) such as client IPs.
 You can usually do so by using a [`mutate`](https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html) filter.
+
+**Note:** In version 1.1.0 and greater of this plugin you can also specify a list of labels to allowlist via the `include_fields` configuration.
 
 For example the configuration below :
 
@@ -204,6 +208,10 @@ If using the [GrafanaLab's hosted Loki](https://grafana.com/products/cloud/), th
 
 Message field to use for log lines. You can use logstash key accessor language to grab nested property, for example : `[log][message]`.
 
+#### include_fields
+
+An array of fields which will be mapped to labels and sent to Loki, when this list is configured **only** these fields will be sent, all other fields will be ignored.
+
 #### batch_wait
 
 Interval in seconds to wait before pushing a batch of records to Loki. This means even if the [batch size](#batch_size) is not reached after `batch_wait` a partial batch will be sent, this is to ensure freshness of the data.
@@ -259,7 +267,7 @@ filter {
     }
   }
   mutate {
-    remove_field => ["tags"]
+    remove_field => ["tags"]  # Note: with include_fields defined below this wouldn't be necessary
   }
 }
 
@@ -273,6 +281,7 @@ output {
     min_delay => 3
     max_delay => 500
     message_field => "message"
+    include_fields => ["container_name","namespace","pod","host"]
   }
   # stdout { codec => rubydebug }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

The current behavior of the output plugin will map all fields in logstash to labels in Loki, given how different these systems do indexing this can easily result in some very high cardinality labels being sent to Loki.

Logstash has a way to mutate and remove fields specifically however this can be cumbersome or difficult to maintain.

This PR introduces a new config which is an optional list of field names which will be sent to Loki as labels.

When this list is configured, ONLY these labels will be sent to Loki.

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
