### PR TITLE
Docs: Fix promtail <client_config> block heading

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -157,10 +157,9 @@ The `server` block configures Promtail's behavior as an HTTP server:
 [health_check_target: <bool> | default = true]
 ```
 
-## clients
+## client_config
 
-The `clients` block configures how Promtail connects to instances of
-Loki:
+`client_config` configures how Promtail connects to instances of Loki:
 
 ```yaml
 # The URL where Loki is listening, denoted in Loki as http_listen_address and


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix promtail <client_config> block heading, wrongly named <client>

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
