### PR TITLE
Build: simplify make targets to just run every time

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -353,7 +353,7 @@ local manifest(apps) = pipeline('manifest') {
         image: 'koalaman/shellcheck-alpine:stable',
         commands: ['apk add make bash && make lint-scripts'],
       },
-      make('loki', container=false) { depends_on: ['clone'] },
+      make('loki', container=false) { depends_on: ['clone', 'check-generated-files'] },
       make('validate-example-configs', container=false) { depends_on: ['loki'] },
       make('check-example-config-doc', container=false) { depends_on: ['clone'] },
     ],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -77,6 +77,7 @@ steps:
   - make BUILD_IN_CONTAINER=false loki
   depends_on:
   - clone
+  - check-generated-files
   image: grafana/loki-build-image:0.20.0
   name: loki
 - commands:
@@ -1064,6 +1065,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: ca18b0336abbfa2af076bcf301c13450ce1a8cdad68b0d7c4a5a3e6fbb6a3140
+hmac: 6d010031b5c18947ac4710106d06f119e77d715ddc687983227700254b27e6d8
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,6 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 # 'make: Entering directory '/src/loki' phase.
 DONT_FIND := -name tools -prune -o -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o
 
-# These are all the application files, they are included in the various binary rules as dependencies
-# to make sure binaries are rebuilt if any source files change.
-GO_FILES := $(shell find . $(DONT_FIND) -name cmd -prune -o -type f -name '*.go' -print)
-
 # Build flags
 VPREFIX := github.com/grafana/loki/pkg/util/build
 GO_LDFLAGS   := -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
**What this PR does / why we need it**:

If I had a dollar for every time we had build failures related to file modified times and `make`.....

This PR removes any dependant targets from our binary build commands such that they run every time, I'm tired of chasing down weird modified time bugs related to git checkouts and file changes because git doesn't store timestamps and thus this functionality in make is extremely brittle and wastes more time than it ever saved.

We have separate checks in our CI to make sure generated assests are regenerated if they are changed, we don't need to do that as part of something like `make loki`


NOTE: While troubleshooting what turned out to be a drone issue, I also removed all the `mod=vendor` stuff we had in place to work through the migration of go from versions 1.13-1.16 which I'm about 99% sure isn't necessary anymore.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
