### PR TITLE
Fix apply retention issue

### DIFF
--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -408,7 +408,7 @@ func (c *Compactor) CompactTable(ctx context.Context, tableName string, applyRet
 
 	interval := retention.ExtractIntervalFromTableName(tableName)
 	intervalMayHaveExpiredChunks := false
-	if c.cfg.RetentionEnabled && applyRetention {
+	if applyRetention {
 		intervalMayHaveExpiredChunks = c.expirationChecker.IntervalMayHaveExpiredChunks(interval, "")
 	}
 
@@ -424,7 +424,7 @@ func (c *Compactor) RunCompaction(ctx context.Context, applyRetention bool) erro
 	status := statusSuccess
 	start := time.Now()
 
-	if c.cfg.RetentionEnabled {
+	if applyRetention {
 		c.expirationChecker.MarkPhaseStarted()
 	}
 
@@ -439,7 +439,7 @@ func (c *Compactor) RunCompaction(ctx context.Context, applyRetention bool) erro
 			}
 		}
 
-		if c.cfg.RetentionEnabled {
+		if applyRetention {
 			if status == statusSuccess {
 				c.expirationChecker.MarkPhaseFinished()
 			} else {

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -550,7 +550,7 @@ func (e *expirationChecker) MarkPhaseFinished() {
 }
 
 func (e *expirationChecker) IntervalMayHaveExpiredChunks(interval model.Interval, userID string) bool {
-	return e.retentionExpiryChecker.IntervalMayHaveExpiredChunks(interval, "") || e.deletionExpiryChecker.IntervalMayHaveExpiredChunks(interval, "")
+	return e.retentionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID) || e.deletionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID)
 }
 
 func (e *expirationChecker) DropFromIndex(ref retention.ChunkEntry, tableEndTime model.Time, now model.Time) bool {

--- a/pkg/storage/stores/shipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/shipper/compactor/compactor_test.go
@@ -107,7 +107,7 @@ func TestCompactor_RunCompaction(t *testing.T) {
 	cm := storage.NewClientMetrics()
 	defer cm.Unregister()
 	compactor := setupTestCompactor(t, tempDir, cm)
-	err := compactor.RunCompaction(context.Background(), true)
+	err := compactor.RunCompaction(context.Background(), false)
 	require.NoError(t, err)
 
 	for name := range tables {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We have `MarkPhaseStarted` and `MarkPhaseEnded` calls to notify retention and deletion expiry checker about start/end of chunk mark phase before applying retention. When `MarkPhaseStarted` is called on the deletion expiry checker, it would load all the delete requests to process and `MarkPhaseEnded` would mark those delete requests as processed.

We recently added a config to run mark phase at a different interval than compaction interval so it means we do not always apply retention when running compaction, based on the config. The bug here we have is we were always calling `MarkPhaseStarted` and `MarkPhaseEnded` which was causing the delete requests to be marked as processed even without processing them.

This also fixes another bug in the consolidated `IntervalMayHaveExpiredChunks` which was not passing `userID` to downstream retention and deletion expiry checker.
