### PR TITLE
Docs: Fix the command line description of the grpc_server_max_send_msg_size parameter

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -216,7 +216,7 @@ configures the HTTP and gRPC server communication of the launched service(s).
 [grpc_server_max_recv_msg_size: <int> | default = 4194304]
 
 # Max gRPC message size that can be sent
-# CLI flag: -server.grpc-max-recv-msg-size-bytes
+# CLI flag: -server.grpc-max-send-msg-size-bytes
 [grpc_server_max_send_msg_size: <int> | default = 4194304]
 
 # Limit on the number of concurrent streams for gRPC calls (0 = unlimited)


### PR DESCRIPTION
Docs: Fix the command line description of the **grpc_server_max_send_msg_size** parameter