### PR TITLE
metrics: Add `user` label to `worker_inflight_queries`

### DIFF
--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -7,7 +7,7 @@ import (
 
 type Metrics struct {
 	concurrentWorkers             prometheus.Gauge
-	inflightRequests              prometheus.Gauge
+	inflightRequests              *prometheus.GaugeVec
 	frontendClientRequestDuration *prometheus.HistogramVec
 	frontendClientsGauge          prometheus.Gauge
 }
@@ -18,10 +18,10 @@ func NewMetrics(conf Config, r prometheus.Registerer) *Metrics {
 			Name: "loki_querier_worker_concurrency",
 			Help: "Number of concurrent querier workers",
 		}),
-		inflightRequests: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		inflightRequests: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_querier_worker_inflight_queries",
 			Help: "Number of queries being processed by the querier workers",
-		}),
+		}, []string{"user"}),
 		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",

--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -21,7 +21,7 @@ func NewMetrics(conf Config, r prometheus.Registerer) *Metrics {
 		inflightRequests: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_querier_worker_inflight_queries",
 			Help: "Number of queries being processed by the querier workers",
-		}, []string{"user"}),
+		}, []string{"user", "querier"}),
 		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",

--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -21,7 +21,7 @@ func NewMetrics(conf Config, r prometheus.Registerer) *Metrics {
 		inflightRequests: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_querier_worker_inflight_queries",
 			Help: "Number of queries being processed by the querier workers",
-		}, []string{"user", "querier"}),
+		}, []string{"user"}),
 		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID, "querier", sp.querierID).Inc()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID, "querier", sp.querierID).Dec()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Inc()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID, "querier", sp.querierID).Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Dec()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID, "querier", sp.querierID).Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.Inc()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.Dec()
+			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Add additional `user`  label to the existing `loki_querier_worker_inflight_queries` metrics.
This enables us observe per tenant in flight requests in the query workers.

/cc @owen-d 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:


**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
