### PR TITLE
Restart Docker target if stopped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [5280](https://github.com/grafana/loki/pull/5280) **jeschkies**: Fix Docker target connection loss.
 * [5243](https://github.com/grafana/loki/pull/5243) **owen-d**: moves `querier.split-queries-by-interval` to limits code only.
 * [5139](https://github.com/grafana/loki/pull/5139) **DylanGuedes**: Drop support for legacy configuration rules format.
 * [5262](https://github.com/grafana/loki/pull/5262) **MichelHollands**: Remove the labelFilter field

--- a/clients/pkg/promtail/targets/docker/target.go
+++ b/clients/pkg/promtail/targets/docker/target.go
@@ -38,7 +38,6 @@ type Target struct {
 	metrics       *Metrics
 
 	cancel  context.CancelFunc
-	ctx     context.Context
 	client  client.APIClient
 	wg      sync.WaitGroup
 	running *atomic.Bool
@@ -201,9 +200,12 @@ func (t *Target) process(r io.Reader, logStream string) {
 // startIfNotRunning starts processing container logs. The operation is idempotent , i.e. the processing cannot be started twice.
 func (t *Target) startIfNotRunning() {
 	if t.running.CAS(false, true) {
+		level.Debug(t.logger).Log("msg", "starting process loop", "container", t.containerName)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.cancel = cancel
 		go t.processLoop(ctx)
+	} else {
+		level.Debug(t.logger).Log("msg", "attempted to start process loop but it's already running", "container", t.containerName)
 	}
 }
 

--- a/clients/pkg/promtail/targets/docker/target_group.go
+++ b/clients/pkg/promtail/targets/docker/target_group.go
@@ -74,6 +74,7 @@ func (tg *targetGroup) addTarget(id string, discoveredLabels model.LabelSet) err
 
 	t, ok := tg.targets[id]
 	if ok {
+		level.Debug(tg.logger).Log("msg", "container target already exists", "container", id)
 		t.startIfNotRunning()
 		return nil
 	}

--- a/clients/pkg/promtail/targets/docker/target_group.go
+++ b/clients/pkg/promtail/targets/docker/target_group.go
@@ -72,8 +72,7 @@ func (tg *targetGroup) addTarget(id string, discoveredLabels model.LabelSet) err
 		}
 	}
 
-	t, ok := tg.targets[id]
-	if ok {
+	if t, ok := tg.targets[id]; ok {
 		level.Debug(tg.logger).Log("msg", "container target already exists", "container", id)
 		t.startIfNotRunning()
 		return nil

--- a/clients/pkg/promtail/targets/docker/target_group.go
+++ b/clients/pkg/promtail/targets/docker/target_group.go
@@ -72,9 +72,9 @@ func (tg *targetGroup) addTarget(id string, discoveredLabels model.LabelSet) err
 		}
 	}
 
-	_, ok := tg.targets[id]
+	t, ok := tg.targets[id]
 	if ok {
-		level.Debug(tg.logger).Log("msg", "ignoring container that is already being scraped", "container", id)
+		t.startIfNotRunning()
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The Docker target would not reconnect to a container if it restarted and
kept the same ID. This should introduces a `startIfNotRunning` method
that will be called to restart scraping the container's logs.

**Which issue(s) this PR fixes**:
Fixes #5259

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
