### PR TITLE
Loki: Don't use boltdb-shipper if gateway communication isn't available

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -144,7 +144,8 @@ func NewIndexClient(name string, cfg Config, schemaCfg config.SchemaConfig, limi
 		if boltDBIndexClientWithShipper != nil {
 			return boltDBIndexClientWithShipper, nil
 		}
-		if cfg.BoltDBShipperConfig.Mode == shipper.ModeReadOnly && cfg.BoltDBShipperConfig.IndexGatewayClientConfig.Address != "" {
+		if cfg.BoltDBShipperConfig.Mode == shipper.ModeReadOnly &&
+			(cfg.BoltDBShipperConfig.IndexGatewayClientConfig.Address != "" || cfg.BoltDBShipperConfig.IndexGatewayClientConfig.Ring != nil) {
 			gateway, err := shipper.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, util_log.Logger)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new condition to our conditional clause that checks if boltdb-shipper should be used for the index or not.

Without this check, there's a chance of boltdb being enabled even if no index gateway ring or index gateway address are available, which would lead to problems as no communication with the index gateway would be possible.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This was previously suggested by Sandeep on https://github.com/grafana/loki/pull/5514#discussion_r828977931, we applied it but somehow lost this during a rebase.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
