### PR TITLE
operator: Fix service monitor's server name for operator metrics

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,3 +3,4 @@
 - [4975](https://github.com/grafana/loki/pull/4975) **periklis**: Provide saner default for loki-operator managed chunk_target_size
 - [4974](https://github.com/grafana/loki/pull/5432) **Red-GV**: Provide storage configuration for Azure, GCS, and Swift through common_config
 - [5345](https://github.com/grafana/loki/pull/5345) **ronensc**: Add flag to create Prometheus rules
+- [5560](https://github.com/grafana/loki/pull/5560) **periklis**: Fix service monitor's server name for operator metrics

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -187,15 +187,12 @@ olm-deploy:  ## Deploy the operator bundle and the operator via OLM into an Kube
 	$(error Set variable REGISTRY_ORG to use a custom container registry org account for local development)
 else
 olm-deploy: olm-deploy-bundle olm-deploy-operator $(OPERATOR_SDK)
-	kubectl create ns $(LOKI_OPERATOR_NS)
-	kubectl label ns/$(LOKI_OPERATOR_NS) openshift.io/cluster-monitoring=true --overwrite
-	$(OPERATOR_SDK) run bundle -n $(LOKI_OPERATOR_NS) --install-mode OwnNamespace $(BUNDLE_IMG)
+	$(OPERATOR_SDK) run bundle -n $(LOKI_OPERATOR_NS) --install-mode AllNamespaces $(BUNDLE_IMG)
 endif
 
 .PHONY: olm-undeploy
 olm-undeploy: $(OPERATOR_SDK) ## Cleanup deployments of the operator bundle and the operator via OLM on an OpenShift cluster selected via KUBECONFIG.
-	$(OPERATOR_SDK) cleanup loki-operator
-	kubectl delete ns $(LOKI_OPERATOR_NS)
+	$(OPERATOR_SDK) cleanup -n $(LOKI_OPERATOR_NS) loki-operator
 
 .PHONY: deploy-size-calculator
 ifeq ($(findstring openshift-logging,$(CALCULATOR_IMG)),openshift-logging)

--- a/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -19,7 +19,7 @@ spec:
     targetPort: 8443
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: loki-operator-controller-manager-metrics-service.openshift-logging.svc
+      serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc
   selector:
     matchLabels:
       app.kubernetes.io/name: loki-operator

--- a/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
+++ b/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
@@ -14,4 +14,4 @@ spec:
       scrapeTimeout: 10s
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: loki-operator-controller-manager-metrics-service.openshift-logging.svc
+        serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc


### PR DESCRIPTION
**What this PR does / why we need it**:
This one provides a small fix missed in #5440 to allow OpenShift's Prometheus to access the operator metrics. Furthermore the make targets `olm-deploy` and `olm-undeploy` are restricted from deleting the managed OpenShift namespace `openshift-operators-redhat`.

**Which issue(s) this PR fixes**:
Fixes #5559

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
