### PR TITLE
Promtail: Remove promtail_log_entries_bytes_bucket histogram

### DIFF
--- a/clients/pkg/promtail/targets/file/metrics.go
+++ b/clients/pkg/promtail/targets/file/metrics.go
@@ -8,11 +8,10 @@ type Metrics struct {
 	reg prometheus.Registerer
 
 	// File-specific metrics
-	readBytes          *prometheus.GaugeVec
-	totalBytes         *prometheus.GaugeVec
-	readLines          *prometheus.CounterVec
-	filesActive        prometheus.Gauge
-	logLengthHistogram *prometheus.HistogramVec
+	readBytes   *prometheus.GaugeVec
+	totalBytes  *prometheus.GaugeVec
+	readLines   *prometheus.CounterVec
+	filesActive prometheus.Gauge
 
 	// Manager metrics
 	failedTargets *prometheus.CounterVec
@@ -45,12 +44,6 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Name:      "files_active_total",
 		Help:      "Number of active files.",
 	})
-	m.logLengthHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "promtail",
-		Name:      "log_entries_bytes",
-		Help:      "the total count of bytes",
-		Buckets:   prometheus.ExponentialBuckets(16, 2, 8),
-	}, []string{"path"})
 
 	m.failedTargets = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
@@ -69,7 +62,6 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			m.totalBytes,
 			m.readLines,
 			m.filesActive,
-			m.logLengthHistogram,
 			m.failedTargets,
 			m.targetsActive,
 		)

--- a/clients/pkg/promtail/targets/file/tailer.go
+++ b/clients/pkg/promtail/targets/file/tailer.go
@@ -150,7 +150,6 @@ func (t *tailer) readLines() {
 		}
 
 		t.metrics.readLines.WithLabelValues(t.path).Inc()
-		t.metrics.logLengthHistogram.WithLabelValues(t.path).Observe(float64(len(line.Text)))
 		entries <- api.Entry{
 			Labels: model.LabelSet{},
 			Entry: logproto.Entry{
@@ -225,5 +224,4 @@ func (t *tailer) cleanupMetrics() {
 	t.metrics.readLines.DeleteLabelValues(t.path)
 	t.metrics.readBytes.DeleteLabelValues(t.path)
 	t.metrics.totalBytes.DeleteLabelValues(t.path)
-	t.metrics.logLengthHistogram.DeleteLabelValues(t.path)
 }

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -60,7 +60,6 @@ Promtail exposes these metrics:
 | `promtail_encoded_bytes_total`            | Counter     | Number of bytes encoded and ready to send.                                                 |
 | `promtail_file_bytes_total`               | Gauge       | Number of bytes read from files.                                                           |
 | `promtail_files_active_total`             | Gauge       | Number of active files.                                                                    |
-| `promtail_log_entries_bytes`              | Histogram   | The total count of bytes read.                                                             |
 | `promtail_request_duration_seconds_count` | Histogram   | Number of send requests.                                                                   |
 | `promtail_sent_bytes_total`               | Counter     | Number of bytes sent.                                                                      |
 | `promtail_sent_entries_total`             | Counter     | Number of log entries sent to the ingester.                                                |

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -120,6 +120,14 @@ The response body has the following schema:
     e.g. if you previously used `__project_id` then you'll need to update your relabel config to use `__gcp_resource_labels_project_id`.
   - `resource_type` has been moved to `__gcp_resource_type`
 
+#### `promtail_log_entries_bytes_bucket` histogram has been removed.
+
+This histogram reports the distribution of log line sizes by file. It has 8 buckets for every file being tailed.
+
+This creates a lot of series and we don't think this metric has enough value to offset the amount of series genereated so we are removing it.
+
+While this isn't a direct replacement, two metrics we find more useful are size and line counters configured via pipeline stages, an example of how to configure these metrics can be found in the [metrics pipeline stage docs](https://grafana.com/docs/loki/latest/clients/promtail/stages/metrics/#counter)
+
 ## 2.4.0
 
 The following are important changes which should be reviewed and understood prior to upgrading Loki.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This histogram reports a distribution of the size (bytes) of every log line processed by promtail, and does so with a label for each file being tailed. There are 8 buckets in the histogram which can quickly lead to a huge amount of exported metrics.

In our experiences, we have found little use for this metric, not enough to justify the cost of the number of series it creates so this PR removes it.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
