### PR TITLE
operator: Replace frontend_worker parallelism with match_max_concurrent

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -4,7 +4,6 @@
 - [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
 - [5701](https://github.com/grafana/loki/pull/5701) **sasagarw**: Make ReplicationFactor optional in LokiStack API
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
-- [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
 - [5615](https://github.com/grafana/loki/pull/5615) **sasagarw**: Document how to connect to LokiStack gateway component
 - [5655](https://github.com/grafana/loki/pull/5655) **xperimental**: Update Loki operand to 2.4.2
 - [5579](https://github.com/grafana/loki/pull/5579) **Red-GV**: Add playbook for responding to operator alerts

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [5699](https://github.com/grafana/loki/pull/5699) **Red-GV**: Configure boltdb_shipper and schema to use Azure, GCS, and Swift storage
 - [5701](https://github.com/grafana/loki/pull/5701) **sasagarw**: Make ReplicationFactor optional in LokiStack API
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
+- [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
 - [5615](https://github.com/grafana/loki/pull/5615) **sasagarw**: Document how to connect to LokiStack gateway component
 - [5655](https://github.com/grafana/loki/pull/5655) **xperimental**: Update Loki operand to 2.4.2
 - [5579](https://github.com/grafana/loki/pull/5579) **Red-GV**: Add playbook for responding to operator alerts

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [5701](https://github.com/grafana/loki/pull/5701) **sasagarw**: Make ReplicationFactor optional in LokiStack API
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
 - [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
+- [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
 - [5615](https://github.com/grafana/loki/pull/5615) **sasagarw**: Document how to connect to LokiStack gateway component
 - [5655](https://github.com/grafana/loki/pull/5655) **xperimental**: Update Loki operand to 2.4.2
 - [5579](https://github.com/grafana/loki/pull/5579) **Red-GV**: Add playbook for responding to operator alerts

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Main
 
 - [5699](https://github.com/grafana/loki/pull/5699) **Red-GV**: Configure boltdb_shipper and schema to use Azure, GCS, and Swift storage
+- [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
 - [5701](https://github.com/grafana/loki/pull/5701) **sasagarw**: Make ReplicationFactor optional in LokiStack API
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
-- [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
 - [5615](https://github.com/grafana/loki/pull/5615) **sasagarw**: Document how to connect to LokiStack gateway component
 - [5655](https://github.com/grafana/loki/pull/5655) **xperimental**: Update Loki operand to 2.4.2

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Main
 
-- [5699](https://github.com/grafana/loki/pull/5699) **Red-GV**: Configure boltdb_shipper and schema to use Azure, GCS, and Swift storage
 - [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent
+- [5699](https://github.com/grafana/loki/pull/5699) **Red-GV**: Configure boltdb_shipper and schema to use Azure, GCS, and Swift storage
 - [5701](https://github.com/grafana/loki/pull/5701) **sasagarw**: Make ReplicationFactor optional in LokiStack API
 - [5695](https://github.com/grafana/loki/pull/5695) **xperimental**: Update Go to 1.17
 - [5615](https://github.com/grafana/loki/pull/5615) **sasagarw**: Document how to connect to LokiStack gateway component

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -64,7 +64,7 @@ func ConfigOptions(opt Options) config.Options {
 		},
 		StorageDirectory: dataDirectory,
 		MaxConcurrent: config.MaxConcurrent{
-			AvailableQuerierCPUCores: opt.ResourceRequirements.Querier.Requests.Cpu().Value(),
+			AvailableQuerierCPUCores: int32(opt.ResourceRequirements.Querier.Requests.Cpu().Value()),
 		},
 		WriteAheadLog: config.WriteAheadLog{
 			Directory:             walDirectory,

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -63,9 +63,8 @@ func ConfigOptions(opt Options) config.Options {
 			Port: grpcPort,
 		},
 		StorageDirectory: dataDirectory,
-		QueryParallelism: config.Parallelism{
-			QuerierCPULimits:      opt.ResourceRequirements.Querier.Requests.Cpu().Value(),
-			QueryFrontendReplicas: opt.Stack.Template.QueryFrontend.Replicas,
+		MaxConcurrent: config.MaxConcurrent{
+			AvailableQuerierCPUCores: opt.ResourceRequirements.Querier.Requests.Cpu().Value(),
 		},
 		WriteAheadLog: config.WriteAheadLog{
 			Directory:             walDirectory,

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -38,7 +38,7 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  parallelism: 1
+  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -113,7 +113,7 @@ querier:
     max_look_back_period: 30s
     timeout: 3m
   extra_query_delay: 0s
-  max_concurrent: 10
+  max_concurrent: 2
   query_ingesters_within: 3h
   query_timeout: 1m
   tail_max_duration: 1h
@@ -205,9 +205,8 @@ overrides:
 			Port: 9095,
 		},
 		StorageDirectory: "/tmp/loki",
-		QueryParallelism: Parallelism{
-			QuerierCPULimits:      2,
-			QueryFrontendReplicas: 2,
+		MaxConcurrent: MaxConcurrent{
+			AvailableQuerierCPUCores: 2,
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
@@ -260,7 +259,7 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  parallelism: 1
+  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -335,7 +334,7 @@ querier:
     max_look_back_period: 30s
     timeout: 3m
   extra_query_delay: 0s
-  max_concurrent: 10
+  max_concurrent: 2
   query_ingesters_within: 3h
   query_timeout: 1m
   tail_max_duration: 1h
@@ -444,9 +443,8 @@ overrides:
 			Port: 9095,
 		},
 		StorageDirectory: "/tmp/loki",
-		QueryParallelism: Parallelism{
-			QuerierCPULimits:      2,
-			QueryFrontendReplicas: 2,
+		MaxConcurrent: MaxConcurrent{
+			AvailableQuerierCPUCores: 2,
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
@@ -508,9 +506,8 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 			Port: 9095,
 		},
 		StorageDirectory: "/tmp/loki",
-		QueryParallelism: Parallelism{
-			QuerierCPULimits:      2,
-			QueryFrontendReplicas: 2,
+		MaxConcurrent: MaxConcurrent{
+			AvailableQuerierCPUCores: 2,
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -134,7 +134,7 @@ querier:
   query_ingesters_within: 3h
   query_timeout: 1m
   tail_max_duration: 1h
-  max_concurrent: {{ .MaxConcurrent.Value }}
+  max_concurrent: {{ .MaxConcurrent.AvailableQuerierCPUCores }}
 query_range:
   align_queries_with_step: true
   cache_results: true

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -56,7 +56,7 @@ frontend_worker:
   frontend_address: {{ .FrontendWorker.FQDN }}:{{ .FrontendWorker.Port }}
   grpc_client_config:
     max_send_msg_size: 104857600
-  parallelism: {{ .QueryParallelism.Value }}
+  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -134,7 +134,7 @@ querier:
   query_ingesters_within: 3h
   query_timeout: 1m
   tail_max_duration: 1h
-  max_concurrent: 10
+  max_concurrent: {{ .MaxConcurrent.Value }}
 query_range:
   align_queries_with_step: true
   cache_results: true

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -19,7 +19,7 @@ type Options struct {
 	Querier          Address
 	IndexGateway     Address
 	StorageDirectory string
-	QueryParallelism Parallelism
+	MaxConcurrent    MaxConcurrent
 	WriteAheadLog    WriteAheadLog
 
 	ObjectStorage storage.Options
@@ -33,11 +33,9 @@ type Address struct {
 	Port int
 }
 
-// Parallelism for query processing parallelism
-// and rate limiting.
-type Parallelism struct {
-	QuerierCPULimits      int64
-	QueryFrontendReplicas int32
+// MaxConcurrent for query concurrent processing.
+type MaxConcurrent struct {
+	AvailableQuerierCPUCores int64
 }
 
 // WriteAheadLog for ingester processing
@@ -46,11 +44,9 @@ type WriteAheadLog struct {
 	IngesterMemoryRequest int64
 }
 
-// Value calculates the floor of the division of
-// querier cpu limits to the query frontend replicas
-// available.
-func (p Parallelism) Value() int32 {
-	return int32(math.Floor(float64(p.QuerierCPULimits) / float64(p.QueryFrontendReplicas)))
+// Value returns the number of available CPU cores per querier.
+func (p MaxConcurrent) Value() int32 {
+	return int32(p.AvailableQuerierCPUCores)
 }
 
 // ReplayMemoryCeiling calculates 50% of the ingester memory

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -35,18 +35,13 @@ type Address struct {
 
 // MaxConcurrent for query concurrent processing.
 type MaxConcurrent struct {
-	AvailableQuerierCPUCores int64
+	AvailableQuerierCPUCores int32
 }
 
 // WriteAheadLog for ingester processing
 type WriteAheadLog struct {
 	Directory             string
 	IngesterMemoryRequest int64
-}
-
-// Value returns the number of available CPU cores per querier.
-func (p MaxConcurrent) Value() int32 {
-	return int32(p.AvailableQuerierCPUCores)
 }
 
 // ReplayMemoryCeiling calculates 50% of the ingester memory

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -33,7 +33,7 @@ type Address struct {
 	Port int
 }
 
-// MaxConcurrent for query concurrent processing.
+// MaxConcurrent for concurrent query processing.
 type MaxConcurrent struct {
 	AvailableQuerierCPUCores int32
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a long-standing recommendation to switch from using the `frontend_worker.parallelism` config option for `frontend_worker.match_max_concurrent: true` that sync the value from `querier.max_concurrent`. Later represents the upper bound of parallel queries to process per querier based on available CPU cores.

**Which issue(s) this PR fixes**:
Fixes [Recommendation request](https://github.com/grafana/loki/pull/4881#discussion_r770303369)

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
