### PR TITLE
golangci-lint: Check for pointers to enclosing loop variables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,7 @@ linters:
     - unused
     - typecheck
     - depguard
+    - exportloopref
 
 issues:
   exclude:

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -258,10 +258,11 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 			},
 		},
 	} {
+		tcCopy := tc
 		t.Run(tc.name, func(t *testing.T) {
 			resetTables()
 			tableManager.cfg.QueryReadyNumDays = tc.queryReadyNumDaysCfg
-			tableManager.cfg.Limits = &tc.queryReadinessLimits
+			tableManager.cfg.Limits = &tcCopy.queryReadinessLimits
 			require.NoError(t, tableManager.ensureQueryReadiness(context.Background()))
 
 			for name, table := range tableManager.tables {


### PR DESCRIPTION
Using the pointer to the enclosing loop variable in a range loop likely
leads to unwanted behaviour. Introducing the check [`exportloopref`](https://github.com/kyoh86/exportloopref) helps
to prevent the usage of such pointers.

> The iteration variables may be declared by the "range" clause using a
> form of short variable declaration (:=). In this case their types are
> set to the types of the respective iteration values and their scope is
> the block of the "for" statement; they are re-used in each iteration.

https://go.dev/ref/spec#For_statements

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>