### PR TITLE
build a new batch while starting to process a bucket

### DIFF
--- a/pkg/storage/stores/shipper/compactor/table.go
+++ b/pkg/storage/stores/shipper/compactor/table.go
@@ -430,10 +430,9 @@ func readFile(logger log.Logger, path string, writeBatch func(userID string, bat
 		}
 	}()
 
-	batch := make([]indexEntry, 0, batchSize)
-
 	return db.View(func(tx *bbolt.Tx) error {
 		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+			batch := make([]indexEntry, 0, batchSize)
 			bucketNameStr := string(name)
 			err := b.ForEach(func(k, v []byte) error {
 				ie := indexEntry{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
I noticed that while iterating through buckets for building index batch for writes, I was not clearing the batch while processing the next bucket. The batch gets recreated only when it gets full. This causes us to write duplicate index in other users index files.
This PR fixes the issue by creating a new batch while staring to process a bucket.
