### PR TITLE
less opaque chunk keys on fs with v12

### DIFF
--- a/pkg/storage/chunk/local/fixtures.go
+++ b/pkg/storage/chunk/local/fixtures.go
@@ -43,7 +43,7 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	chunkClient = objectclient.NewClient(oClient, objectclient.Base64Encoder, chunk.SchemaConfig{})
+	chunkClient = objectclient.NewClient(oClient, objectclient.FSEncoder, chunk.SchemaConfig{})
 
 	tableClient, err = NewTableClient(f.dirname)
 	if err != nil {

--- a/pkg/storage/chunk/objectclient/client_test.go
+++ b/pkg/storage/chunk/objectclient/client_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/chunk"
 )
 
 func MustParseDayTime(s string) chunk.DayTime {
@@ -14,7 +15,9 @@ func MustParseDayTime(s string) chunk.DayTime {
 	if err != nil {
 		panic(err)
 	}
-	return chunk.DayTime{model.TimeFromUnix(t.Unix())}
+	return chunk.DayTime{
+		Time: model.TimeFromUnix(t.Unix()),
+	}
 }
 
 func TestFSEncoder(t *testing.T) {

--- a/pkg/storage/chunk/objectclient/client_test.go
+++ b/pkg/storage/chunk/objectclient/client_test.go
@@ -1,0 +1,76 @@
+package objectclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func MustParseDayTime(s string) chunk.DayTime {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return chunk.DayTime{model.TimeFromUnix(t.Unix())}
+}
+
+func TestFSEncoder(t *testing.T) {
+	schema := chunk.SchemaConfig{
+		Configs: []chunk.PeriodConfig{
+			{
+				From:   MustParseDayTime("2020-01-01"),
+				Schema: "v11",
+			},
+			{
+				From:   MustParseDayTime("2022-01-01"),
+				Schema: "v12",
+			},
+		},
+	}
+
+	// chunk that resolves to v11
+	oldChunk := chunk.Chunk{
+		UserID:      "fake",
+		From:        MustParseDayTime("2020-01-02").Time,
+		Through:     MustParseDayTime("2020-01-03").Time,
+		Checksum:    123,
+		Fingerprint: 456,
+		ChecksumSet: true,
+	}
+
+	// chunk that resolves to v12
+	newChunk := chunk.Chunk{
+		UserID:      "fake",
+		From:        MustParseDayTime("2022-01-02").Time,
+		Through:     MustParseDayTime("2022-01-03").Time,
+		Checksum:    123,
+		Fingerprint: 456,
+		ChecksumSet: true,
+	}
+
+	for _, tc := range []struct {
+		desc string
+		from string
+		exp  string
+	}{
+		{
+			desc: "before v12 encodes entire chunk",
+			from: schema.ExternalKey(oldChunk),
+			exp:  "ZmFrZS8xYzg6MTZmNjM4ZDQ0MDA6MTZmNjhiM2EwMDA6N2I=",
+		},
+		{
+			desc: "v12+ encodes encodes the non-directory trail",
+			from: schema.ExternalKey(newChunk),
+			exp:  "fake/1c8/MTdlMTgxNWY4MDA6MTdlMWQzYzU0MDA6N2I=",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			chk, err := chunk.ParseExternalKey("fake", tc.from)
+			require.Nil(t, err)
+			require.Equal(t, tc.exp, FSEncoder(schema, chk))
+		})
+	}
+}

--- a/pkg/storage/chunk/schema_config.go
+++ b/pkg/storage/chunk/schema_config.go
@@ -504,6 +504,14 @@ func (cfg SchemaConfig) ExternalKey(chunk Chunk) string {
 	}
 }
 
+// VersionForChunk will return the schema version associated with the `From` timestamp of a chunk.
+// The schema and chunk must be valid+compatible as the errors are not checked.
+func (cfg SchemaConfig) VersionForChunk(c Chunk) int {
+	p, _ := cfg.SchemaForTime(c.From)
+	v, _ := p.VersionAsInt()
+	return v
+}
+
 // pre-checksum
 func (cfg SchemaConfig) legacyExternalKey(chunk Chunk) string {
 	// This is the inverse of chunk.parseLegacyExternalKey, with "<user id>/" prepended.

--- a/pkg/storage/chunk/storage/factory.go
+++ b/pkg/storage/chunk/storage/factory.go
@@ -330,7 +330,7 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, clien
 		if err != nil {
 			return nil, err
 		}
-		return objectclient.NewClientWithMaxParallel(store, objectclient.Base64Encoder, cfg.MaxParallelGetChunk, schemaCfg), nil
+		return objectclient.NewClientWithMaxParallel(store, objectclient.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
 	case StorageTypeGrpc:
 		return grpc.NewStorageClient(cfg.GrpcConfig, schemaCfg)
 	default:

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -191,7 +191,7 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig loki_storage
 	if c.cfg.RetentionEnabled {
 		var encoder objectclient.KeyEncoder
 		if _, ok := objectClient.(*local.FSObjectClient); ok {
-			encoder = objectclient.Base64Encoder
+			encoder = objectclient.FSEncoder
 		}
 
 		chunkClient := objectclient.NewClient(objectClient, encoder, schemaConfig.SchemaConfig)

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -389,7 +389,7 @@ func TestChunkRewriter(t *testing.T) {
 			require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{tt.chunk}))
 			store.Stop()
 
-			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir, cm), objectclient.Base64Encoder, schemaCfg.SchemaConfig)
+			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir, cm), objectclient.FSEncoder, schemaCfg.SchemaConfig)
 			for _, indexTable := range store.indexTables() {
 				err := indexTable.DB.Update(func(tx *bbolt.Tx) error {
 					bucket := tx.Bucket(local.IndexBucketName)
@@ -668,7 +668,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			tables := store.indexTables()
 			require.Len(t, tables, len(tc.expectedDeletedSeries))
 
-			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir, cm), objectclient.Base64Encoder, schemaCfg.SchemaConfig)
+			chunkClient := objectclient.NewClient(newTestObjectClient(store.chunkDir, cm), objectclient.FSEncoder, schemaCfg.SchemaConfig)
 
 			for i, table := range tables {
 				seriesCleanRecorder := newSeriesCleanRecorder()


### PR DESCRIPTION
This PR piggybacks on the yet-unreleased v12 schema in order to make some much needed improvements to the chunk key encoding when using the `fileystem` backend. Previously, the entire key was base64 encoded, meaning all chunks regardless of tenant were stored in the same directory. This made discoverability hard (the keys were opaque) and caused performance problems at scale (one infinitely growing directory). Now, in v12+ schemas, the filesystem will use `<user>/<fingerprint>/base64Encode(<start>:<end>:<checksum>)`. 

Running locally will now look like:
```
$ tree chunks
chunks
└── fake
    └── 655259a8c67c182c
        └── MTdlYjY2OWY5MmI6MTdlYjY2OWY5MmY6ODFjNTZiZGI=
```
