### PR TITLE
[promtail] Mark promtail single client config flags and config file block as deprecated

### DIFF
--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -46,17 +46,17 @@ type Config struct {
 // RegisterFlags with prefix registers flags where every name is prefixed by
 // prefix. If prefix is a non-empty string, prefix should end with a period.
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.Var(&c.URL, prefix+"client.url", "URL of log server")
-	f.DurationVar(&c.BatchWait, prefix+"client.batch-wait", BatchWait, "Maximum wait period before sending batch.")
-	f.IntVar(&c.BatchSize, prefix+"client.batch-size-bytes", BatchSize, "Maximum batch size to accrue before sending. ")
+	f.Var(&c.URL, prefix+"client.url", "URL of log server (deprecated).")
+	f.DurationVar(&c.BatchWait, prefix+"client.batch-wait", BatchWait, "Maximum wait period before sending batch (deprecated).")
+	f.IntVar(&c.BatchSize, prefix+"client.batch-size-bytes", BatchSize, "Maximum batch size to accrue before sending (deprecated).")
 	// Default backoff schedule: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(4.267m) For a total time of 511.5s(8.5m) before logs are lost
-	f.IntVar(&c.BackoffConfig.MaxRetries, prefix+"client.max-retries", MaxRetries, "Maximum number of retires when sending batches.")
-	f.DurationVar(&c.BackoffConfig.MinBackoff, prefix+"client.min-backoff", MinBackoff, "Initial backoff time between retries.")
-	f.DurationVar(&c.BackoffConfig.MaxBackoff, prefix+"client.max-backoff", MaxBackoff, "Maximum backoff time between retries.")
-	f.DurationVar(&c.Timeout, prefix+"client.timeout", Timeout, "Maximum time to wait for server to respond to a request")
-	f.Var(&c.ExternalLabels, prefix+"client.external-labels", "list of external labels to add to each log (e.g: --client.external-labels=lb1=v1,lb2=v2)")
+	f.IntVar(&c.BackoffConfig.MaxRetries, prefix+"client.max-retries", MaxRetries, "Maximum number of retires when sending batches (deprecated).")
+	f.DurationVar(&c.BackoffConfig.MinBackoff, prefix+"client.min-backoff", MinBackoff, "Initial backoff time between retries (deprecated).")
+	f.DurationVar(&c.BackoffConfig.MaxBackoff, prefix+"client.max-backoff", MaxBackoff, "Maximum backoff time between retries (deprecated).")
+	f.DurationVar(&c.Timeout, prefix+"client.timeout", Timeout, "Maximum time to wait for server to respond to a request (deprecated).")
+	f.Var(&c.ExternalLabels, prefix+"client.external-labels", "list of external labels to add to each log (e.g: --client.external-labels=lb1=v1,lb2=v2) (deprecated).")
 
-	f.StringVar(&c.TenantID, prefix+"client.tenant-id", "", "Tenant ID to use when pushing logs to Loki.")
+	f.StringVar(&c.TenantID, prefix+"client.tenant-id", "", "Tenant ID to use when pushing logs to Loki (deprecated).")
 }
 
 // RegisterFlags registers flags.

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	dskit_flagext "github.com/grafana/dskit/flagext"
 
 	yaml "gopkg.in/yaml.v2"
@@ -59,8 +61,9 @@ func (c Config) String() string {
 	return string(b)
 }
 
-func (c *Config) Setup() {
+func (c *Config) Setup(l log.Logger) {
 	if c.ClientConfig.URL.URL != nil {
+		level.Warn(l).Log("msg", "use of CLI client.* and config file Client block are both deprecated in favour of the config file Clients block and will be removed in a future release")
 		// if a single client config is used we add it to the multiple client config for backward compatibility
 		c.ClientConfigs = append(c.ClientConfigs, c.ClientConfig)
 	}

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/go-kit/log"
 	dskitflagext "github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -137,7 +138,7 @@ func TestConfig_Setup(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			tt.in.Setup()
+			tt.in.Setup(log.NewNopLogger())
 			require.Equal(t, tt.expected, tt.in)
 		})
 	}

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -61,7 +61,7 @@ func New(cfg config.Config, metrics *client.Metrics, dryRun bool, opts ...Option
 		o(promtail)
 	}
 
-	cfg.Setup()
+	cfg.Setup(promtail.logger)
 
 	if cfg.LimitsConfig.ReadlineRateEnabled {
 		stages.SetReadLineRateLimiter(cfg.LimitsConfig.ReadlineRate, cfg.LimitsConfig.ReadlineBurst, cfg.LimitsConfig.ReadlineRateDrop)

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1797,7 +1797,7 @@ server:
 positions:
   filename: /var/log/positions.yaml # This location needs to be writeable by Promtail.
 
-client:
+clients:
   url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
 
 scrape_configs:
@@ -1826,8 +1826,8 @@ server:
 positions:
   filename: /var/log/positions.yaml # This location needs to be writeable by Promtail.
 
-client:
-  url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
+clients:
+  - url: http://ip_or_hostname_where_Loki_run:3100/loki/api/v1/push
 
 scrape_configs:
  - job_name: system


### PR DESCRIPTION
It can be confusing to end users to try and understand the interaction between setting `client`, `clients` (in the config file), and cli flags `client.*` (such as `client.url`) as to which has priority and what will happen if multiple are set. See [this](https://grafana.slack.com/archives/CEPJRLQNL/p1649334559202859) community slack thread.

Here I am proposing that we mark the config file `client` block and CLI `client.*` flags as deprecated, including a warning log line when they are used, in preparation for removing them in a future release.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

**Checklist**
- [x] Documentation added
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
