### PR TITLE
[operator] Allowing reconcile loop to requeue if secret is missing

### DIFF
--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -651,7 +651,7 @@ func TestCreateOrUpdateLokiStack_WhenMissingSecret_SetDegraded(t *testing.T) {
 	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
 
 	// make sure error is returned to re-trigger reconciliation
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// make sure status and status-update calls
 	require.NotZero(t, k.StatusCallCount())
@@ -706,7 +706,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidSecret_SetDegraded(t *testing.T) {
 	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
 
 	// make sure error is returned to re-trigger reconciliation
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// make sure status and status-update calls
 	require.NotZero(t, k.StatusCallCount())
@@ -780,7 +780,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidTenantsConfiguration_SetDegraded(t *
 	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, ff)
 
 	// make sure error is returned to re-trigger reconciliation
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// make sure status and status-update calls
 	require.NotZero(t, k.StatusCallCount())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The Loki Operator does not requeue the reconcile loop if it is missing or cannot extract the data from the secret object. This is because the nullable error from the result of the status request is returned instead of an error. This PR changes the behavior so that an error is always returned in these cases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
