### PR TITLE
Ruler: Rule group not found API message

### DIFF
--- a/pkg/ruler/rulestore/objectclient/rule_store.go
+++ b/pkg/ruler/rulestore/objectclient/rule_store.go
@@ -54,7 +54,7 @@ func NewRuleStore(client chunk.ObjectClient, loadConcurrency int, logger log.Log
 func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rulespb.RuleGroupDesc) (*rulespb.RuleGroupDesc, error) {
 	reader, _, err := o.client.GetObject(ctx, objectKey)
 	if err != nil {
-		if err.Error() == chunk.ErrStorageObjectNotFound.Error() {
+		if o.client.IsObjectNotFoundErr(err)  {
 			level.Debug(o.logger).Log("msg", "rule group does not exist", "name", objectKey)
 			return nil, errors.Wrapf(rulestore.ErrGroupNotFound, "get rule group user=%q, namespace=%q, name=%q", rg.GetUser(), rg.GetNamespace(), rg.GetName())
 		}

--- a/pkg/ruler/rulestore/objectclient/rule_store.go
+++ b/pkg/ruler/rulestore/objectclient/rule_store.go
@@ -54,7 +54,7 @@ func NewRuleStore(client chunk.ObjectClient, loadConcurrency int, logger log.Log
 func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rulespb.RuleGroupDesc) (*rulespb.RuleGroupDesc, error) {
 	reader, _, err := o.client.GetObject(ctx, objectKey)
 	if err != nil {
-		if o.client.IsObjectNotFoundErr(err)  {
+		if o.client.IsObjectNotFoundErr(err) {
 			level.Debug(o.logger).Log("msg", "rule group does not exist", "name", objectKey)
 			return nil, errors.Wrapf(rulestore.ErrGroupNotFound, "get rule group user=%q, namespace=%q, name=%q", rg.GetUser(), rg.GetNamespace(), rg.GetName())
 		}

--- a/pkg/ruler/rulestore/objectclient/rule_store.go
+++ b/pkg/ruler/rulestore/objectclient/rule_store.go
@@ -214,7 +214,7 @@ func (o *RuleStore) SetRuleGroup(ctx context.Context, userID string, namespace s
 func (o *RuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespace string, groupName string) error {
 	objectKey := generateRuleObjectKey(userID, namespace, groupName)
 	err := o.client.DeleteObject(ctx, objectKey)
-	if err == chunk.ErrStorageObjectNotFound {
+	if o.client.IsObjectNotFoundErr(err) {
 		return rulestore.ErrGroupNotFound
 	}
 	return err

--- a/pkg/storage/chunk/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/gcp/gcs_object_client.go
@@ -125,9 +125,6 @@ func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.R
 func (s *GCSObjectClient) getObject(ctx context.Context, objectKey string) (rc io.ReadCloser, size int64, err error) {
 	reader, err := s.getsBuckets.Object(objectKey).NewReader(ctx)
 	if err != nil {
-		if err == storage.ErrObjectNotExist {
-			return nil, 0, chunk.ErrStorageObjectNotFound
-		}
 		return nil, 0, err
 	}
 

--- a/pkg/storage/chunk/gcp/gcs_object_client.go
+++ b/pkg/storage/chunk/gcp/gcs_object_client.go
@@ -125,6 +125,9 @@ func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.R
 func (s *GCSObjectClient) getObject(ctx context.Context, objectKey string) (rc io.ReadCloser, size int64, err error) {
 	reader, err := s.getsBuckets.Object(objectKey).NewReader(ctx)
 	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return nil, 0, chunk.ErrStorageObjectNotFound
+		}
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
We copied over the ruler code as part of #5089, and it seems that at the same time we stopped depending on the object storage implementation of Cortex. Turns out, there are (slight) differences between the clients which meant that response returned by the API when we try to get a rule group that is not found had changed.

This ensures that is consistent with the error assertion that we have in the code for the ruler.

https://github.com/grafana/loki/blob/7fafe94e1abb230338e5ae0fd177216da3ad67af/pkg/ruler/rulestore/objectclient/rule_store.go#L56-L63

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
