### PR TITLE
improve boltdb-shipper logging to help debug index query latency issues

### DIFF
--- a/pkg/storage/stores/shipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/downloads/index_set.go
@@ -279,7 +279,7 @@ func (t *indexSet) Sync(ctx context.Context) (err error) {
 
 // sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
 func (t *indexSet) sync(ctx context.Context, lock bool) (err error) {
-	level.Debug(t.logger).Log("msg", "syncing files")
+	level.Debug(t.logger).Log("msg", "syncing index files")
 
 	defer func() {
 		status := statusSuccess
@@ -294,7 +294,7 @@ func (t *indexSet) sync(ctx context.Context, lock bool) (err error) {
 		return err
 	}
 
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("sync updates. toDownload: %s, toDelete: %s", toDownload, toDelete))
+	level.Debug(t.logger).Log("msg", "index sync updates", "toDownload", fmt.Sprint(toDownload), "toDelete", fmt.Sprint(toDelete))
 
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {

--- a/pkg/storage/stores/shipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/downloads/index_set.go
@@ -96,13 +96,13 @@ func (t *indexSet) Init() (err error) {
 
 	defer func() {
 		if err != nil {
-			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to initialize table %s, cleaning it up", t.tableName), "err", err)
+			level.Error(t.logger).Log("msg", "failed to initialize table, cleaning it up", "err", err)
 			t.err = err
 
 			// cleaning up files due to error to avoid returning invalid results.
 			for fileName := range t.dbs {
 				if err := t.cleanupDB(fileName); err != nil {
-					level.Error(util_log.Logger).Log("msg", "failed to cleanup partially downloaded file", "filename", fileName, "err", err)
+					level.Error(t.logger).Log("msg", "failed to cleanup partially downloaded file", "filename", fileName, "err", err)
 				}
 			}
 		}
@@ -194,7 +194,7 @@ func (t *indexSet) MultiQueries(ctx context.Context, queries []chunk.IndexQuery,
 	t.lastUsedAt = time.Now()
 
 	logger := util_log.WithContext(ctx, t.logger)
-	level.Debug(logger).Log("table-name", t.tableName, "query-count", len(queries))
+	level.Debug(logger).Log("query-count", len(queries), "dbs-count", len(t.dbs))
 
 	for name, db := range t.dbs {
 		err := db.View(func(tx *bbolt.Tx) error {
@@ -279,7 +279,7 @@ func (t *indexSet) Sync(ctx context.Context) (err error) {
 
 // sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
 func (t *indexSet) sync(ctx context.Context, lock bool) (err error) {
-	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.tableName))
+	level.Debug(t.logger).Log("msg", "syncing files")
 
 	defer func() {
 		status := statusSuccess
@@ -294,7 +294,7 @@ func (t *indexSet) sync(ctx context.Context, lock bool) (err error) {
 		return err
 	}
 
-	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownload, toDelete))
+	level.Debug(t.logger).Log("msg", fmt.Sprintf("sync updates. toDownload: %s, toDelete: %s", toDownload, toDelete))
 
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {

--- a/pkg/storage/stores/shipper/storage/cached_client.go
+++ b/pkg/storage/stores/shipper/storage/cached_client.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/loki/pkg/util/spanlogger"
 	"path"
 	"strings"
 	"sync"
@@ -123,6 +124,13 @@ func (c *cachedObjectClient) buildCache(ctx context.Context) error {
 	if time.Since(c.cacheBuiltAt) < cacheTimeout {
 		return nil
 	}
+
+	logger := spanlogger.FromContextWithFallback(ctx, util_log.Logger)
+	level.Info(logger).Log("msg", "building index list cache")
+	now := time.Now()
+	defer func() {
+		level.Info(logger).Log("msg", "index list cache built", "duration", time.Since(now))
+	}()
 
 	objects, _, err := c.ObjectClient.List(ctx, "", "")
 	if err != nil {

--- a/pkg/storage/stores/shipper/storage/cached_client.go
+++ b/pkg/storage/stores/shipper/storage/cached_client.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/loki/pkg/util/spanlogger"
 	"path"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/chunk"
 	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Improve logging on query path to help debug latency and other possible issues in `boltdb-shipper`.
I have added logs to query traces if the query has to refresh the objects list cache and download the index at query time.
