### PR TITLE
Release entryBufferPool once

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -706,7 +706,7 @@ func (i *reverseEntryIterator) load() {
 
 func (i *reverseEntryIterator) Next() bool {
 	i.load()
-	if len(i.buf.entries) == 0 {
+	if i.buf == nil || len(i.buf.entries) == 0 {
 		i.release()
 		return false
 	}


### PR DESCRIPTION
While investigating an issue, I found a bug where we can put the `*entryBuffer`  back into the pool twice. This PR ensures we only release it once.

This PR also improves efficiency a bit by ensuring we don't `nil` the underlying slice unnecessarily, instead letting the pool reuse it.

This can happen when:
First, we put it into the pool here:
```go
func (i *reverseEntryIterator) Next() bool {
	i.load()
	if len(i.buf.entries) == 0 {
		entryBufferPool.Put(i.buf)
		i.buf.entries = nil
		return false
	}
	i.cur, i.buf.entries = i.buf.entries[len(i.buf.entries)-1], i.buf.entries[:len(i.buf.entries)-1]
	return true
}
```
then it gets `Get()`'d by another goroutine, has it's `entries` appended, then the original goroutine puts it into the pool a second time here:
```go
func (i *reverseEntryIterator) Close() error {
	if i.buf.entries != nil {
		i.buf.entries = i.buf.entries[:0]
		entryBufferPool.Put(i.buf)
		i.buf.entries = nil
	}
	if !i.loaded {
		return i.iter.Close()
	}
	return nil
}
```