### PR TITLE
Tsdb/sharding

### DIFF
--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -284,6 +285,10 @@ func ParseShard(input string) (parsed ShardAnnotation, err error) {
 type ShardAnnotation struct {
 	Shard int
 	Of    int
+}
+
+func (shard ShardAnnotation) Match(fp model.Fingerprint) bool {
+	return uint64(fp)%uint64(shard.Of) == uint64(shard.Shard)
 }
 
 // String encodes a shardAnnotation into a label value

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -30,8 +31,8 @@ func (r ChunkRef) Less(x ChunkRef) bool {
 
 type Index interface {
 	Bounded
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error)
-	Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error)
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error)
+	Series(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
 }

--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -3,9 +3,10 @@ package tsdb
 import (
 	"context"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 type Series struct {

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"sort"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
 )
 
 type MultiIndex struct {

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
@@ -90,9 +91,9 @@ func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, f
 	return results, nil
 }
 
-func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
 	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.GetChunkRefs(ctx, userID, from, through, matchers...)
+		return idx.GetChunkRefs(ctx, userID, from, through, shard, matchers...)
 	})
 
 	if err != nil {
@@ -130,9 +131,9 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 
 }
 
-func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
+func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
 	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.Series(ctx, userID, from, through, matchers...)
+		return idx.Series(ctx, userID, from, through, shard, matchers...)
 	})
 
 	if err != nil {

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -67,7 +67,7 @@ func TestMultiIndex(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("GetChunkRefs", func(t *testing.T) {
-		refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.Nil(t, err)
 
 		expected := []ChunkRef{
@@ -104,7 +104,7 @@ func TestMultiIndex(t *testing.T) {
 	})
 
 	t.Run("Series", func(t *testing.T) {
-		xs, err := idx.Series(context.Background(), "fake", 2, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		xs, err := idx.Series(context.Background(), "fake", 2, 5, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.Nil(t, err)
 		expected := []Series{
 			{

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
@@ -25,84 +26,92 @@ func (i *TSDBIndex) Bounds() (model.Time, model.Time) {
 	return model.Time(from), model.Time(through)
 }
 
-func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	queryBounds := newBounds(from, through)
+func (i *TSDBIndex) forSeries(
+	from, through model.Time,
+	shard *astmapper.ShardAnnotation,
+	fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta),
+	matchers ...*labels.Matcher,
+) error {
 	p, err := PostingsForMatchers(i.reader, matchers...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	var (
-		res  []ChunkRef // TODO(owen-d): pool, reduce allocs
 		ls   labels.Labels
 		chks []index.ChunkMeta
 	)
 
 	for p.Next() {
 		if err := i.reader.Series(p.At(), &ls, &chks); err != nil {
-			return nil, err
+			return err
 		}
 
-		// cache hash calculation across chunks of the same series
-		// TODO(owen-d): Should we store this in the index? in an in-mem cache?
-		var hash uint64
-
-		// TODO(owen-d): use logarithmic approach
-		for _, chk := range chks {
-
-			// current chunk is outside the range of this request
-			if !Overlap(queryBounds, chk) {
-				continue
-			}
-
-			if hash == 0 {
-				hash = ls.Hash()
-			}
-
-			res = append(res, ChunkRef{
-				User:        userID, // assumed to be the same, will be enforced by caller.
-				Fingerprint: model.Fingerprint(hash),
-				Start:       chk.From(),
-				End:         chk.Through(),
-				Checksum:    chk.Checksum,
-			})
+		hash := ls.Hash()
+		// skip series that belong to different shards
+		if shard != nil && !shard.Match(model.Fingerprint(hash)) {
+			continue
 		}
+
+		fn(ls, model.Fingerprint(hash), chks)
 	}
-	return res, p.Err()
+	return p.Err()
 }
 
-func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time, matchers ...*labels.Matcher) ([]Series, error) {
+func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
 	queryBounds := newBounds(from, through)
-	p, err := PostingsForMatchers(i.reader, matchers...)
-	if err != nil {
+	var res []ChunkRef // TODO(owen-d): pool, reduce allocs
+
+	if err := i.forSeries(from, through, shard,
+		func(ls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+			// TODO(owen-d): use logarithmic approach
+			for _, chk := range chks {
+
+				// current chunk is outside the range of this request
+				if !Overlap(queryBounds, chk) {
+					continue
+				}
+
+				res = append(res, ChunkRef{
+					User:        userID, // assumed to be the same, will be enforced by caller.
+					Fingerprint: fp,
+					Start:       chk.From(),
+					End:         chk.Through(),
+					Checksum:    chk.Checksum,
+				})
+			}
+		},
+		matchers...); err != nil {
 		return nil, err
 	}
 
-	var (
-		res  []Series // TODO(owen-d): reduce allocs
-		ls   labels.Labels
-		chks []index.ChunkMeta
-	)
+	return res, nil
+}
 
-	for p.Next() {
-		if err := i.reader.Series(p.At(), &ls, &chks); err != nil {
-			return nil, err
-		}
+func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
+	queryBounds := newBounds(from, through)
+	var res []Series // TODO(owen-d): pool, reduce allocs
 
-		// TODO(owen-d): use logarithmic approach
-		for _, chk := range chks {
+	if err := i.forSeries(from, through, shard,
+		func(ls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+			// TODO(owen-d): use logarithmic approach
+			for _, chk := range chks {
 
-			if Overlap(queryBounds, chk) {
-				// this series has at least one chunk in the desired range
-				res = append(res, Series{
-					Labels:      ls.Copy(),
-					Fingerprint: model.Fingerprint(ls.Hash()),
-				})
-				break
+				if Overlap(queryBounds, chk) {
+					// this series has at least one chunk in the desired range
+					res = append(res, Series{
+						Labels:      ls.Copy(),
+						Fingerprint: fp,
+					})
+					break
+				}
 			}
-		}
+		},
+		matchers...); err != nil {
+		return nil, err
 	}
-	return res, p.Err()
+
+	return res, nil
 }
 
 func (i *TSDBIndex) LabelNames(_ context.Context, _ string, _, _ model.Time, matchers ...*labels.Matcher) ([]string, error) {

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -27,7 +27,6 @@ func (i *TSDBIndex) Bounds() (model.Time, model.Time) {
 }
 
 func (i *TSDBIndex) forSeries(
-	from, through model.Time,
 	shard *astmapper.ShardAnnotation,
 	fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta),
 	matchers ...*labels.Matcher,
@@ -62,7 +61,7 @@ func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through
 	queryBounds := newBounds(from, through)
 	var res []ChunkRef // TODO(owen-d): pool, reduce allocs
 
-	if err := i.forSeries(from, through, shard,
+	if err := i.forSeries(shard,
 		func(ls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 			// TODO(owen-d): use logarithmic approach
 			for _, chk := range chks {
@@ -92,7 +91,7 @@ func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time
 	queryBounds := newBounds(from, through)
 	var res []Series // TODO(owen-d): pool, reduce allocs
 
-	if err := i.forSeries(from, through, shard,
+	if err := i.forSeries(shard,
 		func(ls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 			// TODO(owen-d): use logarithmic approach
 			for _, chk := range chks {

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -137,7 +137,8 @@ func TestSingleIdx(t *testing.T) {
 
 		expected := []Series{
 			{
-				Labels: mustParseLabels(`{foo="bar"}`),
+				Labels:      mustParseLabels(`{foo="bar"}`),
+				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
 			},
 		}
 		require.Equal(t, expected, xs)

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
@@ -58,7 +59,7 @@ func TestSingleIdx(t *testing.T) {
 	idx := BuildIndex(t, cases)
 
 	t.Run("GetChunkRefs", func(t *testing.T) {
-		refs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		refs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.Nil(t, err)
 
 		expected := []ChunkRef{
@@ -94,14 +95,49 @@ func TestSingleIdx(t *testing.T) {
 		require.Equal(t, expected, refs)
 	})
 
+	t.Run("GetChunkRefsSharded", func(t *testing.T) {
+		shard := astmapper.ShardAnnotation{
+			Shard: 1,
+			Of:    2,
+		}
+		shardedRefs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, &shard, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Nil(t, err)
+
+		require.Equal(t, []ChunkRef{{
+			User:        "fake",
+			Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+			Start:       1,
+			End:         10,
+			Checksum:    3,
+		}}, shardedRefs)
+
+	})
+
 	t.Run("Series", func(t *testing.T) {
-		xs, err := idx.Series(context.Background(), "fake", 8, 9, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		xs, err := idx.Series(context.Background(), "fake", 8, 9, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.Nil(t, err)
 
 		expected := []Series{
 			{
 				Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
 				Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+			},
+		}
+		require.Equal(t, expected, xs)
+	})
+
+	t.Run("SeriesSharded", func(t *testing.T) {
+		shard := astmapper.ShardAnnotation{
+			Shard: 0,
+			Of:    2,
+		}
+
+		xs, err := idx.Series(context.Background(), "fake", 0, 10, &shard, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Nil(t, err)
+
+		expected := []Series{
+			{
+				Labels: mustParseLabels(`{foo="bar"}`),
 			},
 		}
 		require.Equal(t, expected, xs)

--- a/tools/tsdb/tsdb-map/main_test.go
+++ b/tools/tsdb/tsdb-map/main_test.go
@@ -77,7 +77,7 @@ func BenchmarkQuery_GetChunkRefs(b *testing.B) {
 		idx := tsdb.NewTSDBIndex(reader)
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := idx.GetChunkRefs(context.Background(), "fake", 0, math.MaxInt64, bm.matchers...)
+				_, err := idx.GetChunkRefs(context.Background(), "fake", 0, math.MaxInt64, nil, bm.matchers...)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
This PR adds support for shard-aware index querying, specifically to the `GetChunkRefs` and `Series` methods. This is an initial PR and is relatively naive, but implements the required functionality and leaves us open to improving it in the future.

closes https://github.com/grafana/loki/issues/5581
ref https://github.com/grafana/loki/issues/5428