### PR TITLE
Support `SelectLogs` and `SelectSamples` in multi-tenant querier.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -229,7 +229,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	}
 
 	if t.Cfg.Querier.MultiTenantQueriesEnabled {
-		t.Querier = querier.NewMultiTenantQuerier(*q, util_log.Logger)
+		t.Querier = querier.NewMultiTenantQuerier(q, util_log.Logger)
 	} else {
 		t.Querier = q
 	}

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -80,9 +80,10 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 
 		iters[i] = NewTenantSampleIterator(id, iter)
 	}
-	return iter.NewMergeSampleIterator(ctx, iters), nil
+	return iter.NewSortSampleIterator(iters), nil
 }
 
+// TenantEntry Iterator wraps an entry iterator and adds the tenant label.
 type TenantEntryIterator struct {
 	iter.EntryIterator
 	tenantID string
@@ -106,6 +107,7 @@ func (i *TenantEntryIterator) Labels() string {
 	return builder.Labels().String()
 }
 
+// TenantEntry Iterator wraps a sample iterator and adds the tenant label.
 type TenantSampleIterator struct {
 	iter.SampleIterator
 	tenantID string

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -44,7 +44,7 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 	}
 
 	iters := make([]iter.EntryIterator, len(tenantIDs))
-	for _, id := range tenantIDs {
+	for i, id := range tenantIDs {
 		singleContext := user.InjectUserID(ctx, id)
 		iter, err := q.Querier.SelectLogs(singleContext, params)
 
@@ -52,7 +52,7 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 			return nil, err
 		}
 
-		iters = append(iters, NewTenantEntryIterator(id, iter))
+		iters[i] = NewTenantEntryIterator(id, iter)
 	}
 	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
 }
@@ -70,7 +70,7 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 	}
 
 	iters := make([]iter.SampleIterator, len(tenantIDs))
-	for _, id := range tenantIDs {
+	for i, id := range tenantIDs {
 		singleContext := user.InjectUserID(ctx, id)
 		iter, err := q.Querier.SelectSamples(singleContext, params)
 
@@ -78,7 +78,7 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 			return nil, err
 		}
 
-		iters = append(iters, NewTenantSampleIterator(id, iter))
+		iters[i] = NewTenantSampleIterator(id, iter)
 	}
 	return iter.NewMergeSampleIterator(ctx, iters), nil
 }

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -94,7 +94,7 @@ func NewTenantEntryIterator(id string, iter iter.EntryIterator) *TenantEntryIter
 }
 
 func (i *TenantEntryIterator) Labels() string {
-	// TODO: cache manipulated labels
+	// TODO: cache manipulated labels and add a benchmark.
 	lbls, _ := logql.ParseLabels(i.EntryIterator.Labels())
 	builder := labels.NewBuilder(lbls.WithoutLabels(defaultTenantLabel))
 

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -52,7 +52,7 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 			return nil, err
 		}
 
-		iters[i] = NewTenantEntryIterator(id, iter)
+		iters[i] = NewTenantEntryIterator(iter, id)
 	}
 	return iter.NewSortEntryIterator(iters, params.Direction), nil
 }
@@ -78,7 +78,7 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 			return nil, err
 		}
 
-		iters[i] = NewTenantSampleIterator(id, iter)
+		iters[i] = NewTenantSampleIterator(iter, id)
 	}
 	return iter.NewSortSampleIterator(iters), nil
 }
@@ -89,7 +89,7 @@ type TenantEntryIterator struct {
 	tenantID string
 }
 
-func NewTenantEntryIterator(id string, iter iter.EntryIterator) *TenantEntryIterator {
+func NewTenantEntryIterator(iter iter.EntryIterator, id string) *TenantEntryIterator {
 	return &TenantEntryIterator{EntryIterator: iter, tenantID: id}
 }
 
@@ -113,7 +113,7 @@ type TenantSampleIterator struct {
 	tenantID string
 }
 
-func NewTenantSampleIterator(id string, iter iter.SampleIterator) *TenantSampleIterator {
+func NewTenantSampleIterator(iter iter.SampleIterator, id string) *TenantSampleIterator {
 	return &TenantSampleIterator{SampleIterator: iter, tenantID: id}
 }
 

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -54,7 +54,7 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 
 		iters[i] = NewTenantEntryIterator(id, iter)
 	}
-	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
+	return iter.NewSortEntryIterator(iters, params.Direction), nil
 }
 
 func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -1,15 +1,70 @@
 package querier
 
 import (
+	"context"
+
 	"github.com/go-kit/log"
+	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/tenant"
 )
 
 // MultiTenantQuerier is able to query across different tenants.
 type MultiTenantQuerier struct {
 	SingleTenantQuerier
+	resolver tenant.Resolver
 }
 
 // NewMultiTenantQuerier returns a new querier able to query across different tenants.
 func NewMultiTenantQuerier(querier SingleTenantQuerier, logger log.Logger) *MultiTenantQuerier {
-	return &MultiTenantQuerier{SingleTenantQuerier: querier}
+	return &MultiTenantQuerier{
+		SingleTenantQuerier: querier,
+		resolver:            tenant.NewMultiResolver(),
+	}
+}
+
+func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
+
+	tenantIDs, err := q.resolver.TenantIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	iters := make([]iter.EntryIterator, len(tenantIDs))
+
+	for _, id := range tenantIDs {
+		singleContext := user.InjectUserID(ctx, id)
+		iter, err := q.SingleTenantQuerier.SelectLogs(singleContext, params)
+
+		if err != nil {
+			return nil, err
+		}
+
+		iters = append(iters, NewTenantIterator(id, iter))
+	}
+	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
+}
+
+func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
+
+	tenantIDs, err := q.resolver.TenantIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	iters := make([]iter.EntryIterator, len(tenantIDs))
+
+	for _, id := range tenantIDs {
+		singleContext := user.InjectUserID(ctx, id)
+		iter, err := q.SingleTenantQuerier.SelectSamples(singleContext, params)
+
+		if err != nil {
+			return nil, err
+		}
+
+		iters = append(iters, NewTenantIterator(id, iter))
+	}
+	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
 }

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -95,11 +95,15 @@ func NewTenantEntryIterator(id string, iter iter.EntryIterator) *TenantEntryIter
 func (i *TenantEntryIterator) Labels() string {
 	// TODO: cache manipulated labels
 	lbls, _ := logql.ParseLabels(i.EntryIterator.Labels())
+	builder := labels.NewBuilder(lbls.WithoutLabels(defaultTenantLabel))
 
-	// TODO: handle if lbls.Has(defaultTenantLabel)
+	// Prefix label if it conflicts with the tenant label.
+	if lbls.Has(defaultTenantLabel) {
+		builder.Set(retainExistingPrefix+defaultTenantLabel, lbls.Get(defaultTenantLabel))
+	}
+	builder.Set(defaultTenantLabel, i.tenantID)
 
-	lbls = append(lbls, labels.Label{Name: defaultTenantLabel, Value: i.tenantID})
-	return lbls.String()
+	return builder.Labels().String()
 }
 
 type TenantSampleIterator struct {
@@ -114,9 +118,13 @@ func NewTenantSampleIterator(id string, iter iter.SampleIterator) *TenantSampleI
 func (i *TenantSampleIterator) Labels() string {
 	// TODO: cache manipulated labels
 	lbls, _ := logql.ParseLabels(i.SampleIterator.Labels())
+	builder := labels.NewBuilder(lbls.WithoutLabels(defaultTenantLabel))
 
-	// TODO: handle if lbls.Has(defaultTenantLabel)
+	// Prefix label if it conflicts with the tenant label.
+	if lbls.Has(defaultTenantLabel) {
+		builder.Set(retainExistingPrefix+defaultTenantLabel, lbls.Get(defaultTenantLabel))
+	}
+	builder.Set(defaultTenantLabel, i.tenantID)
 
-	lbls = append(lbls, labels.Label{Name: defaultTenantLabel, Value: i.tenantID})
-	return lbls.String()
+	return builder.Labels().String()
 }

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -16,29 +16,58 @@ import (
 )
 
 func TestMultiTenantQuerier_SelectLogs(t *testing.T) {
-	querier := newQuerierMock()
-	querier.On("SelectLogs", mock.Anything, mock.Anything).Return(func() iter.EntryIterator { return mockStreamIterator(1, 2) }, nil)
+	for _, tc := range []struct {
+		desc      string
+		orgID     string
+		expLabels []string
+		expLines  []string
+	}{
+		{
+			"two tenants",
+			"1|2",
+			[]string{
+				`{__tenant_id__="1", type="test"}`,
+				`{__tenant_id__="1", type="test"}`,
+				`{__tenant_id__="2", type="test"}`,
+				`{__tenant_id__="2", type="test"}`,
+			},
+			[]string{"line 1", "line 2", "line 1", "line 2"},
+		},
+		{
+			"one tenant",
+			"1",
+			[]string{
+				`{type="test"}`,
+				`{type="test"}`,
+			},
+			[]string{"line 1", "line 2"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			querier := newQuerierMock()
+			querier.On("SelectLogs", mock.Anything, mock.Anything).Return(func() iter.EntryIterator { return mockStreamIterator(1, 2) }, nil)
 
-	multi_tenant := NewMultiTenantQuerier(querier, log.NewNopLogger())
+			multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
 
-	ctx := user.InjectOrgID(context.Background(), "1|2")
-	params := logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
-		Selector:  `{type="test"}`,
-		Direction: logproto.BACKWARD,
-		Limit:     0,
-		Shards:    nil,
-		Start:     time.Unix(0, 1),
-		End:       time.Unix(0, time.Now().UnixNano()),
-	}}
-	iter, err := multi_tenant.SelectLogs(ctx, params)
-	require.NoError(t, err)
+			ctx := user.InjectOrgID(context.Background(), tc.orgID)
+			params := logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
+				Selector:  `{type="test"}`,
+				Direction: logproto.BACKWARD,
+				Limit:     0,
+				Shards:    nil,
+				Start:     time.Unix(0, 1),
+				End:       time.Unix(0, time.Now().UnixNano()),
+			}}
+			iter, err := multiTenantQuerier.SelectLogs(ctx, params)
+			require.NoError(t, err)
 
-	iter.Next()
-	require.Equal(t, `{type="test", __tenant_id__="1"}`, iter.Labels())
-	iter.Next()
-	require.Equal(t, `{type="test", __tenant_id__="1"}`, iter.Labels())
-	iter.Next()
-	require.Equal(t, `{type="test", __tenant_id__="2"}`, iter.Labels())
-	iter.Next()
-	require.Equal(t, `{type="test", __tenant_id__="2"}`, iter.Labels())
+			entriesCount := 0
+			for iter.Next() {
+				require.Equal(t, tc.expLabels[entriesCount], iter.Labels())
+				require.Equal(t, tc.expLines[entriesCount], iter.Entry().Line)
+				entriesCount++
+			}
+			require.Equalf(t, len(tc.expLabels), entriesCount, "Expected %d entries but got %d", len(tc.expLabels), entriesCount)
+		})
+	}
 }

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -1,0 +1,44 @@
+package querier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
+)
+
+func TestMultiTenantQuerier_SelectLogs(t *testing.T) {
+	querier := newQuerierMock()
+	querier.On("SelectLogs", mock.Anything, mock.Anything).Return(func() iter.EntryIterator { return mockStreamIterator(1, 2) }, nil)
+
+	multi_tenant := NewMultiTenantQuerier(querier, log.NewNopLogger())
+
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+	params := logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
+		Selector:  `{type="test"}`,
+		Direction: logproto.BACKWARD,
+		Limit:     0,
+		Shards:    nil,
+		Start:     time.Unix(0, 1),
+		End:       time.Unix(0, time.Now().UnixNano()),
+	}}
+	iter, err := multi_tenant.SelectLogs(ctx, params)
+	require.NoError(t, err)
+
+	iter.Next()
+	require.Equal(t, `{type="test", __tenant_id__="1"}`, iter.Labels())
+	iter.Next()
+	require.Equal(t, `{type="test", __tenant_id__="1"}`, iter.Labels())
+	iter.Next()
+	require.Equal(t, `{type="test", __tenant_id__="2"}`, iter.Labels())
+	iter.Next()
+	require.Equal(t, `{type="test", __tenant_id__="2"}`, iter.Labels())
+}

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -124,7 +124,6 @@ func TestMultiTenantQuerier_SelectSamples(t *testing.T) {
 	}
 }
 
-// copied from range_vector_test.go
 var samples = []logproto.Sample{
 	{Timestamp: time.Unix(2, 0).UnixNano(), Hash: 1, Value: 1.},
 	{Timestamp: time.Unix(5, 0).UnixNano(), Hash: 2, Value: 1.},

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -402,3 +402,31 @@ func mockStreamWithLabels(from int, quantity int, labels string) logproto.Stream
 		Labels:  labels,
 	}
 }
+
+type querierMock struct {
+	util.ExtendedMock
+}
+
+func newQuerierMock() *querierMock {
+	return &querierMock{}
+}
+
+func (q *querierMock) SelectLogs(context.Context, logql.SelectLogParams) (iter.EntryIterator, error) {
+	return nil, errors.New("querierMock.SelectLogs() has not been mocked")
+}
+
+func (q *querierMock) SelectSamples(context.Context, logql.SelectSampleParams) (iter.SampleIterator, error) {
+	return nil, errors.New("querierMock.SelectSamples() has not been mocked")
+}
+
+func (q *querierMock) Label(ctx context.Context, req *logproto.LabelRequest) (*logproto.LabelResponse, error) {
+	return nil, errors.New("querierMock.Label() has not been mocked")
+}
+
+func (q *querierMock) Series(ctx context.Context, req *logproto.SeriesRequest) (*logproto.SeriesResponse, error) {
+	return nil, errors.New("querierMock.Series() has not been mocked")
+}
+
+func (q *querierMock) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer, error) {
+	return nil, errors.New("querierMock.Tail() has not been mocked")
+}

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -413,7 +413,7 @@ func newQuerierMock() *querierMock {
 
 func (q *querierMock) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
 	args := q.Called(ctx, params)
-	return args.Get(0).(iter.EntryIterator), args.Error(1)
+	return args.Get(0).(func() iter.EntryIterator)(), args.Error(1)
 }
 
 func (q *querierMock) SelectSamples(context.Context, logql.SelectSampleParams) (iter.SampleIterator, error) {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -411,8 +411,9 @@ func newQuerierMock() *querierMock {
 	return &querierMock{}
 }
 
-func (q *querierMock) SelectLogs(context.Context, logql.SelectLogParams) (iter.EntryIterator, error) {
-	return nil, errors.New("querierMock.SelectLogs() has not been mocked")
+func (q *querierMock) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
+	args := q.Called(ctx, params)
+	return args.Get(0).(iter.EntryIterator), args.Error(1)
 }
 
 func (q *querierMock) SelectSamples(context.Context, logql.SelectSampleParams) (iter.SampleIterator, error) {

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -416,8 +416,9 @@ func (q *querierMock) SelectLogs(ctx context.Context, params logql.SelectLogPara
 	return args.Get(0).(func() iter.EntryIterator)(), args.Error(1)
 }
 
-func (q *querierMock) SelectSamples(context.Context, logql.SelectSampleParams) (iter.SampleIterator, error) {
-	return nil, errors.New("querierMock.SelectSamples() has not been mocked")
+func (q *querierMock) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
+	args := q.Called(ctx, params)
+	return args.Get(0).(func() iter.SampleIterator)(), args.Error(1)
 }
 
 func (q *querierMock) Label(ctx context.Context, req *logproto.LabelRequest) (*logproto.LabelResponse, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds some functionality to the `MultiTenantQuerier` stub. `SelectLogs` and `SelectSamples` fan out into multiple calls, one for each tenant. The returned iterators are then merged back together and the proper tenant label is added.

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private#232

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
