### PR TITLE
Refactor HeapIterator into Merge and Sort Iterator.

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -818,7 +818,7 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 		if ordered {
 			it = iter.NewNonOverlappingIterator(blockItrs, "")
 		} else {
-			it = iter.NewHeapIterator(ctx, blockItrs, direction)
+			it = iter.NewSortEntryIterator(blockItrs, direction)
 		}
 
 		return iter.NewTimeRangedIterator(
@@ -851,7 +851,7 @@ func (c *MemChunk) Iterator(ctx context.Context, mintT, maxtT time.Time, directi
 	if ordered {
 		return iter.NewNonOverlappingIterator(blockItrs, ""), nil
 	}
-	return iter.NewHeapIterator(ctx, blockItrs, direction), nil
+	return iter.NewSortEntryIterator(blockItrs, direction), nil
 }
 
 // Iterator implements Chunk.
@@ -886,7 +886,7 @@ func (c *MemChunk) SampleIterator(ctx context.Context, from, through time.Time, 
 	if ordered {
 		it = iter.NewNonOverlappingSampleIterator(its, "")
 	} else {
-		it = iter.NewHeapSampleIterator(ctx, its)
+		it = iter.NewSortSampleIterator(its)
 	}
 
 	return iter.NewTimeRangedSampleIterator(
@@ -1041,7 +1041,7 @@ func (hb *headBlock) Iterator(ctx context.Context, direction logproto.Direction,
 	for _, stream := range streams {
 		streamsResult = append(streamsResult, *stream)
 	}
-	return iter.NewStreamsIterator(ctx, streamsResult, direction)
+	return iter.NewStreamsIterator(streamsResult, direction)
 }
 
 func (hb *headBlock) SampleIterator(ctx context.Context, mint, maxt int64, extractor log.StreamSampleExtractor) iter.SampleIterator {
@@ -1082,7 +1082,7 @@ func (hb *headBlock) SampleIterator(ctx context.Context, mint, maxt int64, extra
 	for _, s := range series {
 		seriesRes = append(seriesRes, *s)
 	}
-	return iter.SampleIteratorWithClose(iter.NewMultiSeriesIterator(ctx, seriesRes), func() error {
+	return iter.SampleIteratorWithClose(iter.NewMultiSeriesIterator(seriesRes), func() error {
 		for _, s := range series {
 			SamplesPool.Put(s.Samples)
 		}

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -257,7 +257,7 @@ func (hb *unorderedHeadBlock) Iterator(
 	for _, stream := range streams {
 		streamsResult = append(streamsResult, *stream)
 	}
-	return iter.NewStreamsIterator(ctx, streamsResult, direction)
+	return iter.NewStreamsIterator(streamsResult, direction)
 }
 
 // nolint:unused
@@ -308,7 +308,7 @@ func (hb *unorderedHeadBlock) SampleIterator(
 	for _, s := range series {
 		seriesRes = append(seriesRes, *s)
 	}
-	return iter.SampleIteratorWithClose(iter.NewMultiSeriesIterator(ctx, seriesRes), func() error {
+	return iter.SampleIteratorWithClose(iter.NewMultiSeriesIterator(seriesRes), func() error {
 		for _, s := range series {
 			SamplesPool.Put(s.Samples)
 		}

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -306,7 +306,7 @@ func (i *instance) getLabelsFromFingerprint(fp model.Fingerprint) labels.Labels 
 	return s.labels
 }
 
-func (i *instance) Query(ctx context.Context, req logql.SelectLogParams) ([]iter.EntryIterator, error) {
+func (i *instance) Query(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error) {
 	expr, err := req.LogSelector()
 	if err != nil {
 		return nil, err
@@ -341,10 +341,10 @@ func (i *instance) Query(ctx context.Context, req logql.SelectLogParams) ([]iter
 		return nil, err
 	}
 
-	return iters, nil
+	return iter.NewSortEntryIterator(iters, req.Direction), nil
 }
 
-func (i *instance) QuerySample(ctx context.Context, req logql.SelectSampleParams) ([]iter.SampleIterator, error) {
+func (i *instance) QuerySample(ctx context.Context, req logql.SelectSampleParams) (iter.SampleIterator, error) {
 	expr, err := req.Expr()
 	if err != nil {
 		return nil, err
@@ -386,7 +386,7 @@ func (i *instance) QuerySample(ctx context.Context, req logql.SelectSampleParams
 		return nil, err
 	}
 
-	return iters, nil
+	return iter.NewSortSampleIterator(iters), nil
 }
 
 // Label returns the label names or values depending on the given request

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	loki_runtime "github.com/grafana/loki/pkg/runtime"
@@ -497,7 +496,7 @@ func Test_Iterator(t *testing.T) {
 	}
 
 	// prepare iterators.
-	itrs, err := instance.Query(ctx,
+	it, err := instance.Query(ctx,
 		logql.SelectLogParams{
 			QueryRequest: &logproto.QueryRequest{
 				Selector:  `{job="3"} | logfmt`,
@@ -509,12 +508,11 @@ func Test_Iterator(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	heapItr := iter.NewHeapIterator(ctx, itrs, direction)
 
 	// assert the order is preserved.
 	var res *logproto.QueryResponse
 	require.NoError(t,
-		sendBatches(ctx, heapItr,
+		sendBatches(ctx, it,
 			fakeQueryServer(
 				func(qr *logproto.QueryResponse) error {
 					res = qr
@@ -578,7 +576,7 @@ func Test_ChunkFilter(t *testing.T) {
 	}
 
 	// prepare iterators.
-	itrs, err := instance.Query(ctx,
+	it, err := instance.Query(ctx,
 		logql.SelectLogParams{
 			QueryRequest: &logproto.QueryRequest{
 				Selector:  `{job="3"}`,
@@ -590,7 +588,6 @@ func Test_ChunkFilter(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	it := iter.NewHeapIterator(ctx, itrs, direction)
 	defer it.Close()
 
 	for it.Next() {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -470,7 +470,7 @@ func (s *stream) Iterator(ctx context.Context, statsCtx *stats.Context, from, th
 	if ordered {
 		return iter.NewNonOverlappingIterator(iterators, ""), nil
 	}
-	return iter.NewHeapIterator(ctx, iterators, direction), nil
+	return iter.NewSortEntryIterator(iterators, direction), nil
 }
 
 // Returns an SampleIterator.
@@ -507,7 +507,7 @@ func (s *stream) SampleIterator(ctx context.Context, statsCtx *stats.Context, fr
 	if ordered {
 		return iter.NewNonOverlappingSampleIterator(iterators, ""), nil
 	}
-	return iter.NewHeapSampleIterator(ctx, iterators), nil
+	return iter.NewSortSampleIterator(iterators), nil
 }
 
 func (s *stream) addTailer(t *tailer) {

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -45,7 +45,7 @@ func TestIterator(t *testing.T) {
 
 		// Test dedupe of overlapping iterators with the heap iterator.
 		{
-			iterator: NewHeapIterator(context.Background(), []EntryIterator{
+			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(offset(0, identity), defaultLabels),
 				mkStreamIterator(offset(testSize/2, identity), defaultLabels),
 				mkStreamIterator(offset(testSize, identity), defaultLabels),
@@ -57,7 +57,7 @@ func TestIterator(t *testing.T) {
 
 		// Test dedupe of overlapping iterators with the heap iterator (backward).
 		{
-			iterator: NewHeapIterator(context.Background(), []EntryIterator{
+			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(inverse(offset(0, identity)), defaultLabels),
 				mkStreamIterator(inverse(offset(-testSize/2, identity)), defaultLabels),
 				mkStreamIterator(inverse(offset(-testSize, identity)), defaultLabels),
@@ -69,7 +69,7 @@ func TestIterator(t *testing.T) {
 
 		// Test dedupe of entries with the same timestamp but different entries.
 		{
-			iterator: NewHeapIterator(context.Background(), []EntryIterator{
+			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(offset(0, constant(0)), defaultLabels),
 				mkStreamIterator(offset(0, constant(0)), defaultLabels),
 				mkStreamIterator(offset(testSize, constant(0)), defaultLabels),
@@ -110,7 +110,7 @@ func TestIteratorMultipleLabels(t *testing.T) {
 	}{
 		// Test merging with differing labels but same timestamps and values.
 		{
-			iterator: NewHeapIterator(context.Background(), []EntryIterator{
+			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(identity, "{foobar: \"baz1\"}"),
 				mkStreamIterator(identity, "{foobar: \"baz2\"}"),
 			}, logproto.FORWARD),
@@ -128,7 +128,7 @@ func TestIteratorMultipleLabels(t *testing.T) {
 
 		// Test merging with differing labels but all the same timestamps and different values.
 		{
-			iterator: NewHeapIterator(context.Background(), []EntryIterator{
+			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(constant(0), "{foobar: \"baz1\"}"),
 				mkStreamIterator(constant(0), "{foobar: \"baz2\"}"),
 			}, logproto.FORWARD),
@@ -158,7 +158,7 @@ func TestIteratorMultipleLabels(t *testing.T) {
 	}
 }
 
-func TestHeapIteratorPrefetch(t *testing.T) {
+func TestMergeIteratorPrefetch(t *testing.T) {
 	t.Parallel()
 
 	type tester func(t *testing.T, i HeapIterator)
@@ -182,7 +182,7 @@ func TestHeapIteratorPrefetch(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			i := NewHeapIterator(context.Background(), []EntryIterator{
+			i := NewMergeEntryIterator(context.Background(), []EntryIterator{
 				mkStreamIterator(identity, "{foobar: \"baz1\"}"),
 				mkStreamIterator(identity, "{foobar: \"baz2\"}"),
 			}, logproto.FORWARD)
@@ -234,7 +234,7 @@ func inverse(g generator) generator {
 	}
 }
 
-func TestHeapIteratorDeduplication(t *testing.T) {
+func TestMergeIteratorDeduplication(t *testing.T) {
 	foo := logproto.Stream{
 		Labels: `{app="foo"}`,
 		Entries: []logproto.Entry{
@@ -272,7 +272,7 @@ func TestHeapIteratorDeduplication(t *testing.T) {
 		require.NoError(t, it.Error())
 	}
 	// forward iteration
-	it := NewHeapIterator(context.Background(), []EntryIterator{
+	it := NewMergeEntryIterator(context.Background(), []EntryIterator{
 		NewStreamIterator(foo),
 		NewStreamIterator(bar),
 		NewStreamIterator(foo),
@@ -284,7 +284,7 @@ func TestHeapIteratorDeduplication(t *testing.T) {
 	assertIt(it, false, len(foo.Entries))
 
 	// backward iteration
-	it = NewHeapIterator(context.Background(), []EntryIterator{
+	it = NewMergeEntryIterator(context.Background(), []EntryIterator{
 		mustReverseStreamIterator(NewStreamIterator(foo)),
 		mustReverseStreamIterator(NewStreamIterator(bar)),
 		mustReverseStreamIterator(NewStreamIterator(foo)),
@@ -308,8 +308,8 @@ func TestReverseIterator(t *testing.T) {
 	itr1 := mkStreamIterator(inverse(offset(testSize, identity)), defaultLabels)
 	itr2 := mkStreamIterator(inverse(offset(testSize, identity)), "{foobar: \"bazbar\"}")
 
-	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
-	reversedIter, err := NewReversedIter(heapIterator, testSize, false)
+	mergeIterator := NewMergeEntryIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
+	reversedIter, err := NewReversedIter(mergeIterator, testSize, false)
 	require.NoError(t, err)
 
 	for i := int64((testSize / 2) + 1); i <= testSize; i++ {
@@ -347,8 +347,8 @@ func TestReverseEntryIteratorUnlimited(t *testing.T) {
 	itr1 := mkStreamIterator(offset(testSize, identity), defaultLabels)
 	itr2 := mkStreamIterator(offset(testSize, identity), "{foobar: \"bazbar\"}")
 
-	heapIterator := NewHeapIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
-	reversedIter, err := NewReversedIter(heapIterator, 0, false)
+	mergeIterator := NewMergeEntryIterator(context.Background(), []EntryIterator{itr1, itr2}, logproto.BACKWARD)
+	reversedIter, err := NewReversedIter(mergeIterator, 0, false)
 	require.NoError(t, err)
 
 	var ct int
@@ -546,7 +546,7 @@ func Test_DuplicateCount(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, ctx := stats.NewContext(context.Background())
-			it := NewHeapIterator(ctx, test.iters, test.direction)
+			it := NewMergeEntryIterator(ctx, test.iters, test.direction)
 			defer it.Close()
 			for it.Next() {
 			}
@@ -636,7 +636,7 @@ func TestNonOverlappingClose(t *testing.T) {
 	require.Equal(t, true, b.closed.Load())
 }
 
-func BenchmarkHeapIterator(b *testing.B) {
+func BenchmarkSortIterator(b *testing.B) {
 	var (
 		ctx          = context.Background()
 		streams      []logproto.Stream
@@ -658,18 +658,130 @@ func BenchmarkHeapIterator(b *testing.B) {
 		streams[i], streams[j] = streams[j], streams[i]
 	})
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		var itrs []EntryIterator
-		for i := 0; i < streamsCount; i++ {
-			itrs = append(itrs, NewStreamIterator(streams[i]))
+	b.Run("merge sort", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			var itrs []EntryIterator
+			for i := 0; i < streamsCount; i++ {
+				itrs = append(itrs, NewStreamIterator(streams[i]))
+			}
+			b.StartTimer()
+			it := NewMergeEntryIterator(ctx, itrs, logproto.BACKWARD)
+			for it.Next() {
+				it.Entry()
+			}
+			it.Close()
 		}
-		b.StartTimer()
-		it := NewHeapIterator(ctx, itrs, logproto.BACKWARD)
+	})
+
+	b.Run("sort", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			var itrs []EntryIterator
+			for i := 0; i < streamsCount; i++ {
+				itrs = append(itrs, NewStreamIterator(streams[i]))
+			}
+			b.StartTimer()
+			it := NewSortEntryIterator(itrs, logproto.BACKWARD)
+			for it.Next() {
+				it.Entry()
+			}
+			it.Close()
+		}
+	})
+}
+
+func Test_EntrySortIterator(t *testing.T) {
+	t.Run("backward", func(t *testing.T) {
+		t.Parallel()
+		it := NewSortEntryIterator(
+			[]EntryIterator{
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 5)},
+						{Timestamp: time.Unix(0, 3)},
+						{Timestamp: time.Unix(0, 0)},
+					},
+					Labels: `{foo="bar"}`,
+				}),
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 4)},
+						{Timestamp: time.Unix(0, 2)},
+						{Timestamp: time.Unix(0, 1)},
+					},
+					Labels: `{foo="buzz"}`,
+				}),
+			}, logproto.BACKWARD)
+		var i int64 = 5
+		defer it.Close()
 		for it.Next() {
-			it.Entry()
+			require.Equal(t, time.Unix(0, i), it.Entry().Timestamp)
+			i--
 		}
-		it.Close()
-	}
+	})
+	t.Run("forward", func(t *testing.T) {
+		t.Parallel()
+		it := NewSortEntryIterator(
+			[]EntryIterator{
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 0)},
+						{Timestamp: time.Unix(0, 3)},
+						{Timestamp: time.Unix(0, 5)},
+					},
+					Labels: `{foo="bar"}`,
+				}),
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 1)},
+						{Timestamp: time.Unix(0, 2)},
+						{Timestamp: time.Unix(0, 4)},
+					},
+					Labels: `{foo="buzz"}`,
+				}),
+			}, logproto.FORWARD)
+		var i int64
+		defer it.Close()
+		for it.Next() {
+			require.Equal(t, time.Unix(0, i), it.Entry().Timestamp)
+			i++
+		}
+	})
+	t.Run("forward sort by stream", func(t *testing.T) {
+		t.Parallel()
+		it := NewSortEntryIterator(
+			[]EntryIterator{
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 0)},
+						{Timestamp: time.Unix(0, 3)},
+						{Timestamp: time.Unix(0, 5)},
+					},
+					Labels: `b`,
+				}),
+				NewStreamIterator(logproto.Stream{
+					Entries: []logproto.Entry{
+						{Timestamp: time.Unix(0, 0)},
+						{Timestamp: time.Unix(0, 1)},
+						{Timestamp: time.Unix(0, 2)},
+						{Timestamp: time.Unix(0, 4)},
+					},
+					Labels: `a`,
+				}),
+			}, logproto.FORWARD)
+		// The first entry appears in both so we expect it to be sorted by Labels.
+		require.True(t, it.Next())
+		require.Equal(t, time.Unix(0, 0), it.Entry().Timestamp)
+		require.Equal(t, `a`, it.Labels())
+
+		var i int64
+		defer it.Close()
+		for it.Next() {
+			require.Equal(t, time.Unix(0, i), it.Entry().Timestamp)
+			i++
+		}
+	})
 }

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -104,8 +104,8 @@ var carSeries = logproto.Series{
 	},
 }
 
-func TestNewHeapSampleIterator(t *testing.T) {
-	it := NewHeapSampleIterator(context.Background(),
+func TestNewMergeSampleIterator(t *testing.T) {
+	it := NewMergeSampleIterator(context.Background(),
 		[]SampleIterator{
 			NewSeriesIterator(varSeries),
 			NewSeriesIterator(carSeries),
@@ -194,7 +194,7 @@ func TestReadSampleBatch(t *testing.T) {
 	require.Equal(t, uint32(1), size)
 	require.NoError(t, err)
 
-	res, size, err = ReadSampleBatch(NewMultiSeriesIterator(context.Background(), []logproto.Series{carSeries, varSeries}), 100)
+	res, size, err = ReadSampleBatch(NewMultiSeriesIterator([]logproto.Series{carSeries, varSeries}), 100)
 	require.ElementsMatch(t, []logproto.Series{carSeries, varSeries}, res.Series)
 	require.Equal(t, uint32(6), size)
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestSampleIteratorWithClose_ReturnsError(t *testing.T) {
 	assert.Equal(t, err, err2)
 }
 
-func BenchmarkHeapSampleIterator(b *testing.B) {
+func BenchmarkSortSampleIterator(b *testing.B) {
 	var (
 		ctx          = context.Background()
 		series       []logproto.Series
@@ -299,18 +299,102 @@ func BenchmarkHeapSampleIterator(b *testing.B) {
 		series[i], series[j] = series[j], series[i]
 	})
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		var itrs []SampleIterator
-		for i := 0; i < seriesCount; i++ {
-			itrs = append(itrs, NewSeriesIterator(series[i]))
+	b.Run("merge", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			var itrs []SampleIterator
+			for i := 0; i < seriesCount; i++ {
+				itrs = append(itrs, NewSeriesIterator(series[i]))
+			}
+			b.StartTimer()
+			it := NewMergeSampleIterator(ctx, itrs)
+			for it.Next() {
+				it.Sample()
+			}
+			it.Close()
 		}
-		b.StartTimer()
-		it := NewHeapSampleIterator(ctx, itrs)
+	})
+	b.Run("sort", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			var itrs []SampleIterator
+			for i := 0; i < seriesCount; i++ {
+				itrs = append(itrs, NewSeriesIterator(series[i]))
+			}
+			b.StartTimer()
+			it := NewSortSampleIterator(itrs)
+			for it.Next() {
+				it.Sample()
+			}
+			it.Close()
+		}
+	})
+}
+
+func Test_SampleSortIterator(t *testing.T) {
+	t.Run("forward", func(t *testing.T) {
+		t.Parallel()
+		it := NewSortSampleIterator(
+			[]SampleIterator{
+				NewSeriesIterator(logproto.Series{
+					Samples: []logproto.Sample{
+						{Timestamp: 0},
+						{Timestamp: 3},
+						{Timestamp: 5},
+					},
+					Labels: `{foo="bar"}`,
+				}),
+				NewSeriesIterator(logproto.Series{
+					Samples: []logproto.Sample{
+						{Timestamp: 1},
+						{Timestamp: 2},
+						{Timestamp: 4},
+					},
+					Labels: `{foo="bar"}`,
+				}),
+			})
+		var i int64
+		defer it.Close()
 		for it.Next() {
-			it.Sample()
+			require.Equal(t, i, it.Sample().Timestamp)
+			i++
 		}
-		it.Close()
-	}
+	})
+	t.Run("forward sort by stream", func(t *testing.T) {
+		t.Parallel()
+		it := NewSortSampleIterator(
+			[]SampleIterator{
+				NewSeriesIterator(logproto.Series{
+					Samples: []logproto.Sample{
+						{Timestamp: 0},
+						{Timestamp: 3},
+						{Timestamp: 5},
+					},
+					Labels: `b`,
+				}),
+				NewSeriesIterator(logproto.Series{
+					Samples: []logproto.Sample{
+						{Timestamp: 0},
+						{Timestamp: 1},
+						{Timestamp: 2},
+						{Timestamp: 4},
+					},
+					Labels: `a`,
+				}),
+			})
+
+		// The first entry appears in both so we expect it to be sorted by Labels.
+		require.True(t, it.Next())
+		require.Equal(t, int64(0), it.Sample().Timestamp)
+		require.Equal(t, `a`, it.Labels())
+
+		var i int64
+		defer it.Close()
+		for it.Next() {
+			require.Equal(t, i, it.Sample().Timestamp)
+			i++
+		}
+	})
 }

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -32,9 +32,7 @@ const (
 	defaultMaxFileSize       = 20 * (1 << 20) // 20MB
 )
 
-var (
-	ErrNotSupported = errors.New("not supported")
-)
+var ErrNotSupported = errors.New("not supported")
 
 // FileClient is a type of LogCLI client that do LogQL on log lines from
 // the given file directly, instead get log lines from Loki servers.
@@ -63,7 +61,6 @@ func NewFileClient(r io.ReadCloser) *FileClient {
 		labels:      []string{defaultLabelKey},
 		labelValues: []string{defaultLabelValue},
 	}
-
 }
 
 func (f *FileClient) Query(q string, limit int, t time.Time, direction logproto.Direction, quiet bool) (*loghttp.QueryResponse, error) {
@@ -278,7 +275,6 @@ func newFileIterator(
 	}
 
 	return iter.NewStreamsIterator(
-		ctx,
 		streamResult,
 		params.Direction,
 	), nil

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -195,7 +195,7 @@ type querier struct {
 	labels labels.Labels
 }
 
-func (q *querier) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
+func (q *querier) SelectLogs(_ context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
 	expr, err := params.LogSelector()
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract selector for logs: %w", err)
@@ -204,7 +204,7 @@ func (q *querier) SelectLogs(ctx context.Context, params logql.SelectLogParams) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract pipeline for logs: %w", err)
 	}
-	return newFileIterator(ctx, q.r, params, pipeline.ForStream(q.labels))
+	return newFileIterator(q.r, params, pipeline.ForStream(q.labels))
 }
 
 func (q *querier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
@@ -212,7 +212,6 @@ func (q *querier) SelectSamples(ctx context.Context, params logql.SelectSamplePa
 }
 
 func newFileIterator(
-	ctx context.Context,
 	r io.Reader,
 	params logql.SelectLogParams,
 	pipeline logqllog.StreamPipeline,

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -34,7 +34,7 @@ var (
 )
 
 func newSampleIterator() iter.SampleIterator {
-	return iter.NewHeapSampleIterator(context.Background(), []iter.SampleIterator{
+	return iter.NewSortSampleIterator([]iter.SampleIterator{
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:  labelFoo.String(),
 			Samples: samples,

--- a/pkg/logql/sharding.go
+++ b/pkg/logql/sharding.go
@@ -324,7 +324,7 @@ func (ev *DownstreamEvaluator) Iterator(
 			xs = append(xs, iter)
 		}
 
-		return iter.NewHeapIterator(ctx, xs, params.Direction()), nil
+		return iter.NewSortEntryIterator(xs, params.Direction()), nil
 
 	default:
 		return nil, EvaluatorUnsupportedType(expr, ev)
@@ -401,5 +401,5 @@ func ResultIterator(res logqlmodel.Result, params Params) (iter.EntryIterator, e
 	if !ok {
 		return nil, fmt.Errorf("unexpected type (%s) for ResultIterator; expected %s", res.Data.Type(), logqlmodel.ValueTypeStreams)
 	}
-	return iter.NewStreamsIterator(context.Background(), streams, params.Direction()), nil
+	return iter.NewStreamsIterator(streams, params.Direction()), nil
 }

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -90,7 +90,7 @@ outer:
 		}
 	}
 
-	return iter.NewHeapIterator(ctx, streamIters, req.Direction), nil
+	return iter.NewSortEntryIterator(streamIters, req.Direction), nil
 }
 
 func processStream(in []logproto.Stream, pipeline log.Pipeline) []logproto.Stream {
@@ -200,7 +200,7 @@ outer:
 	filtered := processSeries(matched, extractor)
 
 	return iter.NewTimeRangedSampleIterator(
-		iter.NewMultiSeriesIterator(ctx, filtered),
+		iter.NewMultiSeriesIterator(filtered),
 		req.Start.UnixNano(),
 		req.End.UnixNano()+1,
 	), nil

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -142,8 +142,10 @@ func (q *Querier) SelectLogs(ctx context.Context, params logql.SelectLogParams) 
 
 		iters = append(iters, storeIter)
 	}
-
-	return iter.NewHeapIterator(ctx, iters, params.Direction), nil
+	if len(iters) == 1 {
+		return iters[0], nil
+	}
+	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
 }
 
 func (q *Querier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
@@ -185,7 +187,7 @@ func (q *Querier) SelectSamples(ctx context.Context, params logql.SelectSamplePa
 
 		iters = append(iters, storeIter)
 	}
-	return iter.NewHeapSampleIterator(ctx, iters), nil
+	return iter.NewMergeSampleIterator(ctx, iters), nil
 }
 
 func (q *Querier) buildQueryIntervals(queryStart, queryEnd time.Time) (*interval, *interval) {

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -272,7 +272,7 @@ func newTailer(
 	waitEntryThrottle time.Duration,
 ) *Tailer {
 	t := Tailer{
-		openStreamIterator:        iter.NewHeapIterator(context.Background(), []iter.EntryIterator{historicEntries}, logproto.FORWARD),
+		openStreamIterator:        iter.NewMergeEntryIterator(context.Background(), []iter.EntryIterator{historicEntries}, logproto.FORWARD),
 		querierTailClients:        querierTailClients,
 		delayFor:                  delayFor,
 		responseChan:              make(chan *loghttp.TailResponse, maxBufferedTailResponses),

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -396,8 +396,10 @@ func (it *logBatchIterator) newChunksIterator(b *chunkBatch) (iter.EntryIterator
 	if err != nil {
 		return nil, err
 	}
-
-	return iter.NewHeapIterator(it.ctx, iters, it.direction), nil
+	if len(iters) == 1 {
+		return iters[0], nil
+	}
+	return iter.NewSortEntryIterator(iters, it.direction), nil
 }
 
 func (it *logBatchIterator) buildIterators(chks map[model.Fingerprint][][]*LazyChunk, from, through time.Time, nextChunk *LazyChunk) ([]iter.EntryIterator, error) {
@@ -440,7 +442,7 @@ func (it *logBatchIterator) buildHeapIterator(chks [][]*LazyChunk, from, through
 		result = append(result, iter.NewNonOverlappingIterator(iterators, ""))
 	}
 
-	return iter.NewHeapIterator(it.ctx, result, it.direction), nil
+	return iter.NewMergeEntryIterator(it.ctx, result, it.direction), nil
 }
 
 type sampleBatchIterator struct {
@@ -537,7 +539,7 @@ func (it *sampleBatchIterator) newChunksIterator(b *chunkBatch) (iter.SampleIter
 		return nil, err
 	}
 
-	return iter.NewHeapSampleIterator(it.ctx, iters), nil
+	return iter.NewSortSampleIterator(iters), nil
 }
 
 func (it *sampleBatchIterator) buildIterators(chks map[model.Fingerprint][][]*LazyChunk, from, through time.Time, nextChunk *LazyChunk) ([]iter.SampleIterator, error) {
@@ -574,7 +576,7 @@ func (it *sampleBatchIterator) buildHeapIterator(chks [][]*LazyChunk, from, thro
 		result = append(result, iter.NewNonOverlappingSampleIterator(iterators, ""))
 	}
 
-	return iter.NewHeapSampleIterator(it.ctx, result), nil
+	return iter.NewMergeSampleIterator(it.ctx, result), nil
 }
 
 func removeMatchersByName(matchers []*labels.Matcher, names ...string) []*labels.Matcher {


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR is a first step toward fixing #4500 and will be followed up by other PRs that changes how deduplication works.

This PR refactor the `HeapIterator` into two distinct Iterators for different use:
- The `Merge` iterator __sort and deduplicate__ samples/entries
- The `Sort` iterator only sort samples and entries.

For convenience we were using the `HeapIterator` everywhere, but in most cases we only needed to sort samples and entries. I've changed the usage everywhere it was possible.

Bonus point the `Sort` iterator is **25%** faster than the `Merge` one.

```
goos: darwin
goarch: amd64
pkg: github.com/grafana/loki/pkg/iter
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
BenchmarkSortIterator
BenchmarkSortIterator/merge_sort
BenchmarkSortIterator/merge_sort-16         	     264	   4133693 ns/op	    8600 B/op	       5 allocs/op
BenchmarkSortIterator/sort
BenchmarkSortIterator/sort-16               	     346	   3466275 ns/op	    1950 B/op	       3 allocs/op
PASS
coverage: 15.8% of statements
ok  	github.com/grafana/loki/pkg/iter	3.206s
```

**Checklist**
- [x] Documentation added
- [x] Tests updated ( I've removed deduplication on the engine, wasn't interesting)
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
