### PR TITLE
operator: Add missing label matcher for openshift logging tenant mode

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [5729](https://github.com/grafana/loki/pull/5729) **periklis**: Add missing label matcher for openshift logging tenant mode (OpenShift)
 - [5691](https://github.com/grafana/loki/pull/5691) **sasagarw**: Fix immediate reset of degraded condition
 - [5704](https://github.com/grafana/loki/pull/5704) **xperimental**: Update operator-sdk to 1.18.1
 - [5693](https://github.com/grafana/loki/pull/5693) **periklis**: Replace frontend_worker parallelism with match_max_concurrent

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -200,6 +200,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--opa.package=lokistack",
+										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",
@@ -293,6 +294,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--opa.package=lokistack",
+										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",
@@ -430,6 +432,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--opa.package=lokistack",
+										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -67,10 +67,9 @@ func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile strin
 	}
 
 	return corev1.Container{
-		Name:            opaContainerName,
-		Image:           image,
-		ImagePullPolicy: corev1.PullAlways,
-		Args:            args,
+		Name:  opaContainerName,
+		Image: image,
+		Args:  args,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          GatewayOPAHTTPPortName,

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	envRelatedImageOPA = "RELATED_IMAGE_OPA"
-	defaultOPAImage    = "quay.io/observatorium/opa-openshift:latest"
-	opaContainerName   = "opa"
-	opaDefaultPackage  = "lokistack"
-	opaDefaultAPIGroup = "loki.grafana.com"
-	opaMetricsPortName = "opa-metrics"
+	envRelatedImageOPA     = "RELATED_IMAGE_OPA"
+	defaultOPAImage        = "quay.io/observatorium/opa-openshift:latest"
+	opaContainerName       = "opa"
+	opaDefaultPackage      = "lokistack"
+	opaDefaultAPIGroup     = "loki.grafana.com"
+	opaMetricsPortName     = "opa-metrics"
+	opaDefaultLabelMatcher = "kubernetes_namespace_name"
 )
 
 func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile string, withTLS bool) corev1.Container {
@@ -35,6 +36,7 @@ func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile strin
 	args = []string{
 		"--log.level=warn",
 		fmt.Sprintf("--opa.package=%s", opaDefaultPackage),
+		fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatcher),
 		fmt.Sprintf("--web.listen=:%d", GatewayOPAHTTPPort),
 		fmt.Sprintf("--web.internal.listen=:%d", GatewayOPAInternalPort),
 		fmt.Sprintf("--web.healthchecks.url=http://localhost:%d", GatewayOPAHTTPPort),
@@ -65,9 +67,10 @@ func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile strin
 	}
 
 	return corev1.Container{
-		Name:  opaContainerName,
-		Image: image,
-		Args:  args,
+		Name:            opaContainerName,
+		Image:           image,
+		ImagePullPolicy: corev1.PullAlways,
+		Args:            args,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          GatewayOPAHTTPPortName,


### PR DESCRIPTION
**What this PR does / why we need it**:
The following PR adds the missing `--opa.matcher` command line argument for the opa-openshift sidecar used when tenant mode is `openshift-logging`. This extra parameters compiles a prometheus label matcher used by Loki to limit non-admin users to have access only to logs of pods in namespace they are granted accesss to.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
