### PR TITLE
[promtail] Add a log message stating that client level stream lag labels are deprecated

### DIFF
--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -163,7 +163,7 @@ type Tripperware func(http.RoundTripper) http.RoundTripper
 // New makes a new Client.
 func New(metrics *Metrics, cfg Config, streamLagLabels []string, logger log.Logger) (Client, error) {
 	if cfg.StreamLagLabels.String() != "" {
-		return nil, errors.New(fmt.Sprintf("client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored: %+v", cfg.StreamLagLabels.String()))
+		return nil, fmt.Errorf("client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored: %+v", cfg.StreamLagLabels.String())
 	}
 	return newClient(metrics, cfg, streamLagLabels, logger)
 }

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -162,6 +162,9 @@ type Tripperware func(http.RoundTripper) http.RoundTripper
 
 // New makes a new Client.
 func New(metrics *Metrics, cfg Config, streamLagLabels []string, logger log.Logger) (Client, error) {
+	if cfg.StreamLagLabels.String() != "" {
+		level.Warn(logger).Log("msg", "client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored", "stream_lag_labels", cfg.StreamLagLabels.String())
+	}
 	return newClient(metrics, cfg, streamLagLabels, logger)
 }
 

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -163,7 +163,7 @@ type Tripperware func(http.RoundTripper) http.RoundTripper
 // New makes a new Client.
 func New(metrics *Metrics, cfg Config, streamLagLabels []string, logger log.Logger) (Client, error) {
 	if cfg.StreamLagLabels.String() != "" {
-		level.Warn(logger).Log("msg", "client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored", "stream_lag_labels", cfg.StreamLagLabels.String())
+		return nil, errors.New(fmt.Sprintf("client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored: %+v", cfg.StreamLagLabels.String()))
 	}
 	return newClient(metrics, cfg, streamLagLabels, logger)
 }


### PR DESCRIPTION
Add a log message stating that client level stream lag labels deprecated and will not be used. 

Alternatively, we have talked about simply removing this field from the client config. This would break users who currently have the `stream_lag_labels` field set, but would really only be problematic for users who had multiple clients configured with different `stream_lag_labels` values. However, this configuration is technically not semantically correct, and wouldn't be accepted in future versions of promtail anyways. 

I'm opening this PR so we have a single place where we can make a decision on which of these two options to go with:
1. the change in this PR, and remove the deprecated in a future major release
2. make the breaking change now

Personally I would choose option 2 but if we want to keep the current (in main branch) implementation we should at least log that the per client value will ignored (as in this PR)

Signed-off-by: Callum Styan <callumstyan@gmail.com>
