### PR TITLE
regexp filter: use modified package with optimisations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 require (
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.2.0
-	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
+	github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb
 	github.com/mattn/go-ieproxy v0.0.1
 	github.com/xdg-go/scram v1.0.2
 	gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8 h1:aEOagXOTqtN9gd4
 github.com/grafana/go-gelf v0.0.0-20211112153804-126646b86de8/go.mod h1:QAvS2C7TtQRhhv9Uf/sxD+BUhpkrPFm5jK/9MzUiDCY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
-github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
-github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb h1:wwzNkyaQwcXCzQuKoWz3lwngetmcyg+EhW0fF5lz73M=
+github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03 h1:fGgFrAraMB0BaPfYumu+iulfDXwHm+GFyHA4xEtBqI8=
 github.com/grafana/tail v0.0.0-20201004203643-7aa4e4a91f03/go.mod h1:GIMXMPB/lRAllP5rVDvcGif87ryO2hgD7tCtHMdHrho=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/vendor/github.com/grafana/regexp/README.md
+++ b/vendor/github.com/grafana/regexp/README.md
@@ -10,3 +10,10 @@ The `main` branch is non-optimised: switch over to [`speedup`](https://github.co
 ## Benchmarks:
 
 ![image](https://user-images.githubusercontent.com/8125524/152182951-856549ed-6044-4285-b799-69b31f598e32.png)
+
+## Links to upstream changes:
+* [regexp: allow patterns with no alternates to be one-pass](https://go-review.googlesource.com/c/go/+/353711)
+* [regexp: speed up onepass prefix check](https://go-review.googlesource.com/c/go/+/354909)
+* [regexp: handle prefix string with fold-case](https://go-review.googlesource.com/c/go/+/358756)
+* [regexp: avoid copying each instruction executed](https://go-review.googlesource.com/c/go/+/355789)
+* [regexp: allow prefix string anchored at beginning](https://go-review.googlesource.com/c/go/+/377294)

--- a/vendor/github.com/grafana/regexp/onepass.go
+++ b/vendor/github.com/grafana/regexp/onepass.go
@@ -5,10 +5,12 @@
 package regexp
 
 import (
-	"regexp/syntax"
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // "One-pass" regexp execution.
@@ -37,10 +39,10 @@ type onePassInst struct {
 // is the entire match. Pc is the index of the last rune instruction
 // in the string. The OnePassPrefix skips over the mandatory
 // EmptyBeginText
-func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
+func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, foldCase bool, pc uint32) {
 	i := &p.Inst[p.Start]
 	if i.Op != syntax.InstEmptyWidth || (syntax.EmptyOp(i.Arg))&syntax.EmptyBeginText == 0 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 	pc = i.Out
 	i = &p.Inst[pc]
@@ -50,12 +52,13 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 	}
 	// Avoid allocation of buffer if prefix is empty.
 	if iop(i) != syntax.InstRune || len(i.Rune) != 1 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 
+	foldCase = (syntax.Flags(i.Arg)&syntax.FoldCase != 0)
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && syntax.Flags(i.Arg)&syntax.FoldCase == 0 {
+	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && (syntax.Flags(i.Arg)&syntax.FoldCase != 0) == foldCase && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		pc, i = i.Out, &p.Inst[i.Out]
 	}
@@ -64,7 +67,7 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 		p.Inst[i.Out].Op == syntax.InstMatch {
 		complete = true
 	}
-	return buf.String(), complete, pc
+	return buf.String(), complete, foldCase, pc
 }
 
 // OnePassNext selects the next actionable state of the prog, based on the input character.
@@ -471,12 +474,20 @@ func compileOnePass(prog *syntax.Prog) (p *onePassProg) {
 		syntax.EmptyOp(prog.Inst[prog.Start].Arg)&syntax.EmptyBeginText != syntax.EmptyBeginText {
 		return nil
 	}
-	// every instruction leading to InstMatch must be EmptyEndText
+	hasAlt := false
+	for _, inst := range prog.Inst {
+		if inst.Op == syntax.InstAlt || inst.Op == syntax.InstAltMatch {
+			hasAlt = true
+			break
+		}
+	}
+	// If we have alternates, every instruction leading to InstMatch must be EmptyEndText.
+	// Also, any match on empty text must be $.
 	for _, inst := range prog.Inst {
 		opOut := prog.Inst[inst.Out].Op
 		switch inst.Op {
 		default:
-			if opOut == syntax.InstMatch {
+			if opOut == syntax.InstMatch && hasAlt {
 				return nil
 			}
 		case syntax.InstAlt, syntax.InstAltMatch:

--- a/vendor/github.com/grafana/regexp/regexp.go
+++ b/vendor/github.com/grafana/regexp/regexp.go
@@ -68,12 +68,13 @@ package regexp
 import (
 	"bytes"
 	"io"
-	"regexp/syntax"
 	"strconv"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // Regexp is the representation of a compiled regular expression.
@@ -90,6 +91,7 @@ type Regexp struct {
 	prefixBytes    []byte         // prefix, as a []byte
 	prefixRune     rune           // first rune in prefix
 	prefixEnd      uint32         // pc for last rune in prefix
+	prefixFoldCase bool           // check prefix case-insensitive
 	mpool          int            // pool for machines
 	matchcap       int            // size of recorded match lengths
 	prefixComplete bool           // prefix is the entire regexp
@@ -195,10 +197,10 @@ func compile(expr string, mode syntax.Flags, longest bool) (*Regexp, error) {
 		minInputLen: minInputLen(re),
 	}
 	if regexp.onepass == nil {
-		regexp.prefix, regexp.prefixComplete = prog.Prefix()
+		regexp.prefix, regexp.prefixComplete, regexp.prefixFoldCase = prog.PrefixAndCase()
 		regexp.maxBitStateLen = maxBitStateLen(prog)
 	} else {
-		regexp.prefix, regexp.prefixComplete, regexp.prefixEnd = onePassPrefix(prog)
+		regexp.prefix, regexp.prefixComplete, regexp.prefixFoldCase, regexp.prefixEnd = onePassPrefix(prog)
 	}
 	if regexp.prefix != "" {
 		// TODO(rsc): Remove this allocation by adding
@@ -396,10 +398,26 @@ func (i *inputString) canCheckPrefix() bool {
 }
 
 func (i *inputString) hasPrefix(re *Regexp) bool {
+	if re.prefixFoldCase {
+		n := len(re.prefix)
+		return len(i.str) >= n && strings.EqualFold(i.str[0:n], re.prefix)
+	}
 	return strings.HasPrefix(i.str, re.prefix)
 }
 
 func (i *inputString) index(re *Regexp, pos int) int {
+	if re.prefixFoldCase {
+		n := len(re.prefix)
+		// Brute-force compare at every position; could replace with sophisticated algo like strings.Index
+		for p := pos; p+n <= len(i.str); {
+			if strings.EqualFold(i.str[p:p+n], re.prefix) {
+				return p - pos
+			}
+			_, w := i.step(p)
+			p += w
+		}
+		return -1
+	}
 	return strings.Index(i.str[pos:], re.prefix)
 }
 
@@ -443,10 +461,26 @@ func (i *inputBytes) canCheckPrefix() bool {
 }
 
 func (i *inputBytes) hasPrefix(re *Regexp) bool {
+	if re.prefixFoldCase {
+		n := len(re.prefixBytes)
+		return len(i.str) >= n && bytes.EqualFold(i.str[0:n], re.prefixBytes)
+	}
 	return bytes.HasPrefix(i.str, re.prefixBytes)
 }
 
 func (i *inputBytes) index(re *Regexp, pos int) int {
+	if re.prefixFoldCase {
+		n := len(re.prefixBytes)
+		// Brute-force compare at every position; could replace with sophisticated algo like bytes.Index
+		for p := pos; p+n <= len(i.str); {
+			if bytes.EqualFold(i.str[p:p+n], re.prefixBytes) {
+				return p - pos
+			}
+			_, w := i.step(p)
+			p += w
+		}
+		return -1
+	}
 	return bytes.Index(i.str[pos:], re.prefixBytes)
 }
 

--- a/vendor/github.com/grafana/regexp/syntax/prog.go
+++ b/vendor/github.com/grafana/regexp/syntax/prog.go
@@ -145,20 +145,37 @@ func (i *Inst) op() InstOp {
 // regexp must start with. Complete is true if the prefix
 // is the entire match.
 func (p *Prog) Prefix() (prefix string, complete bool) {
-	i := p.skipNop(uint32(p.Start))
+	prefix, complete, foldCase := p.PrefixAndCase()
+	if foldCase {
+		return "", false
+	}
+	return prefix, complete
+}
+
+// Prefix returns a literal string that all matches for the
+// regexp must start with. Complete is true if the prefix
+// is the entire match. FoldCase is true if the string should
+// match in upper or lower case.
+func (p *Prog) PrefixAndCase() (prefix string, complete bool, foldCase bool) {
+	i := &p.Inst[p.Start]
+	// Skip any no-op, capturing or begin-text instructions
+	for i.Op == InstNop || i.Op == InstCapture || (i.Op == InstEmptyWidth && EmptyOp(i.Arg)&EmptyBeginText != 0) {
+		i = &p.Inst[i.Out]
+	}
 
 	// Avoid allocation of buffer if prefix is empty.
 	if i.op() != InstRune || len(i.Rune) != 1 {
-		return "", i.Op == InstMatch
+		return "", i.Op == InstMatch, false
 	}
 
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for i.op() == InstRune && len(i.Rune) == 1 && Flags(i.Arg)&FoldCase == 0 {
+	foldCase = (Flags(i.Arg)&FoldCase != 0)
+	for i.op() == InstRune && len(i.Rune) == 1 && (Flags(i.Arg)&FoldCase != 0) == foldCase {
 		buf.WriteRune(i.Rune[0])
 		i = p.skipNop(i.Out)
 	}
-	return buf.String(), i.Op == InstMatch
+	return buf.String(), i.Op == InstMatch, foldCase
 }
 
 // StartCond returns the leading empty-width conditions that must

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,7 +541,7 @@ github.com/grafana/dskit/ring/util
 github.com/grafana/dskit/runtimeconfig
 github.com/grafana/dskit/services
 github.com/grafana/dskit/spanlogger
-# github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
+# github.com/grafana/regexp v0.0.0-20220304100321-149c8afcd6cb
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a repeat of #5315, which was reverted in #5413.

See https://github.com/grafana/regexp/tree/speedup#readme

Includes the following changes proposed upstream:
* [regexp: allow patterns with no alternates to be one-pass](https://go-review.googlesource.com/c/go/+/353711)
* [regexp: speed up onepass prefix check](https://go-review.googlesource.com/c/go/+/354909)
* [regexp: handle prefix string with fold-case](https://go-review.googlesource.com/c/go/+/358756)
* [regexp: avoid copying each instruction executed](https://go-review.googlesource.com/c/go/+/355789)
* [regexp: allow prefix string anchored at beginning](https://go-review.googlesource.com/c/go/+/377294)

**Checklist**
- NA Documentation added - not user-visible.
- NA Tests updated - no functionality changes.
- NA Add an entry in the `CHANGELOG.md` about the changes - there is already an entry for #5315.
