### PR TITLE
Backport 4761: Set querier worker max concurrent regardless of run configurati…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -274,8 +274,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-require github.com/cloudflare/cloudflare-go v0.27.0 // indirect
-
 // Upgrade to run with gRPC 1.3.0 and above.
 replace github.com/sercand/kuberesolver => github.com/sercand/kuberesolver v2.4.0+incompatible
 

--- a/go.mod
+++ b/go.mod
@@ -274,12 +274,7 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-require (
-	github.com/cloudflare/cloudflare-go v0.27.0
-	github.com/gofrs/flock v0.7.1 // indirect
-	github.com/gogo/status v1.1.0
-	github.com/oklog/ulid v1.3.1
-)
+require github.com/cloudflare/cloudflare-go v0.27.0 // indirect
 
 // Upgrade to run with gRPC 1.3.0 and above.
 replace github.com/sercand/kuberesolver => github.com/sercand/kuberesolver v2.4.0+incompatible

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -213,6 +213,8 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	if t.Cfg.Ingester.QueryStoreMaxLookBackPeriod != 0 {
 		t.Cfg.Querier.IngesterQueryStoreMaxLookback = t.Cfg.Ingester.QueryStoreMaxLookBackPeriod
 	}
+	// Querier worker's max concurrent requests must be the same as the querier setting
+	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.MaxConcurrent
 
 	var err error
 	t.Querier, err = querier.New(t.Cfg.Querier, t.Store, t.ingesterQuerier, t.overrides)

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -131,9 +131,6 @@ func InitWorkerService(
 
 	internalHandler = internalMiddleware.Wrap(internalHandler)
 
-	//Querier worker's max concurrent requests must be the same as the querier setting
-	(*cfg.QuerierWorkerConfig).MaxConcurrentRequests = cfg.QuerierMaxConcurrent
-
 	//Return a querier worker pointed to the internal querier HTTP handler so there is not a conflict in routes between the querier
 	//and the query frontend
 	return querier_worker.NewQuerierWorker(

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -224,18 +224,6 @@ func Test_InitQuerierService(t *testing.T) {
 			}
 		})
 
-		t.Run("set the worker's max concurrent request to the same as the max concurrent setting for the querier", func(t *testing.T) {
-			for _, config := range nonStandaloneTargetPermutations {
-				workerConfig := querier_worker.Config{}
-				config.QuerierWorkerConfig = &workerConfig
-				config.QuerierMaxConcurrent = 42
-
-				testContext(config, nil)
-
-				assert.Equal(t, 42, workerConfig.MaxConcurrentRequests)
-			}
-		})
-
 		t.Run("always return a query worker service", func(t *testing.T) {
 			for _, config := range nonStandaloneTargetPermutations {
 				workerConfig := querier_worker.Config{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,6 +212,8 @@ github.com/cespare/xxhash
 # github.com/cespare/xxhash/v2 v2.1.2
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
+# github.com/cloudflare/cloudflare-go v0.27.0
+## explicit; go 1.15
 # github.com/containerd/containerd v1.5.4
 ## explicit; go 1.16
 github.com/containerd/containerd/errdefs

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,8 +212,6 @@ github.com/cespare/xxhash
 # github.com/cespare/xxhash/v2 v2.1.2
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cloudflare/cloudflare-go v0.27.0
-## explicit; go 1.15
 # github.com/containerd/containerd v1.5.4
 ## explicit; go 1.16
 github.com/containerd/containerd/errdefs


### PR DESCRIPTION
…on. (#4761)

* always set the querier worker MaxConcurrentRequests

* removing a test which doesn't apply as this setting isn't being set in worker_service.go anymore

(cherry picked from commit 88ef940ede3ecf965481a104b4fdb35cad7bb79f)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Backports #4761 to 2.4 release branch