### PR TITLE
Makefile: run lint and tests with default garbage-collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ publish: packages
 # To run this efficiently on your workstation, run this from the root dir:
 # docker run --rm --tty -i -v $(pwd)/.cache:/go/cache -v $(pwd)/.pkg:/go/pkg -v $(pwd):/src/loki grafana/loki-build-image:0.17.0 lint
 lint:
-	GO111MODULE=on GOGC=10 golangci-lint run -v
+	GO111MODULE=on golangci-lint run -v
 	faillint -paths "sync/atomic=go.uber.org/atomic" ./...
 
 ########
@@ -260,7 +260,7 @@ lint:
 ########
 
 test: all
-	GOGC=10 $(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./...
 
 #########
 # Clean #


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting GOGC=10 makes Go run garbage-collection every time the heap gets 10% bigger than it was before, which does keep the max size down but slows down memory-intensive operations.

Since this was [added for CircleCI](https://github.com/grafana/loki/pull/1022/commits/edea13fd929f27426d4b1a090923ad2b343a22fd), and we don't run those operations on CircleCI any more, remove the setting.

Comparison: tests go from 3min 10sec to 2min 14sec and lint from 3min 53sec to 1min 9sec.
Before:
```
$ GOGC=10 /bin/time go test --count=1 ./...
406.41user 76.88system 3:10.22elapsed 254%CPU (0avgtext+0avgdata 953252maxresident)k
348928inputs+7543984outputs (7044major+5071863minor)pagefaults 0swaps

$ golangci-lint cache clean
$ GOGC=10 /bin/time golangci-lint run -v
[...]
INFO Memory: 1719 samples, avg is 1151.9MB, max is 2096.4MB 
INFO Execution took 3m52.338049062s               
Command exited with non-zero status 1
809.98user 36.44system 3:53.05elapsed 363%CPU (0avgtext+0avgdata 2005896maxresident)k
2138360inputs+122872outputs (295major+540853minor)pagefaults 0swaps
```

After:
```
$ /bin/time go test --count=1 ./...
307.18user 46.39system 2:14.44elapsed 262%CPU (0avgtext+0avgdata 1149340maxresident)k
296inputs+7542656outputs (6214major+5333517minor)pagefaults 0swaps

$ golangci-lint cache clean
$ /bin/time golangci-lint run -v
INFO Memory: 473 samples, avg is 2639.7MB, max is 4503.1MB 
INFO Execution took 1m8.551118307s                
Command exited with non-zero status 1
220.88user 20.38system 1:09.32elapsed 348%CPU (0avgtext+0avgdata 4418872maxresident)k
493192inputs+122968outputs (5major+1164526minor)pagefaults 0swaps
```


**Checklist**
- NA Documentation added
- NA Tests updated
- NA Add an entry in the `CHANGELOG.md` about the changes.
