### PR TITLE
improve mutex locking when writing index in boltdb-shipper

### DIFF
--- a/pkg/storage/stores/shipper/uploads/table.go
+++ b/pkg/storage/stores/shipper/uploads/table.go
@@ -226,15 +226,18 @@ func (lt *Table) MultiQueries(ctx context.Context, queries []chunk.IndexQuery, c
 }
 
 func (lt *Table) getOrAddDB(name string) (*bbolt.DB, error) {
+	lt.dbsMtx.RLock()
+	db, ok := lt.dbs[name]
+	lt.dbsMtx.RUnlock()
+
+	if ok {
+		return db, nil
+	}
+
 	lt.dbsMtx.Lock()
 	defer lt.dbsMtx.Unlock()
 
-	var (
-		db  *bbolt.DB
-		err error
-		ok  bool
-	)
-
+	var err error
 	db, ok = lt.dbs[name]
 	if !ok {
 		db, err = shipper_util.SafeOpenBoltdbFile(filepath.Join(lt.path, name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
We currently take an exclusive lock for each index write to check whether desired index file exists which can cause contention. This PR improves the code by checking index file exists with a read lock and then takes a write lock to create if it does not exist.
