### PR TITLE
Include tenant ID label in label values.

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -101,7 +101,7 @@ func (q *MultiTenantQuerier) Label(ctx context.Context, req *logproto.LabelReque
 		return nil, err
 	}
 
-	if req.Name == defaultTenantLabel {
+	if req.Values && req.Name == defaultTenantLabel {
 		return &logproto.LabelResponse{Values: tenantIDs}, nil
 	}
 
@@ -118,6 +118,11 @@ func (q *MultiTenantQuerier) Label(ctx context.Context, req *logproto.LabelReque
 		}
 
 		responses[i] = resp
+	}
+
+	// Append tenant ID label name if label names are requested.
+	if !req.Values {
+		responses = append(responses, &logproto.LabelResponse{Values: []string{defaultTenantLabel}})
 	}
 
 	return logproto.MergeLabelResponses(responses)

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -279,7 +279,7 @@ func TestMultiTenantQuerier_Label(t *testing.T) {
 	mockLabelRequest := func(name string) *logproto.LabelRequest {
 		return &logproto.LabelRequest{
 			Name:   name,
-			Values: true,
+			Values: name != "",
 			Start:  &start,
 			End:    &end,
 		}
@@ -316,6 +316,18 @@ func TestMultiTenantQuerier_Label(t *testing.T) {
 			name:           defaultTenantLabel,
 			orgID:          "1",
 			expectedLabels: []string{"1"},
+		},
+		{
+			desc:           "label names for multiple tenants",
+			name:           "",
+			orgID:          "1|2",
+			expectedLabels: []string{defaultTenantLabel, "test"},
+		},
+		{
+			desc:           "label names for a single tenant",
+			name:           "",
+			orgID:          "1",
+			expectedLabels: []string{"test"},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to fully support tenant ID label filtering we need to return `__tenant_id__` in the label names.

**Which issue(s) this PR fixes**:
Fixes #5754, #5753

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
