### PR TITLE
Change usagestats expvars so they can be set twice

### DIFF
--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -168,7 +168,7 @@ func NewString(name string) *expvar.String {
 	return expvar.NewString(statsPrefix + name)
 }
 
-// Target sets the target name.
+// Target sets the target name. This can be set multiple times.
 func Target(target string) {
 	existing := expvar.Get(statsPrefix + targetKey)
 	if existing != nil {

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -170,6 +170,14 @@ func NewString(name string) *expvar.String {
 
 // Target sets the target name.
 func Target(target string) {
+	existing := expvar.Get(statsPrefix + targetKey)
+	if existing != nil {
+		if s, ok := existing.(*expvar.String); ok {
+			s.Set(target)
+			return
+		}
+		panic("target is set to a non-string value")
+	}
 	NewString(targetKey).Set(target)
 }
 

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -194,27 +194,11 @@ func NewString(name string) *expvar.String {
 
 // Target sets the target name. This can be set multiple times.
 func Target(target string) {
-	existing := expvar.Get(statsPrefix + targetKey)
-	if existing != nil {
-		if s, ok := existing.(*expvar.String); ok {
-			s.Set(target)
-			return
-		}
-		panic("target is set to a non-string value")
-	}
 	NewString(targetKey).Set(target)
 }
 
 // Edition sets the edition name. This can be set multiple times.
 func Edition(edition string) {
-	existing := expvar.Get(statsPrefix + editionKey)
-	if existing != nil {
-		if s, ok := existing.(*expvar.String); ok {
-			s.Set(edition)
-			return
-		}
-		panic("edition is set to a non-string value")
-	}
 	NewString(editionKey).Set(edition)
 }
 

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -154,17 +154,41 @@ func memstats() interface{} {
 }
 
 // NewFloat returns a new Float stats object.
+// If a Float stats object with the same name already exists it is returned.
 func NewFloat(name string) *expvar.Float {
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if f, ok := existing.(*expvar.Float); ok {
+			return f
+		}
+		panic(fmt.Sprintf("%v is set to a non-float value", name))
+	}
 	return expvar.NewFloat(statsPrefix + name)
 }
 
 // NewInt returns a new Int stats object.
+// If an Int stats object object with the same name already exists it is returned.
 func NewInt(name string) *expvar.Int {
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if i, ok := existing.(*expvar.Int); ok {
+			return i
+		}
+		panic(fmt.Sprintf("%v is set to a non-int value", name))
+	}
 	return expvar.NewInt(statsPrefix + name)
 }
 
 // NewString returns a new String stats object.
+// If a String stats object with the same name already exists it is returned.
 func NewString(name string) *expvar.String {
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if s, ok := existing.(*expvar.String); ok {
+			return s
+		}
+		panic(fmt.Sprintf("%v is set to a non-string value", name))
+	}
 	return expvar.NewString(statsPrefix + name)
 }
 
@@ -215,6 +239,7 @@ type Statistics struct {
 // - count
 // - stddev
 // - stdvar
+// If a Statistics object with the same name already exists it is returned.
 func NewStatistics(name string) *Statistics {
 	s := &Statistics{
 		min:   atomic.NewFloat64(math.Inf(0)),
@@ -223,6 +248,13 @@ func NewStatistics(name string) *Statistics {
 		avg:   atomic.NewFloat64(0),
 		mean:  atomic.NewFloat64(0),
 		value: atomic.NewFloat64(0),
+	}
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if s, ok := existing.(*Statistics); ok {
+			return s
+		}
+		panic(fmt.Sprintf("%v is set to a non-Statistics value", name))
 	}
 	expvar.Publish(statsPrefix+name, s)
 	return s
@@ -301,11 +333,19 @@ type Counter struct {
 }
 
 // NewCounter returns a new Counter stats object.
+// If a Counter stats object with the same name already exists it is returned.
 func NewCounter(name string) *Counter {
 	c := &Counter{
 		total:     atomic.NewInt64(0),
 		rate:      atomic.NewFloat64(0),
 		resetTime: time.Now(),
+	}
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if c, ok := existing.(*Counter); ok {
+			return c
+		}
+		panic(fmt.Sprintf("%v is set to a non-Counter value", name))
 	}
 	expvar.Publish(statsPrefix+name, c)
 	return c
@@ -344,11 +384,19 @@ type WordCounter struct {
 }
 
 // NewWordCounter returns a new WordCounter stats object.
-// WordCounter object is thread-safe and count the amount of word recorded.
+// The WordCounter object is thread-safe and counts the number of words recorded.
+// If a WordCounter stats object with the same name already exists it is returned.
 func NewWordCounter(name string) *WordCounter {
 	c := &WordCounter{
 		count: atomic.NewInt64(0),
 		words: sync.Map{},
+	}
+	existing := expvar.Get(statsPrefix + name)
+	if existing != nil {
+		if w, ok := existing.(*WordCounter); ok {
+			return w
+		}
+		panic(fmt.Sprintf("%v is set to a non-WordCounter value", name))
 	}
 	expvar.Publish(statsPrefix+name, c)
 	return c

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -173,8 +173,16 @@ func Target(target string) {
 	NewString(targetKey).Set(target)
 }
 
-// Edition sets the edition name.
+// Edition sets the edition name. This can be set multiple times.
 func Edition(edition string) {
+	existing := expvar.Get(statsPrefix + editionKey)
+	if existing != nil {
+		if s, ok := existing.(*expvar.String); ok {
+			s.Set(edition)
+			return
+		}
+		panic("edition is set to a non-string value")
+	}
 	NewString(editionKey).Set(edition)
 }
 

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -19,6 +19,7 @@ func Test_BuildReport(t *testing.T) {
 		CreatedAt: now,
 	}
 
+	Edition("non-OSS")
 	Edition("OSS")
 	Target("compactor")
 	NewString("compression").Set("lz4")

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -23,14 +23,21 @@ func Test_BuildReport(t *testing.T) {
 	Edition("OSS")
 	Target("distributor")
 	Target("compactor")
+	NewString("compression").Set("snappy")
 	NewString("compression").Set("lz4")
+	NewInt("compression_ratio").Set(50)
 	NewInt("compression_ratio").Set(100)
 	NewFloat("size_mb").Set(100.1)
+	NewFloat("size_mb").Set(200.1)
 	NewCounter("lines_written").Inc(200)
 	s := NewStatistics("query_throughput")
+	s.Record(25)
+	s = NewStatistics("query_throughput")
 	s.Record(300)
 	s.Record(5)
 	w := NewWordCounter("active_tenants")
+	w.Add("buz")
+	w = NewWordCounter("active_tenants")
 	w.Add("foo")
 	w.Add("bar")
 	w.Add("foo")
@@ -45,13 +52,13 @@ func Test_BuildReport(t *testing.T) {
 	require.Equal(t, r.Metrics["num_goroutine"], runtime.NumGoroutine())
 	require.Equal(t, r.Metrics["compression"], "lz4")
 	require.Equal(t, r.Metrics["compression_ratio"], int64(100))
-	require.Equal(t, r.Metrics["size_mb"], 100.1)
+	require.Equal(t, r.Metrics["size_mb"], 200.1)
 	require.Equal(t, r.Metrics["lines_written"].(map[string]interface{})["total"], int64(200))
 	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["min"], float64(5))
 	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["max"], float64(300))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["count"], int64(2))
-	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["avg"], float64(300+5)/2)
-	require.Equal(t, r.Metrics["active_tenants"], int64(2))
+	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["count"], int64(3))
+	require.Equal(t, r.Metrics["query_throughput"].(map[string]interface{})["avg"], float64(25+300+5)/3)
+	require.Equal(t, r.Metrics["active_tenants"], int64(3))
 
 	out, _ := jsoniter.MarshalIndent(r, "", " ")
 	t.Log(string(out))
@@ -96,4 +103,46 @@ func TestWordCounter(t *testing.T) {
 		}()
 	}
 	require.Equal(t, int64(2), w.Value())
+}
+
+func TestPanics(t *testing.T) {
+	require.Panics(t, func() {
+		NewStatistics("panicstats")
+		NewWordCounter("panicstats")
+	})
+
+	require.Panics(t, func() {
+		NewWordCounter("panicwordcounter")
+		NewCounter("panicwordcounter")
+	})
+
+	require.Panics(t, func() {
+		NewCounter("paniccounter")
+		NewStatistics("paniccounter")
+	})
+
+	require.Panics(t, func() {
+		NewFloat("panicfloat")
+		NewInt("panicfloat")
+	})
+
+	require.Panics(t, func() {
+		NewInt("panicint")
+		NewString("panicint")
+	})
+
+	require.Panics(t, func() {
+		NewString("panicstring")
+		NewFloat("panicstring")
+	})
+
+	require.Panics(t, func() {
+		NewFloat(targetKey)
+		Target("new target")
+	})
+
+	require.Panics(t, func() {
+		NewFloat(editionKey)
+		Edition("new edition")
+	})
 }

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -21,6 +21,7 @@ func Test_BuildReport(t *testing.T) {
 
 	Edition("non-OSS")
 	Edition("OSS")
+	Target("distributor")
 	Target("compactor")
 	NewString("compression").Set("lz4")
 	NewInt("compression_ratio").Set(100)


### PR DESCRIPTION
**What this PR does / why we need it**:

The expvars generated in functions like `Edition()`, `Target()` and others in the usagestats package can be called twice. Previously it would panic in that case.

**Checklist**
- [ ] Documentation added
- [X] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>