### PR TITLE
gcs client: use fake credentials in unit test

### DIFF
--- a/pkg/storage/chunk/gcp/instrumentation.go
+++ b/pkg/storage/chunk/gcp/instrumentation.go
@@ -71,10 +71,12 @@ func gcsInstrumentation(ctx context.Context, scope string, insecure bool, http2 
 		customTransport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 		customTransport.ForceAttemptHTTP2 = false
 	}
+	transportOptions := []option.ClientOption{option.WithScopes(scope)}
 	if insecure {
 		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		transportOptions = append(transportOptions, option.WithAPIKey("insecure"))
 	}
-	transport, err := google_http.NewTransport(ctx, customTransport, option.WithScopes(scope))
+	transport, err := google_http.NewTransport(ctx, customTransport, transportOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This avoids the GCS library looking up credentials from the user's environment and possibly contacting Google servers, as described at https://cloud.google.com/docs/authentication/production

['Insecure' mode](https://github.com/grafana/loki/blob/ba6a2fd41eb0d506015f24fb6f7904c25b8e166c/pkg/storage/chunk/gcp/gcs_object_client.go#L37) is only used in unit tests, so I piggy-backed on that to set a fake API key.

**Which issue(s) this PR fixes**:
Fixes #5832 

**Checklist**
- NA Documentation added
- NA Tests updated
- NA - not user-visible. Add an entry in the `CHANGELOG.md` about the changes.
