### PR TITLE
logstash: re-add bundle update and update bundler

### DIFF
--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /home/logstash/
 
 RUN bundle config set --local path /usr/share/logstash/vendor/bundle && \
     bundle install && \
+    bundle update && \
     bundle exec rake vendor && \
     bundle exec rspec
 

--- a/clients/cmd/logstash/Dockerfile
+++ b/clients/cmd/logstash/Dockerfile
@@ -1,4 +1,4 @@
-FROM logstash:7.16.1
+FROM logstash:7.16.3
 
 USER logstash
 ENV PATH /usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/vendor/bundle/jruby/2.5.0/bin:/usr/share/logstash/jdk/bin:$PATH
@@ -6,7 +6,7 @@ ENV LOGSTASH_PATH /usr/share/logstash
 ENV GEM_PATH /usr/share/logstash/vendor/bundle/jruby/2.5.0
 ENV GEM_HOME /usr/share/logstash/vendor/bundle/jruby/2.5.0
 
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.3.6
 
 COPY --chown=logstash:logstash ./clients/cmd/logstash/ /home/logstash/
 WORKDIR /home/logstash/


### PR DESCRIPTION
To get CI to pass we removed the `bundle update` command in #5268

Revisiting that PR it looks like we can continue to use the update command if we also update the version of the gem bundler.

This also updates the logstash version to the latest patchfix release.