### PR TITLE
usagestats tests: don't check unpredictable number

### DIFF
--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -50,7 +50,7 @@ func Test_BuildReport(t *testing.T) {
 	require.Equal(t, r.Edition, "OSS")
 	require.Equal(t, r.Target, "compactor")
 	require.Equal(t, r.Metrics["num_cpu"], runtime.NumCPU())
-	require.Equal(t, r.Metrics["num_goroutine"], runtime.NumGoroutine())
+	// Don't check num_goroutine because it could have changed since the report was created.
 	require.Equal(t, r.Metrics["compression"], "lz4")
 	require.Equal(t, r.Metrics["compression_ratio"], int64(100))
 	require.Equal(t, r.Metrics["size_mb"], 200.1)


### PR DESCRIPTION
**What this PR does / why we need it**:

If this test is run alongside a number of other tests then the number of goroutines can change between when the report is generated and when the result is checked, which will cause the test to fail.

**Checklist**
- NA Documentation added
- [x] Tests updated
- NA Add an entry in the `CHANGELOG.md` about the changes.
