### PR TITLE
Replace `PromQL` -> `LogQL` wordings in Querier logs

### DIFF
--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -28,7 +28,7 @@ type Config struct {
 
 	Parallelism           int  `yaml:"parallelism"`
 	MatchMaxConcurrency   bool `yaml:"match_max_concurrent"`
-	MaxConcurrentRequests int  `yaml:"-"` // Must be same as passed to PromQL Engine.
+	MaxConcurrentRequests int  `yaml:"-"` // Must be same as passed to LogQL Engine.
 
 	QuerierID string `yaml:"id"`
 
@@ -260,7 +260,7 @@ func (w *querierWorker) resetConcurrency() {
 
 		// If concurrency is 0 then MaxConcurrentRequests is less than the total number of
 		// frontends/schedulers. In order to prevent accidentally starving a frontend or scheduler we are just going to
-		// always connect once to every target.  This is dangerous b/c we may start exceeding PromQL
+		// always connect once to every target.  This is dangerous b/c we may start exceeding LogQL
 		// max concurrency.
 		if concurrency == 0 {
 			concurrency = 1
@@ -272,7 +272,7 @@ func (w *querierWorker) resetConcurrency() {
 	}
 
 	if totalConcurrency > w.cfg.MaxConcurrentRequests {
-		level.Warn(w.logger).Log("msg", "total worker concurrency is greater than promql max concurrency. Queries may be queued in the querier which reduces QOS")
+		level.Warn(w.logger).Log("msg", "total worker concurrency is greater than logql max concurrency. Queries may be queued in the querier which reduces QOS")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Confusing log messages from the query worker
```
"total worker concurrency is greater than promql max concurrency. Queries may be queued in the querier which reduces QOS"
```
NOTE: `promql` instead of `logql`

**Which issue(s) this PR fixes**:
Fixes NA

**Special notes for your reviewer**:

