### PR TITLE
Fix Azure issue where 404 not recognized

### DIFF
--- a/pkg/storage/chunk/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/azure/blob_storage_client.go
@@ -286,6 +286,13 @@ func (c *BlobStorageConfig) Validate() error {
 
 // IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
 func (b *BlobStorage) IsObjectNotFoundErr(err error) bool {
+	// Some versions of the SDK return a pointer, cover both cases
+	// to be sure
 	var e azblob.StorageError
-	return errors.As(err, &e) && e.ErrorCode == azblob.StorageErrorCodeBlobNotFound
+	if errors.As(err, &e) {
+		return e.ErrorCode == azblob.StorageErrorCodeBlobNotFound
+	}
+
+	var ep *azblob.StorageError
+	return errors.As(err, &ep) && ep.ErrorCode == azblob.StorageErrorCodeBlobNotFound
 }

--- a/pkg/storage/chunk/azure/blob_storage_client_test.go
+++ b/pkg/storage/chunk/azure/blob_storage_client_test.go
@@ -3,10 +3,13 @@ package azure
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -95,4 +98,26 @@ func Test_Hedging(t *testing.T) {
 			require.Eventually(t, func() bool { return tc.expectedCalls == count.Load() }, time.Second, time.Millisecond, "expected calls %d, got %d", tc.expectedCalls, count.Load())
 		})
 	}
+}
+
+func Test_IsObjectNotFoundErr(t *testing.T) {
+	c, err := NewBlobStorage(
+		&BlobStorageConfig{
+			AccountName: "account",
+			Environment: azureGlobal,
+			MaxRetries:  0,
+		},
+		metrics,
+		hedging.Config{})
+	require.NoError(t, err)
+
+	storageError := azblob.StorageError{
+		ErrorCode: azblob.StorageErrorCodeBlobNotFound,
+	}
+
+	err = fmt.Errorf("wrapping error %w", &storageError)
+	require.True(t, c.IsObjectNotFoundErr(err))
+
+	err = fmt.Errorf("wrapping error %w", storageError)
+	require.True(t, c.IsObjectNotFoundErr(err))
 }


### PR DESCRIPTION
In the recent Azure SDK update, the type of the wrapped `not found` error changed to a pointer and caused `errors.As` to fail. This change updates our check to cover both pointer and non-pointer cases.