### PR TITLE
fix broken index gateway benchmark due to missing limits

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -29,7 +29,6 @@ const (
 type Limits interface {
 	AllByUserID() map[string]*validation.Limits
 	DefaultLimits() *validation.Limits
-	QueryReadyIndexNumDays(userID string) int
 }
 
 type Config struct {

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -293,10 +293,6 @@ func (m *mockLimits) DefaultLimits() *validation.Limits {
 	}
 }
 
-func (m *mockLimits) QueryReadyIndexNumDays(userID string) int {
-	return m.queryReadyIndexNumDaysByUser[userID]
-}
-
 type mockTable struct {
 	tableExpired               bool
 	queryReadinessDoneForUsers []string

--- a/pkg/storage/stores/shipper/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/gateway_client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 	util_math "github.com/grafana/loki/pkg/util/math"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 const (
@@ -162,6 +163,16 @@ func buildTableName(i int) string {
 	return fmt.Sprintf("%s%d", tableNamePrefix, i)
 }
 
+type mockLimits struct{}
+
+func (m mockLimits) AllByUserID() map[string]*validation.Limits {
+	return map[string]*validation.Limits{}
+}
+
+func (m mockLimits) DefaultLimits() *validation.Limits {
+	return &validation.Limits{}
+}
+
 func benchmarkIndexQueries(b *testing.B, queries []chunk.IndexQuery) {
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
@@ -211,6 +222,7 @@ func benchmarkIndexQueries(b *testing.B, queries []chunk.IndexQuery) {
 		SyncInterval:      15 * time.Minute,
 		CacheTTL:          15 * time.Minute,
 		QueryReadyNumDays: 30,
+		Limits:            mockLimits{},
 	}, bclient, storage.NewIndexStorageClient(fs, "index/"), nil)
 	require.NoError(b, err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Index gateway benchmarks were failing due to limits not being initialized. This PR fixes it.
I have also cleaned up an unused method `QueryReadyIndexNumDays` from the limits interface.
