### PR TITLE
Other: Update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,6 @@
   c. Use sentence case, not title case.
   d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
 3. Rebase your PR if it gets out of sync with main
-4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
 -->
 
 **What this PR does / why we need it**:
@@ -17,7 +16,16 @@ Fixes #<issue number>
 
 **Special notes for your reviewer**:
 
+<!--
+Note about CHANGELOG entries, if a change adds:
+* an important feature
+* fixes an issue present in a previous release, 
+* causes a change in operation that would be useful for an operator of Loki to know
+then please add a CHANGELOG entry.
+
+For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.
+-->
 **Checklist**
 - [ ] Documentation added
 - [ ] Tests updated
-- [ ] Add an entry in the `CHANGELOG.md` about the changes.
+- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,18 @@ Note about CHANGELOG entries, if a change adds:
 then please add a CHANGELOG entry.
 
 For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.
+
+Note about the upgrade guide, if this changes:
+* default configuration values
+* metric names or label names
+* changes existing log lines such as the metrics.go query output line
+* configuration parameters 
+* anything to do with any API
+* any other change that would require special attention or extra steps to upgrade
+Please document clearly what changed AND what needs to be done in the upgrade guide.
 -->
 **Checklist**
 - [ ] Documentation added
 - [ ] Tests updated
 - [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
+- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`


### PR DESCRIPTION
We would like to start creating a more curated changelog, and do so when PR's are added/merged.

The template update explains to only add PR's if they are for fixes to issues in previous released versions, new features, or important changes.

It's the job of the Loki Team Member that merges the PR to make sure the changelog entry is necessary and written such that it's easy to consume by someone scanning the changelog when looking to update Loki to a new release.