### PR TITLE
Mark GELF support in Promtail as experimental

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -315,6 +315,8 @@ see the [configuration](../../configuration/#kafka) section for more information
 
 ## GELF
 
+<span style="background-color:#f3f973;">GELF support in Promtail is an experimental feature.</span>
+
 Promtail supports listening message using the [GELF](https://docs.graylog.org/docs/gelf) UDP protocol.
 The GELF targets can be configured using the `gelf` stanza:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the GELF support in Promtail uses a library that is not necessarily meant for production usage in servers, it should be marked as experimental feature, until the library is replaced.

See https://github.com/grafana/loki/issues/5644 for more information.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>


**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
