### PR TITLE
Loki: Flush chunks one at a time

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -107,6 +107,7 @@ type chunkDesc struct {
 	closed  bool
 	synced  bool
 	flushed time.Time
+	reason  string
 
 	lastUpdated time.Time
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This modifies our ingesters flushing strategy to flush one chunk at a time instead of flushing them in a bulk. This has two benefits/fixes in relation to the current implementation:
1. Imagine we have 250 chunks to flush, but chunk 125 fails to flush. In the previous implementation, we would first encode all 250 chunks, but flushing chunk 125 would fail so the time encoding the last 125 chunks would be a waste
2. Flushes are marked with `cs[i].flushed = time.Now()`. In the previous implementation, a chunk flush could only be marked if all other flushes also succeeded. This makes it more granular, helping chunks to not be flushed multiple times.

This PR also refactor related functions into smaller pieces.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
For reference, see https://github.com/grafana/loki/issues/5267#issuecomment-1096919667.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
