### PR TITLE
v12 chunk format handling in retention

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/index_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/index_test.go
@@ -2,6 +2,7 @@ package retention
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,13 +27,71 @@ func Test_schemaPeriodForTable(t *testing.T) {
 		{"first table", schemaCfg, "index_" + indexFromTime(dayFromTime(start).Time.Time()), schemaCfg.Configs[0], true},
 		{"4 hour after first table", schemaCfg, "index_" + indexFromTime(dayFromTime(start).Time.Time().Add(4*time.Hour)), schemaCfg.Configs[0], true},
 		{"second schema", schemaCfg, "index_" + indexFromTime(dayFromTime(start.Add(28*time.Hour)).Time.Time()), schemaCfg.Configs[1], true},
-		{"now", schemaCfg, "index_" + indexFromTime(time.Now()), schemaCfg.Configs[2], true},
+		{"third schema", schemaCfg, "index_" + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), schemaCfg.Configs[2], true},
+		{"now", schemaCfg, "index_" + indexFromTime(time.Now()), schemaCfg.Configs[3], true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, actualFound := schemaPeriodForTable(tt.config, tt.tableName)
 			require.Equal(t, tt.expected, actual)
 			require.Equal(t, tt.expectedFound, actualFound)
+		})
+	}
+}
+
+func TestParseChunkID(t *testing.T) {
+	type resp struct {
+		userID        string
+		from, through int64
+		valid         bool
+	}
+	for _, tc := range []struct {
+		name         string
+		chunkID      string
+		expectedResp resp
+	}{
+		{
+			name:    "older than v12 chunk format",
+			chunkID: "fake/57f628c7f6d57aad:162c699f000:162c69a07eb:eb242d99",
+			expectedResp: resp{
+				userID:  "fake",
+				from:    1523750400000,
+				through: 1523750406123,
+				valid:   true,
+			},
+		},
+		{
+			name:    "v12+ chunk format",
+			chunkID: "fake/57f628c7f6d57aad/162c699f000:162c69a07eb:eb242d99",
+			expectedResp: resp{
+				userID:  "fake",
+				from:    1523750400000,
+				through: 1523750406123,
+				valid:   true,
+			},
+		},
+		{
+			name:    "invalid format",
+			chunkID: "fake:57f628c7f6d57aad:162c699f000:162c69a07eb:eb242d99",
+			expectedResp: resp{
+				valid: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			userID, hexFrom, hexThrough, valid := parseChunkID([]byte(tc.chunkID))
+			if !tc.expectedResp.valid {
+				require.False(t, valid)
+			} else {
+				require.Equal(t, tc.expectedResp.userID, string(userID))
+				from, err := strconv.ParseInt(unsafeGetString(hexFrom), 16, 64)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedResp.from, from)
+
+				through, err := strconv.ParseInt(unsafeGetString(hexThrough), 16, 64)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedResp.through, through)
+			}
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/objectclient"
 	"github.com/grafana/loki/pkg/storage/chunk/storage"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -217,6 +218,23 @@ func Test_EmptyTable(t *testing.T) {
 			NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil)
 		require.NoError(t, err)
 		require.True(t, empty)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// table with no chunks should error
+	tempDir := t.TempDir()
+	emptyDB, err := util.SafeOpenBoltdbFile(filepath.Join(tempDir, "empty.db"))
+	require.NoError(t, err)
+	err = emptyDB.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucket(local.IndexBucketName)
+		require.NoError(t, err)
+
+		it, err := newChunkIndexIterator(bucket, schema.config)
+		require.NoError(t, err)
+		_, _, err = markforDelete(context.Background(), tables[0].name, noopWriter{}, it, noopCleaner{},
+			NewExpirationChecker(&fakeLimits{}), nil)
+		require.Equal(t, err, errNoChunksFound)
 		return nil
 	})
 	require.NoError(t, err)

--- a/pkg/storage/stores/shipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/util_test.go
@@ -77,6 +77,17 @@ var (
 					},
 					RowShards: 16,
 				},
+				{
+					From:       dayFromTime(start.Add(100 * time.Hour)),
+					IndexType:  "boltdb",
+					ObjectType: "filesystem",
+					Schema:     "v12",
+					IndexTables: chunk.PeriodicTableConfig{
+						Prefix: "index_",
+						Period: time.Hour * 24,
+					},
+					RowShards: 16,
+				},
 			},
 		},
 	}
@@ -88,6 +99,7 @@ var (
 		{"v9", schemaCfg.Configs[0].From.Time, schemaCfg.Configs[0]},
 		{"v10", schemaCfg.Configs[1].From.Time, schemaCfg.Configs[1]},
 		{"v11", schemaCfg.Configs[2].From.Time, schemaCfg.Configs[2]},
+		{"v12", schemaCfg.Configs[3].From.Time, schemaCfg.Configs[3]},
 	}
 
 	sweepMetrics = newSweeperMetrics(prometheus.DefaultRegisterer)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
While applying retention, compactor looks for chunk ids in specific formats. If it can't find any chunks it drops the whole table.
Since the recent `v12` chunk id format is not recognized by the compactor, it drops the whole table while applying retention on table using `v12` schema.

This PR makes the retention code aware of `v12` chunk id format and adds a safety mechanism to fail the retention operation when it can't find any chunk ids in the table.

**Checklist**
- [x] Tests updated
