### PR TITLE
operator: Align PVC storage size requests for all lokistack t-shirt sizes

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [5893](https://github.com/grafana/loki/pull/5893) **periklis**: Align PVC storage size requests for all lokistack t-shirt sizes
 - [5884](https://github.com/grafana/loki/pull/5884) **periklis**: Update Loki operand to v2.5.0
 - [5748](https://github.com/grafana/loki/pull/5748) **Red-GV**: Update Prometheus go client to 12.1
 - [5739](https://github.com/grafana/loki/pull/5739) **sasagarw**: Change UUIDs to tenant name in doc

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -36,7 +36,7 @@ var ResourceRequirementsTable = map[lokiv1beta1.LokiStackSizeType]ComponentResou
 			},
 		},
 		Ingester: ResourceRequirements{
-			PVCSize: resource.MustParse("1Gi"),
+			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -55,7 +55,7 @@ var ResourceRequirementsTable = map[lokiv1beta1.LokiStackSizeType]ComponentResou
 			},
 		},
 		Compactor: ResourceRequirements{
-			PVCSize: resource.MustParse("1Gi"),
+			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -68,14 +68,14 @@ var ResourceRequirementsTable = map[lokiv1beta1.LokiStackSizeType]ComponentResou
 			},
 		},
 		IndexGateway: ResourceRequirements{
-			PVCSize: resource.MustParse("5Gi"),
+			PVCSize: resource.MustParse("50Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:    resource.MustParse("500m"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		},
 		WALStorage: ResourceRequirements{
-			PVCSize: resource.MustParse("15Gi"),
+			PVCSize: resource.MustParse("150Gi"),
 		},
 	},
 	lokiv1beta1.SizeOneXSmall: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the PVC storage size requests of `1x.extra-small` with the requests of `1x.small` and `1x.medium`. This allows seamless upgrades of all stateful Loki components w/o the need to implement an particular migration handler in the operator. Since `1x.extra-small` is used only for demostration purposes, it would have been an overkill to write a handler that cleans up PVCs and statefulsets before re-creating the in the next bigger t-shirt size.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
