### PR TITLE
operator: Fix port name used for gRPC services

### DIFF
--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -16,7 +16,7 @@ const (
 	protocolTCP = "TCP"
 
 	lokiHTTPPortName   = "metrics"
-	lokiGRPCPortName   = "grpc"
+	lokiGRPCPortName   = "grpclb"
 	lokiGossipPortName = "gossip-ring"
 
 	gatewayContainerName    = "gateway"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The operator generates Kubernetes services to be used for load-balancing between the different components. The services provide both A and SRV records, which are both used by the gRPC implementation. Currently the "port name" used for the Service (`grpc`) does not match the DNS service name the [lookup uses](https://github.com/grafana/loki/blob/main/vendor/google.golang.org/grpc/internal/resolver/dns/dns_resolver.go#L252) (`grpclb`). This leads to components emitting an error that the SRV record can not be found during runtime.

**Which issue(s) this PR fixes**:
Fixes #5492 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
