### PR TITLE
TestPromtail: avoid hanging when test fails midway

### DIFF
--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -114,6 +114,9 @@ func (p *Promtail) Client() client.Client {
 func (p *Promtail) Shutdown() {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
+	if p.stopped {
+		return
+	}
 	p.stopped = true
 	if p.server != nil {
 		p.server.Shutdown()

--- a/clients/pkg/promtail/promtail_test.go
+++ b/clients/pkg/promtail/promtail_test.go
@@ -86,6 +86,9 @@ func TestPromtail(t *testing.T) {
 		server    = &http.Server{Addr: "localhost:3100", Handler: nil}
 	)
 	defer func() {
+		if t.Failed() {
+			return // Test has already failed; don't wait for everything to shut down.
+		}
 		fmt.Fprintf(os.Stdout, "wait close")
 		wg.Wait()
 		if err != nil {
@@ -117,6 +120,7 @@ func TestPromtail(t *testing.T) {
 			err = errors.Wrap(err, "Failed to start promtail")
 		}
 	}()
+	defer p.Shutdown() // In case the test fails before the call to Shutdown below.
 
 	expectedCounts := map[string]int{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Check if the test has already failed before waiting for everything to exit.

Also call `Shutdown()` via `defer` so we clean up those resources when the test fails.

**Which issue(s) this PR fixes**:
Fixes #5836

**Special notes for your reviewer**:

**Checklist**
- NA Documentation added
- [x] Tests updated
- NA Add an entry in the `CHANGELOG.md` about the changes.

