### PR TITLE
Update MultiTenantQuerier `Series()` and `Label()` to use `user.InjectOrgID()` instead of `user.InjectUserID()`

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -94,7 +94,7 @@ func (q *MultiTenantQuerier) Label(ctx context.Context, req *logproto.LabelReque
 
 	responses := make([]*logproto.LabelResponse, len(tenantIDs))
 	for i, id := range tenantIDs {
-		singleContext := user.InjectUserID(ctx, id)
+		singleContext := user.InjectOrgID(ctx, id)
 		resp, err := q.Querier.Label(singleContext, req)
 		if err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func (q *MultiTenantQuerier) Series(ctx context.Context, req *logproto.SeriesReq
 
 	responses := make([]*logproto.SeriesResponse, len(tenantIDs))
 	for i, id := range tenantIDs {
-		singleContext := user.InjectUserID(ctx, id)
+		singleContext := user.InjectOrgID(ctx, id)
 		resp, err := q.Querier.Series(singleContext, req)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

During testing for multi-tenant queries we discovered an issue with tenant IDs resulting from using the incorrect inject method. This PR updates `Label` and `Series` to use the correct method.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
