### PR TITLE
operator: Change endpoints for generated liveness and readiness probes

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [5576](https://github.com/grafana/loki/pull/5576) **xperimental**: Change endpoints for generated liveness and readiness probes
 - [5560](https://github.com/grafana/loki/pull/5560) **periklis**: Fix service monitor's server name for operator metrics
 - [5345](https://github.com/grafana/loki/pull/5345) **ronensc**: Add flag to create Prometheus rules
 - [4974](https://github.com/grafana/loki/pull/5432) **Red-GV**: Provide storage configuration for Azure, GCS, and Swift through common_config

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -75,19 +75,7 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -64,7 +64,7 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/ready",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -78,7 +78,7 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -61,21 +61,8 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
 					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					PeriodSeconds:       10,
-					InitialDelaySeconds: 15,
-					TimeoutSeconds:      1,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-				},
-				LivenessProbe: lokiLivenessProbe(),
+				ReadinessProbe: lokiReadinessProbe(),
+				LivenessProbe:  lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -77,7 +77,7 @@ func NewDistributorDeployment(opts Options) *appsv1.Deployment {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/ready",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -91,7 +91,7 @@ func NewDistributorDeployment(opts Options) *appsv1.Deployment {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -74,21 +74,8 @@ func NewDistributorDeployment(opts Options) *appsv1.Deployment {
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
 					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					PeriodSeconds:       10,
-					InitialDelaySeconds: 15,
-					TimeoutSeconds:      1,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-				},
-				LivenessProbe: lokiLivenessProbe(),
+				ReadinessProbe: lokiReadinessProbe(),
+				LivenessProbe:  lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -88,19 +88,7 @@ func NewDistributorDeployment(opts Options) *appsv1.Deployment {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -74,19 +74,7 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -63,7 +63,7 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/ready",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -77,7 +77,7 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -60,21 +60,8 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
 					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					PeriodSeconds:       10,
-					InitialDelaySeconds: 15,
-					TimeoutSeconds:      1,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-				},
-				LivenessProbe: lokiLivenessProbe(),
+				ReadinessProbe: lokiReadinessProbe(),
+				LivenessProbe:  lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -60,21 +60,8 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
 					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					PeriodSeconds:       10,
-					InitialDelaySeconds: 15,
-					TimeoutSeconds:      1,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-				},
-				LivenessProbe: lokiLivenessProbe(),
+				ReadinessProbe: lokiReadinessProbe(),
+				LivenessProbe:  lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -63,7 +63,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/ready",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -77,7 +77,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -74,19 +74,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -59,21 +59,8 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
 					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					PeriodSeconds:       10,
-					InitialDelaySeconds: 15,
-					TimeoutSeconds:      1,
-					SuccessThreshold:    1,
-					FailureThreshold:    3,
-				},
-				LivenessProbe: lokiLivenessProbe(),
+				ReadinessProbe: lokiReadinessProbe(),
+				LivenessProbe:  lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -73,19 +73,7 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -62,7 +62,7 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/ready",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -76,7 +76,7 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -68,7 +68,7 @@ func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiReadinessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -82,7 +82,7 @@ func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/metrics",
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -83,19 +83,7 @@ func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 					SuccessThreshold:    1,
 					FailureThreshold:    3,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiLivenessPath,
-							Port:   intstr.FromInt(httpPort),
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					TimeoutSeconds:   2,
-					PeriodSeconds:    30,
-					FailureThreshold: 10,
-					SuccessThreshold: 1,
-				},
+				LivenessProbe: lokiLivenessProbe(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          lokiHTTPPortName,

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -68,7 +68,11 @@ func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   lokiReadinessPath,
+							// The frontend will only return ready once a querier has connected to it.
+							// Because the service used for connecting the querier to the frontend only lists ready
+							// instances there's sequencing issue. For now, we re-use the liveness-probe path
+							// for the readiness-probe as a workaround.
+							Path:   lokiLivenessPath,
 							Port:   intstr.FromInt(httpPort),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -7,6 +7,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -236,5 +237,21 @@ func serviceMonitorEndpoint(portName, serviceName, namespace string, enableTLS b
 		Port:   portName,
 		Path:   "/metrics",
 		Scheme: "http",
+	}
+}
+
+func lokiLivenessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   lokiLivenessPath,
+				Port:   intstr.FromInt(httpPort),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		TimeoutSeconds:   2,
+		PeriodSeconds:    30,
+		FailureThreshold: 10,
+		SuccessThreshold: 1,
 	}
 }

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -255,3 +255,20 @@ func lokiLivenessProbe() *corev1.Probe {
 		SuccessThreshold: 1,
 	}
 }
+
+func lokiReadinessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   lokiReadinessPath,
+				Port:   intstr.FromInt(httpPort),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 15,
+		TimeoutSeconds:      1,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -19,6 +19,9 @@ const (
 	lokiGRPCPortName   = "grpclb"
 	lokiGossipPortName = "gossip-ring"
 
+	lokiLivenessPath  = "/loki/api/v1/status/buildinfo"
+	lokiReadinessPath = "/ready"
+
 	gatewayContainerName    = "gateway"
 	gatewayHTTPPort         = 8080
 	gatewayInternalPort     = 8081


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Changes the endpoints used by the liveness and readiness-probes generated by loki-operator to avoid unnecessary errors related to response size.

The PR also consolidates the readiness and liveness probes into a single place.

**Which issue(s) this PR fixes**:
Fixes #5575 

**Special notes for your reviewer**:
- The readiness-probe for `query-frontend` is not using the proper readiness path because the load-balancer only contains ready pods and the readiness-check is waiting for clients to connect, causing a non-satisfiable condition.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
