### PR TITLE
Change default installation namespace on OpenShift

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -12,10 +12,10 @@ default: all
 # Updates this value when a new version of the product should include this operator and its bundle.
 CLUSTER_LOGGING_VERSION ?= 5.1.preview.1
 
-# CLUSTER_LOGGING_NS
-# defines the default namespace of the OpenShift Cluster Logging product.
+# LOKI_OPERATOR_NS
+# defines the default namespace of the Loki Operator in OpenShift.
 # Loki Operator will be installed in this namespace.
-CLUSTER_LOGGING_NS ?= openshift-operators-redhat
+LOKI_OPERATOR_NS ?= openshift-operators-redhat
 
 # VERSION
 # defines the project version for the bundle.
@@ -179,15 +179,15 @@ olm-deploy:  ## Deploy the operator bundle and the operator via OLM into an Kube
 	$(error Set variable REGISTRY_ORG to use a custom container registry org account for local development)
 else
 olm-deploy: olm-deploy-bundle olm-deploy-operator $(OPERATOR_SDK)
-	kubectl create ns $(CLUSTER_LOGGING_NS)
-	kubectl label ns/$(CLUSTER_LOGGING_NS) openshift.io/cluster-monitoring=true --overwrite
-	$(OPERATOR_SDK) run bundle -n $(CLUSTER_LOGGING_NS) --install-mode OwnNamespace $(BUNDLE_IMG)
+	kubectl create ns $(LOKI_OPERATOR_NS)
+	kubectl label ns/$(LOKI_OPERATOR_NS) openshift.io/cluster-monitoring=true --overwrite
+	$(OPERATOR_SDK) run bundle -n $(LOKI_OPERATOR_NS) --install-mode OwnNamespace $(BUNDLE_IMG)
 endif
 
 .PHONY: olm-undeploy
 olm-undeploy: $(OPERATOR_SDK) ## Cleanup deployments of the operator bundle and the operator via OLM on an OpenShift cluster selected via KUBECONFIG.
 	$(OPERATOR_SDK) cleanup loki-operator
-	kubectl delete ns $(CLUSTER_LOGGING_NS)
+	kubectl delete ns $(LOKI_OPERATOR_NS)
 
 .PHONY: deploy-size-calculator
 ifeq ($(findstring openshift-logging,$(CALCULATOR_IMG)),openshift-logging)

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -14,7 +14,8 @@ CLUSTER_LOGGING_VERSION ?= 5.1.preview.1
 
 # CLUSTER_LOGGING_NS
 # defines the default namespace of the OpenShift Cluster Logging product.
-CLUSTER_LOGGING_NS ?= openshift-logging
+# Loki Operator will be installed in this namespace.
+CLUSTER_LOGGING_NS ?= openshift-operators-redhat
 
 # VERSION
 # defines the project version for the bundle.

--- a/operator/docs/forwarding_logs_to_gateway.md
+++ b/operator/docs/forwarding_logs_to_gateway.md
@@ -36,7 +36,7 @@ metadata:
   name: lokistack-dev-tenant-logs-role
 rules:
 - apiGroups:
-  - 'loki.openshift.io'
+  - 'loki.grafana.com'
   resources:
   - application
   - infrastructure

--- a/operator/docs/hack_loki_operator.md
+++ b/operator/docs/hack_loki_operator.md
@@ -93,12 +93,12 @@ It will undeploy controller from the configured Kubernetes cluster in [~/.kube/c
 
   where `$YOUR_QUAY_ORG` is your personal [quay.io](http://quay.io/) account where you can push container images and `$VERSION` can be any random version number such as `v0.0.1`.
 
-  The above command will deploy the operator to your active Openshift cluster defined by your local [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/). The operator will be running in the `openshift-logging` namespace.
+  The above command will deploy the operator to your active Openshift cluster defined by your local [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/). The operator will be running in the `openshift-operators-redhat` namespace.
 
 * You can confirm that the operator is up and running using:
 
   ```console
-  kubectl -n openshift-logging get pods
+  kubectl -n openshift-operators-redhat get pods
   ```
 
 * Now you need to create a storage secret for the operator. This can be done using:
@@ -157,7 +157,7 @@ It will undeploy controller from the configured Kubernetes cluster in [~/.kube/c
   If you don't want `lokistack-gateway` component [1] then you can skip it by removing the `--with-lokistack-gateway` args from the `loki-operator-controller-manager` deployment:
 
   ```console
-  kubectl -n openshift-logging edit deployment/loki-operator-controller-manager
+  kubectl -n openshift-operators-redhat edit deployment/loki-operator-controller-manager
   ```
 
   Delete the flag `--with-lokistack-gateway` from the `args` section and save the file. This will update the deployment and now you can create LokiStack instance using:

--- a/operator/docs/hack_loki_operator.md
+++ b/operator/docs/hack_loki_operator.md
@@ -101,6 +101,12 @@ It will undeploy controller from the configured Kubernetes cluster in [~/.kube/c
   kubectl -n openshift-operators-redhat get pods
   ```
 
+* Next step is to create the `openshift-logging` namespace in the cluster:
+
+  ```console
+  kubectl create ns openshift-logging
+  ```
+
 * Now you need to create a storage secret for the operator. This can be done using:
 
   ```console

--- a/operator/docs/hack_operator_make_run.md
+++ b/operator/docs/hack_operator_make_run.md
@@ -130,14 +130,16 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
 * Now you need to create a storage secret for the operator. This can be done using:
 
   ```console
-  ./hack/deploy-aws-storage-secret.sh <BUCKET_NAME>
+  make olm-deploy-example-storage-secret
   ```
 
-  This secret will be available in `openshift-logging` namespace. You can check the `hack/deploy-aws-storage-secret.sh` file to check the content of the secret. By default, the script will pull credential information using the `aws` cli. However, these values can be overwritten. For example:
+  OR
 
   ```console
-  REGION=us-west-1 ./hack/deploy-aws-storage-secret.sh <BUCKET_NAME>
+  ./hack/deploy-example-secret.sh openshift-logging
   ```
+
+  This secret will be available in openshift-logging namespace. You can check the `hack/deploy-example-secret.sh` file to check the content of the secret.
 
 * Once the object storage secret is created, you can now create a LokiStack instance:
 

--- a/operator/docs/hack_operator_make_run.md
+++ b/operator/docs/hack_operator_make_run.md
@@ -130,16 +130,14 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
 * Now you need to create a storage secret for the operator. This can be done using:
 
   ```console
-  make olm-deploy-example-storage-secret
+  ./hack/deploy-aws-storage-secret.sh <BUCKET_NAME>
   ```
 
-  OR
+  This secret will be available in `openshift-logging` namespace. You can check the `hack/deploy-aws-storage-secret.sh` file to check the content of the secret. By default, the script will pull credential information using the `aws` cli. However, these values can be overwritten. For example:
 
   ```console
-  ./hack/deploy-example-secret.sh openshift-logging
+  REGION=us-west-1 ./hack/deploy-aws-storage-secret.sh <BUCKET_NAME>
   ```
-
-  This secret will be available in openshift-logging namespace. You can check the `hack/deploy-example-secret.sh` file to check the content of the secret.
 
 * Once the object storage secret is created, you can now create a LokiStack instance:
 

--- a/operator/docs/storage_size_calculator.md
+++ b/operator/docs/storage_size_calculator.md
@@ -17,6 +17,12 @@ Storage Size Calculator is used to have an idea on how to properly size a Loki c
 
 * Deploy the [Loki Operator](https://github.com/grafana/loki/blob/master/operator/docs/hack_loki_operator.md#hacking-on-loki-operator-on-openshift) to the cluster.
 
+* Create the `openshift-logging` namespace in the cluster:
+
+  ```console
+  kubectl create ns openshift-logging
+  ```
+
 * Deploy the storage size calculator by executing following command in the terminal:
 
   ```console

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -203,9 +203,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.listen=:8082",
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",
-										`--openshift.mappings=application=loki.openshift.io`,
-										`--openshift.mappings=infrastructure=loki.openshift.io`,
-										`--openshift.mappings=audit=loki.openshift.io`,
+										`--openshift.mappings=application=loki.grafana.com`,
+										`--openshift.mappings=infrastructure=loki.grafana.com`,
+										`--openshift.mappings=audit=loki.grafana.com`,
 									},
 									Ports: []corev1.ContainerPort{
 										{
@@ -298,9 +298,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.healthchecks.url=http://localhost:8082",
 										"--tls.internal.server.cert-file=/var/run/tls/tls.crt",
 										"--tls.internal.server.key-file=/var/run/tls/tls.key",
-										`--openshift.mappings=application=loki.openshift.io`,
-										`--openshift.mappings=infrastructure=loki.openshift.io`,
-										`--openshift.mappings=audit=loki.openshift.io`,
+										`--openshift.mappings=application=loki.grafana.com`,
+										`--openshift.mappings=infrastructure=loki.grafana.com`,
+										`--openshift.mappings=audit=loki.grafana.com`,
 									},
 									Ports: []corev1.ContainerPort{
 										{
@@ -435,9 +435,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.healthchecks.url=http://localhost:8082",
 										"--tls.internal.server.cert-file=/var/run/tls/tls.crt",
 										"--tls.internal.server.key-file=/var/run/tls/tls.key",
-										`--openshift.mappings=application=loki.openshift.io`,
-										`--openshift.mappings=infrastructure=loki.openshift.io`,
-										`--openshift.mappings=audit=loki.openshift.io`,
+										`--openshift.mappings=application=loki.grafana.com`,
+										`--openshift.mappings=infrastructure=loki.grafana.com`,
+										`--openshift.mappings=audit=loki.grafana.com`,
 									},
 									Ports: []corev1.ContainerPort{
 										{

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -14,7 +14,7 @@ const (
 	defaultOPAImage    = "quay.io/observatorium/opa-openshift:latest"
 	opaContainerName   = "opa"
 	opaDefaultPackage  = "lokistack"
-	opaDefaultAPIGroup = "loki.openshift.io"
+	opaDefaultAPIGroup = "loki.grafana.com"
 	opaMetricsPortName = "opa-metrics"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
- updates the default namespace for openshift to `openshift-operators-redhat`.
- updates the reference from `loki.openshift.io` -> `loki.grafana.com`

**Which issue(s) this PR fixes**:
Fixes #5440 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
