### PR TITLE
Fix debug image by updating Delve version

### DIFF
--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -11,7 +11,7 @@ RUN make clean && make BUILD_IN_CONTAINER=false loki-debug
 FROM       alpine:3.13
 RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
-COPY       --from=build /go/bin/dlv /usr/bin/dlv
+COPY       --from=build /usr/bin/dlv /usr/bin/dlv
 COPY       cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml
 EXPOSE     3100
 
@@ -24,5 +24,5 @@ RUN apk add --no-cache libc6-compat
 # Run delve, ending with -- because we pass params via kubernetes, per the docs:
 #   Pass flags to the program you are debugging using --, for example:`
 #   dlv exec ./hello -- server --config conf/config.toml`
-ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--log", "--continue" , "--api-version=2", "exec", "/usr/bin/loki-debug", "--"]
+ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--log", "--continue", "--accept-multiclient" , "--api-version=2", "exec", "/usr/bin/loki-debug", "--"]
 CMD        ["-config.file=/etc/loki/local-config.yaml"]

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -40,6 +40,9 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 FROM golang:1.17.8 as faillint
 RUN GO111MODULE=on go get github.com/fatih/faillint@v1.5.0
 
+FROM golang:1.17.8 as delve
+RUN GO111MODULE=on go get github.com/go-delve/delve/cmd/dlv@v1.7.3
+
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
 FROM golang:1.17.8 as ghr
@@ -64,6 +67,7 @@ COPY --from=lychee /usr/bin/lychee /usr/bin/lychee
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 COPY --from=drone /usr/local/bin/drone /usr/bin/drone
 COPY --from=faillint /go/bin/faillint /usr/bin/faillint
+COPY --from=delve /go/bin/dlv /usr/bin/dlv
 COPY --from=ghr /go/bin/ghr /usr/bin/ghr
 COPY --from=nfpm /go/bin/nfpm /usr/bin/nfpm
 
@@ -76,7 +80,6 @@ RUN GO111MODULE=on go get \
     github.com/golang/protobuf/protoc-gen-go@v1.3.1 \
     github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 \
     github.com/gogo/protobuf/gogoproto@v1.3.0 \
-    github.com/go-delve/delve/cmd/dlv@v1.3.2 \
     # Due to the lack of a proper release tag, we use the commit hash of
     # https://github.com/golang/tools/releases v0.1.7
     golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69 \


### PR DESCRIPTION
**What this PR does / why we need it**:
The current version of Delve we are using for the debug Docker image does not support newer versions of Go. This PR updates the version we use of Delve so it works with the current version of Go we use for Loki.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
