### PR TITLE
Tsdb/sharding-benchmarks

### DIFF
--- a/pkg/storage/tsdb/index.go
+++ b/pkg/storage/tsdb/index.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 type Series struct {
@@ -32,8 +32,8 @@ func (r ChunkRef) Less(x ChunkRef) bool {
 
 type Index interface {
 	Bounded
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error)
-	Series(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error)
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error)
+	Series(ctx context.Context, userID string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
 }

--- a/pkg/storage/tsdb/index/shard.go
+++ b/pkg/storage/tsdb/index/shard.go
@@ -1,0 +1,38 @@
+package index
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	// ShardLabel is a reserved label referencing a cortex shard
+	ShardLabel = "__tsdb_shard__"
+	// ShardLabelFmt is the fmt of the ShardLabel key.
+	ShardLabelFmt = "%d_of_%d"
+)
+
+// ShardAnnotation is a convenience struct which holds data from a parsed shard label
+type ShardAnnotation struct {
+	Shard uint32
+	Of    uint32
+}
+
+func (shard ShardAnnotation) Match(fp model.Fingerprint) bool {
+	return uint64(fp)%uint64(shard.Of) == uint64(shard.Shard)
+}
+
+// String encodes a shardAnnotation into a label value
+func (shard ShardAnnotation) String() string {
+	return fmt.Sprintf(ShardLabelFmt, shard.Shard, shard.Of)
+}
+
+// Label generates the ShardAnnotation as a label
+func (shard ShardAnnotation) Label() labels.Label {
+	return labels.Label{
+		Name:  ShardLabel,
+		Value: shard.String(),
+	}
+}

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 type MultiIndex struct {
@@ -92,7 +92,7 @@ func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, f
 	return results, nil
 }
 
-func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
 	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
 		return idx.GetChunkRefs(ctx, userID, from, through, shard, matchers...)
 	})
@@ -132,7 +132,7 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 
 }
 
-func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
+func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
 	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
 		return idx.Series(ctx, userID, from, through, shard, matchers...)
 	})

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
@@ -27,7 +26,7 @@ func (i *TSDBIndex) Bounds() (model.Time, model.Time) {
 }
 
 func (i *TSDBIndex) forSeries(
-	shard *astmapper.ShardAnnotation,
+	shard *index.ShardAnnotation,
 	fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta),
 	matchers ...*labels.Matcher,
 ) error {
@@ -57,7 +56,7 @@ func (i *TSDBIndex) forSeries(
 	return p.Err()
 }
 
-func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
 	queryBounds := newBounds(from, through)
 	var res []ChunkRef // TODO(owen-d): pool, reduce allocs
 
@@ -87,7 +86,7 @@ func (i *TSDBIndex) GetChunkRefs(_ context.Context, userID string, from, through
 	return res, nil
 }
 
-func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time, shard *astmapper.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
+func (i *TSDBIndex) Series(_ context.Context, _ string, from, through model.Time, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
 	queryBounds := newBounds(from, through)
 	var res []Series // TODO(owen-d): pool, reduce allocs
 

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
@@ -96,7 +95,7 @@ func TestSingleIdx(t *testing.T) {
 	})
 
 	t.Run("GetChunkRefsSharded", func(t *testing.T) {
-		shard := astmapper.ShardAnnotation{
+		shard := index.ShardAnnotation{
 			Shard: 1,
 			Of:    2,
 		}
@@ -127,7 +126,7 @@ func TestSingleIdx(t *testing.T) {
 	})
 
 	t.Run("SeriesSharded", func(t *testing.T) {
-		shard := astmapper.ShardAnnotation{
+		shard := index.ShardAnnotation{
 			Shard: 0,
 			Of:    2,
 		}


### PR DESCRIPTION
This PR does the following:
1) Copies `ShardAnnotation` over to the `tsdb/index` package, both where it will remain and for alignment with other sharding work (followup PR)
2) Adds a sharding-aware benchmark to prove sharding optimizations with.

ref https://github.com/grafana/loki/issues/5428