### PR TITLE
fix a panic in index-gateway caused by double closing of a channel

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -156,7 +156,7 @@ func (t *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, ca
 	}
 
 	for _, uid := range []string{userID, ""} {
-		indexSet, err := t.getOrCreateIndexSet(uid, true)
+		indexSet, err := t.getOrCreateIndexSet(uid)
 		if err != nil {
 			return err
 		}
@@ -232,19 +232,23 @@ func (t *Table) Sync(ctx context.Context) error {
 	return nil
 }
 
-func (t *Table) getOrCreateIndexSet(id string, async bool) (IndexSet, error) {
+// getOrCreateIndexSet gets or creates the index set for the userID.
+// If it does not exist, it creates a new one and initializes it in a goroutine.
+// Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
+func (t *Table) getOrCreateIndexSet(id string) (IndexSet, error) {
 	t.indexSetsMtx.RLock()
 	indexSet, ok := t.indexSets[id]
 	t.indexSetsMtx.RUnlock()
 	if ok {
 		return indexSet, nil
 	}
+	time.Sleep(time.Second)
 
 	t.indexSetsMtx.Lock()
+	defer t.indexSetsMtx.Unlock()
 
 	indexSet, ok = t.indexSets[id]
 	if ok {
-		t.indexSetsMtx.Unlock()
 		return indexSet, nil
 	}
 
@@ -254,32 +258,20 @@ func (t *Table) getOrCreateIndexSet(id string, async bool) (IndexSet, error) {
 		baseIndexSet = t.baseCommonIndexSet
 	}
 
-	// instantiate the index set, add it to the map and unlock the mutex before calling Init()
+	// instantiate the index set, add it to the map
 	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.boltDBIndexClient, t.logger, t.metrics)
 	if err != nil {
 		return nil, err
 	}
 	t.indexSets[id] = indexSet
 
-	t.indexSetsMtx.Unlock()
-
-	// We want to do the initialization of table in async mode while serving the queries to honor their timeouts while
-	// for background tasks like ensuring query readiness, we want to do the initialization in synchronous mode.
-	// The idea here is that we want to create an instance of indexSet first and set its reference so that
-	// no other goroutine creates another instance of indexSet.
-	if async {
-		go func() {
-			err := indexSet.Init()
-			if err != nil {
-				level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
-			}
-		}()
-	} else {
+	// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
+	go func() {
 		err := indexSet.Init()
 		if err != nil {
-			return nil, err
+			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
 		}
-	}
+	}()
 
 	return indexSet, nil
 }
@@ -290,10 +282,15 @@ func (t *Table) EnsureQueryReadiness(ctx context.Context) error {
 		return err
 	}
 
-	commonIndexSet, err := t.getOrCreateIndexSet("", false)
+	commonIndexSet, err := t.getOrCreateIndexSet("")
 	if err != nil {
 		return err
 	}
+	err = commonIndexSet.AwaitReady(ctx)
+	if err != nil {
+		return err
+	}
+
 	commonIndexSet.UpdateLastUsedAt()
 
 	missingUserIDs := make([]string, 0, len(userIDs))
@@ -313,7 +310,11 @@ func (t *Table) EnsureQueryReadiness(ctx context.Context) error {
 // downloadUserIndexes downloads user specific index files concurrently.
 func (t *Table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
 	return concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), maxDownloadConcurrency, func(ctx context.Context, userID interface{}) error {
-		_, err := t.getOrCreateIndexSet(userID.(string), false)
-		return err
+		indexSet, err := t.getOrCreateIndexSet(userID.(string))
+		if err != nil {
+			return err
+		}
+
+		return indexSet.AwaitReady(ctx)
 	})
 }

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -242,7 +242,6 @@ func (t *Table) getOrCreateIndexSet(id string) (IndexSet, error) {
 	if ok {
 		return indexSet, nil
 	}
-	time.Sleep(time.Second)
 
 	t.indexSetsMtx.Lock()
 	defer t.indexSetsMtx.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
When `getOrCreateIndexSet` method is called concurrently, the caller who is creating the index set should be the only one calling its `Init` function. I did a mistake in not returning the index set from the callers who found the index set already and continuing with initialization. This PR fixes the issue by avoiding calling `Init` function on index sets multiple times.
