### PR TITLE
updates clusterrole and clusterrolebinding apiVersions in promtail.sh

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -327,7 +327,7 @@ kind: ServiceAccount
 metadata:
   name: promtail
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: promtail
@@ -345,7 +345,7 @@ rules:
   - list
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: promtail


### PR DESCRIPTION
Our script currently won't work for anything v1.22+. This PR uses the new apiVersions which will. This change is also backwards compatible for any k8s versions v1.8 or newer: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122