### PR TITLE
Revert "Simplify code for write path in distributor (#5248)"

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/grafana/loki/pkg/ingester"
 	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/runtime"
@@ -35,6 +34,10 @@ import (
 	loki_net "github.com/grafana/loki/pkg/util/net"
 	"github.com/grafana/loki/pkg/util/test"
 	"github.com/grafana/loki/pkg/validation"
+)
+
+const (
+	numIngesters = 5
 )
 
 var (
@@ -73,7 +76,7 @@ func TestDistributor(t *testing.T) {
 			expectedError:    httpgrpc.Errorf(http.StatusBadRequest, validation.InvalidLabelsErrorMsg, "{ab\"", "1:4: parse error: unterminated quoted string"),
 		},
 	} {
-		t.Run(fmt.Sprintf("[%d](lines=%v)", i, tc.lines), func(t *testing.T) {
+		t.Run(fmt.Sprintf("[%d](samples=%v)", i, tc.lines), func(t *testing.T) {
 			limits := &validation.Limits{}
 			flagext.DefaultValues(limits)
 			limits.EnforceMetricName = false
@@ -81,7 +84,8 @@ func TestDistributor(t *testing.T) {
 			limits.IngestionBurstSizeMB = ingestionRateLimit
 			limits.MaxLineSize = fe.ByteSize(tc.maxLineSize)
 
-			distributors := prepare(t, 1, 5, limits, nil)
+			d := prepare(t, limits, nil, nil)
+			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			request := makeWriteRequest(tc.lines, 10)
 
@@ -89,7 +93,7 @@ func TestDistributor(t *testing.T) {
 				request.Streams[0].Labels = `{ab"`
 			}
 
-			response, err := distributors[i%len(distributors)].Push(ctx, request)
+			response, err := d.Push(ctx, request)
 			assert.Equal(t, tc.expectedResponse, response)
 			assert.Equal(t, tc.expectedError, err)
 		})
@@ -101,11 +105,12 @@ func Test_SortLabelsOnPush(t *testing.T) {
 	flagext.DefaultValues(limits)
 	limits.EnforceMetricName = false
 	ingester := &mockIngester{}
-	distributors := prepare(t, 1, 5, limits, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	d := prepare(t, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 	request := makeWriteRequest(10, 10)
 	request.Streams[0].Labels = `{buzz="f", a="b"}`
-	_, err := distributors[0].Push(ctx, request)
+	_, err := d.Push(ctx, request)
 	require.NoError(t, err)
 	require.Equal(t, `{a="b", buzz="f"}`, ingester.pushed[0].Streams[0].Labels)
 }
@@ -123,9 +128,11 @@ func Test_TruncateLogLines(t *testing.T) {
 
 	t.Run("it truncates lines to MaxLineSize when MaxLineSizeTruncate is true", func(t *testing.T) {
 		limits, ingester := setup()
-		distributors := prepare(t, 1, 5, limits, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
 
-		_, err := distributors[0].Push(ctx, makeWriteRequest(1, 10))
+		d := prepare(t, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
+
+		_, err := d.Push(ctx, makeWriteRequest(1, 10))
 		require.NoError(t, err)
 		require.Len(t, ingester.pushed[0].Streams[0].Entries[0].Line, 5)
 	})
@@ -135,8 +142,9 @@ func Benchmark_SortLabelsOnPush(b *testing.B) {
 	limits := &validation.Limits{}
 	flagext.DefaultValues(limits)
 	limits.EnforceMetricName = false
-	distributors := prepare(&testing.T{}, 1, 5, limits, nil)
-	d := distributors[0]
+	ingester := &mockIngester{}
+	d := prepare(&testing.T{}, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 	request := makeWriteRequest(10, 10)
 	vCtx := d.validator.getValidationContextForTime(testTime, "123")
 	for n := 0; n < b.N; n++ {
@@ -160,14 +168,17 @@ func Benchmark_Push(b *testing.B) {
 	limits.RejectOldSamples = true
 	limits.RejectOldSamplesMaxAge = model.Duration(24 * time.Hour)
 	limits.CreationGracePeriod = model.Duration(24 * time.Hour)
-	distributors := prepare(&testing.T{}, 1, 5, limits, nil)
+	ingester := &mockIngester{}
+	d := prepare(&testing.T{}, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 	request := makeWriteRequest(100000, 100)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, err := distributors[0].Push(ctx, request)
+
+		_, err := d.Push(ctx, request)
 		if err != nil {
 			require.NoError(b, err)
 		}
@@ -182,7 +193,9 @@ func Benchmark_PushWithLineTruncation(b *testing.B) {
 	limits.MaxLineSizeTruncate = true
 	limits.MaxLineSize = 50
 
-	distributors := prepare(&testing.T{}, 1, 5, limits, nil)
+	ingester := &mockIngester{}
+	d := prepare(&testing.T{}, limits, nil, func(addr string) (ring_client.PoolClient, error) { return ingester, nil })
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 	request := makeWriteRequest(100000, 100)
 
 	b.ResetTimer()
@@ -190,7 +203,7 @@ func Benchmark_PushWithLineTruncation(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 
-		_, err := distributors[0].Push(ctx, request)
+		_, err := d.Push(ctx, request)
 		if err != nil {
 			require.NoError(b, err)
 		}
@@ -259,8 +272,26 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			limits.IngestionRateMB = testData.ingestionRateMB
 			limits.IngestionBurstSizeMB = testData.ingestionBurstSizeMB
 
-			distributors := prepare(t, testData.distributors, 5, limits, nil)
+			// Init a shared KVStore
+			kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
+			// Start all expected distributors
+			distributors := make([]*Distributor, testData.distributors)
+			for i := 0; i < testData.distributors; i++ {
+				distributors[i] = prepare(t, limits, kvStore, nil)
+				defer services.StopAndAwaitTerminated(context.Background(), distributors[i]) //nolint:errcheck
+			}
+
+			// If the distributors ring is setup, wait until the first distributor
+			// updates to the expected size
+			if distributors[0].distributorsRing != nil {
+				test.Poll(t, time.Second, testData.distributors, func() interface{} {
+					return distributors[0].distributorsLifecycler.HealthyInstancesCount()
+				})
+			}
+
+			// Push samples in multiple requests to the first distributor
 			for _, push := range testData.pushes {
 				request := makeWriteRequest(1, push.bytes)
 				response, err := distributors[0].Push(ctx, request)
@@ -277,99 +308,51 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 	}
 }
 
-func prepare(t *testing.T, numDistributors, numIngesters int, limits *validation.Limits, factory func(addr string) (ring_client.PoolClient, error)) []*Distributor {
-	t.Helper()
-
-	ingesters := make([]mockIngester, numIngesters)
-	for i := 0; i < numIngesters; i++ {
-		ingesters[i] = mockIngester{}
-	}
-
-	ingesterByAddr := map[string]*mockIngester{}
-	ingesterDescs := map[string]ring.InstanceDesc{}
-
-	for i := range ingesters {
-		addr := fmt.Sprintf("ingester-%d", i)
-		ingesterDescs[addr] = ring.InstanceDesc{
-			Addr:                addr,
-			State:               ring.ACTIVE,
-			Timestamp:           time.Now().Unix(),
-			RegisteredTimestamp: time.Now().Add(-10 * time.Minute).Unix(),
-			Tokens:              []uint32{uint32((math.MaxUint32 / numIngesters) * i)},
-		}
-		ingesterByAddr[addr] = &ingesters[i]
-	}
-
-	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
-
-	err := kvStore.CAS(context.Background(), ingester.RingKey,
-		func(_ interface{}) (interface{}, bool, error) {
-			return &ring.Desc{
-				Ingesters: ingesterDescs,
-			}, true, nil
-		},
+func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory func(addr string) (ring_client.PoolClient, error)) *Distributor {
+	var (
+		distributorConfig Config
+		clientConfig      client.Config
 	)
+	flagext.DefaultValues(&distributorConfig, &clientConfig)
+
+	overrides, err := validation.NewOverrides(*limits, nil)
 	require.NoError(t, err)
 
-	ingestersRing, err := ring.New(ring.Config{
-		KVStore: kv.Config{
-			Mock: kvStore,
-		},
-		HeartbeatTimeout:  60 * time.Minute,
-		ReplicationFactor: 3,
-	}, ingester.RingKey, ingester.RingKey, nil, nil)
+	// Mock the ingesters ring
+	ingesters := map[string]*mockIngester{}
+	for i := 0; i < numIngesters; i++ {
+		ingesters[fmt.Sprintf("ingester%d", i)] = &mockIngester{}
+	}
 
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ingestersRing))
-
-	test.Poll(t, time.Second, numIngesters, func() interface{} {
-		return ingestersRing.InstancesCount()
-	})
+	ingestersRing := &mockRing{
+		replicationFactor: 3,
+	}
+	for addr := range ingesters {
+		ingestersRing.ingesters = append(ingestersRing.ingesters, ring.InstanceDesc{
+			Addr: addr,
+		})
+	}
 
 	loopbackName, err := loki_net.LoopbackInterfaceName()
 	require.NoError(t, err)
 
-	distributors := make([]*Distributor, numDistributors)
-	for i := 0; i < numDistributors; i++ {
-		var distributorConfig Config
-		var clientConfig client.Config
-		flagext.DefaultValues(&distributorConfig, &clientConfig)
-
-		distributorConfig.DistributorRing.HeartbeatPeriod = 100 * time.Millisecond
-		distributorConfig.DistributorRing.InstanceID = strconv.Itoa(rand.Int())
-		distributorConfig.DistributorRing.KVStore.Mock = kvStore
-		distributorConfig.DistributorRing.InstanceAddr = "127.0.0.1"
-		distributorConfig.DistributorRing.InstanceInterfaceNames = []string{loopbackName}
-		distributorConfig.factory = factory
-		if factory == nil {
-			distributorConfig.factory = func(addr string) (ring_client.PoolClient, error) {
-				return ingesterByAddr[addr], nil
-			}
+	distributorConfig.DistributorRing.HeartbeatPeriod = 100 * time.Millisecond
+	distributorConfig.DistributorRing.InstanceID = strconv.Itoa(rand.Int())
+	distributorConfig.DistributorRing.KVStore.Mock = kvStore
+	distributorConfig.DistributorRing.KVStore.Store = "inmemory"
+	distributorConfig.DistributorRing.InstanceInterfaceNames = []string{loopbackName}
+	distributorConfig.factory = factory
+	if factory == nil {
+		distributorConfig.factory = func(addr string) (ring_client.PoolClient, error) {
+			return ingesters[addr], nil
 		}
-
-		overrides, err := validation.NewOverrides(*limits, nil)
-		require.NoError(t, err)
-
-		d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, prometheus.NewPedanticRegistry())
-		require.NoError(t, err)
-		require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
-		distributors[i] = d
 	}
 
-	if distributors[0].distributorsRing != nil {
-		test.Poll(t, time.Second, numDistributors, func() interface{} {
-			return distributors[0].distributorsLifecycler.HealthyInstancesCount()
-		})
-	}
+	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 
-	t.Cleanup(func() {
-		assert.NoError(t, closer.Close())
-		for _, d := range distributors {
-			assert.NoError(t, services.StopAndAwaitTerminated(context.Background(), d))
-		}
-		ingestersRing.StopAsync()
-	})
-	return distributors
+	return d
 }
 
 func makeWriteRequest(lines int, size int) *logproto.PushRequest {
@@ -408,4 +391,73 @@ func (i *mockIngester) Push(ctx context.Context, in *logproto.PushRequest, opts 
 
 func (i *mockIngester) Close() error {
 	return nil
+}
+
+// Copied from Cortex; TODO(twilkie) - factor this our and share it.
+// mockRing doesn't do virtual nodes, just returns mod(key) + replicationFactor
+// ingesters.
+type mockRing struct {
+	prometheus.Counter
+	ingesters         []ring.InstanceDesc
+	replicationFactor uint32
+}
+
+func (r mockRing) Get(key uint32, op ring.Operation, buf []ring.InstanceDesc, _ []string, _ []string) (ring.ReplicationSet, error) {
+	result := ring.ReplicationSet{
+		MaxErrors: 1,
+		Instances: buf[:0],
+	}
+	for i := uint32(0); i < r.replicationFactor; i++ {
+		n := (key + i) % uint32(len(r.ingesters))
+		result.Instances = append(result.Instances, r.ingesters[n])
+	}
+	return result, nil
+}
+
+func (r mockRing) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error) {
+	return r.GetReplicationSetForOperation(op)
+}
+
+func (r mockRing) GetReplicationSetForOperation(op ring.Operation) (ring.ReplicationSet, error) {
+	return ring.ReplicationSet{
+		Instances: r.ingesters,
+		MaxErrors: 1,
+	}, nil
+}
+
+func (r mockRing) ReplicationFactor() int {
+	return int(r.replicationFactor)
+}
+
+func (r mockRing) InstancesCount() int {
+	return len(r.ingesters)
+}
+
+func (r mockRing) Subring(key uint32, n int) ring.ReadRing {
+	return r
+}
+
+func (r mockRing) HasInstance(instanceID string) bool {
+	for _, ing := range r.ingesters {
+		if ing.Addr != instanceID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r mockRing) ShuffleShard(identifier string, size int) ring.ReadRing {
+	// take advantage of pass by value to bound to size:
+	r.ingesters = r.ingesters[:size]
+	return r
+}
+
+func (r mockRing) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ring.ReadRing {
+	return r
+}
+
+func (r mockRing) CleanupShuffleShardCache(identifier string) {}
+
+func (r mockRing) GetInstanceState(instanceID string) (ring.InstanceState, error) {
+	return 0, nil
 }

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -1,12 +1,14 @@
 package distributor
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/validation"
@@ -17,10 +19,11 @@ func TestDistributorRingHandler(t *testing.T) {
 	flagext.DefaultValues(limits)
 
 	runServer := func() *httptest.Server {
-		distributors := prepare(t, 1, 3, limits, nil)
+		d := prepare(t, limits, nil, nil)
+		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			distributors[0].ServeHTTP(w, r)
+			d.ServeHTTP(w, r)
 		}))
 	}
 


### PR DESCRIPTION
This reverts commit 10b93cebe54af5b3af65308d5e0724e5aec2bb50.

We discovered that these changes can lead to log deduplication issues.