### PR TITLE
Fix orphaned metrics in the file tailer

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -275,15 +275,20 @@ func (t *FileTarget) startTailing(ps []string) {
 		if _, ok := t.tails[p]; ok {
 			continue
 		}
+
 		fi, err := os.Stat(p)
 		if err != nil {
 			level.Error(t.logger).Log("msg", "failed to tail file, stat failed", "error", err, "filename", p)
+			t.metrics.totalBytes.DeleteLabelValues(p)
 			continue
 		}
+
 		if fi.IsDir() {
 			level.Info(t.logger).Log("msg", "failed to tail file", "error", "file is a directory", "filename", p)
+			t.metrics.totalBytes.DeleteLabelValues(p)
 			continue
 		}
+
 		level.Debug(t.logger).Log("msg", "tailing new file", "filename", p)
 		tailer, err := newTailer(t.metrics, t.logger, t.handler, t.positions, p)
 		if err != nil {


### PR DESCRIPTION
Individual tailers are responsible for cleaning up their own metrics but in the case where no tailer is created because: 
- The file to be tailed exists [here](https://github.com/grafana/loki/blob/cdde6aa49dbb98d6bbfa0f29e0b3b3023211ca08/clients/pkg/promtail/targets/file/filetarget.go#L214) 
- but is gone by the time `startTailing` is called [here](https://github.com/grafana/loki/blob/cdde6aa49dbb98d6bbfa0f29e0b3b3023211ca08/clients/pkg/promtail/targets/file/filetarget.go#L238)

We orphan metrics for the affected paths.

This PR makes sure to cleanup any metrics for the path when there's an error creating the associated tailer.