### PR TITLE
Tsdb/idempotent builder

### DIFF
--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -34,7 +34,6 @@ func (b *Builder) AddSeries(ls labels.Labels, chks []ChunkMeta) {
 			labels: ls,
 		}
 		b.streams[id] = s
-		return
 	}
 
 	s.chunks = append(s.chunks, chks...)

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -17,6 +17,11 @@ type Builder struct {
 	streams map[string]*stream
 }
 
+type stream struct {
+	labels labels.Labels
+	chunks []ChunkMeta
+}
+
 func NewBuilder() *Builder {
 	return &Builder{streams: make(map[string]*stream)}
 }
@@ -29,6 +34,7 @@ func (b *Builder) AddSeries(ls labels.Labels, chks []ChunkMeta) {
 			labels: ls,
 		}
 		b.streams[id] = s
+		return
 	}
 
 	s.chunks = append(s.chunks, chks...)
@@ -81,9 +87,4 @@ func (b *Builder) Build(ctx context.Context, dir string) error {
 	}
 
 	return writer.Close()
-}
-
-type stream struct {
-	labels labels.Labels
-	chunks []ChunkMeta
 }

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -19,7 +19,7 @@ type Builder struct {
 
 type stream struct {
 	labels labels.Labels
-	chunks []ChunkMeta
+	chunks ChunkMetas
 }
 
 func NewBuilder() *Builder {
@@ -81,7 +81,7 @@ func (b *Builder) Build(ctx context.Context, dir string) error {
 
 	// Add series
 	for i, s := range streams {
-		if err := writer.AddSeries(storage.SeriesRef(i), s.labels, s.chunks...); err != nil {
+		if err := writer.AddSeries(storage.SeriesRef(i), s.labels, s.chunks.finalize()...); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -28,16 +28,12 @@ func (c ChunkMetas) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 // Sort by (MinTime, MaxTime, Checksum)
 func (c ChunkMetas) Less(i, j int) bool {
 	a, b := c[i], c[j]
-	if a.MinTime < b.MinTime {
-		return true
-	} else if a.MinTime > b.MinTime {
-		return false
+	if a.MinTime != b.MinTime {
+		return a.MinTime < b.MinTime
 	}
 
-	if a.MaxTime < b.MaxTime {
-		return true
-	} else if a.MaxTime > b.MaxTime {
-		return false
+	if a.MaxTime != b.MaxTime {
+		return a.MaxTime < b.MaxTime
 	}
 
 	return a.Checksum < b.Checksum

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -56,7 +56,7 @@ func (c ChunkMetas) finalize() ChunkMetas {
 	// minimize reslicing costs due to duplicates
 	for i := 1; i < len(c); i++ {
 		x := c[i]
-		if x.Checksum == prior.Checksum {
+		if x.MinTime == prior.MinTime && x.MaxTime == prior.MaxTime && x.Checksum == prior.Checksum {
 			res = append(res, c[lastDuplicate+1:i]...)
 			lastDuplicate = i
 		}

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -15,3 +15,26 @@ type ChunkMeta struct {
 
 	Entries uint32
 }
+
+type ChunkMetas []ChunkMeta
+
+func (c ChunkMetas) Len() int      { return len(c) }
+func (c ChunkMetas) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+
+// Sort by (MinTime, MaxTime, Checksum)
+func (c ChunkMetas) Less(i, j int) bool {
+	a, b := c[i], c[j]
+	if a.MinTime < b.MinTime {
+		return true
+	} else if a.MinTime > b.MinTime {
+		return false
+	}
+
+	if a.MaxTime < b.MaxTime {
+		return true
+	} else if a.MaxTime > b.MaxTime {
+		return false
+	}
+
+	return a.Checksum < b.Checksum
+}

--- a/pkg/storage/tsdb/index/chunk_test.go
+++ b/pkg/storage/tsdb/index/chunk_test.go
@@ -1,0 +1,53 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test all sort variants
+func TestChunkMetasSort(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		a, b ChunkMeta
+	}{
+		{
+			desc: "prefer mintime",
+			a: ChunkMeta{
+				MinTime: 0,
+				MaxTime: 5,
+			},
+			b: ChunkMeta{
+				MinTime: 1,
+				MaxTime: 4,
+			},
+		},
+		{
+			desc: "delegate maxtime",
+			a: ChunkMeta{
+				MaxTime:  2,
+				Checksum: 2,
+			},
+			b: ChunkMeta{
+				MaxTime:  3,
+				Checksum: 1,
+			},
+		},
+		{
+			desc: "delegate checksum",
+			a: ChunkMeta{
+				Checksum: 1,
+			},
+			b: ChunkMeta{
+				Checksum: 2,
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			xs := ChunkMetas{tc.a, tc.b}
+			require.Equal(t, true, xs.Less(0, 1))
+			require.Equal(t, false, xs.Less(1, 0))
+		})
+	}
+}

--- a/pkg/storage/tsdb/index/chunk_test.go
+++ b/pkg/storage/tsdb/index/chunk_test.go
@@ -51,3 +51,91 @@ func TestChunkMetasSort(t *testing.T) {
 		})
 	}
 }
+
+func TestChunkMetasFinalize(t *testing.T) {
+	mkMeta := func(x int) ChunkMeta {
+		return ChunkMeta{
+			MinTime:  int64(x),
+			Checksum: uint32(x),
+		}
+	}
+	for _, tc := range []struct {
+		desc          string
+		input, output ChunkMetas
+	}{
+		{
+			desc: "reorder",
+			input: []ChunkMeta{
+				mkMeta(2),
+				mkMeta(1),
+				mkMeta(3),
+			},
+			output: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(3),
+			},
+		},
+		{
+			desc: "remove duplicates",
+			input: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(2),
+				mkMeta(3),
+			},
+			output: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(3),
+			},
+		},
+		{
+			desc: "remove trailing duplicates",
+			input: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(2),
+				mkMeta(3),
+				mkMeta(4),
+				mkMeta(4),
+				mkMeta(5),
+				mkMeta(5),
+			},
+			output: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(3),
+				mkMeta(4),
+				mkMeta(5),
+			},
+		},
+		{
+			desc: "cleanup after last duplicate",
+			input: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(2),
+				mkMeta(3),
+				mkMeta(4),
+				mkMeta(5),
+				mkMeta(5),
+				mkMeta(6),
+				mkMeta(7),
+			},
+			output: []ChunkMeta{
+				mkMeta(1),
+				mkMeta(2),
+				mkMeta(3),
+				mkMeta(4),
+				mkMeta(5),
+				mkMeta(6),
+				mkMeta(7),
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.output, tc.input.finalize())
+		})
+	}
+}


### PR DESCRIPTION
Ensures the Index builder utility reorders and dedupes chunkmetas within each series before writing the index.