### PR TITLE
Promtil: Fix a panic when using the loki push api target.

### DIFF
--- a/clients/pkg/promtail/targets/lokipush/pushtarget_test.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtarget_test.go
@@ -70,7 +70,7 @@ func TestLokiPushTarget(t *testing.T) {
 		},
 	}
 
-	pt, err := NewPushTarget(logger, eh, rlbl, "job1", config, nil)
+	pt, err := NewPushTarget(logger, eh, rlbl, "job1", config)
 	require.NoError(t, err)
 
 	// Build a client to send logs
@@ -163,7 +163,7 @@ func TestPlaintextPushTarget(t *testing.T) {
 		KeepTimestamp: true,
 	}
 
-	pt, err := NewPushTarget(logger, eh, []*relabel.Config{}, "job2", config, nil)
+	pt, err := NewPushTarget(logger, eh, []*relabel.Config{}, "job2", config)
 	require.NoError(t, err)
 
 	// Send some logs

--- a/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
@@ -44,7 +44,7 @@ func NewPushTargetManager(
 			return nil, err
 		}
 
-		t, err := NewPushTarget(logger, pipeline.Wrap(client), cfg.RelabelConfigs, cfg.JobName, cfg.PushConfig, reg)
+		t, err := NewPushTarget(logger, pipeline.Wrap(client), cfg.RelabelConfigs, cfg.JobName, cfg.PushConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

We were passing in the active metrics registry to the util tool that sets up the logger to be used by the push server, this resulted in a duplicate metrics registration.

The metric being registered is not important so this PR just passes in an empty registry to use to init the logger.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
