### PR TITLE
Refactor sharding engine to downstream engine

### DIFF
--- a/pkg/logql/ast.go
+++ b/pkg/logql/ast.go
@@ -764,6 +764,10 @@ type SampleExpr interface {
 	Expr
 }
 
+func badASTMapping(got Expr) error {
+	return fmt.Errorf("bad AST mapping: expected SampleExpr, but got (%T)", got)
+}
+
 type RangeAggregationExpr struct {
 	Left      *LogRange
 	Operation string

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -61,7 +61,7 @@ func TestMappingEquivalence(t *testing.T) {
 
 		opts := EngineOpts{}
 		regular := NewEngine(opts, q, NoLimits, log.NewNopLogger())
-		sharded := NewShardedEngine(opts, MockDownstreamer{regular}, nilMetrics, NoLimits, log.NewNopLogger())
+		sharded := NewDownstreamEngine(opts, MockDownstreamer{regular}, nilMetrics, NoLimits, log.NewNopLogger())
 
 		t.Run(tc.query, func(t *testing.T) {
 			params := NewLiteralParams(

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -78,10 +78,6 @@ func (r *shardRecorder) Finish() {
 	}
 }
 
-func badASTMapping(expected string, got Expr) error {
-	return fmt.Errorf("Bad AST mapping: expected one type (%s), but got (%T)", expected, got)
-}
-
 func NewShardMapper(shards int, metrics *ShardingMetrics) (ShardMapper, error) {
 	if shards < 2 {
 		return ShardMapper{}, fmt.Errorf("Cannot create ShardMapper with <2 shards. Received %d", shards)
@@ -154,11 +150,11 @@ func (m ShardMapper) Map(expr Expr, r *shardRecorder) (Expr, error) {
 		}
 		lhsSampleExpr, ok := lhsMapped.(SampleExpr)
 		if !ok {
-			return nil, badASTMapping("SampleExpr", lhsMapped)
+			return nil, badASTMapping(lhsMapped)
 		}
 		rhsSampleExpr, ok := rhsMapped.(SampleExpr)
 		if !ok {
-			return nil, badASTMapping("SampleExpr", rhsMapped)
+			return nil, badASTMapping(rhsMapped)
 		}
 		e.SampleExpr = lhsSampleExpr
 		e.RHS = rhsSampleExpr
@@ -218,7 +214,7 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *VectorAggregationExpr, r *sh
 		}
 		sampleExpr, ok := subMapped.(SampleExpr)
 		if !ok {
-			return nil, badASTMapping("SampleExpr", subMapped)
+			return nil, badASTMapping(subMapped)
 		}
 
 		return &VectorAggregationExpr{

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	logger "log"
 	"sort"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/labels"
@@ -277,4 +279,13 @@ func mustParseLabels(s string) labels.Labels {
 	}
 
 	return labels
+}
+
+func removeWhiteSpace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == ' ' || unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -74,7 +74,7 @@ func newASTMapperware(
 		confs:   confs,
 		logger:  log.With(logger, "middleware", "QueryShard.astMapperware"),
 		next:    next,
-		ng:      logql.NewShardedEngine(logql.EngineOpts{}, DownstreamHandler{next}, metrics, limits, logger),
+		ng:      logql.NewDownstreamEngine(logql.EngineOpts{}, DownstreamHandler{next}, metrics, limits, logger),
 		metrics: metrics,
 	}
 }
@@ -83,7 +83,7 @@ type astMapperware struct {
 	confs   ShardingConfigs
 	logger  log.Logger
 	next    queryrangebase.Handler
-	ng      *logql.ShardedEngine
+	ng      *logql.DownstreamEngine
 	metrics *logql.ShardingMetrics
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

* Rename ShardedEngine to DownstreamEngine
* Minor code refactorings

With the introduction of split by range middleware for instant queries, the engine is reused for executing multiple downstream computations in parallel without a shard factor (optional). As a result, the engine should be renamed to DownstreamEngine.

**Which issue(s) this PR fixes**:

NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
