### PR TITLE
Release 2.5.x

### DIFF
--- a/docs/sources/logql/log_queries.md
+++ b/docs/sources/logql/log_queries.md
@@ -242,7 +242,7 @@ It will evaluate first `duration >= 20ms or method="GET"`. To evaluate first `me
 
 > Label filter expressions are the only expression allowed after the unwrap expression. This is mainly to allow filtering errors from the metric extraction.
 
-Label filter expressions have support matching IP addresses. See [Matching IP addresses](ip/) for details.
+Label filter expressions have support matching IP addresses. See [Matching IP addresses](../ip/) for details.
 
 ### Parser expression
 

--- a/docs/sources/release-notes/v2-5.md
+++ b/docs/sources/release-notes/v2-5.md
@@ -1,6 +1,54 @@
 ---
 title: V2.5
-weight: 88
+weight: 77
 ---
 
 # Version 2.5 release notes
+
+Loki 2.5 focuses on X items:
+
+- item 1 here
+- item 2 here
+
+## Features and enhancements
+
+- Feature description here.
+- Another feature description here.
+
+For a full list of all changes please look at the [CHANGELOG](https://github.com/grafana/loki/blob/main/CHANGELOG.md).
+
+## Upgrade Considerations
+
+**Do we need this section?**
+
+Please read the [upgrade guide](../../upgrading/#240) before updating Loki.
+
+We made a lot of changes to Loki’s configuration as part of this release.
+We have tried our best to make sure changes are compatible with existing configurations, however some changes to default limits may impact users who didn't have values explicitly set for these limits in their configuration files.
+
+### v2.5.0 changes to defaults
+
+**Do we need this section?**
+
+Here is a list of limit defaults that have changed in v2.5.0:
+
+| config | new default | old default |
+| --- | --- | --- |
+| param name here | new value | old value |
+
+## Bug fixes
+
+### 2.5.0 bug fixes
+2.0.0 fixes these bugs:
+
+- [PR XXXX](https://github.com/grafana/loki/pull/XXXX) **github-handle**: Description of the bug fix here.
+
+## Security fixes
+
+**Do we need this section?**
+
+### 2.5.0 security fixes
+
+Version 2.5.0 contains X security-related fix:
+
+* [PR XXXX](https://github.com/grafana/loki/pull/XXXX) Description of security-related fix here.


### PR DESCRIPTION
backports:

- #5533 https://github.com/grafana/loki/pull/5533
- #5550 https://github.com/grafana/loki/pull/5550
