### PR TITLE
Fixes deduping issues when using LogQL parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+* [5770](https://github.com/grafana/loki/pull/5770) **cyriltovena** Fixes deduping issues when using LogQL parser.
 * [5696](https://github.com/grafana/loki/pull/5696) **paullryan** don't block scraping of new logs from cloudflare within promtail if an error is received from cloudflare about too early logs.
 * [5685](https://github.com/grafana/loki/pull/5625) **chaudum** Fix bug in push request parser that allowed users to send arbitrary non-string data as "log line".
 * [5707](https://github.com/grafana/loki/pull/5707) **franzwong** Promtail: Rename config name limit_config to limits_config.

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -795,6 +795,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 			for j := 0; j < int(streamCount); j++ {
 				for k := 0; k < 2; k++ { // 2 line per entry
 					require.True(t, it.Next())
+					require.Equal(t, jsonLine(i, k), it.Entry().Line)
 					require.Equal(t, i, it.Entry().Timestamp.UnixNano())
 				}
 			}
@@ -822,6 +823,7 @@ func Test_DedupeIngesterParser(t *testing.T) {
 			for j := 0; j < int(streamCount); j++ {
 				for k := 0; k < 2; k++ { // 2 line per entry
 					require.True(t, it.Next())
+					require.Equal(t, jsonLine(i, k), it.Entry().Line)
 					require.Equal(t, i, it.Entry().Timestamp.UnixNano())
 				}
 			}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -747,6 +747,140 @@ func Test_DedupeIngester(t *testing.T) {
 	})
 }
 
+func Test_DedupeIngesterParser(t *testing.T) {
+	var (
+		requests      = int64(100)
+		streamCount   = int64(10)
+		streams       []labels.Labels
+		ingesterCount = 30
+
+		ingesterConfig = defaultIngesterTestConfig(t)
+		ctx, _         = user.InjectIntoGRPCRequest(user.InjectOrgID(context.Background(), "foo"))
+	)
+	// make sure we will cut blocks and chunks and use head chunks
+	ingesterConfig.TargetChunkSize = 800
+	ingesterConfig.BlockSize = 300
+
+	// created many different ingesters
+	ingesterSet, closer := createIngesterSets(t, ingesterConfig, ingesterCount)
+	defer closer()
+
+	for i := int64(0); i < streamCount; i++ {
+		streams = append(streams, labels.FromStrings("foo", "bar", "bar", fmt.Sprintf("baz%d", i)))
+	}
+
+	for i := int64(0); i < requests; i++ {
+		for _, ing := range ingesterSet {
+			_, err := ing.Push(ctx, buildPushJSONRequest(i, streams))
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("backward log", func(t *testing.T) {
+		iterators := make([]iter.EntryIterator, 0, len(ingesterSet))
+		for _, client := range ingesterSet {
+			stream, err := client.Query(ctx, &logproto.QueryRequest{
+				Selector:  `{foo="bar"} | json`,
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(0, requests+1),
+				Limit:     uint32(requests * streamCount * 2),
+				Direction: logproto.BACKWARD,
+			})
+			require.NoError(t, err)
+			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.BACKWARD))
+		}
+		it := iter.NewMergeEntryIterator(ctx, iterators, logproto.BACKWARD)
+
+		for i := requests - 1; i >= 0; i-- {
+			for j := 0; j < int(streamCount); j++ {
+				for k := 0; k < 2; k++ { // 2 line per entry
+					require.True(t, it.Next())
+					require.Equal(t, i, it.Entry().Timestamp.UnixNano())
+				}
+			}
+		}
+		require.False(t, it.Next())
+		require.NoError(t, it.Error())
+	})
+
+	t.Run("forward log", func(t *testing.T) {
+		iterators := make([]iter.EntryIterator, 0, len(ingesterSet))
+		for _, client := range ingesterSet {
+			stream, err := client.Query(ctx, &logproto.QueryRequest{
+				Selector:  `{foo="bar"} | json`, // making it difficult to dedupe by removing uncommon label.
+				Start:     time.Unix(0, 0),
+				End:       time.Unix(0, requests+1),
+				Limit:     uint32(requests * streamCount * 2),
+				Direction: logproto.FORWARD,
+			})
+			require.NoError(t, err)
+			iterators = append(iterators, iter.NewQueryClientIterator(stream, logproto.FORWARD))
+		}
+		it := iter.NewMergeEntryIterator(ctx, iterators, logproto.FORWARD)
+
+		for i := int64(0); i < requests; i++ {
+			for j := 0; j < int(streamCount); j++ {
+				for k := 0; k < 2; k++ { // 2 line per entry
+					require.True(t, it.Next())
+					require.Equal(t, i, it.Entry().Timestamp.UnixNano())
+				}
+			}
+		}
+		require.False(t, it.Next())
+		require.NoError(t, it.Error())
+	})
+	t.Run("no sum metrics", func(t *testing.T) {
+		iterators := make([]iter.SampleIterator, 0, len(ingesterSet))
+		for _, client := range ingesterSet {
+			stream, err := client.QuerySample(ctx, &logproto.SampleQueryRequest{
+				Selector: `rate({foo="bar"} | json [1m])`,
+				Start:    time.Unix(0, 0),
+				End:      time.Unix(0, requests+1),
+			})
+			require.NoError(t, err)
+			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+		}
+		it := iter.NewMergeSampleIterator(ctx, iterators)
+
+		for i := int64(0); i < requests; i++ {
+			for j := 0; j < int(streamCount); j++ {
+				for k := 0; k < 2; k++ { // 2 line per entry
+					require.True(t, it.Next())
+					require.Equal(t, float64(1), it.Sample().Value)
+					require.Equal(t, i, it.Sample().Timestamp)
+				}
+			}
+		}
+		require.False(t, it.Next())
+		require.NoError(t, it.Error())
+	})
+	t.Run("sum metrics", func(t *testing.T) {
+		iterators := make([]iter.SampleIterator, 0, len(ingesterSet))
+		for _, client := range ingesterSet {
+			stream, err := client.QuerySample(ctx, &logproto.SampleQueryRequest{
+				Selector: `sum by (c,d,e,foo) (rate({foo="bar"} | json [1m]))`,
+				Start:    time.Unix(0, 0),
+				End:      time.Unix(0, requests+1),
+			})
+			require.NoError(t, err)
+			iterators = append(iterators, iter.NewSampleQueryClientIterator(stream))
+		}
+		it := iter.NewMergeSampleIterator(ctx, iterators)
+
+		for i := int64(0); i < requests; i++ {
+			for j := 0; j < int(streamCount); j++ {
+				for k := 0; k < 2; k++ { // 2 line per entry
+					require.True(t, it.Next())
+					require.Equal(t, float64(1), it.Sample().Value)
+					require.Equal(t, i, it.Sample().Timestamp)
+				}
+			}
+		}
+		require.False(t, it.Next())
+		require.NoError(t, it.Error())
+	})
+}
+
 type ingesterClient struct {
 	logproto.PusherClient
 	logproto.QuerierClient
@@ -821,4 +955,33 @@ func buildPushRequest(ts int64, streams []labels.Labels) *logproto.PushRequest {
 	}
 
 	return req
+}
+
+func buildPushJSONRequest(ts int64, streams []labels.Labels) *logproto.PushRequest {
+	req := &logproto.PushRequest{}
+
+	for _, stream := range streams {
+		req.Streams = append(req.Streams, logproto.Stream{
+			Labels: stream.String(),
+			Entries: []logproto.Entry{
+				{
+					Timestamp: time.Unix(0, ts),
+					Line:      jsonLine(ts, 0),
+				},
+				{
+					Timestamp: time.Unix(0, ts),
+					Line:      jsonLine(ts, 1),
+				},
+			},
+		})
+	}
+
+	return req
+}
+
+func jsonLine(ts int64, i int) string {
+	if i%2 == 0 {
+		return fmt.Sprintf(`{"a":"b", "c":"d", "e":"f", "g":"h", "ts":"%d"}`, ts)
+	}
+	return fmt.Sprintf(`{"e":"f", "h":"i", "j":"k", "g":"h", "ts":"%d"}`, ts)
 }

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -71,11 +71,11 @@ func TestIterator(t *testing.T) {
 		// Test dedupe of entries with the same timestamp but different entries.
 		{
 			iterator: NewMergeEntryIterator(context.Background(), []EntryIterator{
-				mkStreamIterator(offset(0, constant(0)), defaultLabels),
-				mkStreamIterator(offset(0, constant(0)), defaultLabels),
-				mkStreamIterator(offset(testSize, constant(0)), defaultLabels),
+				mkStreamIterator(identity, defaultLabels),
+				mkStreamIterator(identity, defaultLabels),
+				mkStreamIterator(offset(testSize, identity), defaultLabels),
 			}, logproto.FORWARD),
-			generator: constant(0),
+			generator: identity,
 			length:    2 * testSize,
 			labels:    defaultLabels,
 		},

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -139,7 +139,13 @@ func (h sampleIteratorHeap) Less(i, j int) bool {
 	s1, s2 := h.its[i].Sample(), h.its[j].Sample()
 	if s1.Timestamp == s2.Timestamp {
 		if h.its[i].StreamHash() == 0 {
+			if h.its[i].Labels() == h.its[j].Labels() {
+				return s1.Hash < s2.Hash
+			}
 			return h.its[i].Labels() < h.its[j].Labels()
+		}
+		if h.its[i].StreamHash() == h.its[j].StreamHash() {
+			return s1.Hash < s2.Hash
 		}
 		return h.its[i].StreamHash() < h.its[j].StreamHash()
 	}

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1200,7 +1200,6 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 				newLazyChunk(logproto.Stream{
 					Labels: fooLabelsWithName.String(),
 					Entries: []logproto.Entry{
-
 						{
 							Timestamp: time.Unix(2, 0),
 							Line:      "2",
@@ -1253,18 +1252,17 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 					Entries: []logproto.Entry{
 						{
 							Timestamp: time.Unix(1, 0),
-							Line:      "1",
+							Line:      "2",
 						},
 						{
 							Timestamp: time.Unix(1, 0),
-							Line:      "2",
+							Line:      "1",
 						},
 					},
 				}),
 				newLazyChunk(logproto.Stream{
 					Labels: fooLabelsWithName.String(),
 					Entries: []logproto.Entry{
-
 						{
 							Timestamp: time.Unix(1, 0),
 							Line:      "2",
@@ -1282,12 +1280,12 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 					Samples: []logproto.Sample{
 						{
 							Timestamp: time.Unix(1, 0).UnixNano(),
-							Hash:      xxhash.Sum64String("1"),
+							Hash:      xxhash.Sum64String("2"),
 							Value:     1.,
 						},
 						{
 							Timestamp: time.Unix(1, 0).UnixNano(),
-							Hash:      xxhash.Sum64String("2"),
+							Hash:      xxhash.Sum64String("1"),
 							Value:     1.,
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue when deduping logs and samples when using LogQL parser but also when streams and timestamps are equal.

The LogQL parser would extract labels and shuffle the order when batching via GRPC, however when reconstructing the order using the heap and go sorting, because the hash and the timestamp are equal, the less function would be false for all case leading to unstable sort.

Unfortunately if the sort is unstable then deduping will most likely not work, as we need to see entry tuples together.

The solution basically is to force the sort to be stable UNLESS it's a real duplicate (ts + stream hash + line) in which case we don't really care if it's unstable, since the natural order of duplicates isn't important. See the snippet below:

```diff
func (h iteratorSortHeap) Less(i, j int) bool {
        t1, t2 := h.iteratorHeap[i].Entry().Timestamp.UnixNano(), h.iteratorHeap[j].Entry().Timestamp.UnixNano()
        if t1 == t2 {
+               if h.iteratorHeap[i].StreamHash() == h.iteratorHeap[j].StreamHash() {
+                       return h.iteratorHeap[i].Entry().Line < h.iteratorHeap[j].Entry().Line
+               }
                return h.iteratorHeap[i].StreamHash() < h.iteratorHeap[j].StreamHash()
        }
```


**Special notes for your reviewer**:

**Checklist**
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
