### PR TITLE
Promtail: skip glob search if filetarget path is an existing file and not a directory

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -182,11 +182,16 @@ func (t *FileTarget) run() {
 }
 
 func (t *FileTarget) sync() error {
-
-	// Gets current list of files to tail.
-	matches, err := doublestar.Glob(t.path)
-	if err != nil {
-		return errors.Wrap(err, "filetarget.sync.filepath.Glob")
+	var matches []string
+	if fi, err := os.Stat(t.path); err == nil && !fi.IsDir() {
+		// if the path points to a file that exists, then it we can skip the Glob search
+		matches = []string{t.path}
+	} else {
+		// Gets current list of files to tail.
+		matches, err = doublestar.Glob(t.path)
+		if err != nil {
+			return errors.Wrap(err, "filetarget.sync.filepath.Glob")
+		}
 	}
 
 	if len(matches) == 0 {


### PR DESCRIPTION
Signed-off-by: Roger Steneteg <rsteneteg@ea.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Skips Glob search if the target path is an existing file and not a directory, skipping the glob search reduces the I/O operations on the storage

**Which issue(s) this PR fixes**:
Fixes #5245

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
