### PR TITLE
operator: Add RBAC for Prometheus service discovery to Loki component metrics (OpenShift)

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [5588](https://github.com/grafana/loki/pull/5588) **periklis**: Add RBAC for Prometheus service discovery to Loki component metrics (OpenShift)
 - [5576](https://github.com/grafana/loki/pull/5576) **xperimental**: Change endpoints for generated liveness and readiness probes
 - [5560](https://github.com/grafana/loki/pull/5560) **periklis**: Fix service monitor's server name for operator metrics
 - [5345](https://github.com/grafana/loki/pull/5345) **ronensc**: Add flag to create Prometheus rules

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -547,6 +547,8 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -112,6 +112,8 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/operator/controllers/lokistack_controller.go
+++ b/operator/controllers/lokistack_controller.go
@@ -76,7 +76,7 @@ type LokiStackReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods;nodes;services;endpoints;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update
@@ -139,7 +139,9 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		Owns(&appsv1.Deployment{}, updateOrDeleteOnlyPred).
 		Owns(&appsv1.StatefulSet{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRole{}, updateOrDeleteOnlyPred).
-		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred)
+		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
+		Owns(&rbacv1.Role{}, updateOrDeleteOnlyPred).
+		Owns(&rbacv1.RoleBinding{}, updateOrDeleteOnlyPred)
 
 	if r.Flags.EnablePrometheusAlerts {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)

--- a/operator/controllers/lokistack_controller_test.go
+++ b/operator/controllers/lokistack_controller_test.go
@@ -117,8 +117,21 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			pred:  updateOrDeleteOnlyPred,
 		},
 		{
-			obj:   &networkingv1.Ingress{},
+			obj:   &rbacv1.Role{},
 			index: 7,
+			pred:  updateOrDeleteOnlyPred,
+		},
+		{
+			obj:   &rbacv1.RoleBinding{},
+			index: 8,
+			pred:  updateOrDeleteOnlyPred,
+		},
+		// The next two share the same index, because the
+		// controller either reconciles an Ingress (i.e. Kubernetes)
+		// or a Route (i.e. OpenShift).
+		{
+			obj:   &networkingv1.Ingress{},
+			index: 9,
 			flags: manifests.FeatureFlags{
 				EnableGatewayRoute: false,
 			},
@@ -126,7 +139,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 		},
 		{
 			obj:   &routev1.Route{},
-			index: 7,
+			index: 9,
 			flags: manifests.FeatureFlags{
 				EnableGatewayRoute: true,
 			},
@@ -143,7 +156,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 		require.NoError(t, err)
 
 		// Require Owns-Calls for all owned resources
-		require.Equal(t, 8, b.OwnsCallCount())
+		require.Equal(t, 10, b.OwnsCallCount())
 
 		// Require Owns-call options to have delete predicate only
 		obj, opts := b.OwnsArgsForCall(tst.index)

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -29,12 +29,13 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	case lokiv1beta1.OpenshiftLogging:
 		defaults := openshift.NewOptions(
 			opts.Name,
-			GatewayName(opts.Name),
 			opts.Namespace,
+			GatewayName(opts.Name),
 			opts.GatewayBaseDomain,
 			serviceNameGatewayHTTP(opts.Name),
 			gatewayHTTPPortName,
 			ComponentLabels(LabelGatewayComponent, opts.Name),
+			opts.Flags.EnableServiceMonitors,
 			opts.Flags.EnableCertificateSigningService,
 			opts.TenantConfigMap,
 		)

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -82,8 +82,8 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				OpenShiftOptions: openshift.Options{
 					BuildOpts: openshift.BuildOptions{
 						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
 						GatewayName:          "lokistack-gateway-lokistack-ocp",
-						GatewayNamespace:     "stack-ns",
 						GatewaySvcName:       "lokistack-gateway-http-lokistack-ocp",
 						GatewaySvcTargetPort: "public",
 						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -145,9 +145,9 @@ func TestBuildGateway_HasExtraObjectsForTenantMode(t *testing.T) {
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
-				GatewayName:      "abc",
-				GatewayNamespace: "efgh",
-				LokiStackName:    "abc",
+				GatewayName:        "abc",
+				LokiStackName:      "abc",
+				LokiStackNamespace: "efgh",
 			},
 		},
 		Stack: lokiv1beta1.LokiStackSpec{
@@ -176,10 +176,10 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_RouteSvcMatches(t *testing.T
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
 				GatewayName:          "abc",
-				GatewayNamespace:     "efgh",
 				GatewaySvcName:       serviceNameGatewayHTTP("abcd"),
 				GatewaySvcTargetPort: gatewayHTTPPortName,
 				LokiStackName:        "abc",
+				LokiStackNamespace:   "efgh",
 			},
 		},
 		Stack: lokiv1beta1.LokiStackSpec{
@@ -213,10 +213,10 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ServiceAccountNameMatches(t 
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
 				GatewayName:          GatewayName("abcd"),
-				GatewayNamespace:     "efgh",
 				GatewaySvcName:       serviceNameGatewayHTTP("abcd"),
 				GatewaySvcTargetPort: gatewayHTTPPortName,
 				LokiStackName:        "abc",
+				LokiStackNamespace:   "efgh",
 			},
 		},
 		Stack: lokiv1beta1.LokiStackSpec{
@@ -248,10 +248,10 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ReplacesIngressWithRoute(t *
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
 				GatewayName:          GatewayName("abcd"),
-				GatewayNamespace:     "efgh",
 				GatewaySvcName:       serviceNameGatewayHTTP("abcd"),
 				GatewaySvcTargetPort: gatewayHTTPPortName,
 				LokiStackName:        "abc",
+				LokiStackNamespace:   "efgh",
 			},
 		},
 		Stack: lokiv1beta1.LokiStackSpec{

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -61,6 +61,16 @@ func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
 			wantCrb := desired.(*rbacv1.ClusterRoleBinding)
 			mutateClusterRoleBinding(crb, wantCrb)
 
+		case *rbacv1.Role:
+			r := existing.(*rbacv1.Role)
+			wantR := desired.(*rbacv1.Role)
+			mutateRole(r, wantR)
+
+		case *rbacv1.RoleBinding:
+			rb := existing.(*rbacv1.RoleBinding)
+			wantRb := desired.(*rbacv1.RoleBinding)
+			mutateRoleBinding(rb, wantRb)
+
 		case *appsv1.Deployment:
 			dpl := existing.(*appsv1.Deployment)
 			wantDpl := desired.(*appsv1.Deployment)
@@ -127,9 +137,20 @@ func mutateClusterRole(existing, desired *rbacv1.ClusterRole) {
 }
 
 func mutateClusterRoleBinding(existing, desired *rbacv1.ClusterRoleBinding) {
+	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Subjects = desired.Subjects
-	existing.RoleRef = desired.RoleRef
+}
+
+func mutateRole(existing, desired *rbacv1.Role) {
+	existing.Annotations = desired.Annotations
+	existing.Labels = desired.Labels
+	existing.Rules = desired.Rules
+}
+
+func mutateRoleBinding(existing, desired *rbacv1.RoleBinding) {
+	existing.Annotations = desired.Annotations
+	existing.Labels = desired.Labels
 	existing.Subjects = desired.Subjects
 }
 

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -306,6 +306,12 @@ func TestGetMutateFunc_MutateClusterRole(t *testing.T) {
 }
 
 func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
+	roleRef := rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "a-role",
+	}
+
 	got := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -315,11 +321,7 @@ func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
 				"test": "test",
 			},
 		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "a-role",
-		},
+		RoleRef: roleRef,
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
@@ -365,7 +367,128 @@ func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
 	// Partial mutation checks
 	require.Exactly(t, got.Labels, want.Labels)
 	require.Exactly(t, got.Annotations, want.Annotations)
-	require.Exactly(t, got.RoleRef, want.RoleRef)
+	require.Exactly(t, got.RoleRef, roleRef)
+	require.Exactly(t, got.Subjects, want.Subjects)
+
+}
+
+func TestGetMutateFunc_MutateRole(t *testing.T) {
+	got := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test": "test",
+			},
+			Annotations: map[string]string{
+				"test": "test",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"group-a"},
+				Resources: []string{"res-a"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+
+	want := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test":  "test",
+				"other": "label",
+			},
+			Annotations: map[string]string{
+				"test":  "test",
+				"other": "annotation",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"groupa-a"},
+				Resources: []string{"resa-a"},
+				Verbs:     []string{"get", "create"},
+			},
+			{
+				APIGroups: []string{"groupa-b"},
+				Resources: []string{"resa-b"},
+				Verbs:     []string{"list", "create"},
+			},
+		},
+	}
+
+	f := manifests.MutateFuncFor(got, want)
+	err := f()
+	require.NoError(t, err)
+
+	// Partial mutation checks
+	require.Exactly(t, got.Labels, want.Labels)
+	require.Exactly(t, got.Annotations, want.Annotations)
+	require.Exactly(t, got.Rules, want.Rules)
+}
+
+func TestGetMutateFunc_MutateRoleBinding(t *testing.T) {
+	roleRef := rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     "a-role",
+	}
+
+	got := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test": "test",
+			},
+			Annotations: map[string]string{
+				"test": "test",
+			},
+		},
+		RoleRef: roleRef,
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "service-me",
+				Namespace: "stack-ns",
+			},
+		},
+	}
+
+	want := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test":  "test",
+				"other": "label",
+			},
+			Annotations: map[string]string{
+				"test":  "test",
+				"other": "annotation",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "b-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "service-me",
+				Namespace: "stack-ns",
+			},
+			{
+				Kind: "User",
+				Name: "a-user",
+			},
+		},
+	}
+
+	f := manifests.MutateFuncFor(got, want)
+	err := f()
+	require.NoError(t, err)
+
+	// Partial mutation checks
+	require.Exactly(t, got.Labels, want.Labels)
+	require.Exactly(t, got.Annotations, want.Annotations)
+	require.Exactly(t, got.RoleRef, roleRef)
 	require.Exactly(t, got.Subjects, want.Subjects)
 }
 

--- a/operator/internal/manifests/openshift/build.go
+++ b/operator/internal/manifests/openshift/build.go
@@ -12,6 +12,14 @@ func Build(opts Options) []client.Object {
 		BuildClusterRoleBinding(opts),
 	}
 
+	if opts.BuildOpts.EnableServiceMonitors {
+		objs = append(
+			objs,
+			BuildMonitoringRole(opts),
+			BuildMonitoringRoleBinding(opts),
+		)
+	}
+
 	if opts.BuildOpts.EnableCertificateSigningService {
 		objs = append(objs, BuildServiceCAConfigMap(opts))
 	}

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBuild_ServiceAccountRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
+	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, false, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	sa := objs[1].(*corev1.ServiceAccount)
@@ -24,7 +24,7 @@ func TestBuild_ServiceAccountRefMatches(t *testing.T) {
 }
 
 func TestBuild_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
+	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, false, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	cr := objs[2].(*rbacv1.ClusterRole)
@@ -34,8 +34,20 @@ func TestBuild_ClusterRoleRefMatches(t *testing.T) {
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
 }
 
+func TestBuild_MonitoringClusterRoleRefMatches(t *testing.T) {
+	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, true, false, map[string]TenantData{})
+
+	objs := Build(opts)
+	cr := objs[4].(*rbacv1.Role)
+	rb := objs[5].(*rbacv1.RoleBinding)
+
+	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
+	require.Equal(t, cr.Name, rb.RoleRef.Name)
+
+}
+
 func TestBuild_ServiceAccountAnnotationsRouteRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
+	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, false, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	rt := objs[0].(*routev1.Route)

--- a/operator/internal/manifests/openshift/monitoring_rbac.go
+++ b/operator/internal/manifests/openshift/monitoring_rbac.go
@@ -1,0 +1,63 @@
+package openshift
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	monitoringServiceAccountName = "prometheus-k8s"
+	monitoringNamespace          = "openshift-monitoring"
+)
+
+// BuildMonitoringRole returns a Role resource that defines
+// list and watch access on pods, services and endpoints.
+func BuildMonitoringRole(opts Options) *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Role",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      monitoringRbacName(opts.BuildOpts.LokiStackName),
+			Namespace: opts.BuildOpts.LokiStackNamespace,
+			Labels:    opts.BuildOpts.Labels,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "services", "endpoints"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+}
+
+// BuildMonitoringRoleBinding returns a RoleBinding resource that binds the
+// OpenShift Cluster Monitoring Prometheus service account `prometheus-k8s` to the
+// LokiStack namespace to allow discovering LokiStack owned pods, services and endpoints.
+func BuildMonitoringRoleBinding(opts Options) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      monitoringRbacName(opts.BuildOpts.LokiStackName),
+			Namespace: opts.BuildOpts.LokiStackNamespace,
+			Labels:    opts.BuildOpts.Labels,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     monitoringRbacName(opts.BuildOpts.LokiStackName),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      monitoringServiceAccountName,
+				Namespace: monitoringNamespace,
+			},
+		},
+	}
+}

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -37,11 +37,12 @@ type AuthorizationSpec struct {
 // on openshift.
 type BuildOptions struct {
 	LokiStackName                   string
+	LokiStackNamespace              string
 	GatewayName                     string
-	GatewayNamespace                string
 	GatewaySvcName                  string
 	GatewaySvcTargetPort            string
 	Labels                          map[string]string
+	EnableServiceMonitors           bool
 	EnableCertificateSigningService bool
 }
 
@@ -53,13 +54,14 @@ type TenantData struct {
 
 // NewOptions returns an openshift options struct.
 func NewOptions(
-	stackName string,
-	gwName, gwNamespace, gwBaseDomain, gwSvcName, gwPortName string,
+	stackName, stackNamespace string,
+	gwName, gwBaseDomain, gwSvcName, gwPortName string,
 	gwLabels map[string]string,
+	enableServiceMonitors bool,
 	enableCertSigningService bool,
 	tenantConfigMap map[string]TenantData,
 ) Options {
-	host := ingressHost(stackName, gwNamespace, gwBaseDomain)
+	host := ingressHost(stackName, stackNamespace, gwBaseDomain)
 
 	var authn []AuthenticationSpec
 	for _, name := range defaultTenants {
@@ -85,11 +87,12 @@ func NewOptions(
 	return Options{
 		BuildOpts: BuildOptions{
 			LokiStackName:                   stackName,
+			LokiStackNamespace:              stackNamespace,
 			GatewayName:                     gwName,
-			GatewayNamespace:                gwNamespace,
 			GatewaySvcName:                  gwSvcName,
 			GatewaySvcTargetPort:            gwPortName,
 			Labels:                          gwLabels,
+			EnableServiceMonitors:           enableServiceMonitors,
 			EnableCertificateSigningService: enableCertSigningService,
 		},
 		Authentication: authn,

--- a/operator/internal/manifests/openshift/rbac.go
+++ b/operator/internal/manifests/openshift/rbac.go
@@ -70,7 +70,7 @@ func BuildClusterRoleBinding(opts Options) *rbacv1.ClusterRoleBinding {
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccountName(opts),
-				Namespace: opts.BuildOpts.GatewayNamespace,
+				Namespace: opts.BuildOpts.LokiStackNamespace,
 			},
 		},
 	}

--- a/operator/internal/manifests/openshift/route.go
+++ b/operator/internal/manifests/openshift/route.go
@@ -17,7 +17,7 @@ func BuildRoute(opts Options) client.Object {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      routeName(opts),
-			Namespace: opts.BuildOpts.GatewayNamespace,
+			Namespace: opts.BuildOpts.LokiStackNamespace,
 			Labels:    opts.BuildOpts.Labels,
 		},
 		Spec: routev1.RouteSpec{

--- a/operator/internal/manifests/openshift/service_ca.go
+++ b/operator/internal/manifests/openshift/service_ca.go
@@ -20,7 +20,7 @@ func BuildServiceCAConfigMap(opts Options) *corev1.ConfigMap {
 			},
 			Labels:    opts.BuildOpts.Labels,
 			Name:      serviceCABundleName(opts),
-			Namespace: opts.BuildOpts.GatewayNamespace,
+			Namespace: opts.BuildOpts.LokiStackNamespace,
 		},
 	}
 }

--- a/operator/internal/manifests/openshift/serviceaccount.go
+++ b/operator/internal/manifests/openshift/serviceaccount.go
@@ -20,7 +20,7 @@ func BuildServiceAccount(opts Options) client.Object {
 			Annotations: serviceAccountAnnotations(opts),
 			Labels:      opts.BuildOpts.Labels,
 			Name:        serviceAccountName(opts),
-			Namespace:   opts.BuildOpts.GatewayNamespace,
+			Namespace:   opts.BuildOpts.LokiStackNamespace,
 		},
 		AutomountServiceAccountToken: pointer.Bool(true),
 	}

--- a/operator/internal/manifests/openshift/serviceaccount_test.go
+++ b/operator/internal/manifests/openshift/serviceaccount_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildServiceAccount_AnnotationsMatchDefaultTenants(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
+	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, false, false, map[string]TenantData{})
 
 	sa := BuildServiceAccount(opts)
 	require.Len(t, sa.GetAnnotations(), len(defaultTenants))

--- a/operator/internal/manifests/openshift/var.go
+++ b/operator/internal/manifests/openshift/var.go
@@ -37,6 +37,10 @@ func clusterRoleName(opts Options) string {
 	return opts.BuildOpts.GatewayName
 }
 
+func monitoringRbacName(stackName string) string {
+	return fmt.Sprintf("%s-metrics-discovery", stackName)
+}
+
 func ingressHost(stackName, namespace, baseDomain string) string {
 	return fmt.Sprintf("%s-%s.apps.%s", stackName, namespace, baseDomain)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the capability to reconcile RBAC for the OpenShift `openshift-monitoring:prometheus-k8s` serviceaccount to scrape LokiStack owned Loki components (e.g. distributor, ingester) metrics.

**Which issue(s) this PR fixes**:
Fixes #5563

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
