### PR TITLE
add a metric for tracking the duration it took to sync the tables in queriers/index-gateways

### DIFF
--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -35,8 +35,8 @@ type metrics struct {
 	// metrics for measuring performance of downloading of files per period initially i.e for the first time
 	tablesDownloadDurationSeconds *downloadTableDurationMetric
 
-	tablesSyncOperationTotal           *prometheus.CounterVec
-	tablesSyncOperationDurationSeconds prometheus.Gauge
+	tablesSyncOperationTotal               *prometheus.CounterVec
+	tablesDownloadOperationDurationSeconds prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -53,10 +53,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "tables_sync_operation_total",
 			Help:      "Total number of tables sync operations done by status",
 		}, []string{"status"}),
-		tablesSyncOperationDurationSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		tablesDownloadOperationDurationSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki_boltdb_shipper",
-			Name:      "tables_sync_operation_duration_seconds",
-			Help:      "Time (in seconds) spent in syncing all the tables",
+			Name:      "tables_download_operation_duration_seconds",
+			Help:      "Time (in seconds) spent in downloading updated files for all the tables",
 		}),
 	}
 

--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -35,7 +35,8 @@ type metrics struct {
 	// metrics for measuring performance of downloading of files per period initially i.e for the first time
 	tablesDownloadDurationSeconds *downloadTableDurationMetric
 
-	tablesSyncOperationTotal *prometheus.CounterVec
+	tablesSyncOperationTotal           *prometheus.CounterVec
+	tablesSyncOperationDurationSeconds prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -52,6 +53,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "tables_sync_operation_total",
 			Help:      "Total number of tables sync operations done by status",
 		}, []string{"status"}),
+		tablesSyncOperationDurationSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "tables_sync_operation_duration_seconds",
+			Help:      "Time (in seconds) spent in syncing all the tables",
+		}),
 	}
 
 	return m

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -185,12 +185,15 @@ func (tm *TableManager) syncTables(ctx context.Context) error {
 	tm.tablesMtx.RLock()
 	defer tm.tablesMtx.RUnlock()
 
+	start := time.Now()
 	var err error
 
 	defer func() {
 		status := statusSuccess
 		if err != nil {
 			status = statusFailure
+		} else {
+			tm.metrics.tablesSyncOperationDurationSeconds.Set(time.Since(start).Seconds())
 		}
 
 		tm.metrics.tablesSyncOperationTotal.WithLabelValues(status).Inc()

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -192,11 +192,10 @@ func (tm *TableManager) syncTables(ctx context.Context) error {
 		status := statusSuccess
 		if err != nil {
 			status = statusFailure
-		} else {
-			tm.metrics.tablesSyncOperationDurationSeconds.Set(time.Since(start).Seconds())
 		}
 
 		tm.metrics.tablesSyncOperationTotal.WithLabelValues(status).Inc()
+		tm.metrics.tablesDownloadOperationDurationSeconds.Set(time.Since(start).Seconds())
 	}()
 
 	level.Info(util_log.Logger).Log("msg", "syncing tables")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We do not have a metric tracking how long it takes to do a sync of all the tables. This PR adds the metric, which can be used for alerting if the sync operation is not happening fast enough.
