### PR TITLE
Change path for deploy config

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -44,7 +44,7 @@ local pull_secret = secret('dockerconfigjson', 'secret/data/common/gcr', '.docke
 local github_secret = secret('github_token', 'infra/data/ci/github/grafanabot', 'pat');
 
 // Injected in a secret because this is a public repository and having the config here would leak our environment names
-local deploy_configuration = secret('deploy_config', 'common/loki/ci/autodeploy', 'config.json');
+local deploy_configuration = secret('deploy_config', 'common/loki/does/not/exists/ci/autodeploy', 'config.json');
 
 
 local run(name, commands) = {

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -44,7 +44,7 @@ local pull_secret = secret('dockerconfigjson', 'secret/data/common/gcr', '.docke
 local github_secret = secret('github_token', 'infra/data/ci/github/grafanabot', 'pat');
 
 // Injected in a secret because this is a public repository and having the config here would leak our environment names
-local deploy_configuration = secret('deploy_config', 'common/loki/does/not/exists/ci/autodeploy', 'config.json');
+local deploy_configuration = secret('deploy_config', 'common/loki_ci_autodeploy', 'config.json');
 
 
 local run(name, commands) = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
This PR fixes the Drone build pipeline which is failing in the `deploy` stage ([example](https://drone.grafana.net/grafana/loki/9271/14/3)).

Before this change, we were reading the deploy config from the vault at `common/loki/ci/auto deploy. Problem is, you cannot place secrets at `common` at arbitrary paths, but rather at either

- `common/<cluster>/<secret>`
- `common/<secret>`

See: https://raintank-corp.slack.com/archives/CBJQK4SGJ/p1646215951096039?thread_ts=1646210720.153469&cid=CBJQK4SGJ

We moved the secret to `common/loki_ci_autodeploy`.

**Which issue(s) this PR fixes**:
Fixes N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
