### PR TITLE
Revert "metrics: Add `user` label to `worker_inflight_queries` (#5485)"

### DIFF
--- a/pkg/querier/worker/metrics.go
+++ b/pkg/querier/worker/metrics.go
@@ -7,7 +7,7 @@ import (
 
 type Metrics struct {
 	concurrentWorkers             prometheus.Gauge
-	inflightRequests              *prometheus.GaugeVec
+	inflightRequests              prometheus.Gauge
 	frontendClientRequestDuration *prometheus.HistogramVec
 	frontendClientsGauge          prometheus.Gauge
 }
@@ -18,10 +18,10 @@ func NewMetrics(conf Config, r prometheus.Registerer) *Metrics {
 			Name: "loki_querier_worker_concurrency",
 			Help: "Number of concurrent querier workers",
 		}),
-		inflightRequests: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+		inflightRequests: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_querier_worker_inflight_queries",
 			Help: "Number of queries being processed by the querier workers",
-		}, []string{"user"}),
+		}),
 		frontendClientRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_querier_query_frontend_request_duration_seconds",
 			Help:    "Time spend doing requests to frontend.",

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -130,12 +130,12 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 
 			start := time.Now()
 			tenant, _ := tenant.TenantID(ctx)
-			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Inc()
+			sp.metrics.inflightRequests.Inc()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "enqueue")
 
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
-			sp.metrics.inflightRequests.WithLabelValues(request.UserID).Dec()
+			sp.metrics.inflightRequests.Dec()
 			level.Debug(logger).Log("msg", "tracking inflight request", "tenant", tenant, "op", "dequeue", "duration", time.Since(start))
 
 			// Report back to scheduler that processing of the query has finished.


### PR DESCRIPTION
This reverts commit 45d5f28e67b156c84d412c36c2ffd2f082303dfe.

This commit inadvertantly created the possibility of a cardinality explosion in large clusters, as it creates metrics in accordance with `n_tenants * n_queriers`.