### PR TITLE
Update dskit version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 .defaults: &defaults
   docker:
-    - image: grafana/loki-build-image:0.13.0
+    - image: grafana/loki-build-image:0.19.0
   working_directory: /src/loki
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [5392](https://github.com/grafana/loki/pull/5392) **MichelHollands**: Update dskit version.
 * [5361](https://github.com/grafana/loki/pull/5361) **ctovena**: Add usage report to grafana.com.
 * [5289](https://github.com/grafana/loki/pull/5289) **ctovena**: Fix deduplication bug in queries when mutating labels.
 * [5302](https://github.com/grafana/loki/pull/5302) **MasslessParticle** Update azure blobstore client to use new sdk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Main
 
-* [5392](https://github.com/grafana/loki/pull/5392) **MichelHollands**: Update dskit version.
+* [5392](https://github.com/grafana/loki/pull/5392) **MichelHollands**: Etcd credentials are parsed as secrets instead of plain text now.
 * [5361](https://github.com/grafana/loki/pull/5361) **ctovena**: Add usage report to grafana.com.
 * [5289](https://github.com/grafana/loki/pull/5289) **ctovena**: Fix deduplication bug in queries when mutating labels.
 * [5302](https://github.com/grafana/loki/pull/5302) **MasslessParticle** Update azure blobstore client to use new sdk.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -704,7 +704,7 @@ ring:
 
   # Name of network interface to read addresses from.
   # CLI flag: -<prefix>.instance-interface-names
-  [instance_interface_names: <list of string> | default = [eth0 en0]]
+  [instance_interface_names: <list of string> | default = [<private network interfaces>]]
 
   # The number of tokens the lifecycler will generate and put into the ring if
   # it joined without transferring tokens from another lifecycler.
@@ -1079,7 +1079,7 @@ lifecycler:
   # CLI flag: -ingester.lifecycler.interface
   interface_names:
 
-    - [<string> ... | default = ["eth0", "en0"]]
+    - [<string> ... | default = [<private network interfaces>]]
 
   # Duration to sleep before exiting to ensure metrics are scraped.
   # CLI flag: -ingester.final-sleep
@@ -2483,7 +2483,7 @@ This way, one doesn't have to replicate configuration in multiple places.
 # If "instance_interface_names" under the common ring section is configured,
 # this common "instance_interface_names" is only applied to the frontend, but not for
 # ring related components (ex: distributor, ruler, etc).
-[instance_interface_names: <list of string>]
+[instance_interface_names: <list of string> | default = [<private network interfaces>]]
 
 # A common address used by Loki components to advertise their address.
 # If a more specific "instance_addr" is set, this is ignored.
@@ -2609,7 +2609,7 @@ kvstore:
 
 # Name of network interface to read addresses from.
 # CLI flag: -<prefix>.instance-interface-names
-[instance_interface_names: <list of string> | default = [eth0 en0]]
+[instance_interface_names: <list of string> | default = [<private network interfaces>]]
 
 # IP address to advertise in the ring.
 # CLI flag: -<prefix>.instance-addr

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/grafana/dskit v0.0.0-20220209070952-ea22a8f662d0
+	github.com/grafana/dskit v0.0.0-20220211095946-19921f863583
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/consul/api v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,8 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
-github.com/grafana/dskit v0.0.0-20220209070952-ea22a8f662d0 h1:R0Pw7VjouhYSS7bsMdxEidcJbCq1KUBCzPgsh7805NM=
-github.com/grafana/dskit v0.0.0-20220209070952-ea22a8f662d0/go.mod h1:Q9WmQ9cVkrHx6g4KSl6TN+N3vEOkDZd9RtyXCHd5OPQ=
+github.com/grafana/dskit v0.0.0-20220211095946-19921f863583 h1:UCLVGNJptATClAs4CbClVmn5b4YA6GTG3yoCObI//0E=
+github.com/grafana/dskit v0.0.0-20220211095946-19921f863583/go.mod h1:q51XdMLLHNZJSG6KOGujC20ed2OoLFdx0hBmOEVfRs0=
 github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8 h1:aEOagXOTqtN9gd4jiDuP/5a81HdoJBqkVfn8WaxbsK4=
 github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8/go.mod h1:QAvS2C7TtQRhhv9Uf/sxD+BUhpkrPFm5jK/9MzUiDCY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -46,7 +47,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeartbeatTimeout, "distributor.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled).")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "distributor.ring.instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, "distributor.ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, "distributor.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -25,7 +25,7 @@ type RingConfig struct {
 
 	// Instance details
 	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
 	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
 	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -103,7 +103,7 @@ type Config struct {
 
 // RegisterFlags registers the flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.LifecyclerConfig.RegisterFlags(f)
+	cfg.LifecyclerConfig.RegisterFlags(f, util_log.Logger)
 	cfg.WAL.RegisterFlags(f)
 
 	f.IntVar(&cfg.MaxTransferRetries, "ingester.max-transfer-retries", 0, "Number of times to try and transfer chunks before falling back to flushing. If set to 0 or negative value, transfers are disabled.")

--- a/pkg/loki/common/common.go
+++ b/pkg/loki/common/common.go
@@ -30,6 +30,7 @@ type Config struct {
 	//
 	// Internally, addresses will be resolved in the order that this is configured.
 	// By default, the list of used interfaces are, in order: "eth0", "en0", and your loopback net interface (probably "lo").
+	// If an interface does not have a private IP address it is filtered out, falling back to "eth0" and "en0" if none are left.
 	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
 
 	// InstanceAddr represents a common ip used by instances to advertise their address.

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -323,11 +323,6 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 
 	if reflect.DeepEqual(cfg.Distributor.DistributorRing.InstanceInterfaceNames, defaults.Distributor.DistributorRing.InstanceInterfaceNames) {
 		cfg.Distributor.DistributorRing.InstanceInterfaceNames = append(cfg.Distributor.DistributorRing.InstanceInterfaceNames, loopbackIface)
-	} else {
-		// TODO: revert this before merging
-		fmt.Printf("distributor interface names: %v, defaults: %v\n",
-			cfg.Distributor.DistributorRing.InstanceInterfaceNames,
-			defaults.Distributor.DistributorRing.InstanceInterfaceNames)
 	}
 
 	if reflect.DeepEqual(cfg.Common.Ring.InstanceInterfaceNames, defaults.Common.Ring.InstanceInterfaceNames) {
@@ -340,20 +335,10 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 
 	if reflect.DeepEqual(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames) {
 		cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames = append(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, loopbackIface)
-	} else {
-		// TODO: revert this before merging
-		fmt.Printf("query scheduler interface names: %v, defaults: %v\n",
-			cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames,
-			defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames)
 	}
 
 	if reflect.DeepEqual(cfg.Ruler.Ring.InstanceInterfaceNames, defaults.Ruler.Ring.InstanceInterfaceNames) {
 		cfg.Ruler.Ring.InstanceInterfaceNames = append(cfg.Ruler.Ring.InstanceInterfaceNames, loopbackIface)
-	} else {
-		// TODO: revert this before merging
-		fmt.Printf("ruler interface names: %v, defaults: %v\n",
-			cfg.Ruler.Ring.InstanceInterfaceNames,
-			defaults.Ruler.Ring.InstanceInterfaceNames)
 	}
 }
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -323,6 +323,10 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 
 	if reflect.DeepEqual(cfg.Distributor.DistributorRing.InstanceInterfaceNames, defaults.Distributor.DistributorRing.InstanceInterfaceNames) {
 		cfg.Distributor.DistributorRing.InstanceInterfaceNames = append(cfg.Distributor.DistributorRing.InstanceInterfaceNames, loopbackIface)
+	} else {
+		fmt.Printf("distributor interface names: %v, defaults: %v\n",
+			cfg.Distributor.DistributorRing.InstanceInterfaceNames,
+			defaults.Distributor.DistributorRing.InstanceInterfaceNames)
 	}
 
 	if reflect.DeepEqual(cfg.Common.Ring.InstanceInterfaceNames, defaults.Common.Ring.InstanceInterfaceNames) {
@@ -335,10 +339,18 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 
 	if reflect.DeepEqual(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames) {
 		cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames = append(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, loopbackIface)
+	} else {
+		fmt.Printf("query scheduler interface names: %v, defaults: %v\n",
+			cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames,
+			defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames)
 	}
 
 	if reflect.DeepEqual(cfg.Ruler.Ring.InstanceInterfaceNames, defaults.Ruler.Ring.InstanceInterfaceNames) {
 		cfg.Ruler.Ring.InstanceInterfaceNames = append(cfg.Ruler.Ring.InstanceInterfaceNames, loopbackIface)
+	} else {
+		fmt.Printf("ruler interface names: %v, defaults: %v\n",
+			cfg.Ruler.Ring.InstanceInterfaceNames,
+			defaults.Ruler.Ring.InstanceInterfaceNames)
 	}
 }
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -324,6 +324,7 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 	if reflect.DeepEqual(cfg.Distributor.DistributorRing.InstanceInterfaceNames, defaults.Distributor.DistributorRing.InstanceInterfaceNames) {
 		cfg.Distributor.DistributorRing.InstanceInterfaceNames = append(cfg.Distributor.DistributorRing.InstanceInterfaceNames, loopbackIface)
 	} else {
+		// TODO: revert this before merging
 		fmt.Printf("distributor interface names: %v, defaults: %v\n",
 			cfg.Distributor.DistributorRing.InstanceInterfaceNames,
 			defaults.Distributor.DistributorRing.InstanceInterfaceNames)
@@ -340,6 +341,7 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 	if reflect.DeepEqual(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames) {
 		cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames = append(cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames, loopbackIface)
 	} else {
+		// TODO: revert this before merging
 		fmt.Printf("query scheduler interface names: %v, defaults: %v\n",
 			cfg.QueryScheduler.SchedulerRing.InstanceInterfaceNames,
 			defaults.QueryScheduler.SchedulerRing.InstanceInterfaceNames)
@@ -348,6 +350,7 @@ func appendLoopbackInterface(cfg, defaults *ConfigWrapper) {
 	if reflect.DeepEqual(cfg.Ruler.Ring.InstanceInterfaceNames, defaults.Ruler.Ring.InstanceInterfaceNames) {
 		cfg.Ruler.Ring.InstanceInterfaceNames = append(cfg.Ruler.Ring.InstanceInterfaceNames, loopbackIface)
 	} else {
+		// TODO: revert this before merging
 		fmt.Printf("ruler interface names: %v, defaults: %v\n",
 			cfg.Ruler.Ring.InstanceInterfaceNames,
 			defaults.Ruler.Ring.InstanceInterfaceNames)

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1101,7 +1101,7 @@ query_scheduler:
 		assert.Equal(t, config.Distributor.DistributorRing.InstanceInterfaceNames, []string{"distributoriface"})
 		assert.Equal(t, config.QueryScheduler.SchedulerRing.InstanceInterfaceNames, []string{"scheduleriface"})
 		assert.Equal(t, config.Ruler.Ring.InstanceInterfaceNames, []string{"ruleriface"})
-		assert.Equal(t, config.Ingester.LifecyclerConfig.InfNames, []string{"eth0", "en0", defaultIface})
+		assert.Equal(t, config.Ingester.LifecyclerConfig.InfNames, []string{"eth0", defaultIface})
 	})
 }
 
@@ -1113,9 +1113,9 @@ func TestLoopbackAppendingToFrontendV2(t *testing.T) {
 	t.Run("when using common or ingester ring configs, loopback should be added to interface names", func(t *testing.T) {
 		config, _, err := configWrapperFromYAML(t, minimalConfig, []string{})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"eth0", "en0", defaultIface}, config.Frontend.FrontendV2.InfNames)
-		assert.Equal(t, []string{"eth0", "en0", defaultIface}, config.Ingester.LifecyclerConfig.InfNames)
-		assert.Equal(t, []string{"eth0", "en0", defaultIface}, config.Common.Ring.InstanceInterfaceNames)
+		assert.Equal(t, []string{"eth0", defaultIface}, config.Frontend.FrontendV2.InfNames)
+		assert.Equal(t, []string{"eth0", defaultIface}, config.Ingester.LifecyclerConfig.InfNames)
+		assert.Equal(t, []string{"eth0", defaultIface}, config.Common.Ring.InstanceInterfaceNames)
 	})
 
 	t.Run("loopback shouldn't be in FrontendV2 interface names if set by user", func(t *testing.T) {

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/loki/common"
 	"github.com/grafana/loki/pkg/storage/bucket/swift"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/storage"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/cfg"
+	util_log "github.com/grafana/loki/pkg/util/log"
 	loki_net "github.com/grafana/loki/pkg/util/net"
 )
 
@@ -1101,7 +1103,9 @@ query_scheduler:
 		assert.Equal(t, config.Distributor.DistributorRing.InstanceInterfaceNames, []string{"distributoriface"})
 		assert.Equal(t, config.QueryScheduler.SchedulerRing.InstanceInterfaceNames, []string{"scheduleriface"})
 		assert.Equal(t, config.Ruler.Ring.InstanceInterfaceNames, []string{"ruleriface"})
-		assert.Equal(t, config.Ingester.LifecyclerConfig.InfNames, []string{"eth0", defaultIface})
+		expectedInterfaces := netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
+		expectedInterfaces = append(expectedInterfaces, defaultIface)
+		assert.Equal(t, config.Ingester.LifecyclerConfig.InfNames, expectedInterfaces)
 	})
 }
 
@@ -1113,9 +1117,11 @@ func TestLoopbackAppendingToFrontendV2(t *testing.T) {
 	t.Run("when using common or ingester ring configs, loopback should be added to interface names", func(t *testing.T) {
 		config, _, err := configWrapperFromYAML(t, minimalConfig, []string{})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"eth0", defaultIface}, config.Frontend.FrontendV2.InfNames)
-		assert.Equal(t, []string{"eth0", defaultIface}, config.Ingester.LifecyclerConfig.InfNames)
-		assert.Equal(t, []string{"eth0", defaultIface}, config.Common.Ring.InstanceInterfaceNames)
+		expectedInterfaces := netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
+		expectedInterfaces = append(expectedInterfaces, defaultIface)
+		assert.Equal(t, expectedInterfaces, config.Frontend.FrontendV2.InfNames)
+		assert.Equal(t, expectedInterfaces, config.Ingester.LifecyclerConfig.InfNames)
+		assert.Equal(t, expectedInterfaces, config.Common.Ring.InstanceInterfaceNames)
 	})
 
 	t.Run("loopback shouldn't be in FrontendV2 interface names if set by user", func(t *testing.T) {

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/netutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/loki/common"
 	"github.com/grafana/loki/pkg/storage/bucket/swift"

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/opentracing/opentracing-go"
@@ -26,6 +27,7 @@ import (
 	"github.com/grafana/loki/pkg/querier/stats"
 	"github.com/grafana/loki/pkg/tenant"
 	lokigrpc "github.com/grafana/loki/pkg/util/httpgrpc"
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 // Config for a Frontend.
@@ -48,7 +50,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.DNSLookupPeriod, "frontend.scheduler-dns-lookup-period", 10*time.Second, "How often to resolve the scheduler-address, in order to look for new query-scheduler instances. Also used to determine how often to poll the scheduler-ring for addresses if the scheduler-ring is configured.")
 	f.IntVar(&cfg.WorkerConcurrency, "frontend.scheduler-worker-concurrency", 5, "Number of concurrent workers forwarding queries to single query-scheduler.")
 
-	cfg.InfNames = []string{"eth0", "en0"}
+	cfg.InfNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	f.Var((*flagext.StringSlice)(&cfg.InfNames), "frontend.instance-interface-names", "Name of network interface to read address from. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend.")
 	f.StringVar(&cfg.Addr, "frontend.instance-addr", "", "IP address to advertise to querier (via scheduler) (resolved via interfaces by default).")
 	f.IntVar(&cfg.Port, "frontend.instance-port", 0, "Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).")

--- a/pkg/ruler/base/ruler_ring.go
+++ b/pkg/ruler/base/ruler_ring.go
@@ -9,7 +9,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 const (
@@ -61,7 +63,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeartbeatTimeout, "ruler.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which rulers are considered unhealthy within the ring. 0 = never (timeout disabled).")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "ruler.ring.instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, "ruler.ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, "ruler.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/pkg/ruler/base/ruler_ring.go
+++ b/pkg/ruler/base/ruler_ring.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
+
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 

--- a/pkg/ruler/base/ruler_ring.go
+++ b/pkg/ruler/base/ruler_ring.go
@@ -39,7 +39,7 @@ type RingConfig struct {
 
 	// Instance details
 	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
 	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
 	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
 	NumTokens              int      `yaml:"num_tokens"`

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -37,7 +37,7 @@ func GetFirstAddressOf(names []string) (string, error) {
 		return ipAddr, nil
 	}
 	if ipAddr == "" {
-		return "", fmt.Errorf("No address found for %s", names)
+		return "", fmt.Errorf("no address found for %s", names)
 	}
 	if strings.HasPrefix(ipAddr, `169.254.`) {
 		level.Warn(util_log.Logger).Log("msg", "using automatic private ip", "address", ipAddr)

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -57,7 +58,7 @@ func (cfg *RingConfig) RegisterFlagsWithPrefix(flagsPrefix, storePrefix string, 
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, flagsPrefix+"ring.zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones.")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util_log.Logger)
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), flagsPrefix+"ring.instance-interface-names", "Name of network interface to read address from.")
 	f.StringVar(&cfg.InstanceAddr, flagsPrefix+"ring.instance-addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.InstancePort, flagsPrefix+"ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -30,7 +30,7 @@ type RingConfig struct {
 
 	// Instance details
 	InstanceID             string   `yaml:"instance_id"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
 	InstancePort           int      `yaml:"instance_port"`
 	InstanceAddr           string   `yaml:"instance_addr"`
 	InstanceZone           string   `yaml:"instance_availability_zone"`

--- a/vendor/github.com/grafana/dskit/grpcclient/grpcclient.go
+++ b/vendor/github.com/grafana/dskit/grpcclient/grpcclient.go
@@ -39,7 +39,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // RegisterFlagsWithPrefix registers flags with prefix.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
-	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
+	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 100<<20, "gRPC client max send message size (bytes).")
 	f.StringVar(&cfg.GRPCCompression, prefix+".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
 	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")

--- a/vendor/github.com/grafana/dskit/kv/etcd/etcd.go
+++ b/vendor/github.com/grafana/dskit/kv/etcd/etcd.go
@@ -27,8 +27,8 @@ type Config struct {
 	EnableTLS   bool               `yaml:"tls_enabled" category:"advanced"`
 	TLS         dstls.ClientConfig `yaml:",inline"`
 
-	UserName string `yaml:"username"`
-	Password string `yaml:"password"`
+	UserName string         `yaml:"username"`
+	Password flagext.Secret `yaml:"password"`
 }
 
 // Clientv3Facade is a subset of all Etcd client operations that are required
@@ -58,7 +58,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.IntVar(&cfg.MaxRetries, prefix+"etcd.max-retries", 10, "The maximum number of retries to do for failed ops.")
 	f.BoolVar(&cfg.EnableTLS, prefix+"etcd.tls-enabled", false, "Enable TLS.")
 	f.StringVar(&cfg.UserName, prefix+"etcd.username", "", "Etcd username.")
-	f.StringVar(&cfg.Password, prefix+"etcd.password", "", "Etcd password.")
+	f.Var(&cfg.Password, prefix+"etcd.password", "Etcd password.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix+"etcd", f)
 }
 
@@ -105,7 +105,7 @@ func New(cfg Config, codec codec.Codec, logger log.Logger) (*Client, error) {
 		PermitWithoutStream:  true,
 		TLS:                  tlsConfig,
 		Username:             cfg.UserName,
-		Password:             cfg.Password,
+		Password:             cfg.Password.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/grafana/dskit/kv/memberlist/tcp_transport.go
+++ b/vendor/github.com/grafana/dskit/kv/memberlist/tcp_transport.go
@@ -51,7 +51,7 @@ type TCPTransportConfig struct {
 	PacketWriteTimeout time.Duration `yaml:"packet_write_timeout" category:"advanced"`
 
 	// Transport logs lot of messages at debug level, so it deserves an extra flag for turning it on
-	TransportDebug bool `yaml:"-"`
+	TransportDebug bool `yaml:"-" category:"advanced"`
 
 	// Where to put custom metrics. nil = don't register.
 	MetricsRegisterer prometheus.Registerer `yaml:"-"`

--- a/vendor/github.com/grafana/dskit/netutil/netutil.go
+++ b/vendor/github.com/grafana/dskit/netutil/netutil.go
@@ -1,0 +1,57 @@
+package netutil
+
+import (
+	"net"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+var (
+	getInterfaceAddrs = (*net.Interface).Addrs
+)
+
+// PrivateNetworkInterfaces lists network interfaces and returns those having an address conformant to RFC1918
+func PrivateNetworkInterfaces(logger log.Logger) []string {
+	ints, err := net.Interfaces()
+	if err != nil {
+		level.Warn(logger).Log("msg", "error getting network interfaces", "err", err)
+	}
+	return privateNetworkInterfaces(ints, []string{}, logger)
+}
+
+func PrivateNetworkInterfacesWithFallback(fallback []string, logger log.Logger) []string {
+	ints, err := net.Interfaces()
+	if err != nil {
+		level.Warn(logger).Log("msg", "error getting network interfaces", "err", err)
+	}
+	return privateNetworkInterfaces(ints, fallback, logger)
+}
+
+// private testable function that checks each given interface
+func privateNetworkInterfaces(all []net.Interface, fallback []string, logger log.Logger) []string {
+	var privInts []string
+	for _, i := range all {
+		addrs, err := getInterfaceAddrs(&i)
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting addresses from network interface", "interface", i.Name, "err", err)
+		}
+		for _, a := range addrs {
+			s := a.String()
+			ip, _, err := net.ParseCIDR(s)
+			if err != nil {
+				level.Warn(logger).Log("msg", "error parsing network interface IP address", "interface", i.Name, "addr", s, "err", err)
+				continue
+			}
+			if ip.IsPrivate() {
+				privInts = append(privInts, i.Name)
+				break
+			}
+		}
+	}
+	if len(privInts) == 0 {
+		return fallback
+	}
+	level.Debug(logger).Log("msg", "found network interfaces with private IP addresses assigned", "interfaces", privInts)
+	return privInts
+}

--- a/vendor/github.com/grafana/dskit/ring/ring.go
+++ b/vendor/github.com/grafana/dskit/ring/ring.go
@@ -123,10 +123,10 @@ var (
 // Config for a Ring
 type Config struct {
 	KVStore              kv.Config              `yaml:"kvstore"`
-	HeartbeatTimeout     time.Duration          `yaml:"heartbeat_timeout"`
+	HeartbeatTimeout     time.Duration          `yaml:"heartbeat_timeout" category:"advanced"`
 	ReplicationFactor    int                    `yaml:"replication_factor"`
 	ZoneAwarenessEnabled bool                   `yaml:"zone_awareness_enabled"`
-	ExcludedZones        flagext.StringSliceCSV `yaml:"excluded_zones"`
+	ExcludedZones        flagext.StringSliceCSV `yaml:"excluded_zones" category:"advanced"`
 
 	// Whether the shuffle-sharding subring cache is disabled. This option is set
 	// internally and never exposed to the user.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -623,8 +623,8 @@ github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.2
 ## explicit; go 1.12
 github.com/gorilla/websocket
-# github.com/grafana/dskit v0.0.0-20220209070952-ea22a8f662d0
-## explicit; go 1.16
+# github.com/grafana/dskit v0.0.0-20220211095946-19921f863583
+## explicit; go 1.17
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/concurrency
 github.com/grafana/dskit/crypto/tls
@@ -642,6 +642,7 @@ github.com/grafana/dskit/limiter
 github.com/grafana/dskit/middleware
 github.com/grafana/dskit/modules
 github.com/grafana/dskit/multierror
+github.com/grafana/dskit/netutil
 github.com/grafana/dskit/ring
 github.com/grafana/dskit/ring/client
 github.com/grafana/dskit/ring/shard


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the dskit version and update the Loki code so the new extra logger parameter for the RegisterFlags function of the LifecyclerConfig is given when registering the flags of the ingester.

This latest dskit version also updates the LifecyclerConfig so that only [private interfaces are used](https://github.com/grafana/dskit/pull/126). This required changes to unit tests. Additionally the private interface call was added to other rings: frontend, ruler and distributor. These do not use the LifeCycler from dskit.

The CircleCI config was updated as well because dskit now requires Go 1.17.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>