### PR TITLE
use default retention period to check user index may have expired chunks when user does not have custom retention

### DIFF
--- a/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
@@ -92,10 +92,11 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 	const dayDuration = 24 * time.Hour
 	now := model.Now()
 	for _, tc := range []struct {
-		name                                   string
-		limit                                  fakeLimits
-		expectedLatestRetentionStartTime       model.Time
-		expectedLatestRetentionStartTimeByUser map[string]model.Time
+		name                                    string
+		limit                                   fakeLimits
+		expectedLatestRetentionStartTime        model.Time
+		expectedLatestDefaultRetentionStartTime model.Time
+		expectedLatestRetentionStartTimeByUser  map[string]model.Time
 	}{
 		{
 			name: "only default retention set",
@@ -104,8 +105,9 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 					retentionPeriod: 7 * dayDuration,
 				},
 			},
-			expectedLatestRetentionStartTime:       now.Add(-7 * dayDuration),
-			expectedLatestRetentionStartTimeByUser: map[string]model.Time{},
+			expectedLatestRetentionStartTime:        now.Add(-7 * dayDuration),
+			expectedLatestDefaultRetentionStartTime: now.Add(-7 * dayDuration),
+			expectedLatestRetentionStartTimeByUser:  map[string]model.Time{},
 		},
 		{
 			name: "default retention period smallest",
@@ -123,7 +125,8 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 					"1": {retentionPeriod: 15 * dayDuration},
 				},
 			},
-			expectedLatestRetentionStartTime: now.Add(-7 * dayDuration),
+			expectedLatestRetentionStartTime:        now.Add(-7 * dayDuration),
+			expectedLatestDefaultRetentionStartTime: now.Add(-7 * dayDuration),
 			expectedLatestRetentionStartTimeByUser: map[string]model.Time{
 				"0": now.Add(-12 * dayDuration),
 				"1": now.Add(-15 * dayDuration),
@@ -145,7 +148,8 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 					"1": {retentionPeriod: 5 * dayDuration},
 				},
 			},
-			expectedLatestRetentionStartTime: now.Add(-3 * dayDuration),
+			expectedLatestRetentionStartTime:        now.Add(-3 * dayDuration),
+			expectedLatestDefaultRetentionStartTime: now.Add(-3 * dayDuration),
 			expectedLatestRetentionStartTimeByUser: map[string]model.Time{
 				"0": now.Add(-7 * dayDuration),
 				"1": now.Add(-5 * dayDuration),
@@ -181,7 +185,8 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 					},
 				},
 			},
-			expectedLatestRetentionStartTime: now.Add(-5 * dayDuration),
+			expectedLatestRetentionStartTime:        now.Add(-5 * dayDuration),
+			expectedLatestDefaultRetentionStartTime: now.Add(-7 * dayDuration),
 			expectedLatestRetentionStartTimeByUser: map[string]model.Time{
 				"0": now.Add(-10 * dayDuration),
 				"1": now.Add(-5 * dayDuration),
@@ -217,7 +222,8 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 					},
 				},
 			},
-			expectedLatestRetentionStartTime: now.Add(-2 * dayDuration),
+			expectedLatestRetentionStartTime:        now.Add(-2 * dayDuration),
+			expectedLatestDefaultRetentionStartTime: now.Add(-7 * dayDuration),
 			expectedLatestRetentionStartTimeByUser: map[string]model.Time{
 				"0": now.Add(-10 * dayDuration),
 				"1": now.Add(-2 * dayDuration),
@@ -225,55 +231,114 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			latestRetentionStartTime, latestRetentionStartTimeByUser := findLatestRetentionStartTime(now, tc.limit)
+			latestRetentionStartTime, latestDefaultRetentionStartTime, latestRetentionStartTimeByUser := findLatestRetentionStartTime(now, tc.limit)
 			require.Equal(t, tc.expectedLatestRetentionStartTime, latestRetentionStartTime)
+			require.Equal(t, tc.expectedLatestDefaultRetentionStartTime, latestDefaultRetentionStartTime)
 			require.Equal(t, tc.expectedLatestRetentionStartTimeByUser, latestRetentionStartTimeByUser)
 		})
 	}
 }
 
 func TestExpirationChecker_IntervalMayHaveExpiredChunks(t *testing.T) {
+	now := model.Now()
+	expirationChecker := expirationChecker{
+		overallLatestRetentionStartTime: now.Add(-24 * time.Hour),
+		defaultLatestRetentionStartTime: now.Add(-48 * time.Hour),
+		latestRetentionStartTimeByUser: map[string]model.Time{
+			"user0": now.Add(-72 * time.Hour),
+			"user1": now.Add(-24 * time.Hour),
+		},
+	}
+
 	for _, tc := range []struct {
-		name              string
-		expirationChecker expirationChecker
-		interval          model.Interval
-		hasExpiredChunks  bool
+		name             string
+		userID           string
+		interval         model.Interval
+		hasExpiredChunks bool
 	}{
+		// common index using overallLatestRetentionStartTime
 		{
-			name: "not expired",
-			expirationChecker: expirationChecker{
-				latestRetentionStartTime: model.Now().Add(-24 * time.Hour),
-			},
+			name: "common index - not expired",
 			interval: model.Interval{
-				Start: model.Now().Add(-time.Hour),
-				End:   model.Now(),
+				Start: now.Add(-23 * time.Hour),
+				End:   now,
 			},
 		},
 		{
-			name: "partially expired",
-			expirationChecker: expirationChecker{
-				latestRetentionStartTime: model.Now().Add(-24 * time.Hour),
-			},
+			name: "common index - partially expired",
 			interval: model.Interval{
-				Start: model.Now().Add(-25 * time.Hour),
-				End:   model.Now().Add(-22 * time.Hour),
+				Start: now.Add(-25 * time.Hour),
+				End:   now.Add(-22 * time.Hour),
 			},
 			hasExpiredChunks: true,
 		},
 		{
-			name: "fully expired",
-			expirationChecker: expirationChecker{
-				latestRetentionStartTime: model.Now().Add(-24 * time.Hour),
-			},
+			name: "common index - fully expired",
 			interval: model.Interval{
-				Start: model.Now().Add(-26 * time.Hour),
-				End:   model.Now().Add(-25 * time.Hour),
+				Start: now.Add(-26 * time.Hour),
+				End:   now.Add(-25 * time.Hour),
+			},
+			hasExpiredChunks: true,
+		},
+
+		// user0 having custom retention
+		{
+			name:   "user0 index - not expired",
+			userID: "user0",
+			interval: model.Interval{
+				Start: now.Add(-71 + time.Hour),
+				End:   now,
+			},
+		},
+		{
+			name:   "user0 index - partially expired",
+			userID: "user0",
+			interval: model.Interval{
+				Start: now.Add(-73 * time.Hour),
+				End:   now.Add(-71 * time.Hour),
+			},
+			hasExpiredChunks: true,
+		},
+		{
+			name:   "user0 index - fully expired",
+			userID: "user0",
+			interval: model.Interval{
+				Start: now.Add(-74 * time.Hour),
+				End:   now.Add(-73 * time.Hour),
+			},
+			hasExpiredChunks: true,
+		},
+
+		// user3 not having custom retention so using defaultLatestRetentionStartTime
+		{
+			name:   "user3 index - not expired",
+			userID: "user3",
+			interval: model.Interval{
+				Start: now.Add(-47 * time.Hour),
+				End:   now,
+			},
+		},
+		{
+			name:   "user3 index - partially expired",
+			userID: "user3",
+			interval: model.Interval{
+				Start: now.Add(-49 * time.Hour),
+				End:   now.Add(-47 * time.Hour),
+			},
+			hasExpiredChunks: true,
+		},
+		{
+			name:   "user3 index - fully expired",
+			userID: "user3",
+			interval: model.Interval{
+				Start: now.Add(-50 * time.Hour),
+				End:   now.Add(-49 * time.Hour),
 			},
 			hasExpiredChunks: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.hasExpiredChunks, tc.expirationChecker.IntervalMayHaveExpiredChunks(tc.interval, ""))
+			require.Equal(t, tc.hasExpiredChunks, expirationChecker.IntervalMayHaveExpiredChunks(tc.interval, tc.userID))
 		})
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When checking whether user specific index tables may have any expired chunks, we were using the smallest overall retention period instead of the smallest default retention period.

This causes us to unnecessarily download user index tables in some cases, for e.g:
We have a default config of `30d`, `user1` has a custom stream retention of `24h` and `user2` has no retention config.
Here the overall smallest retention period is `24h` and the smallest default retention is `30d`.
When checking if `user2`'s index table may have expired chunks based on table interval, we should be considering `30d` retention and not `24h`.

**Checklist**
- [x] Tests updated
