### PR TITLE
Update fluent-bit output name

### DIFF
--- a/docs/sources/clients/aws/ecs/ecs-task.json
+++ b/docs/sources/clients/aws/ecs/ecs-task.json
@@ -34,7 +34,7 @@
             "logConfiguration": {
                 "logDriver": "awsfirelens",
                 "options": {
-                    "Name": "loki",
+                    "Name": "grafana-loki",
                     "Url": "https://<userid>:<grafancloud apikey>@logs-prod-us-central1.grafana.net/loki/api/v1/push",
                     "Labels": "{job=\"firelens\"}",
                     "RemoveKeys": "container_id,ecs_task_arn",


### PR DESCRIPTION
**What this PR does / why we need it**:

The configuration of the Fluent Bit plugin uses `grafana-loki` as [output name](https://github.com/grafana/loki/blob/main/clients/cmd/fluent-bit/fluent-bit.conf). In the documentation for ECS `loki` is used wrongly. This PR updates the ECS example to use `grafana-loki` as well. 

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
