### PR TITLE
Return bad request for multi-tenant tail.

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -236,18 +236,19 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tenantID, err := tenant.TenantID(r.Context())
+	if err != nil {
+		level.Warn(logger).Log("msg", "error getting tenant id", "err", err)
+		serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, err.Error()), w)
+		return
+	}
+
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error in upgrading websocket", "err", err)
 		return
 	}
 
-	tenantID, err := tenant.TenantID(r.Context())
-	if err != nil {
-		level.Error(logger).Log("msg", "error getting tenant id", "err", err)
-		serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, err.Error()), w)
-		return
-	}
 	level.Info(logger).Log("msg", "starting to tail logs", "tenant", tenantID, "selectors", req.Query)
 
 	defer func() {

--- a/tools/dev/loki-boltdb-storage-s3/config/datasource.yaml
+++ b/tools/dev/loki-boltdb-storage-s3/config/datasource.yaml
@@ -8,3 +8,7 @@ datasources:
     type: loki
     access: proxy
     url: http://query-frontend:8007
+    jsonData:
+      httpHeaderName1: 'X-Scope-OrgID'
+    secureJsonData:
+      httpHeaderValue1: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
The `/tail` endpoint is expected to return `HTTP 400` bad request when more than one tenant is present in the context. This change introduces this behaviour *bofore* the connection is upgraded to a web socket.

This pull request also fixes the datasource configuration for the Docker Compose development environment.

**Which issue(s) this PR fixes**:
Closes #5753

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
