### PR TITLE
General: print fatal stacktraces to stderr for improved readability

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -97,7 +97,10 @@ func CheckFatal(location string, err error, logger log.Logger) {
 		logger = log.With(logger, "msg", "error "+location)
 	}
 	// %+v gets the stack trace from errors using github.com/pkg/errors
-	logger.Log("err", fmt.Sprintf("%+v", err))
+	errStr := fmt.Sprintf("%+v", err)
+	fmt.Fprintln(os.Stderr, errStr)
+
+	logger.Log("err", errStr)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Prints fatal stacktraces to `stderr` for improved readability.
Currently our fatal error messages are logged like this:

```
level=error ts=2022-03-14T09:06:10.700672214Z caller=log.go:103 msg="error running loki" err="failed services\ngithub.com/grafana/loki/pkg/loki.(*Loki).Run\n\t/loki/pkg/loki/loki.go:420\nmain.main\n\t/loki/cmd/loki/main.go:108\nruntime.main\n\t/home/danny/sdk/go1.17.4/src/runtime/proc.go:255\nruntime.goexit\n\t/home/danny/sdk/go1.17.4/src/runtime/asm_amd64.s:1581"
```

This is pretty difficult to read.
This log line will be maintained, but we will additionally log the error message to `stderr`:

```
failed services
github.com/grafana/loki/pkg/loki.(*Loki).Run
        /loki/pkg/loki/loki.go:420
main.main
        /loki/cmd/loki/main.go:108
runtime.main
        /home/danny/sdk/go1.17.4/src/runtime/proc.go:255
runtime.goexit
        /home/danny/sdk/go1.17.4/src/runtime/asm_amd64.s:1581
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
