### PR TITLE
docs: Add section in troubleshooting for timeout errors (504, context cancelled, error processing requests)

### DIFF
--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -44,17 +44,25 @@ Promtail yet. There may be one of many root causes:
 
 ## Loki Timeouts (504 errors, context canelled, error processing requests)
 
-These errors have many different possible causes. Main things to review with respect to Loki are:
+These errors can have many possible causes. With respect to Loki you should review the following first:
+### Loki Configuration
+
 - Loki configuration querier.query_timeout
 - server.http_server_read_timeout
 - server.http_server_write_timeout
 - server.http_server_idle_timeout
+
+### Loki Deployment
+
 - If you have a reverse proxy in front of Loki (ie. between Loki and Grafana) then check any timeouts configured there (ie. NGINX proxy read timeout)
 
-To determine if the issue is related to the Loki deployment or another system (Grafana, or another client) attempt to run a [logcli](https://grafana.com/docs/loki/latest/getting-started/logcli/) query as "directly" as you can. IE if running on VMs then run the query on that local machinem. If running in K8S the port forward the loki HTTP port and attempt to run the query there. If you still get a timeout then review the dot points above. If you do not then continue reading and some other common timeout issues will be mentioned.
+### Other Causes
+
+To determine if the issue is related to Loki itself or another system (Grafana, clientside error) attempt to run a [logcli](https://grafana.com/docs/loki/latest/getting-started/logcli/) query as "directly" as you can. IE. if running on VMs then run the query on that local machine. If running in K8S then port forward the Loki HTTP port and attempt to run the query there. If you do not get a timeout then continue on and some common causes of timeouts external to Loki will be mentioned (if you still get a timeout review the [list](#loki-configuration) above).
 
 - Grafana Dataproxy [timeout](https://grafana.com/docs/grafana/latest/administration/configuration/#dataproxy) (make sure you configure Grafana with a large enough dataproxy timeout)
-- Any reverse proxies or load balancers between your client and Grafana. Queries to Grafana are made from the your local browser with Grafana serving as a proxy, therefore both connections to Grafana and from Grafana to Loki must have large timeouts configured (IE. Browser -> Grafana -> Loki)
+- Any reverse proxies or load balancers between your client and Grafana. This is because queries to Grafana are made from the your local browser with Grafana serving as a proxy ("dataproxy"), therefore connections from your client to Grafana must have their timeout configured as well (IE. **Browser -> Grafana** -> Loki)
+    - Note: As stated above you must also configure timeouts appropriately from Grafana to Loki - see [here](#loki-configuration) for how to do that.
 
 
 ## Troubleshooting targets

--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -51,9 +51,9 @@ These errors have many different possible causes. Main things to review with res
 - server.http_server_idle_timeout
 - If you have a reverse proxy in front of Loki (ie. between Loki and Grafana) then check any timeouts configured there (ie. NGINX proxy read timeout)
 
-To determine if the issue is related to the Loki deployment or another system (Grafana, or another client) attempt to run a logcli query as "directly" as you can. IE if running on VMs then run the query on that local machinem. If running in K8S the port forward the loki HTTP port and attempt to run the query there. If you still get a timeout then review the dot points above. If you do not then continue reading and some other common timeout issues will be mentioned.
+To determine if the issue is related to the Loki deployment or another system (Grafana, or another client) attempt to run a [logcli](https://grafana.com/docs/loki/latest/getting-started/logcli/) query as "directly" as you can. IE if running on VMs then run the query on that local machinem. If running in K8S the port forward the loki HTTP port and attempt to run the query there. If you still get a timeout then review the dot points above. If you do not then continue reading and some other common timeout issues will be mentioned.
 
-- Grafana Dataproxy timeout (make sure you configure Grafana with a large enough dataproxy timeout)
+- Grafana Dataproxy [timeout](https://grafana.com/docs/grafana/latest/administration/configuration/#dataproxy) (make sure you configure Grafana with a large enough dataproxy timeout)
 - Any reverse proxies or load balancers between your client and Grafana. Queries to Grafana are made from the your local browser with Grafana serving as a proxy, therefore both connections to Grafana and from Grafana to Loki must have large timeouts configured (IE. Browser -> Grafana -> Loki)
 
 

--- a/docs/sources/getting-started/troubleshooting.md
+++ b/docs/sources/getting-started/troubleshooting.md
@@ -42,6 +42,21 @@ Promtail yet. There may be one of many root causes:
 - Your pods are running with different labels than the ones Promtail is
   configured to read. Check `scrape_configs` to validate.
 
+## Loki Timeouts (504 errors, context canelled, error processing requests)
+
+These errors have many different possible causes. Main things to review with respect to Loki are:
+- Loki configuration querier.query_timeout
+- server.http_server_read_timeout
+- server.http_server_write_timeout
+- server.http_server_idle_timeout
+- If you have a reverse proxy in front of Loki (ie. between Loki and Grafana) then check any timeouts configured there (ie. NGINX proxy read timeout)
+
+To determine if the issue is related to the Loki deployment or another system (Grafana, or another client) attempt to run a logcli query as "directly" as you can. IE if running on VMs then run the query on that local machinem. If running in K8S the port forward the loki HTTP port and attempt to run the query there. If you still get a timeout then review the dot points above. If you do not then continue reading and some other common timeout issues will be mentioned.
+
+- Grafana Dataproxy timeout (make sure you configure Grafana with a large enough dataproxy timeout)
+- Any reverse proxies or load balancers between your client and Grafana. Queries to Grafana are made from the your local browser with Grafana serving as a proxy, therefore both connections to Grafana and from Grafana to Loki must have large timeouts configured (IE. Browser -> Grafana -> Loki)
+
+
 ## Troubleshooting targets
 
 Promtail exposes two web pages that can be used to understand how its service


### PR DESCRIPTION
We had many issues with configuring timeout errors. The main kicker for us was the Timeout between the Grafana client and the Grafana interface (nothing to do with Loki). This PR adds a small section to the troubleshooting guide to mention some potential causes of timeout errors and where you should look to resolve them.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

This PR extends the documentation and would have assisted us with a problem we were having.

**Which issue(s) this PR fixes**:
Fixes [#<issue number>](https://github.com/grafana/loki/issues/349)

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
