### PR TITLE
Ingester: add block_idle_period and block_idle_size

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -646,6 +646,10 @@ func (c *MemChunk) UncompressedSize() int {
 	return size
 }
 
+func (c *MemChunk) HeadSize() int {
+	return c.head.UncompressedSize()
+}
+
 // CompressedSize implements Chunk.
 func (c *MemChunk) CompressedSize() int {
 	size := 0
@@ -679,7 +683,7 @@ func (c *MemChunk) Append(entry *logproto.Entry) error {
 	}
 
 	if c.head.UncompressedSize() >= c.blockSize {
-		return c.cut()
+		return c.Cut()
 	}
 
 	return nil
@@ -688,7 +692,7 @@ func (c *MemChunk) Append(entry *logproto.Entry) error {
 // Close implements Chunk.
 // TODO: Fix this to check edge cases.
 func (c *MemChunk) Close() error {
-	if err := c.cut(); err != nil {
+	if err := c.Cut(); err != nil {
 		return err
 	}
 	return c.reorder()
@@ -735,7 +739,7 @@ func (c *MemChunk) ConvertHead(desired HeadBlockFmt) error {
 }
 
 // cut a new block and add it to finished blocks.
-func (c *MemChunk) cut() error {
+func (c *MemChunk) Cut() error {
 	if c.head.IsEmpty() {
 		return nil
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -71,6 +71,8 @@ type Config struct {
 	FlushOpTimeout      time.Duration     `yaml:"flush_op_timeout"`
 	RetainPeriod        time.Duration     `yaml:"chunk_retain_period"`
 	MaxChunkIdle        time.Duration     `yaml:"chunk_idle_period"`
+	MaxBlockIdle        time.Duration     `yaml:"block_idle_period"`
+	MinBlockIdleSize    int               `yaml:"block_idle_size"`
 	BlockSize           int               `yaml:"chunk_block_size"`
 	TargetChunkSize     int               `yaml:"chunk_target_size"`
 	ChunkEncoding       string            `yaml:"chunk_encoding"`
@@ -112,6 +114,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 10*time.Second, "")
 	f.DurationVar(&cfg.RetainPeriod, "ingester.chunks-retain-period", 0, "")
 	f.DurationVar(&cfg.MaxChunkIdle, "ingester.chunks-idle-period", 30*time.Minute, "")
+	f.DurationVar(&cfg.MaxBlockIdle, "ingester.block-idle-period", 1*time.Hour, "")
+	f.IntVar(&cfg.MinBlockIdleSize, "ingester.block-idle-size", 128*1024, "")
 	f.IntVar(&cfg.BlockSize, "ingester.chunks-block-size", 256*1024, "")
 	f.IntVar(&cfg.TargetChunkSize, "ingester.chunk-target-size", 1572864, "") // 1.5 MB
 	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", chunkenc.EncGZIP.String(), fmt.Sprintf("The algorithm to use for compressing chunk. (%s)", chunkenc.SupportedEncoding()))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends idle chunk flushing to also set a threshold for idle block cutting.

This is restricted based on a minimum size for the block to prevent small blocks from being cut.

This is a good way to keep memory down when working with larger chunk idle times creating a two steps in the memory reduction process.

If Block Idle is larger than chunk idle or if block idle size then this feature will not be used. 

**Which issue(s) this PR fixes**:
This does not implement but is an assist to #5608 in regards to the root cause (too much ingester memory usage)

**Special notes for your reviewer**:

If approved I'll do documentation. Golang is new to me so I'd like a contribution for tests.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
