### PR TITLE
Add more context to tailer-> ingester connect error.

### DIFF
--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -172,7 +173,7 @@ func (t *Tailer) checkIngesterConnections() error {
 
 	newConnections, err := t.tailDisconnectedIngesters(connectedIngestersAddr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to connect with one or more ingester(s) during tailing: %w", err)
 	}
 
 	if len(newConnections) != 0 {


### PR DESCRIPTION


Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
NOTE: When client is tailing, Querier **has** to create grpc connections to **all** the ingesters.

Sometimes when ingester is rolloing out and Querier unable to connect to ingester when
client is tailing, then error message reported by Querier is confusing.

This PR add some context to it.

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
