### PR TITLE
Docs: Hint about potential high cardinality metrics

### DIFF
--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -82,6 +82,13 @@ exposed by Promtail at its `/metrics` endpoint. See Promtail's documentation on
 An example Grafana dashboard was built by the community and is available as
 dashboard [10004](https://grafana.com/dashboards/10004).
 
+## Metrics cardinality
+
+Some of the metrics above are emitted per tracked file (active) with the file path included in the labels. 
+Depending on your setup, this may result in very large amount of label values across the environment (cardinality). This is generally discouraged by [Prometheus](https://prometheus.io/docs/practices/naming/#labels) and may result with unwanted side effects. 
+Make sure to review the emitted metrics before starting scraping with Prometheus and config the scraping accordingly if you suspect this might be an issue.
+
+
 ## Mixins
 
 The Loki repository has a [mixin](https://github.com/grafana/loki/blob/master/production/loki-mixin) that includes a

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -84,9 +84,9 @@ dashboard [10004](https://grafana.com/dashboards/10004).
 
 ## Metrics cardinality
 
-Some of the metrics above are emitted per tracked file (active) with the file path included in the labels. 
-Depending on your setup, this may result in very large amount of label values across the environment (cardinality). This is generally discouraged by [Prometheus](https://prometheus.io/docs/practices/naming/#labels) and may result with unwanted side effects. 
-Make sure to review the emitted metrics before starting scraping with Prometheus and config the scraping accordingly if you suspect this might be an issue.
+Some of the Loki observability metrics are emitted per tracked file (active), with the file path included in labels. 
+This increases the quantity of label values across the environment, thereby increasing cardinality. Best practices with Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) discourage increasing cardinality in this way. 
+Review your emitted metrics before scraping with Prometheus, and configure the scraping to avoid this issue.
 
 
 ## Mixins


### PR DESCRIPTION
**What this PR does / why we need it**:
Add warning about potential high cardinality metrics due to the file path being included in some of the metrics. 
Depending on the setup, such config can result in a very large amount of label values, which is not recommended by Prometheus.
This can result in increased storage, slow down of queries, extra costs and so on.

Address what has been discussed in #5553.

**Which issue(s) this PR fixes**:
Fixes #5553

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
