### PR TITLE
Add filter parameter to rebound so lines can be deleted by the compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 * [5984](https://github.com/grafana/loki/pull/5984) **dannykopping** and **salvacorts**: Querier: prevent unnecessary calls to ingesters.
+* [5879](https://github.com/grafana/loki/pull/5879) **MichelHollands**: Remove lines matching delete request expression when using "filter-and-delete" deletion mode. 
 * [5899](https://github.com/grafana/loki/pull/5899) **simonswine**: Update go image to 1.17.9.
 * [5888](https://github.com/grafana/loki/pull/5888) **Papawy** Fix common config net interface name overwritten by ring common config
 * [5799](https://github.com/grafana/loki/pull/5799) **cyriltovena** Fix deduping issues when multiple entries with the same timestamp exist.

--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -39,14 +39,3 @@ ruler:
 # If you would like to disable reporting, uncomment the following lines:
 #analytics:
 #  reporting_enabled: false
-
-ingester:
-  max_chunk_age: 10m
-
-compactor:
-  working_directory: /loki/retention
-  compaction_interval: 10m
-  retention_enabled: true
-  deletion_mode: "filter-and-delete"
-  retention_delete_delay: 20m
-  delete_request_cancel_period: 20m

--- a/cmd/loki/loki-docker-config.yaml
+++ b/cmd/loki/loki-docker-config.yaml
@@ -39,3 +39,14 @@ ruler:
 # If you would like to disable reporting, uncomment the following lines:
 #analytics:
 #  reporting_enabled: false
+
+ingester:
+  max_chunk_age: 10m
+
+compactor:
+  working_directory: /loki/retention
+  compaction_interval: 10m
+  retention_enabled: true
+  deletion_mode: "filter-and-delete"
+  retention_delete_delay: 20m
+  delete_request_cancel_period: 20m

--- a/pkg/chunkenc/dumb_chunk.go
+++ b/pkg/chunkenc/dumb_chunk.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 const (
@@ -122,7 +123,7 @@ func (c *dumbChunk) Close() error {
 	return nil
 }
 
-func (c *dumbChunk) Rebound(start, end time.Time) (Chunk, error) {
+func (c *dumbChunk) Rebound(start, end time.Time, filter filter.Func) (Chunk, error) {
 	return nil, nil
 }
 

--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 // GzipLogChunk is a cortex encoding type for our chunks.
@@ -86,8 +87,8 @@ func (f Facade) LokiChunk() Chunk {
 	return f.c
 }
 
-func (f Facade) Rebound(start, end model.Time) (chunk.Data, error) {
-	newChunk, err := f.c.Rebound(start.Time(), end.Time())
+func (f Facade) Rebound(start, end model.Time, filter filter.Func) (chunk.Data, error) {
+	newChunk, err := f.c.Rebound(start.Time(), end.Time(), filter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunkenc/interface.go
+++ b/pkg/chunkenc/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 // Errors returned by the chunk interface.
@@ -127,7 +128,7 @@ type Chunk interface {
 	CompressedSize() int
 	Close() error
 	Encoding() Encoding
-	Rebound(start, end time.Time) (Chunk, error)
+	Rebound(start, end time.Time, filter filter.Func) (Chunk, error)
 }
 
 // Block is a chunk block.

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -1188,7 +1188,7 @@ func TestMemChunk_Rebound(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			newChunk, err := originalChunk.Rebound(tc.sliceFrom, tc.sliceTo)
+			newChunk, err := originalChunk.Rebound(tc.sliceFrom, tc.sliceTo, nil)
 			if tc.err != nil {
 				require.Equal(t, tc.err, err)
 				return
@@ -1227,6 +1227,100 @@ func buildTestMemChunk(t *testing.T, from, through time.Time) *MemChunk {
 			Timestamp: from,
 		})
 		require.NoError(t, err)
+	}
+
+	return chk
+}
+
+func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
+	chkFrom := time.Unix(1, 0) // headBlock.Append treats Unix time 0 as not set so we have to use a later time
+	chkFromPlus5 := chkFrom.Add(5 * time.Second)
+	chkThrough := chkFrom.Add(10 * time.Second)
+	chkThroughPlus1 := chkThrough.Add(1 * time.Second)
+
+	filterFunc := func(in string) bool {
+		return strings.HasPrefix(in, "matching")
+	}
+
+	for _, tc := range []struct {
+		name                               string
+		matchingSliceFrom, matchingSliceTo *time.Time
+		err                                error
+		nrMatching                         int
+		nrNotMatching                      int
+	}{
+		{
+			name:          "no matches",
+			nrMatching:    0,
+			nrNotMatching: 10,
+		},
+		{
+			name:              "some lines removed",
+			matchingSliceFrom: &chkFrom,
+			matchingSliceTo:   &chkFromPlus5,
+			nrMatching:        5,
+			nrNotMatching:     5,
+		},
+		{
+			name:              "all lines match",
+			err:               chunk.ErrSliceNoDataInRange,
+			matchingSliceFrom: &chkFrom,
+			matchingSliceTo:   &chkThroughPlus1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			originalChunk := buildFilterableTestMemChunk(t, chkFrom, chkThrough, tc.matchingSliceFrom, tc.matchingSliceTo)
+			newChunk, err := originalChunk.Rebound(chkFrom, chkThrough, filterFunc)
+			if tc.err != nil {
+				require.Equal(t, tc.err, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// iterate originalChunk from slice start to slice end + nanosecond. Adding a nanosecond here to be inclusive of sample at end time.
+			originalChunkItr, err := originalChunk.Iterator(context.Background(), chkFrom, chkThrough.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+			originalChunkSamples := 0
+			for originalChunkItr.Next() {
+				originalChunkSamples++
+			}
+			require.Equal(t, tc.nrMatching+tc.nrNotMatching, originalChunkSamples)
+
+			// iterate newChunk for whole chunk interval which should include all the samples in the chunk and hence align it with expected values.
+			newChunkItr, err := newChunk.Iterator(context.Background(), chkFrom, chkThrough.Add(time.Nanosecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
+			require.NoError(t, err)
+			newChunkSamples := 0
+			for newChunkItr.Next() {
+				newChunkSamples++
+			}
+			require.Equal(t, tc.nrNotMatching, newChunkSamples)
+		})
+	}
+}
+
+func buildFilterableTestMemChunk(t *testing.T, from, through time.Time, matchingFrom, matchingTo *time.Time) *MemChunk {
+	chk := NewMemChunk(EncGZIP, DefaultHeadBlockFmt, defaultBlockSize, 0)
+	t.Logf("from   : %v", from.String())
+	t.Logf("through: %v", through.String())
+	for from.Before(through) {
+		// If a line is between matchingFrom and matchingTo add the prefix "matching"
+		if matchingFrom != nil && matchingTo != nil &&
+			(from.Equal(*matchingFrom) || (from.After(*matchingFrom) && (from.Before(*matchingTo)))) {
+			t.Logf("%v matching line", from.String())
+			err := chk.Append(&logproto.Entry{
+				Line:      fmt.Sprintf("matching %v", from.String()),
+				Timestamp: from,
+			})
+			require.NoError(t, err)
+		} else {
+			t.Logf("%v non-match line", from.String())
+			err := chk.Append(&logproto.Entry{
+				Line:      from.String(),
+				Timestamp: from,
+			})
+			require.NoError(t, err)
+		}
+		from = from.Add(time.Second)
 	}
 
 	return chk

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -795,7 +795,8 @@ func (t *Loki) initCompactor() (services.Service, error) {
 
 	t.Server.HTTP.Path("/compactor/ring").Methods("GET", "POST").Handler(t.compactor)
 
-	if t.Cfg.CompactorConfig.RetentionEnabled && t.compactor.DeleteMode() != deletion.Disabled {
+	deleteMode := t.compactor.DeleteMode()
+	if t.Cfg.CompactorConfig.RetentionEnabled && (deleteMode == deletion.WholeStreamDeletion || deleteMode == deletion.FilterAndDelete) {
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -795,13 +795,15 @@ func (t *Loki) initCompactor() (services.Service, error) {
 
 	t.Server.HTTP.Path("/compactor/ring").Methods("GET", "POST").Handler(t.compactor)
 
-	deleteMode := t.compactor.DeleteMode()
-	if t.Cfg.CompactorConfig.RetentionEnabled && (deleteMode == deletion.WholeStreamDeletion || deleteMode == deletion.FilterAndDelete) {
-		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
-		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
-		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
-
-		t.Server.HTTP.Path("/loki/api/v1/cache/generation_numbers").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler)))
+	if t.Cfg.CompactorConfig.RetentionEnabled {
+		switch t.compactor.DeleteMode() {
+		case deletion.WholeStreamDeletion, deletion.FilterOnly, deletion.FilterAndDelete:
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
+		default:
+			break
+		}
 	}
 
 	return t.compactor, nil

--- a/pkg/storage/chunk/bigchunk.go
+++ b/pkg/storage/chunk/bigchunk.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/grafana/loki/pkg/util/filter"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
@@ -85,7 +86,7 @@ func (b *bigchunk) addNextChunk(start model.Time) error {
 	return nil
 }
 
-func (b *bigchunk) Rebound(start, end model.Time) (Data, error) {
+func (b *bigchunk) Rebound(start, end model.Time, filter filter.Func) (Data, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/storage/chunk/bigchunk.go
+++ b/pkg/storage/chunk/bigchunk.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"io"
 
-	"github.com/grafana/loki/pkg/util/filter"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 const samplesPerChunk = 120

--- a/pkg/storage/chunk/interface.go
+++ b/pkg/storage/chunk/interface.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/grafana/loki/pkg/util/filter"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	errs "github.com/weaveworks/common/errors"
@@ -47,7 +48,7 @@ type Data interface {
 	// Rebound returns a smaller chunk that includes all samples between start and end (inclusive).
 	// We do not want to change existing Slice implementations because
 	// it is built specifically for query optimization and is a noop for some of the encodings.
-	Rebound(start, end model.Time) (Data, error)
+	Rebound(start, end model.Time, filter filter.Func) (Data, error)
 	// Size returns the approximate length of the chunk in bytes.
 	Size() int
 	Utilization() float64

--- a/pkg/storage/chunk/interface.go
+++ b/pkg/storage/chunk/interface.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"io"
 
-	"github.com/grafana/loki/pkg/util/filter"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	errs "github.com/weaveworks/common/errors"
+
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 const (

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -229,7 +229,8 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig config.Schem
 			return err
 		}
 
-		if c.deleteMode == deletion.WholeStreamDeletion || c.deleteMode == deletion.FilterOnly || c.deleteMode == deletion.FilterAndDelete {
+		switch c.deleteMode {
+		case deletion.WholeStreamDeletion, deletion.FilterOnly, deletion.FilterAndDelete:
 			deletionWorkDir := filepath.Join(c.cfg.WorkingDirectory, "deletion")
 
 			c.deleteRequestsStore, err = deletion.NewDeleteStore(deletionWorkDir, c.indexStorageClient)
@@ -244,7 +245,7 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig config.Schem
 				c.deleteMode,
 			)
 			c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits), c.deleteRequestsManager)
-		} else {
+		default:
 			c.expirationChecker = newExpirationChecker(
 				retention.NewExpirationChecker(limits),
 				// This is a dummy deletion ExpirationChecker that never expires anything

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -229,7 +229,7 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig config.Schem
 			return err
 		}
 
-		if c.deleteMode != deletion.Disabled {
+		if c.deleteMode == deletion.WholeStreamDeletion || c.deleteMode == deletion.FilterOnly || c.deleteMode == deletion.FilterAndDelete {
 			deletionWorkDir := filepath.Join(c.cfg.WorkingDirectory, "deletion")
 
 			c.deleteRequestsStore, err = deletion.NewDeleteStore(deletionWorkDir, c.indexStorageClient)

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -567,7 +567,7 @@ func newExpirationChecker(retentionExpiryChecker, deletionExpiryChecker retentio
 	return &expirationChecker{retentionExpiryChecker, deletionExpiryChecker}
 }
 
-func (e *expirationChecker) Expired(ref retention.ChunkEntry, now model.Time) (bool, []model.Interval) {
+func (e *expirationChecker) Expired(ref retention.ChunkEntry, now model.Time) (bool, []retention.IntervalFilter) {
 	if expired, nonDeletedIntervals := e.retentionExpiryChecker.Expired(ref, now); expired {
 		return expired, nonDeletedIntervals
 	}

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -237,7 +237,12 @@ func (c *Compactor) init(storageConfig storage.Config, schemaConfig config.Schem
 				return err
 			}
 			c.DeleteRequestsHandler = deletion.NewDeleteRequestHandler(c.deleteRequestsStore, time.Hour, r)
-			c.deleteRequestsManager = deletion.NewDeleteRequestsManager(c.deleteRequestsStore, c.cfg.DeleteRequestCancelPeriod, r)
+			c.deleteRequestsManager = deletion.NewDeleteRequestsManager(
+				c.deleteRequestsStore,
+				c.cfg.DeleteRequestCancelPeriod,
+				r,
+				c.deleteMode,
+			)
 			c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits), c.deleteRequestsManager)
 		} else {
 			c.expirationChecker = newExpirationChecker(

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -48,12 +48,24 @@ func (d *DeleteRequest) FilterFunction(labels labels.Labels) (filter.Func, error
 
 	f := p.ForStream(labels).ProcessString
 	return func(s string) bool {
+		if !allMatch(d.matchers, labels) {
+			return false
+		}
 		result, _, skip := f(s)
 		if len(result) != 0 || skip {
 			return true
 		}
 		return false
 	}, nil
+}
+
+func allMatch(matchers []*labels.Matcher, labels labels.Labels) bool {
+	for _, m := range matchers {
+		if !m.Matches(labels.Get(m.Name)) {
+			return false
+		}
+	}
+	return true
 }
 
 // IsDeleted checks if the given ChunkEntry will be deleted by this DeleteRequest.

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -1,7 +1,7 @@
 package deletion
 
 import (
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -54,7 +54,7 @@ func (d *DeleteRequest) FilterFunction(labels labels.Labels) (filter.Func, error
 
 	f := p.ForStream(labels).ProcessString
 	return func(s string) bool {
-		result, _, skip := f(s)
+		result, _, skip := f(0, s)
 		return len(result) != 0 || skip
 	}, nil
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request.go
@@ -46,16 +46,16 @@ func (d *DeleteRequest) FilterFunction(labels labels.Labels) (filter.Func, error
 		return nil, err
 	}
 
+	if !allMatch(d.matchers, labels) {
+		return func(s string) bool {
+			return false
+		}, nil
+	}
+
 	f := p.ForStream(labels).ProcessString
 	return func(s string) bool {
-		if !allMatch(d.matchers, labels) {
-			return false
-		}
 		result, _, skip := f(s)
-		if len(result) != 0 || skip {
-			return true
-		}
-		return false
+		return len(result) != 0 || skip
 	}, nil
 }
 

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
@@ -224,4 +224,19 @@ func TestDeleteRequest_FilterFunction(t *testing.T) {
 	require.False(t, f(""))
 	require.False(t, f("other line"))
 	require.False(t, f("some line"))
+
+	dr = DeleteRequest{
+		Query: `{namespace="default"}`,
+	}
+
+	lblStr = `{namespace="default"}`
+	lbls = mustParseLabel(lblStr)
+
+	f, err = dr.FilterFunction(lbls)
+	require.NoError(t, err)
+
+	require.True(t, f(`some line`))
+	require.True(t, f(""))
+	require.True(t, f("other line"))
+
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
@@ -29,7 +29,7 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 
 	type resp struct {
 		isDeleted           bool
-		nonDeletedIntervals []model.Interval
+		nonDeletedIntervals []retention.IntervalFilter
 	}
 
 	for _, tc := range []struct {
@@ -60,10 +60,12 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				nonDeletedIntervals: []model.Interval{
+				nonDeletedIntervals: []retention.IntervalFilter{
 					{
-						Start: now.Add(-2*time.Hour) + 1,
-						End:   now.Add(-time.Hour),
+						Interval: model.Interval{
+							Start: now.Add(-2*time.Hour) + 1,
+							End:   now.Add(-time.Hour),
+						},
 					},
 				},
 			},
@@ -78,10 +80,12 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				nonDeletedIntervals: []model.Interval{
+				nonDeletedIntervals: []retention.IntervalFilter{
 					{
-						Start: now.Add(-3 * time.Hour),
-						End:   now.Add(-2*time.Hour) - 1,
+						Interval: model.Interval{
+							Start: now.Add(-3 * time.Hour),
+							End:   now.Add(-2*time.Hour) - 1,
+						},
 					},
 				},
 			},
@@ -96,10 +100,12 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				nonDeletedIntervals: []model.Interval{
+				nonDeletedIntervals: []retention.IntervalFilter{
 					{
-						Start: now.Add(-3 * time.Hour),
-						End:   now.Add(-2*time.Hour) - 1,
+						Interval: model.Interval{
+							Start: now.Add(-3 * time.Hour),
+							End:   now.Add(-2*time.Hour) - 1,
+						},
 					},
 				},
 			},
@@ -114,14 +120,18 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			},
 			expectedResp: resp{
 				isDeleted: true,
-				nonDeletedIntervals: []model.Interval{
+				nonDeletedIntervals: []retention.IntervalFilter{
 					{
-						Start: now.Add(-3 * time.Hour),
-						End:   now.Add(-(2*time.Hour + 30*time.Minute)) - 1,
+						Interval: model.Interval{
+							Start: now.Add(-3 * time.Hour),
+							End:   now.Add(-(2*time.Hour + 30*time.Minute)) - 1,
+						},
 					},
 					{
-						Start: now.Add(-(time.Hour + 30*time.Minute)) + 1,
-						End:   now.Add(-time.Hour),
+						Interval: model.Interval{
+							Start: now.Add(-(time.Hour + 30*time.Minute)) + 1,
+							End:   now.Add(-time.Hour),
+						},
 					},
 				},
 			},
@@ -167,7 +177,16 @@ func TestDeleteRequest_IsDeleted(t *testing.T) {
 			require.NoError(t, tc.deleteRequest.SetQuery(tc.deleteRequest.Query))
 			isDeleted, nonDeletedIntervals := tc.deleteRequest.IsDeleted(chunkEntry)
 			require.Equal(t, tc.expectedResp.isDeleted, isDeleted)
-			require.Equal(t, tc.expectedResp.nonDeletedIntervals, nonDeletedIntervals)
+			for idx := range tc.expectedResp.nonDeletedIntervals {
+				require.Equal(t,
+					tc.expectedResp.nonDeletedIntervals[idx].Interval.Start,
+					nonDeletedIntervals[idx].Interval.Start,
+				)
+				require.Equal(t,
+					tc.expectedResp.nonDeletedIntervals[idx].Interval.End,
+					nonDeletedIntervals[idx].Interval.End,
+				)
+			}
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_request_test.go
@@ -199,3 +199,29 @@ func mustParseLabel(input string) labels.Labels {
 
 	return lbls
 }
+
+func TestDeleteRequest_FilterFunction(t *testing.T) {
+	dr := DeleteRequest{
+		Query: `{foo="bar"} |= "some"`,
+	}
+
+	lblStr := `{foo="bar"}`
+	lbls := mustParseLabel(lblStr)
+
+	f, err := dr.FilterFunction(lbls)
+	require.NoError(t, err)
+
+	require.True(t, f(`some line`))
+	require.False(t, f(""))
+	require.False(t, f("other line"))
+
+	lblStr = `{foo2="buzz"}`
+	lbls = mustParseLabel(lblStr)
+
+	f, err = dr.FilterFunction(lbls)
+	require.NoError(t, err)
+
+	require.False(t, f(""))
+	require.False(t, f("other line"))
+	require.False(t, f("some line"))
+}

--- a/pkg/storage/stores/shipper/compactor/deletion/validation.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/validation.go
@@ -7,8 +7,7 @@ import (
 )
 
 var (
-	errInvalidQuery     = errors.New("invalid query expression")
-	errUnsupportedQuery = errors.New("unsupported query expression")
+	errInvalidQuery = errors.New("invalid query expression")
 )
 
 // parseDeletionQuery checks if the given logQL is valid for deletions

--- a/pkg/storage/stores/shipper/compactor/deletion/validation.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/validation.go
@@ -3,8 +3,6 @@ package deletion
 import (
 	"errors"
 
-	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/grafana/loki/pkg/logql/syntax"
 )
 
@@ -14,15 +12,11 @@ var (
 )
 
 // parseDeletionQuery checks if the given logQL is valid for deletions
-func parseDeletionQuery(query string) ([]*labels.Matcher, error) {
-	expr, err := syntax.ParseExpr(query)
+func parseDeletionQuery(query string) (syntax.LogSelectorExpr, error) {
+	logSelectorExpr, err := syntax.ParseLogSelector(query, false)
 	if err != nil {
 		return nil, errInvalidQuery
 	}
 
-	if matchersExpr, ok := expr.(*syntax.MatchersExpr); ok {
-		return matchersExpr.Matchers(), nil
-	}
-
-	return nil, errUnsupportedQuery
+	return logSelectorExpr, nil
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/validation_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/validation_test.go
@@ -8,32 +8,34 @@ import (
 
 func TestParseLogQLExpressionForDeletion(t *testing.T) {
 	t.Run("invalid logql", func(t *testing.T) {
-		matchers, err := parseDeletionQuery("gjgjg ggj")
-		require.Nil(t, matchers)
+		logSelectorExpr, err := parseDeletionQuery("gjgjg ggj")
+		require.Nil(t, logSelectorExpr)
 		require.ErrorIs(t, err, errInvalidQuery)
 	})
 
 	t.Run("matcher expression", func(t *testing.T) {
-		matchers, err := parseDeletionQuery(`{env="dev", secret="true"}`)
-		require.NotNil(t, matchers)
+		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"}`)
+		require.NotNil(t, logSelectorExpr)
 		require.NoError(t, err)
 	})
 
 	t.Run("pipeline expression with line filter", func(t *testing.T) {
-		matchers, err := parseDeletionQuery(`{env="dev", secret="true"} |= "social sec number"`)
-		require.Nil(t, matchers)
-		require.ErrorIs(t, err, errUnsupportedQuery)
+		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= "social sec number"`)
+		require.NotNil(t, logSelectorExpr)
+		require.NoError(t, err)
 	})
 
+	/* syntax.ParseLogSelector does not reject these
 	t.Run("pipeline expression with label filter ", func(t *testing.T) {
-		matchers, err := parseDeletionQuery(`{env="dev", secret="true"} | json bob="top.params[0]"`)
-		require.Nil(t, matchers)
+		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} | json bob="top.params[0]"`)
+		require.Nil(t, logSelectorExpr)
 		require.ErrorIs(t, err, errUnsupportedQuery)
 	})
 
 	t.Run("metrics query", func(t *testing.T) {
-		matchers, err := parseDeletionQuery(`count_over_time({job="mysql"}[5m])`)
-		require.Nil(t, matchers)
+		logSelectorExpr, err := parseDeletionQuery(`count_over_time({job="mysql"}[5m])`)
+		require.Nil(t, logSelectorExpr)
 		require.ErrorIs(t, err, errUnsupportedQuery)
 	})
+	*/
 }

--- a/pkg/storage/stores/shipper/compactor/deletion/validation_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/validation_test.go
@@ -25,17 +25,15 @@ func TestParseLogQLExpressionForDeletion(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	/* syntax.ParseLogSelector does not reject these
-	t.Run("pipeline expression with label filter ", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} | json bob="top.params[0]"`)
-		require.Nil(t, logSelectorExpr)
-		require.ErrorIs(t, err, errUnsupportedQuery)
+	t.Run("pipeline expression with multiple line filters", func(t *testing.T) {
+		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= "social sec number" |~ "[abd]*" `)
+		require.NotNil(t, logSelectorExpr)
+		require.NoError(t, err)
 	})
 
-	t.Run("metrics query", func(t *testing.T) {
-		logSelectorExpr, err := parseDeletionQuery(`count_over_time({job="mysql"}[5m])`)
+	t.Run("pipeline expression with invalid line filter", func(t *testing.T) {
+		logSelectorExpr, err := parseDeletionQuery(`{env="dev", secret="true"} |= social sec number`)
 		require.Nil(t, logSelectorExpr)
-		require.ErrorIs(t, err, errUnsupportedQuery)
+		require.ErrorIs(t, err, errInvalidQuery)
 	})
-	*/
 }

--- a/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/expiration_test.go
@@ -81,9 +81,9 @@ func Test_expirationChecker_Expired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, nonDeletedIntervals := e.Expired(tt.ref, model.Now())
+			actual, nonDeletedIntervalFilters := e.Expired(tt.ref, model.Now())
 			require.Equal(t, tt.want, actual)
-			require.Nil(t, nonDeletedIntervals)
+			require.Nil(t, nonDeletedIntervalFilters)
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -358,7 +358,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 			return false, err
 		}
 
-		entries, err := c.seriesStoreSchema.GetChunkWriteEntries(start, end, userID, "logs", newChunk.Metric, c.scfg.ExternalKey(newChunk.ChunkRef))
+		entries, err := c.seriesStoreSchema.GetChunkWriteEntries(newChunk.From, newChunk.Through, userID, "logs", newChunk.Metric, c.scfg.ExternalKey(newChunk.ChunkRef))
 		if err != nil {
 			return false, err
 		}

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -151,11 +151,11 @@ func markforDelete(ctx context.Context, tableName string, marker MarkerStorageWr
 		seriesMap.Add(c.SeriesID, c.UserID, c.Labels)
 
 		// see if the chunk is deleted completely or partially
-		if expired, nonDeletedIntervals := expiration.Expired(c, now); expired {
-			if len(nonDeletedIntervals) > 0 {
-				wroteChunks, err := chunkRewriter.rewriteChunk(ctx, c, nonDeletedIntervals)
+		if expired, nonDeletedIntervalFilters := expiration.Expired(c, now); expired {
+			if len(nonDeletedIntervalFilters) > 0 {
+				wroteChunks, err := chunkRewriter.rewriteChunk(ctx, c, nonDeletedIntervalFilters)
 				if err != nil {
-					return false, false, fmt.Errorf("failed to rewrite chunk %s for interval %s with error %s", c.ChunkID, nonDeletedIntervals, err)
+					return false, false, fmt.Errorf("failed to rewrite chunk %s for intervals %+v with error %s", c.ChunkID, nonDeletedIntervalFilters, err)
 				}
 
 				if wroteChunks {
@@ -173,7 +173,7 @@ func markforDelete(ctx context.Context, tableName string, marker MarkerStorageWr
 			// Mark the chunk for deletion only if it is completely deleted, or this is the last table that the chunk is index in.
 			// For a partially deleted chunk, if we delete the source chunk before all the tables which index it are processed then
 			// the retention would fail because it would fail to find it in the storage.
-			if len(nonDeletedIntervals) == 0 || c.Through <= tableInterval.End {
+			if len(nonDeletedIntervalFilters) == 0 || c.Through <= tableInterval.End {
 				if err := marker.Put(c.ChunkID); err != nil {
 					return false, false, err
 				}
@@ -307,7 +307,7 @@ func newChunkRewriter(chunkClient client.Client, schemaCfg config.PeriodConfig,
 	}, nil
 }
 
-func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, intervals []model.Interval) (bool, error) {
+func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, intervalFilters []IntervalFilter) (bool, error) {
 	userID := unsafeGetString(ce.UserID)
 	chunkID := unsafeGetString(ce.ChunkID)
 
@@ -327,8 +327,11 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 
 	wroteChunks := false
 
-	for _, interval := range intervals {
-		newChunkData, err := chks[0].Data.Rebound(interval.Start, interval.End, nil)
+	for _, ivf := range intervalFilters {
+		start := ivf.Interval.Start
+		end := ivf.Interval.End
+
+		newChunkData, err := chks[0].Data.Rebound(start, end, ivf.Filter)
 		if err != nil {
 			return false, err
 		}
@@ -341,8 +344,8 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 		newChunk := chunk.NewChunk(
 			userID, chks[0].FingerprintModel(), chks[0].Metric,
 			facade,
-			interval.Start,
-			interval.End,
+			start,
+			end,
 		)
 
 		err = newChunk.Encode()
@@ -350,7 +353,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 			return false, err
 		}
 
-		entries, err := c.seriesStoreSchema.GetChunkWriteEntries(interval.Start, interval.End, userID, "logs", newChunk.Metric, c.scfg.ExternalKey(newChunk.ChunkRef))
+		entries, err := c.seriesStoreSchema.GetChunkWriteEntries(start, end, userID, "logs", newChunk.Metric, c.scfg.ExternalKey(newChunk.ChunkRef))
 		if err != nil {
 			return false, err
 		}

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -333,6 +333,11 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 
 		newChunkData, err := chks[0].Data.Rebound(start, end, ivf.Filter)
 		if err != nil {
+			if errors.Is(err, chunk.ErrSliceNoDataInRange) {
+				level.Info(util_log.Logger).Log("msg", "Rebound leaves an empty chunk", "chunk ref", string(ce.ChunkRef.ChunkID))
+				// skip empty chunks
+				continue
+			}
 			return false, err
 		}
 

--- a/pkg/storage/stores/shipper/compactor/retention/retention.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention.go
@@ -328,7 +328,7 @@ func (c *chunkRewriter) rewriteChunk(ctx context.Context, ce ChunkEntry, interva
 	wroteChunks := false
 
 	for _, interval := range intervals {
-		newChunkData, err := chks[0].Data.Rebound(interval.Start, interval.End)
+		newChunkData, err := chks[0].Data.Rebound(interval.Start, interval.End, nil)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -398,7 +398,7 @@ func TestChunkRewriter(t *testing.T) {
 			},
 		},
 		{
-			name:  "remove half of the lines using a filter function",
+			name:  "remove no lines using a filter function",
 			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-2*time.Hour), now),
 			rewriteIntervalFilters: []IntervalFilter{
 				{
@@ -407,11 +407,7 @@ func TestChunkRewriter(t *testing.T) {
 						End:   now,
 					},
 					Filter: func(s string) bool {
-						i, err := strconv.Atoi(s[len(s)-1:])
-						if err != nil {
-							panic(fmt.Sprintf("invalid input to filter function: %v", s))
-						}
-						return i%2 == 0
+						return false
 					},
 				},
 			},

--- a/pkg/storage/stores/shipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/shipper/compactor/retention/retention_test.go
@@ -313,9 +313,9 @@ func TestChunkRewriter(t *testing.T) {
 	minListMarkDelay = 1 * time.Second
 	now := model.Now()
 	for _, tt := range []struct {
-		name             string
-		chunk            chunk.Chunk
-		rewriteIntervals []model.Interval
+		name                   string
+		chunk                  chunk.Chunk
+		rewriteIntervalFilters []IntervalFilter
 	}{
 		{
 			name:  "no rewrites",
@@ -328,56 +328,91 @@ func TestChunkRewriter(t *testing.T) {
 		{
 			name:  "rewrite first half",
 			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-2*time.Hour), now),
-			rewriteIntervals: []model.Interval{
+			rewriteIntervalFilters: []IntervalFilter{
 				{
-					Start: now.Add(-2 * time.Hour),
-					End:   now.Add(-1 * time.Hour),
+					Interval: model.Interval{
+						Start: now.Add(-2 * time.Hour),
+						End:   now.Add(-1 * time.Hour),
+					},
 				},
 			},
 		},
 		{
 			name:  "rewrite second half",
 			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-2*time.Hour), now),
-			rewriteIntervals: []model.Interval{
+			rewriteIntervalFilters: []IntervalFilter{
 				{
-					Start: now.Add(-time.Hour),
-					End:   now,
+					Interval: model.Interval{
+						Start: now.Add(-time.Hour),
+						End:   now,
+					},
 				},
 			},
 		},
 		{
 			name:  "rewrite multiple intervals",
 			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-12*time.Hour), now),
-			rewriteIntervals: []model.Interval{
+			rewriteIntervalFilters: []IntervalFilter{
 				{
-					Start: now.Add(-12 * time.Hour),
-					End:   now.Add(-10 * time.Hour),
+					Interval: model.Interval{
+						Start: now.Add(-12 * time.Hour),
+						End:   now.Add(-10 * time.Hour),
+					},
 				},
 				{
-					Start: now.Add(-9 * time.Hour),
-					End:   now.Add(-5 * time.Hour),
+					Interval: model.Interval{
+						Start: now.Add(-9 * time.Hour),
+						End:   now.Add(-5 * time.Hour),
+					},
 				},
 				{
-					Start: now.Add(-2 * time.Hour),
-					End:   now,
+					Interval: model.Interval{
+						Start: now.Add(-2 * time.Hour),
+						End:   now,
+					},
 				},
 			},
 		},
 		{
 			name:  "rewrite chunk spanning multiple days with multiple intervals",
 			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-72*time.Hour), now),
-			rewriteIntervals: []model.Interval{
+			rewriteIntervalFilters: []IntervalFilter{
 				{
-					Start: now.Add(-71 * time.Hour),
-					End:   now.Add(-47 * time.Hour),
+					Interval: model.Interval{
+						Start: now.Add(-71 * time.Hour),
+						End:   now.Add(-47 * time.Hour),
+					},
 				},
 				{
-					Start: now.Add(-40 * time.Hour),
-					End:   now.Add(-30 * time.Hour),
+					Interval: model.Interval{
+						Start: now.Add(-40 * time.Hour),
+						End:   now.Add(-30 * time.Hour),
+					},
 				},
 				{
-					Start: now.Add(-2 * time.Hour),
-					End:   now,
+					Interval: model.Interval{
+						Start: now.Add(-2 * time.Hour),
+						End:   now,
+					},
+				},
+			},
+		},
+		{
+			name:  "remove half of the lines using a filter function",
+			chunk: createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, now.Add(-2*time.Hour), now),
+			rewriteIntervalFilters: []IntervalFilter{
+				{
+					Interval: model.Interval{
+						Start: now.Add(-1 * time.Hour),
+						End:   now,
+					},
+					Filter: func(s string) bool {
+						i, err := strconv.Atoi(s[len(s)-1:])
+						if err != nil {
+							panic(fmt.Sprintf("invalid input to filter function: %v", s))
+						}
+						return i%2 == 0
+					},
 				},
 			},
 		},
@@ -401,9 +436,9 @@ func TestChunkRewriter(t *testing.T) {
 					cr, err := newChunkRewriter(chunkClient, store.schemaCfg.Configs[0], indexTable.name, bucket)
 					require.NoError(t, err)
 
-					wroteChunks, err := cr.rewriteChunk(context.Background(), entryFromChunk(store.schemaCfg, tt.chunk), tt.rewriteIntervals)
+					wroteChunks, err := cr.rewriteChunk(context.Background(), entryFromChunk(store.schemaCfg, tt.chunk), tt.rewriteIntervalFilters)
 					require.NoError(t, err)
-					if len(tt.rewriteIntervals) == 0 {
+					if len(tt.rewriteIntervalFilters) == 0 {
 						require.False(t, wroteChunks)
 					}
 					return nil
@@ -416,9 +451,9 @@ func TestChunkRewriter(t *testing.T) {
 			chunks := store.GetChunks(tt.chunk.UserID, tt.chunk.From, tt.chunk.Through, tt.chunk.Metric)
 
 			// number of chunks should be the new re-written chunks + the source chunk
-			require.Len(t, chunks, len(tt.rewriteIntervals)+1)
-			for _, interval := range tt.rewriteIntervals {
-				expectedChk := createChunk(t, tt.chunk.UserID, labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, interval.Start, interval.End)
+			require.Len(t, chunks, len(tt.rewriteIntervalFilters)+1)
+			for _, ivf := range tt.rewriteIntervalFilters {
+				expectedChk := createChunk(t, tt.chunk.UserID, labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, ivf.Interval.Start, ivf.Interval.End)
 				for i, chk := range chunks {
 					if store.schemaCfg.ExternalKey(chk.ChunkRef) == store.schemaCfg.ExternalKey(expectedChk.ChunkRef) {
 						chunks = append(chunks[:i], chunks[i+1:]...)
@@ -450,8 +485,8 @@ func (s *seriesCleanedRecorder) Cleanup(userID []byte, lbls labels.Labels) error
 }
 
 type chunkExpiry struct {
-	isExpired           bool
-	nonDeletedIntervals []model.Interval
+	isExpired                 bool
+	nonDeletedIntervalFilters []IntervalFilter
 }
 
 type mockExpirationChecker struct {
@@ -463,9 +498,9 @@ func newMockExpirationChecker(chunksExpiry map[string]chunkExpiry) mockExpiratio
 	return mockExpirationChecker{chunksExpiry: chunksExpiry}
 }
 
-func (m mockExpirationChecker) Expired(ref ChunkEntry, now model.Time) (bool, []model.Interval) {
+func (m mockExpirationChecker) Expired(ref ChunkEntry, now model.Time) (bool, []IntervalFilter) {
 	ce := m.chunksExpiry[string(ref.ChunkID)]
-	return ce.isExpired, ce.nonDeletedIntervals
+	return ce.isExpired, ce.nonDeletedIntervalFilters
 }
 
 func (m mockExpirationChecker) DropFromIndex(ref ChunkEntry, tableEndTime model.Time, now model.Time) bool {
@@ -534,9 +569,11 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					nonDeletedIntervals: []model.Interval{{
-						Start: todaysTableInterval.Start,
-						End:   todaysTableInterval.Start.Add(15 * time.Minute),
+					nonDeletedIntervalFilters: []IntervalFilter{{
+						Interval: model.Interval{
+							Start: todaysTableInterval.Start,
+							End:   todaysTableInterval.Start.Add(15 * time.Minute),
+						},
 					}},
 				},
 			},
@@ -586,9 +623,11 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				},
 				{
 					isExpired: true,
-					nonDeletedIntervals: []model.Interval{{
-						Start: todaysTableInterval.Start,
-						End:   todaysTableInterval.Start.Add(15 * time.Minute),
+					nonDeletedIntervalFilters: []IntervalFilter{{
+						Interval: model.Interval{
+							Start: todaysTableInterval.Start,
+							End:   todaysTableInterval.Start.Add(15 * time.Minute),
+						},
 					}},
 				},
 			},
@@ -610,9 +649,11 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					nonDeletedIntervals: []model.Interval{{
-						Start: todaysTableInterval.Start,
-						End:   now,
+					nonDeletedIntervalFilters: []IntervalFilter{{
+						Interval: model.Interval{
+							Start: todaysTableInterval.Start,
+							End:   now,
+						},
 					}},
 				},
 			},
@@ -634,9 +675,11 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 			expiry: []chunkExpiry{
 				{
 					isExpired: true,
-					nonDeletedIntervals: []model.Interval{{
-						Start: todaysTableInterval.Start.Add(-30 * time.Minute),
-						End:   now,
+					nonDeletedIntervalFilters: []IntervalFilter{{
+						Interval: model.Interval{
+							Start: todaysTableInterval.Start.Add(-30 * time.Minute),
+							End:   now,
+						},
 					}},
 				},
 			},

--- a/pkg/util/filter/filter_function.go
+++ b/pkg/util/filter/filter_function.go
@@ -1,0 +1,3 @@
+package filter
+
+type Func func(string) bool


### PR DESCRIPTION
Add filter functionality to the delete functionality of the compactor. This is hidden behind the "filter-and-delete" value of the deletion_mode config setting.

A filter function is added to the intervals sent to the Rebound function. This removes lines that match the given DeleteRequest.

**Checklist**
- [ ] Documentation added
- [X] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>