### PR TITLE
logcli: Remove port from TLS server name when provided in --addr

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -228,7 +228,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 		if err != nil {
 			return err
 		}
-		client.TLSConfig.ServerName = u.Host
+		client.TLSConfig.ServerName = strings.Split(u.Host, ":")[0]
 		return nil
 	}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

If connecting to a TLS secured endpoint with an explicit port with logcli, certificate validation fails:

```
logcli --ca-cert=$TLS_CA --cert=$TLS_CERT --key=$TLS_KEY --addr=https://<host>:<port> labels
error sending request Get "https://<host>:<port>/loki/api/v1/labels?end=1645559631967253910&start=1645556031967253910": x509: certificate is valid for <host>, <SAN>, not <host>:<port>
Error doing request: Run out of attempts while querying the server
```
The problem can be (insecurely) avoided by adding a `--tls-skip-verify` option. 

This PR ensures that the ServerName field of the TLSConfig struct contains only the host if a port is provided to avoid
the failure. 

**Which issue(s) this PR fixes**:

Per Contribution guide, didn't open an issue since this is a one-liner... but I can create one if needed.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
