### PR TITLE
build generic index shipper to be shared between boltdb-shipper and tsdb-shipper

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 
-	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	shipper_util "github.com/grafana/loki/pkg/storage/stores/shipper/util"
@@ -59,7 +59,7 @@ func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.I
 		return nil, fmt.Errorf("userID must be empty")
 	}
 
-	err := chunk_util.EnsureDirectory(cacheLocation)
+	err := util.EnsureDirectory(cacheLocation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -117,7 +117,7 @@ func (t *indexSet) Init() (err error) {
 		}
 
 		fullPath := filepath.Join(t.cacheLocation, fileInfo.Name())
-		// if we fail to open a boltdb file, lets skip it and let sync operation re-download the file from storage.
+		// if we fail to open an index file, lets skip it and let sync operation re-download the file from storage.
 		idx, err := t.openIndexFileFunc(fullPath)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to open existing index file %s, removing the file and continuing without it to let the sync operation catch up", fullPath), "err", err)

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -121,9 +121,9 @@ func (t *indexSet) Init() (err error) {
 		idx, err := t.openIndexFileFunc(fullPath)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to open existing index file %s, removing the file and continuing without it to let the sync operation catch up", fullPath), "err", err)
-			// Sometimes files get corrupted when the process gets killed in the middle of a download operation which causes boltdb client to panic.
-			// We already recover the panic but the lock on the file is not released by boltdb client which causes the reopening of the file to fail when the sync operation tries it.
-			// We want to remove the file failing to open to get rid of the lock.
+			// Sometimes files get corrupted when the process gets killed in the middle of a download operation which can cause problems in reading the file.
+			// Implementation of openIndexFileFunc should take care of gracefully handling corrupted files.
+			// Let us just remove the file and let the sync operation re-download it.
 			if err := os.Remove(fullPath); err != nil {
 				level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to remove index file %s which failed to open", fullPath))
 			}

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -1,0 +1,361 @@
+package downloads
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
+
+	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	shipper_util "github.com/grafana/loki/pkg/storage/stores/shipper/util"
+	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/grafana/loki/pkg/util/spanlogger"
+)
+
+type IndexSet interface {
+	Init() error
+	Close()
+	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
+	DropAllDBs() error
+	Err() error
+	LastUsedAt() time.Time
+	UpdateLastUsedAt()
+	Sync(ctx context.Context) (err error)
+	AwaitReady(ctx context.Context) error
+}
+
+// indexSet is a collection of multiple files created for a same table by various ingesters.
+// All the public methods are concurrency safe and take care of mutexes to avoid any data race.
+type indexSet struct {
+	openIndexFileFunc index.OpenIndexFileFunc
+	baseIndexSet      storage.IndexSet
+	tableName, userID string
+	cacheLocation     string
+	logger            log.Logger
+
+	lastUsedAt time.Time
+	index      map[string]index.Index
+	indexMtx   *mtxWithReadiness
+	err        error
+
+	cancelFunc context.CancelFunc // helps with cancellation of initialization if we are asked to stop.
+}
+
+func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.IndexSet, openIndexFileFunc index.OpenIndexFileFunc,
+	logger log.Logger) (IndexSet, error) {
+	if baseIndexSet.IsUserBasedIndexSet() && userID == "" {
+		return nil, fmt.Errorf("userID must not be empty")
+	} else if !baseIndexSet.IsUserBasedIndexSet() && userID != "" {
+		return nil, fmt.Errorf("userID must be empty")
+	}
+
+	err := chunk_util.EnsureDirectory(cacheLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	is := indexSet{
+		openIndexFileFunc: openIndexFileFunc,
+		baseIndexSet:      baseIndexSet,
+		tableName:         tableName,
+		userID:            userID,
+		cacheLocation:     cacheLocation,
+		logger:            logger,
+		lastUsedAt:        time.Now(),
+		index:             map[string]index.Index{},
+		indexMtx:          newMtxWithReadiness(),
+		cancelFunc:        func() {},
+	}
+
+	return &is, nil
+}
+
+// Init downloads all the db files for the table from object storage.
+func (t *indexSet) Init() (err error) {
+	// Using background context to avoid cancellation of download when request times out.
+	// We would anyways need the files for serving next requests.
+	ctx, cancelFunc := context.WithTimeout(context.Background(), downloadTimeout)
+	t.cancelFunc = cancelFunc
+
+	logger := spanlogger.FromContextWithFallback(ctx, t.logger)
+
+	defer func() {
+		if err != nil {
+			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to initialize table %s, cleaning it up", t.tableName), "err", err)
+			t.err = err
+
+			// cleaning up files due to error to avoid returning invalid results.
+			for fileName := range t.index {
+				if err := t.cleanupDB(fileName); err != nil {
+					level.Error(util_log.Logger).Log("msg", "failed to cleanup partially downloaded file", "filename", fileName, "err", err)
+				}
+			}
+		}
+		t.cancelFunc()
+		t.indexMtx.markReady()
+	}()
+
+	filesInfo, err := ioutil.ReadDir(t.cacheLocation)
+	if err != nil {
+		return err
+	}
+
+	// open all the locally present files first to avoid downloading them again during sync operation below.
+	for _, fileInfo := range filesInfo {
+		if fileInfo.IsDir() {
+			continue
+		}
+
+		fullPath := filepath.Join(t.cacheLocation, fileInfo.Name())
+		// if we fail to open a boltdb file, lets skip it and let sync operation re-download the file from storage.
+		idx, err := t.openIndexFileFunc(fullPath)
+		if err != nil {
+			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to open existing index file %s, removing the file and continuing without it to let the sync operation catch up", fullPath), "err", err)
+			// Sometimes files get corrupted when the process gets killed in the middle of a download operation which causes boltdb client to panic.
+			// We already recover the panic but the lock on the file is not released by boltdb client which causes the reopening of the file to fail when the sync operation tries it.
+			// We want to remove the file failing to open to get rid of the lock.
+			if err := os.Remove(fullPath); err != nil {
+				level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to remove index file %s which failed to open", fullPath))
+			}
+			continue
+		}
+
+		t.index[fileInfo.Name()] = idx
+	}
+
+	level.Debug(logger).Log("msg", fmt.Sprintf("opened %d local files, now starting sync operation", len(t.index)))
+
+	// sync the table to get new files and remove the deleted ones from storage.
+	err = t.sync(ctx, false)
+	if err != nil {
+		return
+	}
+
+	level.Debug(logger).Log("msg", "finished syncing files")
+
+	return
+}
+
+// Close Closes references to all the index.
+func (t *indexSet) Close() {
+	// stop the initialization if it is still ongoing.
+	t.cancelFunc()
+
+	err := t.indexMtx.lock(context.Background())
+	if err != nil {
+		level.Error(t.logger).Log("msg", "failed to acquire lock for closing index", "err", err)
+		return
+	}
+	defer t.indexMtx.unlock()
+
+	for name, db := range t.index {
+		if err := db.Close(); err != nil {
+			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to close file %s", name), "err", err)
+		}
+	}
+
+	t.index = map[string]index.Index{}
+}
+
+func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+	if err := t.indexMtx.rLock(ctx); err != nil {
+		return err
+	}
+	defer t.indexMtx.rUnlock()
+
+	for _, idx := range t.index {
+		if err := callback(idx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DropAllDBs closes reference to all the open index and removes the local files.
+func (t *indexSet) DropAllDBs() error {
+	err := t.indexMtx.lock(context.Background())
+	if err != nil {
+		return err
+	}
+	defer t.indexMtx.unlock()
+
+	for fileName := range t.index {
+		if err := t.cleanupDB(fileName); err != nil {
+			return err
+		}
+	}
+
+	return os.RemoveAll(t.cacheLocation)
+}
+
+// Err returns the err which is usually set when there was any issue in Init.
+func (t *indexSet) Err() error {
+	return t.err
+}
+
+// LastUsedAt returns the time at which table was last used for querying.
+func (t *indexSet) LastUsedAt() time.Time {
+	return t.lastUsedAt
+}
+
+func (t *indexSet) UpdateLastUsedAt() {
+	t.lastUsedAt = time.Now()
+}
+
+// cleanupDB closes and removes the local file.
+func (t *indexSet) cleanupDB(fileName string) error {
+	df, ok := t.index[fileName]
+	if !ok {
+		return fmt.Errorf("file %s not found in files collection for cleaning up", fileName)
+	}
+
+	filePath := df.Path()
+
+	if err := df.Close(); err != nil {
+		return err
+	}
+
+	delete(t.index, fileName)
+
+	return os.Remove(filePath)
+}
+
+func (t *indexSet) Sync(ctx context.Context) (err error) {
+	return t.sync(ctx, true)
+}
+
+// sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
+func (t *indexSet) sync(ctx context.Context, lock bool) (err error) {
+	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.tableName))
+
+	toDownload, toDelete, err := t.checkStorageForUpdates(ctx, lock)
+	if err != nil {
+		return err
+	}
+
+	level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownload, toDelete))
+
+	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
+	if err != nil {
+		return err
+	}
+
+	if lock {
+		err = t.indexMtx.lock(ctx)
+		if err != nil {
+			return err
+		}
+		defer t.indexMtx.unlock()
+	}
+
+	for _, fileName := range downloadedFiles {
+		filePath := filepath.Join(t.cacheLocation, fileName)
+		idx, err := t.openIndexFileFunc(filePath)
+		if err != nil {
+			return err
+		}
+
+		t.index[fileName] = idx
+	}
+
+	for _, db := range toDelete {
+		err := t.cleanupDB(db)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkStorageForUpdates compares files from cache with storage and builds the list of files to be downloaded from storage and to be deleted from cache
+func (t *indexSet) checkStorageForUpdates(ctx context.Context, lock bool) (toDownload []storage.IndexFile, toDelete []string, err error) {
+	// listing tables from store
+	var files []storage.IndexFile
+
+	files, err = t.baseIndexSet.ListFiles(ctx, t.tableName, t.userID)
+	if err != nil {
+		return
+	}
+
+	listedDBs := make(map[string]struct{}, len(files))
+
+	if lock {
+		err = t.indexMtx.rLock(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer t.indexMtx.rUnlock()
+	}
+
+	for _, file := range files {
+		listedDBs[file.Name] = struct{}{}
+
+		// Checking whether file was already downloaded, if not, download it.
+		// We do not ever upload files in the object store with the same name but different contents so we do not consider downloading modified files again.
+		_, ok := t.index[file.Name]
+		if !ok {
+			toDownload = append(toDownload, file)
+		}
+	}
+
+	for db := range t.index {
+		if _, isOK := listedDBs[db]; !isOK {
+			toDelete = append(toDelete, db)
+		}
+	}
+
+	return
+}
+
+func (t *indexSet) AwaitReady(ctx context.Context) error {
+	return t.indexMtx.awaitReady(ctx)
+}
+
+func (t *indexSet) downloadFileFromStorage(ctx context.Context, fileName, folderPathForTable string) error {
+	return shipper_util.DownloadFileFromStorage(filepath.Join(folderPathForTable, fileName), shipper_util.IsCompressedFile(fileName),
+		true, shipper_util.LoggerWithFilename(t.logger, fileName), func() (io.ReadCloser, error) {
+			return t.baseIndexSet.GetFile(ctx, t.tableName, t.userID, fileName)
+		})
+}
+
+// doConcurrentDownload downloads objects(files) concurrently. It ignores only missing file errors caused by removal of file by compaction.
+// It returns the names of the files downloaded successfully and leaves it upto the caller to open those files.
+func (t *indexSet) doConcurrentDownload(ctx context.Context, files []storage.IndexFile) ([]string, error) {
+	downloadedFiles := make([]string, 0, len(files))
+	downloadedFilesMtx := sync.Mutex{}
+
+	err := concurrency.ForEachJob(ctx, len(files), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
+		fileName := files[idx].Name
+		err := t.downloadFileFromStorage(ctx, fileName, t.cacheLocation)
+		if err != nil {
+			if t.baseIndexSet.IsFileNotFoundErr(err) {
+				level.Info(util_log.Logger).Log("msg", fmt.Sprintf("ignoring missing file %s, possibly removed during compaction", fileName))
+				return nil
+			}
+			return err
+		}
+
+		downloadedFilesMtx.Lock()
+		downloadedFiles = append(downloadedFiles, fileName)
+		downloadedFilesMtx.Unlock()
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return downloadedFiles, nil
+}

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -1,0 +1,91 @@
+package downloads
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+func buildTestIndexSet(t *testing.T, userID, path string) (*indexSet, stopFunc) {
+	storageClient := buildTestStorageClient(t, path)
+	cachePath := filepath.Join(path, cacheDirName)
+
+	baseIndexSet := storage.NewIndexSet(storageClient, userID != "")
+	idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet,
+		func(path string) (index.Index, error) {
+			return openMockIndexFile(t, path), nil
+		}, util_log.Logger)
+	require.NoError(t, err)
+
+	require.NoError(t, idxSet.Init())
+
+	return idxSet.(*indexSet), idxSet.Close
+}
+
+func TestIndexSet_Init(t *testing.T) {
+	tempDir := t.TempDir()
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+	var indexesSetup []string
+
+	checkIndexSet := func() {
+		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
+		require.Len(t, indexSet.index, len(indexesSetup))
+		verifyIndexForEach(t, indexesSetup, func(callbackFunc func(index.Index) error) error {
+			return indexSet.ForEach(context.Background(), callbackFunc)
+		})
+		stopFunc()
+	}
+
+	// check index set without any local files and in storage
+	checkIndexSet()
+
+	// setup some indexes in object storage
+	setupIndexesAtPath(t, userID, filepath.Join(objectStoragePath, tableName, userID), 0, 10)
+	indexesSetup = buildListOfExpectedIndexes(userID, 0, 10)
+
+	// check index set twice; first run to have new files to download, second run to test with no changes in storage.
+	for i := 0; i < 2; i++ {
+		checkIndexSet()
+	}
+
+	// delete a file from storage which should get removed from local as well
+	indexSetPathPathInStorage := filepath.Join(objectStoragePath, tableName, userID)
+	require.NoError(t, os.Remove(filepath.Join(indexSetPathPathInStorage, indexesSetup[0])))
+	indexesSetup = indexesSetup[1:]
+
+	checkIndexSet()
+}
+
+func TestIndexSet_doConcurrentDownload(t *testing.T) {
+	tempDir := t.TempDir()
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+
+	for _, tc := range []int{0, 10, maxDownloadConcurrency, maxDownloadConcurrency * 2} {
+		t.Run(fmt.Sprintf("%d indexes", tc), func(t *testing.T) {
+			userID := fmt.Sprint(tc)
+			setupIndexesAtPath(t, userID, filepath.Join(objectStoragePath, tableName, userID), 0, tc)
+			indexesSetup := buildListOfExpectedIndexes(userID, 0, tc)
+
+			indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
+			defer func() {
+				stopFunc()
+			}()
+
+			// ensure that we have `tc` number of files downloaded and opened.
+			if tc > 0 {
+				require.Len(t, indexSet.index, tc)
+			}
+			verifyIndexForEach(t, indexesSetup, func(callbackFunc func(index.Index) error) error {
+				return indexSet.ForEach(context.Background(), callbackFunc)
+			})
+		})
+	}
+}

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -11,11 +11,12 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/pkg/errors"
+
 	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	util_log "github.com/grafana/loki/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // timeout for downloading initial files for a table to avoid leaking resources by allowing it to take all the time.

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -1,0 +1,347 @@
+package downloads
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
+	"github.com/pkg/errors"
+	"go.etcd.io/bbolt"
+
+	"github.com/grafana/loki/pkg/storage/chunk"
+	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+// timeout for downloading initial files for a table to avoid leaking resources by allowing it to take all the time.
+const (
+	downloadTimeout        = 5 * time.Minute
+	maxDownloadConcurrency = 50
+)
+
+type BoltDBIndexClient interface {
+	QueryWithCursor(_ context.Context, c *bbolt.Cursor, query chunk.IndexQuery, callback chunk.QueryPagesCallback) error
+}
+
+type Table interface {
+	Close()
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
+	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
+	Sync(ctx context.Context) error
+	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
+}
+
+// table is a collection of multiple files created for a same table by various ingesters.
+// All the public methods are concurrency safe and take care of mutexes to avoid any data race.
+type table struct {
+	name              string
+	cacheLocation     string
+	storageClient     storage.Client
+	openIndexFileFunc index.OpenIndexFileFunc
+
+	baseUserIndexSet, baseCommonIndexSet storage.IndexSet
+
+	logger       log.Logger
+	indexSets    map[string]IndexSet
+	indexSetsMtx sync.RWMutex
+}
+
+// NewTable just creates an instance of table without trying to load files from local storage or object store.
+// It is used for initializing table at query time.
+func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc) Table {
+	table := table{
+		name:               name,
+		cacheLocation:      cacheLocation,
+		storageClient:      storageClient,
+		baseUserIndexSet:   storage.NewIndexSet(storageClient, true),
+		baseCommonIndexSet: storage.NewIndexSet(storageClient, false),
+		logger:             log.With(util_log.Logger, "table-name", name),
+		openIndexFileFunc:  openIndexFileFunc,
+		indexSets:          map[string]IndexSet{},
+	}
+
+	return &table
+}
+
+// LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
+// It is used for loading and initializing table at startup. It would initialize index sets which already had files locally.
+func LoadTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc) (Table, error) {
+	err := chunk_util.EnsureDirectory(cacheLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	filesInfo, err := ioutil.ReadDir(cacheLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	table := table{
+		name:               name,
+		cacheLocation:      cacheLocation,
+		storageClient:      storageClient,
+		baseUserIndexSet:   storage.NewIndexSet(storageClient, true),
+		baseCommonIndexSet: storage.NewIndexSet(storageClient, false),
+		logger:             log.With(util_log.Logger, "table-name", name),
+		indexSets:          map[string]IndexSet{},
+		openIndexFileFunc:  openIndexFileFunc,
+	}
+
+	level.Debug(table.logger).Log("msg", fmt.Sprintf("opening locally present files for table %s", name), "files", fmt.Sprint(filesInfo))
+
+	// common index files are outside the directories and user index files are in the directories
+	for _, fileInfo := range filesInfo {
+		if !fileInfo.IsDir() {
+			continue
+		}
+
+		userID := fileInfo.Name()
+		userIndexSet, err := NewIndexSet(name, userID, filepath.Join(cacheLocation, userID),
+			table.baseUserIndexSet, openIndexFileFunc, loggerWithUserID(table.logger, userID))
+		if err != nil {
+			return nil, err
+		}
+
+		err = userIndexSet.Init()
+		if err != nil {
+			return nil, err
+		}
+
+		table.indexSets[userID] = userIndexSet
+	}
+
+	commonIndexSet, err := NewIndexSet(name, "", cacheLocation, table.baseCommonIndexSet,
+		openIndexFileFunc, table.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	err = commonIndexSet.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	table.indexSets[""] = commonIndexSet
+
+	return &table, nil
+}
+
+// Close Closes references to all the index.
+func (t *table) Close() {
+	t.indexSetsMtx.Lock()
+	defer t.indexSetsMtx.Unlock()
+
+	for _, userIndexSet := range t.indexSets {
+		userIndexSet.Close()
+	}
+
+	t.indexSets = map[string]IndexSet{}
+}
+
+func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+	// iterate through both user and common index
+	for _, uid := range []string{userID, ""} {
+		indexSet, err := t.getOrCreateIndexSet(uid, true)
+		if err != nil {
+			return err
+		}
+
+		if indexSet.Err() != nil {
+			level.Error(util_log.WithContext(ctx, t.logger)).Log("msg", fmt.Sprintf("index set %s has some problem, cleaning it up", uid), "err", indexSet.Err())
+			if err := indexSet.DropAllDBs(); err != nil {
+				level.Error(t.logger).Log("msg", fmt.Sprintf("failed to cleanup broken index set %s", uid), "err", err)
+			}
+
+			t.indexSetsMtx.Lock()
+			delete(t.indexSets, userID)
+			t.indexSetsMtx.Unlock()
+
+			return indexSet.Err()
+		}
+
+		err = indexSet.ForEach(ctx, callback)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string {
+	t.indexSetsMtx.RLock()
+	defer t.indexSetsMtx.RUnlock()
+
+	var expiredIndexSets []string
+	commonIndexSetExpired := false
+
+	for userID, userIndexSet := range t.indexSets {
+		lastUsedAt := userIndexSet.LastUsedAt()
+		if lastUsedAt.Add(ttl).Before(now) {
+			if userID == "" {
+				// add the userID for common index set at the end of the list to make sure it is the last one cleaned up
+				// because we remove directories containing the index sets which in case of common index is
+				// the parent directory of all the user index sets.
+				commonIndexSetExpired = true
+			} else {
+				expiredIndexSets = append(expiredIndexSets, userID)
+			}
+		}
+	}
+
+	if commonIndexSetExpired {
+		expiredIndexSets = append(expiredIndexSets, "")
+	}
+
+	return expiredIndexSets
+}
+
+// DropUnusedIndex drops the index set if it has not been queried for at least ttl duration.
+// It returns true if the whole table gets dropped.
+func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) {
+	indexSetsToCleanup := t.findExpiredIndexSets(ttl, now)
+
+	if len(indexSetsToCleanup) > 0 {
+		t.indexSetsMtx.Lock()
+		defer t.indexSetsMtx.Unlock()
+		for _, userID := range indexSetsToCleanup {
+			level.Info(t.logger).Log("msg", fmt.Sprintf("cleaning up expired index set %s", userID))
+			err := t.indexSets[userID].DropAllDBs()
+			if err != nil {
+				return false, err
+			}
+
+			delete(t.indexSets, userID)
+		}
+
+		return len(t.indexSets) == 0, nil
+	}
+
+	return false, nil
+}
+
+// Sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
+func (t *table) Sync(ctx context.Context) error {
+	level.Debug(t.logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.name))
+
+	t.indexSetsMtx.RLock()
+	defer t.indexSetsMtx.RUnlock()
+
+	for userID, indexSet := range t.indexSets {
+		if err := indexSet.Sync(ctx); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to sync index set %s for table %s", userID, t.name))
+		}
+	}
+
+	return nil
+}
+
+// getOrCreateIndexSet gets or creates the index set for the userID.
+// If it does not exist, it creates a new one and initializes it in a goroutine.
+// Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
+// forQuerying must be set to true only getting the index for querying since
+// it captures the amount of time it takes to download the index at query time.
+func (t *table) getOrCreateIndexSet(id string, forQuerying bool) (IndexSet, error) {
+	t.indexSetsMtx.RLock()
+	indexSet, ok := t.indexSets[id]
+	t.indexSetsMtx.RUnlock()
+	if ok {
+		return indexSet, nil
+	}
+
+	t.indexSetsMtx.Lock()
+	defer t.indexSetsMtx.Unlock()
+
+	indexSet, ok = t.indexSets[id]
+	if ok {
+		return indexSet, nil
+	}
+
+	var err error
+	baseIndexSet := t.baseUserIndexSet
+	if id == "" {
+		baseIndexSet = t.baseCommonIndexSet
+	}
+
+	// instantiate the index set, add it to the map
+	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc,
+		loggerWithUserID(t.logger, id))
+	if err != nil {
+		return nil, err
+	}
+	t.indexSets[id] = indexSet
+
+	// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
+	go func() {
+		if forQuerying {
+			start := time.Now()
+			defer func() {
+				duration := time.Since(start).Seconds()
+				level.Info(loggerWithUserID(t.logger, id)).Log("msg", "downloaded index set at query time", "duration", duration)
+			}()
+		}
+
+		err := indexSet.Init()
+		if err != nil {
+			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
+		}
+	}()
+
+	return indexSet, nil
+}
+
+// EnsureQueryReadiness ensures that we have downloaded the common index as well as user index for the provided userIDs.
+// When ensuring query readiness for a table, we will always download common index set because it can include index for one of the provided user ids.
+func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
+	commonIndexSet, err := t.getOrCreateIndexSet("", false)
+	if err != nil {
+		return err
+	}
+	err = commonIndexSet.AwaitReady(ctx)
+	if err != nil {
+		return err
+	}
+
+	commonIndexSet.UpdateLastUsedAt()
+
+	missingUserIDs := make([]string, 0, len(userIDs))
+	t.indexSetsMtx.RLock()
+	for _, userID := range userIDs {
+		if userIndexSet, ok := t.indexSets[userID]; !ok {
+			missingUserIDs = append(missingUserIDs, userID)
+		} else {
+			userIndexSet.UpdateLastUsedAt()
+		}
+	}
+	t.indexSetsMtx.RUnlock()
+
+	return t.downloadUserIndexes(ctx, missingUserIDs)
+}
+
+// downloadUserIndexes downloads user specific index files concurrently.
+func (t *table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
+	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
+		indexSet, err := t.getOrCreateIndexSet(userIDs[idx], false)
+		if err != nil {
+			return err
+		}
+
+		return indexSet.AwaitReady(ctx)
+	})
+}
+
+func loggerWithUserID(logger log.Logger, userID string) log.Logger {
+	if userID == "" {
+		return logger
+	}
+
+	return log.With(logger, "user-id", userID)
+}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -1,0 +1,347 @@
+package downloads
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log/level"
+
+	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/grafana/loki/pkg/validation"
+)
+
+const (
+	cacheCleanupInterval = time.Hour
+	durationDay          = 24 * time.Hour
+)
+
+type Limits interface {
+	AllByUserID() map[string]*validation.Limits
+	DefaultLimits() *validation.Limits
+}
+
+type TableManager interface {
+	Stop()
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
+}
+
+type Config struct {
+	CacheDir          string
+	SyncInterval      time.Duration
+	CacheTTL          time.Duration
+	QueryReadyNumDays int
+	Limits            Limits
+}
+
+type tableManager struct {
+	cfg                Config
+	openIndexFileFunc  index.OpenIndexFileFunc
+	indexStorageClient storage.Client
+
+	tables    map[string]Table
+	tablesMtx sync.RWMutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewTableManager(cfg Config, openIndexFileFunc index.OpenIndexFileFunc, indexStorageClient storage.Client) (TableManager, error) {
+	if err := chunk_util.EnsureDirectory(cfg.CacheDir); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tm := &tableManager{
+		cfg:                cfg,
+		openIndexFileFunc:  openIndexFileFunc,
+		indexStorageClient: indexStorageClient,
+		tables:             make(map[string]Table),
+		ctx:                ctx,
+		cancel:             cancel,
+	}
+
+	// load the existing tables first.
+	err := tm.loadLocalTables()
+	if err != nil {
+		// call Stop to close open file references.
+		tm.Stop()
+		return nil, err
+	}
+
+	// download the missing tables.
+	err = tm.ensureQueryReadiness(ctx)
+	if err != nil {
+		// call Stop to close open file references.
+		tm.Stop()
+		return nil, err
+	}
+
+	go tm.loop()
+	return tm, nil
+}
+
+func (tm *tableManager) loop() {
+	tm.wg.Add(1)
+	defer tm.wg.Done()
+
+	syncTicker := time.NewTicker(tm.cfg.SyncInterval)
+	defer syncTicker.Stop()
+
+	cacheCleanupTicker := time.NewTicker(cacheCleanupInterval)
+	defer cacheCleanupTicker.Stop()
+
+	for {
+		select {
+		case <-syncTicker.C:
+			err := tm.syncTables(tm.ctx)
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "error syncing local boltdb files with storage", "err", err)
+			}
+
+			// we need to keep ensuring query readiness to download every days new table which would otherwise be downloaded only during queries.
+			err = tm.ensureQueryReadiness(tm.ctx)
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "error ensuring query readiness of tables", "err", err)
+			}
+		case <-cacheCleanupTicker.C:
+			err := tm.cleanupCache()
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "error cleaning up expired tables", "err", err)
+			}
+		case <-tm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (tm *tableManager) Stop() {
+	tm.cancel()
+	tm.wg.Wait()
+
+	tm.tablesMtx.Lock()
+	defer tm.tablesMtx.Unlock()
+
+	for _, table := range tm.tables {
+		table.Close()
+	}
+}
+
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
+	table, err := tm.getOrCreateTable(tableName)
+	if err != nil {
+		return err
+	}
+	return table.ForEach(ctx, userID, callback)
+}
+
+func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {
+	// if table is already there, use it.
+	tm.tablesMtx.RLock()
+	table, ok := tm.tables[tableName]
+	tm.tablesMtx.RUnlock()
+
+	if !ok {
+		tm.tablesMtx.Lock()
+		defer tm.tablesMtx.Unlock()
+
+		// check if some other competing goroutine got the lock before us and created the table, use it if so.
+		table, ok = tm.tables[tableName]
+		if !ok {
+			// table not found, creating one.
+			level.Info(util_log.Logger).Log("msg", fmt.Sprintf("downloading all files for table %s", tableName))
+
+			tablePath := filepath.Join(tm.cfg.CacheDir, tableName)
+			err := chunk_util.EnsureDirectory(tablePath)
+			if err != nil {
+				return nil, err
+			}
+
+			table = NewTable(tableName, filepath.Join(tm.cfg.CacheDir, tableName), tm.indexStorageClient, tm.openIndexFileFunc)
+			tm.tables[tableName] = table
+		}
+	}
+
+	return table, nil
+}
+
+func (tm *tableManager) syncTables(ctx context.Context) error {
+	tm.tablesMtx.RLock()
+	defer tm.tablesMtx.RUnlock()
+
+	level.Info(util_log.Logger).Log("msg", "syncing tables")
+
+	for _, table := range tm.tables {
+		err := table.Sync(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (tm *tableManager) cleanupCache() error {
+	tm.tablesMtx.Lock()
+	defer tm.tablesMtx.Unlock()
+
+	level.Info(util_log.Logger).Log("msg", "cleaning tables cache")
+
+	for name, table := range tm.tables {
+		level.Info(util_log.Logger).Log("msg", fmt.Sprintf("cleaning up expired table %s", name))
+		isEmpty, err := table.DropUnusedIndex(tm.cfg.CacheTTL, time.Now())
+		if err != nil {
+			return err
+		}
+
+		if isEmpty {
+			delete(tm.tables, name)
+		}
+	}
+
+	return nil
+}
+
+// ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
+func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
+	activeTableNumber := getActiveTableNumber()
+
+	// find the largest query readiness number
+	largestQueryReadinessNum := tm.cfg.QueryReadyNumDays
+	if defaultLimits := tm.cfg.Limits.DefaultLimits(); defaultLimits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+		largestQueryReadinessNum = defaultLimits.QueryReadyIndexNumDays
+	}
+
+	queryReadinessNumByUserID := make(map[string]int)
+	for userID, limits := range tm.cfg.Limits.AllByUserID() {
+		if limits.QueryReadyIndexNumDays != 0 {
+			queryReadinessNumByUserID[userID] = limits.QueryReadyIndexNumDays
+			if limits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+				largestQueryReadinessNum = limits.QueryReadyIndexNumDays
+			}
+		}
+	}
+
+	// return early if no table has to be downloaded for query readiness
+	if largestQueryReadinessNum == 0 {
+		return nil
+	}
+
+	tables, err := tm.indexStorageClient.ListTables(ctx)
+	if err != nil {
+		return err
+	}
+
+	// regex for finding daily tables which have a 5 digit number at the end.
+	re, err := regexp.Compile(`.+[0-9]{5}$`)
+	if err != nil {
+		return err
+	}
+
+	for _, tableName := range tables {
+		if !re.MatchString(tableName) {
+			continue
+		}
+
+		tableNumber, err := strconv.ParseInt(tableName[len(tableName)-5:], 10, 64)
+		if err != nil {
+			return err
+		}
+
+		// continue if the table is not within query readiness
+		if activeTableNumber-tableNumber > int64(largestQueryReadinessNum) {
+			continue
+		}
+
+		// list the users that have dedicated index files for this table
+		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName)
+		if err != nil {
+			return err
+		}
+
+		// find the users whos index we need to keep ready for querying from this table
+		usersToBeQueryReadyFor := tm.findUsersInTableForQueryReadiness(tableNumber, usersWithIndex, queryReadinessNumByUserID)
+
+		// continue if both user index and common index is not required to be downloaded for query readiness
+		if len(usersToBeQueryReadyFor) == 0 && activeTableNumber-tableNumber > int64(tm.cfg.QueryReadyNumDays) {
+			continue
+		}
+
+		table, err := tm.getOrCreateTable(tableName)
+		if err != nil {
+			return err
+		}
+
+		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// findUsersInTableForQueryReadiness returns the users that needs their index to be query ready based on the tableNumber and
+// query readiness number provided per user
+func (tm *tableManager) findUsersInTableForQueryReadiness(tableNumber int64, usersWithIndexInTable []string,
+	queryReadinessNumByUserID map[string]int) []string {
+	activeTableNumber := getActiveTableNumber()
+	usersToBeQueryReadyFor := []string{}
+
+	for _, userID := range usersWithIndexInTable {
+		// use the query readiness config for the user if it exists or use the default config
+		queryReadyNumDays, ok := queryReadinessNumByUserID[userID]
+		if !ok {
+			queryReadyNumDays = tm.cfg.Limits.DefaultLimits().QueryReadyIndexNumDays
+		}
+
+		if queryReadyNumDays == 0 {
+			continue
+		}
+
+		if activeTableNumber-tableNumber <= int64(queryReadyNumDays) {
+			usersToBeQueryReadyFor = append(usersToBeQueryReadyFor, userID)
+		}
+	}
+
+	return usersToBeQueryReadyFor
+}
+
+// loadLocalTables loads tables present locally.
+func (tm *tableManager) loadLocalTables() error {
+	filesInfo, err := ioutil.ReadDir(tm.cfg.CacheDir)
+	if err != nil {
+		return err
+	}
+
+	for _, fileInfo := range filesInfo {
+		if !fileInfo.IsDir() {
+			continue
+		}
+
+		level.Info(util_log.Logger).Log("msg", fmt.Sprintf("loading local table %s", fileInfo.Name()))
+
+		table, err := LoadTable(fileInfo.Name(), filepath.Join(tm.cfg.CacheDir, fileInfo.Name()), tm.indexStorageClient, tm.openIndexFileFunc)
+		if err != nil {
+			return err
+		}
+
+		tm.tables[fileInfo.Name()] = table
+	}
+
+	return nil
+}
+
+func getActiveTableNumber() int64 {
+	periodSecs := int64(durationDay / time.Second)
+
+	return time.Now().Unix() / periodSecs
+}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-kit/log/level"
 
-	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -56,7 +56,7 @@ type tableManager struct {
 }
 
 func NewTableManager(cfg Config, openIndexFileFunc index.OpenIndexFileFunc, indexStorageClient storage.Client) (TableManager, error) {
-	if err := chunk_util.EnsureDirectory(cfg.CacheDir); err != nil {
+	if err := util.EnsureDirectory(cfg.CacheDir); err != nil {
 		return nil, err
 	}
 
@@ -161,7 +161,7 @@ func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {
 			level.Info(util_log.Logger).Log("msg", fmt.Sprintf("downloading all files for table %s", tableName))
 
 			tablePath := filepath.Join(tm.cfg.CacheDir, tableName)
-			err := chunk_util.EnsureDirectory(tablePath)
+			err := util.EnsureDirectory(tablePath)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -253,6 +253,7 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			tc := tc // just to make the linter happy
 			resetTables()
 			tableManager.cfg.QueryReadyNumDays = tc.queryReadyNumDaysCfg
 			tableManager.cfg.Limits = &tc.queryReadinessLimits

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -1,0 +1,326 @@
+package downloads
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/chunk/local"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	"github.com/grafana/loki/pkg/validation"
+)
+
+const (
+	objectsStorageDirName = "objects"
+	cacheDirName          = "cache"
+)
+
+func buildTestStorageClient(t *testing.T, path string) storage.Client {
+	objectStoragePath := filepath.Join(path, objectsStorageDirName)
+	fsObjectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
+	require.NoError(t, err)
+
+	return storage.NewIndexStorageClient(fsObjectClient, "")
+}
+
+type stopFunc func()
+
+func buildTestTableManager(t *testing.T, path string) (*tableManager, stopFunc) {
+	indexStorageClient := buildTestStorageClient(t, path)
+	cachePath := filepath.Join(path, cacheDirName)
+
+	cfg := Config{
+		CacheDir:     cachePath,
+		SyncInterval: time.Hour,
+		CacheTTL:     time.Hour,
+		Limits:       &mockLimits{},
+	}
+	tblManager, err := NewTableManager(cfg, func(s string) (index.Index, error) {
+		return openMockIndexFile(t, s), nil
+	}, indexStorageClient)
+	require.NoError(t, err)
+
+	return tblManager.(*tableManager), func() {
+		tblManager.Stop()
+	}
+}
+
+func TestTableManager_ForEach(t *testing.T) {
+	tempDir := t.TempDir()
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+
+	tables := []string{"table1", "table2"}
+	users := []string{"", "user1"}
+	for _, tableName := range tables {
+		for _, userID := range users {
+			setupIndexesAtPath(t, userID, filepath.Join(objectStoragePath, tableName, userID), 1, 5)
+		}
+	}
+
+	tableManager, stopFunc := buildTestTableManager(t, tempDir)
+	defer stopFunc()
+
+	for _, tableName := range tables {
+		for i, userID := range []string{"user1", "common-index-user"} {
+			expectedIndexes := buildListOfExpectedIndexes("", 1, 5)
+			if i == 0 {
+				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
+			}
+			verifyIndexForEach(t, expectedIndexes, func(callbackFunc func(index.Index) error) error {
+				return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
+			})
+		}
+	}
+}
+
+func TestTableManager_cleanupCache(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tableManager, stopFunc := buildTestTableManager(t, tempDir)
+	defer stopFunc()
+
+	// one table that would expire and other one won't
+	expiredTableName := "expired-table"
+	nonExpiredTableName := "non-expired-table"
+
+	tableManager.tables[expiredTableName] = &mockTable{}
+	tableManager.tables[nonExpiredTableName] = &mockTable{}
+
+	// call cleanupCache and verify that no tables are cleaned up because they are not yet expired.
+	require.NoError(t, tableManager.cleanupCache())
+	require.Len(t, tableManager.tables, 2)
+
+	// set the flag for expiredTable to expire.
+	tableManager.tables[expiredTableName].(*mockTable).tableExpired = true
+
+	// call the cleanupCache and verify that we still have nonExpiredTable and expiredTable is gone.
+	require.NoError(t, tableManager.cleanupCache())
+	require.Len(t, tableManager.tables, 1)
+
+	_, ok := tableManager.tables[expiredTableName]
+	require.False(t, ok)
+
+	_, ok = tableManager.tables[nonExpiredTableName]
+	require.True(t, ok)
+}
+
+func TestTableManager_ensureQueryReadiness(t *testing.T) {
+	activeTableNumber := getActiveTableNumber()
+	mockIndexStorageClient := &mockIndexStorageClient{
+		userIndexesInTables: map[string][]string{},
+	}
+
+	cfg := Config{
+		SyncInterval: time.Hour,
+		CacheTTL:     time.Hour,
+	}
+
+	tableManager := &tableManager{
+		cfg:                cfg,
+		indexStorageClient: mockIndexStorageClient,
+		tables:             make(map[string]Table),
+		ctx:                context.Background(),
+		cancel:             func() {},
+	}
+
+	buildTableName := func(idx int) string {
+		return fmt.Sprintf("table_%d", activeTableNumber-int64(idx))
+	}
+
+	// setup 10 tables with 5 latest tables having user index for user1 and user2
+	for i := 0; i < 10; i++ {
+		tableName := buildTableName(i)
+		tableManager.tables[tableName] = &mockTable{}
+		mockIndexStorageClient.tablesInStorage = append(mockIndexStorageClient.tablesInStorage, tableName)
+		if i < 5 {
+			mockIndexStorageClient.userIndexesInTables[tableName] = []string{"user1", "user2"}
+		}
+	}
+
+	// function for resetting state of mockTables
+	resetTables := func() {
+		for _, table := range tableManager.tables {
+			table.(*mockTable).queryReadinessDoneForUsers = nil
+		}
+	}
+
+	for _, tc := range []struct {
+		name                 string
+		queryReadyNumDaysCfg int
+		queryReadinessLimits mockLimits
+
+		expectedQueryReadinessDoneForUsers map[string][]string
+	}{
+		{
+			name:                 "no query readiness configured",
+			queryReadinessLimits: mockLimits{},
+		},
+		{
+			name:                 "common index: 5 days",
+			queryReadyNumDaysCfg: 5,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {},
+				buildTableName(1): {},
+				buildTableName(2): {},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {}, // NOTE: we include an extra table since we are counting days back from current point in time
+			},
+		},
+		{
+			name:                 "common index: 20 days",
+			queryReadyNumDaysCfg: 20,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {},
+				buildTableName(1): {},
+				buildTableName(2): {},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {},
+				buildTableName(6): {},
+				buildTableName(7): {},
+				buildTableName(8): {},
+				buildTableName(9): {},
+			},
+		},
+		{
+			name: "user index default: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 2,
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+			},
+		},
+		{
+			name: "common index: 5 days, user index default: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 2,
+			},
+			queryReadyNumDaysCfg: 5,
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {},
+				buildTableName(4): {},
+				buildTableName(5): {},
+			},
+		},
+		{
+			name: "user1: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysByUser: map[string]int{"user1": 2},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1"},
+				buildTableName(1): {"user1"},
+				buildTableName(2): {"user1"},
+			},
+		},
+		{
+			name: "user1: 2 days, user2: 20 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysByUser: map[string]int{"user1": 2, "user2": 20},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {"user2"},
+				buildTableName(4): {"user2"},
+			},
+		},
+		{
+			name: "user index default: 3 days, user1: 2 days",
+			queryReadinessLimits: mockLimits{
+				queryReadyIndexNumDaysDefault: 3,
+				queryReadyIndexNumDaysByUser:  map[string]int{"user1": 2},
+			},
+			expectedQueryReadinessDoneForUsers: map[string][]string{
+				buildTableName(0): {"user1", "user2"},
+				buildTableName(1): {"user1", "user2"},
+				buildTableName(2): {"user1", "user2"},
+				buildTableName(3): {"user2"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetTables()
+			tableManager.cfg.QueryReadyNumDays = tc.queryReadyNumDaysCfg
+			tableManager.cfg.Limits = &tc.queryReadinessLimits
+			require.NoError(t, tableManager.ensureQueryReadiness(context.Background()))
+
+			for name, table := range tableManager.tables {
+				require.Equal(t, tc.expectedQueryReadinessDoneForUsers[name], table.(*mockTable).queryReadinessDoneForUsers, "table: %s", name)
+			}
+		})
+	}
+}
+
+type mockLimits struct {
+	queryReadyIndexNumDaysDefault int
+	queryReadyIndexNumDaysByUser  map[string]int
+}
+
+func (m *mockLimits) AllByUserID() map[string]*validation.Limits {
+	allByUserID := map[string]*validation.Limits{}
+	for userID := range m.queryReadyIndexNumDaysByUser {
+		allByUserID[userID] = &validation.Limits{
+			QueryReadyIndexNumDays: m.queryReadyIndexNumDaysByUser[userID],
+		}
+	}
+
+	return allByUserID
+}
+
+func (m *mockLimits) DefaultLimits() *validation.Limits {
+	return &validation.Limits{
+		QueryReadyIndexNumDays: m.queryReadyIndexNumDaysDefault,
+	}
+}
+
+type mockTable struct {
+	tableExpired               bool
+	queryReadinessDoneForUsers []string
+}
+
+func (m *mockTable) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+	return nil
+}
+
+func (m *mockTable) Close() {}
+
+func (m *mockTable) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) {
+	return m.tableExpired, nil
+}
+
+func (m *mockTable) Sync(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockTable) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
+	m.queryReadinessDoneForUsers = userIDs
+	return nil
+}
+
+type mockIndexStorageClient struct {
+	storage.Client
+	tablesInStorage     []string
+	userIndexesInTables map[string][]string
+}
+
+func (m *mockIndexStorageClient) ListTables(ctx context.Context) ([]string, error) {
+	return m.tablesInStorage, nil
+}
+
+func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
+	return []storage.IndexFile{}, m.userIndexesInTables[tableName], nil
+}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/storage/chunk/local"
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	"github.com/grafana/loki/pkg/validation"

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -1,0 +1,422 @@
+package downloads
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+const (
+	userID    = "user-id"
+	tableName = "test"
+)
+
+// storageClientWithFakeObjectsInList adds a fake object in the list call response which
+// helps with testing the case where objects gets deleted in the middle of a Sync/Download operation due to compaction.
+type storageClientWithFakeObjectsInList struct {
+	storage.Client
+}
+
+func newStorageClientWithFakeObjectsInList(storageClient storage.Client) storage.Client {
+	return storageClientWithFakeObjectsInList{storageClient}
+}
+
+func (o storageClientWithFakeObjectsInList) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
+	files, userIDs, err := o.Client.ListFiles(ctx, tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	files = append(files, storage.IndexFile{
+		Name:       "fake-object",
+		ModifiedAt: time.Now(),
+	})
+
+	return files, userIDs, nil
+}
+
+func buildTestTable(t *testing.T, path string) (*table, stopFunc) {
+	storageClient := buildTestStorageClient(t, path)
+	cachePath := filepath.Join(path, cacheDirName)
+
+	table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
+		return openMockIndexFile(t, path), nil
+	}).(*table)
+	_, usersWithIndex, err := table.storageClient.ListFiles(context.Background(), tableName)
+	require.NoError(t, err)
+	require.NoError(t, table.EnsureQueryReadiness(context.Background(), usersWithIndex))
+
+	return table, table.Close
+}
+
+type mockIndexSet struct {
+	IndexSet
+	indexes     []index.Index
+	failQueries bool
+	lastUsedAt  time.Time
+}
+
+func (m *mockIndexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+	for _, idx := range m.indexes {
+		if err := callback(idx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockIndexSet) Err() error {
+	var err error
+	if m.failQueries {
+		err = errors.New("fail queries")
+	}
+	return err
+}
+
+func (m *mockIndexSet) DropAllDBs() error {
+	return nil
+}
+
+func (m *mockIndexSet) LastUsedAt() time.Time {
+	return m.lastUsedAt
+}
+
+func (m *mockIndexSet) UpdateLastUsedAt() {
+	m.lastUsedAt = time.Now()
+}
+
+func TestTable_ForEach(t *testing.T) {
+	usersToSetup := []string{"user1", "user2"}
+	for name, tc := range map[string]struct {
+		withError  bool
+		withUserID string
+	}{
+		"without error": {
+			withUserID: usersToSetup[0],
+		},
+		"with error": {
+			withError:  true,
+			withUserID: usersToSetup[0],
+		},
+		"query with user2": {
+			withUserID: usersToSetup[1],
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			table := table{
+				indexSets: map[string]IndexSet{},
+				logger:    util_log.Logger,
+			}
+
+			table.indexSets[""] = &mockIndexSet{}
+			for _, userID := range usersToSetup {
+				var testIndexes []index.Index
+				for _, indexPath := range setupIndexesAtPath(t, userID, t.TempDir(), 0, 5) {
+					testIndexes = append(testIndexes, openMockIndexFile(t, indexPath))
+				}
+				table.indexSets[userID] = &mockIndexSet{
+					failQueries: tc.withError,
+					indexes:     testIndexes,
+				}
+			}
+
+			var indexesFound []index.Index
+
+			err := table.ForEach(context.Background(), tc.withUserID, func(idx index.Index) error {
+				indexesFound = append(indexesFound, idx)
+				return nil
+			})
+			if tc.withError {
+				require.Error(t, err)
+				require.Len(t, table.indexSets, len(usersToSetup))
+				ensureIndexSetExistsInTable(t, &table, "")
+				for _, userID := range usersToSetup {
+					if userID != tc.withUserID {
+						ensureIndexSetExistsInTable(t, &table, userID)
+					}
+				}
+			} else {
+				require.NoError(t, err)
+				require.Len(t, table.indexSets, len(usersToSetup)+1)
+				require.Equal(t, table.indexSets[tc.withUserID].(*mockIndexSet).indexes, indexesFound)
+			}
+		})
+	}
+}
+
+func TestTable_DropUnusedIndex(t *testing.T) {
+	ttl := 24 * time.Hour
+	now := time.Now()
+	notExpiredIndexUserID := "not-expired-user-based-index"
+	expiredIndexUserID := "expired-user-based-index"
+
+	// initialize some indexSets with indexSet for expiredIndexUserID being expired
+	indexSets := map[string]IndexSet{
+		"":                    &mockIndexSet{lastUsedAt: time.Now()},
+		notExpiredIndexUserID: &mockIndexSet{lastUsedAt: time.Now().Add(-time.Hour)},
+		expiredIndexUserID:    &mockIndexSet{lastUsedAt: now.Add(-25 * time.Hour)},
+	}
+
+	table := table{
+		indexSets: indexSets,
+		logger:    util_log.Logger,
+	}
+
+	// ensure that we only find expiredIndexUserID to be dropped
+	require.Equal(t, []string{expiredIndexUserID}, table.findExpiredIndexSets(ttl, now))
+
+	// dropping unused indexSets should drop only index set for expiredIndexUserID
+	allIndexSetsDropped, err := table.DropUnusedIndex(ttl, now)
+	require.NoError(t, err)
+	require.False(t, allIndexSetsDropped)
+
+	// verify that we only dropped index set for expiredIndexUserID
+	require.Len(t, table.indexSets, 2)
+	ensureIndexSetExistsInTable(t, &table, "")
+	ensureIndexSetExistsInTable(t, &table, notExpiredIndexUserID)
+
+	// change the lastUsedAt for all indexSets so that all of them get dropped
+	for _, indexSets := range table.indexSets {
+		indexSets.(*mockIndexSet).lastUsedAt = now.Add(-25 * time.Hour)
+	}
+
+	// ensure that we get userID of common index set at the end
+	require.Equal(t, []string{notExpiredIndexUserID, ""}, table.findExpiredIndexSets(ttl, now))
+
+	allIndexSetsDropped, err = table.DropUnusedIndex(ttl, now)
+	require.NoError(t, err)
+	require.True(t, allIndexSetsDropped)
+}
+
+func TestTable_EnsureQueryReadiness(t *testing.T) {
+	tempDir := t.TempDir()
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+
+	// setup table in storage with 1 common db and 2 users with a db each
+	tablePath := filepath.Join(objectStoragePath, tableName)
+	setupIndexesAtPath(t, "", tablePath, 0, 5)
+	usersToSetup := []string{"user1", "user2"}
+	for _, userID := range usersToSetup {
+		setupIndexesAtPath(t, userID, tablePath, 0, 5)
+	}
+
+	storageClient := buildTestStorageClient(t, tempDir)
+
+	for _, tc := range []struct {
+		name                       string
+		usersToDoQueryReadinessFor []string
+	}{
+		{
+			name: "only common index to be query ready",
+		},
+		{
+			name:                       "one of the users to be query ready",
+			usersToDoQueryReadinessFor: []string{"user-1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cachePath := t.TempDir()
+			table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
+				return openMockIndexFile(t, path), nil
+			}).(*table)
+			defer func() {
+				table.Close()
+			}()
+
+			// EnsureQueryReadiness should update the last used at time of common index set
+			require.NoError(t, table.EnsureQueryReadiness(context.Background(), tc.usersToDoQueryReadinessFor))
+			require.Len(t, table.indexSets, len(tc.usersToDoQueryReadinessFor)+1)
+			for _, userID := range append(tc.usersToDoQueryReadinessFor, "") {
+				ensureIndexSetExistsInTable(t, table, userID)
+				require.InDelta(t, time.Now().Unix(), table.indexSets[userID].(*indexSet).lastUsedAt.Unix(), 5)
+			}
+
+			// change the last used at to verify that it gets updated when we do the query readiness again
+			for _, idxSet := range table.indexSets {
+				idxSet.(*indexSet).lastUsedAt = time.Now().Add(-time.Hour)
+			}
+
+			// Running it multiple times should not have an impact other than updating last used at time
+			for i := 0; i < 2; i++ {
+				require.NoError(t, table.EnsureQueryReadiness(context.Background(), tc.usersToDoQueryReadinessFor))
+				require.Len(t, table.indexSets, len(tc.usersToDoQueryReadinessFor)+1)
+				for _, userID := range append(tc.usersToDoQueryReadinessFor, "") {
+					ensureIndexSetExistsInTable(t, table, userID)
+					require.InDelta(t, time.Now().Unix(), table.indexSets[userID].(*indexSet).lastUsedAt.Unix(), 5)
+				}
+			}
+		})
+	}
+}
+
+func TestTable_Sync(t *testing.T) {
+	tempDir := t.TempDir()
+
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+	tablePathInStorage := filepath.Join(objectStoragePath, tableName)
+
+	// list of dbs to create except newDB that would be added later as part of updates
+	deleteDB := "delete"
+	noUpdatesDB := "no-updates"
+	newDB := "new"
+
+	require.NoError(t, os.MkdirAll(tablePathInStorage, 0755))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(tablePathInStorage, deleteDB), []byte(deleteDB), 0755))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(tablePathInStorage, noUpdatesDB), []byte(noUpdatesDB), 0755))
+
+	// create table instance
+	table, stopFunc := buildTestTable(t, tempDir)
+	defer stopFunc()
+
+	// replace the storage client with the one that adds fake objects in the list call
+	table.storageClient = newStorageClientWithFakeObjectsInList(table.storageClient)
+
+	// check that table has expected indexes setup
+	var indexesFound []string
+	err := table.ForEach(context.Background(), userID, func(idx index.Index) error {
+		indexesFound = append(indexesFound, idx.Name())
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(indexesFound)
+	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
+
+	// add a sleep since we are updating a file and CI is sometimes too fast to create a difference in mtime of files
+	time.Sleep(time.Second)
+
+	// remove deleteDB and add the newDB
+	require.NoError(t, os.Remove(filepath.Join(tablePathInStorage, deleteDB)))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(tablePathInStorage, newDB), []byte(newDB), 0755))
+
+	// sync the table
+	require.NoError(t, table.Sync(context.Background()))
+
+	// check that table got the new index and dropped the deleted index
+	indexesFound = []string{}
+	err = table.ForEach(context.Background(), userID, func(idx index.Index) error {
+		indexesFound = append(indexesFound, idx.Name())
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(indexesFound)
+	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
+
+	// verify files in cache where dbs for the table are synced to double check.
+	expectedFilesInDir := map[string]struct{}{
+		noUpdatesDB: {},
+		newDB:       {},
+	}
+	filesInfo, err := ioutil.ReadDir(tablePathInStorage)
+	require.NoError(t, err)
+	require.Len(t, table.indexSets[""].(*indexSet).index, len(expectedFilesInDir))
+
+	for _, fileInfo := range filesInfo {
+		require.False(t, fileInfo.IsDir())
+		_, ok := expectedFilesInDir[fileInfo.Name()]
+		require.True(t, ok)
+	}
+}
+
+func TestLoadTable(t *testing.T) {
+	tempDir := t.TempDir()
+
+	objectStoragePath := filepath.Join(tempDir, objectsStorageDirName)
+	tablePathInStorage := filepath.Join(objectStoragePath, tableName)
+
+	// setup the table in storage with some records
+	setupIndexesAtPath(t, "", tablePathInStorage, 0, 5)
+	setupIndexesAtPath(t, userID, filepath.Join(tablePathInStorage, userID), 0, 5)
+
+	storageClient := buildTestStorageClient(t, tempDir)
+	tablePathInCache := filepath.Join(tempDir, cacheDirName, tableName)
+
+	storageClient = newStorageClientWithFakeObjectsInList(storageClient)
+
+	// try loading the table.
+	table, err := LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
+		return openMockIndexFile(t, path), nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	// check the loaded table to see it has right index files.
+	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
+	verifyIndexForEach(t, expectedIndexes, func(callbackFunc func(index.Index) error) error {
+		return table.ForEach(context.Background(), userID, callbackFunc)
+	})
+
+	// close the table to test reloading of table with already having files in the cache dir.
+	table.Close()
+
+	// add some more files to the storage.
+	setupIndexesAtPath(t, "", tablePathInStorage, 5, 10)
+	setupIndexesAtPath(t, userID, filepath.Join(tablePathInStorage, userID), 5, 10)
+
+	// try loading the table, it should skip loading corrupt file and reload it from storage.
+	table, err = LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
+		return openMockIndexFile(t, path), nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	defer table.Close()
+
+	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
+	verifyIndexForEach(t, expectedIndexes, func(callbackFunc func(index.Index) error) error {
+		return table.ForEach(context.Background(), userID, callbackFunc)
+	})
+}
+
+func buildListOfExpectedIndexes(userID string, start, end int) []string {
+	var expectedIndexes []string
+	for ; start < end; start++ {
+		expectedIndexes = append(expectedIndexes, buildIndexFilename(userID, start))
+	}
+
+	return expectedIndexes
+}
+
+func ensureIndexSetExistsInTable(t *testing.T, table *table, indexSetName string) {
+	_, ok := table.indexSets[indexSetName]
+	require.True(t, ok)
+}
+
+func verifyIndexForEach(t *testing.T, expectedIndexes []string, forEachFunc func(callbackFunc func(index.Index) error) error) {
+	var indexesFound []string
+	err := forEachFunc(func(idx index.Index) error {
+		// get the reader for the index.
+		readSeeker, err := idx.Reader()
+		require.NoError(t, err)
+
+		// seek it to 0
+		_, err = readSeeker.Seek(0, 0)
+		require.NoError(t, err)
+
+		// read the contents of the index.
+		buf, err := ioutil.ReadAll(readSeeker)
+		require.NoError(t, err)
+
+		// see if it matches the name of the file
+		require.Equal(t, idx.Name(), string(buf))
+
+		indexesFound = append(indexesFound, idx.Name())
+		return nil
+	})
+	require.NoError(t, err)
+
+	sort.Strings(indexesFound)
+	sort.Strings(expectedIndexes)
+	require.Equal(t, expectedIndexes, indexesFound)
+}

--- a/pkg/storage/stores/indexshipper/downloads/testutil.go
+++ b/pkg/storage/stores/indexshipper/downloads/testutil.go
@@ -1,0 +1,56 @@
+package downloads
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockIndex struct {
+	*os.File
+}
+
+func openMockIndexFile(t *testing.T, path string) *mockIndex {
+	fl, err := os.Open(path)
+	require.NoError(t, err)
+	return &mockIndex{fl}
+}
+
+func (m *mockIndex) Name() string {
+	return filepath.Base(m.File.Name())
+}
+
+func (m *mockIndex) Path() string {
+	return m.File.Name()
+}
+
+func (m *mockIndex) Reader() (io.ReadSeeker, error) {
+	return m.File, nil
+}
+
+func setupIndexesAtPath(t *testing.T, userID, path string, start, end int) []string {
+	require.NoError(t, os.MkdirAll(path, 0755))
+	var testIndexes []string
+	for ; start < end; start++ {
+		fileName := buildIndexFilename(userID, start)
+		indexPath := filepath.Join(path, fileName)
+
+		require.NoError(t, ioutil.WriteFile(indexPath, []byte(fileName), 0755))
+		testIndexes = append(testIndexes, indexPath)
+	}
+
+	return testIndexes
+}
+
+func buildIndexFilename(userID string, indexNum int) string {
+	if userID == "" {
+		return strconv.Itoa(indexNum)
+	}
+
+	return userID + "-" + strconv.Itoa(indexNum)
+}

--- a/pkg/storage/stores/indexshipper/downloads/util.go
+++ b/pkg/storage/stores/indexshipper/downloads/util.go
@@ -1,0 +1,59 @@
+package downloads
+
+import (
+	"context"
+	"sync"
+)
+
+// mtxWithReadiness combines a mutex with readiness channel. It would acquire lock only when the channel is closed to mark it ready.
+type mtxWithReadiness struct {
+	mtx   sync.RWMutex
+	ready chan struct{}
+}
+
+func newMtxWithReadiness() *mtxWithReadiness {
+	return &mtxWithReadiness{
+		ready: make(chan struct{}),
+	}
+}
+
+func (m *mtxWithReadiness) markReady() {
+	close(m.ready)
+}
+
+func (m *mtxWithReadiness) awaitReady(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.ready:
+		return nil
+	}
+}
+
+func (m *mtxWithReadiness) lock(ctx context.Context) error {
+	err := m.awaitReady(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.mtx.Lock()
+	return nil
+}
+
+func (m *mtxWithReadiness) unlock() {
+	m.mtx.Unlock()
+}
+
+func (m *mtxWithReadiness) rLock(ctx context.Context) error {
+	err := m.awaitReady(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.mtx.RLock()
+	return nil
+}
+
+func (m *mtxWithReadiness) rUnlock() {
+	m.mtx.RUnlock()
+}

--- a/pkg/storage/stores/indexshipper/index/index.go
+++ b/pkg/storage/stores/indexshipper/index/index.go
@@ -1,0 +1,13 @@
+package index
+
+import "io"
+
+type Index interface {
+	Name() string
+	Path() string
+	Close() error
+	Reader() (io.ReadSeeker, error)
+}
+
+type OpenIndexFileFunc func(string) (Index, error)
+type ForEachIndexCallback func(Index) error

--- a/pkg/storage/stores/indexshipper/index/index.go
+++ b/pkg/storage/stores/indexshipper/index/index.go
@@ -9,5 +9,8 @@ type Index interface {
 	Reader() (io.ReadSeeker, error)
 }
 
+// OpenIndexFileFunc opens an index file stored at the given path.
+// There is a possibility of files being corrupted due to abrupt shutdown so
+// the implementation should take care of gracefully handling failures in opening corrupted files.
 type OpenIndexFileFunc func(string) (Index, error)
 type ForEachIndexCallback func(Index) error

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-kit/log/level"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/chunk/client"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/uploads"
@@ -83,7 +83,7 @@ type indexShipper struct {
 
 // NewIndexShipper creates a shipper for providing index store functionality using index files and object storage.
 // It manages the whole life cycle of uploading the index and downloading the index at query time.
-func NewIndexShipper(cfg Config, storageClient chunk.ObjectClient, limits downloads.Limits) (IndexShipper, error) {
+func NewIndexShipper(cfg Config, storageClient client.ObjectClient, limits downloads.Limits) (IndexShipper, error) {
 	shipper := indexShipper{
 		cfg: cfg,
 	}
@@ -98,7 +98,7 @@ func NewIndexShipper(cfg Config, storageClient chunk.ObjectClient, limits downlo
 	return &shipper, nil
 }
 
-func (s *indexShipper) init(storageClient chunk.ObjectClient, limits downloads.Limits) error {
+func (s *indexShipper) init(storageClient client.ObjectClient, limits downloads.Limits) error {
 	indexStorageClient := storage.NewIndexStorageClient(storageClient, s.cfg.SharedStoreKeyPrefix)
 
 	if s.cfg.Mode != ModeReadOnly {

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -1,0 +1,165 @@
+package indexshipper
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/uploads"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+type Mode string
+
+const (
+	// ModeReadWrite is to allow both read and write
+	ModeReadWrite = Mode("RW")
+	// ModeReadOnly is to allow only read operations
+	ModeReadOnly = Mode("RO")
+	// ModeWriteOnly is to allow only write operations
+	ModeWriteOnly = Mode("WO")
+
+	// UploadInterval defines interval for when we check if there are new index files to upload.
+	// It's also used to snapshot the currently written index tables so the snapshots can be used for reads.
+	UploadInterval = 1 * time.Minute
+)
+
+type Index interface {
+	Close() error
+}
+
+type IndexShipper interface {
+	// AddIndex adds an immutable index to a logical table which would eventually get uploaded to the object store.
+	AddIndex(tableName, userID string, index index.Index) error
+	// ForEach lets us iterates through each index file in a table for a specific user.
+	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
+	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
+	ForEach(ctx context.Context, tableName, userID string, callback func(index index.Index) error) error
+	Stop()
+}
+
+type Config struct {
+	ActiveIndexDirectory string        `yaml:"active_index_directory"`
+	SharedStoreType      string        `yaml:"shared_store"`
+	SharedStoreKeyPrefix string        `yaml:"shared_store_key_prefix"`
+	CacheLocation        string        `yaml:"cache_location"`
+	CacheTTL             time.Duration `yaml:"cache_ttl"`
+	ResyncInterval       time.Duration `yaml:"resync_interval"`
+	QueryReadyNumDays    int           `yaml:"query_ready_num_days"`
+
+	UploaderName           string
+	IngesterName           string
+	Mode                   Mode
+	IngesterDBRetainPeriod time.Duration
+}
+
+// RegisterFlagsWithPrefix registers flags.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.ActiveIndexDirectory, prefix+".shipper.active-index-directory", "", "Directory where ingesters would write index files which would then be uploaded by shipper to configured storage")
+	f.StringVar(&cfg.SharedStoreType, prefix+".shipper.shared-store", "", "Shared store for keeping index files. Supported types: gcs, s3, azure, filesystem")
+	f.StringVar(&cfg.SharedStoreKeyPrefix, prefix+".shipper.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator but should always end with it")
+	f.StringVar(&cfg.CacheLocation, prefix+".shipper.cache-location", "", "Cache location for restoring index files from storage for queries")
+	f.DurationVar(&cfg.CacheTTL, prefix+".shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
+	f.DurationVar(&cfg.ResyncInterval, prefix+".shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
+	f.IntVar(&cfg.QueryReadyNumDays, prefix+".shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
+}
+
+type indexShipper struct {
+	cfg               Config
+	openIndexFileFunc index.OpenIndexFileFunc
+	uploadsManager    uploads.TableManager
+	downloadsManager  downloads.TableManager
+
+	stopOnce sync.Once
+}
+
+// NewIndexShipper creates a shipper for providing index store functionality using index files and object storage.
+// It manages the whole life cycle of uploading the index and downloading the index at query time.
+func NewIndexShipper(cfg Config, storageClient chunk.ObjectClient, limits downloads.Limits) (IndexShipper, error) {
+	shipper := indexShipper{
+		cfg: cfg,
+	}
+
+	err := shipper.init(storageClient, limits)
+	if err != nil {
+		return nil, err
+	}
+
+	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("starting index shipper in %s mode", cfg.Mode))
+
+	return &shipper, nil
+}
+
+func (s *indexShipper) init(storageClient chunk.ObjectClient, limits downloads.Limits) error {
+	indexStorageClient := storage.NewIndexStorageClient(storageClient, s.cfg.SharedStoreKeyPrefix)
+
+	if s.cfg.Mode != ModeReadOnly {
+		cfg := uploads.Config{
+			Uploader:       s.cfg.UploaderName,
+			UploadInterval: UploadInterval,
+			DBRetainPeriod: s.cfg.IngesterDBRetainPeriod,
+		}
+		uploadsManager, err := uploads.NewTableManager(cfg, indexStorageClient)
+		if err != nil {
+			return err
+		}
+
+		s.uploadsManager = uploadsManager
+	}
+
+	if s.cfg.Mode != ModeWriteOnly {
+		cfg := downloads.Config{
+			CacheDir:          s.cfg.CacheLocation,
+			SyncInterval:      s.cfg.ResyncInterval,
+			CacheTTL:          s.cfg.CacheTTL,
+			QueryReadyNumDays: s.cfg.QueryReadyNumDays,
+			Limits:            limits,
+		}
+		downloadsManager, err := downloads.NewTableManager(cfg, s.openIndexFileFunc, indexStorageClient)
+		if err != nil {
+			return err
+		}
+
+		s.downloadsManager = downloadsManager
+	}
+
+	return nil
+}
+
+func (s *indexShipper) AddIndex(tableName, userID string, index index.Index) error {
+	return s.uploadsManager.AddIndex(tableName, userID, index)
+}
+
+func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, callback func(index index.Index) error) error {
+	if s.downloadsManager != nil {
+		return s.downloadsManager.ForEach(ctx, tableName, userID, callback)
+	}
+
+	if s.uploadsManager != nil {
+		return s.uploadsManager.ForEach(tableName, userID, callback)
+	}
+
+	return nil
+}
+
+func (s *indexShipper) Stop() {
+	s.stopOnce.Do(s.stop)
+}
+
+func (s *indexShipper) stop() {
+	if s.uploadsManager != nil {
+		s.uploadsManager.Stop()
+	}
+
+	if s.downloadsManager != nil {
+		s.downloadsManager.Stop()
+	}
+}

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -1,0 +1,251 @@
+package uploads
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/pkg/chunkenc"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+type IndexSet interface {
+	Add(idx index.Index)
+	Upload(ctx context.Context) error
+	Cleanup(indexRetainPeriod time.Duration) error
+	ForEach(callback index.ForEachIndexCallback) error
+	Close()
+}
+
+// indexSet is a collection of multiple files created for a same table by various ingesters.
+// All the public methods are concurrency safe and take care of mutexes to avoid any data race.
+type indexSet struct {
+	storageIndexSet   storage.IndexSet
+	tableName, userID string
+	logger            log.Logger
+	uploader          string
+
+	index    map[string]index.Index
+	indexMtx sync.RWMutex
+
+	indexUploadTime    map[string]time.Time
+	indexUploadTimeMtx sync.RWMutex
+}
+
+func NewIndexSet(tableName, userID string, baseIndexSet storage.IndexSet, logger log.Logger) (IndexSet, error) {
+	if baseIndexSet.IsUserBasedIndexSet() && userID == "" {
+		return nil, fmt.Errorf("userID must not be empty")
+	} else if !baseIndexSet.IsUserBasedIndexSet() && userID != "" {
+		return nil, fmt.Errorf("userID must be empty")
+	}
+
+	is := indexSet{
+		storageIndexSet: baseIndexSet,
+		tableName:       tableName,
+		index:           map[string]index.Index{},
+		indexUploadTime: map[string]time.Time{},
+		userID:          userID,
+		logger:          logger,
+	}
+
+	return &is, nil
+}
+
+func (t *indexSet) Add(idx index.Index) {
+	t.indexMtx.Lock()
+	defer t.indexMtx.Unlock()
+
+	t.index[idx.Name()] = idx
+}
+
+func (t *indexSet) ForEach(callback index.ForEachIndexCallback) error {
+	t.indexMtx.RLock()
+	defer t.indexMtx.RUnlock()
+
+	for _, idx := range t.index {
+		if err := callback(idx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Upload uploads all the dbs which are never uploaded or have been modified since the last batch was uploaded.
+func (t *indexSet) Upload(ctx context.Context) error {
+	t.indexMtx.RLock()
+	defer t.indexMtx.RUnlock()
+
+	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("uploading table %s", t.tableName))
+
+	for name, idx := range t.index {
+		// if the file is uploaded already do not upload it again.
+		t.indexUploadTimeMtx.RLock()
+		_, ok := t.indexUploadTime[name]
+		t.indexUploadTimeMtx.RUnlock()
+
+		if ok {
+			continue
+		}
+
+		if err := t.uploadIndex(ctx, idx); err != nil {
+			return err
+		}
+
+		t.indexUploadTimeMtx.Lock()
+		t.indexUploadTime[name] = time.Now()
+		t.indexUploadTimeMtx.Unlock()
+	}
+
+	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("finished uploading table %s", t.tableName))
+
+	return nil
+}
+
+// Close Closes references to all the indexes.
+func (t *indexSet) Close() {
+	t.indexMtx.Lock()
+	defer t.indexMtx.Unlock()
+
+	for name, idx := range t.index {
+		if err := idx.Close(); err != nil {
+			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to close index %s", name), "err", err)
+		}
+	}
+
+	t.index = map[string]index.Index{}
+}
+
+func (t *indexSet) uploadIndex(ctx context.Context, idx index.Index) error {
+	fileName := idx.Name()
+	level.Debug(t.logger).Log("msg", fmt.Sprintf("uploading index %s", fileName))
+
+	idxPath := idx.Path()
+
+	filePath := fmt.Sprintf("%s%s", idxPath, tempFileSuffix)
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close temp file", "path", filePath, "err", err)
+		}
+
+		if err := os.Remove(filePath); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to remove temp file", "path", filePath, "err", err)
+		}
+	}()
+
+	compressedWriter := chunkenc.Gzip.GetWriter(f)
+	defer chunkenc.Gzip.PutWriter(compressedWriter)
+
+	idxReader, err := idx.Reader()
+	if err != nil {
+		return err
+	}
+
+	_, err = idxReader.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(compressedWriter, idxReader)
+	if err != nil {
+		return err
+	}
+
+	err = compressedWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	// flush the file to disk and seek the file to the beginning.
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	if _, err := f.Seek(0, 0); err != nil {
+		return err
+	}
+
+	return t.storageIndexSet.PutFile(ctx, t.tableName, t.userID, t.buildFileName(fileName), f)
+}
+
+// Cleanup removes indexes which are already uploaded and have been retained for period longer than indexRetainPeriod since they were uploaded.
+func (t *indexSet) Cleanup(indexRetainPeriod time.Duration) error {
+	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("cleaning up unwanted indexes from table %s", t.tableName))
+
+	var filesToCleanup []string
+	cutoffTime := time.Now().Add(-indexRetainPeriod)
+
+	t.indexMtx.RLock()
+
+	for name := range t.index {
+		t.indexMtx.RLock()
+		indexUploadTime, ok := t.indexUploadTime[name]
+		t.indexMtx.RUnlock()
+
+		if ok && indexUploadTime.Before(cutoffTime) {
+			filesToCleanup = append(filesToCleanup, name)
+		}
+	}
+
+	t.indexMtx.RUnlock()
+
+	for i := range filesToCleanup {
+		level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("dropping uploaded index %s from table %s", filesToCleanup[i], t.tableName))
+
+		if err := t.removeIndex(filesToCleanup[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// removeIndex closes the index and removes the file locally.
+func (t *indexSet) removeIndex(name string) error {
+	t.indexMtx.Lock()
+	defer t.indexMtx.Unlock()
+
+	idx, ok := t.index[name]
+	if !ok {
+		return nil
+	}
+
+	err := idx.Close()
+	if err != nil {
+		return err
+	}
+
+	delete(t.index, name)
+
+	t.indexUploadTimeMtx.Lock()
+	delete(t.indexUploadTime, name)
+	t.indexUploadTimeMtx.Unlock()
+
+	return os.Remove(idx.Path())
+}
+
+func (t *indexSet) buildFileName(indexName string) string {
+	// Files are stored with <uploader>-<index-name>
+	fileName := fmt.Sprintf("%s-%s", t.uploader, indexName)
+
+	// if the file is a migrated one then don't add its name to the object key otherwise we would re-upload them again here with a different name.
+	// This is kept for historic reasons of boltdb-shipper.
+	if t.tableName == indexName {
+		fileName = t.uploader
+	}
+
+	return fmt.Sprintf("%s.gz", fileName)
+}

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -191,9 +191,9 @@ func (t *indexSet) Cleanup(indexRetainPeriod time.Duration) error {
 	t.indexMtx.RLock()
 
 	for name := range t.index {
-		t.indexMtx.RLock()
+		t.indexUploadTimeMtx.RLock()
 		indexUploadTime, ok := t.indexUploadTime[name]
-		t.indexMtx.RUnlock()
+		t.indexUploadTimeMtx.RUnlock()
 
 		if ok && indexUploadTime.Before(cutoffTime) {
 			filesToCleanup = append(filesToCleanup, name)

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -1,0 +1,163 @@
+package uploads
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/testutil"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+const userID = "user-id"
+
+func TestIndexSet_Add(t *testing.T) {
+	tempDir := t.TempDir()
+	testStorageClient := buildTestStorageClient(t, tempDir)
+
+	for _, userID := range []string{userID, ""} {
+		t.Run(userID, func(t *testing.T) {
+			indexSet, err := NewIndexSet(testTableName, userID, storage.NewIndexSet(testStorageClient, userID != ""), util_log.Logger)
+			require.NoError(t, err)
+
+			defer indexSet.Close()
+
+			testIndexes := buildTestIndexes(t, t.TempDir(), 10)
+			for _, testIndex := range testIndexes {
+				indexSet.Add(testIndex)
+			}
+
+			// see if we can find all the added indexes in the table.
+			indexesFound := map[string]*mockIndex{}
+			err = indexSet.ForEach(func(index index.Index) error {
+				indexesFound[index.Path()] = index.(*mockIndex)
+				return nil
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, testIndexes, indexesFound)
+		})
+	}
+}
+
+func TestIndexSet_Upload(t *testing.T) {
+	tempDir := t.TempDir()
+	testStorageClient := buildTestStorageClient(t, tempDir)
+
+	for _, userID := range []string{userID, ""} {
+		t.Run(userID, func(t *testing.T) {
+			idxSet, err := NewIndexSet(testTableName, userID, storage.NewIndexSet(testStorageClient, userID != ""), util_log.Logger)
+			require.NoError(t, err)
+
+			defer idxSet.Close()
+
+			testIndexes := buildTestIndexes(t, t.TempDir(), 5)
+			for _, testIndex := range testIndexes {
+				idxSet.Add(testIndex)
+			}
+
+			err = idxSet.Upload(context.Background())
+			require.NoError(t, err)
+
+			for _, testIndex := range testIndexes {
+				indexPathInStorage := filepath.Join(tempDir, objectsStorageDirName, testTableName, userID, idxSet.(*indexSet).buildFileName(testIndex.Name()))
+				require.FileExists(t, indexPathInStorage)
+
+				// compare the contents of created test index and uploaded index in storage
+				_, err = testIndex.Seek(0, 0)
+				require.NoError(t, err)
+				expectedIndexContent, err := ioutil.ReadAll(testIndex.File)
+				require.NoError(t, err)
+				require.Equal(t, expectedIndexContent, readCompressedFile(t, indexPathInStorage))
+			}
+		})
+	}
+}
+
+func TestIndexSet_Cleanup(t *testing.T) {
+	dbRetainPeriod := 5 * time.Minute
+	tempDir := t.TempDir()
+	testStorageClient := buildTestStorageClient(t, tempDir)
+
+	for _, userID := range []string{userID, ""} {
+		t.Run(userID, func(t *testing.T) {
+			idxSet, err := NewIndexSet(testTableName, userID, storage.NewIndexSet(testStorageClient, userID != ""), util_log.Logger)
+			require.NoError(t, err)
+			defer idxSet.Close()
+
+			testIndexes := buildTestIndexes(t, t.TempDir(), 5)
+			for _, testIndex := range testIndexes {
+				idxSet.Add(testIndex)
+			}
+
+			// upload the indexes
+			err = idxSet.Upload(context.Background())
+			require.NoError(t, err)
+
+			// cleanup the indexes outside the retention period
+			err = idxSet.Cleanup(dbRetainPeriod)
+			require.NoError(t, err)
+
+			// all the indexes should be retained since they were just uploaded
+			indexesFound := map[string]*mockIndex{}
+			err = idxSet.ForEach(func(index index.Index) error {
+				indexesFound[index.Path()] = index.(*mockIndex)
+				return nil
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, testIndexes, indexesFound)
+
+			// change the upload time of some of the indexes to now-(retention period+minute) so that they get dropped during cleanup
+			indexToCleanup := map[string]struct{}{}
+			for _, testIndex := range testIndexes {
+				indexToCleanup[testIndex.Path()] = struct{}{}
+				idxSet.(*indexSet).indexUploadTime[testIndex.Name()] = time.Now().Add(-(dbRetainPeriod + time.Minute))
+				if len(indexToCleanup) == 2 {
+					break
+				}
+			}
+
+			// cleanup the indexes outside the retention period
+			err = idxSet.Cleanup(dbRetainPeriod)
+			require.NoError(t, err)
+
+			// get all the indexes that are retained
+			indexesFound = map[string]*mockIndex{}
+			err = idxSet.ForEach(func(index index.Index) error {
+				indexesFound[index.Path()] = index.(*mockIndex)
+				return nil
+			})
+			require.NoError(t, err)
+
+			// we should have only the indexes whose upload time was not changed above
+			require.Len(t, indexesFound, len(testIndexes)-(len(indexToCleanup)))
+			for _, testIndex := range testIndexes {
+				if _, ok := indexToCleanup[testIndex.Path()]; ok {
+					// make sure that file backing the index is dropped from local disk
+					require.NoFileExists(t, testIndex.Path())
+					continue
+				}
+				require.Contains(t, indexesFound, testIndex.Path())
+			}
+		})
+	}
+}
+
+// readCompressedFile reads the contents of a compressed file at given path.
+func readCompressedFile(t *testing.T, path string) []byte {
+	tempDir := t.TempDir()
+	decompressedFilePath := filepath.Join(tempDir, "decompressed")
+	testutil.DecompressFile(t, path, decompressedFilePath)
+
+	fileContent, err := ioutil.ReadFile(decompressedFilePath)
+	require.NoError(t, err)
+
+	return fileContent
+}

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -1,0 +1,137 @@
+package uploads
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+const (
+	// a temp file is created during uploads with name of the db + tempFileSuffix
+	tempFileSuffix = ".temp"
+)
+
+type Table interface {
+	Name() string
+	AddIndex(userID string, idx index.Index) error
+	ForEach(userID string, callback index.ForEachIndexCallback) error
+	Upload(ctx context.Context) error
+	Cleanup(indexRetainPeriod time.Duration) error
+	Stop()
+}
+
+// table is a collection of multiple dbs created for a same table by the ingester.
+// All the public methods are concurrency safe and take care of mutexes to avoid any data race.
+type table struct {
+	name                                 string
+	uploader                             string
+	baseUserIndexSet, baseCommonIndexSet storage.IndexSet
+	logger                               log.Logger
+
+	indexSet    map[string]IndexSet
+	indexSetMtx sync.RWMutex
+}
+
+// NewTable create a new table instance.
+func NewTable(name, uploader string, storageClient storage.Client) Table {
+	return &table{
+		name:               name,
+		uploader:           uploader,
+		baseUserIndexSet:   storage.NewIndexSet(storageClient, true),
+		baseCommonIndexSet: storage.NewIndexSet(storageClient, false),
+		logger:             log.With(util_log.Logger, "table-name", name),
+		indexSet:           make(map[string]IndexSet),
+	}
+}
+
+// Name returns the name of the table.
+func (lt *table) Name() string {
+	return lt.name
+}
+
+// AddIndex adds a new index to the table.
+func (lt *table) AddIndex(userID string, idx index.Index) error {
+	lt.indexSetMtx.Lock()
+	defer lt.indexSetMtx.Unlock()
+
+	if _, ok := lt.indexSet[userID]; !ok {
+		baseIndexSet := lt.baseUserIndexSet
+		if userID == "" {
+			baseIndexSet = lt.baseCommonIndexSet
+		}
+		idxSet, err := NewIndexSet(lt.name, userID, baseIndexSet, loggerWithUserID(lt.logger, userID))
+		if err != nil {
+			return err
+		}
+
+		lt.indexSet[userID] = idxSet
+	}
+
+	lt.indexSet[userID].Add(idx)
+	return nil
+}
+
+// ForEach iterates over all the indexes belonging to the user.
+func (lt *table) ForEach(userID string, callback index.ForEachIndexCallback) error {
+	lt.indexSetMtx.RLock()
+	defer lt.indexSetMtx.RUnlock()
+
+	idxSet, ok := lt.indexSet[userID]
+	if !ok {
+		return nil
+	}
+
+	return idxSet.ForEach(callback)
+}
+
+// Upload uploads the index to object storage.
+func (lt *table) Upload(ctx context.Context) error {
+	lt.indexSetMtx.RLock()
+	defer lt.indexSetMtx.RUnlock()
+
+	for _, indexSet := range lt.indexSet {
+		if err := indexSet.Upload(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Cleanup removes indexes which are already uploaded and have been retained for period longer than indexRetainPeriod since they were uploaded.
+func (lt *table) Cleanup(indexRetainPeriod time.Duration) error {
+	lt.indexSetMtx.RLock()
+	defer lt.indexSetMtx.RUnlock()
+
+	for _, indexSet := range lt.indexSet {
+		if err := indexSet.Cleanup(indexRetainPeriod); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Stop closes all the open dbs.
+func (lt *table) Stop() {
+	lt.indexSetMtx.Lock()
+	defer lt.indexSetMtx.Unlock()
+
+	for _, indexSet := range lt.indexSet {
+		indexSet.Close()
+	}
+}
+
+func loggerWithUserID(logger log.Logger, userID string) log.Logger {
+	if userID == "" {
+		return logger
+	}
+
+	return log.With(logger, "user-id", userID)
+}

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -26,7 +26,9 @@ type Table interface {
 	Stop()
 }
 
-// table is a collection of multiple dbs created for a same table by the ingester.
+// table is a collection of one or more index files created by the ingester or compacted by the compactor.
+// A table would provide a logical grouping for index by a period. This period is controlled by `schema_config.configs.index.period` config.
+// It contains index for all the users sending logs to Loki.
 // All the public methods are concurrency safe and take care of mutexes to avoid any data race.
 type table struct {
 	name                                 string

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -1,0 +1,137 @@
+package uploads
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	util_log "github.com/grafana/loki/pkg/util/log"
+)
+
+type Config struct {
+	Uploader       string
+	UploadInterval time.Duration
+	DBRetainPeriod time.Duration
+}
+
+type TableManager interface {
+	Stop()
+	AddIndex(tableName, userID string, index index.Index) error
+	ForEach(tableName, userID string, callback index.ForEachIndexCallback) error
+}
+
+type tableManager struct {
+	cfg           Config
+	storageClient storage.Client
+
+	tables    map[string]Table
+	tablesMtx sync.RWMutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewTableManager(cfg Config, storageClient storage.Client) (TableManager, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tm := tableManager{
+		cfg:           cfg,
+		storageClient: storageClient,
+		tables:        map[string]Table{},
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+
+	go tm.loop()
+	return &tm, nil
+}
+
+func (tm *tableManager) loop() {
+	tm.wg.Add(1)
+	defer tm.wg.Done()
+
+	tm.uploadTables(context.Background())
+
+	syncTicker := time.NewTicker(tm.cfg.UploadInterval)
+	defer syncTicker.Stop()
+
+	for {
+		select {
+		case <-syncTicker.C:
+			tm.uploadTables(context.Background())
+		case <-tm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (tm *tableManager) Stop() {
+	level.Info(util_log.Logger).Log("msg", "stopping table manager")
+
+	tm.cancel()
+	tm.wg.Wait()
+
+	tm.uploadTables(context.Background())
+
+	tm.tablesMtx.Lock()
+	defer tm.tablesMtx.Unlock()
+	for _, table := range tm.tables {
+		table.Stop()
+	}
+
+	tm.tables = map[string]Table{}
+}
+
+func (tm *tableManager) AddIndex(tableName, userID string, index index.Index) error {
+	return tm.getOrCreateTable(tableName).AddIndex(userID, index)
+}
+
+func (tm *tableManager) getOrCreateTable(tableName string) Table {
+	tm.tablesMtx.RLock()
+	table, ok := tm.tables[tableName]
+	tm.tablesMtx.RUnlock()
+
+	if !ok {
+		tm.tablesMtx.Lock()
+		defer tm.tablesMtx.Unlock()
+
+		table, ok = tm.tables[tableName]
+		if !ok {
+			table = NewTable(tableName, tm.cfg.Uploader, tm.storageClient)
+			tm.tables[tableName] = table
+		}
+	}
+
+	return table
+}
+
+func (tm *tableManager) ForEach(tableName, userID string, callback index.ForEachIndexCallback) error {
+	table := tm.getOrCreateTable(tableName)
+	return table.ForEach(userID, callback)
+}
+
+func (tm *tableManager) uploadTables(ctx context.Context) {
+	tm.tablesMtx.RLock()
+	defer tm.tablesMtx.RUnlock()
+
+	level.Info(util_log.Logger).Log("msg", "uploading tables")
+
+	for _, table := range tm.tables {
+		err := table.Upload(ctx)
+		if err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to upload table", "table", table.Name(), "err", err)
+			continue
+		}
+
+		// cleanup uploaded dbs from local disk after retain period
+		err = table.Cleanup(tm.cfg.DBRetainPeriod)
+		if err != nil {
+			// we do not want to stop uploading of dbs due to failures in cleaning them up so logging just the error here.
+			level.Error(util_log.Logger).Log("msg", "failed to cleanup uploaded index past their retention period", "table", table.Name(), "err", err)
+		}
+	}
+}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/pkg/storage/chunk/local"
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 )

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -1,0 +1,79 @@
+package uploads
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/chunk/local"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+)
+
+const objectsStorageDirName = "objects"
+
+func buildTestStorageClient(t *testing.T, path string) storage.Client {
+	objectStoragePath := filepath.Join(path, objectsStorageDirName)
+	fsObjectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: objectStoragePath})
+	require.NoError(t, err)
+
+	return storage.NewIndexStorageClient(fsObjectClient, "")
+}
+
+type stopFunc func()
+
+func buildTestTableManager(t *testing.T, testDir string) (TableManager, stopFunc) {
+	storageClient := buildTestStorageClient(t, testDir)
+
+	cfg := Config{
+		Uploader:       "test-table-manager",
+		UploadInterval: time.Hour,
+	}
+	tm, err := NewTableManager(cfg, storageClient)
+	require.NoError(t, err)
+
+	return tm, func() {
+		tm.Stop()
+		require.NoError(t, os.RemoveAll(testDir))
+	}
+}
+
+func TestTableManager(t *testing.T) {
+	testDir := t.TempDir()
+
+	testTableManager, stopFunc := buildTestTableManager(t, testDir)
+	defer stopFunc()
+
+	for tableIdx := 0; tableIdx < 2; tableIdx++ {
+		tableName := "table-" + strconv.Itoa(tableIdx)
+		t.Run(tableName, func(t *testing.T) {
+			for userIdx := 0; userIdx < 2; userIdx++ {
+				userID := "user-" + strconv.Itoa(userIdx)
+				t.Run(userID, func(t *testing.T) {
+					userIndexPath := filepath.Join(testDir, tableName, userID)
+					require.NoError(t, os.MkdirAll(userIndexPath, 0755))
+
+					// build some test indexes and add them to the table.
+					testIndexes := buildTestIndexes(t, userIndexPath, 5)
+					for _, testIndex := range testIndexes {
+						require.NoError(t, testTableManager.AddIndex(tableName, userID, testIndex))
+					}
+
+					// see if we can find all the added indexes in the table.
+					indexesFound := map[string]*mockIndex{}
+					err := testTableManager.ForEach(tableName, userID, func(index index.Index) error {
+						indexesFound[index.Path()] = index.(*mockIndex)
+						return nil
+					})
+					require.NoError(t, err)
+
+					require.Equal(t, testIndexes, indexesFound)
+				})
+			}
+		})
+	}
+}

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -1,0 +1,48 @@
+package uploads
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+)
+
+const (
+	testTableName = "test-table"
+	uploader      = "test-uploader"
+)
+
+func TestTable(t *testing.T) {
+	tempDir := t.TempDir()
+	storageClient := buildTestStorageClient(t, tempDir)
+	testTable := NewTable(testTableName, uploader, storageClient)
+	defer testTable.Stop()
+
+	for userIdx := 0; userIdx < 2; userIdx++ {
+		userID := "user-" + strconv.Itoa(userIdx)
+		t.Run(userID, func(t *testing.T) {
+			userIndexPath := filepath.Join(tempDir, testTableName, userID)
+			require.NoError(t, os.MkdirAll(userIndexPath, 0755))
+
+			// build some test indexes and add them to the table.
+			testIndexes := buildTestIndexes(t, userIndexPath, 5)
+			for _, testIndex := range testIndexes {
+				require.NoError(t, testTable.AddIndex(userID, testIndex))
+			}
+
+			// see if we can find all the added indexes in the table.
+			indexesFound := map[string]*mockIndex{}
+			err := testTable.ForEach(userID, func(index index.Index) error {
+				indexesFound[index.Path()] = index.(*mockIndex)
+				return nil
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, testIndexes, indexesFound)
+		})
+	}
+}

--- a/pkg/storage/stores/indexshipper/uploads/testutil.go
+++ b/pkg/storage/stores/indexshipper/uploads/testutil.go
@@ -1,0 +1,49 @@
+package uploads
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockIndex struct {
+	*os.File
+}
+
+func newMockIndex(t *testing.T, path string) *mockIndex {
+	fl, err := os.Create(path)
+	require.NoError(t, err)
+	return &mockIndex{fl}
+}
+
+func (m *mockIndex) Name() string {
+	return filepath.Base(m.File.Name())
+}
+
+func (m *mockIndex) Path() string {
+	return m.File.Name()
+}
+
+func (m *mockIndex) Reader() (io.ReadSeeker, error) {
+	return m.File, nil
+}
+
+func buildTestIndexes(t *testing.T, path string, numIndexes int) map[string]*mockIndex {
+	testIndexes := make(map[string]*mockIndex)
+	for i := 0; i < numIndexes; i++ {
+		fileName := fmt.Sprintf("index-%d", i)
+		indexPath := filepath.Join(path, fileName)
+
+		index := newMockIndex(t, indexPath)
+		_, err := index.WriteString(fileName)
+		require.NoError(t, err)
+
+		testIndexes[indexPath] = index
+	}
+
+	return testIndexes
+}

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -39,7 +39,6 @@ const (
 	FilesystemObjectStoreType = "filesystem"
 
 	// UploadInterval defines interval for when we check if there are new index files to upload.
-	// It's also used to snapshot the currently written index tables so the snapshots can be used for reads.
 	UploadInterval = 1 * time.Minute
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
Build a generic index shipper which would be shared by `boltdb-shipper` and `tsdb-shipper` for shipping index files.
Since tsdb and boltdb based index files would have different query APIs and the way the index would be built, `index-shipper` would just manage the immutable index with following interface:
```
type Index interface {
	Name() string
	Path() string
	Close() error
	Reader() (io.ReadSeeker, error)
}
```
It has all the properties of `boltdb-shipper` like query readiness, query time downloading of index, syncs etc.
This does not have any impact yet since the code is not wired. I will slowly start wiring `boltdb-shipper` to start using `index-shipper`.

The thing that is still left to be decided is whether we will have different directories for storing boltdb and tsdb files to differentiate between type of files or we will have an extension to determine the type of file.

**Checklist**
- [x] Tests updated
