### PR TITLE
bounds utility for tsdb lib

### DIFF
--- a/pkg/storage/tsdb/bounds.go
+++ b/pkg/storage/tsdb/bounds.go
@@ -1,0 +1,22 @@
+package tsdb
+
+import "github.com/prometheus/common/model"
+
+type Bounded interface {
+	Bounds() (model.Time, model.Time)
+}
+
+type bounds struct {
+	mint, maxt model.Time
+}
+
+func newBounds(mint, maxt model.Time) bounds { return bounds{mint: mint, maxt: maxt} }
+
+func (b bounds) Bounds() (model.Time, model.Time) { return b.mint, b.maxt }
+
+func Overlap(a, b Bounded) bool {
+	aFrom, aThrough := a.Bounds()
+	bFrom, bThrough := b.Bounds()
+
+	return aFrom < bThrough && aThrough > bFrom
+}

--- a/pkg/storage/tsdb/bounds_test.go
+++ b/pkg/storage/tsdb/bounds_test.go
@@ -1,0 +1,36 @@
+package tsdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlap(t *testing.T) {
+	for i, tc := range []struct {
+		a, b    Bounded
+		overlap bool
+	}{
+		{
+			a:       newBounds(1, 5),
+			b:       newBounds(2, 6),
+			overlap: true,
+		},
+		{
+			a:       newBounds(1, 5),
+			b:       newBounds(6, 7),
+			overlap: false,
+		},
+		{
+			// ensure [start,end) inclusivity works as expected
+			a:       newBounds(1, 5),
+			b:       newBounds(5, 6),
+			overlap: false,
+		},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			require.Equal(t, tc.overlap, Overlap(tc.a, tc.b))
+		})
+	}
+}

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -19,6 +19,7 @@ type ChunkRef struct {
 }
 
 type Index interface {
+	Bounded
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
 	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -18,8 +18,9 @@ type ChunkMeta struct {
 	Entries uint32
 }
 
-func (c ChunkMeta) From() model.Time    { return model.Time(c.MinTime) }
-func (c ChunkMeta) Through() model.Time { return model.Time(c.MaxTime) }
+func (c ChunkMeta) From() model.Time                 { return model.Time(c.MinTime) }
+func (c ChunkMeta) Through() model.Time              { return model.Time(c.MaxTime) }
+func (c ChunkMeta) Bounds() (model.Time, model.Time) { return c.From(), c.Through() }
 
 type ChunkMetas []ChunkMeta
 


### PR DESCRIPTION
Rather than coding bespoke overlap checks everywhere, this PR puts the logic into an interface which  is reused more easily and is less error prone.

ref https://github.com/grafana/loki/issues/5428