### PR TITLE
Fix path to binary in Dockerfile for querytee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ cmd/loki-canary/loki-canary
 clients/cmd/fluent-bit/out_grafana_loki.so
 clients/cmd/fluent-bit/out_grafana_loki.h
 cmd/migrate/migrate
+cmd/querytee/querytee
 /loki
 /promtail
 /logcli

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -6,5 +6,5 @@ RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
 
 FROM alpine:3.13
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /src/loki/cmd/querytee/loki-querytee /usr/bin/querytee
+COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]


### PR DESCRIPTION
The Dockerfile referenced an incorrect path of the querytee binary
causing the build of the querytee image to fail.

```console
$ make loki-querytee-image
docker build -t grafana/loki-querytee:main-84c97ce -f cmd/querytee/Dockerfile .
Sending build context to Docker daemon  650.6MB
...
Step 7/8 : COPY --from=build /src/loki/cmd/querytee/loki-querytee /usr/bin/querytee
COPY failed: stat src/loki/cmd/querytee/loki-querytee: file does not exist
make: *** [Makefile:526: loki-querytee-image] Error 1
```

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
