### PR TITLE
fix missing file during rpm and deb packaging step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,11 @@ dist: clean
 	pushd dist && sha256sum * > SHA256SUMS && popd
 
 packages: dist
+	mkdir -p dist/tmp
+	unzip dist/logcli-linux-amd64.zip -d dist/tmp
 	nfpm package -f tools/nfpm.yaml -p rpm -t dist/
 	nfpm package -f tools/nfpm.yaml -p deb -t dist/
+	rm -rf dist/tmp
 
 publish: packages
 	./tools/release

--- a/tools/nfpm.yaml
+++ b/tools/nfpm.yaml
@@ -1,10 +1,11 @@
+---
 name: "logcli"
 arch: "amd64"
 platform: "linux"
 version: ${CIRCLE_TAG}
 section: "default"
 provides:
-- logcli 
+  - logcli
 maintainer: "Grafana Labs <support@grafana.com>"
 description: |
   LogCLI is the command-line interface to Loki.
@@ -13,5 +14,5 @@ vendor: "Grafana Labs Inc"
 homepage: "https://grafana.com/loki"
 license: "AGPL-3.0"
 contents:
-- src: ./dist/logcli-linux-amd64
-  dst: /usr/local/bin/logcli
+  - src: ./dist/tmp/logcli-linux-amd64
+    dst: /usr/local/bin/logcli


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

The `packages` step in our Makefile has never worked as far as I can tell, this fixes it so the Circle CI release job will work.

**Which issue(s) this PR fixes**:
The `-m` flag during the `zip` stage of `dist` will move the file into the resulting zip, meaning it is no longer in the `dist` folder. As a result, the `packages` step, which is looking for the compiled `logcli-linux-amd64` binary in the `dist` folder will always fail. 

This change unzips the `logcli` zip to a tmp folder so the `packages` step can find it.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
