### PR TITLE
Use loki-build-image to build loki instead of golang image

### DIFF
--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2 as build
+FROM grafana/loki-build-image as build
 
 COPY . /src/loki
 WORKDIR /src/loki


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
cmd/loki/Dockerfile currently uses golang:1.17.2
The latter does not contain the goyacc command.
This means that the Dockerfile's entrypoint will fail if any yacc files need to be regenerated.
Example: https://drone.grafana.net/grafana/loki/8367/3/3

cmd/loki/Dockerfile.debug, however, uses grafana/loki-build-image instead of golang:1.17.2.
grafana/loki-build-image is based on golang:1.17.6, but with goyacc and other tools added.

Rather than add those tools to cmd/loki/Dockerfile, causing duplication, I'd like to change the Dockerfile to use loki-build-image instead.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
