### PR TITLE
CI: moving autodeploy configuration secret to new location

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -44,7 +44,7 @@ local pull_secret = secret('dockerconfigjson', 'secret/data/common/gcr', '.docke
 local github_secret = secret('github_token', 'infra/data/ci/github/grafanabot', 'pat');
 
 // Injected in a secret because this is a public repository and having the config here would leak our environment names
-local deploy_configuration = secret('deploy_config', 'infra/data/ci/loki/deploy', 'config.json');
+local deploy_configuration = secret('deploy_config', 'common/loki/ci/autodeploy', 'config.json');
 
 
 local run(name, commands) = {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1060,11 +1060,11 @@ name: ecr_secret_key
 ---
 get:
   name: config.json
-  path: infra/data/ci/loki/deploy
+  path: common/loki/ci/autodeploy
 kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: 6d010031b5c18947ac4710106d06f119e77d715ddc687983227700254b27e6d8
+hmac: 6fdb7d9dd0a3d62a7e1a8eaec15ec5e7b940fafb7362261d86730d5523e16e43
 
 ...


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Moved autodeploy configuration into `common`, so the Loki team can access & modify the secret.
The `infra/ci` path is protected, and we have to reach out to another team to retrieve/update this secret every time, which is annoying to both parties involved and is unnecessary.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
