### PR TITLE
Embed fingerprints in TSDB

### DIFF
--- a/pkg/storage/tsdb/index/index_test.go
+++ b/pkg/storage/tsdb/index/index_test.go
@@ -197,7 +197,7 @@ func TestIndexRW_Postings(t *testing.T) {
 	var c []ChunkMeta
 
 	for i := 0; p.Next(); i++ {
-		err := ir.Series(p.At(), &l, &c)
+		_, err := ir.Series(p.At(), &l, &c)
 
 		require.NoError(t, err)
 		require.Equal(t, 0, len(c))
@@ -312,7 +312,8 @@ func TestPostingsMany(t *testing.T) {
 		var lbls labels.Labels
 		var metas []ChunkMeta
 		for it.Next() {
-			require.NoError(t, ir.Series(it.At(), &lbls, &metas))
+			_, err := ir.Series(it.At(), &lbls, &metas)
+			require.NoError(t, err)
 			got = append(got, lbls.Get("i"))
 		}
 		require.NoError(t, it.Err())
@@ -419,7 +420,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 
 			ref := gotp.At()
 
-			err := ir.Series(ref, &lset, &chks)
+			_, err := ir.Series(ref, &lset, &chks)
 			require.NoError(t, err)
 
 			err = mi.Series(expp.At(), &explset, &expchks)

--- a/pkg/storage/tsdb/querier.go
+++ b/pkg/storage/tsdb/querier.go
@@ -68,7 +68,7 @@ type IndexReader interface {
 	// Series populates the given labels and chunk metas for the series identified
 	// by the reference.
 	// Returns storage.ErrNotFound if the ref does not resolve to a known series.
-	Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]index.ChunkMeta) error
+	Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
 
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)

--- a/pkg/storage/tsdb/querier_test.go
+++ b/pkg/storage/tsdb/querier_test.go
@@ -102,13 +102,15 @@ func TestQueryIndex(t *testing.T) {
 	)
 
 	require.True(t, p.Next())
-	require.Nil(t, reader.Series(p.At(), &ls, &chks))
+	_, err = reader.Series(p.At(), &ls, &chks)
+	require.Nil(t, err)
 	// the second series should be the first returned as it's lexicographically sorted
 	// and bazz < foo
 	require.Equal(t, cases[1].labels.String(), ls.String())
 	require.Equal(t, cases[1].chunks, chks)
 	require.True(t, p.Next())
-	require.Nil(t, reader.Series(p.At(), &ls, &chks))
+	_, err = reader.Series(p.At(), &ls, &chks)
+	require.Nil(t, err)
 	// Now we should encounter the series "added" first.
 	require.Equal(t, cases[0].labels.String(), ls.String())
 	require.Equal(t, cases[0].chunks, chks)


### PR DESCRIPTION
Opening/closing this PR for visibility.
@cyriltovena and I had guessed that embedding the label hash (fingerprint) into TSDB would be a net gain for read speeds, but after implementing it, that does not seem the case:

```
benchmarks:

name                                         old time/op    new time/op    delta
Query_PostingsForMatchers/match_ns-4           4.19µs ± 0%    4.08µs ± 0%   ~     (p=1.000 n=1+1)
Query_PostingsForMatchers/match_ns_regexp-4    4.16µs ± 0%    4.07µs ± 0%   ~     (p=1.000 n=1+1)
Query_GetChunkRefs/match_ns-4                  22.5ms ± 0%    22.1ms ± 0%   ~     (p=1.000 n=1+1)
Query_GetChunkRefs/match_ns_regexp-4           22.2ms ± 0%    22.2ms ± 0%   ~     (p=1.000 n=1+1)

name                                         old alloc/op   new alloc/op   delta
Query_PostingsForMatchers/match_ns-4            80.0B ± 0%     80.0B ± 0%   ~     (all equal)
Query_PostingsForMatchers/match_ns_regexp-4     80.0B ± 0%     80.0B ± 0%   ~     (all equal)
Query_GetChunkRefs/match_ns-4                  33.9MB ± 0%    33.9MB ± 0%   ~     (p=1.000 n=1+1)
Query_GetChunkRefs/match_ns_regexp-4           33.9MB ± 0%    33.9MB ± 0%   ~     (p=1.000 n=1+1)

name                                         old allocs/op  new allocs/op  delta
Query_PostingsForMatchers/match_ns-4             4.00 ± 0%      4.00 ± 0%   ~     (all equal)
Query_PostingsForMatchers/match_ns_regexp-4      4.00 ± 0%      4.00 ± 0%   ~     (all equal)
Query_GetChunkRefs/match_ns-4                   7.77k ± 0%     7.77k ± 0%   ~     (all equal)
Query_GetChunkRefs/match_ns_regexp-4            7.77k ± 0%     7.77k ± 0%   ~     (all equal)

sizing:

-rw-r--r-- 1 owen users 57M Mar  9 09:23 /tmp/loki-tsdb-a
-rw-r--r-- 1 owen users 58M Mar  9 09:24 /tmp/loki-tsdb-b
```

I'd guess this is because most of our time is spent on other operations which eclipse the potential benefit of this, such as growing slices in `GetChunkRefs`:

![image](https://user-images.githubusercontent.com/8173478/157464530-ce9f0301-d38f-4e5e-a131-95090e90dd39.png)


ref https://github.com/grafana/loki/issues/5428