### PR TITLE
Tsdb/index interface

### DIFF
--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -21,6 +21,6 @@ type ChunkRef struct {
 type Interface interface {
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
 	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
-	LabelNames(ctx context.Context, userID string, from, through model.Time) ([]string, error)
-	LabelValues(ctx context.Context, userID string, from, through model.Time, name string) ([]string, error)
+	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
+	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
 }

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -1,0 +1,26 @@
+package tsdb
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type Series struct {
+	Labels labels.Labels
+}
+
+type ChunkRef struct {
+	User        string
+	Fingerprint model.Fingerprint
+	Start, End  model.Time
+	Checksum    uint32
+}
+
+type Interface interface {
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
+	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
+	LabelNames(ctx context.Context, userID string, from, through model.Time) ([]string, error)
+	LabelValues(ctx context.Context, userID string, from, through model.Time, name string) ([]string, error)
+}

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -18,7 +18,7 @@ type ChunkRef struct {
 	Checksum    uint32
 }
 
-type Interface interface {
+type Index interface {
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
 	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"sort"
+
+	"github.com/prometheus/common/model"
 )
 
 // Meta holds information about a chunk of data.
@@ -15,6 +17,9 @@ type ChunkMeta struct {
 
 	Entries uint32
 }
+
+func (c ChunkMeta) From() model.Time    { return model.Time(c.MinTime) }
+func (c ChunkMeta) Through() model.Time { return model.Time(c.MaxTime) }
 
 type ChunkMetas []ChunkMeta
 

--- a/pkg/storage/tsdb/querier.go
+++ b/pkg/storage/tsdb/querier.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 
@@ -275,4 +276,59 @@ func findSetMatches(pattern string) []string {
 		}
 	}
 	return matches
+}
+
+func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
+	// We're only interested in metrics which have the label <name>.
+	requireLabel, err := labels.NewMatcher(labels.MatchNotEqual, name, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to instantiate label matcher")
+	}
+
+	var p index.Postings
+	p, err = PostingsForMatchers(r, append(matchers, requireLabel)...)
+	if err != nil {
+		return nil, err
+	}
+
+	dedupe := map[string]interface{}{}
+	for p.Next() {
+		v, err := r.LabelValueFor(p.At(), name)
+		if err != nil {
+			if err == storage.ErrNotFound {
+				continue
+			}
+
+			return nil, err
+		}
+		dedupe[v] = nil
+	}
+
+	if err = p.Err(); err != nil {
+		return nil, err
+	}
+
+	values := make([]string, 0, len(dedupe))
+	for value := range dedupe {
+		values = append(values, value)
+	}
+
+	return values, nil
+}
+
+func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]string, error) {
+	p, err := PostingsForMatchers(r, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	var postings []storage.SeriesRef
+	for p.Next() {
+		postings = append(postings, p.At())
+	}
+	if p.Err() != nil {
+		return nil, errors.Wrapf(p.Err(), "postings for label names with matchers")
+	}
+
+	return r.LabelNamesFor(postings...)
 }

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -97,7 +97,7 @@ func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time
 }
 
 func (i *TSDBIndex) LabelNames(_ context.Context, _ string, _, _ model.Time) ([]string, error) {
-	return i.reader.LabelNames(nil)
+	return i.reader.LabelNames()
 }
 
 func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, name string) ([]string, error) {

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -3,11 +3,13 @@ package tsdb
 import (
 	"context"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
+// nolint
 type TSDBIndex struct {
 	reader IndexReader
 }

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -1,0 +1,97 @@
+package tsdb
+
+import (
+	"context"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type TSDBIndex struct {
+	reader IndexReader
+}
+
+func NewTSDBIndex(reader IndexReader) *TSDBIndex {
+	return &TSDBIndex{
+		reader: reader,
+	}
+}
+
+func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+
+	p, err := PostingsForMatchers(i.reader, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		res  []ChunkRef // TODO(owen-d): pool, reduce allocs
+		ls   labels.Labels
+		chks []index.ChunkMeta
+	)
+
+	for p.Next() {
+		if err := i.reader.Series(p.At(), &ls, &chks); err != nil {
+			return nil, err
+		}
+
+		// cache hash calculation across chunks of the same series
+		// TODO(owen-d): Should we store this in the index? in an in-mem cache?
+		var hash uint64
+
+		// TODO(owen-d): use logarithmic approach
+		for _, chk := range chks {
+
+			// current chunk is outside the range of this request
+			if chk.From() > through || chk.Through() < from {
+				continue
+			}
+
+			if hash == 0 {
+				hash = ls.Hash()
+			}
+
+			res = append(res, ChunkRef{
+				User:        userID, // assumed to be the same, will be enforced by caller.
+				Fingerprint: model.Fingerprint(hash),
+				Start:       chk.From(),
+				End:         chk.Through(),
+				Checksum:    chk.Checksum,
+			})
+		}
+	}
+	return res, p.Err()
+}
+
+func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
+	p, err := PostingsForMatchers(i.reader, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		res  []Series // TODO(owen-d): reduce allocs
+		ls   labels.Labels
+		chks []index.ChunkMeta
+	)
+
+	for p.Next() {
+		if err := i.reader.Series(p.At(), &ls, &chks); err != nil {
+			return nil, err
+		}
+
+		// TODO(owen-d): use logarithmic approach
+		for _, chk := range chks {
+
+			if chk.From() < through && chk.Through() >= from {
+				// this series has at least one chunk in the desired range
+				res = append(res, Series{
+					Labels: ls.Copy(),
+				})
+				break
+			}
+		}
+	}
+	return res, p.Err()
+}

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -95,3 +95,11 @@ func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time
 	}
 	return res, p.Err()
 }
+
+func (i *TSDBIndex) LabelNames(_ context.Context, _ string, _, _ model.Time) ([]string, error) {
+	return i.reader.LabelNames(nil)
+}
+
+func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, name string) ([]string, error) {
+	return i.reader.LabelValues(name)
+}

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -98,10 +98,17 @@ func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time
 	return res, p.Err()
 }
 
-func (i *TSDBIndex) LabelNames(_ context.Context, _ string, _, _ model.Time) ([]string, error) {
-	return i.reader.LabelNames()
+func (i *TSDBIndex) LabelNames(_ context.Context, _ string, _, _ model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) == 0 {
+		return i.reader.LabelNames()
+	}
+
+	return labelNamesWithMatchers(i.reader, matchers...)
 }
 
-func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, name string) ([]string, error) {
-	return i.reader.LabelValues(name)
+func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
+	if len(matchers) == 0 {
+		return i.reader.LabelValues(name)
+	}
+	return labelValuesWithMatchers(i.reader, name, matchers...)
 }

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -44,7 +44,7 @@ func TestSingleIdx(t *testing.T) {
 			},
 		},
 		{
-			Labels: mustParseLabels(`{foo="bard", bazz="buzz", bonk="borb"}`),
+			Labels: mustParseLabels(`{foo="bard", bazz="bozz", bonk="borb"}`),
 			Chunks: []index.ChunkMeta{
 				{
 					MinTime:  1,
@@ -113,9 +113,22 @@ func TestSingleIdx(t *testing.T) {
 		require.Equal(t, []string{"bazz", "bonk", "foo"}, ls)
 	})
 
+	t.Run("LabelNamesWithMatchers", func(t *testing.T) {
+		// request data at the end of the tsdb range, but it should return all labels present
+		ls, err := idx.LabelNames(context.Background(), "fake", 9, 10, labels.MustNewMatcher(labels.MatchEqual, "bazz", "buzz"))
+		require.Nil(t, err)
+		require.Equal(t, []string{"bazz", "foo"}, ls)
+	})
+
 	t.Run("LabelValues", func(t *testing.T) {
 		vs, err := idx.LabelValues(context.Background(), "fake", 9, 10, "foo")
 		require.Nil(t, err)
 		require.Equal(t, []string{"bar", "bard"}, vs)
+	})
+
+	t.Run("LabelValuesWithMatchers", func(t *testing.T) {
+		vs, err := idx.LabelValues(context.Background(), "fake", 9, 10, "foo", labels.MustNewMatcher(labels.MatchEqual, "bazz", "buzz"))
+		require.Nil(t, err)
+		require.Equal(t, []string{"bar"}, vs)
 	})
 }

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 func TestSingleIdx(t *testing.T) {

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -1,0 +1,120 @@
+package tsdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleIdx(t *testing.T) {
+	cases := []LoadableSeries{
+		{
+			Labels: mustParseLabels(`{foo="bar"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  0,
+					MaxTime:  3,
+					Checksum: 0,
+				},
+				{
+					MinTime:  1,
+					MaxTime:  4,
+					Checksum: 1,
+				},
+				{
+					MinTime:  2,
+					MaxTime:  5,
+					Checksum: 2,
+				},
+			},
+		},
+		{
+			Labels: mustParseLabels(`{foo="bar", bazz="buzz"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  1,
+					MaxTime:  10,
+					Checksum: 3,
+				},
+			},
+		},
+		{
+			Labels: mustParseLabels(`{foo="bard", bazz="buzz", bonk="borb"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  1,
+					MaxTime:  7,
+					Checksum: 4,
+				},
+			},
+		},
+	}
+
+	idx := BuildIndex(t, cases)
+
+	t.Run("GetChunkRefs", func(t *testing.T) {
+		refs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Nil(t, err)
+
+		expected := []ChunkRef{
+			{
+				User:        "fake",
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+				Start:       1,
+				End:         10,
+				Checksum:    3,
+			},
+			{
+				User:        "fake",
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Start:       0,
+				End:         3,
+				Checksum:    0,
+			},
+			{
+				User:        "fake",
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Start:       1,
+				End:         4,
+				Checksum:    1,
+			},
+			{
+				User:        "fake",
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+				Start:       2,
+				End:         5,
+				Checksum:    2,
+			},
+		}
+		require.Equal(t, expected, refs)
+	})
+
+	t.Run("Series", func(t *testing.T) {
+		xs, err := idx.Series(context.Background(), "fake", 8, 9, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Nil(t, err)
+
+		expected := []Series{
+			{
+				Labels: mustParseLabels(`{foo="bar", bazz="buzz"}`),
+			},
+		}
+		require.Equal(t, expected, xs)
+	})
+
+	t.Run("LabelNames", func(t *testing.T) {
+		// request data at the end of the tsdb range, but it should return all labels present
+		ls, err := idx.LabelNames(context.Background(), "fake", 9, 10)
+		require.Nil(t, err)
+		require.Equal(t, []string{"bazz", "bonk", "foo"}, ls)
+	})
+
+	t.Run("LabelValues", func(t *testing.T) {
+		vs, err := idx.LabelValues(context.Background(), "fake", 9, 10, "foo")
+		require.Nil(t, err)
+		require.Equal(t, []string{"bar", "bard"}, vs)
+	})
+}

--- a/pkg/storage/tsdb/util_test.go
+++ b/pkg/storage/tsdb/util_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 type LoadableSeries struct {

--- a/pkg/storage/tsdb/util_test.go
+++ b/pkg/storage/tsdb/util_test.go
@@ -1,0 +1,31 @@
+package tsdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+type LoadableSeries struct {
+	Labels labels.Labels
+	Chunks index.ChunkMetas
+}
+
+func BuildIndex(t *testing.T, cases []LoadableSeries) *TSDBIndex {
+	dir := t.TempDir()
+	b := index.NewBuilder()
+
+	for _, s := range cases {
+		b.AddSeries(s.Labels, s.Chunks)
+	}
+
+	require.Nil(t, b.Build(context.Background(), dir))
+
+	reader, err := index.NewFileReader(dir)
+	require.Nil(t, err)
+
+	return NewTSDBIndex(reader)
+}


### PR DESCRIPTION
This PR introduces an `Index` interface and an implementation which uses TSDB to service it:

```go
type Interface interface {
	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
}
```

This is subject to change, but lays a foundation for the interface we expect TSDB to satisfy. I'll be opening followup PRs to query multiple TSDBs, group TSDBs by tenant, instrument/cache the calls, etc.

ref https://github.com/grafana/loki/issues/5428