### PR TITLE
add experimental mmap api

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -754,7 +754,7 @@ func (c *MemChunk) cut() error {
 	if err != nil {
 		return err
 	}
-	copy(buffer, buffer2)
+	copy(buffer2, buffer)
 
 	mint, maxt := c.head.Bounds()
 	blk := &block{

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"io"
 	"reflect"
+	"runtime"
 	"time"
 	"unsafe"
 
@@ -104,7 +105,7 @@ type MemChunk struct {
 	targetSize int
 
 	// The finished blocks.
-	blocks []block
+	blocks []*block
 	// The compressed size of all the blocks
 	cutBlockSize int
 
@@ -335,7 +336,7 @@ func NewMemChunk(enc Encoding, head HeadBlockFmt, blockSize, targetSize int) *Me
 	return &MemChunk{
 		blockSize:  blockSize,  // The blockSize in bytes.
 		targetSize: targetSize, // Desired chunk size in compressed bytes
-		blocks:     []block{},
+		blocks:     []*block{},
 
 		format: DefaultChunkFormat,
 		head:   head.NewBlock(),
@@ -388,10 +389,10 @@ func NewByteChunk(b []byte, blockSize, targetSize int) (*MemChunk, error) {
 
 	// Read the number of blocks.
 	num := db.uvarint()
-	bc.blocks = make([]block, 0, num)
+	bc.blocks = make([]*block, 0, num)
 
 	for i := 0; i < num; i++ {
-		var blk block
+		blk := &block{}
 		// Read #entries.
 		blk.numEntries = db.uvarint()
 
@@ -734,27 +735,41 @@ func (c *MemChunk) ConvertHead(desired HeadBlockFmt) error {
 	return nil
 }
 
+func finalizeBlock(b *block) {
+	MmapFree(b.b)
+}
+
 // cut a new block and add it to finished blocks.
 func (c *MemChunk) cut() error {
 	if c.head.IsEmpty() {
 		return nil
 	}
 
-	b, err := c.head.Serialise(getWriterPool(c.encoding))
+	buffer, err := c.head.Serialise(getWriterPool(c.encoding))
 	if err != nil {
 		return err
 	}
 
+	buffer2, err := MmapAlloc(len(buffer))
+	if err != nil {
+		return err
+	}
+	copy(buffer, buffer2)
+
 	mint, maxt := c.head.Bounds()
-	c.blocks = append(c.blocks, block{
-		b:                b,
+	blk := &block{
+		b:                buffer2,
 		numEntries:       c.head.Entries(),
 		mint:             mint,
 		maxt:             maxt,
 		uncompressedSize: c.head.UncompressedSize(),
-	})
+	}
 
-	c.cutBlockSize += len(b)
+	runtime.SetFinalizer(blk, finalizeBlock)
+
+	c.blocks = append(c.blocks, blk)
+
+	c.cutBlockSize += len(buffer)
 
 	c.head.Reset()
 	return nil
@@ -953,7 +968,7 @@ func (c *MemChunk) Rebound(start, end time.Time) (Chunk, error) {
 // chances of chunk<>block encoding drift in the codebase as the latter is parameterized by the former.
 type encBlock struct {
 	enc Encoding
-	block
+	*block
 }
 
 func (b encBlock) Iterator(ctx context.Context, pipeline log.StreamPipeline) iter.EntryIterator {

--- a/pkg/chunkenc/mmap.go
+++ b/pkg/chunkenc/mmap.go
@@ -1,0 +1,32 @@
+// Package mmap implements a large block memory allocator using
+// anonymous memory maps.
+// Inspired by rclone's mmap library
+
+package chunkenc
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// Alloc allocates size bytes and returns a slice containing them.  If
+// the allocation fails it will return with an error.  This is best
+// used for allocations which are a multiple of the PageSize.
+func MmapAlloc(size int) ([]byte, error) {
+	mem, err := unix.Mmap(-1, 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to allocate memory for buffer")
+	}
+	return mem, nil
+}
+
+// Free frees buffers allocated by Alloc.  Note it should be passed
+// the same slice (not a derived slice) that Alloc returned.  If the
+// free fails it will return with an error.
+func MmapFree(mem []byte) error {
+	err := unix.Munmap(mem)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmap memory")
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses Mmap for compressed chunk data to reduce pressure on linux reclaiming blocks due to golang not returning pages to linux system memory until under high memory pressure. This can cause exteremly high CPU load peaks as all the reclaim work is deferred until the system is under pressure.

```
10001          9 31.1 29.8 23733032 2429272 ?    Ssl  Mar19 301:49 /usr/bin/loki -config.file=/etc/loki/config/config.yaml -target=ingester -config.expand-env=true
```

2GB RSS, 23GB virtual. 24GB ram system under high reclaim pressure (process stalled)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
