### PR TITLE
doc: fix default table for 2.4 release

### DIFF
--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -206,9 +206,9 @@ present in your Loki config: `ingestion_rate_strategy`, `max_global_streams_per_
 
 | config | new default | old default|
 | --- | --- | --- |
-| chunk_retain_period | 30s | 0s |
-| chunk_idle_period | 1h | 30m |
-| chunk_target_size | 1048576 | 1572864 |
+| chunk_retain_period | 0s | 30s |
+| chunk_idle_period | 30m | 1h |
+| chunk_target_size | 1572864 | 1048576 |
 
 * chunk_retain_period is necessary when using an index queries cache which is not enabled by default. If you have configured an index_queries_cache_config section make sure that you set chunk_retain_period larger than your cache TTL
 * chunk_idle_period is how long before a chunk which receives no logs is flushed.


### PR DESCRIPTION
The new default for :
- `chunk_retain_period` is `0s`, not `30s`
- `chunk_idle_period` is `30m`, not `1h`
- `chunk_target_size ` is `1572864`, not `1048576`

According to https://grafana.com/docs/loki/v2.4/configuration/#ingester_config

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
The documentation is misleading.