### PR TITLE
Tsdb/multi idx

### DIFF
--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -18,10 +18,51 @@ type ChunkRef struct {
 	Checksum    uint32
 }
 
+// Compares by (Start, End)
+// Assumes User is equivalent
+func (r ChunkRef) Less(x ChunkRef) bool {
+	if r.Start != x.Start {
+		return r.Start < x.Start
+	}
+	return r.End <= x.End
+}
+
 type Index interface {
 	Bounded
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
 	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
+}
+
+// utility for heapsort
+type ChunkRefHeap [][]ChunkRef
+
+func (h ChunkRefHeap) Len() int { return len(h) }
+func (h ChunkRefHeap) Less(i, j int) bool {
+	return h[i][0].Less(h[j][0])
+}
+func (h ChunkRefHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+// Push a []ChunkRef to the heap
+func (h *ChunkRefHeap) Push(x interface{}) {
+	*h = append(*h, x.([]ChunkRef))
+}
+
+// Pop a single ChunkRef from the heap
+func (h *ChunkRefHeap) Pop() interface{} {
+	old := *h
+	n := h.Len()
+	x := old[n-1]
+	*h = old[:n-1]
+
+	result := x[0]
+	rem := x[1:]
+	if len(rem) > 0 {
+		h.Push(rem)
+	}
+
+	return result
 }

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Series struct {
-	Labels labels.Labels
+	Labels      labels.Labels
+	Fingerprint model.Fingerprint
 }
 
 type ChunkRef struct {

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -34,35 +34,3 @@ type Index interface {
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
 }
-
-// utility for heapsort
-type ChunkRefHeap [][]ChunkRef
-
-func (h ChunkRefHeap) Len() int { return len(h) }
-func (h ChunkRefHeap) Less(i, j int) bool {
-	return h[i][0].Less(h[j][0])
-}
-func (h ChunkRefHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-}
-
-// Push a []ChunkRef to the heap
-func (h *ChunkRefHeap) Push(x interface{}) {
-	*h = append(*h, x.([]ChunkRef))
-}
-
-// Pop a single ChunkRef from the heap
-func (h *ChunkRefHeap) Pop() interface{} {
-	old := *h
-	n := h.Len()
-	x := old[n-1]
-	*h = old[:n-1]
-
-	result := x[0]
-	rem := x[1:]
-	if len(rem) > 0 {
-		h.Push(rem)
-	}
-
-	return result
-}

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -1,0 +1,150 @@
+package tsdb
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/sync/errgroup"
+)
+
+type MultiIndex struct {
+	indices []Index
+}
+
+// bounded is optional, but if supplied, it will wrap each passed index in NewParallelIndex
+func NewBoundedMultiIndex(bounded *BoundedParallelism, indices ...Index) (Index, error) {
+	if len(indices) == 0 {
+		return nil, errors.New("must supply at least one index")
+	}
+
+	if len(indices) == 1 {
+		if bounded == nil {
+			return indices[0], nil
+		}
+		return NewParallelIndex(bounded, indices[0]), nil
+	}
+
+	sort.Slice(indices, func(i, j int) bool {
+		aFrom, aThrough := indices[i].Bounds()
+		bFrom, bThrough := indices[j].Bounds()
+
+		if aFrom != bFrom {
+			return aFrom < bFrom
+		}
+		// tiebreaker uses through
+		return aThrough <= bThrough
+	})
+
+	if bounded == nil {
+		return &MultiIndex{indices: indices}, nil
+	}
+
+	limited := make([]Index, 0, len(indices))
+	for _, idx := range indices {
+		limited = append(limited, NewParallelIndex(bounded, idx))
+	}
+	return &MultiIndex{indices: limited}, nil
+}
+
+func (i *MultiIndex) Bounds() (model.Time, model.Time) {
+	var lowest, highest model.Time
+	for _, idx := range i.indices {
+		from, through := idx.Bounds()
+		if lowest == 0 || from < lowest {
+			lowest = from
+		}
+
+		if highest == 0 || through > highest {
+			highest = through
+		}
+	}
+
+	return lowest, highest
+}
+
+func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+	queryBounds := newBounds(from, through)
+	g, ctx := errgroup.WithContext(ctx)
+
+	// ensure we prebuffer the channel by the maximum possible
+	// return length so our goroutines don't block
+	ch := make(chan []ChunkRef, len(i.indices))
+
+	for _, idx := range i.indices {
+		// ignore indices which can't match this query
+		if Overlap(queryBounds, idx) {
+			// run all queries in linked goroutines (cancel after first err),
+			// bounded by parallelism controls if applicable.
+			g.Go(func() error {
+				refs, err := idx.GetChunkRefs(ctx, userID, from, through, matchers...)
+				if err != nil {
+					return err
+				}
+				ch <- refs
+				return nil
+			})
+		}
+	}
+
+	// wait for work to finish or error|ctx expiration
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	close(ch)
+
+	refHeap := &ChunkRefHeap{}
+	var maxLn int // maximum number of chunk refs, assuming no duplicates
+	for refs := range ch {
+		maxLn += len(refs)
+		if len(refs) > 0 {
+			// TODO(owen-d): There is a lot of potentially unnecessary sorting
+			// we're doing. Here, as well as the heapsort later on to dedupe.
+			// It may be better to just use a map for deduping and ignore ordering.
+			// Additionally, if we store series in TSDB by sorted fingerprints
+			// instead of lexicographically by labels, we could skip
+			// this current sort step and use the heapsort for deduping
+			// by using a (fingerprint > from > through) ordering scheme therein.
+			// I want to try that out as a later optimization, so I'm leaving
+			// this comment as a breadcrumb
+			sort.Slice(refs, func(i, j int) bool {
+				return refs[i].Less(refs[j])
+			})
+			heap.Push(refHeap, refs)
+		}
+	}
+
+	// optimistically allocate the maximum length slice
+	// to avoid growing incrementally
+	results := make([]ChunkRef, 0, maxLn)
+	var last ChunkRef
+	for refHeap.Len() > 0 {
+		next := heap.Pop(refHeap).(ChunkRef)
+
+		// duplicate, ignore
+		if last == next {
+			continue
+		}
+
+		results = append(results, next)
+		last = next
+	}
+
+	return results, nil
+
+}
+
+func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
+	panic("unimplemented!")
+}
+
+func (i *MultiIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	panic("unimplemented!")
+}
+
+func (i *MultiIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
+	panic("unimplemented!")
+}

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -131,13 +131,111 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 }
 
 func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
-	panic("unimplemented!")
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+		return idx.Series(ctx, userID, from, through, matchers...)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var maxLn int // maximum number of chunk refs, assuming no duplicates
+	xs := make([][]Series, 0, len(i.indices))
+	for _, group := range groups {
+		x := group.([]Series)
+		maxLn += len(x)
+		xs = append(xs, x)
+	}
+
+	// optimistically allocate the maximum length slice
+	// to avoid growing incrementally
+	results := make([]Series, 0, maxLn)
+	seen := make(map[model.Fingerprint]struct{})
+
+	for _, seriesSet := range xs {
+		for _, s := range seriesSet {
+			_, ok := seen[s.Fingerprint]
+			if ok {
+				continue
+			}
+			seen[s.Fingerprint] = struct{}{}
+			results = append(results, s)
+		}
+	}
+
+	return results, nil
 }
 
 func (i *MultiIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	panic("unimplemented!")
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+		return idx.LabelNames(ctx, userID, from, through, matchers...)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var maxLn int // maximum number of chunk refs, assuming no duplicates
+	xs := make([][]string, 0, len(i.indices))
+	for _, group := range groups {
+		x := group.([]string)
+		maxLn += len(x)
+		xs = append(xs, x)
+	}
+
+	// optimistically allocate the maximum length slice
+	// to avoid growing incrementally
+	results := make([]string, 0, maxLn)
+	seen := make(map[string]struct{})
+
+	for _, ls := range xs {
+		for _, l := range ls {
+			_, ok := seen[l]
+			if ok {
+				continue
+			}
+			seen[l] = struct{}{}
+			results = append(results, l)
+		}
+	}
+
+	return results, nil
+
 }
 
 func (i *MultiIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	panic("unimplemented!")
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+		return idx.LabelValues(ctx, userID, from, through, name, matchers...)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var maxLn int // maximum number of chunk refs, assuming no duplicates
+	xs := make([][]string, 0, len(i.indices))
+	for _, group := range groups {
+		x := group.([]string)
+		maxLn += len(x)
+		xs = append(xs, x)
+	}
+
+	// optimistically allocate the maximum length slice
+	// to avoid growing incrementally
+	results := make([]string, 0, maxLn)
+	seen := make(map[string]struct{})
+
+	for _, ls := range xs {
+		for _, l := range ls {
+			_, ok := seen[l]
+			if ok {
+				continue
+			}
+			seen[l] = struct{}{}
+			results = append(results, l)
+		}
+	}
+
+	return results, nil
+
 }

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -1,7 +1,6 @@
 package tsdb
 
 import (
-	"container/heap"
 	"context"
 	"errors"
 	"sort"
@@ -15,17 +14,13 @@ type MultiIndex struct {
 	indices []Index
 }
 
-// bounded is optional, but if supplied, it will wrap each passed index in NewParallelIndex
-func NewBoundedMultiIndex(bounded *BoundedParallelism, indices ...Index) (Index, error) {
+func NewMultiIndex(indices ...Index) (Index, error) {
 	if len(indices) == 0 {
 		return nil, errors.New("must supply at least one index")
 	}
 
 	if len(indices) == 1 {
-		if bounded == nil {
-			return indices[0], nil
-		}
-		return NewParallelIndex(bounded, indices[0]), nil
+		return indices[0], nil
 	}
 
 	sort.Slice(indices, func(i, j int) bool {
@@ -39,15 +34,7 @@ func NewBoundedMultiIndex(bounded *BoundedParallelism, indices ...Index) (Index,
 		return aThrough <= bThrough
 	})
 
-	if bounded == nil {
-		return &MultiIndex{indices: indices}, nil
-	}
-
-	limited := make([]Index, 0, len(indices))
-	for _, idx := range indices {
-		limited = append(limited, NewParallelIndex(bounded, idx))
-	}
-	return &MultiIndex{indices: limited}, nil
+	return &MultiIndex{indices: indices}, nil
 }
 
 func (i *MultiIndex) Bounds() (model.Time, model.Time) {
@@ -66,13 +53,13 @@ func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 	return lowest, highest
 }
 
-func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, fn func(context.Context, Index) (interface{}, error)) ([]interface{}, error) {
 	queryBounds := newBounds(from, through)
 	g, ctx := errgroup.WithContext(ctx)
 
 	// ensure we prebuffer the channel by the maximum possible
 	// return length so our goroutines don't block
-	ch := make(chan []ChunkRef, len(i.indices))
+	ch := make(chan interface{}, len(i.indices))
 
 	for _, idx := range i.indices {
 		// ignore indices which can't match this query
@@ -80,11 +67,11 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 			// run all queries in linked goroutines (cancel after first err),
 			// bounded by parallelism controls if applicable.
 			g.Go(func() error {
-				refs, err := idx.GetChunkRefs(ctx, userID, from, through, matchers...)
+				got, err := fn(ctx, idx)
 				if err != nil {
 					return err
 				}
-				ch <- refs
+				ch <- got
 				return nil
 			})
 		}
@@ -96,41 +83,47 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 	}
 	close(ch)
 
-	refHeap := &ChunkRefHeap{}
-	var maxLn int // maximum number of chunk refs, assuming no duplicates
-	for refs := range ch {
-		maxLn += len(refs)
-		if len(refs) > 0 {
-			// TODO(owen-d): There is a lot of potentially unnecessary sorting
-			// we're doing. Here, as well as the heapsort later on to dedupe.
-			// It may be better to just use a map for deduping and ignore ordering.
-			// Additionally, if we store series in TSDB by sorted fingerprints
-			// instead of lexicographically by labels, we could skip
-			// this current sort step and use the heapsort for deduping
-			// by using a (fingerprint > from > through) ordering scheme therein.
-			// I want to try that out as a later optimization, so I'm leaving
-			// this comment as a breadcrumb
-			sort.Slice(refs, func(i, j int) bool {
-				return refs[i].Less(refs[j])
-			})
-			heap.Push(refHeap, refs)
-		}
+	results := make([]interface{}, 0, len(i.indices))
+	for x := range ch {
+		results = append(results, x)
+	}
+	return results, nil
+}
+
+func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+		return idx.GetChunkRefs(ctx, userID, from, through, matchers...)
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
+	var maxLn int // maximum number of chunk refs, assuming no duplicates
+	refGroups := make([][]ChunkRef, 0, len(i.indices))
+	for _, group := range groups {
+		rg := group.([]ChunkRef)
+		maxLn += len(rg)
+		refGroups = append(refGroups, rg)
+	}
 	// optimistically allocate the maximum length slice
 	// to avoid growing incrementally
 	results := make([]ChunkRef, 0, maxLn)
-	var last ChunkRef
-	for refHeap.Len() > 0 {
-		next := heap.Pop(refHeap).(ChunkRef)
 
-		// duplicate, ignore
-		if last == next {
-			continue
+	// keep track of duplicates
+	seen := make(map[ChunkRef]struct{})
+
+	// TODO(owen-d): Do this more efficiently,
+	// not all indices overlap each other
+	for _, group := range refGroups {
+		for _, ref := range group {
+			_, ok := seen[ref]
+			if ok {
+				continue
+			}
+			seen[ref] = struct{}{}
+			results = append(results, ref)
 		}
-
-		results = append(results, next)
-		last = next
 	}
 
 	return results, nil

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -1,0 +1,103 @@
+package tsdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiIndex_GetChunkRefs(t *testing.T) {
+	cases := []LoadableSeries{
+		{
+			Labels: mustParseLabels(`{foo="bar"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  0,
+					MaxTime:  3,
+					Checksum: 0,
+				},
+				{
+					MinTime:  1,
+					MaxTime:  4,
+					Checksum: 1,
+				},
+				{
+					MinTime:  2,
+					MaxTime:  5,
+					Checksum: 2,
+				},
+			},
+		},
+		{
+			Labels: mustParseLabels(`{foo="bar", bazz="buzz"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  1,
+					MaxTime:  10,
+					Checksum: 3,
+				},
+			},
+		},
+		{
+			// should be excluded due to bounds checking
+			Labels: mustParseLabels(`{foo="bar", bazz="bozz"}`),
+			Chunks: []index.ChunkMeta{
+				{
+					MinTime:  8,
+					MaxTime:  9,
+					Checksum: 4,
+				},
+			},
+		},
+	}
+
+	// group 5 indices together, all with duplicate data
+	n := 5
+	var indices []Index
+	for i := 0; i < n; i++ {
+		indices = append(indices, BuildIndex(t, cases))
+	}
+
+	idx, err := NewBoundedMultiIndex(NewBoundedParallelism(n), indices...)
+	require.Nil(t, err)
+
+	refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Nil(t, err)
+
+	expected := []ChunkRef{
+		{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+			Start:       0,
+			End:         3,
+			Checksum:    0,
+		},
+		{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+			Start:       1,
+			End:         4,
+			Checksum:    1,
+		},
+		{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+			Start:       1,
+			End:         10,
+			Checksum:    3,
+		},
+		{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+			Start:       2,
+			End:         5,
+			Checksum:    2,
+		},
+	}
+	require.Equal(t, expected, refs)
+
+}

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 func TestMultiIndex(t *testing.T) {

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -62,13 +62,20 @@ func TestMultiIndex_GetChunkRefs(t *testing.T) {
 		indices = append(indices, BuildIndex(t, cases))
 	}
 
-	idx, err := NewBoundedMultiIndex(NewBoundedParallelism(n), indices...)
+	idx, err := NewMultiIndex(indices...)
 	require.Nil(t, err)
 
 	refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 	require.Nil(t, err)
 
 	expected := []ChunkRef{
+		{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+			Start:       1,
+			End:         10,
+			Checksum:    3,
+		},
 		{
 			User:        "fake",
 			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
@@ -82,13 +89,6 @@ func TestMultiIndex_GetChunkRefs(t *testing.T) {
 			Start:       1,
 			End:         4,
 			Checksum:    1,
-		},
-		{
-			User:        "fake",
-			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
-			Start:       1,
-			End:         10,
-			Checksum:    3,
 		},
 		{
 			User:        "fake",

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -95,7 +95,8 @@ func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time
 			if Overlap(queryBounds, chk) {
 				// this series has at least one chunk in the desired range
 				res = append(res, Series{
-					Labels: ls.Copy(),
+					Labels:      ls.Copy(),
+					Fingerprint: model.Fingerprint(ls.Hash()),
 				})
 				break
 			}

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -100,7 +100,8 @@ func TestSingleIdx(t *testing.T) {
 
 		expected := []Series{
 			{
-				Labels: mustParseLabels(`{foo="bar", bazz="buzz"}`),
+				Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
 			},
 		}
 		require.Equal(t, expected, xs)


### PR DESCRIPTION
This PR introduces an index implementation which wraps multiple underlying indices (i.e. multiple TSDB files). In the course of implementing it, I also adjusted the `Series` response type to include the `model.Fingerprint` for use in deduping. I think we can revive the old https://github.com/grafana/loki/pull/5591 PR to make this easier as well.

ref https://github.com/grafana/loki/issues/5428