### PR TITLE
index wrapper for bounding parallelism

### DIFF
--- a/pkg/storage/tsdb/parallel.go
+++ b/pkg/storage/tsdb/parallel.go
@@ -1,0 +1,84 @@
+package tsdb
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type BoundedParallelism struct {
+	parallelism chan struct{}
+}
+
+func NewBoundedParallelism(parallelism int) *BoundedParallelism {
+	ch := make(chan struct{}, parallelism)
+
+	// seed the channel
+	for i := 0; i < parallelism; i++ {
+		ch <- struct{}{}
+	}
+
+	return &BoundedParallelism{parallelism: ch}
+}
+
+func (p *BoundedParallelism) Run(ctx context.Context, fn func()) error {
+	select {
+	case <-ctx.Done():
+	case <-p.parallelism:
+		fn()
+		p.parallelism <- struct{}{}
+	}
+	return ctx.Err()
+}
+
+// ParallelIndex wraps an index and ensures it respects a maximum parallelization factor.
+type ParallelIndex struct {
+	p *BoundedParallelism
+	Index
+}
+
+func NewParallelIndex(p *BoundedParallelism, i Index) *ParallelIndex {
+	return &ParallelIndex{
+		p:     p,
+		Index: i,
+	}
+}
+
+func (i *ParallelIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (res []ChunkRef, err error) {
+	if err := i.p.Run(ctx, func() {
+		res, err = i.Index.GetChunkRefs(ctx, userID, from, through, matchers...)
+	}); err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+func (i *ParallelIndex) Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (res []Series, err error) {
+	if err := i.p.Run(ctx, func() {
+		res, err = i.Index.Series(ctx, userID, from, through, matchers...)
+	}); err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+func (i *ParallelIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (res []string, err error) {
+	if err := i.p.Run(ctx, func() {
+		res, err = i.Index.LabelNames(ctx, userID, from, through, matchers...)
+	}); err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (i *ParallelIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) (res []string, err error) {
+	if err := i.p.Run(ctx, func() {
+		res, err = i.Index.LabelValues(ctx, userID, from, through, name, matchers...)
+	}); err != nil {
+		return nil, err
+	}
+	return
+}

--- a/pkg/storage/tsdb/parallel_test.go
+++ b/pkg/storage/tsdb/parallel_test.go
@@ -1,0 +1,95 @@
+package tsdb
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+type delayedIdx time.Duration
+
+func (t delayedIdx) Bounds() (model.Time, model.Time) { return 0, math.MaxInt64 }
+func (t delayedIdx) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+	<-time.After(time.Duration(t))
+	return nil, nil
+}
+func (t delayedIdx) Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
+	<-time.After(time.Duration(t))
+	return nil, nil
+}
+func (t delayedIdx) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	<-time.After(time.Duration(t))
+	return nil, nil
+}
+func (t delayedIdx) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
+	<-time.After(time.Duration(t))
+	return nil, nil
+}
+
+func TestParallelIndex(t *testing.T) {
+	duration := 10 * time.Millisecond
+	p := 5
+	idx := NewParallelIndex(NewBoundedParallelism(p), delayedIdx(duration))
+
+	for _, tc := range []struct {
+		desc string
+		fn   func(context.Context) error
+	}{
+		{
+			desc: "GetChunkRefs",
+			fn: func(ctx context.Context) error {
+				_, err := idx.GetChunkRefs(ctx, "", 1, 2)
+				return err
+			},
+		},
+		{
+			desc: "Series",
+			fn: func(ctx context.Context) error {
+				_, err := idx.Series(ctx, "", 1, 2)
+				return err
+			},
+		},
+		{
+			desc: "LabelNames",
+			fn: func(ctx context.Context) error {
+				_, err := idx.LabelNames(ctx, "", 1, 2)
+				return err
+			},
+		},
+		{
+			desc: "LabelValues",
+			fn: func(ctx context.Context) error {
+				_, err := idx.LabelValues(ctx, "", 1, 2, "foo")
+				return err
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var completions atomic.Int32
+
+			// cancel after 150% of the delay duration in our index
+			// this should ensure we only finish one round of parallelism
+			ctx, _ := context.WithTimeout(context.Background(), duration*3/2)
+
+			// try to run double the parallelism
+			for i := 0; i < 2*p; i++ {
+
+				go func() {
+					if err := tc.fn(ctx); err == nil {
+						completions.Inc()
+					}
+				}()
+			}
+			<-ctx.Done()
+			// realistically, due to machine/runtime scheduling, it's not unlikely to see less
+			// than one entire round complete.
+			require.LessOrEqual(t, int(completions.Load()), p)
+		})
+	}
+}

--- a/pkg/storage/tsdb/parallel_test.go
+++ b/pkg/storage/tsdb/parallel_test.go
@@ -75,7 +75,7 @@ func TestParallelIndex(t *testing.T) {
 
 			// cancel after 150% of the delay duration in our index
 			// this should ensure we only finish one round of parallelism
-			ctx, _ := context.WithTimeout(context.Background(), duration*3/2)
+			ctx, _ := context.WithTimeout(context.Background(), duration*3/2) // nolint:govet
 
 			// try to run double the parallelism
 			for i := 0; i < 2*p; i++ {


### PR DESCRIPTION
This adds a utility for bounding parallelism for underlying index implementations. 

ref https://github.com/grafana/loki/issues/5428