### PR TITLE
boltdb shipper index gateway client improvements

### DIFF
--- a/pkg/storage/stores/shipper/gateway_client.go
+++ b/pkg/storage/stores/shipper/gateway_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,7 +22,10 @@ import (
 	util_math "github.com/grafana/loki/pkg/util/math"
 )
 
-const maxQueriesPerGoroutine = 100
+const (
+	maxQueriesPerGrpc      = 200
+	maxConcurrentGrpcCalls = 10
+)
 
 type IndexGatewayClientConfig struct {
 	Address          string            `yaml:"server_address,omitempty"`
@@ -78,24 +82,17 @@ func (s *GatewayClient) Stop() {
 }
 
 func (s *GatewayClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error {
-	errs := make(chan error)
-
-	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
-		q := queries[i:util_math.Min(i+maxQueriesPerGoroutine, len(queries))]
-		go func(queries []chunk.IndexQuery) {
-			errs <- s.doQueries(ctx, queries, callback)
-		}(q)
+	if len(queries) <= maxQueriesPerGrpc {
+		return s.doQueries(ctx, queries, callback)
 	}
 
-	var lastErr error
-	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
-		err := <-errs
-		if err != nil {
-			lastErr = err
-		}
+	jobsCount := len(queries) / maxQueriesPerGrpc
+	if len(queries)%maxQueriesPerGrpc != 0 {
+		jobsCount++
 	}
-
-	return lastErr
+	return concurrency.ForEachJob(ctx, jobsCount, maxConcurrentGrpcCalls, func(ctx context.Context, idx int) error {
+		return s.doQueries(ctx, queries[idx*maxQueriesPerGrpc:util_math.Min((idx+1)*maxQueriesPerGrpc, len(queries))], callback)
+	})
 }
 
 func (s *GatewayClient) doQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error {

--- a/pkg/storage/stores/shipper/gateway_client.go
+++ b/pkg/storage/stores/shipper/gateway_client.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	maxQueriesPerGrpc      = 200
+	maxQueriesPerGrpc      = 100
 	maxConcurrentGrpcCalls = 10
 )
 

--- a/pkg/storage/stores/shipper/util/queries.go
+++ b/pkg/storage/stores/shipper/util/queries.go
@@ -8,7 +8,7 @@ import (
 	util_math "github.com/grafana/loki/pkg/util/math"
 )
 
-const maxQueriesPerGoroutine = 100
+const maxQueriesPerGoroutine = 200
 
 type TableQuerier interface {
 	MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error
@@ -32,7 +32,6 @@ func DoParallelQueries(ctx context.Context, tableQuerier TableQuerier, queries [
 	errs := make(chan error)
 
 	id := NewIndexDeduper(callback)
-
 	if len(queries) <= maxQueriesPerGoroutine {
 		return tableQuerier.MultiQueries(ctx, queries, id.Callback)
 	}

--- a/pkg/storage/stores/shipper/util/queries.go
+++ b/pkg/storage/stores/shipper/util/queries.go
@@ -8,7 +8,7 @@ import (
 	util_math "github.com/grafana/loki/pkg/util/math"
 )
 
-const maxQueriesPerGoroutine = 200
+const maxQueriesPerGoroutine = 100
 
 type TableQuerier interface {
 	MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error


### PR DESCRIPTION
**What this PR does / why we need it**:
We do an unbounded number of concurrent grpc calls from the index gateway clients and limit just the number of queries per grpc call to 100. If a large number of queries are made then the number of concurrent grpc calls go high as well. For 1M queries, we would do 10K grpc calls concurrently. This causes the index gateway server to be overwhelmed and possibly a lot of contention on the client as well.

This PR improves it by doing the following changes:
* Bound the number of concurrent grpc calls being made by index gateway clients to 10.
* Increase the max queries per grpc calls from index gateway client and max concurrent query processing in index gateway servers to 200.

These changes let us performance gains of about 60% as per the benchmark doing 1M queries:
```
benchmark                    old ns/op      new ns/op      delta
Benchmark_MultiQueries-8     7798108907     2991646469     -61.64%

benchmark                    old allocs     new allocs     delta
Benchmark_MultiQueries-8     47906005       46383858       -3.18%

benchmark                    old bytes      new bytes      delta
Benchmark_MultiQueries-8     2694492664     2626628264     -2.52%
```

Huge thanks to @cyriltovena for all the help!
