### PR TITLE
Update retention.md

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -165,7 +165,7 @@ section of the Loki configuration reference for all available options.
 Alternatively, the `table-manager.retention-period` and
 `table-manager.retention-deletes-enabled` command line flags can be used. The
 provided retention period needs to be a duration represented as a string that
-can be parsed using Go's [time.Duration](https://golang.org/pkg/time/#ParseDuration).
+can be parsed using prometheus common [model.Duration](https://pkg.go.dev/github.com/prometheus/common/model#ParseDuration) e.g. `7d`, `1w`, `168h`.
 
 > **WARNING**: The retention period must be a multiple of the index and chunks table
 `period`, configured in the [`period_config`](../../../configuration#period_config)


### PR DESCRIPTION
Retention policy actually accept suffix such as `d` and `w` but Go's time.ParseDuration does not.
See https://github.com/grafana/loki/blob/a2dd73158621441fe2d83346e792913c6770c945/pkg/storage/chunk/table_manager.go#L93

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The retention_period actually accept suffix such as `d` and `w`. Go's time package ParseDuration does not. This is confusing.
**Which issue(s) this PR fixes**:
No issues for that

**Special notes for your reviewer**:
I don't think this is worth noting in changelog but let me know if it should.

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
