### PR TITLE
Parse duration expressions in accordance with promql

### DIFF
--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -66,7 +66,7 @@ func Test_SampleExpr_String(t *testing.T) {
 	for _, tc := range []string{
 		`rate( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
 		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] )`,
-		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] offset 10m )`,
+		`absent_over_time( ( {job="mysql"} |="error" !="timeout" ) [10s] offset 10d )`,
 		`sum without(a) ( rate ( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum by(a) (rate( ( {job="mysql"} |="error" !="timeout" ) [10s] ) )`,
 		`sum(count_over_time({job="mysql"}[5m]))`,
@@ -78,7 +78,7 @@ func Test_SampleExpr_String(t *testing.T) {
 		`sum(count_over_time({job="mysql"} | pattern "<foo> bar <buzz>" | json [5m]))`,
 		`sum(count_over_time({job="mysql"} | unpack | json [5m]))`,
 		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m]))`,
-		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m] offset 10m))`,
+		`sum(count_over_time({job="mysql"} | regexp "(?P<foo>foo|bar)" [5m] offset 10y))`,
 		`topk(10,sum(rate({region="us-east1"}[5m])) by (name))`,
 		`topk by (name)(10,sum(rate({region="us-east1"}[5m])))`,
 		`avg( rate( ( {job="nginx"} |= "GET" ) [10s] ) ) by (region)`,

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -254,7 +254,7 @@ func tryScanDuration(number string, l *scanner.Scanner) (time.Duration, bool) {
 	for i := 0; i < consumed; i++ {
 		_ = l.Next()
 	}
-	return time.Duration(duration), true
+	return duration, true
 }
 
 func isDurationRune(r rune) bool {

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -240,10 +240,15 @@ func tryScanDuration(number string, l *scanner.Scanner) (time.Duration, bool) {
 		return 0, false
 	}
 	// we've found more characters before a whitespace or the end
+	durationString := sb.String()
 	var duration time.Duration
-	prometheusDuration, err := model.ParseDuration(sb.String())
+	// Try to parse promql style durations first, to ensure that we support the same duration
+	// units as promql
+	prometheusDuration, err := model.ParseDuration(durationString)
 	if err != nil {
-		duration, err = time.ParseDuration(sb.String())
+		// Fall back to standard library's time.ParseDuration if a promql style
+		// duration couldn't be parsed.
+		duration, err = time.ParseDuration(durationString)
 		if err != nil {
 			return 0, false
 		}

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -274,9 +274,9 @@ func parseDuration(d string) (time.Duration, error) {
 }
 
 func isDurationRune(r rune) bool {
-	// "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w", "y".
 	switch r {
-	case 'n', 's', 'u', 'm', 'h', 'µ', 'y', 'w', 'd':
+	case 'n', 'u', 'µ', 'm', 's', 'h', 'd', 'w', 'y':
 		return true
 	default:
 		return false

--- a/pkg/logql/lex.go
+++ b/pkg/logql/lex.go
@@ -240,21 +240,27 @@ func tryScanDuration(number string, l *scanner.Scanner) (time.Duration, bool) {
 		return 0, false
 	}
 	// we've found more characters before a whitespace or the end
-	d, err := time.ParseDuration(sb.String())
+	var duration time.Duration
+	prometheusDuration, err := model.ParseDuration(sb.String())
 	if err != nil {
-		return 0, false
+		duration, err = time.ParseDuration(sb.String())
+		if err != nil {
+			return 0, false
+		}
+	} else {
+		duration = time.Duration(prometheusDuration)
 	}
 	// we need to consume the scanner, now that we know this is a duration.
 	for i := 0; i < consumed; i++ {
 		_ = l.Next()
 	}
-	return d, true
+	return time.Duration(duration), true
 }
 
 func isDurationRune(r rune) bool {
 	// "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	switch r {
-	case 'n', 's', 'u', 'm', 'h', 'µ':
+	case 'n', 's', 'u', 'm', 'h', 'µ', 'y', 'w', 'd':
 		return true
 	default:
 		return false

--- a/pkg/logql/lex_test.go
+++ b/pkg/logql/lex_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 	"text/scanner"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -124,5 +125,33 @@ func Test_isFunction(t *testing.T) {
 				t.Errorf("isFunction() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_parseDuration(t *testing.T) {
+	const MICROSECOND = 1000 * time.Nanosecond
+	const DAY = 24 * time.Hour
+	const WEEK = 7 * DAY
+	const YEAR = 365 * DAY
+
+	for _, tc := range []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"1ns", time.Nanosecond},
+		{"1s", time.Second},
+		{"1us", MICROSECOND},
+		{"1m", time.Minute},
+		{"1h", time.Hour},
+		{"1µs", MICROSECOND},
+		{"1y", YEAR},
+		{"1w", WEEK},
+		{"1d", DAY},
+		{"1h15m30.918273645s", time.Hour + 15*time.Minute + 30*time.Second + 918273645*time.Nanosecond},
+	} {
+		actual, err := parseDuration(tc.input)
+
+		require.Equal(t, err, nil)
+		require.Equal(t, tc.expected, actual)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Add support for promql-like duration units in logql
**Which issue(s) this PR fixes**:
Fixes #5199

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
