### PR TITLE
Compactor improvements

### DIFF
--- a/pkg/storage/stores/shipper/compactor/table.go
+++ b/pkg/storage/stores/shipper/compactor/table.go
@@ -450,9 +450,11 @@ func readFile(logger log.Logger, path string, writeBatch func(userID string, bat
 		}
 	}()
 
+	batch := make([]indexEntry, 0, batchSize)
+
 	return db.View(func(tx *bbolt.Tx) error {
 		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
-			batch := make([]indexEntry, 0, batchSize)
+			batch = batch[:0]
 			bucketNameStr := string(name)
 			err := b.ForEach(func(k, v []byte) error {
 				ie := indexEntry{
@@ -473,8 +475,7 @@ func readFile(logger log.Logger, path string, writeBatch func(userID string, bat
 					if err != nil {
 						return err
 					}
-					// todo(cyriltovena) we should just re-slice to avoid allocations
-					batch = make([]indexEntry, 0, batchSize)
+					batch = batch[:0]
 				}
 
 				return nil

--- a/pkg/storage/stores/shipper/compactor/table_test.go
+++ b/pkg/storage/stores/shipper/compactor/table_test.go
@@ -35,236 +35,238 @@ type indexSetState struct {
 }
 
 func TestTable_Compaction(t *testing.T) {
-	numUsers := 5
+	for _, numUsers := range []int{uploadIndexSetsConcurrency / 2, uploadIndexSetsConcurrency, uploadIndexSetsConcurrency * 2} {
+		t.Run(fmt.Sprintf("numUsers=%d", numUsers), func(t *testing.T) {
+			for _, tc := range []struct {
+				numUnCompactedCommonDBs  int
+				numUnCompactedPerUserDBs int
+				numCompactedDBs          int
 
-	for _, tc := range []struct {
-		numUnCompactedCommonDBs  int
-		numUnCompactedPerUserDBs int
-		numCompactedDBs          int
+				shouldInitializeCommonIndexSet bool
+				commonIndexSetState            *indexSetState
 
-		shouldInitializeCommonIndexSet bool
-		commonIndexSetState            *indexSetState
-
-		shouldInitializeUserIndexSet bool
-		userIndexSetState            *indexSetState
-	}{
-		{},
-		{
-			numCompactedDBs: 1,
-		},
-		{
-			numCompactedDBs: 2,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs: 1,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs: 10,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs: 10,
-			numCompactedDBs:         1,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs: 10,
-			numCompactedDBs:         2,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedPerUserDBs: 1,
-			commonIndexSetState: &indexSetState{
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedPerUserDBs: 1,
-			numCompactedDBs:          1,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedPerUserDBs: 1,
-			numCompactedDBs:          2,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedPerUserDBs: 10,
-			commonIndexSetState: &indexSetState{
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs:  10,
-			numUnCompactedPerUserDBs: 10,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs:  10,
-			numUnCompactedPerUserDBs: 10,
-			numCompactedDBs:          1,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-		{
-			numUnCompactedCommonDBs:  10,
-			numUnCompactedPerUserDBs: 10,
-			numCompactedDBs:          2,
-			commonIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-			userIndexSetState: &indexSetState{
-				uploadCompactedDB:   true,
-				removeSourceObjects: true,
-			},
-		},
-	} {
-		commonDBsConfig := testutil.DBsConfig{
-			NumCompactedDBs:   tc.numCompactedDBs,
-			NumUnCompactedDBs: tc.numUnCompactedCommonDBs,
-		}
-		perUserDBsConfig := testutil.PerUserDBsConfig{
-			DBsConfig: testutil.DBsConfig{
-				NumCompactedDBs:   tc.numCompactedDBs,
-				NumUnCompactedDBs: tc.numUnCompactedPerUserDBs,
-			},
-			NumUsers: numUsers,
-		}
-
-		t.Run(fmt.Sprintf("%s ; %s", commonDBsConfig.String(), perUserDBsConfig.String()), func(t *testing.T) {
-			tempDir := t.TempDir()
-
-			objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
-			tablePathInStorage := filepath.Join(objectStoragePath, tableName)
-			tableWorkingDirectory := filepath.Join(tempDir, workingDirName, tableName)
-
-			testutil.SetupTable(t, filepath.Join(objectStoragePath, tableName), commonDBsConfig, perUserDBsConfig)
-			testutil.SetupTable(t, filepath.Join(objectStoragePath, fmt.Sprintf("%s-copy", tableName)), commonDBsConfig, perUserDBsConfig)
-
-			// do the compaction
-			objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
-			require.NoError(t, err)
-
-			table, err := newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-				nil, nil)
-			require.NoError(t, err)
-
-			require.NoError(t, table.compact(false))
-
-			numUserIndexSets, numCommonIndexSets := 0, 0
-			for _, is := range table.indexSets {
-				if is.baseIndexSet.IsUserBasedIndexSet() {
-					require.Equal(t, tc.userIndexSetState.uploadCompactedDB, is.uploadCompactedDB)
-					require.Equal(t, tc.userIndexSetState.removeSourceObjects, is.removeSourceObjects)
-					numUserIndexSets++
-				} else {
-					require.Equal(t, tc.commonIndexSetState.uploadCompactedDB, is.uploadCompactedDB)
-					require.Equal(t, tc.commonIndexSetState.removeSourceObjects, is.removeSourceObjects)
-					numCommonIndexSets++
+				shouldInitializeUserIndexSet bool
+				userIndexSetState            *indexSetState
+			}{
+				{},
+				{
+					numCompactedDBs: 1,
+				},
+				{
+					numCompactedDBs: 2,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs: 1,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs: 10,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs: 10,
+					numCompactedDBs:         1,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs: 10,
+					numCompactedDBs:         2,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedPerUserDBs: 1,
+					commonIndexSetState: &indexSetState{
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedPerUserDBs: 1,
+					numCompactedDBs:          1,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedPerUserDBs: 1,
+					numCompactedDBs:          2,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedPerUserDBs: 10,
+					commonIndexSetState: &indexSetState{
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs:  10,
+					numUnCompactedPerUserDBs: 10,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs:  10,
+					numUnCompactedPerUserDBs: 10,
+					numCompactedDBs:          1,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+				{
+					numUnCompactedCommonDBs:  10,
+					numUnCompactedPerUserDBs: 10,
+					numCompactedDBs:          2,
+					commonIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+					userIndexSetState: &indexSetState{
+						uploadCompactedDB:   true,
+						removeSourceObjects: true,
+					},
+				},
+			} {
+				commonDBsConfig := testutil.DBsConfig{
+					NumCompactedDBs:   tc.numCompactedDBs,
+					NumUnCompactedDBs: tc.numUnCompactedCommonDBs,
 				}
-				require.False(t, is.compactedDBRecreated)
-			}
+				perUserDBsConfig := testutil.PerUserDBsConfig{
+					DBsConfig: testutil.DBsConfig{
+						NumCompactedDBs:   tc.numCompactedDBs,
+						NumUnCompactedDBs: tc.numUnCompactedPerUserDBs,
+					},
+					NumUsers: numUsers,
+				}
 
-			if tc.commonIndexSetState != nil {
-				require.Equal(t, 1, numCommonIndexSets)
-			} else {
-				require.Equal(t, 0, numCommonIndexSets)
-			}
+				t.Run(fmt.Sprintf("%s ; %s", commonDBsConfig.String(), perUserDBsConfig.String()), func(t *testing.T) {
+					tempDir := t.TempDir()
 
-			if tc.userIndexSetState != nil {
-				require.Equal(t, numUsers, numUserIndexSets)
-			} else {
-				require.Equal(t, 0, numUserIndexSets)
-			}
+					objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+					tablePathInStorage := filepath.Join(objectStoragePath, tableName)
+					tableWorkingDirectory := filepath.Join(tempDir, workingDirName, tableName)
 
-			// verify the state in the storage after compaction.
-			expectedNumCommonDBs := 0
-			if (commonDBsConfig.NumUnCompactedDBs + commonDBsConfig.NumCompactedDBs) > 0 {
-				expectedNumCommonDBs = 1
-			}
-			numExpectedUsers := 0
-			if (perUserDBsConfig.NumUnCompactedDBs + perUserDBsConfig.NumCompactedDBs) > 0 {
-				numExpectedUsers = numUsers
-			}
-			validateTable(t, tablePathInStorage, expectedNumCommonDBs, numExpectedUsers, func(filename string) {
-				require.True(t, strings.HasSuffix(filename, ".gz"))
-			})
+					testutil.SetupTable(t, filepath.Join(objectStoragePath, tableName), commonDBsConfig, perUserDBsConfig)
+					testutil.SetupTable(t, filepath.Join(objectStoragePath, fmt.Sprintf("%s-copy", tableName)), commonDBsConfig, perUserDBsConfig)
 
-			// verify we have all the kvs in compacted db which were there in source dbs.
-			compareCompactedTable(t, tablePathInStorage, filepath.Join(objectStoragePath, "test-copy"))
+					// do the compaction
+					objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
+					require.NoError(t, err)
 
-			// running compaction again should not do anything.
-			table, err = newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-				nil, nil)
-			require.NoError(t, err)
+					table, err := newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
+						nil, nil)
+					require.NoError(t, err)
 
-			require.NoError(t, table.compact(false))
+					require.NoError(t, table.compact(false))
 
-			for _, is := range table.indexSets {
-				require.False(t, is.uploadCompactedDB)
-				require.False(t, is.removeSourceObjects)
-				require.False(t, is.compactedDBRecreated)
+					numUserIndexSets, numCommonIndexSets := 0, 0
+					for _, is := range table.indexSets {
+						if is.baseIndexSet.IsUserBasedIndexSet() {
+							require.Equal(t, tc.userIndexSetState.uploadCompactedDB, is.uploadCompactedDB)
+							require.Equal(t, tc.userIndexSetState.removeSourceObjects, is.removeSourceObjects)
+							numUserIndexSets++
+						} else {
+							require.Equal(t, tc.commonIndexSetState.uploadCompactedDB, is.uploadCompactedDB)
+							require.Equal(t, tc.commonIndexSetState.removeSourceObjects, is.removeSourceObjects)
+							numCommonIndexSets++
+						}
+						require.False(t, is.compactedDBRecreated)
+					}
+
+					if tc.commonIndexSetState != nil {
+						require.Equal(t, 1, numCommonIndexSets)
+					} else {
+						require.Equal(t, 0, numCommonIndexSets)
+					}
+
+					if tc.userIndexSetState != nil {
+						require.Equal(t, numUsers, numUserIndexSets)
+					} else {
+						require.Equal(t, 0, numUserIndexSets)
+					}
+
+					// verify the state in the storage after compaction.
+					expectedNumCommonDBs := 0
+					if (commonDBsConfig.NumUnCompactedDBs + commonDBsConfig.NumCompactedDBs) > 0 {
+						expectedNumCommonDBs = 1
+					}
+					numExpectedUsers := 0
+					if (perUserDBsConfig.NumUnCompactedDBs + perUserDBsConfig.NumCompactedDBs) > 0 {
+						numExpectedUsers = numUsers
+					}
+					validateTable(t, tablePathInStorage, expectedNumCommonDBs, numExpectedUsers, func(filename string) {
+						require.True(t, strings.HasSuffix(filename, ".gz"))
+					})
+
+					// verify we have all the kvs in compacted db which were there in source dbs.
+					compareCompactedTable(t, tablePathInStorage, filepath.Join(objectStoragePath, "test-copy"))
+
+					// running compaction again should not do anything.
+					table, err = newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
+						nil, nil)
+					require.NoError(t, err)
+
+					require.NoError(t, table.compact(false))
+
+					for _, is := range table.indexSets {
+						require.False(t, is.uploadCompactedDB)
+						require.False(t, is.removeSourceObjects)
+						require.False(t, is.compactedDBRecreated)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
It includes two improvements:
1. After we are done compacting the files, the operation of upload and cleanup happens for one tenant at a time. When we have a lot of tenants this takes a lot of time. This PR improves it by concurrently doing upload and cleanup for 10 tenants at a time.
2. While doing compaction, we create a new slice for the index batch when it either gets full or we move to the next tenant bucket. This PR changes the code to reuse the same slice for batching the index.

**Checklist**
- [x] Tests updated
