### PR TITLE
Push: add deflate compression in post requests

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -1,6 +1,7 @@
 package push
 
 import (
+	"compress/flate"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -67,6 +68,10 @@ func ParseRequest(logger log.Logger, userID string, r *http.Request, tenantsRete
 		}
 		defer gzipReader.Close()
 		body = gzipReader
+	case "deflate":
+		flateReader := flate.NewReader(bodySize)
+		defer flateReader.Close()
+		body = flateReader
 	default:
 		return nil, fmt.Errorf("Content-Encoding %q not supported", contentEncoding)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

HTTP server recognize `Content-Encoding: deflate` request header and unpack request body.