### PR TITLE
Disable sharding of count/avg when labels are mutated

### DIFF
--- a/pkg/logql/ast_test.go
+++ b/pkg/logql/ast_test.go
@@ -394,7 +394,6 @@ func BenchmarkContainsFilter(b *testing.B) {
 			}
 		})
 	}
-
 }
 
 func Test_parserExpr_Parser(t *testing.T) {

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -160,6 +160,14 @@ func TestMappingStrings(t *testing.T) {
 			out: `rate({foo="bar"} | json | label_format foo=bar [5m])`,
 		},
 		{
+			in:  `count(rate({foo="bar"} | json [5m]))`,
+			out: `count(downstream<rate({foo="bar"} | json [5m]), shard=0_of_2> ++ downstream<rate({foo="bar"} | json [5m]), shard=1_of_2>)`,
+		},
+		{
+			in:  `avg(rate({foo="bar"} | json [5m]))`,
+			out: `avg(downstream<rate({foo="bar"} | json [5m]), shard=0_of_2> ++ downstream<rate({foo="bar"} | json [5m]), shard=1_of_2>)`,
+		},
+		{
 			in:  `{foo="bar"} |= "id=123"`,
 			out: `downstream<{foo="bar"}|="id=123", shard=0_of_2> ++ downstream<{foo="bar"}|="id=123", shard=1_of_2>`,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

Counting distinct values cannot be sharded when mutating labels over multiple shards, since the same label can appears across multiple shard and will be counted twice.

Since avg() uses count then the same logic is applied for it too.

**Which issue(s) this PR fixes**:
Fixes #5461

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
