### PR TITLE
cleanup: consolidate util strings contain functions

### DIFF
--- a/clients/pkg/logentry/stages/timestamp.go
+++ b/clients/pkg/logentry/stages/timestamp.go
@@ -78,7 +78,7 @@ func validateTimestampConfig(cfg *TimestampConfig) (parser, error) {
 	if cfg.ActionOnFailure == nil {
 		cfg.ActionOnFailure = util.StringRef(TimestampActionOnFailureDefault)
 	} else {
-		if !util.StringSliceContains(TimestampActionOnFailureOptions, *cfg.ActionOnFailure) {
+		if !util.StringsContain(TimestampActionOnFailureOptions, *cfg.ActionOnFailure) {
 			return nil, fmt.Errorf(ErrInvalidActionOnFailure, TimestampActionOnFailureOptions)
 		}
 	}

--- a/clients/pkg/promtail/targets/kafka/target_syncer.go
+++ b/clients/pkg/promtail/targets/kafka/target_syncer.go
@@ -159,7 +159,7 @@ func withSASLAuthentication(cfg sarama.Config, authCfg scrapeconfig.KafkaAuthent
 		sarama.SASLTypeSCRAMSHA256,
 		sarama.SASLTypePlaintext,
 	}
-	if !util.StringSliceContains(supportedMechanism, string(authCfg.SASLConfig.Mechanism)) {
+	if !util.StringsContain(supportedMechanism, string(authCfg.SASLConfig.Mechanism)) {
 		return nil, fmt.Errorf("error unsupported sasl mechanism: %s", authCfg.SASLConfig.Mechanism)
 	}
 

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -10,16 +10,6 @@ func StringRef(value string) *string {
 	return &value
 }
 
-func StringSliceContains(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-
-	return false
-}
-
 // SnakeCase converts given string `s` into `snake_case`.
 func SnakeCase(s string) string {
 	var buf bytes.Buffer

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStringSliceContains(t *testing.T) {
+func TestStringsContain(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -32,7 +32,7 @@ func TestStringSliceContains(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			actual := StringSliceContains(testData.inputSlice, testData.inputValue)
+			actual := StringsContain(testData.inputSlice, testData.inputValue)
 			assert.Equal(t, testData.expected, actual)
 		})
 	}


### PR DESCRIPTION
Noticed a duplicate `StringsContain` function so this is a tiny PR to consolidate the functions.

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
