### PR TITLE
Fix two remote_timeout configs in ingester_client block

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1006,10 +1006,11 @@ pool_config:
   # How quickly a dead client will be removed after it has been detected
   # to disappear. Set this to a value to allow time for a secondary
   # health check to recover the missing client.
-  [remotetimeout: <duration>]
+  # CLI flag: -ingester.client.healthcheck-timeout
+  [remote_timeout: <duration>]
 
 # The remote request timeout on the client side.
-# CLI flag: -ingester.client.healthcheck-timeout
+# CLI flag: -ingester.client.timeout
 [remote_timeout: <duration> | default = 5s]
 
 # Configures how the gRPC connection to ingesters work as a client

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1007,7 +1007,7 @@ pool_config:
   # to disappear. Set this to a value to allow time for a secondary
   # health check to recover the missing client.
   # CLI flag: -ingester.client.healthcheck-timeout
-  [remote_timeout: <duration>]
+  [remote_timeout: <duration> | default = 1s]
 
 # The remote request timeout on the client side.
 # CLI flag: -ingester.client.timeout

--- a/pkg/distributor/clientpool/ingester_client_pool.go
+++ b/pkg/distributor/clientpool/ingester_client_pool.go
@@ -21,7 +21,7 @@ var clients = promauto.NewGauge(prometheus.GaugeOpts{
 type PoolConfig struct {
 	ClientCleanupPeriod  time.Duration `yaml:"client_cleanup_period"`
 	HealthCheckIngesters bool          `yaml:"health_check_ingesters"`
-	RemoteTimeout        time.Duration `yaml:"-"`
+	RemoteTimeout        time.Duration `yaml:"remote_timeout"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

1. Expose `remote_timeout` under `pool_config` block in yaml config file, as expected in documentation.
2. Fix mismatched flags `-ingester.client.healthcheck-timeout` and `-ingester.client.timeout` in documentation.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

`remotetimeout` inside `pool_config` has been renamed to `remote_timeout`. This change does not affect any previous config file, since `remotetimeout` has never been actually exposed in yaml before.

loki-local-config.yaml:
```
ingester_client:
  pool_config:
    remotetimeout: 1s

auth_enabled: false
...
```
Running with latest version:
```
> loki -config.file=./loki-local-config.yaml
failed parsing config: ./loki-local-config.yaml: yaml: unmarshal errors:
  line 3: field remotetimeout not found in type distributor.PoolConfig
```

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
