### PR TITLE
Add inflight requests metric for scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -92,6 +92,7 @@ type Scheduler struct {
 	connectedFrontendClients prometheus.GaugeFunc
 	queueDuration            prometheus.Histogram
 	schedulerRunning         prometheus.Gauge
+	inflightRequests         prometheus.Summary
 
 	// Ring used for finding schedulers
 	ringLifecycler *ring.BasicLifecycler
@@ -173,6 +174,13 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	s.schedulerRunning = promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 		Name: "cortex_query_scheduler_running",
 		Help: "Value will be 1 if the scheduler is in the ReplicationSet and actively receiving/processing requests",
+	})
+	s.inflightRequests = promauto.With(registerer).NewSummary(prometheus.SummaryOpts{
+		Name:       "cortex_query_scheduler_inflight_requests",
+		Help:       "Number of inflight requests (either queued or processing) sampled at a regular interval. Quantile buckets keep track of inflight requests over the last 60s.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+		MaxAge:     time.Minute,
+		AgeBuckets: 6,
 	})
 
 	s.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(s.cleanupMetricsForInactiveUser)
@@ -632,15 +640,23 @@ func (s *Scheduler) starting(ctx context.Context) (err error) {
 }
 
 func (s *Scheduler) running(ctx context.Context) error {
-	t := time.NewTicker(ringCheckPeriod)
-	defer t.Stop()
+	// We observe inflight requests frequently and at regular intervals, to have a good
+	// approximation of max inflight requests over percentiles of time. We also do it with
+	// a ticker so that we keep tracking it even if we have no new queries but stuck inflight
+	// requests (eg. queriers are all crashing).
+	inflightRequestsTicker := time.NewTicker(250 * time.Millisecond)
+	defer inflightRequestsTicker.Stop()
+
+	ringCheckTicker := time.NewTicker(ringCheckPeriod)
+	defer ringCheckTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case err := <-s.subservicesWatcher.Chan():
 			return errors.Wrap(err, "scheduler subservice failed")
-		case <-t.C:
+		case <-ringCheckTicker.C:
 			if !s.cfg.UseSchedulerRing {
 				continue
 			}
@@ -650,6 +666,12 @@ func (s *Scheduler) running(ctx context.Context) error {
 				continue
 			}
 			s.setRunState(isInSet)
+		case <-inflightRequestsTicker.C:
+			s.pendingRequestsMu.Lock()
+			inflight := len(s.pendingRequests)
+			s.pendingRequestsMu.Unlock()
+
+			s.inflightRequests.Observe(float64(inflight))
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new metric to the query-scheduler component.
The metric, `cortex_query_scheduler_inflight_requests`, reports the number of inflight requests (either queued or processing) sampled at a regular interval.

We'll use this metric as part of our querier autoscaling project.
We need to trigger scaling based on something that affects the querier's workload.
Queriers pull tasks from schedulers’ queues, thereafter, we will take both the size of the queue and the number of tasks being processed.

`cortex_query_scheduler_inflight_requests` is a summary so we can use percentiles to answer the question: For the past 5 mins, what was the size of the queue more than 75% of the time? Counterintuitively, taking just the maximum size of the queue is not a good idea since we may have a spike of jobs that take a very short amount of time to get processed, hence the spike not lasting long enough to be worth scaling up the queries.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
