### PR TITLE
loki: Fix common config net interface name overwritten by ring common config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+* [5888](https://github.com/grafana/loki/pull/5888) **Papawy** Fix common config net interface name overwritten by ring common config
 * [5799](https://github.com/grafana/loki/pull/5799) **cyriltovena** Fix deduping issues when multiple entries with the same timestamp exist.
 * [5799](https://github.com/grafana/loki/pull/5799) **cyriltovena** Fixes deduping issues when multiple entries exists with the same timestamp.
 * [5780](https://github.com/grafana/loki/pull/5780) **simonswine**: Update alpine image to 3.15.4.

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -121,20 +121,16 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 // - "instance-interface-names", a list of net interfaces used when looking for addresses.
 func applyInstanceConfigs(r, defaults *ConfigWrapper) {
 	if !reflect.DeepEqual(r.Common.InstanceAddr, defaults.Common.InstanceAddr) {
-		r.Ingester.LifecyclerConfig.Addr = r.Common.InstanceAddr
-		r.CompactorConfig.CompactorRing.InstanceAddr = r.Common.InstanceAddr
-		r.Distributor.DistributorRing.InstanceAddr = r.Common.InstanceAddr
-		r.Ruler.Ring.InstanceAddr = r.Common.InstanceAddr
-		r.QueryScheduler.SchedulerRing.InstanceAddr = r.Common.InstanceAddr
+		if reflect.DeepEqual(r.Common.Ring.InstanceAddr, defaults.Common.Ring.InstanceAddr) {
+			r.Common.Ring.InstanceAddr = r.Common.InstanceAddr
+		}
 		r.Frontend.FrontendV2.Addr = r.Common.InstanceAddr
 	}
 
 	if !reflect.DeepEqual(r.Common.InstanceInterfaceNames, defaults.Common.InstanceInterfaceNames) {
-		r.Ingester.LifecyclerConfig.InfNames = r.Common.InstanceInterfaceNames
-		r.CompactorConfig.CompactorRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
-		r.Distributor.DistributorRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
-		r.Ruler.Ring.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
-		r.QueryScheduler.SchedulerRing.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		if reflect.DeepEqual(r.Common.Ring.InstanceInterfaceNames, defaults.Common.Ring.InstanceInterfaceNames) {
+			r.Common.Ring.InstanceInterfaceNames = r.Common.InstanceInterfaceNames
+		}
 		r.Frontend.FrontendV2.InfNames = r.Common.InstanceInterfaceNames
 	}
 }

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1484,4 +1484,42 @@ common:
 		assert.Equal(t, []string{"ringsshouldntusethis"}, config.Frontend.FrontendV2.InfNames) // not a ring.
 		assert.Equal(t, []string{"ringsshouldusethis"}, config.CompactorConfig.CompactorRing.InstanceInterfaceNames)
 	})
+
+	t.Run("common instance net interface doesn't get overwritten by common ring config", func(t *testing.T) {
+		yamlContent := `common:
+  instance_interface_names:
+  - interface
+  ring:
+    kvstore:
+      store: inmemory`
+
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"interface"}, config.Distributor.DistributorRing.InstanceInterfaceNames)
+		assert.Equal(t, []string{"interface"}, config.Ingester.LifecyclerConfig.InfNames)
+		assert.Equal(t, []string{"interface"}, config.Ruler.Ring.InstanceInterfaceNames)
+		assert.Equal(t, []string{"interface"}, config.QueryScheduler.SchedulerRing.InstanceInterfaceNames)
+		assert.Equal(t, []string{"interface"}, config.Frontend.FrontendV2.InfNames)
+		assert.Equal(t, []string{"interface"}, config.CompactorConfig.CompactorRing.InstanceInterfaceNames)
+	})
+
+	t.Run("common instance net interface doesn't supersede net interface from common ring with additional config", func(t *testing.T) {
+		yamlContent := `common:
+  instance_interface_names:
+  - ringsshouldntusethis
+  ring:
+    instance_interface_names:
+    - ringsshouldusethis
+    kvstore:
+      store: inmemory`
+
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"ringsshouldusethis"}, config.Distributor.DistributorRing.InstanceInterfaceNames)
+		assert.Equal(t, []string{"ringsshouldusethis"}, config.Ingester.LifecyclerConfig.InfNames)
+		assert.Equal(t, []string{"ringsshouldusethis"}, config.Ruler.Ring.InstanceInterfaceNames)
+		assert.Equal(t, []string{"ringsshouldusethis"}, config.QueryScheduler.SchedulerRing.InstanceInterfaceNames)
+		assert.Equal(t, []string{"ringsshouldntusethis"}, config.Frontend.FrontendV2.InfNames) // not a ring.
+		assert.Equal(t, []string{"ringsshouldusethis"}, config.CompactorConfig.CompactorRing.InstanceInterfaceNames)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
In the case where `instance_interface_names` is declared in the common
configuration AND the common ring configuration is also present,
`instance_interface_names` from common configuration is overwritten by
default ring configuration for all ring components.

This behavior is not the one described in documentation. 

This commit fix this issue by overwriting common ring net interface
config IF it is deeply equal to the default one.

Example:

```
common:
  instance_interface_names:
  - interface
  ring:
    kvstore:
      store: inmemory
```

Then (example with Distributor configuration),
```
Distributor.DistributorRing.InstanceInterfaceNames == defaults.Common.Ring.InstanceInterfaceNames
```

but should be

```
Distributor.DistributorRing.InstanceInterfaceNames == []string{"interface"}
```

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
