### PR TITLE
operator: change uuids to tenant name in doc

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [5739](https://github.com/grafana/loki/pull/5739) **sasagarw** Change UUIDs to tenant name in doc
 - [5729](https://github.com/grafana/loki/pull/5729) **periklis**: Add missing label matcher for openshift logging tenant mode (OpenShift)
 - [5691](https://github.com/grafana/loki/pull/5691) **sasagarw**: Fix immediate reset of degraded condition
 - [5704](https://github.com/grafana/loki/pull/5704) **xperimental**: Update operator-sdk to 1.18.1

--- a/operator/docs/forwarding_logs_to_gateway.md
+++ b/operator/docs/forwarding_logs_to_gateway.md
@@ -229,7 +229,9 @@ kubectl -n openshift-logging edit lokistack
 ```yaml
 limits:
     tenants:
-        4a5bb098-7caf-42ec-9b1a-8e1d979bfb95:
+        <TENANT_NAME>:
             IngestionLimits:
                 IngestionRate: 15
 ```
+
+where `<TENANT_NAME>` can be application, audit or infrastructure.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
After merge of #5624, use of UUIDs for generated tenants in tenant-mode openshift-logging has been eliminated. The tenant name is re-used as tenant id.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
