### PR TITLE
Update references to the latest build image

### DIFF
--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.20.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.20.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image as build
+FROM grafana/loki-build-image:0.20.0 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.20.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.20.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.18.0
+ARG BUILD_IMAGE=grafana/loki-build-image:0.20.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .


### PR DESCRIPTION
**What this PR does / why we need it**:

This uses the latest alpine:3.15.4 image build image with tag `0.20.0` everywhere. Esp. promtail seems to have been stuck on an older tag.
