### PR TITLE
Promtail docs: Fix link to `unpack` LogQL documentation

### DIFF
--- a/docs/sources/clients/promtail/stages/pack.md
+++ b/docs/sources/clients/promtail/stages/pack.md
@@ -57,7 +57,7 @@ This would create a log line
 }
 ```
 
-**Loki 2.2 also includes a new [`unpack`](../../../../logql/#unpack) parser to work with the pack stage.**
+**Loki 2.2 also includes a new [`unpack`](../../../../logql/log_queries/#unpack) parser to work with the pack stage.**
 
 For example:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The link to `unpack` documentation is broken

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
