### PR TITLE
promtail/targets/syslog: Enable best effort parsing for Syslog messages

### DIFF
--- a/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser.go
+++ b/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser.go
@@ -24,9 +24,9 @@ func ParseStream(r io.Reader, callback func(res *syslog.Result), maxMessageLengt
 
 	b := firstByte[0]
 	if b == '<' {
-		nontransparent.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength)).Parse(buf)
+		nontransparent.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
 	} else if b >= '0' && b <= '9' {
-		octetcounting.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength)).Parse(buf)
+		octetcounting.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
 	} else {
 		return fmt.Errorf("invalid or unsupported framing. first byte: '%s'", firstByte)
 	}

--- a/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
@@ -435,7 +435,7 @@ func testSyslogTargetWithTLS(t *testing.T, octetCounting bool) {
 		`<165>1    -   An application event log entry...`,
 		`<165>1 2018-10-11T22:14:15.007Z host5 e -   An application event log entry...`,
 	}
-	messages := append(malformeddMessages,validMessages...)
+	messages := append(malformeddMessages, validMessages...)
 
 	err = writeMessagesToStream(c, messages, octetCounting)
 	require.NoError(t, err)

--- a/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
@@ -424,19 +424,26 @@ func testSyslogTargetWithTLS(t *testing.T, octetCounting bool) {
 	c, err := tls.Dial("tcp", addr, &tlsConfig)
 	require.NoError(t, err)
 
-	messages := []string{
+	validMessages := []string{
 		`<165>1 2018-10-11T22:14:15.003Z host5 e - id1 [custom@32473 exkey="1"] An application event log entry...`,
 		`<165>1 2018-10-11T22:14:15.005Z host5 e - id2 [custom@32473 exkey="2"] An application event log entry...`,
 		`<165>1 2018-10-11T22:14:15.007Z host5 e - id3 [custom@32473 exkey="3"] An application event log entry...`,
 	}
+	// Messages that are malformed but still valid.
+	// This causes error messages being written, but the parser does not stop and close the connection.
+	malformeddMessages := []string{
+		`<165>1    -   An application event log entry...`,
+		`<165>1 2018-10-11T22:14:15.007Z host5 e -   An application event log entry...`,
+	}
+	messages := append(malformeddMessages,validMessages...)
 
 	err = writeMessagesToStream(c, messages, octetCounting)
 	require.NoError(t, err)
 	require.NoError(t, c.Close())
 
 	require.Eventuallyf(t, func() bool {
-		return len(client.Received()) == len(messages)
-	}, time.Second, time.Millisecond, "Expected to receive %d messages, got %d.", len(messages), len(client.Received()))
+		return len(client.Received()) == len(validMessages)
+	}, time.Second, time.Millisecond, "Expected to receive %d messages, got %d.", len(validMessages), len(client.Received()))
 
 	require.Equal(t, model.LabelSet{
 		"test": "syslog_target",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This change enables best effort parsing for Syslog messages in the Syslog target within Promtail.
Right now, a malformed message will stop the syslog parser. However, the criteria for a message to be considered "valid" is [very low](https://github.com/grafana/loki/blob/b4bb8a1a46b4c1d1e234ee9f2f688435e5d455bc/vendor/github.com/influxdata/go-syslog/v3/rfc5424/syslog_message.go#L88).
By using the best effort option, a malformed or partially parsed message will not stop the parsing loop anymore, which otherwise would eventually close the TCP connection.
Parsing errors will still be logged and tracked in metrics.
Malformed messages will not be passed back to Promtail.  

**Which issue(s) this PR fixes**:
Fixes #5395
Fixes #4270

Also presumably:
Fixes #4871
Fixes #4808 

**Special notes for your reviewer**:

Just checked this in our setup and was able to verify that this change indeed fixes TCP connection problems in Rsyslog (with error -2027).

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
