### PR TITLE
Speed up re-labelling in multi-tenant queries.

### DIFF
--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -154,7 +154,7 @@ func newSampleIterator() iter.SampleIterator {
 }
 
 func BenchmarkTenantEntryIteratorLabels(b *testing.B) {
-	it := NewMockEntryIterator(12)
+	it := newMockEntryIterator(12)
 	tenantIter := NewTenantEntryIterator(it, "tenant_1") 
 
 	b.ResetTimer()
@@ -169,7 +169,7 @@ type mockEntryIterator struct{
 	labels string
 }
 
-func NewMockEntryIterator(numLabels int) mockEntryIterator {
+func newMockEntryIterator(numLabels int) mockEntryIterator {
 	builder := labels.NewBuilder(nil)
 	for i := 1; i <= numLabels; i++ {
 		builder.Set(fmt.Sprintf("label_%d", i), strconv.Itoa(i))

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -155,7 +155,7 @@ func newSampleIterator() iter.SampleIterator {
 
 func BenchmarkTenantEntryIteratorLabels(b *testing.B) {
 	it := newMockEntryIterator(12)
-	tenantIter := NewTenantEntryIterator(it, "tenant_1") 
+	tenantIter := NewTenantEntryIterator(it, "tenant_1")
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -165,7 +165,7 @@ func BenchmarkTenantEntryIteratorLabels(b *testing.B) {
 	}
 }
 
-type mockEntryIterator struct{
+type mockEntryIterator struct {
 	labels string
 }
 
@@ -174,7 +174,7 @@ func newMockEntryIterator(numLabels int) mockEntryIterator {
 	for i := 1; i <= numLabels; i++ {
 		builder.Set(fmt.Sprintf("label_%d", i), strconv.Itoa(i))
 	}
-	return mockEntryIterator{ labels: builder.Labels().String()}
+	return mockEntryIterator{labels: builder.Labels().String()}
 }
 
 func (it mockEntryIterator) Labels() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
› benchstat before.txt after.txt
name                          old time/op    new time/op    delta
TenantEntryIteratorLabels-16    13.4µs ± 1%     2.4µs ± 1%  -81.81%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
TenantEntryIteratorLabels-16    4.15kB ± 0%    0.90kB ± 0%  -78.40%  (p=0.002 n=8+10)

name                          old allocs/op  new allocs/op  delta
TenantEntryIteratorLabels-16      44.0 ± 0%      29.0 ± 0%  -34.09%  (p=0.000 n=10+10)
```

This patch introduces a cache for re-labeling series from multi-tenant queries.

**Which issue(s) this PR fixes**:
Fixes #5653

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
