### PR TITLE
Tsdb/compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage.txt
 .terraform*
 *.tfstate*
 *.tfvars
+
+# vscode
+.vscode

--- a/pkg/storage/tsdb/bounds.go
+++ b/pkg/storage/tsdb/bounds.go
@@ -1,9 +1,29 @@
 package tsdb
 
-import "github.com/prometheus/common/model"
+import (
+	"math"
+
+	"github.com/prometheus/common/model"
+)
 
 type Bounded interface {
 	Bounds() (model.Time, model.Time)
+}
+
+// InclusiveBounds will ensure the underlying Bounded implementation
+// is turned into [lower,upper] inclusivity.
+// Generally, we consider bounds to be `[lower,upper)` inclusive
+// This helper will account for integer overflow.
+// Because model.Time is millisecond-precise, but Loki uses nanosecond precision,
+// be careful usage can handle an extra millisecond being added.
+func inclusiveBounds(b Bounded) (model.Time, model.Time) {
+	lower, upper := b.Bounds()
+
+	if int64(upper) < math.MaxInt64 {
+		upper++
+	}
+
+	return lower, upper
 }
 
 type bounds struct {

--- a/pkg/storage/tsdb/bounds_test.go
+++ b/pkg/storage/tsdb/bounds_test.go
@@ -2,8 +2,10 @@ package tsdb
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +33,30 @@ func TestOverlap(t *testing.T) {
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			require.Equal(t, tc.overlap, Overlap(tc.a, tc.b))
+		})
+	}
+}
+
+func TestInclusiveBounds(t *testing.T) {
+	for i, tc := range []struct {
+		input        Bounded
+		lower, upper int64
+	}{
+		{
+			input: newBounds(0, 4),
+			lower: 0,
+			upper: 5, // increment upper by 1
+		},
+		{
+			input: newBounds(0, math.MaxInt64),
+			lower: 0,
+			upper: math.MaxInt64, // do nothing since we're already at the maximum value.
+		},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			a, b := inclusiveBounds(tc.input)
+			require.Equal(t, model.Time(tc.lower), a)
+			require.Equal(t, model.Time(tc.upper), b)
 		})
 	}
 }

--- a/pkg/storage/tsdb/compact.go
+++ b/pkg/storage/tsdb/compact.go
@@ -2,10 +2,6 @@ package tsdb
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
-	"os"
-	"path/filepath"
 
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
@@ -15,16 +11,18 @@ import (
 type Compactor struct {
 	// metrics
 	// file names (tenant, bounds, checksum?)
-	tenant string
+	tenant    string
+	parentDir string
 }
 
-func NewCompactor(tenant string) *Compactor {
+func NewCompactor(tenant, parentDir string) *Compactor {
 	return &Compactor{
-		tenant: tenant,
+		tenant:    tenant,
+		parentDir: parentDir,
 	}
 }
 
-func (c *Compactor) Compact(ctx context.Context, indices ...*TSDBIndex) (res Identifier, err error) {
+func (c *Compactor) Compact(ctx context.Context, indices ...*TSDBIndex) (res index.Identifier, err error) {
 	// No need to compact a single index file
 	if len(indices) == 1 {
 		return indices[0].Identifier(c.tenant), nil
@@ -35,8 +33,6 @@ func (c *Compactor) Compact(ctx context.Context, indices ...*TSDBIndex) (res Ide
 	if err != nil {
 		return res, err
 	}
-
-	lower, upper := inclusiveBounds(multi)
 
 	// Instead of using the MultiIndex.forIndices helper, we loop over each sub-index manually.
 	// The index builder is single threaded, so we avoid races.
@@ -55,41 +51,5 @@ func (c *Compactor) Compact(ctx context.Context, indices ...*TSDBIndex) (res Ide
 		}
 	}
 
-	// First write tenant/index-bounds-random.staging
-	rng := rand.Int63()
-	name := fmt.Sprintf("%s-%d-%d-%x.staging", index.IndexFilename, lower, upper, rng)
-	tmpPath := filepath.Join(c.tenant, name)
-
-	if err := b.Build(ctx, tmpPath); err != nil {
-		return res, err
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(tmpPath)
-		}
-	}()
-
-	// checksum and copy to
-	reader, err := index.NewFileReader(tmpPath)
-	if err != nil {
-		return res, err
-	}
-
-	// load the newly compacted index to grab checksum, promptly close
-	idx := NewTSDBIndex(reader)
-	checksum := idx.Checksum()
-	idx.Close()
-
-	dst := Identifier{
-		Tenant:   c.tenant,
-		From:     lower,
-		Through:  upper,
-		Checksum: checksum,
-	}
-
-	if err := os.Rename(tmpPath, dst.String()); err != nil {
-		return res, err
-	}
-
-	return dst, nil
+	return b.Build(ctx, c.parentDir, c.tenant)
 }

--- a/pkg/storage/tsdb/compact.go
+++ b/pkg/storage/tsdb/compact.go
@@ -1,0 +1,101 @@
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type Compactor struct {
+	// metrics
+	// file names (tenant, bounds, checksum?)
+	tenant string
+}
+
+func NewCompactor(tenant string) *Compactor {
+	return &Compactor{
+		tenant: tenant,
+	}
+}
+
+func (c *Compactor) Compact(ctx context.Context, indices ...*TSDBIndex) (res Identifier, err error) {
+	// TODO(owen-d): optimize fast path when there's only one index file.
+	b := index.NewBuilder()
+
+	multi, err := NewMultiIndex(indices...)
+	if err != nil {
+		return res, err
+	}
+	lower, upper := inclusiveBounds(multi)
+
+	// Instead of using the MultiIndex.forIndices helper, we loop over each sub-index manually.
+	// The index builder is single threaded, so we avoid races.
+	// Additionally, this increases the likelihood we add chunks in order
+	// by processing the indices in ascending order.
+	for _, idx := range multi.indices {
+		if err := idx.forSeries(
+			nil,
+			func(ls labels.Labels, _ model.Fingerprint, chks []index.ChunkMeta) {
+				// AddSeries copies chks into it's own slice
+				b.AddSeries(ls.Copy(), chks)
+			},
+			labels.MustNewMatcher(labels.MatchEqual, "", ""),
+		); err != nil {
+			return res, err
+		}
+	}
+
+	// First write tenant/index-bounds-random.staging
+	rng := rand.Int63()
+	name := fmt.Sprintf("%s-%d-%d-%x.staging", index.IndexFilename, lower, upper, rng)
+	tmpPath := filepath.Join(c.tenant, name)
+
+	if err := b.Build(ctx, tmpPath); err != nil {
+		return res, err
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tmpPath)
+		}
+	}()
+
+	// checksum and copy to
+	reader, err := index.NewFileReader(tmpPath)
+	if err != nil {
+		return res, err
+	}
+
+	// load the newly compacted index to grab checksum, promptly close
+	idx := NewTSDBIndex(reader)
+	checksum := idx.Checksum()
+	idx.Close()
+
+	// bucket/tenant/index-bounds-checksum.tsdb
+	dst := filepath.Join(
+		c.tenant,
+		fmt.Sprintf(
+			"%s-%d-%d-%x.tsdb",
+			index.IndexFilename,
+			lower,
+			upper,
+			checksum,
+		),
+	)
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return res, err
+	}
+
+	return Identifier{
+		Tenant:   c.tenant,
+		From:     lower,
+		Through:  upper,
+		Checksum: checksum,
+	}, nil
+}

--- a/pkg/storage/tsdb/compact.go
+++ b/pkg/storage/tsdb/compact.go
@@ -3,9 +3,10 @@ package tsdb
 import (
 	"context"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 type Compactor struct {

--- a/pkg/storage/tsdb/compact_test.go
+++ b/pkg/storage/tsdb/compact_test.go
@@ -1,0 +1,136 @@
+package tsdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// no file error
+// single file passthrough
+// multi file works
+// multi file dedupes
+
+func TestCompactor(t *testing.T) {
+	for _, tc := range []struct {
+		desc  string
+		err   bool
+		input [][]LoadableSeries
+		exp   []ChunkRef
+	}{
+		{
+			desc: "errors no file",
+			err:  true,
+		},
+		{
+			desc: "single file",
+			err:  false,
+			input: [][]LoadableSeries{
+				{
+					{
+						Labels: mustParseLabels(`{foo="bar"}`),
+						Chunks: []index.ChunkMeta{
+							{
+								MinTime:  0,
+								MaxTime:  3,
+								Checksum: 0,
+							},
+							{
+								MinTime:  1,
+								MaxTime:  4,
+								Checksum: 1,
+							},
+							{
+								MinTime:  2,
+								MaxTime:  5,
+								Checksum: 2,
+							},
+						},
+					},
+					{
+						Labels: mustParseLabels(`{foo="bar", bazz="buzz"}`),
+						Chunks: []index.ChunkMeta{
+							{
+								MinTime:  1,
+								MaxTime:  10,
+								Checksum: 3,
+							},
+						},
+					},
+				},
+			},
+			exp: []ChunkRef{
+				{
+					User:        "fake",
+					Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+					Start:       0,
+					End:         3,
+					Checksum:    0,
+				},
+				{
+					User:        "fake",
+					Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+					Start:       1,
+					End:         4,
+					Checksum:    1,
+				},
+				{
+					User:        "fake",
+					Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar"}`).Hash()),
+					Start:       2,
+					End:         5,
+					Checksum:    2,
+				},
+				{
+					User:        "fake",
+					Fingerprint: model.Fingerprint(mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash()),
+					Start:       1,
+					End:         10,
+					Checksum:    3,
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir := t.TempDir()
+			c := NewCompactor("fake", dir)
+
+			var indices []*TSDBIndex
+			for _, cases := range tc.input {
+				idx := BuildIndex(t, dir, "fake", cases)
+				defer idx.Close()
+				indices = append(indices, idx)
+			}
+
+			out, err := c.Compact(context.Background(), indices...)
+			if tc.err {
+				require.NotNil(t, err)
+				return
+			}
+
+			idx, err := LoadTSDBIdentifier(dir, out)
+			require.Nil(t, err)
+			defer idx.Close()
+
+			from, through := inclusiveBounds(idx)
+			res, err := idx.GetChunkRefs(
+				context.Background(),
+				"fake",
+				from,
+				through,
+				nil,
+				nil,
+				labels.MustNewMatcher(labels.MatchEqual, "", ""),
+			)
+
+			require.Nil(t, err)
+			require.Equal(t, tc.exp, res)
+
+		})
+	}
+
+}

--- a/pkg/storage/tsdb/compact_test.go
+++ b/pkg/storage/tsdb/compact_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/loki/pkg/storage/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
 func TestCompactor(t *testing.T) {
@@ -383,6 +384,7 @@ func TestCompactor(t *testing.T) {
 			require.Equal(t, tc.exp, res)
 
 		})
+
 	}
 
 }

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -2,8 +2,10 @@ package index
 
 import (
 	"context"
+	"path/filepath"
 	"sort"
 
+	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -40,6 +42,13 @@ func (b *Builder) AddSeries(ls labels.Labels, chks []ChunkMeta) {
 }
 
 func (b *Builder) Build(ctx context.Context, dir string) error {
+	// Ensure the parent dir exists (i.e. <bucket>/<tenant>/)
+	if parent := filepath.Dir(dir); parent != "" {
+		if err := chunk_util.EnsureDirectory(parent); err != nil {
+			return err
+		}
+	}
+
 	writer, err := NewWriter(ctx, dir)
 	if err != nil {
 		return err

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -36,7 +36,7 @@ func (i Identifier) String() string {
 	)
 }
 
-func (i Identifier) Combine(parentDir string) string {
+func (i Identifier) FilePath(parentDir string) string {
 	return filepath.Join(parentDir, i.String())
 }
 
@@ -159,7 +159,7 @@ func (b *Builder) Build(ctx context.Context, dir, tenant string) (id Identifier,
 		}
 	}()
 
-	dst := id.Combine(dir)
+	dst := id.FilePath(dir)
 
 	if err := os.Rename(tmpPath, dst); err != nil {
 		return id, err

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -2,13 +2,42 @@ package index
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"os"
 	"path/filepath"
 	"sort"
 
 	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 )
+
+// Identifier has all the information needed to resolve a TSDB index
+// Notably this abstracts away OS path separators, etc.
+type Identifier struct {
+	Tenant        string
+	From, Through model.Time
+	Checksum      uint32
+}
+
+func (i Identifier) String() string {
+	return filepath.Join(
+		i.Tenant,
+		fmt.Sprintf(
+			"%s-%d-%d-%x.tsdb",
+			IndexFilename,
+			i.From,
+			i.Through,
+			i.Checksum,
+		),
+	)
+}
+
+func (i Identifier) Combine(parentDir string) string {
+	return filepath.Join(parentDir, i.String())
+}
 
 // Builder is a helper used to create tsdb indices.
 // It can accept streams in any order and will create the tsdb
@@ -41,17 +70,23 @@ func (b *Builder) AddSeries(ls labels.Labels, chks []ChunkMeta) {
 	s.chunks = append(s.chunks, chks...)
 }
 
-func (b *Builder) Build(ctx context.Context, dir string) error {
-	// Ensure the parent dir exists (i.e. <bucket>/<tenant>/)
-	if parent := filepath.Dir(dir); parent != "" {
+func (b *Builder) Build(ctx context.Context, dir, tenant string) (id Identifier, err error) {
+	// Ensure the parent dir exists (i.e. index/<bucket>/<tenant>/)
+	parent := filepath.Join(dir, tenant)
+	if parent != "" {
 		if err := chunk_util.EnsureDirectory(parent); err != nil {
-			return err
+			return id, err
 		}
 	}
 
-	writer, err := NewWriter(ctx, dir)
+	// First write tenant/index-bounds-random.staging
+	rng := rand.Int63()
+	name := fmt.Sprintf("%s-%x.staging", IndexFilename, rng)
+	tmpPath := filepath.Join(parent, name)
+
+	writer, err := NewWriter(ctx, tmpPath)
 	if err != nil {
-		return err
+		return id, err
 	}
 	// TODO(owen-d): multithread
 
@@ -86,16 +121,49 @@ func (b *Builder) Build(ctx context.Context, dir string) error {
 	// Add symbols
 	for _, symbol := range symbols {
 		if err := writer.AddSymbol(symbol); err != nil {
-			return err
+			return id, err
 		}
 	}
 
 	// Add series
 	for i, s := range streams {
 		if err := writer.AddSeries(storage.SeriesRef(i), s.labels, s.chunks.finalize()...); err != nil {
-			return err
+			return id, err
 		}
 	}
 
-	return writer.Close()
+	if err := writer.Close(); err != nil {
+		return id, err
+	}
+
+	reader, err := NewFileReader(tmpPath)
+	if err != nil {
+		return id, err
+	}
+
+	from, through := reader.Bounds()
+
+	// load the newly compacted index to grab checksum, promptly close
+	id = Identifier{
+		Tenant:   tenant,
+		From:     model.Time(from),
+		Through:  model.Time(through),
+		Checksum: reader.Checksum(),
+	}
+
+	reader.Close()
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tmpPath)
+		}
+	}()
+
+	dst := id.Combine(dir)
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return id, err
+	}
+
+	return id, nil
+
 }

--- a/pkg/storage/tsdb/index/builder.go
+++ b/pkg/storage/tsdb/index/builder.go
@@ -8,10 +8,11 @@ import (
 	"path/filepath"
 	"sort"
 
-	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+
+	chunk_util "github.com/grafana/loki/pkg/storage/chunk/util"
 )
 
 // Identifier has all the information needed to resolve a TSDB index

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -51,7 +51,7 @@ func (c ChunkMetas) finalize() ChunkMetas {
 		return c
 	}
 
-	var res ChunkMetas
+	res := PoolChunkMetas.Get()
 	lastDuplicate := -1
 	prior := c[0]
 
@@ -68,11 +68,14 @@ func (c ChunkMetas) finalize() ChunkMetas {
 	// no duplicates were found, short circuit
 	// by returning unmodified underlying slice
 	if len(res) == 0 {
+		PoolChunkMetas.Put(res) // release unused slice to pool
 		return c
 	}
 
 	// otherwise, append any remaining values
 	res = append(res, c[lastDuplicate+1:]...)
+	// release self to pool; res will be returned instead
+	PoolChunkMetas.Put(c)
 	return res
 
 }

--- a/pkg/storage/tsdb/index/chunk.go
+++ b/pkg/storage/tsdb/index/chunk.go
@@ -51,7 +51,7 @@ func (c ChunkMetas) finalize() ChunkMetas {
 		return c
 	}
 
-	res := PoolChunkMetas.Get()
+	res := ChunkMetasPool.Get()
 	lastDuplicate := -1
 	prior := c[0]
 
@@ -68,14 +68,14 @@ func (c ChunkMetas) finalize() ChunkMetas {
 	// no duplicates were found, short circuit
 	// by returning unmodified underlying slice
 	if len(res) == 0 {
-		PoolChunkMetas.Put(res) // release unused slice to pool
+		ChunkMetasPool.Put(res) // release unused slice to pool
 		return c
 	}
 
 	// otherwise, append any remaining values
 	res = append(res, c[lastDuplicate+1:]...)
 	// release self to pool; res will be returned instead
-	PoolChunkMetas.Put(c)
+	ChunkMetasPool.Put(c)
 	return res
 
 }

--- a/pkg/storage/tsdb/index/index.go
+++ b/pkg/storage/tsdb/index/index.go
@@ -157,6 +157,7 @@ type TOC struct {
 // Metadata is TSDB-level metadata
 type Metadata struct {
 	From, Through int64
+	Checksum      uint32
 }
 
 func (m *Metadata) EnsureBounds(from, through int64) {
@@ -196,8 +197,9 @@ func NewTOCFromByteSlice(bs ByteSlice) (*TOC, error) {
 		PostingsTable:      d.Be64(),
 		FingerprintOffsets: d.Be64(),
 		Metadata: Metadata{
-			From:    d.Be64int64(),
-			Through: d.Be64int64(),
+			From:     d.Be64int64(),
+			Through:  d.Be64int64(),
+			Checksum: expCRC,
 		},
 	}, nil
 }
@@ -1548,6 +1550,10 @@ func (r *Reader) lookupSymbol(o uint32) (string, error) {
 
 func (r *Reader) Bounds() (int64, int64) {
 	return r.toc.Metadata.From, r.toc.Metadata.Through
+}
+
+func (r *Reader) Checksum() uint32 {
+	return r.toc.Metadata.Checksum
 }
 
 // Symbols returns an iterator over the symbols that exist within the index.

--- a/pkg/storage/tsdb/index/index.go
+++ b/pkg/storage/tsdb/index/index.go
@@ -50,7 +50,7 @@ const (
 	// FormatV2 represents 2 version of index.
 	FormatV2 = 2
 
-	indexFilename = "index"
+	IndexFilename = "index"
 
 	// store every 1024 series' fingerprints in the fingerprint offsets table
 	fingerprintInterval = 1 << 10

--- a/pkg/storage/tsdb/index/index_test.go
+++ b/pkg/storage/tsdb/index/index_test.go
@@ -122,7 +122,7 @@ func (m mockIndex) Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]Ch
 func TestIndexRW_Create_Open(t *testing.T) {
 	dir := t.TempDir()
 
-	fn := filepath.Join(dir, indexFilename)
+	fn := filepath.Join(dir, IndexFilename)
 
 	// An empty index must still result in a readable file.
 	iw, err := NewWriter(context.Background(), fn)
@@ -147,7 +147,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 func TestIndexRW_Postings(t *testing.T) {
 	dir := t.TempDir()
 
-	fn := filepath.Join(dir, indexFilename)
+	fn := filepath.Join(dir, IndexFilename)
 
 	iw, err := NewWriter(context.Background(), fn)
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestIndexRW_Postings(t *testing.T) {
 func TestPostingsMany(t *testing.T) {
 	dir := t.TempDir()
 
-	fn := filepath.Join(dir, indexFilename)
+	fn := filepath.Join(dir, IndexFilename)
 
 	iw, err := NewWriter(context.Background(), fn)
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		})
 	}
 
-	iw, err := NewWriter(context.Background(), filepath.Join(dir, indexFilename))
+	iw, err := NewWriter(context.Background(), filepath.Join(dir, IndexFilename))
 	require.NoError(t, err)
 
 	syms := []string{}
@@ -402,7 +402,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	err = iw.Close()
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(filepath.Join(dir, indexFilename))
+	ir, err := NewFileReader(filepath.Join(dir, IndexFilename))
 	require.NoError(t, err)
 
 	for p := range mi.postings {

--- a/pkg/storage/tsdb/index/pool.go
+++ b/pkg/storage/tsdb/index/pool.go
@@ -1,0 +1,22 @@
+package index
+
+import "sync"
+
+var PoolChunkMetas poolChunkMetas
+
+type poolChunkMetas struct {
+	pool sync.Pool
+}
+
+func (p *poolChunkMetas) Get() []ChunkMeta {
+	if xs := p.pool.Get(); xs != nil {
+		return xs.([]ChunkMeta)
+	}
+	return make([]ChunkMeta, 0, 1<<10)
+}
+
+func (p *poolChunkMetas) Put(xs []ChunkMeta) {
+	xs = xs[:0]
+	//nolint:staticcheck
+	p.pool.Put(xs)
+}

--- a/pkg/storage/tsdb/index/pool.go
+++ b/pkg/storage/tsdb/index/pool.go
@@ -2,20 +2,20 @@ package index
 
 import "sync"
 
-var PoolChunkMetas poolChunkMetas
+var ChunkMetasPool PoolChunkMetas
 
-type poolChunkMetas struct {
+type PoolChunkMetas struct {
 	pool sync.Pool
 }
 
-func (p *poolChunkMetas) Get() []ChunkMeta {
+func (p *PoolChunkMetas) Get() []ChunkMeta {
 	if xs := p.pool.Get(); xs != nil {
 		return xs.([]ChunkMeta)
 	}
 	return make([]ChunkMeta, 0, 1<<10)
 }
 
-func (p *poolChunkMetas) Put(xs []ChunkMeta) {
+func (p *PoolChunkMetas) Put(xs []ChunkMeta) {
 	xs = xs[:0]
 	//nolint:staticcheck
 	p.pool.Put(xs)

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -16,13 +16,9 @@ type MultiIndex struct {
 	indices []*TSDBIndex
 }
 
-func NewMultiIndex(indices ...*TSDBIndex) (Index, error) {
-	if len(indices) == 0 {
-		return nil, errors.New("must supply at least one index")
-	}
-
-	if len(indices) == 1 {
-		return indices[0], nil
+func NewMultiIndex(indices ...*TSDBIndex) (*MultiIndex, error) {
+	if len(indices) < 2 {
+		return nil, errors.New("must supply at least two indices")
 	}
 
 	sort.Slice(indices, func(i, j int) bool {

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -17,8 +17,8 @@ type MultiIndex struct {
 }
 
 func NewMultiIndex(indices ...*TSDBIndex) (*MultiIndex, error) {
-	if len(indices) < 2 {
-		return nil, errors.New("must supply at least two indices")
+	if len(indices) == 0 {
+		return nil, errors.New("must supply at least one index")
 	}
 
 	sort.Slice(indices, func(i, j int) bool {

--- a/pkg/storage/tsdb/multi_file_index.go
+++ b/pkg/storage/tsdb/multi_file_index.go
@@ -13,10 +13,10 @@ import (
 )
 
 type MultiIndex struct {
-	indices []Index
+	indices []*TSDBIndex
 }
 
-func NewMultiIndex(indices ...Index) (Index, error) {
+func NewMultiIndex(indices ...*TSDBIndex) (Index, error) {
 	if len(indices) == 0 {
 		return nil, errors.New("must supply at least one index")
 	}
@@ -55,7 +55,7 @@ func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 	return lowest, highest
 }
 
-func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, fn func(context.Context, Index) (interface{}, error)) ([]interface{}, error) {
+func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, fn func(context.Context, *TSDBIndex) (interface{}, error)) ([]interface{}, error) {
 	queryBounds := newBounds(from, through)
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -98,7 +98,7 @@ func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, thro
 	}
 	res = res[:0]
 
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx *TSDBIndex) (interface{}, error) {
 		return idx.GetChunkRefs(ctx, userID, from, through, nil, shard, matchers...)
 	})
 
@@ -134,7 +134,7 @@ func (i *MultiIndex) Series(ctx context.Context, userID string, from, through mo
 	}
 	res = res[:0]
 
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx *TSDBIndex) (interface{}, error) {
 		return idx.Series(ctx, userID, from, through, nil, shard, matchers...)
 	})
 
@@ -161,7 +161,7 @@ func (i *MultiIndex) Series(ctx context.Context, userID string, from, through mo
 }
 
 func (i *MultiIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx *TSDBIndex) (interface{}, error) {
 		return idx.LabelNames(ctx, userID, from, through, matchers...)
 	})
 
@@ -198,7 +198,7 @@ func (i *MultiIndex) LabelNames(ctx context.Context, userID string, from, throug
 }
 
 func (i *MultiIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
+	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx *TSDBIndex) (interface{}, error) {
 		return idx.LabelValues(ctx, userID, from, through, name, matchers...)
 	})
 

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -58,7 +58,7 @@ func TestMultiIndex(t *testing.T) {
 
 	// group 5 indices together, all with duplicate data
 	n := 5
-	var indices []Index
+	var indices []*TSDBIndex
 	for i := 0; i < n; i++ {
 		indices = append(indices, BuildIndex(t, cases))
 	}

--- a/pkg/storage/tsdb/multi_file_index_test.go
+++ b/pkg/storage/tsdb/multi_file_index_test.go
@@ -59,8 +59,9 @@ func TestMultiIndex(t *testing.T) {
 	// group 5 indices together, all with duplicate data
 	n := 5
 	var indices []*TSDBIndex
+	dir := t.TempDir()
 	for i := 0; i < n; i++ {
-		indices = append(indices, BuildIndex(t, cases))
+		indices = append(indices, BuildIndex(t, dir, "fake", cases))
 	}
 
 	idx, err := NewMultiIndex(indices...)

--- a/pkg/storage/tsdb/pool.go
+++ b/pkg/storage/tsdb/pool.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ChunkMetasPool = index.ChunkMetasPool // re-exporting
+	ChunkMetasPool = &index.ChunkMetasPool // re-exporting
 	SeriesPool     PoolSeries
 	ChunkRefsPool  PoolChunkRefs
 )

--- a/pkg/storage/tsdb/pool.go
+++ b/pkg/storage/tsdb/pool.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	chunkMetasPool index.PoolChunkMetas // private, internal pkg use only
+	ChunkMetasPool = index.ChunkMetasPool // re-exporting
 	SeriesPool     PoolSeries
 	ChunkRefsPool  PoolChunkRefs
 )

--- a/pkg/storage/tsdb/pool.go
+++ b/pkg/storage/tsdb/pool.go
@@ -7,27 +7,10 @@ import (
 )
 
 var (
-	chunkMetasPool poolChunkMetas // private, internal pkg use only
+	chunkMetasPool index.PoolChunkMetas // private, internal pkg use only
 	SeriesPool     PoolSeries
 	ChunkRefsPool  PoolChunkRefs
 )
-
-type poolChunkMetas struct {
-	pool sync.Pool
-}
-
-func (p *poolChunkMetas) Get() []index.ChunkMeta {
-	if xs := p.pool.Get(); xs != nil {
-		return xs.([]index.ChunkMeta)
-	}
-	return make([]index.ChunkMeta, 0, 1<<10)
-}
-
-func (p *poolChunkMetas) Put(xs []index.ChunkMeta) {
-	xs = xs[:0]
-	//nolint:staticcheck
-	p.pool.Put(xs)
-}
 
 type PoolSeries struct {
 	pool sync.Pool

--- a/pkg/storage/tsdb/querier.go
+++ b/pkg/storage/tsdb/querier.go
@@ -44,6 +44,8 @@ type IndexReader interface {
 	// Bounds returns the earliest and latest samples in the index
 	Bounds() (int64, int64)
 
+	Checksum() uint32
+
 	// Symbols return an iterator over sorted string symbols that may occur in
 	// series' labels and indices. It is not safe to use the returned strings
 	// beyond the lifetime of the index reader.

--- a/pkg/storage/tsdb/querier_test.go
+++ b/pkg/storage/tsdb/querier_test.go
@@ -91,7 +91,7 @@ func TestQueryIndex(t *testing.T) {
 	dst, err := b.Build(context.Background(), dir, "fake")
 	require.Nil(t, err)
 
-	reader, err := index.NewFileReader(dst.Combine(dir))
+	reader, err := index.NewFileReader(dst.FilePath(dir))
 	require.Nil(t, err)
 
 	p, err := PostingsForMatchers(reader, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))

--- a/pkg/storage/tsdb/querier_test.go
+++ b/pkg/storage/tsdb/querier_test.go
@@ -88,9 +88,10 @@ func TestQueryIndex(t *testing.T) {
 		b.AddSeries(s.labels, s.chunks)
 	}
 
-	require.Nil(t, b.Build(context.Background(), dir))
+	dst, err := b.Build(context.Background(), dir, "fake")
+	require.Nil(t, err)
 
-	reader, err := index.NewFileReader(dir)
+	reader, err := index.NewFileReader(dst.Combine(dir))
 	require.Nil(t, err)
 
 	p, err := PostingsForMatchers(reader, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -10,7 +10,7 @@ import (
 )
 
 func LoadTSDBIdentifier(dir string, id index.Identifier) (*TSDBIndex, error) {
-	return LoadTSDB(id.Combine(dir))
+	return LoadTSDB(id.FilePath(dir))
 }
 
 func LoadTSDB(name string) (*TSDBIndex, error) {

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -38,8 +38,8 @@ func (i *TSDBIndex) forSeries(
 	}
 
 	var ls labels.Labels
-	chks := chunkMetasPool.Get()
-	defer chunkMetasPool.Put(chks)
+	chks := ChunkMetasPool.Get()
+	defer ChunkMetasPool.Put(chks)
 
 	for p.Next() {
 		hash, err := i.reader.Series(p.At(), &ls, &chks)

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -9,6 +9,14 @@ import (
 	"github.com/grafana/loki/pkg/storage/tsdb/index"
 )
 
+// Identifier has all the information needed to resolve a TSDB index
+// Notably this abstracts away OS path separators, etc.
+type Identifier struct {
+	Tenant        string
+	From, Through model.Time
+	Checksum      uint32
+}
+
 // nolint
 type TSDBIndex struct {
 	reader IndexReader
@@ -18,6 +26,10 @@ func NewTSDBIndex(reader IndexReader) *TSDBIndex {
 	return &TSDBIndex{
 		reader: reader,
 	}
+}
+
+func (i *TSDBIndex) Close() error {
+	return i.reader.Close()
 }
 
 func (i *TSDBIndex) Bounds() (model.Time, model.Time) {

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -133,3 +133,7 @@ func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, na
 	}
 	return labelValuesWithMatchers(i.reader, name, matchers...)
 }
+
+func (i *TSDBIndex) Checksum() uint32 {
+	return i.reader.Checksum()
+}

--- a/pkg/storage/tsdb/single_file_index.go
+++ b/pkg/storage/tsdb/single_file_index.go
@@ -2,6 +2,8 @@ package tsdb
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -15,6 +17,19 @@ type Identifier struct {
 	Tenant        string
 	From, Through model.Time
 	Checksum      uint32
+}
+
+func (i Identifier) String() string {
+	return filepath.Join(
+		i.Tenant,
+		fmt.Sprintf(
+			"%s-%d-%d-%x.tsdb",
+			index.IndexFilename,
+			i.From,
+			i.Through,
+			i.Checksum,
+		),
+	)
 }
 
 // nolint
@@ -148,4 +163,14 @@ func (i *TSDBIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, na
 
 func (i *TSDBIndex) Checksum() uint32 {
 	return i.reader.Checksum()
+}
+
+func (i *TSDBIndex) Identifier(tenant string) Identifier {
+	lower, upper := i.Bounds()
+	return Identifier{
+		Tenant:   tenant,
+		From:     lower,
+		Through:  upper,
+		Checksum: i.Checksum(),
+	}
 }

--- a/pkg/storage/tsdb/single_file_index_test.go
+++ b/pkg/storage/tsdb/single_file_index_test.go
@@ -55,7 +55,7 @@ func TestSingleIdx(t *testing.T) {
 		},
 	}
 
-	idx := BuildIndex(t, cases)
+	idx := BuildIndex(t, t.TempDir(), "fake", cases)
 
 	t.Run("GetChunkRefs", func(t *testing.T) {
 		refs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))

--- a/pkg/storage/tsdb/util_test.go
+++ b/pkg/storage/tsdb/util_test.go
@@ -24,7 +24,7 @@ func BuildIndex(t *testing.T, dir, tenant string, cases []LoadableSeries) *TSDBI
 
 	dst, err := b.Build(context.Background(), dir, tenant)
 	require.Nil(t, err)
-	location := dst.Combine(dir)
+	location := dst.FilePath(dir)
 
 	idx, err := LoadTSDB(location)
 	require.Nil(t, err)

--- a/pkg/storage/tsdb/util_test.go
+++ b/pkg/storage/tsdb/util_test.go
@@ -15,18 +15,18 @@ type LoadableSeries struct {
 	Chunks index.ChunkMetas
 }
 
-func BuildIndex(t *testing.T, cases []LoadableSeries) *TSDBIndex {
-	dir := t.TempDir()
+func BuildIndex(t *testing.T, dir, tenant string, cases []LoadableSeries) *TSDBIndex {
 	b := index.NewBuilder()
 
 	for _, s := range cases {
 		b.AddSeries(s.Labels, s.Chunks)
 	}
 
-	require.Nil(t, b.Build(context.Background(), dir))
-
-	reader, err := index.NewFileReader(dir)
+	dst, err := b.Build(context.Background(), dir, tenant)
 	require.Nil(t, err)
+	location := dst.Combine(dir)
 
-	return NewTSDBIndex(reader)
+	idx, err := LoadTSDB(location)
+	require.Nil(t, err)
+	return idx
 }

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	source = flag.String("source", "", "the source boltdb file")
-	dest   = flag.String("dest", "", "the dest tsdb file")
+	dest   = flag.String("dest", "", "the dest tsdb dir")
 	// Hardcode a periodconfig for convenience as the boltdb iterator needs one
 	// NB: must match the index file you're reading from
 	periodConfig = func() chunk.PeriodConfig {
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	log.Println("writing index")
-	if err := builder.Build(context.Background(), *dest); err != nil {
+	if _, err := builder.Build(context.Background(), *dest, "fake"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This PR introduces a first pass at a TSDB compactor. It also standardizes the names of TSDB files to the format `"index-${from}-${through}-${checksum}.tsdb"`. It combines multiple TSDB files and dedupes their contents where appropriate.

To do this, I've added a `Checksum() uint32` method where appropriate (`IndexReader` and `TSDBIndex`).
For added performance, I also moved the `[]ChunkMetas` pool into the underlying `tsdb/index` package although it's still exported and used by the `tsdb` package as well as the `index` package now.

ref https://github.com/grafana/loki/issues/5428