### PR TITLE
Do not insert missing point when sharding

### DIFF
--- a/pkg/logql/matrix.go
+++ b/pkg/logql/matrix.go
@@ -44,13 +44,6 @@ func (m *MatrixStepper) Next() (bool, int64, promql.Vector) {
 		ln := len(series.Points)
 
 		if ln == 0 || series.Points[0].T != ts {
-			vec = append(vec, promql.Sample{
-				Point: promql.Point{
-					T: ts,
-					V: 0,
-				},
-				Metric: series.Metric,
-			})
 			continue
 		}
 

--- a/pkg/logql/matrix_test.go
+++ b/pkg/logql/matrix_test.go
@@ -45,19 +45,11 @@ func TestMatrixStepper(t *testing.T) {
 				Point:  promql.Point{T: start.UnixNano(), V: 0},
 				Metric: labels.Labels{{Name: "foo", Value: "bar"}},
 			},
-			promql.Sample{
-				Point:  promql.Point{T: start.UnixNano(), V: 0},
-				Metric: labels.Labels{{Name: "bazz", Value: "buzz"}},
-			},
 		},
 		{
 			promql.Sample{
 				Point:  promql.Point{T: start.Add(step).UnixNano() / int64(time.Millisecond), V: 1},
 				Metric: labels.Labels{{Name: "foo", Value: "bar"}},
-			},
-			promql.Sample{
-				Point:  promql.Point{T: start.Add(step).UnixNano() / int64(time.Millisecond), V: 0},
-				Metric: labels.Labels{{Name: "bazz", Value: "buzz"}},
 			},
 		},
 		{
@@ -75,10 +67,6 @@ func TestMatrixStepper(t *testing.T) {
 				Point:  promql.Point{T: start.Add(3*step).UnixNano() / int64(time.Millisecond), V: 3},
 				Metric: labels.Labels{{Name: "foo", Value: "bar"}},
 			},
-			promql.Sample{
-				Point:  promql.Point{T: start.Add(3*step).UnixNano() / int64(time.Millisecond), V: 0},
-				Metric: labels.Labels{{Name: "bazz", Value: "buzz"}},
-			},
 		},
 		{
 			promql.Sample{
@@ -95,21 +83,8 @@ func TestMatrixStepper(t *testing.T) {
 				Point:  promql.Point{T: start.Add(5*step).UnixNano() / int64(time.Millisecond), V: 5},
 				Metric: labels.Labels{{Name: "foo", Value: "bar"}},
 			},
-			promql.Sample{
-				Point:  promql.Point{T: start.Add(5*step).UnixNano() / int64(time.Millisecond), V: 0},
-				Metric: labels.Labels{{Name: "bazz", Value: "buzz"}},
-			},
 		},
-		{
-			promql.Sample{
-				Point:  promql.Point{T: start.Add(6*step).UnixNano() / int64(time.Millisecond), V: 0},
-				Metric: labels.Labels{{Name: "foo", Value: "bar"}},
-			},
-			promql.Sample{
-				Point:  promql.Point{T: start.Add(6*step).UnixNano() / int64(time.Millisecond), V: 0},
-				Metric: labels.Labels{{Name: "bazz", Value: "buzz"}},
-			},
-		},
+		{},
 	}
 
 	for i := 0; i <= int(end.Sub(start)/step); i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

I recently runs into a problem with the query-frontend where the query wasn't the right result but the querier would return the right result.

Turns out this is due to querysharding, when doing sharding we actually insert missing 0 point when stepping  on the results of each shards.

However this is wrong, zero during a min_over_time means something different, or even when dividing during a binary operations this can cause the creation of NaN.

The solution is simple we don't need to insert those points.

**Which issue(s) this PR fixes**:
Fixes #5438

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
