### PR TITLE
fix boltdb-shipper doc

### DIFF
--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -73,7 +73,7 @@ Let us talk about more in depth about how both Ingesters and Queriers work when 
 
 ### Ingesters
 
-Ingesters keep writing the index to BoltDB files in `active_index_directory` and BoltDB Shipper keeps looking for new and updated files in that directory every 15 Minutes to upload them to the shared object store.
+Ingesters keep writing the index to BoltDB files in `active_index_directory` and BoltDB Shipper keeps looking for new and updated files in that directory every 1 Minutes to upload them to the shared object store.
 When running Loki in clustered mode there could be multiple ingesters serving write requests hence each of them generating BoltDB files locally.
 
 **Note:** To avoid any loss of index when Ingester crashes it is recommended to run Ingesters as statefulset(when using k8s) with a persistent storage for storing index files.


### PR DESCRIPTION

	// UploadInterval defines interval for when we check if there are new index files to upload.
	// It's also used to snapshot the currently written index tables so the snapshots can be used for reads.
	UploadInterval = 1 * time.Minute


![image](https://user-images.githubusercontent.com/9583245/162120104-3881a87e-bf88-4f70-984a-9c7fc9957bb0.png)

@sandeepsukhani 