### PR TITLE
Loki: include the component in metrics.go log line

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -144,7 +144,7 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	}
 
 	if q.record {
-		RecordMetrics(ctx, q.params, status, statResult, data)
+		RecordMetrics(ctx, q.logger, q.params, status, statResult, data)
 	}
 
 	return logqlmodel.Result{

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -2,6 +2,7 @@ package logql
 
 import (
 	"context"
+	"github.com/go-kit/log"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -72,9 +73,9 @@ var (
 	linePerSecondLogUsage    = usagestats.NewStatistics("query_log_lines_per_second")
 )
 
-func RecordMetrics(ctx context.Context, p Params, status string, stats logql_stats.Result, result promql_parser.Value) {
+func RecordMetrics(ctx context.Context, log log.Logger, p Params, status string, stats logql_stats.Result, result promql_parser.Value) {
 	var (
-		logger        = util_log.WithContext(ctx, util_log.Logger)
+		logger        = util_log.WithContext(ctx, log)
 		rt            = string(GetRangeType(p))
 		latencyType   = latencyTypeFast
 		returnedLines = 0

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -2,10 +2,10 @@ package logql
 
 import (
 	"context"
-	"github.com/go-kit/log"
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -66,7 +66,7 @@ func TestLogSlowQuery(t *testing.T) {
 
 	ctx = context.WithValue(ctx, httpreq.QueryTagsHTTPHeader, "Source=logvolhist,Feature=Beta")
 
-	RecordMetrics(ctx, LiteralParams{
+	RecordMetrics(ctx, util_log.Logger, LiteralParams{
 		qs:        `{foo="bar"} |= "buzz"`,
 		direction: logproto.BACKWARD,
 		end:       now,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/go-kit/log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -621,7 +622,7 @@ func (t *Loki) initRuler() (_ services.Service, err error) {
 		return nil, err
 	}
 
-	engine := logql.NewEngine(t.Cfg.Querier.Engine, q, t.overrides, util_log.Logger)
+	engine := logql.NewEngine(t.Cfg.Querier.Engine, q, t.overrides, log.With(util_log.Logger, "component", "ruler"))
 
 	t.ruler, err = ruler.NewRuler(
 		t.Cfg.Ruler,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-kit/log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"context"
 	"flag"
+	"github.com/go-kit/log"
 	"net/http"
 	"time"
 
@@ -89,13 +90,13 @@ func New(cfg Config, store storage.Store, ingesterQuerier *IngesterQuerier, limi
 		limits:          limits,
 	}
 
-	querier.engine = logql.NewEngine(cfg.Engine, &querier, limits, util_log.Logger)
+	querier.engine = logql.NewEngine(cfg.Engine, &querier, limits, log.With(util_log.Logger, "component", "querier"))
 
 	return &querier, nil
 }
 
 func (q *Querier) SetQueryable(queryable logql.Querier) {
-	q.engine = logql.NewEngine(q.cfg.Engine, queryable, q.limits, util_log.Logger)
+	q.engine = logql.NewEngine(q.cfg.Engine, queryable, q.limits, log.With(util_log.Logger, "component", "querier"))
 }
 
 // Select Implements logql.Querier which select logs via matchers and regex filters.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -3,10 +3,10 @@ package querier
 import (
 	"context"
 	"flag"
-	"github.com/go-kit/log"
 	"net/http"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -4,13 +4,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/go-kit/log"
-	util_log "github.com/grafana/loki/pkg/util/log"
 	"net"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/middleware"
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
+	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/go-kit/log"
+	util_log "github.com/grafana/loki/pkg/util/log"
 	"net"
 	"net/http"
 	"strconv"
@@ -26,7 +28,7 @@ const ctxKey ctxKeyType = "stats"
 
 var (
 	defaultMetricRecorder = metricRecorderFn(func(data *queryData) {
-		logql.RecordMetrics(data.ctx, data.params, data.status, *data.statistics, data.result)
+		logql.RecordMetrics(data.ctx, log.With(util_log.Logger, "component", "frontend"), data.params, data.status, *data.statistics, data.result)
 	})
 	// StatsHTTPMiddleware is an http middleware to record stats for query_range filter.
 	StatsHTTPMiddleware = statsHTTPMiddleware(defaultMetricRecorder)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When running the single binary or in SSD mode, it's essentially impossible to disambiguate metrics.go output from the querier executing a subquery and the accumulated result output by the frontend.

This PR introduces a component to the logger to easily tell which component is outputting the metrics.go stats


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
