### PR TITLE
Test multi-tenant context propagation.

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -39,13 +39,12 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 	}
 
 	if len(tenantIDs) == 1 {
-		singleContext := user.InjectUserID(ctx, tenantIDs[0])
-		return q.Querier.SelectLogs(singleContext, params)
+		return q.Querier.SelectLogs(ctx, params)
 	}
 
 	iters := make([]iter.EntryIterator, len(tenantIDs))
 	for i, id := range tenantIDs {
-		singleContext := user.InjectUserID(ctx, id)
+		singleContext := user.InjectOrgID(ctx, id)
 		iter, err := q.Querier.SelectLogs(singleContext, params)
 		if err != nil {
 			return nil, err
@@ -63,13 +62,12 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 	}
 
 	if len(tenantIDs) == 1 {
-		singleContext := user.InjectUserID(ctx, tenantIDs[0])
-		return q.Querier.SelectSamples(singleContext, params)
+		return q.Querier.SelectSamples(ctx, params)
 	}
 
 	iters := make([]iter.SampleIterator, len(tenantIDs))
 	for i, id := range tenantIDs {
-		singleContext := user.InjectUserID(ctx, id)
+		singleContext := user.InjectOrgID(ctx, id)
 		iter, err := q.Querier.SelectSamples(singleContext, params)
 		if err != nil {
 			return nil, err

--- a/tools/dev/loki-boltdb-storage-s3/README.md
+++ b/tools/dev/loki-boltdb-storage-s3/README.md
@@ -53,8 +53,8 @@ If you use vs-code, you can add this snippet bellow in your [`launch.json`](http
     "substitutePath": [
         {
             "from": "${workspaceFolder}",
-            "to": "${workspaceFolder}",
-        },
+            "to": "${workspaceFolder}"
+        }
     ],
     "port": 18002,
     "host": "127.0.0.1",
@@ -62,8 +62,8 @@ If you use vs-code, you can add this snippet bellow in your [`launch.json`](http
     "remotePath": "/loki/loki",
     "showLog": true,
     "trace": "log",
-    "logOutput": "rpc",
-},
+    "logOutput": "rpc"
+}
 ```
 
 Then you can debug `ingester-1` with the `Launch Loki remote` configuration within the debugging tab.

--- a/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
@@ -92,7 +92,7 @@ querier:
     multi_tenant_queries_enabled: true
 query_range:
     align_queries_with_step: true
-    cache_results: false 
+    cache_results: true
     max_retries: 5
     parallelise_shardable_queries: true
     results_cache:

--- a/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
@@ -1,4 +1,4 @@
-auth_enabled: false
+auth_enabled: true 
 chunk_store_config:
     chunk_cache_config:
         memcached:
@@ -89,9 +89,10 @@ querier:
         timeout: 5m
     query_ingesters_within: 2h
     query_timeout: 5m
+    multi_tenant_queries_enabled: true
 query_range:
     align_queries_with_step: true
-    cache_results: true
+    cache_results: false 
     max_retries: 5
     parallelise_shardable_queries: true
     results_cache:

--- a/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
+++ b/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
@@ -252,3 +252,15 @@ services:
     command: ["-f", "json", "-l", "-d", "2s"]
     depends_on:
       - distributor
+
+  log-gen-2:
+    logging:
+      driver: loki-compose
+      options:
+        loki-url: "http://localhost:8001/loki/api/v1/push"
+        loki-retries: "1"
+        loki-tenant-id: "2"
+    image: mingrammer/flog
+    command: ["-f", "json", "-l", "-d", "2s"]
+    depends_on:
+      - distributor

--- a/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
+++ b/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       options:
         loki-url: "http://localhost:8001/loki/api/v1/push"
         loki-retries: "1"
+        loki-tenant-id: "1"
     image: consul
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
@@ -14,9 +15,9 @@ services:
   minio:
     logging:
       <<: *logging
-    image: minio/minio
+    image: minio/minio:RELEASE.2022-03-11T23-57-45Z
     entrypoint: sh
-    command: -c 'mkdir -p /data/loki && /usr/bin/minio server /data'
+    command: -c 'mkdir -p /data/loki && /opt/bin/minio server /data'
     environment:
       - MINIO_ACCESS_KEY=loki
       - MINIO_SECRET_KEY=supersecret
@@ -248,6 +249,6 @@ services:
     logging:
       <<: *logging
     image: mingrammer/flog
-    command: ["-f", "json", "-l", "-s", "1s"]
+    command: ["-f", "json", "-l", "-d", "2s"]
     depends_on:
       - distributor


### PR DESCRIPTION
**What this PR does / why we need it**:
The original change injected the user id when the org id was required to fetch all data.

**Which issue(s) this PR fixes**:
Fixes grafana/loki-private#230

**Special notes for your reviewer**:
The changes can be tested as follows
1. Change working directory to `tools/dev/loki-boltdb-storage-s3`.
2. Call `./compose-up.sh` to boot the cluster.
3. Query the logs with
    ```
   curl -v -X GET -G "http://localhost:8007/loki/api/v1/query_range" -H "X-Scope-OrgID: 1|2"   --data-urlencode 'query={compose_service=~"log-gen.*"}' | jq '.data.result[].stream'
    ```
    It will should two streams with `__tenant_id: 1` and `__tenant_id_: 2` as part of the labels.


**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.

