### PR TITLE
set match_max_concurrent true by default

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -971,7 +971,7 @@ The `frontend_worker` configures the worker - running within the Loki querier - 
 
 # Force worker concurrency to match the -querier.max-concurrent option. Overrides querier.worker-parallelism.
 # CLI flag: -querier.worker-match-max-concurrent
-[match_max_concurrent: <boolean> | default = false]
+[match_max_concurrent: <boolean> | default = true]
 
 # How often to query the frontend_address DNS to resolve frontend addresses.
 # Also used to determine how often to poll the scheduler-ring for addresses if configured.

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -88,7 +88,7 @@ Meanwhile, the legacy format is a string in the following format:
 
 The body of HTTP error responses from API endpoints changed from plain text to
 JSON. The `Content-Type` header was previously already set incorrectly to
-`application/json`. Therefore returning JSON fixes this incosistency
+`application/json`. Therefore returning JSON fixes this inconsistency.
 
 The response body has the following schema:
 
@@ -102,11 +102,12 @@ The response body has the following schema:
 
 #### Changes to default configuration values
 
-* `parallelise_shardable_queries` under the Query Range config now defaults to `true`, it was `false`.
-* `split_queries_by_interval` under the Query Range config now defaults to `30m`, it was `0s`.
-* `max_chunk_age` for the Ingester now defaults to `2h` instead of `1h`.
-* `query_ingesters_within` under the Queier config now defaults to `3h`, it was previously set to 0, meaning always query ingesters.
-* `max_concurrent` under the Querier config now defaults to `10` instead of `20`, since is should be the same as the Frontend Worker's `parallelism` setting (which is `10`).
+* `parallelise_shardable_queries` under the `query_range` config now defaults to `true`.
+* `split_queries_by_interval` under the `limits_config` config now defaults to `30m`, it was `0s`.
+* `max_chunk_age` in the `ingester` config now defaults to `2h` previously it was `1h`.
+* `query_ingesters_within` under the `querier` config now defaults to `3h`, previously it was `0s`. Any query (or subquery) that has an end time more than `3h` ago will not be sent to the ingesters, this saves work on the ingesters for data they normally don't contain. If you regularly write old data to Loki you may need to return this value to `0s` to always query ingesters. 
+* `max_concurrent` under the `querier` config now defaults to `10` instead of `20`.
+* `match_max_concurrent` under the `frontend_worker` config now defaults to true, this supersedes the `parallelism` setting which can now be removed from your config. Controlling query parallelism of a single process can now be done with the `querier` `max_concurrent` setting.
 
 ### Promtail
 

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -42,7 +42,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.DNSLookupPeriod, "querier.dns-lookup-period", 3*time.Second, "How often to query DNS for query-frontend or query-scheduler address. Also used to determine how often to poll the scheduler-ring for addresses if the scheduler-ring is configured.")
 
 	f.IntVar(&cfg.Parallelism, "querier.worker-parallelism", 10, "Number of simultaneous queries to process per query-frontend or query-scheduler.")
-	f.BoolVar(&cfg.MatchMaxConcurrency, "querier.worker-match-max-concurrent", false, "Force worker concurrency to match the -querier.max-concurrent option. Overrides querier.worker-parallelism.")
+	f.BoolVar(&cfg.MatchMaxConcurrency, "querier.worker-match-max-concurrent", true, "Force worker concurrency to match the -querier.max-concurrent option. Overrides querier.worker-parallelism.")
 	f.StringVar(&cfg.QuerierID, "querier.id", "", "Querier ID, sent to frontend service to identify requests from the same querier. Defaults to hostname.")
 
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-client", f)


### PR DESCRIPTION
Signed-off-by: Edward Welch <edward.welch@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

We enable parallelism by default now it makes sense to me to enable `match_max_concurrent: true` by default such that to control a queriers parallelism you only need to adjust:

```
querier:
  max_concurrent: 10
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
