### PR TITLE
Docs: Fix links and formatting of HTTP API page

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -21,44 +21,28 @@ These endpoints are exposed by all components:
 - [`GET /config`](#get-config)
 - [`GET /loki/api/v1/status/buildinfo`](#get-lokiapiv1statusbuildinfo)
 
-These endpoints are exposed by the querier and the frontend:
+These endpoints are exposed by the querier and the query frontend:
 
-- [Loki's HTTP API](#lokis-http-api)
-  - [Microservices Mode](#microservices-mode)
-  - [Matrix, Vector, And Streams](#matrix-vector-and-streams)
-  - [`GET /loki/api/v1/query`](#get-lokiapiv1query)
-    - [Examples](#examples)
-  - [`GET /loki/api/v1/query_range`](#get-lokiapiv1query_range)
-        - [Step vs Interval](#step-versus-interval)
-    - [Examples](#examples-1)
-  - [`GET /loki/api/v1/labels`](#get-lokiapiv1labels)
-    - [Examples](#examples-2)
-  - [`GET /loki/api/v1/label/<name>/values`](#get-lokiapiv1labelnamevalues)
-    - [Examples](#examples-3)
-  - [`GET /loki/api/v1/tail`](#get-lokiapiv1tail)
-  - [`POST /loki/api/v1/push`](#post-lokiapiv1push)
-    - [Examples](#examples-4)
-  - [`GET /api/prom/tail`](#get-apipromtail)
-  - [`GET /api/prom/query`](#get-apipromquery)
-    - [Examples](#examples-5)
-  - [`GET /api/prom/label`](#get-apipromlabel)
-    - [Examples](#examples-6)
-  - [`GET /api/prom/label/<name>/values`](#get-apipromlabelnamevalues)
-    - [Examples](#examples-7)
-  - [`POST /api/prom/push`](#post-apiprompush)
-    - [Examples](#examples-8)
-  - [`GET /ready`](#get-ready)
-  - [`GET /metrics`](#get-metrics)
-  - [Series](#series)
-    - [Examples](#examples-9)
-  - [Statistics](#statistics)
+- [`GET /loki/api/v1/query`](#get-lokiapiv1query)
+- [`GET /loki/api/v1/query_range`](#get-lokiapiv1query_range)
+- [`GET /loki/api/v1/labels`](#get-lokiapiv1labels)
+- [`GET /loki/api/v1/label/<name>/values`](#get-lokiapiv1labelnamevalues)
+- [`GET /loki/api/v1/tail`](#get-lokiapiv1tail)
+- [`POST /loki/api/v1/push`](#post-lokiapiv1push)
+- [`GET /ready`](#get-ready)
+- [`GET /metrics`](#get-metrics)
+- **Deprecated** [`GET /api/prom/tail`](#get-apipromtail)
+- **Deprecated** [`GET /api/prom/query`](#get-apipromquery)
+- **Deprecated** [`GET /api/prom/label`](#get-apipromlabel)
+- **Deprecated** [`GET /api/prom/label/<name>/values`](#get-apipromlabelnamevalues)
+- **Deprecated** [`POST /api/prom/push`](#post-apiprompush)
 
-While these endpoints are exposed by just the distributor:
+These endpoints are exposed by the distributor:
 
 - [`POST /loki/api/v1/push`](#post-lokiapiv1push)
 - [`GET /distributor/ring`](#get-distributorring)
 
-And these endpoints are exposed by just the ingester:
+These endpoints are exposed by the ingester:
 
 - [`POST /flush`](#post-flush)
 - [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
@@ -253,12 +237,12 @@ accepts the following query parameters in the URL:
 - `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
 - `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.  Only applies to query types which produce a matrix response.
-- `interval`: <span style="background-color:#f3f973;">This parameter is experimental; see the explanation under Step versus Interval.</span> Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
+- `interval`: <span style="background-color:#f3f973;">This parameter is experimental; see the explanation under Step versus interval.</span> Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
 In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and the frontend.
 
-### Step versus Interval
+### Step versus interval
 
 Use the `step` parameter when making metric queries to Loki, or queries which return a matrix response.  It is evaluated in exactly the same way Prometheus evaluates `step`.  First the query will be evaluated at `start` and then evaluated again at `start + step` and again at `start + step + step` until `end` is reached.  The result will be a matrix of the query result evaluated at each step.
 


### PR DESCRIPTION
Issue https://github.com/grafana/loki/issues/5476 points out deficits in our lists of links to the descriptions of the various endpoints. 

This PR removes the self-referential list items.  The docs reader can also use the links in the right-side navigation to find sections on the page.  So, we don't need links to the various subsections containing examples.

I also added "Deprecated" to the endpoint items in the list that are marked as deprecated, to help doc readers quickly identify the deprecated endpoints.
