### PR TITLE
Remove extra param in call for inflightRequests metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 
 * [5507](https://github.com/grafana/loki/pull/5507) **MichelHollands**: Remove extra param in call for inflightRequests metric. 
-* [5356](https://github.com/grafana/loki/pull/5356) **jbschami**: Enhance lambda-promtail to support adding extra labels from an environment variable value.
-* [5409](https://github.com/grafana/loki/pull/5409) **ldb**: Enable best effort parsing for Syslog messages.
+* [5356](https://github.com/grafana/loki/pull/5356) **jbschami**: Enhance lambda-promtail to support adding extra labels from an environment variable value
+* [5409](https://github.com/grafana/loki/pull/5409) **ldb**: Enable best effort parsing for Syslog messages
 * [5392](https://github.com/grafana/loki/pull/5392) **MichelHollands**: Etcd credentials are parsed as secrets instead of plain text now.
 * [5361](https://github.com/grafana/loki/pull/5361) **ctovena**: Add usage report to grafana.com.
 * [5289](https://github.com/grafana/loki/pull/5289) **ctovena**: Fix deduplication bug in queries when mutating labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Main
 
 
-* [5356](https://github.com/grafana/loki/pull/5356) **jbschami**: Enhance lambda-promtail to support adding extra labels from an environment variable value
-* [5409](https://github.com/grafana/loki/pull/5409) **ldb**: Enable best effort parsing for Syslog messages
+* [5507](https://github.com/grafana/loki/pull/5507) **MichelHollands**: Remove extra param in call for inflightRequests metric. 
+* [5356](https://github.com/grafana/loki/pull/5356) **jbschami**: Enhance lambda-promtail to support adding extra labels from an environment variable value.
+* [5409](https://github.com/grafana/loki/pull/5409) **ldb**: Enable best effort parsing for Syslog messages.
 * [5392](https://github.com/grafana/loki/pull/5392) **MichelHollands**: Etcd credentials are parsed as secrets instead of plain text now.
 * [5361](https://github.com/grafana/loki/pull/5361) **ctovena**: Add usage report to grafana.com.
 * [5289](https://github.com/grafana/loki/pull/5289) **ctovena**: Fix deduplication bug in queries when mutating labels.

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Inc()
+			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Dec()
+			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.


### PR DESCRIPTION
**What this PR does / why we need it**:

The call to update the inflightRequests metric incorrectly adds a "user" argument which seems to be used as a label name. This causes a run time panic as it only expects the label value:

```
10:22:22 enterprise-logs: panic: inconsistent label cardinality: expected 1 label values but got 2 in []string{"user", "test_instance"}
10:22:22 enterprise-logs: goroutine 966 [running]:
10:22:22 enterprise-logs: github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues(0x28933e0, {0xc0015fb9c0, 0xc001a24510, 0xc0001022d0})
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>