### PR TITLE
Remove benchmark cron job.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -371,24 +371,6 @@ local manifest(apps) = pipeline('manifest') {
       },
     ],
   },
-  pipeline('benchmark-cron') {
-    workspace: {
-      base: '/src',
-      path: 'loki',
-    },
-    node: { type: 'no-parallel' },
-    steps: [
-      run('All', ['go test -mod=vendor -bench=Benchmark -benchtime 20x -timeout 120m ./pkg/...']),
-    ],
-    trigger: {
-      event: {
-        include: ['cron'],
-      },
-      cron: {
-        include: ['loki-bench'],
-      },
-    },
-  },
 ] + [
   multiarch_image(arch)
   for arch in archs

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -39,27 +39,27 @@ steps:
   - make BUILD_IN_CONTAINER=false check-drone-drift
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: check-generated-files
 - commands:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: test
 - commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -67,7 +67,7 @@ steps:
   - clone
   - test
   - lint
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -78,19 +78,19 @@ steps:
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.0
+  image: grafana/loki-build-image:0.20.1
   name: check-example-config-doc
 trigger:
   event:
@@ -113,26 +113,6 @@ trigger:
   event:
   - push
   - pull_request
-workspace:
-  base: /src
-  path: loki
----
-kind: pipeline
-name: benchmark-cron
-node:
-  type: no-parallel
-steps:
-- commands:
-  - go test -mod=vendor -bench=Benchmark -benchtime 20x -timeout 120m ./pkg/...
-  image: grafana/loki-build-image:0.20.0
-  name: All
-trigger:
-  cron:
-    include:
-    - loki-bench
-  event:
-    include:
-    - cron
 workspace:
   base: /src
   path: loki
@@ -1065,6 +1045,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: 835c89da39567393f70fb1848d9f010d3276a4ff2e7dd9089b8ea70eee7beb1a
+hmac: c8daf173159729445944aec4a308e53263b9302e485bca9d26f71ef2ac47ce4b
 
 ...


### PR DESCRIPTION
Summary
- The benchmarks were not stable enough.
- They did not yield much value as we did not give much attention to
  them.