### PR TITLE
lambda-promtail: fix typos in CloudFormation and Terraform files.

### DIFF
--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -1,12 +1,12 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   lambda-promtail:
-  
+
   propagate Cloudwatch Logs to Loki/Promtail via Loki Write API.
 
 Parameters:
   WriteAddress:
-    Description: 'address to write to in the form of: http<s>://<location><:port>/loki/api/v1/push'
+    Description: 'Address to write to in the form of: http<s>://<location><:port>/loki/api/v1/push'
     Type: String
     Default: 'http://localhost:8080/loki/api/v1/push'
   ReservedConcurrency:
@@ -14,11 +14,11 @@ Parameters:
     Type: Number
     Default: 2
   Username:
-    Description: The basic auth username, necessarry if writing directly to Grafana Cloud Loki.
+    Description: The basic auth username, necessary if writing directly to Grafana Cloud Loki.
     Type: String
     Default: ""
   Password:
-    Description: The basic auth password, necessarry if writing directly to Grafana Cloud Loki.
+    Description: The basic auth password, necessary if writing directly to Grafana Cloud Loki.
     Type: String
     Default: ""
     NoEcho: true
@@ -31,7 +31,7 @@ Parameters:
     Type: String
     Default: "false"
   ExtraLabels:
-    Descripton: Comma seperated list of extra labels, in the format 'name1,value1,name2,value2,...,nameN,valueN' to add to entries forwarded by Lambda-Promtail.
+    Description: Comma separated list of extra labels, in the format 'name1,value1,name2,value2,...,nameN,valueN' to add to entries forwarded by lambda-promtail.
     Type: String
     Default: ""
 
@@ -106,7 +106,7 @@ Resources:
       DestinationArn: !GetAtt LambdaPromtailFunction.Arn
       FilterPattern: ""
       LogGroupName: "/aws/lambda/some-lamda-log-group"
-  
+
 Outputs:
   LambdaPromtailFunction:
     Description: "Lambda Promtail Function ARN"

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -24,13 +24,13 @@ variable "lambda_promtail_image" {
 
 variable "username" {
   type        = string
-  description = "The basic auth username, necessarry if writing directly to Grafana Cloud Loki."
+  description = "The basic auth username, necessary if writing directly to Grafana Cloud Loki."
   default     = ""
 }
 
 variable "password" {
   type        = string
-  description = "The basic auth password, necessarry if writing directly to Grafana Cloud Loki."
+  description = "The basic auth password, necessary if writing directly to Grafana Cloud Loki."
   sensitive   = true
   default     = ""
 }
@@ -43,7 +43,7 @@ variable "keep_stream" {
 
 variable "extra_labels"{
   type = string
-  description = "Comma seperated list of extra labels, in the format 'name1,value1,name2,value2,...,nameN,valueN' to add to entries forwarded by Lambda-Promtail."
+  description = "Comma separated list of extra labels, in the format 'name1,value1,name2,value2,...,nameN,valueN' to add to entries forwarded by lambda-promtail."
   default = ""
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a typo in the CloudFormation template file (`Descripton`)
which makes it unusable, as well as some other minor typos.

**Which issue(s) this PR fixes**:
n.a.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
