### PR TITLE
Upgrade golang version to v1.17.9 correctly tag build image

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -355,7 +355,7 @@ local manifest(apps) = pipeline('manifest') {
           dockerfile: 'loki-build-image/Dockerfile',
           username: { from_secret: docker_username_secret.name },
           password: { from_secret: docker_password_secret.name },
-          tags: ['0.20.0'],
+          tags: ['0.20.2'],
           dry_run: false,
         },
       },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -12,7 +12,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.20.0
+    - 0.20.2
     username:
       from_secret: docker_username
   when:
@@ -1118,6 +1118,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: a96f66baa9057be9437904081ef78fa7c1584d855ba1c90d22a0bcb4eb0881f7
+hmac: 2f47de5e61231501593c473c31c46c695edabd18e6dd5e06817d272720c144f8
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+* [5899](https://github.com/grafana/loki/pull/5899) **simonswine**: Update go image to 1.17.9.
 * [5888](https://github.com/grafana/loki/pull/5888) **Papawy** Fix common config net interface name overwritten by ring common config
 * [5799](https://github.com/grafana/loki/pull/5799) **cyriltovena** Fix deduping issues when multiple entries with the same timestamp exist.
 * [5799](https://github.com/grafana/loki/pull/5799) **cyriltovena** Fixes deduping issues when multiple entries exists with the same timestamp.

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.20.2
+BUILD_IMAGE_VERSION := 0.20.1
 
 # Docker image info
 IMAGE_PREFIX ?= grafana


### PR DESCRIPTION
Raise version of build image correctly
   
Was raising the makefile first in #5899 . Now read the docs again:
    
https://github.com/grafana/loki/blob/main/docs/sources/maintaining/release-loki-build-image.md
