### PR TITLE
Improve json parser performance

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -22,8 +22,6 @@ import (
 const (
 	jsonSpacer      = '_'
 	duplicateSuffix = "_extracted"
-	trueString      = "true"
-	falseString     = "false"
 )
 
 var (

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -37,18 +37,16 @@ type JSONParser struct {
 	buf []byte // buffer used to build json keys
 	lbs *LabelsBuilder
 
-	keys                  internedStringSet
-	bugerJSONParserEnable bool
-	jsonKeyCache          map[string][][]string
+	keys         internedStringSet
+	jsonKeyCache map[string][][]string
 }
 
 // NewJSONParser creates a log stage that can parse a json log line and add properties as labels.
 func NewJSONParser() *JSONParser {
 	return &JSONParser{
-		buf:                   make([]byte, 0, 1024),
-		keys:                  internedStringSet{},
-		bugerJSONParserEnable: true,
-		jsonKeyCache:          make(map[string][][]string),
+		buf:          make([]byte, 0, 1024),
+		keys:         internedStringSet{},
+		jsonKeyCache: make(map[string][][]string),
 	}
 }
 
@@ -57,15 +55,13 @@ func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 		return line, true
 	}
 	j.lbs = lbs
-	if j.bugerJSONParserEnable {
-		requiredLabels := j.lbs.ParserLabelHints().RequiredLabels()
-		if len(requiredLabels) > 0 {
-			err := j.parseJSONKeyVal(line, requiredLabels)
-			if err != nil {
-				lbs.SetErr(errJSON)
-			}
-			return line, true
+	requiredLabels := j.lbs.ParserLabelHints().RequiredLabels()
+	if len(requiredLabels) > 0 {
+		err := j.parseJSONKeyVal(line, requiredLabels)
+		if err != nil {
+			lbs.SetErr(errJSON)
 		}
+		return line, true
 	}
 
 	err := j.handleJson("", line)
@@ -77,12 +73,9 @@ func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 	return line, true
 }
 
-func (j *JSONParser) RequiredLabelNames() []string { return []string{} }
-
 func (j *JSONParser) handleJson(preKey string, line []byte) error {
 	err := jsonparser.ObjectEach(line, func(key []byte, val []byte, valueType jsonparser.ValueType, offset int) error {
 		jsonKey := preKey + sanitizeLabelKey(string(key), true)
-
 		if valueType == jsonparser.Array {
 			return nil
 		}
@@ -191,6 +184,8 @@ func (j *JSONParser) setJSONVal(field string, v []byte) error {
 	j.lbs.Set(field, string(v))
 	return nil
 }
+
+func (j *JSONParser) RequiredLabelNames() []string { return []string{} }
 
 type RegexpParser struct {
 	regex     *regexp.Regexp

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -92,7 +91,7 @@ func (j *JSONParser) handleJson(preKey string, line []byte) error {
 		if valueType == jsonparser.Object {
 			return j.handleJson(jsonKey+"_", val)
 		}
-		jsonErr := j.setJSONVal(jsonKey, val, valueType)
+		jsonErr := j.setJSONVal(jsonKey, val)
 		if jsonErr != nil {
 			return jsonErr
 		}
@@ -122,7 +121,7 @@ func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error
 				if e != nil {
 					continue
 				}
-				err := j.setJSONVal(field, v, t)
+				err := j.setJSONVal(field, v)
 				if err != nil {
 					return err
 				}
@@ -168,7 +167,7 @@ func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error
 				jsonSpacerIndex++
 				continue
 			}
-			err := j.setJSONVal(field, v, t)
+			err := j.setJSONVal(field, v)
 			if err != nil {
 				return err
 			}
@@ -187,53 +186,12 @@ func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error
 	return nil
 }
 
-func (j *JSONParser) setJSONVal(field string, v []byte, t jsonparser.ValueType) error {
-	val, err := parseStringVal(v, t)
-	if err != nil {
-		return err
-	}
+func (j *JSONParser) setJSONVal(field string, v []byte) error {
 	if j.lbs.BaseHas(field) {
 		field = field + duplicateSuffix
 	}
-	j.lbs.Set(field, val)
+	j.lbs.Set(field, string(v))
 	return nil
-}
-
-func parseStringVal(v []byte, t jsonparser.ValueType) (string, error) {
-	if 1 == 1 {
-		return string(v), nil
-	}
-	var val string
-	var err error
-	if t == jsonparser.String {
-		if bytes.IndexByte(v, '\\') == -1 {
-			val = string(v)
-		} else {
-			val, err = jsonparser.ParseString(v)
-			if err != nil {
-				return val, err
-			}
-		}
-	} else if t == jsonparser.Number {
-		intVal, err := jsonparser.ParseInt(v)
-		if err != nil {
-			return val, err
-		}
-		val = strconv.FormatInt(intVal, 10)
-	} else if t == jsonparser.Boolean {
-		boolVal, err := jsonparser.ParseBoolean(v)
-		if err != nil {
-			return val, err
-		}
-		if boolVal {
-			val = trueString
-		} else {
-			val = falseString
-		}
-	} else {
-		return val, errors.New("unsupported type")
-	}
-	return val, nil
 }
 
 type RegexpParser struct {

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -63,7 +63,7 @@ func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 	if j.bugerJsonParserEnable {
 		requiredLabels := j.lbs.ParserLabelHints().RequiredLabels()
 		if len(requiredLabels) > 0 {
-			err := j.parseJsonKeyVal(line, requiredLabels)
+			err := j.parseJSONKeyVal(line, requiredLabels)
 			if err != nil {
 				lbs.SetErr(errJSON)
 			}
@@ -81,18 +81,6 @@ func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 		return line, true
 	}
 	return line, true
-}
-
-func (j *JSONParser) ParseJsonVal(line []byte, field string, keys []string) error {
-	val, err := jsonparser.GetString(line, keys...)
-	if err != nil {
-		return nil
-	}
-	if j.lbs.BaseHas(field) {
-		field = field + duplicateSuffix
-	}
-	j.lbs.Set(field, val)
-	return nil
 }
 
 func (j *JSONParser) readObject(it *jsoniter.Iterator) error {
@@ -192,7 +180,7 @@ func (j *JSONParser) parseLabelValue(iter *jsoniter.Iterator, prefix, field stri
 
 func (j *JSONParser) RequiredLabelNames() []string { return []string{} }
 
-func (j *JSONParser) parseJsonKeyVal(line []byte, requiredLabels []string) error {
+func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error {
 	//check for "jsonParser-not json line" benchmark
 	if strings.Index(string(line), "{") != 0 {
 		return errors.New("illegal format")

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -117,7 +117,7 @@ func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error
 		if ok {
 			isMatchKey := false
 			for _, key := range cacheKeys {
-				v, t, _, e := jsonparser.Get(line, key...)
+				v, _, _, e := jsonparser.Get(line, key...)
 				if e != nil {
 					continue
 				}
@@ -136,7 +136,7 @@ func (j *JSONParser) parseJSONKeyVal(line []byte, requiredLabels []string) error
 		keyArray := make([]string, 0)
 		jsonSpacerIndex := 0
 		for {
-			v, t, _, e := jsonparser.Get(line, keys...)
+			v, _, _, e := jsonparser.Get(line, keys...)
 			if e != nil {
 				if e != jsonparser.KeyPathNotFoundError {
 					return e

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -25,6 +25,8 @@ type ParserHint interface {
 	//		 sum(rate({app="foo"} | json [5m]))
 	// We don't need to extract any labels from the log line.
 	NoLabels() bool
+
+	RequiredLabels() []string
 }
 
 type parserHint struct {
@@ -59,6 +61,10 @@ func (p *parserHint) ShouldExtractPrefix(prefix string) bool {
 
 func (p *parserHint) NoLabels() bool {
 	return p.noLabels
+}
+
+func (p *parserHint) RequiredLabels() []string {
+	return p.requiredLabels
 }
 
 // newParserHint creates a new parser hint using the list of labels that are seen and required in a query.


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve json parser performance, from 2913 ns/op to 1132 ns/op

**Which issue(s) this PR fixes**:
Fixes [#4328]
reimplement pr: https://github.com/grafana/loki/pull/5417

**Special notes for your reviewer**:
New  Benchmark_Parser
```shell
Benchmark_Parser/json/no_labels_hints-12            250380        4772 ns/op
Benchmark_Parser/json/labels_hints-12               962606        1172 ns/op
Benchmark_Parser/jsonParser-not_json_line/no_labels_hints-12          81525914          13.54 ns/op
Benchmark_Parser/jsonParser-not_json_line/labels_hints-12              6865554         155.3 ns/op
```
Old  Benchmark_Parser
```shell
Benchmark_Parser/json/no_labels_hints-12            299535        3892 ns/op
Benchmark_Parser/json/labels_hints-12               355948        2913 ns/op
Benchmark_Parser/jsonParser-not_json_line/no_labels_hints-12          38245290          30.84 ns/op
Benchmark_Parser/jsonParser-not_json_line/labels_hints-12             39412749          31.16 ns/op
```

key change.
	use "github.com/buger/jsonparser" replace "github.com/json-iterator/go"
![image](https://user-images.githubusercontent.com/9583245/157003865-a83a89ca-9e47-456f-a981-a0811ff0d7cf.png)

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.