### PR TITLE
fix rounding of time to milliseconds

### DIFF
--- a/pkg/util/conv.go
+++ b/pkg/util/conv.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"math"
 	"time"
 	"unsafe"
 
@@ -28,8 +27,15 @@ func MapToModelLabelSet(m map[string]string) model.LabelSet {
 // RoundToMilliseconds returns milliseconds precision time from nanoseconds.
 // from will be rounded down to the nearest milliseconds while through is rounded up.
 func RoundToMilliseconds(from, through time.Time) (model.Time, model.Time) {
-	return model.Time(int64(math.Floor(float64(from.UnixNano()) / float64(time.Millisecond)))),
-		model.Time(int64(math.Ceil(float64(through.UnixNano()) / float64(time.Millisecond))))
+	fromMs := from.UnixNano() / int64(time.Millisecond)
+	throughMs := through.UnixNano() / int64(time.Millisecond)
+
+	// add a millisecond to the through time if the nanosecond offset within the second is not a multiple of milliseconds
+	if int64(through.Nanosecond())%int64(time.Millisecond) != 0 {
+		throughMs++
+	}
+
+	return model.Time(fromMs), model.Time(throughMs)
 }
 
 // LabelsToMetric converts a Labels to Metric

--- a/pkg/util/conv_test.go
+++ b/pkg/util/conv_test.go
@@ -44,6 +44,20 @@ func TestRoundToMilliseconds(t *testing.T) {
 			model.Time(1),
 			model.Time(3),
 		},
+		{
+			"rounding large number in nanoseconds",
+			time.Unix(0, 1643958368442000064),
+			time.Unix(0, 1643958368443000064),
+			model.Time(1643958368442),
+			model.Time(1643958368444),
+		},
+		{
+			"already rounded large number in nanoseconds",
+			time.Unix(0, 1643958368442000000),
+			time.Unix(0, 1643958368443000000),
+			model.Time(1643958368442),
+			model.Time(1643958368443),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The current implementation of RoundToMilliseconds is broken due to improper handling of floating-point operation in go.
See 
![image](https://user-images.githubusercontent.com/1319033/153177789-fb4312c9-6709-41df-9e1f-8cd4c65ed039.png)

This PR fixes it by using simple division and modulo operators

**Checklist**
- [x] Tests updated
