### PR TITLE
Use new build image 0.20.3

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -40,27 +40,27 @@ steps:
   - make BUILD_IN_CONTAINER=false check-drone-drift
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: check-generated-files
 - commands:
   - make BUILD_IN_CONTAINER=false test
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: test
 - commands:
   - make BUILD_IN_CONTAINER=false lint
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -68,7 +68,7 @@ steps:
   - clone
   - test
   - lint
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -79,19 +79,19 @@ steps:
   depends_on:
   - clone
   - check-generated-files
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
-  image: grafana/loki-build-image:0.20.1
+  image: grafana/loki-build-image:0.20.3
   name: check-example-config-doc
 trigger:
   event:
@@ -1118,6 +1118,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: 64871d70248fbe43acab816fe107dc657442ded224b48779ac15f4559143a2c6
+hmac: 6e2865a871f73b7bec7caad285b3999bfdab4e85e29606061663f4c9160cc35c
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ run:
   tests: true
 
   # list of build tags, all linters use it. Default is empty list.
-  build-tags:
+  build-tags: []
 
   # which dirs to skip: they won't be analyzed;
   # can use regexp here: generated.*, regexp is applied on full path;

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.20.1
+BUILD_IMAGE_VERSION := 0.20.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -551,7 +551,7 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 	return &logproto.PushResponse{}, err
 }
 
-func (i *Ingester) GetOrCreateInstance(instanceID string) *instance {
+func (i *Ingester) GetOrCreateInstance(instanceID string) *instance { //nolint:revive
 	inst, ok := i.getInstanceByID(instanceID)
 	if ok {
 		return inst

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -1307,7 +1307,7 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		r.nameSymbols[off] = k
 	}
 
-	r.fingerprintOffsets, err = ReadFingerprintOffsetsTable(r.b, r.toc.FingerprintOffsets)
+	r.fingerprintOffsets, err = readFingerprintOffsetsTable(r.b, r.toc.FingerprintOffsets)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading fingerprint offsets")
 	}
@@ -1522,7 +1522,7 @@ func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64, int) err
 	return d.Err()
 }
 
-func ReadFingerprintOffsetsTable(bs ByteSlice, off uint64) (FingerprintOffsets, error) {
+func readFingerprintOffsetsTable(bs ByteSlice, off uint64) (FingerprintOffsets, error) {
 	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(bs, int(off), castagnoliTable))
 	cnt := d.Be32()
 	res := make(FingerprintOffsets, 0, int(cnt))


### PR DESCRIPTION
**What this PR does / why we need it**:

The new build image uses the latest version **v1.45.2** of golangci-lint. With this version running the `make lint` locally yields the same results as running on CI.

**Special notes for your reviewer**:

* Requires https://github.com/grafana/loki/pull/5924 so that `0.20.3` is built
* ~~This PR contains commits from https://github.com/grafana/loki/pull/5901~~
* The changes in file `.drone/drone.yml` were generated by `make drone`
* Code changes are fixes for the linter:
  ```
   pkg/storage/stores/tsdb/index/index.go:1525:61: unexported-return: exported func ReadFingerprintOffsetsTable returns unexported type index.fingerprintOffsets, which can be annoying to use (revive)
   func ReadFingerprintOffsetsTable(bs ByteSlice, off uint64) (fingerprintOffsets, error) {
                                                            ^
   pkg/ingester/ingester.go:554:59: unexported-return: exported method GetOrCreateInstance returns unexported type *ingester.instance, which can be annoying to use (revive)
   func (i *Ingester) GetOrCreateInstance(instanceID string) *instance {
   ```