### PR TITLE
Correctly sets hash value for headblock iterator

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1015,6 +1015,7 @@ func (hb *headBlock) Iterator(ctx context.Context, direction logproto.Direction,
 		if stream, ok = streams[lhash]; !ok {
 			stream = &logproto.Stream{
 				Labels: parsedLbs.String(),
+				Hash:   lhash,
 			}
 			streams[lhash] = stream
 		}
@@ -1062,8 +1063,9 @@ func (hb *headBlock) SampleIterator(ctx context.Context, mint, maxt int64, extra
 		lhash := parsedLabels.Hash()
 		if s, found = series[lhash]; !found {
 			s = &logproto.Series{
-				Labels:  parsedLabels.String(),
-				Samples: SamplesPool.Get(len(hb.entries)).([]logproto.Sample)[:0],
+				Labels:     parsedLabels.String(),
+				Samples:    SamplesPool.Get(len(hb.entries)).([]logproto.Sample)[:0],
+				StreamHash: lhash,
 			}
 			series[lhash] = s
 		}

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -215,7 +215,6 @@ func (hb *unorderedHeadBlock) Iterator(
 	maxt int64,
 	pipeline log.StreamPipeline,
 ) iter.EntryIterator {
-
 	// We are doing a copy everytime, this is because b.entries could change completely,
 	// the alternate would be that we allocate a new b.entries everytime we cut a block,
 	// but the tradeoff is that queries to near-realtime data would be much lower than
@@ -238,6 +237,7 @@ func (hb *unorderedHeadBlock) Iterator(
 			if stream, ok = streams[lhash]; !ok {
 				stream = &logproto.Stream{
 					Labels: parsedLbs.String(),
+					Hash:   lhash,
 				}
 				streams[lhash] = stream
 			}
@@ -267,7 +267,6 @@ func (hb *unorderedHeadBlock) SampleIterator(
 	maxt int64,
 	extractor log.StreamSampleExtractor,
 ) iter.SampleIterator {
-
 	series := map[uint64]*logproto.Series{}
 
 	_ = hb.forEntries(
@@ -285,8 +284,9 @@ func (hb *unorderedHeadBlock) SampleIterator(
 			lhash := parsedLabels.Hash()
 			if s, found = series[lhash]; !found {
 				s = &logproto.Series{
-					Labels:  parsedLabels.String(),
-					Samples: SamplesPool.Get(hb.lines).([]logproto.Sample)[:0],
+					Labels:     parsedLabels.String(),
+					Samples:    SamplesPool.Get(hb.lines).([]logproto.Sample)[:0],
+					StreamHash: parsedLabels.Hash(),
 				}
 				series[lhash] = s
 			}

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -262,15 +262,17 @@ func TestSeriesRecoveryNoDuplicates(t *testing.T) {
 	}, &result)
 	require.NoError(t, err)
 	require.Len(t, result.resps, 1)
+	lbls := labels.Labels{{Name: "bar", Value: "baz1"}, {Name: "foo", Value: "bar"}}
 	expected := []logproto.Stream{
 		{
-			Labels: `{bar="baz1", foo="bar"}`,
+			Labels: lbls.String(),
 			Entries: []logproto.Entry{
 				{
 					Timestamp: time.Unix(1, 0),
 					Line:      "line 1",
 				},
 			},
+			Hash: lbls.Hash(),
 		},
 	}
 	require.Equal(t, expected, result.resps[0].Streams)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

When doing https://github.com/grafana/loki/pull/5289/files I actually missed to properly set the hash for headblocks.

This result in ingesters not sending the hash for really fresh data (uncut block) and so queriers will not dedupe accordingly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
