### PR TITLE
per user index query readiness with limits overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [5315](https://github.com/grafana/loki/pull/5315) **bboreham**: filters: use faster regexp package
 * [5393](https://github.com/grafana/loki/pull/5393) **sandeepsukhani**: jsonnet: move boltdb-shipper configs set as compactor args to yaml config
 * [5450](https://github.com/grafana/loki/pull/5450) **BenoitKnecht**: pkg/ruler/base: Add external_labels option
+* [5484](https://github.com/grafana/loki/pull/5450) **sandeepsukhani**: Add support for per user index query readiness with limits overrides
 
 # 2.4.1 (2021/11/07)
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -727,7 +727,7 @@ func (t *Loki) initIndexGateway() (services.Service, error) {
 		return nil, err
 	}
 
-	shipperIndexClient, err := shipper.NewShipper(t.Cfg.StorageConfig.BoltDBShipperConfig, objectClient, prometheus.DefaultRegisterer)
+	shipperIndexClient, err := shipper.NewShipper(t.Cfg.StorageConfig.BoltDBShipperConfig, objectClient, t.overrides, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/chunk/storage/caching_fixtures.go
+++ b/pkg/storage/chunk/storage/caching_fixtures.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/chunk/gcp"
 	"github.com/grafana/loki/pkg/storage/chunk/testutils"
-	"github.com/grafana/loki/pkg/util/validation"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 type fixture struct {

--- a/pkg/storage/chunk/storage/factory.go
+++ b/pkg/storage/chunk/storage/factory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/local"
 	"github.com/grafana/loki/pkg/storage/chunk/objectclient"
 	"github.com/grafana/loki/pkg/storage/chunk/openstack"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/downloads"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
@@ -57,7 +58,7 @@ type indexStoreFactories struct {
 }
 
 // IndexClientFactoryFunc defines signature of function which creates chunk.IndexClient for managing index in index store
-type IndexClientFactoryFunc func() (chunk.IndexClient, error)
+type IndexClientFactoryFunc func(limits StoreLimits) (chunk.IndexClient, error)
 
 // TableClientFactoryFunc defines signature of function which creates chunk.TableClient for managing tables in index store
 type TableClientFactoryFunc func() (chunk.TableClient, error)
@@ -72,6 +73,7 @@ func RegisterIndexStore(name string, indexClientFactory IndexClientFactoryFunc, 
 
 // StoreLimits helps get Limits specific to Queries for Stores
 type StoreLimits interface {
+	downloads.Limits
 	CardinalityLimit(userID string) int
 	MaxChunksPerQueryFromStore(userID string) int
 	MaxQueryLength(userID string) time.Duration
@@ -212,7 +214,7 @@ func NewStore(
 		indexClientReg := prometheus.WrapRegistererWith(
 			prometheus.Labels{"component": "index-store-" + s.From.String()}, reg)
 
-		index, err := NewIndexClient(s.IndexType, cfg, schemaCfg, indexClientReg)
+		index, err := NewIndexClient(s.IndexType, cfg, schemaCfg, limits, indexClientReg)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating index client")
 		}
@@ -243,10 +245,10 @@ func NewStore(
 }
 
 // NewIndexClient makes a new index client of the desired type.
-func NewIndexClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, registerer prometheus.Registerer) (chunk.IndexClient, error) {
+func NewIndexClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, limits StoreLimits, registerer prometheus.Registerer) (chunk.IndexClient, error) {
 	if indexClientFactory, ok := customIndexStores[name]; ok {
 		if indexClientFactory.indexClientFactoryFunc != nil {
-			return indexClientFactory.indexClientFactoryFunc()
+			return indexClientFactory.indexClientFactoryFunc(limits)
 		}
 	}
 

--- a/pkg/storage/chunk/storage/factory_test.go
+++ b/pkg/storage/chunk/storage/factory_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/cassandra"
 	"github.com/grafana/loki/pkg/storage/chunk/local"
-	"github.com/grafana/loki/pkg/util/validation"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 func TestFactoryStop(t *testing.T) {
@@ -95,7 +95,7 @@ func TestCustomIndexClient(t *testing.T) {
 		{
 			indexClientName: "boltdb",
 			indexClientFactories: indexStoreFactories{
-				indexClientFactoryFunc: func() (client chunk.IndexClient, e error) {
+				indexClientFactoryFunc: func(_ StoreLimits) (client chunk.IndexClient, e error) {
 					return newBoltDBCustomIndexClient(cfg.BoltDBConfig)
 				},
 			},
@@ -115,7 +115,7 @@ func TestCustomIndexClient(t *testing.T) {
 		{
 			indexClientName: "boltdb",
 			indexClientFactories: indexStoreFactories{
-				indexClientFactoryFunc: func() (client chunk.IndexClient, e error) {
+				indexClientFactoryFunc: func(_ StoreLimits) (client chunk.IndexClient, e error) {
 					return newBoltDBCustomIndexClient(cfg.BoltDBConfig)
 				},
 				tableClientFactoryFunc: func() (client chunk.TableClient, e error) {
@@ -134,7 +134,7 @@ func TestCustomIndexClient(t *testing.T) {
 			RegisterIndexStore(tc.indexClientName, tc.indexClientFactories.indexClientFactoryFunc, tc.indexClientFactories.tableClientFactoryFunc)
 		}
 
-		indexClient, err := NewIndexClient(tc.indexClientName, cfg, schemaCfg, nil)
+		indexClient, err := NewIndexClient(tc.indexClientName, cfg, schemaCfg, nil, nil)
 		if tc.errorExpected {
 			require.Error(t, err)
 		} else {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -425,7 +425,7 @@ func RegisterCustomIndexClients(cfg *Config, cm storage.ClientMetrics, registere
 	// in tests for creating multiple instances of it at a time.
 	var boltDBIndexClientWithShipper chunk.IndexClient
 
-	storage.RegisterIndexStore(shipper.BoltDBShipperType, func() (chunk.IndexClient, error) {
+	storage.RegisterIndexStore(shipper.BoltDBShipperType, func(limits storage.StoreLimits) (chunk.IndexClient, error) {
 		if boltDBIndexClientWithShipper != nil {
 			return boltDBIndexClientWithShipper, nil
 		}
@@ -445,7 +445,7 @@ func RegisterCustomIndexClients(cfg *Config, cm storage.ClientMetrics, registere
 			return nil, err
 		}
 
-		boltDBIndexClientWithShipper, err = shipper.NewShipper(cfg.BoltDBShipperConfig, objectClient, registerer)
+		boltDBIndexClientWithShipper, err = shipper.NewShipper(cfg.BoltDBShipperConfig, objectClient, limits, registerer)
 
 		return boltDBIndexClientWithShipper, err
 	}, func() (client chunk.TableClient, e error) {

--- a/pkg/storage/stores/shipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/downloads/index_set.go
@@ -110,8 +110,6 @@ func (t *indexSet) Init() (err error) {
 		t.dbsMtx.markReady()
 	}()
 
-	startTime := time.Now()
-
 	filesInfo, err := ioutil.ReadDir(t.cacheLocation)
 	if err != nil {
 		return err
@@ -147,9 +145,6 @@ func (t *indexSet) Init() (err error) {
 	if err != nil {
 		return
 	}
-
-	duration := time.Since(startTime).Seconds()
-	t.metrics.tablesDownloadDurationSeconds.add(t.tableName, duration)
 
 	level.Debug(logger).Log("msg", "finished syncing files")
 

--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -1,8 +1,6 @@
 package downloads
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -12,42 +10,19 @@ const (
 	statusSuccess = "success"
 )
 
-type downloadTableDurationMetric struct {
-	sync.RWMutex
-	gauge   prometheus.Gauge
-	periods map[string]float64
-}
-
-func (m *downloadTableDurationMetric) add(period string, downloadDuration float64) {
-	m.Lock()
-	defer m.Unlock()
-	m.periods[period] = downloadDuration
-
-	totalDuration := float64(0)
-	for _, dur := range m.periods {
-		totalDuration += dur
-	}
-
-	m.gauge.Set(totalDuration)
-}
-
 type metrics struct {
-	// metrics for measuring performance of downloading of files per period initially i.e for the first time
-	tablesDownloadDurationSeconds *downloadTableDurationMetric
-
+	queryTimeTableDownloadDurationSeconds  *prometheus.CounterVec
 	tablesSyncOperationTotal               *prometheus.CounterVec
 	tablesDownloadOperationDurationSeconds prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
 	m := &metrics{
-		tablesDownloadDurationSeconds: &downloadTableDurationMetric{
-			periods: map[string]float64{},
-			gauge: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-				Namespace: "loki_boltdb_shipper",
-				Name:      "initial_tables_download_duration_seconds",
-				Help:      "Time (in seconds) spent in downloading of files per table, initially i.e for the first time",
-			})},
+		queryTimeTableDownloadDurationSeconds: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "query_time_table_download_duration_seconds",
+			Help:      "Time (in seconds) spent in downloading of files per table at query time",
+		}, []string{"table"}),
 		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "tables_sync_operation_total",

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -3,7 +3,6 @@ package downloads
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"sync"
@@ -32,17 +31,17 @@ type BoltDBIndexClient interface {
 	QueryWithCursor(_ context.Context, c *bbolt.Cursor, query chunk.IndexQuery, callback chunk.QueryPagesCallback) error
 }
 
-type StorageClient interface {
-	ListTables(ctx context.Context) ([]string, error)
-	ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, error)
-	GetFile(ctx context.Context, tableName, fileName string) (io.ReadCloser, error)
-	GetUserFile(ctx context.Context, tableName, userID, fileName string) (io.ReadCloser, error)
-	IsFileNotFoundErr(err error) bool
+type Table interface {
+	Close()
+	MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error
+	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
+	Sync(ctx context.Context) error
+	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
 }
 
-// Table is a collection of multiple files created for a same table by various ingesters.
+// table is a collection of multiple files created for a same table by various ingesters.
 // All the public methods are concurrency safe and take care of mutexes to avoid any data race.
-type Table struct {
+type table struct {
 	name              string
 	cacheLocation     string
 	metrics           *metrics
@@ -56,10 +55,10 @@ type Table struct {
 	indexSetsMtx sync.RWMutex
 }
 
-// NewTable just creates an instance of Table without trying to load files from local storage or object store.
+// NewTable just creates an instance of table without trying to load files from local storage or object store.
 // It is used for initializing table at query time.
-func NewTable(name, cacheLocation string, storageClient storage.Client, boltDBIndexClient BoltDBIndexClient, metrics *metrics) *Table {
-	table := Table{
+func NewTable(name, cacheLocation string, storageClient storage.Client, boltDBIndexClient BoltDBIndexClient, metrics *metrics) Table {
+	table := table{
 		name:               name,
 		cacheLocation:      cacheLocation,
 		metrics:            metrics,
@@ -76,7 +75,7 @@ func NewTable(name, cacheLocation string, storageClient storage.Client, boltDBIn
 
 // LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
 // It is used for loading and initializing table at startup. It would initialize index sets which already had files locally.
-func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBIndexClient BoltDBIndexClient, metrics *metrics) (*Table, error) {
+func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBIndexClient BoltDBIndexClient, metrics *metrics) (Table, error) {
 	err := chunk_util.EnsureDirectory(cacheLocation)
 	if err != nil {
 		return nil, err
@@ -87,7 +86,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 		return nil, err
 	}
 
-	table := Table{
+	table := table{
 		name:               name,
 		cacheLocation:      cacheLocation,
 		metrics:            metrics,
@@ -139,7 +138,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 }
 
 // Close Closes references to all the dbs.
-func (t *Table) Close() {
+func (t *table) Close() {
 	t.indexSetsMtx.Lock()
 	defer t.indexSetsMtx.Unlock()
 
@@ -151,7 +150,7 @@ func (t *Table) Close() {
 }
 
 // MultiQueries runs multiple queries without having to take lock multiple times for each query.
-func (t *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error {
+func (t *table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return err
@@ -186,7 +185,7 @@ func (t *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, ca
 	return nil
 }
 
-func (t *Table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string {
+func (t *table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string {
 	t.indexSetsMtx.RLock()
 	defer t.indexSetsMtx.RUnlock()
 
@@ -216,7 +215,7 @@ func (t *Table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string 
 
 // DropUnusedIndex drops the index set if it has not been queried for at least ttl duration.
 // It returns true if the whole table gets dropped.
-func (t *Table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) {
+func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) {
 	indexSetsToCleanup := t.findExpiredIndexSets(ttl, now)
 
 	if len(indexSetsToCleanup) > 0 {
@@ -239,7 +238,7 @@ func (t *Table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) 
 }
 
 // Sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
-func (t *Table) Sync(ctx context.Context) error {
+func (t *table) Sync(ctx context.Context) error {
 	level.Debug(t.logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.name))
 
 	t.indexSetsMtx.RLock()
@@ -257,7 +256,7 @@ func (t *Table) Sync(ctx context.Context) error {
 // getOrCreateIndexSet gets or creates the index set for the userID.
 // If it does not exist, it creates a new one and initializes it in a goroutine.
 // Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
-func (t *Table) getOrCreateIndexSet(id string) (IndexSet, error) {
+func (t *table) getOrCreateIndexSet(id string) (IndexSet, error) {
 	t.indexSetsMtx.RLock()
 	indexSet, ok := t.indexSets[id]
 	t.indexSetsMtx.RUnlock()
@@ -298,12 +297,9 @@ func (t *Table) getOrCreateIndexSet(id string) (IndexSet, error) {
 	return indexSet, nil
 }
 
-func (t *Table) EnsureQueryReadiness(ctx context.Context) error {
-	_, userIDs, err := t.storageClient.ListFiles(ctx, t.name)
-	if err != nil {
-		return err
-	}
-
+// EnsureQueryReadiness ensures that we have downloaded the common index as well as user index for the provided userIDs.
+// When ensuring query readiness for a table, we will always download common index set because it can include index for one of the provided user ids.
+func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
 	commonIndexSet, err := t.getOrCreateIndexSet("")
 	if err != nil {
 		return err
@@ -330,7 +326,7 @@ func (t *Table) EnsureQueryReadiness(ctx context.Context) error {
 }
 
 // downloadUserIndexes downloads user specific index files concurrently.
-func (t *Table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
+func (t *table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
 	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
 		indexSet, err := t.getOrCreateIndexSet(userIDs[idx])
 		if err != nil {

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 const (
@@ -25,11 +26,18 @@ const (
 	durationDay          = 24 * time.Hour
 )
 
+type Limits interface {
+	AllByUserID() map[string]*validation.Limits
+	DefaultLimits() *validation.Limits
+	QueryReadyIndexNumDays(userID string) int
+}
+
 type Config struct {
 	CacheDir          string
 	SyncInterval      time.Duration
 	CacheTTL          time.Duration
 	QueryReadyNumDays int
+	Limits            Limits
 }
 
 type TableManager struct {
@@ -37,7 +45,7 @@ type TableManager struct {
 	boltIndexClient    BoltDBIndexClient
 	indexStorageClient storage.Client
 
-	tables    map[string]*Table
+	tables    map[string]Table
 	tablesMtx sync.RWMutex
 	metrics   *metrics
 
@@ -56,7 +64,7 @@ func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, indexStorage
 		cfg:                cfg,
 		boltIndexClient:    boltIndexClient,
 		indexStorageClient: indexStorageClient,
-		tables:             make(map[string]*Table),
+		tables:             make(map[string]Table),
 		metrics:            newMetrics(registerer),
 		ctx:                ctx,
 		cancel:             cancel,
@@ -71,7 +79,7 @@ func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, indexStorage
 	}
 
 	// download the missing tables.
-	err = tm.ensureQueryReadiness()
+	err = tm.ensureQueryReadiness(context.Background())
 	if err != nil {
 		// call Stop to close open file references.
 		tm.Stop()
@@ -101,7 +109,7 @@ func (tm *TableManager) loop() {
 			}
 
 			// we need to keep ensuring query readiness to download every days new table which would otherwise be downloaded only during queries.
-			err = tm.ensureQueryReadiness()
+			err = tm.ensureQueryReadiness(context.Background())
 			if err != nil {
 				level.Error(util_log.Logger).Log("msg", "error ensuring query readiness of tables", "err", err)
 			}
@@ -152,7 +160,7 @@ func (tm *TableManager) query(ctx context.Context, tableName string, queries []c
 	return util.DoParallelQueries(ctx, table, queries, callback)
 }
 
-func (tm *TableManager) getOrCreateTable(tableName string) (*Table, error) {
+func (tm *TableManager) getOrCreateTable(tableName string) (Table, error) {
 	// if table is already there, use it.
 	tm.tablesMtx.RLock()
 	table, ok := tm.tables[tableName]
@@ -232,55 +240,76 @@ func (tm *TableManager) cleanupCache() error {
 }
 
 // ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
-func (tm *TableManager) ensureQueryReadiness() error {
-	if tm.cfg.QueryReadyNumDays == 0 {
+func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
+	activeTableNumber := getActiveTableNumber()
+
+	// find the largest query readiness number
+	largestQueryReadinessNum := tm.cfg.QueryReadyNumDays
+	if defaultLimits := tm.cfg.Limits.DefaultLimits(); defaultLimits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+		largestQueryReadinessNum = defaultLimits.QueryReadyIndexNumDays
+	}
+
+	queryReadinessNumByUserID := make(map[string]int)
+	for userID, limits := range tm.cfg.Limits.AllByUserID() {
+		if limits.QueryReadyIndexNumDays != 0 {
+			queryReadinessNumByUserID[userID] = limits.QueryReadyIndexNumDays
+			if limits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+				largestQueryReadinessNum = limits.QueryReadyIndexNumDays
+			}
+		}
+	}
+
+	// return early if no table has to be downloaded for query readiness
+	if largestQueryReadinessNum == 0 {
 		return nil
 	}
 
-	tableNames, err := tm.indexStorageClient.ListTables(context.Background())
+	tables, err := tm.indexStorageClient.ListTables(ctx)
 	if err != nil {
 		return err
 	}
 
-	// get the names of tables required for being query ready.
-	tableNames, err = tm.tablesRequiredForQueryReadiness(tableNames)
+	// regex for finding daily tables which have a 5 digit number at the end.
+	re, err := regexp.Compile(`.+[0-9]{5}$`)
 	if err != nil {
 		return err
 	}
 
-	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("list of tables required for query-readiness %s", tableNames))
-
-	for _, tableName := range tableNames {
-		tm.tablesMtx.RLock()
-		table, ok := tm.tables[tableName]
-		tm.tablesMtx.RUnlock()
-		if ok {
-			err = table.EnsureQueryReadiness(context.Background())
-			if err != nil {
-				return err
-			}
+	for _, tableName := range tables {
+		if !re.MatchString(tableName) {
 			continue
 		}
 
-		level.Info(util_log.Logger).Log("msg", "table required for query readiness does not exist locally, downloading it", "table-name", tableName)
-		// table doesn't exist, download it.
-		tablePath := filepath.Join(tm.cfg.CacheDir, tableName)
-		err = chunk_util.EnsureDirectory(tablePath)
+		tableNumber, err := strconv.ParseInt(tableName[len(tableName)-5:], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		table, err = LoadTable(tableName, filepath.Join(tm.cfg.CacheDir, tableName), tm.indexStorageClient, tm.boltIndexClient, tm.metrics)
+		// continue if the table is not within query readiness
+		if activeTableNumber-tableNumber > int64(largestQueryReadinessNum) {
+			continue
+		}
+
+		// list the users that have dedicated index files for this table
+		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName)
 		if err != nil {
 			return err
 		}
 
-		tm.tablesMtx.Lock()
-		tm.tables[tableName] = table
-		tm.tablesMtx.Unlock()
+		// find the users whos index we need to keep ready for querying from this table
+		usersToBeQueryReadyFor := tm.findUsersInTableForQueryReadiness(tableNumber, usersWithIndex, queryReadinessNumByUserID)
 
-		err = table.EnsureQueryReadiness(context.Background())
+		// continue if both user index and common index is not required to be downloaded for query readiness
+		if len(usersToBeQueryReadyFor) == 0 && activeTableNumber-tableNumber > int64(tm.cfg.QueryReadyNumDays) {
+			continue
+		}
+
+		table, err := tm.getOrCreateTable(tableName)
 		if err != nil {
+			return err
+		}
+
+		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}
 	}
@@ -288,41 +317,30 @@ func (tm *TableManager) ensureQueryReadiness() error {
 	return nil
 }
 
-// queryReadyTableNumbersRange returns the table numbers range. Table numbers are added as suffix to table names.
-func (tm *TableManager) queryReadyTableNumbersRange() (int64, int64) {
-	newestTableNumber := getActiveTableNumber()
+// findUsersInTableForQueryReadiness returns the users that needs their index to be query ready based on the tableNumber and
+// query readiness number provided per user
+func (tm *TableManager) findUsersInTableForQueryReadiness(tableNumber int64, usersWithIndexInTable []string,
+	queryReadinessNumByUserID map[string]int) []string {
+	activeTableNumber := getActiveTableNumber()
+	usersToBeQueryReadyFor := []string{}
 
-	return newestTableNumber - int64(tm.cfg.QueryReadyNumDays), newestTableNumber
-}
+	for _, userID := range usersWithIndexInTable {
+		// use the query readiness config for the user if it exists or use the default config
+		queryReadyNumDays, ok := queryReadinessNumByUserID[userID]
+		if !ok {
+			queryReadyNumDays = tm.cfg.Limits.DefaultLimits().QueryReadyIndexNumDays
+		}
 
-// tablesRequiredForQueryReadiness returns the names of tables required to be downloaded for being query ready as per configured QueryReadyNumDays.
-// It only considers daily tables for simplicity and we anyways have made it mandatory to have daily tables with boltdb-shipper.
-func (tm *TableManager) tablesRequiredForQueryReadiness(tablesInStorage []string) ([]string, error) {
-	// regex for finding daily tables which have a 5 digit number at the end.
-	re, err := regexp.Compile(`.+[0-9]{5}$`)
-	if err != nil {
-		return nil, err
-	}
-
-	minTableNumber, maxTableNumber := tm.queryReadyTableNumbersRange()
-	var requiredTableNames []string
-
-	for _, tableName := range tablesInStorage {
-		if !re.MatchString(tableName) {
+		if queryReadyNumDays == 0 {
 			continue
 		}
 
-		tableNumber, err := strconv.ParseInt(tableName[len(tableName)-5:], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		if minTableNumber <= tableNumber && tableNumber <= maxTableNumber {
-			requiredTableNames = append(requiredTableNames, tableName)
+		if activeTableNumber-tableNumber <= int64(queryReadyNumDays) {
+			usersToBeQueryReadyFor = append(usersToBeQueryReadyFor, userID)
 		}
 	}
 
-	return requiredTableNames, nil
+	return usersToBeQueryReadyFor
 }
 
 // loadLocalTables loads tables present locally.

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -79,7 +79,7 @@ func NewTableManager(cfg Config, boltIndexClient BoltDBIndexClient, indexStorage
 	}
 
 	// download the missing tables.
-	err = tm.ensureQueryReadiness(context.Background())
+	err = tm.ensureQueryReadiness(ctx)
 	if err != nil {
 		// call Stop to close open file references.
 		tm.Stop()
@@ -109,7 +109,7 @@ func (tm *TableManager) loop() {
 			}
 
 			// we need to keep ensuring query readiness to download every days new table which would otherwise be downloaded only during queries.
-			err = tm.ensureQueryReadiness(context.Background())
+			err = tm.ensureQueryReadiness(tm.ctx)
 			if err != nil {
 				level.Error(util_log.Logger).Log("msg", "error ensuring query readiness of tables", "err", err)
 			}

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -3,17 +3,16 @@ package downloads
 import (
 	"context"
 	"fmt"
-	"math"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/user"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 func buildTestTableManager(t *testing.T, path string) (*TableManager, stopFunc) {
@@ -24,6 +23,7 @@ func buildTestTableManager(t *testing.T, path string) (*TableManager, stopFunc) 
 		CacheDir:     cachePath,
 		SyncInterval: time.Hour,
 		CacheTTL:     time.Hour,
+		Limits:       &mockLimits{},
 	}
 	tableManager, err := NewTableManager(cfg, boltDBIndexClient, indexStorageClient, nil)
 	require.NoError(t, err)
@@ -70,34 +70,21 @@ func TestTableManager_cleanupCache(t *testing.T) {
 	expiredTableName := "expired-table"
 	nonExpiredTableName := "non-expired-table"
 
-	// query for above 2 tables which should set them up in table manager
-	err := tableManager.QueryPages(user.InjectOrgID(context.Background(), "fake"), []chunk.IndexQuery{
-		{TableName: expiredTableName},
-		{TableName: nonExpiredTableName},
-	}, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
-		return true
-	})
-
-	require.NoError(t, err)
-	// table manager should now have 2 tables.
-	require.Len(t, tableManager.tables, 2)
+	tableManager.tables[expiredTableName] = &mockTable{}
+	tableManager.tables[nonExpiredTableName] = &mockTable{}
 
 	// call cleanupCache and verify that no tables are cleaned up because they are not yet expired.
 	require.NoError(t, tableManager.cleanupCache())
 	require.Len(t, tableManager.tables, 2)
 
-	// change the last used at time of expiredTable to before the ttl.
-	expiredTable, ok := tableManager.tables[expiredTableName]
-	require.True(t, ok)
-	for _, idxSet := range expiredTable.indexSets {
-		idxSet.(*indexSet).lastUsedAt = time.Now().Add(-(tableManager.cfg.CacheTTL + time.Minute))
-	}
+	// set the flag for expiredTable to expire.
+	tableManager.tables[expiredTableName].(*mockTable).tableExpired = true
 
 	// call the cleanupCache and verify that we still have nonExpiredTable and expiredTable is gone.
 	require.NoError(t, tableManager.cleanupCache())
 	require.Len(t, tableManager.tables, 1)
 
-	_, ok = tableManager.tables[expiredTableName]
+	_, ok := tableManager.tables[expiredTableName]
 	require.False(t, ok)
 
 	_, ok = tableManager.tables[nonExpiredTableName]
@@ -105,120 +92,222 @@ func TestTableManager_cleanupCache(t *testing.T) {
 }
 
 func TestTableManager_ensureQueryReadiness(t *testing.T) {
+	activeTableNumber := getActiveTableNumber()
+	mockIndexStorageClient := &mockIndexStorageClient{
+		userIndexesInTables: map[string][]string{},
+	}
+
+	cfg := Config{
+		SyncInterval: time.Hour,
+		CacheTTL:     time.Hour,
+	}
+
+	tableManager := &TableManager{
+		cfg:                cfg,
+		indexStorageClient: mockIndexStorageClient,
+		tables:             make(map[string]Table),
+		metrics:            newMetrics(nil),
+		ctx:                context.Background(),
+		cancel:             func() {},
+	}
+
+	buildTableName := func(idx int) string {
+		return fmt.Sprintf("table_%d", activeTableNumber-int64(idx))
+	}
+
+	// setup 10 tables with 5 latest tables having user index for user1 and user2
+	for i := 0; i < 10; i++ {
+		tableName := buildTableName(i)
+		tableManager.tables[tableName] = &mockTable{}
+		mockIndexStorageClient.tablesInStorage = append(mockIndexStorageClient.tablesInStorage, tableName)
+		if i < 5 {
+			mockIndexStorageClient.userIndexesInTables[tableName] = []string{"user1", "user2"}
+		}
+	}
+
+	// function for resetting state of mockTables
+	resetTables := func() {
+		for _, table := range tableManager.tables {
+			table.(*mockTable).queryReadinessDoneForUsers = nil
+		}
+	}
+
 	for _, tc := range []struct {
 		name                 string
 		queryReadyNumDaysCfg int
+		queryReadinessLimits mockLimits
+
+		expectedQueryReadinessDoneForUsers map[string][]string
 	}{
 		{
-			name: "0 queryReadyNumDaysCfg with 10 tables in storage",
+			name:                 "no query readiness configured",
+			queryReadinessLimits: mockLimits{},
 		},
 		{
-			name:                 "5 queryReadyNumDaysCfg with 10 tables in storage",
+			name:                 "common index: 5 days",
 			queryReadyNumDaysCfg: 5,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {},
+				buildTableName(1): {},
+				buildTableName(2): {},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {}, // NOTE: we include an extra table since we are counting days back from current point in time
+			},
 		},
 		{
-			name:                 "20 queryReadyNumDaysCfg with 10 tables in storage",
+			name:                 "common index: 20 days",
 			queryReadyNumDaysCfg: 20,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {},
+				buildTableName(1): {},
+				buildTableName(2): {},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {},
+				buildTableName(6): {},
+				buildTableName(7): {},
+				buildTableName(8): {},
+				buildTableName(9): {},
+			},
+		},
+		{
+			name: "user index default: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 2,
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+			},
+		},
+		{
+			name: "common index: 5 days, user index default: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 2,
+			},
+			queryReadyNumDaysCfg: 5,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {},
+			},
+		},
+		{
+			name: "user1: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysByUser: map[string]int{"user1": 2},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1"},
+				buildTableName(1): {"user1"},
+				buildTableName(2): {"user1"},
+			},
+		},
+		{
+			name: "user1: 2 days, user2: 20 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysByUser: map[string]int{"user1": 2, "user2": 20},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {"user2"},
+				buildTableName(4): {"user2"},
+			},
+		},
+		{
+			name: "user index default: 3 days, user1: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 3,
+				queryReadyIndexNumDaysByUser:  map[string]int{"user1": 2},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {"user2"},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir := t.TempDir()
+			resetTables()
+			tableManager.cfg.QueryReadyNumDays = tc.queryReadyNumDaysCfg
+			tableManager.cfg.Limits = &tc.queryReadinessLimits
+			require.NoError(t, tableManager.ensureQueryReadiness(context.Background()))
 
-			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
-
-			tables := map[string]map[string]testutil.DBConfig{}
-			activeTableNumber := getActiveTableNumber()
-			for i := 0; i < 10; i++ {
-				tables[fmt.Sprintf("table_%d", activeTableNumber-int64(i))] = map[string]testutil.DBConfig{
-					"db": {
-						CompressFile: i%2 == 0,
-						DBRecords: testutil.DBRecords{
-							Start:      i * 10,
-							NumRecords: 10,
-						},
-					},
-				}
-			}
-
-			for name, dbs := range tables {
-				testutil.SetupDBsAtPath(t, filepath.Join(objectStoragePath, name), dbs, nil)
-			}
-
-			boltDBIndexClient, indexStorageClient := buildTestClients(t, tempDir)
-			cachePath := filepath.Join(tempDir, cacheDirName)
-			require.NoError(t, util.EnsureDirectory(cachePath))
-
-			cfg := Config{
-				CacheDir:          cachePath,
-				SyncInterval:      time.Hour,
-				CacheTTL:          time.Hour,
-				QueryReadyNumDays: tc.queryReadyNumDaysCfg,
-			}
-			tableManager := &TableManager{
-				cfg:                cfg,
-				boltIndexClient:    boltDBIndexClient,
-				indexStorageClient: indexStorageClient,
-				tables:             make(map[string]*Table),
-				metrics:            newMetrics(nil),
-				ctx:                context.Background(),
-				cancel:             func() {},
-			}
-
-			defer func() {
-				tableManager.Stop()
-				boltDBIndexClient.Stop()
-			}()
-
-			require.NoError(t, tableManager.ensureQueryReadiness())
-
-			if tc.queryReadyNumDaysCfg == 0 {
-				require.Len(t, tableManager.tables, 0)
-			} else {
-				require.Len(t, tableManager.tables, int(math.Min(float64(tc.queryReadyNumDaysCfg+1), 10)))
+			for name, table := range tableManager.tables {
+				require.Equal(t, tc.expectedQueryReadinessDoneForUsers[name], table.(*mockTable).queryReadinessDoneForUsers, "table: %s", name)
 			}
 		})
 	}
 }
 
-func TestTableManager_tablesRequiredForQueryReadiness(t *testing.T) {
-	numDailyTablesInStorage := 10
-	var tablesInStorage []string
-	// tables with daily table number
-	activeDailyTableNumber := getActiveTableNumber()
-	for i := 0; i < numDailyTablesInStorage; i++ {
-		tablesInStorage = append(tablesInStorage, fmt.Sprintf("table_%d", activeDailyTableNumber-int64(i)))
+type mockLimits struct {
+	queryReadyIndexNumDaysDefault int
+	queryReadyIndexNumDaysByUser  map[string]int
+}
+
+func (m *mockLimits) AllByUserID() map[string]*validation.Limits {
+	allByUserID := map[string]*validation.Limits{}
+	for userID := range m.queryReadyIndexNumDaysByUser {
+		allByUserID[userID] = &validation.Limits{
+			QueryReadyIndexNumDays: m.queryReadyIndexNumDaysByUser[userID],
+		}
 	}
 
-	// tables with weekly table number
-	activeWeeklyTableNumber := time.Now().Unix() / int64((durationDay*7)/time.Second)
-	for i := 0; i < 10; i++ {
-		tablesInStorage = append(tablesInStorage, fmt.Sprintf("table_%d", activeWeeklyTableNumber-int64(i)))
+	return allByUserID
+}
+
+func (m *mockLimits) DefaultLimits() *validation.Limits {
+	return &validation.Limits{
+		QueryReadyIndexNumDays: m.queryReadyIndexNumDaysDefault,
 	}
+}
 
-	// tables without a table number
-	tablesInStorage = append(tablesInStorage, "foo", "bar")
+func (m *mockLimits) QueryReadyIndexNumDays(userID string) int {
+	return m.queryReadyIndexNumDaysByUser[userID]
+}
 
-	for i, tc := range []int{
-		0, 5, 10, 20,
-	} {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			tableManager := &TableManager{
-				cfg: Config{
-					QueryReadyNumDays: tc,
-				},
-			}
+type mockTable struct {
+	tableExpired               bool
+	queryReadinessDoneForUsers []string
+}
 
-			tablesNames, err := tableManager.tablesRequiredForQueryReadiness(tablesInStorage)
-			require.NoError(t, err)
+func (m *mockTable) Close() {}
 
-			numExpectedTables := 0
-			if tc != 0 {
-				numExpectedTables = int(math.Min(float64(tc+1), float64(numDailyTablesInStorage)))
-			}
+func (m *mockTable) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, callback chunk.QueryPagesCallback) error {
+	return nil
+}
 
-			for i := 0; i < numExpectedTables; i++ {
-				require.Equal(t, fmt.Sprintf("table_%d", activeDailyTableNumber-int64(i)), tablesNames[i])
-			}
-		})
-	}
+func (m *mockTable) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) {
+	return m.tableExpired, nil
+}
+
+func (m *mockTable) Sync(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockTable) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
+	m.queryReadinessDoneForUsers = userIDs
+	return nil
+}
+
+type mockIndexStorageClient struct {
+	storage.Client
+	tablesInStorage     []string
+	userIndexesInTables map[string][]string
+}
+
+func (m *mockIndexStorageClient) ListTables(ctx context.Context) ([]string, error) {
+	return m.tablesInStorage, nil
+}
+
+func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
+	return []storage.IndexFile{}, m.userIndexesInTables[tableName], nil
 }

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.CacheLocation, "boltdb.shipper.cache-location", "", "Cache location for restoring boltDB files for queries")
 	f.DurationVar(&cfg.CacheTTL, "boltdb.shipper.cache-ttl", 24*time.Hour, "TTL for boltDB files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, "boltdb.shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
-	f.IntVar(&cfg.QueryReadyNumDays, "boltdb.shipper.query-ready-num-days", 0, "Number of days of index to be kept downloaded for queries. Works only with tables created with 24h period.")
+	f.IntVar(&cfg.QueryReadyNumDays, "boltdb.shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
 	f.BoolVar(&cfg.BuildPerTenantIndex, "boltdb.shipper.build-per-tenant-index", false, "Build per tenant index files")
 }
 
@@ -97,13 +97,13 @@ type Shipper struct {
 }
 
 // NewShipper creates a shipper for syncing local objects with a store
-func NewShipper(cfg Config, storageClient chunk.ObjectClient, registerer prometheus.Registerer) (chunk.IndexClient, error) {
+func NewShipper(cfg Config, storageClient chunk.ObjectClient, limits downloads.Limits, registerer prometheus.Registerer) (chunk.IndexClient, error) {
 	shipper := Shipper{
 		cfg:     cfg,
 		metrics: newMetrics(registerer),
 	}
 
-	err := shipper.init(storageClient, registerer)
+	err := shipper.init(storageClient, limits, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func NewShipper(cfg Config, storageClient chunk.ObjectClient, registerer prometh
 	return &shipper, nil
 }
 
-func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.Registerer) error {
+func (s *Shipper) init(storageClient chunk.ObjectClient, limits downloads.Limits, registerer prometheus.Registerer) error {
 	// When we run with target querier we don't have ActiveIndexDirectory set so using CacheLocation instead.
 	// Also it doesn't matter which directory we use since BoltDBIndexClient doesn't do anything with it but it is good to have a valid path.
 	boltdbIndexClientDir := s.cfg.ActiveIndexDirectory
@@ -156,6 +156,7 @@ func (s *Shipper) init(storageClient chunk.ObjectClient, registerer prometheus.R
 			SyncInterval:      s.cfg.ResyncInterval,
 			CacheTTL:          s.cfg.CacheTTL,
 			QueryReadyNumDays: s.cfg.QueryReadyNumDays,
+			Limits:            limits,
 		}
 		downloadsManager, err := downloads.NewTableManager(cfg, s.boltDBIndexClient, indexStorageClient, registerer)
 		if err != nil {

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -15,20 +15,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/storage/chunk/local"
-	"github.com/grafana/loki/pkg/storage/chunk/storage"
 )
-
-var metrics = storage.NewClientMetrics()
 
 func Test_LeaderElection(t *testing.T) {
 	stabilityCheckInterval = 100 * time.Millisecond
 
 	result := make(chan *ClusterSeed, 10)
-	objectClient, err := storage.NewObjectClient(storage.StorageTypeFileSystem, storage.Config{
-		FSConfig: local.FSConfig{
-			Directory: t.TempDir(),
-		},
-	}, metrics)
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: t.TempDir(),
+	})
 	require.NoError(t, err)
 	for i := 0; i < 3; i++ {
 		go func() {
@@ -86,11 +81,9 @@ func Test_ReportLoop(t *testing.T) {
 	}))
 	usageStatsURL = server.URL
 
-	objectClient, err := storage.NewObjectClient(storage.StorageTypeFileSystem, storage.Config{
-		FSConfig: local.FSConfig{
-			Directory: t.TempDir(),
-		},
-	}, metrics)
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: t.TempDir(),
+	})
 	require.NoError(t, err)
 
 	r, err := NewReporter(Config{Leader: true}, kv.Config{
@@ -149,11 +142,9 @@ func Test_NextReport(t *testing.T) {
 }
 
 func TestWrongKV(t *testing.T) {
-	objectClient, err := storage.NewObjectClient(storage.StorageTypeFileSystem, storage.Config{
-		FSConfig: local.FSConfig{
-			Directory: t.TempDir(),
-		},
-	}, metrics)
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: t.TempDir(),
+	})
 	require.NoError(t, err)
 
 	r, err := NewReporter(Config{Leader: true}, kv.Config{

--- a/pkg/usagestats/seed_test.go
+++ b/pkg/usagestats/seed_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/storage/chunk/local"
-	"github.com/grafana/loki/pkg/storage/chunk/storage"
 )
 
 type dnsProviderMock struct {
@@ -61,11 +60,9 @@ func createMemberlist(t *testing.T, port, memberID int) *memberlist.KV {
 func Test_Memberlist(t *testing.T) {
 	stabilityCheckInterval = time.Second
 
-	objectClient, err := storage.NewObjectClient(storage.StorageTypeFileSystem, storage.Config{
-		FSConfig: local.FSConfig{
-			Directory: t.TempDir(),
-		},
-	}, metrics)
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: t.TempDir(),
+	})
 	require.NoError(t, err)
 	result := make(chan *ClusterSeed, 10)
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -78,6 +78,7 @@ type Limits struct {
 	MaxEntriesLimitPerQuery    int            `yaml:"max_entries_limit_per_query" json:"max_entries_limit_per_query"`
 	MaxCacheFreshness          model.Duration `yaml:"max_cache_freshness_per_query" json:"max_cache_freshness_per_query"`
 	MaxQueriersPerTenant       int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
+	QueryReadyIndexNumDays     int            `yaml:"query_ready_index_num_days" json:"query_ready_index_num_days"`
 
 	// Query frontend enforced limits. The default is actually parameterized by the queryrange config.
 	QuerySplitDuration  model.Duration `yaml:"split_queries_by_interval" json:"split_queries_by_interval"`
@@ -171,6 +172,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.MaxCacheFreshness, "frontend.max-cache-freshness", "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")
 
 	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
+	f.IntVar(&l.QueryReadyIndexNumDays, "store.query-ready-index-num-days", 0, "Number of days of index to be kept always downloaded for queries. Applies only to per user index in boltdb-shipper index store. 0 to disable.")
 
 	_ = l.RulerEvaluationDelay.Set("0s")
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
@@ -356,6 +358,11 @@ func (o *Overrides) MaxQuerySeries(userID string) int {
 // MaxQueriersPerUser returns the maximum number of queriers that can handle requests for this user.
 func (o *Overrides) MaxQueriersPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxQueriersPerTenant
+}
+
+// QueryReadyIndexNumDays returns the number of days for which we have to be query ready for a user.
+func (o *Overrides) QueryReadyIndexNumDays(userID string) int {
+	return o.getOverridesForUser(userID).QueryReadyIndexNumDays
 }
 
 // MaxQueryParallelism returns the limit to the number of sub-queries the


### PR DESCRIPTION
**What this PR does / why we need it**:
The current query readiness support works only on table level. With a cluster building per user index and having query readiness configured, it would add a lot of overhead to keep the active index synced since we get a new index from ingesters every 15 mins.
This PR adds support for more fine-grained control over query readiness for per user index using limits overrides config.

I have also changed the metric to track the duration it takes to download the index at query time. It would be tracked per table. I have not added a user id to it to avoid adding too many series. I have added a log line which we can use for viewing per tenant download duration by both user id and table.

I have also dropped the older metric `loki_boltdb_shipper_initial_tables_download_duration_seconds`, which was not very reliable and the name was not very clear too.

**Checklist**
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
