### PR TITLE
fix the broken query worker code for incrementing inflight queries metric with label values

### DIFF
--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Inc()
+			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.WithLabelValues("user", request.UserID).Dec()
+			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
PR https://github.com/grafana/loki/pull/5485 added `user` label on `worker_inflight_queries` metric. It is using `WithLabelValues` function which requires passing just label values in order of the label names defined in the metric definition but instead it is trying to pass the label name as well. The function name is not super clear which causes a lot of people to fall for it.

This PR fixes the issue since the queriers are panicing with error `panic: inconsistent label cardinality: expected 1 label values but got 2 in []string{"user", "145265"}`.
