### PR TITLE
Logql/parallel binop

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -26,6 +26,10 @@ type Expr interface {
 	fmt.Stringer
 }
 
+func Clone(e Expr) (Expr, error) {
+	return ParseExpr(e.String())
+}
+
 type QueryParams interface {
 	LogSelector() (LogSelectorExpr, error)
 	GetStart() time.Time

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -111,8 +111,8 @@ func (m ShardMapper) Parse(query string) (noop bool, expr Expr, err error) {
 		return false, nil, err
 	}
 
-	mappedStr := mapped.String()
 	originalStr := parsed.String()
+	mappedStr := mapped.String()
 	noop = originalStr == mappedStr
 	if noop {
 		m.metrics.parsed.WithLabelValues(NoopKey).Inc()
@@ -126,6 +126,12 @@ func (m ShardMapper) Parse(query string) (noop bool, expr Expr, err error) {
 }
 
 func (m ShardMapper) Map(expr Expr, r *shardRecorder) (Expr, error) {
+	// immediately clone the passed expr to avoid mutating the original
+	expr, err := Clone(expr)
+	if err != nil {
+		return nil, err
+	}
+
 	switch e := expr.(type) {
 	case *LiteralExpr:
 		return e, nil

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -48,6 +48,12 @@ func ParamsToLokiRequest(params logql.Params, shards logql.Shards) queryrangebas
 	}
 }
 
+// Note: After the introduction of the LimitedRoundTripper,
+// bounding concurrency in the downstreamer is mostly redundant
+// The reason we don't remove it is to prevent malicious queries
+// from creating an unreasonably large number of goroutines, such as
+// the case of a query like `a / a / a / a / a ..etc`, which could try
+// to shard each leg, quickly dispatching an unreasonable number of goroutines.
 func (h DownstreamHandler) Downstreamer() logql.Downstreamer {
 	p := DefaultDownstreamConcurrency
 	locks := make(chan struct{}, p)

--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	DefaultDownstreamConcurrency = 32
+	DefaultDownstreamConcurrency = 128
 )
 
 type DownstreamHandler struct {

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
@@ -92,37 +90,29 @@ type astMapperware struct {
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 	conf, err := ast.confs.GetConf(r)
 	logger := util_log.WithContext(ctx, ast.logger)
-	sp, _ := opentracing.StartSpanFromContext(ctx, "astmapper")
-	defer sp.Finish()
-	sp.LogFields(otlog.String("msg", "setup"))
 	// cannot shard with this timerange
 	if err != nil {
-		sp.LogKV("msg", "error finding shardable configs", "err", err.Error())
 		level.Warn(logger).Log("err", err.Error(), "msg", "skipped AST mapper for request")
 		return ast.next.Do(ctx, r)
 	}
 
 	mapper, err := logql.NewShardMapper(int(conf.RowShards), ast.metrics)
 	if err != nil {
-		sp.LogKV("msg", "error building shardmapper", "err", err.Error())
 		return nil, err
 	}
 
 	noop, parsed, err := mapper.Parse(r.GetQuery())
 	if err != nil {
-		sp.LogKV("msg", "error parsing", "err", err.Error())
 		level.Warn(logger).Log("msg", "failed mapping AST", "err", err.Error(), "query", r.GetQuery())
 		return nil, err
 	}
 	level.Debug(logger).Log("no-op", noop, "mapped", parsed.String())
 
 	if noop {
-		sp.LogKV("msg", "noop")
 		// the ast can't be mapped to a sharded equivalent
 		// so we can bypass the sharding engine.
 		return ast.next.Do(ctx, r)
 	}
-	sp.LogKV("msg", "running query", "query", parsed.String())
 
 	params, err := paramsFromRequest(r)
 	if err != nil {


### PR DESCRIPTION
This PR does a few things:
1) Runs both legs of a binary operation in parallel.
2) Introduces the `Clone()` method for our `Expr`s to ensure we run into mutability bugs less
3) Uses (2) in our sharding code to prevent a mutability bug, in this case one which prevented binary operations from being sharded. This bug has existed since 2020 :sob: and of course I'm the original author :scream: 
4) Increases the `Downstreamer` concurrency. Now that we have the `LimitedRoundTripper`, this structure is largely used to just prevent goroutine explosions via malicious queries, so it feels safe to increase this as it no longer needs to limit access to our tenant queues.

Running this in one of our clusters resulted in sharded binary operations running ~10x faster :tada: 