### PR TITLE
Docs: Add usage reporting section to 2.5 release notes

### DIFF
--- a/docs/sources/release-notes/v2-5.md
+++ b/docs/sources/release-notes/v2-5.md
@@ -55,6 +55,21 @@ We continue to move defaults in Loki to leverage parallelism in all configuratio
 
 In v2.5, all queries will be split and sharded by default. This will likely result in increased memory and CPU usage for Loki processes during queries, if you didn’t previously have these values enabled.
 
+## Usage reporting
+
+Loki 2.5 includes code we added to report anonymous usage statistics back to Grafana Labs, [an issue was created to outline the intent](https://github.com/grafana/loki/issues/5062), and what went into the final implementation [can be seen here in the source](https://github.com/grafana/loki/blob/v2.5.0/pkg/usagestats/stats.go#L75).
+
+Usage reporting helps provide anonymous information on how people use Loki and what the Loki team should focus on for features and documentation. No private information is collected, and all reports are completely anonymous. 
+
+If possible, we ask you to leave the usage reporting feature enabled and help us understand more about Loki! We are also working to figure out how we can share this info with the community so everyone can watch Loki grow.
+
+If you would rather not participate in usage stats reporting, [the feature can be disabled in config](https://grafana.com/docs/loki/latest/configuration/#analytics)
+
+```
+analytics:
+  reporting_enabled: false
+```
+
 ## Bug fixes
 
 ### 2.5.0 bug fixes


### PR DESCRIPTION
I realized I forgot this when writing the blogpost.