### PR TITLE
Fix circular dependencies on k3d desployment

### DIFF
--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -2,9 +2,10 @@
 
 IMAGE_TAG := $(shell ../../../tools/image-tag)
 REGISTRY_PORT ?= 45629
+CLUSTER_NAME := "loki-distributed"
 
 loki-distributed: prepare
-	$(CURDIR)/scripts/create_cluster.sh "loki-distributed"
+	$(CURDIR)/scripts/create_cluster.sh $(CLUSTER_NAME)
 
 down:
 	k3d cluster delete loki-distributed
@@ -19,7 +20,27 @@ update-repos: add-repos
 	tk tool charts vendor
 	jb update
 
-prepare: update-repos build-latest-image
+create-registry:
+	@if ! k3d registry list | grep -q -m 1 grafana; then \
+		echo "Creating registry"; \
+		k3d registry create grafana --port $(REGISTRY_PORT); \
+	else \
+		echo "Registry already exists"; \
+	fi
+
+create-cluster:
+	@if ! k3d cluster list | grep -q -m 1 $(CLUSTER_NAME); then \
+		echo "Creating cluster"; \
+		k3d cluster create $(CLUSTER_NAME) \
+			--servers 1 \
+			--agents 3 \
+			--registry-use "k3d-grafana:$(REGISTRY_PORT)" \
+			--wait; \
+	else \
+		echo "Cluster already exists"; \
+	fi
+
+prepare: create-registry create-cluster update-repos build-latest-image
 
 build-latest-image:
 	make -C $(CURDIR)/../../.. loki-image

--- a/tools/dev/k3d/scripts/create_cluster.sh
+++ b/tools/dev/k3d/scripts/create_cluster.sh
@@ -6,20 +6,6 @@ k3d_dir="$(cd "${current_dir}/.." && pwd)"
 cluster_name="$1"
 namespace="k3d-${cluster_name}"
 environment="${k3d_dir}/environments/${cluster_name}"
-registry_port="${REGISTRY_PORT:-45629}"
-
-if k3d registry list | grep -q -m 1 k3d-grafana; then
-	k3d registry create k3d-grafana \
-		--port "${registry_port}"
-fi
-
-if k3d cluster list | grep -q -m 1 "${cluster_name}"; then
-	k3d cluster create "${cluster_name}" \
-		--servers 1 \
-		--agents 3 \
-		--registry-use "k3d-grafana:${registry_port}" \
-		--wait
-fi
 
 tk env set "${environment}" \
 	--server="https://0.0.0.0:$(k3d node list -o json | jq -r ".[] | select(.name == \"k3d-${cluster_name}-serverlb\") | .portMappings.\"6443\"[] | .HostPort")" \
@@ -27,7 +13,7 @@ tk env set "${environment}" \
 
 kubectl config set-context "${namespace}"
 
-if kubectl get namespaces | grep -q -m 1 "${namespace}"; then
+if ! kubectl get namespaces | grep -q -m 1 "${namespace}"; then
 	kubectl create namespace "${namespace}" || true
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes circular dependencies in the `loki-distributed` make target.

**Special notes for your reviewer**:
When running `make loki-distributed` the following error was prtiented:
```
Get "http://k3d-grafana:45629/v2/": dial tcp 127.0.0.1:45629: connect: connection refused
```

This is due to the `loki-distributed` make target depending on the `prepare` target which will try to push the loki image to the `k3d-grafana` container registry.

Problem is, that would only work if the `k3d-grafana` cluster is already created. Which is not since it’s created on the `create_cluster.sh` script which will be run after the `prepare`  target.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
