### PR TITLE
Ingester: limit max chunks per flush

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -256,7 +256,7 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 	return nil
 }
 
-func (i *Ingester) collectChunksToFlush(instance *instance, fp model.Fingerprint, immediate bool) ([]*chunkDesc, labels.Labels, *sync.RWMutex) {
+func (i *Ingester) collectChunksToFlush(instance *instance, fp model.Fingerprint, immediate bool) ([]*chunkDesc, labels.Labels, *sync.RWMutex, bool) {
 	var stream *stream
 	var ok bool
 	stream, ok = instance.streams.LoadByFP(fp)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -71,6 +71,7 @@ type Config struct {
 	ConcurrentFlushes   int               `yaml:"concurrent_flushes"`
 	FlushCheckPeriod    time.Duration     `yaml:"flush_check_period"`
 	FlushOpTimeout      time.Duration     `yaml:"flush_op_timeout"`
+	MaxChunksPerFlushOp int               `yaml:"max_chunks_per_flush_op"`
 	RetainPeriod        time.Duration     `yaml:"chunk_retain_period"`
 	MaxChunkIdle        time.Duration     `yaml:"chunk_idle_period"`
 	BlockSize           int               `yaml:"chunk_block_size"`
@@ -112,6 +113,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 32, "")
 	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-check-period", 30*time.Second, "")
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 10*time.Minute, "")
+	f.IntVar(&cfg.MaxChunksPerFlushOp, "ingester.max-chunks-per-flush-op", 0, "")
 	f.DurationVar(&cfg.RetainPeriod, "ingester.chunks-retain-period", 0, "")
 	f.DurationVar(&cfg.MaxChunkIdle, "ingester.chunks-idle-period", 30*time.Minute, "")
 	f.IntVar(&cfg.BlockSize, "ingester.chunks-block-size", 256*1024, "")
@@ -144,6 +146,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.IndexShards <= 0 {
 		return fmt.Errorf("invalid ingester index shard factor: %d", cfg.IndexShards)
+	}
+
+	if cfg.MaxChunksPerFlushOp < 0 {
+		return errors.New("max_chunks_per_flush_op must be >=0")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems possible for Loki ingesters to build up streams that are have too many unflushed chunks to successfully flush within a single flush op timeout period. This diff caps the number of chunks that a single flush will attempt to commit to storage. Ideally, this will allow ingesters to incrementally reclaim memory after or during storage degradation.

**Which issue(s) this PR fixes**:
This may address some of the reports in #5267 

**Special notes for your reviewer**:

**Checklist**
- [ ] Tests updated
- [ ] Metrics Added
- [ ] Documentation added
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
