### PR TITLE
[TSDB] Ensure tsdb is sorted by hash then labelset

### DIFF
--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -52,7 +52,10 @@ func (b *Builder) Build(ctx context.Context, dir string) error {
 		streams = append(streams, s)
 	}
 	sort.Slice(streams, func(i, j int) bool {
-		return streams[i].labels.Hash() < streams[j].labels.Hash()
+		if a, b := streams[i].labels.Hash(), streams[j].labels.Hash(); a != b {
+			return a < b
+		}
+		return labels.Compare(streams[i].labels, streams[j].labels) < 0
 	})
 
 	// Build symbols


### PR DESCRIPTION
Small PR to ensure that when fingerprints collide, we sort by labelset.

ref https://github.com/grafana/loki/issues/5428