### PR TITLE
Move promtail StreamLagLabels config to upper level config.Config

### DIFF
--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -111,7 +111,7 @@ func main() {
 		}
 	}
 
-	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.ClientConfigs.StreamLagLabels)
+	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.StreamLagLabels)
 	p, err := promtail.New(config.Config, clientMetrics, config.dryRun)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error creating promtail", "error", err)

--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -111,7 +111,7 @@ func main() {
 		}
 	}
 
-	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.StreamLagLabels)
+	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.Options.StreamLagLabels)
 	p, err := promtail.New(config.Config, clientMetrics, config.dryRun)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error creating promtail", "error", err)

--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
-	dskit_flagext "github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/config"
 
 	lokiflag "github.com/grafana/loki/pkg/util/flagext"
@@ -22,12 +21,7 @@ const (
 	Timeout        = 10 * time.Second
 )
 
-type Configs struct {
-	StreamLagLabels dskit_flagext.StringSliceCSV `yaml:"stream_lag_labels,omitempty"`
-	Configs         []Config                     `yaml:"configs"`
-}
-
-// Config describes configuration for a HTTP pusher client.
+// Config describes configuration for an HTTP pusher client.
 type Config struct {
 	Name      string `yaml:"name,omitempty"`
 	URL       flagext.URLValue
@@ -44,6 +38,9 @@ type Config struct {
 	// The tenant ID to use when pushing logs to Loki (empty string means
 	// single tenant mode)
 	TenantID string `yaml:"tenant_id"`
+
+	// deprecated use StreamLagLabels from config.Config instead
+	StreamLagLabels flagext.StringSliceCSV `yaml:"stream_lag_labels"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -18,17 +18,22 @@ import (
 	"github.com/grafana/loki/pkg/util/flagext"
 )
 
+// Options contains cross-cutting promtail configurations
+type Options struct {
+	StreamLagLabels dskit_flagext.StringSliceCSV `yaml:"stream_lag_labels,omitempty"`
+}
+
 // Config for promtail, describing what files to watch.
 type Config struct {
 	ServerConfig server.Config `yaml:"server,omitempty"`
 	// deprecated use ClientConfigs instead
-	ClientConfig    client.Config                `yaml:"client,omitempty"`
-	ClientConfigs   []client.Config              `yaml:"clients,omitempty"`
-	PositionsConfig positions.Config             `yaml:"positions,omitempty"`
-	ScrapeConfig    []scrapeconfig.Config        `yaml:"scrape_configs,omitempty"`
-	TargetConfig    file.Config                  `yaml:"target_config,omitempty"`
-	LimitConfig     limit.Config                 `yaml:"limit_config,omitempty"`
-	StreamLagLabels dskit_flagext.StringSliceCSV `yaml:"stream_lag_labels,omitempty"`
+	ClientConfig    client.Config         `yaml:"client,omitempty"`
+	ClientConfigs   []client.Config       `yaml:"clients,omitempty"`
+	PositionsConfig positions.Config      `yaml:"positions,omitempty"`
+	ScrapeConfig    []scrapeconfig.Config `yaml:"scrape_configs,omitempty"`
+	TargetConfig    file.Config           `yaml:"target_config,omitempty"`
+	LimitConfig     limit.Config          `yaml:"limit_config,omitempty"`
+	Options         Options               `yaml:"options,omitempty"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -36,6 +36,8 @@ scrape_configs:
 limit_config:
   readline_rate: 100
   readline_burst: 200
+options:
+  stream_lag_labels: foo
 `
 
 func Test_Load(t *testing.T) {
@@ -71,7 +73,9 @@ func TestConfig_Setup(t *testing.T) {
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
 				},
-				StreamLagLabels: []string{},
+				Options: Options{
+					StreamLagLabels: []string{},
+				},
 			},
 			Config{
 				ClientConfig: client.Config{
@@ -85,7 +89,9 @@ func TestConfig_Setup(t *testing.T) {
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
 					},
 				},
-				StreamLagLabels: []string{},
+				Options: Options{
+					StreamLagLabels: []string{},
+				},
 			},
 		},
 		{
@@ -102,7 +108,9 @@ func TestConfig_Setup(t *testing.T) {
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
 				},
-				StreamLagLabels: []string{},
+				Options: Options{
+					StreamLagLabels: []string{},
+				},
 			},
 			Config{
 				ClientConfig: client.Config{
@@ -121,7 +129,9 @@ func TestConfig_Setup(t *testing.T) {
 						URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
 					},
 				},
-				StreamLagLabels: []string{},
+				Options: Options{
+					StreamLagLabels: []string{},
+				},
 			},
 		},
 	} {

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -17,13 +17,12 @@ import (
 
 const testFile = `
 clients:
-  clients:
-    - external_labels:
-          cluster: dev1
-      url: https://1:shh@example.com/loki/api/v1/push
-    - external_labels:
-          cluster: prod1
-      url: https://1:shh@example.com/loki/api/v1/push
+  - external_labels:
+      cluster: dev1
+    url: https://1:shh@example.com/loki/api/v1/push
+  - external_labels:
+      cluster: prod1
+    url: https://1:shh@example.com/loki/api/v1/push
 scrape_configs:
   - job_name: kubernetes-pods-name
     kubernetes_sd_configs:

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -64,33 +64,29 @@ func TestConfig_Setup(t *testing.T) {
 				ClientConfig: client.Config{
 					ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
 				},
-				ClientConfigs: client.Configs{
-					StreamLagLabels: []string{},
-					Configs: []client.Config{
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1"}},
-						},
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
-						},
+				ClientConfigs: []client.Config{
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1"}},
+					},
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
 				},
+				StreamLagLabels: []string{},
 			},
 			Config{
 				ClientConfig: client.Config{
 					ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
 				},
-				ClientConfigs: client.Configs{
-					StreamLagLabels: []string{},
-					Configs: []client.Config{
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1", "foo": "bar"}},
-						},
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
-						},
+				ClientConfigs: []client.Config{
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1", "foo": "bar"}},
+					},
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
 					},
 				},
+				StreamLagLabels: []string{},
 			},
 		},
 		{
@@ -99,38 +95,34 @@ func TestConfig_Setup(t *testing.T) {
 					ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
 					URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
 				},
-				ClientConfigs: client.Configs{
-					StreamLagLabels: []string{},
-					Configs: []client.Config{
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1"}},
-						},
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
-						},
+				ClientConfigs: []client.Config{
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1"}},
+					},
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
 				},
+				StreamLagLabels: []string{},
 			},
 			Config{
 				ClientConfig: client.Config{
 					ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
 					URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
 				},
-				ClientConfigs: client.Configs{
-					StreamLagLabels: []string{},
-					Configs: []client.Config{
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1", "foo": "bar"}},
-						},
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
-						},
-						{
-							ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
-							URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
-						},
+				ClientConfigs: []client.Config{
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client1": "1", "foo": "bar"}},
+					},
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
+					},
+					{
+						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
+						URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
 					},
 				},
+				StreamLagLabels: []string{},
 			},
 		},
 	} {

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -68,13 +68,13 @@ func New(cfg config.Config, metrics *client.Metrics, dryRun bool, opts ...Option
 	}
 	var err error
 	if dryRun {
-		promtail.client, err = client.NewLogger(metrics, cfg.ClientConfigs.StreamLagLabels, promtail.logger, cfg.ClientConfigs.Configs...)
+		promtail.client, err = client.NewLogger(metrics, cfg.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
 		if err != nil {
 			return nil, err
 		}
 		cfg.PositionsConfig.ReadOnly = true
 	} else {
-		promtail.client, err = client.NewMulti(metrics, cfg.ClientConfigs.StreamLagLabels, promtail.logger, cfg.ClientConfigs.Configs...)
+		promtail.client, err = client.NewMulti(metrics, cfg.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
 		if err != nil {
 			return nil, err
 		}

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -68,13 +68,13 @@ func New(cfg config.Config, metrics *client.Metrics, dryRun bool, opts ...Option
 	}
 	var err error
 	if dryRun {
-		promtail.client, err = client.NewLogger(metrics, cfg.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
+		promtail.client, err = client.NewLogger(metrics, cfg.Options.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
 		if err != nil {
 			return nil, err
 		}
 		cfg.PositionsConfig.ReadOnly = true
 	} else {
-		promtail.client, err = client.NewMulti(metrics, cfg.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
+		promtail.client, err = client.NewMulti(metrics, cfg.Options.StreamLagLabels, promtail.logger, cfg.ClientConfigs...)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -98,11 +98,8 @@ scrape_configs:
 # Configures how tailed targets will be watched.
 [target_config: <target_config>]
 
-# A comma-separated list of labels to include in the stream lag metric `promtail_stream_lag_seconds`.
-# The default value is "filename". A "host" label is always included.
-# The stream lag metric indicates which streams are falling behind on writes to Loki;
-# be mindful about using too many labels, as it can increase cardinality.
-[stream_lag_labels: <string> | default = "filename"]
+# Configures additional promtail configurations.
+[options: <options_config>]
 ```
 
 ## server
@@ -1769,6 +1766,16 @@ targets.
 # Period to resync directories being watched and files being tailed to discover
 # new ones or stop watching removed ones.
 sync_period: "10s"
+```
+
+## options_config
+
+```yaml
+# A comma-separated list of labels to include in the stream lag metric `promtail_stream_lag_seconds`.
+# The default value is "filename". A "host" label is always included.
+# The stream lag metric indicates which streams are falling behind on writes to Loki;
+# be mindful about using too many labels, as it can increase cardinality.
+[stream_lag_labels: <string> | default = "filename"]
 ```
 
 ## Example Docker Config

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -97,6 +97,12 @@ scrape_configs:
 
 # Configures how tailed targets will be watched.
 [target_config: <target_config>]
+
+# A comma-separated list of labels to include in the stream lag metric `promtail_stream_lag_seconds`.
+# The default value is "filename". A "host" label is always included.
+# The stream lag metric indicates which streams are falling behind on writes to Loki;
+# be mindful about using too many labels, as it can increase cardinality.
+[stream_lag_labels: <string> | default = "filename"]
 ```
 
 ## server
@@ -158,23 +164,6 @@ The `server` block configures Promtail's behavior as an HTTP server:
 
 The `clients` block configures how Promtail connects to instances of
 Loki:
-
-```yaml
-# A comma-separated list of labels to include in the stream lag metric `promtail_stream_lag_seconds`.
-# The default value is "filename". A "host" label is always included.
-# The stream lag metric indicates which streams are falling behind on writes to Loki;
-# be mindful about using too many labels, as it can increase cardinality.
-[stream_lag_labels: <string> | default = "filename"]
-
-configs:
-  - <client_config>
-```
-
-### client
-
-The `client` block configures how an individual Promtail client connects
-to instances of Loki:
-
 
 ```yaml
 # The URL where Loki is listening, denoted in Loki as http_listen_address and


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

On the refactor PR https://github.com/grafana/loki/pull/5521 configuration `StreamLagLabels` was moved to a new wrapper config, meaning the promtail client configuration now has an additional `configs` parameter:
```
clients:                                                                                                              
   configs:                                                                                                                                                                     
     - external_labels:                                                                                                                                                         
         cluster: dev-eu-west-0                                                                                                                                                 
       url: http://145265:${LOCAL_COLLECTION_WRITER_KEY}@cortex-gw.loki-dev-008.svc.cluster.local/loki/api/v1/push
```

This is a breaking change as clients with the previous configuration will fail.
Therefore, the solution proposed in this PR is to keep the property `stream_lag_labels` in the client.Config as deprecated (and unused) for backward compatibility and move this property to the upper config.Config structure. The new structure is as follows:
```
clients:                                                                                                              
  - external_labels:                                                                                                                                                         
     cluster: dev-eu-west-0                                                                                                                                                 
  url: http://145265:${LOCAL_COLLECTION_WRITER_KEY}@cortex-gw.loki-dev-008.svc.cluster.local/loki/api/v1/push
stream_lag_labels:
  ...
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
