### PR TITLE
add a ms instead of ns to end time of the rebound chunk interval

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -911,7 +911,7 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 
 // Rebound builds a smaller chunk with logs having timestamp from start and end(both inclusive)
 func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
-	// add a nanosecond to end time because the Chunk.Iterator considers end time to be non-inclusive.
+	// add a millisecond to end time because the Chunk.Iterator considers end time to be non-inclusive.
 	itr, err := c.Iterator(context.Background(), start, end.Add(time.Millisecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
 	if err != nil {
 		return nil, err

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -912,7 +912,7 @@ func (c *MemChunk) Blocks(mintT, maxtT time.Time) []Block {
 // Rebound builds a smaller chunk with logs having timestamp from start and end(both inclusive)
 func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
 	// add a nanosecond to end time because the Chunk.Iterator considers end time to be non-inclusive.
-	itr, err := c.Iterator(context.Background(), start, end.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+	itr, err := c.Iterator(context.Background(), start, end.Add(time.Millisecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -152,7 +152,7 @@ func markforDelete(ctx context.Context, tableName string, marker MarkerStorageWr
 			if len(nonDeletedIntervals) > 0 {
 				wroteChunks, err := chunkRewriter.rewriteChunk(ctx, c, nonDeletedIntervals)
 				if err != nil {
-					return false, false, err
+					return false, false, fmt.Errorf("failed to rewrite chunk %s for interval %s with error %s", c.ChunkID, nonDeletedIntervals, err)
 				}
 
 				if wroteChunks {


### PR DESCRIPTION
**What this PR does / why we need it**:
While rebounding chunk with an interval, we get inclusive end time, while the iterator we use for fetching all the samples considers end time to be non-inclusive. Therefore, we added a `ns` to the end time to match the expectation to ensure we included all the requested log lines.

But since we have `ms` precise chunk intervals, which is what the deletion code works on, we lose the ns precision. So adding 1 `ns` makes us not include logs that have > 1 `ns` value. E.g., if the end time of the chunk is `1643958368443` and we have a log at `1643958368443000064`, adding 1 `ns` while rebounding the second half of that chunk would make us not include the log line at `1643958368443000064` since the end time we passed to iterator is `1643958368443000001`.

This PR fixes the issue by adding a `ms` instead of a `ns` before passing the end time to the iterator.
