### PR TITLE
refactor: use `T.TempDir` to create temporary test directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [4857](https://github.com/grafana/loki/pull/4857) **jordanrushing**: New schema v12 changes chunk key structure
 * [5077](https://github.com/grafana/loki/pull/5077) **trevorwhitney**: Change some default values for better out-of-the-box performance
 * [5204](https://github.com/grafana/loki/pull/5204) **trevorwhitney**: Default `max_outstanding_per_tenant` to `2048`
+* [5253](https://github.com/grafana/loki/pull/5253) **Juneezee**: refactor: use `T.TempDir` to create temporary test directory
 
 # 2.4.1 (2021/11/07)
 

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	fmt "fmt"
 	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -55,9 +54,7 @@ func defaultIngesterTestConfigWithWAL(t *testing.T, walDir string) Config {
 }
 
 func TestIngesterWAL(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-	require.Nil(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	ingesterConfig := defaultIngesterTestConfigWithWAL(t, walDir)
 
@@ -137,9 +134,7 @@ func TestIngesterWAL(t *testing.T) {
 }
 
 func TestIngesterWALIgnoresStreamLimits(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-	require.Nil(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	ingesterConfig := defaultIngesterTestConfigWithWAL(t, walDir)
 
@@ -241,9 +236,7 @@ func TestUnflushedChunks(t *testing.T) {
 }
 
 func TestIngesterWALBackpressureSegments(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-	require.Nil(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	ingesterConfig := defaultIngesterTestConfigWithWAL(t, walDir)
 	ingesterConfig.WAL.ReplayMemoryCeiling = 1000
@@ -285,9 +278,7 @@ func TestIngesterWALBackpressureSegments(t *testing.T) {
 }
 
 func TestIngesterWALBackpressureCheckpoint(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-	require.Nil(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	ingesterConfig := defaultIngesterTestConfigWithWAL(t, walDir)
 	ingesterConfig.WAL.ReplayMemoryCeiling = 1000
@@ -580,9 +571,7 @@ func buildChunks(t testing.TB, size int) []Chunk {
 func TestIngesterWALReplaysUnorderedToOrdered(t *testing.T) {
 	for _, waitForCheckpoint := range []bool{false, true} {
 		t.Run(fmt.Sprintf("checkpoint-%v", waitForCheckpoint), func(t *testing.T) {
-			walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-			require.Nil(t, err)
-			defer os.RemoveAll(walDir)
+			walDir := t.TempDir()
 
 			ingesterConfig := defaultIngesterTestConfigWithWAL(t, walDir)
 

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -2,7 +2,6 @@ package ingester
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"sync"
@@ -131,9 +130,7 @@ func buildChunkDecs(t testing.TB) []*chunkDesc {
 func TestWALFullFlush(t *testing.T) {
 	// technically replaced with a fake wal, but the ingester New() function creates a regular wal first,
 	// so we enable creation/cleanup even though it remains unused.
-	walDir, err := ioutil.TempDir(os.TempDir(), "loki-wal")
-	require.Nil(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	store, ing := newTestStore(t, defaultIngesterTestConfigWithWAL(t, walDir), fullWAL{})
 	testData := pushTestSamples(t, ing)

--- a/pkg/querier/base/chunk_tar_test.go
+++ b/pkg/querier/base/chunk_tar_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -15,7 +14,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -52,9 +50,7 @@ func getTarDataFromEnv(t testing.TB) (query string, from, through time.Time, ste
 }
 
 func runRangeQuery(t testing.TB, query string, from, through time.Time, step time.Duration, store chunkstore.ChunkStore) {
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 1, log.NewNopLogger())
 
 	if len(query) == 0 || store == nil {

--- a/pkg/querier/base/querier_test.go
+++ b/pkg/querier/base/querier_test.go
@@ -3,8 +3,6 @@ package base
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -168,12 +166,7 @@ func TestQuerier(t *testing.T) {
 }
 
 func mockTSDB(t *testing.T, mint model.Time, samples int, step, chunkOffset time.Duration, samplesPerChunk int) storage.Queryable {
-	dir, err := ioutil.TempDir("", "tsdb")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	opts := tsdb.DefaultHeadOptions()
 	opts.ChunkDirRoot = dir
@@ -257,9 +250,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{
@@ -728,9 +719,7 @@ func mockDistibutorFor(t *testing.T, cs mockChunkStore, through model.Time) *Moc
 }
 
 func testRangeQuery(t testing.TB, queryable storage.Queryable, end model.Time, q query) *promql.Result {
-	dir, err := ioutil.TempDir("", "test_query")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	from, through, step := time.Unix(0, 0), end.Time(), q.step
@@ -875,9 +864,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{

--- a/pkg/ruler/base/api_test.go
+++ b/pkg/ruler/base/api_test.go
@@ -21,11 +21,9 @@ import (
 )
 
 func TestRuler_rules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -78,11 +76,9 @@ func TestRuler_rules(t *testing.T) {
 }
 
 func TestRuler_rules_special_characters(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockSpecialCharRules))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockSpecialCharRules))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -135,11 +131,9 @@ func TestRuler_rules_special_characters(t *testing.T) {
 }
 
 func TestRuler_alerts(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer r.StopAsync()
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -171,11 +165,9 @@ func TestRuler_alerts(t *testing.T) {
 }
 
 func TestRuler_Create(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -262,11 +254,9 @@ rules:
 }
 
 func TestRuler_DeleteNamespace(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRulesNamespaces))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockRulesNamespaces))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	a := NewAPI(r, r.store, log.NewNopLogger())
@@ -301,11 +291,9 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 }
 
 func TestRuler_LimitsPerGroup(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	r.limits = ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
@@ -356,11 +344,9 @@ rules:
 }
 
 func TestRuler_RulerGroupLimits(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(make(map[string]rulespb.RuleGroupList)))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	r.limits = ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}

--- a/pkg/ruler/base/lifecycle_test.go
+++ b/pkg/ruler/base/lifecycle_test.go
@@ -22,13 +22,11 @@ import (
 func TestRulerShutdown(t *testing.T) {
 	ctx := context.Background()
 
-	config, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
 	m := storage.NewClientMetrics()
 	defer m.Unregister()
-	r, rcleanup := buildRuler(t, config, nil, m, nil)
-	defer rcleanup()
+	r := buildRuler(t, config, nil, m, nil)
 
 	r.cfg.EnableSharding = true
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
@@ -60,12 +58,10 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	const heartbeatTimeout = time.Minute
 
 	ctx := context.Background()
-	config, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	m := storage.NewClientMetrics()
 	defer m.Unregister()
-	r, rcleanup := buildRuler(t, config, nil, m, nil)
-	defer rcleanup()
+	r := buildRuler(t, config, nil, m, nil)
 	r.cfg.EnableSharding = true
 	r.cfg.Ring.HeartbeatPeriod = 100 * time.Millisecond
 	r.cfg.Ring.HeartbeatTimeout = heartbeatTimeout

--- a/pkg/ruler/base/manager_test.go
+++ b/pkg/ruler/base/manager_test.go
@@ -2,8 +2,6 @@ package base
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -20,11 +18,7 @@ import (
 )
 
 func TestSyncRuleGroups(t *testing.T) {
-	dir, err := ioutil.TempDir("", "rules")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	m, err := NewDefaultMultiTenantManager(Config{RulePath: dir}, factory, nil, log.NewNopLogger())
 	require.NoError(t, err)

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -60,12 +59,12 @@ import (
 	"github.com/grafana/loki/pkg/tenant"
 )
 
-func defaultRulerConfig(t testing.TB, store rulestore.RuleStore) (Config, func()) {
+func defaultRulerConfig(t testing.TB, store rulestore.RuleStore) Config {
 	t.Helper()
 
 	// Create a new temporary directory for the rules, so that
 	// each test will run in isolation.
-	rulesDir, _ := ioutil.TempDir("/tmp", "ruler-tests")
+	rulesDir := t.TempDir()
 
 	codec := ring.GetCodec()
 	consul, closer := consul.NewInMemoryClient(codec, log.NewNopLogger(), nil)
@@ -82,12 +81,7 @@ func defaultRulerConfig(t testing.TB, store rulestore.RuleStore) (Config, func()
 	cfg.Ring.InstanceID = "localhost"
 	cfg.EnableQueryStats = false
 
-	// Create a cleanup function that will be called at the end of the test
-	cleanup := func() {
-		defer os.RemoveAll(rulesDir)
-	}
-
-	return cfg, cleanup
+	return cfg
 }
 
 type ruleLimits struct {
@@ -148,12 +142,8 @@ func testQueryableFunc(querierTestConfig *querier.TestConfig, reg prometheus.Reg
 	}
 }
 
-func testSetup(t *testing.T, querierTestConfig *querier.TestConfig) (*promql.Engine, storage.QueryableFunc, Pusher, log.Logger, RulesLimits, prometheus.Registerer, func()) {
-	dir, err := ioutil.TempDir("", filepath.Base(t.Name()))
-	assert.NoError(t, err)
-	cleanup := func() {
-		os.RemoveAll(dir)
-	}
+func testSetup(t *testing.T, querierTestConfig *querier.TestConfig) (*promql.Engine, storage.QueryableFunc, Pusher, log.Logger, RulesLimits, prometheus.Registerer) {
+	dir := t.TempDir()
 
 	tracker := promql.NewActiveQueryTracker(dir, 20, log.NewNopLogger())
 
@@ -173,15 +163,15 @@ func testSetup(t *testing.T, querierTestConfig *querier.TestConfig) (*promql.Eng
 	reg := prometheus.NewRegistry()
 	queryable := testQueryableFunc(querierTestConfig, reg, l)
 
-	return engine, queryable, pusher, l, ruleLimits{evalDelay: 0, maxRuleGroups: 20, maxRulesPerRuleGroup: 15}, reg, cleanup
+	return engine, queryable, pusher, l, ruleLimits{evalDelay: 0, maxRuleGroups: 20, maxRulesPerRuleGroup: 15}, reg
 }
 
-func newManager(t *testing.T, cfg Config) (*DefaultMultiTenantManager, func()) {
-	engine, queryable, pusher, logger, overrides, reg, cleanup := testSetup(t, nil)
+func newManager(t *testing.T, cfg Config) *DefaultMultiTenantManager {
+	engine, queryable, pusher, logger, overrides, reg := testSetup(t, nil)
 	manager, err := NewDefaultMultiTenantManager(cfg, DefaultTenantManagerFactory(cfg, pusher, queryable, engine, overrides, nil), reg, logger)
 	require.NoError(t, err)
 
-	return manager, cleanup
+	return manager
 }
 
 type mockRulerClientsPool struct {
@@ -222,8 +212,8 @@ func newMockClientsPool(cfg Config, logger log.Logger, reg prometheus.Registerer
 	}
 }
 
-func buildRuler(t *testing.T, rulerConfig Config, querierTestConfig *querier.TestConfig, clientMetrics chunk_storage.ClientMetrics, rulerAddrMap map[string]*Ruler) (*Ruler, func()) {
-	engine, queryable, pusher, logger, overrides, reg, cleanup := testSetup(t, querierTestConfig)
+func buildRuler(t *testing.T, rulerConfig Config, querierTestConfig *querier.TestConfig, clientMetrics chunk_storage.ClientMetrics, rulerAddrMap map[string]*Ruler) *Ruler {
+	engine, queryable, pusher, logger, overrides, reg := testSetup(t, querierTestConfig)
 	storage, err := NewLegacyRuleStore(rulerConfig.StoreConfig, hedging.Config{}, clientMetrics, promRules.FileLoader{}, log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -241,19 +231,19 @@ func buildRuler(t *testing.T, rulerConfig Config, querierTestConfig *querier.Tes
 		newMockClientsPool(rulerConfig, logger, reg, rulerAddrMap),
 	)
 	require.NoError(t, err)
-	return ruler, cleanup
+	return ruler
 }
 
-func newTestRuler(t *testing.T, rulerConfig Config) (*Ruler, func()) {
+func newTestRuler(t *testing.T, rulerConfig Config) *Ruler {
 	m := chunk_storage.NewClientMetrics()
 	defer m.Unregister()
-	ruler, cleanup := buildRuler(t, rulerConfig, nil, m, nil)
+	ruler := buildRuler(t, rulerConfig, nil, m, nil)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ruler))
 
 	// Ensure all rules are loaded before usage
 	ruler.syncRules(context.Background(), rulerSyncReasonInitial)
 
-	return ruler, cleanup
+	return ruler
 }
 
 var _ MultiTenantManager = &DefaultMultiTenantManager{}
@@ -272,14 +262,12 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	defer ts.Close()
 
 	// We create an empty rule store so that the ruler will not load any rule from it.
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(nil))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(nil))
 
 	cfg.AlertmanagerURL = ts.URL
 	cfg.AlertmanagerDiscovery = false
 
-	manager, rcleanup := newManager(t, cfg)
-	defer rcleanup()
+	manager := newManager(t, cfg)
 	defer manager.Stop()
 
 	n, err := manager.getOrCreateNotifier("1")
@@ -304,11 +292,9 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 }
 
 func TestRuler_Rules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// test user1
@@ -405,8 +391,7 @@ func TestGetRules(t *testing.T) {
 			rulerAddrMap := map[string]*Ruler{}
 
 			createRuler := func(id string) *Ruler {
-				cfg, cleanUp := defaultRulerConfig(t, newMockRuleStore(allRulesByUser))
-				t.Cleanup(cleanUp)
+				cfg := defaultRulerConfig(t, newMockRuleStore(allRulesByUser))
 
 				cfg.ShardingStrategy = tc.shardingStrategy
 				cfg.EnableSharding = tc.sharding
@@ -420,9 +405,8 @@ func TestGetRules(t *testing.T) {
 				}
 				m := chunk_storage.NewClientMetrics()
 				defer m.Unregister()
-				r, cleanUp := buildRuler(t, cfg, nil, m, rulerAddrMap)
+				r := buildRuler(t, cfg, nil, m, rulerAddrMap)
 				r.limits = ruleLimits{evalDelay: 0, tenantShard: tc.shuffleShardSize}
-				t.Cleanup(cleanUp)
 				rulerAddrMap[id] = r
 				if r.ring != nil {
 					require.NoError(t, services.StartAndAwaitRunning(context.Background(), r.ring))
@@ -925,9 +909,8 @@ func TestSharding(t *testing.T) {
 
 				m := chunk_storage.NewClientMetrics()
 				defer m.Unregister()
-				r, cleanup := buildRuler(t, cfg, nil, m, nil)
+				r := buildRuler(t, cfg, nil, m, nil)
 				r.limits = ruleLimits{evalDelay: 0, tenantShard: tc.shuffleShardSize}
-				t.Cleanup(cleanup)
 
 				if forceRing != nil {
 					r.ring = forceRing
@@ -1122,11 +1105,9 @@ type ruleGroupKey struct {
 }
 
 func TestRuler_ListAllRules(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	defer cleanup()
+	cfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
-	r, rcleanup := newTestRuler(t, cfg)
-	defer rcleanup()
+	r := newTestRuler(t, cfg)
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	router := mux.NewRouter()
@@ -1249,9 +1230,8 @@ func TestRecoverAlertsPostOutage(t *testing.T) {
 	}
 
 	// NEXT, set up ruler config with outage tolerance = 1hr
-	rulerCfg, cleanup := defaultRulerConfig(t, newMockRuleStore(mockRules))
+	rulerCfg := defaultRulerConfig(t, newMockRuleStore(mockRules))
 	rulerCfg.OutageTolerance, _ = time.ParseDuration("1h")
-	defer cleanup()
 
 	// NEXT, set up mock distributor containing sample,
 	// metric: ALERTS_FOR_STATE{alertname="UP_ALERT"}, ts: time.now()-15m, value: time.now()-25m
@@ -1285,9 +1265,8 @@ func TestRecoverAlertsPostOutage(t *testing.T) {
 	m := chunk_storage.NewClientMetrics()
 	defer m.Unregister()
 	// create a ruler but don't start it. instead, we'll evaluate the rule groups manually.
-	r, rcleanup := buildRuler(t, rulerCfg, &querier.TestConfig{Cfg: querierConfig, Distributor: d, Stores: queryables}, m, nil)
+	r := buildRuler(t, rulerCfg, &querier.TestConfig{Cfg: querierConfig, Distributor: d, Stores: queryables}, m, nil)
 	r.syncRules(context.Background(), rulerSyncReasonInitial)
-	defer rcleanup()
 
 	// assert initial state of rule group
 	ruleGroup := r.manager.GetRules("user1")[0]

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -3,7 +3,6 @@ package ruler
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -132,15 +131,9 @@ func setupRegistry(t *testing.T, dir string) *walRegistry {
 	return reg.(*walRegistry)
 }
 
-func createTempWALDir() (string, error) {
-	return ioutil.TempDir(os.TempDir(), "wal")
-}
-
 func TestTenantRemoteWriteConfigWithOverride(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
@@ -152,10 +145,8 @@ func TestTenantRemoteWriteConfigWithOverride(t *testing.T) {
 }
 
 func TestTenantRemoteWriteConfigWithoutOverride(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	// this tenant has no overrides, so will get defaults
 	tenantCfg, err := reg.getTenantConfig("unknown")
@@ -168,10 +159,8 @@ func TestTenantRemoteWriteConfigWithoutOverride(t *testing.T) {
 }
 
 func TestTenantRemoteWriteConfigDisabled(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(disabledRWTenant)
 	require.NoError(t, err)
@@ -181,8 +170,7 @@ func TestTenantRemoteWriteConfigDisabled(t *testing.T) {
 }
 
 func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
 	defer os.RemoveAll(walDir)
 
@@ -195,10 +183,8 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 }
 
 func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(additionalHeadersRWTenant)
 	require.NoError(t, err)
@@ -219,10 +205,8 @@ func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
 }
 
 func TestTenantRemoteWriteHeadersReset(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(noHeadersRWTenant)
 	require.NoError(t, err)
@@ -235,10 +219,8 @@ func TestTenantRemoteWriteHeadersReset(t *testing.T) {
 }
 
 func TestTenantRemoteWriteHeadersNoOverride(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
@@ -251,10 +233,8 @@ func TestTenantRemoteWriteHeadersNoOverride(t *testing.T) {
 }
 
 func TestRelabelConfigOverrides(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(customRelabelsTenant)
 	require.NoError(t, err)
@@ -264,10 +244,8 @@ func TestRelabelConfigOverrides(t *testing.T) {
 }
 
 func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(nilRelabelsTenant)
 	require.NoError(t, err)
@@ -277,10 +255,8 @@ func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
 }
 
 func TestRelabelConfigOverridesEmptySliceWriteRelabels(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	tenantCfg, err := reg.getTenantConfig(emptySliceRelabelsTenant)
 	require.NoError(t, err)
@@ -290,12 +266,10 @@ func TestRelabelConfigOverridesEmptySliceWriteRelabels(t *testing.T) {
 }
 
 func TestRelabelConfigOverridesWithErrors(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
-	_, err = reg.getTenantConfig(badRelabelsTenant)
+	_, err := reg.getTenantConfig(badRelabelsTenant)
 
 	// ensure that relabel validation is being applied
 	require.EqualError(t, err, "failed to parse relabel configs: labeldrop action requires only 'regex', and no other fields")
@@ -326,10 +300,8 @@ func TestWALRegistryCreation(t *testing.T) {
 }
 
 func TestStorageSetup(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	// once the registry is setup and we configure the tenant storage, we should be able
 	// to acquire an appender for the WAL storage
@@ -344,10 +316,8 @@ func TestStorageSetup(t *testing.T) {
 }
 
 func TestStorageSetupWithRemoteWriteDisabled(t *testing.T) {
-	walDir, err := createTempWALDir()
-	require.NoError(t, err)
+	walDir := t.TempDir()
 	reg := setupRegistry(t, walDir)
-	defer os.RemoveAll(walDir)
 
 	// once the registry is setup and we configure the tenant storage, we should be able
 	// to acquire an appender for the WAL storage

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -24,9 +24,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	namespace1 := "ns"
 	namespace2 := "z-another" // This test relies on the fact that ioutil.ReadDir() returns files sorted by name.
 
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ruleGroups := rulefmt.RuleGroups{
 		Groups: []rulefmt.RuleGroup{

--- a/pkg/ruler/storage/cleaner/cleaner_test.go
+++ b/pkg/ruler/storage/cleaner/cleaner_test.go
@@ -4,7 +4,6 @@
 package cleaner
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,12 +26,10 @@ func TestWALCleaner_getAllStorageNoRoot(t *testing.T) {
 }
 
 func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
-	walRoot, err := ioutil.TempDir(os.TempDir(), "getAllStorageSuccess")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	cleaner := newCleaner(walRoot, Config{})
@@ -42,12 +39,10 @@ func TestWALCleaner_getAllStorageSuccess(t *testing.T) {
 }
 
 func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
-	walRoot, err := ioutil.TempDir(os.TempDir(), "getAbandonedStorageBeforeCutoff")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	all := []string{walDir}
@@ -67,12 +62,10 @@ func TestWALCleaner_getAbandonedStorageBeforeCutoff(t *testing.T) {
 }
 
 func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
-	walRoot, err := ioutil.TempDir(os.TempDir(), "getAbandonedStorageAfterCutoff")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	all := []string{walDir}
@@ -95,12 +88,10 @@ func TestWALCleaner_getAbandonedStorageAfterCutoff(t *testing.T) {
 }
 
 func TestWALCleaner_cleanup(t *testing.T) {
-	walRoot, err := ioutil.TempDir(os.TempDir(), "cleanup")
-	require.NoError(t, err)
-	defer os.RemoveAll(walRoot)
+	walRoot := t.TempDir()
 
 	walDir := filepath.Join(walRoot, "instance-1")
-	err = os.MkdirAll(walDir, 0755)
+	err := os.MkdirAll(walDir, 0755)
 	require.NoError(t, err)
 
 	now := time.Now()

--- a/pkg/ruler/storage/instance/instance_test.go
+++ b/pkg/ruler/storage/instance/instance_test.go
@@ -6,7 +6,6 @@ package instance
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -165,9 +164,7 @@ func TestRemoteWriteMetricInterceptor_AllValues(t *testing.T) {
 // instance of the WAL storage and testing that samples get written to it.
 // This test touches most of Instance and is enough for a basic integration test.
 func TestInstance(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	mockStorage := mockWalStorage{
 		series:    make(map[storage.SeriesRef]int),

--- a/pkg/ruler/storage/wal/wal_test.go
+++ b/pkg/ruler/storage/wal/wal_test.go
@@ -5,9 +5,7 @@ package wal
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -30,9 +28,7 @@ func newTestStorage(walDir string) (*Storage, error) {
 }
 
 func TestStorage_InvalidSeries(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -72,9 +68,7 @@ func TestStorage_InvalidSeries(t *testing.T) {
 }
 
 func TestStorage(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -114,9 +108,7 @@ func TestStorage(t *testing.T) {
 }
 
 func TestStorage_ExistingWAL(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -179,9 +171,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 }
 
 func TestStorage_ExistingWAL_RefID(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -212,9 +202,7 @@ func TestStorage_Truncate(t *testing.T) {
 	// after writing all the data, forcefully create 4 more segments,
 	// then do a truncate of a timestamp for _some_ of the data.
 	// then read data back in. Expect to only get the latter half of data.
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -273,9 +261,7 @@ func TestStorage_Truncate(t *testing.T) {
 }
 
 func TestStorage_WriteStalenessMarkers(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)
@@ -327,9 +313,7 @@ func TestStorage_WriteStalenessMarkers(t *testing.T) {
 }
 
 func TestStorage_TruncateAfterClose(t *testing.T) {
-	walDir, err := ioutil.TempDir(os.TempDir(), "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
 	require.NoError(t, err)

--- a/pkg/storage/chunk/local/boltdb_index_client_test.go
+++ b/pkg/storage/chunk/local/boltdb_index_client_test.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,10 +34,7 @@ func setupDB(t *testing.T, boltdbIndexClient *BoltIndexClient, dbname string) {
 }
 
 func TestBoltDBReload(t *testing.T) {
-	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
-	require.NoError(t, err)
-
-	defer require.NoError(t, os.RemoveAll(dirname))
+	dirname := t.TempDir()
 
 	boltdbIndexClient, err := NewBoltDBIndexClient(BoltDBConfig{
 		Directory: dirname,
@@ -78,10 +74,7 @@ func TestBoltDBReload(t *testing.T) {
 }
 
 func TestBoltDB_GetDB(t *testing.T) {
-	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
-	require.NoError(t, err)
-
-	defer require.NoError(t, os.RemoveAll(dirname))
+	dirname := t.TempDir()
 
 	boltdbIndexClient, err := NewBoltDBIndexClient(BoltDBConfig{
 		Directory: dirname,
@@ -121,8 +114,7 @@ func TestBoltDB_GetDB(t *testing.T) {
 
 func Test_CreateTable_BoltdbRW(t *testing.T) {
 	tableName := "test"
-	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
-	require.NoError(t, err)
+	dirname := t.TempDir()
 
 	indexClient, err := NewBoltDBIndexClient(BoltDBConfig{
 		Directory: dirname,
@@ -171,12 +163,7 @@ func Test_CreateTable_BoltdbRW(t *testing.T) {
 }
 
 func TestBoltDB_Writes(t *testing.T) {
-	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(dirname))
-	}()
+	dirname := t.TempDir()
 
 	for i, tc := range []struct {
 		name              string

--- a/pkg/storage/chunk/local/fs_object_client_test.go
+++ b/pkg/storage/chunk/local/fs_object_client_test.go
@@ -19,17 +19,12 @@ import (
 func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
 	deleteFilesOlderThan := 10 * time.Minute
 
-	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
-	require.NoError(t, err)
+	fsChunksDir := t.TempDir()
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
 		Directory: fsChunksDir,
 	})
 	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(fsChunksDir))
-	}()
 
 	file1 := "file1"
 	file2 := "file2"
@@ -64,17 +59,12 @@ func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
 }
 
 func TestFSObjectClient_List(t *testing.T) {
-	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-objects")
-	require.NoError(t, err)
+	fsObjectsDir := t.TempDir()
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
 		Directory: fsObjectsDir,
 	})
 	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(fsObjectsDir))
-	}()
 
 	allFiles := []string{
 		"outer-file1",
@@ -166,17 +156,12 @@ func TestFSObjectClient_List(t *testing.T) {
 }
 
 func TestFSObjectClient_DeleteObject(t *testing.T) {
-	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-delete-object")
-	require.NoError(t, err)
+	fsObjectsDir := t.TempDir()
 
 	bucketClient, err := NewFSObjectClient(FSConfig{
 		Directory: fsObjectsDir,
 	})
 	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(fsObjectsDir))
-	}()
 
 	foldersWithFiles := make(map[string][]string)
 	foldersWithFiles["folder1"] = []string{"file1", "file2"}

--- a/pkg/storage/chunk/storage/factory_test.go
+++ b/pkg/storage/chunk/storage/factory_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -78,10 +77,7 @@ func TestCustomIndexClient(t *testing.T) {
 	cfg := Config{}
 	schemaCfg := chunk.SchemaConfig{}
 
-	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
-	if err != nil {
-		return
-	}
+	dirname := t.TempDir()
 	cfg.BoltDBConfig.Directory = dirname
 
 	for _, tc := range []struct {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2,11 +2,9 @@ package storage
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 	"path"
 	"runtime"
 	"testing"
@@ -787,12 +785,7 @@ type timeRange struct {
 }
 
 func TestStore_MultipleBoltDBShippersInConfig(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "multiple-boltdb-shippers")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	limits, err := validation.NewOverrides(validation.Limits{}, nil)
 	require.NoError(t, err)

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -3,7 +3,6 @@ package compactor
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,12 +37,7 @@ func setupTestCompactor(t *testing.T, tempDir string, clientMetrics storage.Clie
 }
 
 func TestCompactor_RunCompaction(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "compactor-run-compaction")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	tablesPath := filepath.Join(tempDir, "index")
 	tablesCopyPath := filepath.Join(tempDir, "index-copy")
@@ -113,7 +107,7 @@ func TestCompactor_RunCompaction(t *testing.T) {
 	cm := storage.NewClientMetrics()
 	defer cm.Unregister()
 	compactor := setupTestCompactor(t, tempDir, cm)
-	err = compactor.RunCompaction(context.Background(), true)
+	err := compactor.RunCompaction(context.Background(), true)
 	require.NoError(t, err)
 
 	for name := range tables {

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_store_test.go
@@ -3,8 +3,6 @@ package deletion
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -46,11 +44,7 @@ func TestDeleteRequestsStore(t *testing.T) {
 	}
 
 	// build the store
-	tempDir, err := ioutil.TempDir("", "test-delete-requests-store")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	workingDir := filepath.Join(tempDir, "working-dir")
 	objectStorePath := filepath.Join(tempDir, "object-store")

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_table_test.go
@@ -2,7 +2,6 @@ package deletion
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,11 +17,7 @@ import (
 
 func TestDeleteRequestsTable(t *testing.T) {
 	// build test table
-	tempDir, err := ioutil.TempDir("", "test-delete-requests-table")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	workingDir := filepath.Join(tempDir, "working-dir")
 	objectStorePath := filepath.Join(tempDir, "object-store")
@@ -82,14 +77,8 @@ func TestDeleteRequestsTable(t *testing.T) {
 }
 
 func checkRecordsInStorage(t *testing.T, storageFilePath string, start, numRecords int) {
-	tempDir, err := ioutil.TempDir("", "compare-delete-requests-db")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 	tempFilePath := filepath.Join(tempDir, DeleteRequestsTableName)
-	require.NoError(t, err)
 	testutil.DecompressFile(t, storageFilePath, tempFilePath)
 
 	tempDB, err := util.SafeOpenBoltdbFile(tempFilePath)

--- a/pkg/storage/stores/shipper/compactor/table_test.go
+++ b/pkg/storage/stores/shipper/compactor/table_test.go
@@ -192,12 +192,7 @@ func TestTable_Compaction(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%s ; %s", commonDBsConfig.String(), perUserDBsConfig.String()), func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "table-compaction")
-			require.NoError(t, err)
-
-			defer func() {
-				require.NoError(t, os.RemoveAll(tempDir))
-			}()
+			tempDir := t.TempDir()
 
 			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
 			tablePathInStorage := filepath.Join(objectStoragePath, tableName)
@@ -419,12 +414,7 @@ func listDir(t *testing.T, path string) (files, folders []string) {
 }
 
 func TestTable_CompactionFailure(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-compaction-failure")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	tableName := "test"
 	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -3,9 +3,7 @@ package downloads
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,12 +35,7 @@ func buildTestTableManager(t *testing.T, path string) (*TableManager, stopFunc) 
 }
 
 func TestTableManager_QueryPages(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-manager-query-pages")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
 
@@ -68,12 +61,7 @@ func TestTableManager_QueryPages(t *testing.T) {
 }
 
 func TestTableManager_cleanupCache(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "table-manager-cleanup-cache")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	tableManager, stopFunc := buildTestTableManager(t, tempDir)
 	defer stopFunc()
@@ -83,7 +71,7 @@ func TestTableManager_cleanupCache(t *testing.T) {
 	nonExpiredTableName := "non-expired-table"
 
 	// query for above 2 tables which should set them up in table manager
-	err = tableManager.QueryPages(user.InjectOrgID(context.Background(), "fake"), []chunk.IndexQuery{
+	err := tableManager.QueryPages(user.InjectOrgID(context.Background(), "fake"), []chunk.IndexQuery{
 		{TableName: expiredTableName},
 		{TableName: nonExpiredTableName},
 	}, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
@@ -134,12 +122,7 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "table-manager-ensure-query-readiness")
-			require.NoError(t, err)
-
-			defer func() {
-				require.NoError(t, os.RemoveAll(tempDir))
-			}()
+			tempDir := t.TempDir()
 
 			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
 

--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -457,12 +457,7 @@ func TestTable_QueryResponse(t *testing.T) {
 }
 
 func TestLoadTable(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "load-table")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
 	tablePathInStorage := filepath.Join(objectStoragePath, tableName)

--- a/pkg/storage/stores/shipper/storage/client_test.go
+++ b/pkg/storage/stores/shipper/storage/client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,12 +14,7 @@ import (
 )
 
 func TestIndexStorageClient(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-index-storage-client")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	storageKeyPrefix := "prefix/"
 	tablesToSetup := map[string][]string{

--- a/pkg/storage/stores/shipper/table_client_test.go
+++ b/pkg/storage/stores/shipper/table_client_test.go
@@ -3,8 +3,6 @@ package shipper
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -16,12 +14,7 @@ import (
 )
 
 func TestBoltDBShipperTableClient(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "boltdb-shipper")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	cm := storage.NewClientMetrics()
 	objectClient, err := storage.NewObjectClient("filesystem", storage.Config{FSConfig: local.FSConfig{Directory: tempDir}}, cm)

--- a/pkg/storage/stores/shipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_manager_test.go
@@ -2,7 +2,6 @@ package uploads
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,12 +37,7 @@ func buildTestTableManager(t *testing.T, testDir string) (*TableManager, *local.
 }
 
 func TestLoadTables(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "load-tables")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(testDir))
-	}()
+	testDir := t.TempDir()
 
 	boltDBIndexClient, storageClient := buildTestClients(t, testDir)
 	indexPath := filepath.Join(testDir, indexDirName)
@@ -117,12 +111,7 @@ func TestLoadTables(t *testing.T) {
 }
 
 func TestTableManager_BatchWrite(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "batch-write")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(testDir))
-	}()
+	testDir := t.TempDir()
 
 	tm, boltIndexClient, stopFunc := buildTestTableManager(t, testDir)
 	defer func() {
@@ -144,7 +133,6 @@ func TestTableManager_BatchWrite(t *testing.T) {
 
 	require.NoError(t, tm.BatchWrite(context.Background(), writeBatch))
 
-	require.NoError(t, err)
 	require.Len(t, tm.tables, len(tc))
 
 	for tableName, expectedIndex := range tc {
@@ -154,12 +142,7 @@ func TestTableManager_BatchWrite(t *testing.T) {
 }
 
 func TestTableManager_QueryPages(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "query-pages")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(testDir))
-	}()
+	testDir := t.TempDir()
 
 	tm, boltIndexClient, stopFunc := buildTestTableManager(t, testDir)
 	defer func() {

--- a/pkg/storage/stores/shipper/uploads/table_test.go
+++ b/pkg/storage/stores/shipper/uploads/table_test.go
@@ -57,12 +57,7 @@ func buildTestTable(t *testing.T, path string, makePerTenantBuckets bool) (*Tabl
 }
 
 func TestLoadTable(t *testing.T) {
-	indexPath, err := ioutil.TempDir("", "table-load")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(indexPath))
-	}()
+	indexPath := t.TempDir()
 
 	boltDBIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: indexPath})
 	require.NoError(t, err)
@@ -237,12 +232,7 @@ func TestTable_Upload(t *testing.T) {
 
 func compareTableWithStorage(t *testing.T, table *Table, storageDir string) {
 	// use a temp dir for decompressing the files before comparison.
-	tempDir, err := ioutil.TempDir("", "compare-table")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	for name, db := range table.dbs {
 		fileName := table.buildFileName(name)
@@ -278,12 +268,7 @@ func compareTableWithStorage(t *testing.T, table *Table, storageDir string) {
 }
 
 func TestTable_Cleanup(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cleanup")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(testDir))
-	}()
+	testDir := t.TempDir()
 
 	boltDBIndexClient, storageClient := buildTestClients(t, testDir)
 	indexPath := filepath.Join(testDir, indexDirName)
@@ -360,12 +345,7 @@ func TestTable_Cleanup(t *testing.T) {
 }
 
 func Test_LoadBoltDBsFromDir(t *testing.T) {
-	indexPath, err := ioutil.TempDir("", "load-dbs-from-dir")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(indexPath))
-	}()
+	indexPath := t.TempDir()
 
 	// setup some dbs with a snapshot file.
 	tablePath := testutil.SetupDBsAtPath(t, filepath.Join(indexPath, "test-table"), map[string]testutil.DBConfig{
@@ -414,12 +394,7 @@ func Test_LoadBoltDBsFromDir(t *testing.T) {
 }
 
 func TestTable_ImmutableUploads(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "immutable-uploads")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	boltDBIndexClient, storageClient := buildTestClients(t, tempDir)
 	indexPath := filepath.Join(tempDir, indexDirName)
@@ -505,12 +480,7 @@ func TestTable_ImmutableUploads(t *testing.T) {
 }
 
 func TestTable_MultiQueries(t *testing.T) {
-	indexPath, err := ioutil.TempDir("", "table-multi-queries")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(indexPath))
-	}()
+	indexPath := t.TempDir()
 
 	boltDBIndexClient, err := local.NewBoltDBIndexClient(local.BoltDBConfig{Directory: indexPath})
 	require.NoError(t, err)

--- a/pkg/storage/stores/shipper/util/util_test.go
+++ b/pkg/storage/stores/shipper/util/util_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,12 +17,7 @@ import (
 )
 
 func Test_GetFileFromStorage(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "get-file-from-storage")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	// write a file to storage.
 	testData := []byte("test-data")
@@ -66,12 +60,7 @@ func Test_GetFileFromStorage(t *testing.T) {
 }
 
 func Test_CompressFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "compress-file")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
+	tempDir := t.TempDir()
 
 	uncompressedFilePath := filepath.Join(tempDir, "test-file")
 	compressedFilePath := filepath.Join(tempDir, "test-file.gz")

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -1,8 +1,6 @@
 package testutil
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,12 +10,7 @@ import (
 )
 
 func PrepareFilesystemBucket(t testing.TB) (objstore.Bucket, string) {
-	storageDir, err := ioutil.TempDir(os.TempDir(), "bucket")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(storageDir))
-	})
+	storageDir := t.TempDir()
 
 	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
