### PR TITLE
allow read only components to *not* configure an index gateway client…

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -423,7 +423,14 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 	}
 
 	t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Mode = t.Cfg.IndexGateway.Mode
-	t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Ring = t.indexGatewayRing
+	// golang quirk:
+	// Ring is of an interface type ring.ReadRing, indexGatewayRing is of struct type ring.Ring
+	// setting IndexGatewayClientConfig.Ring = t.indexGatewayRing
+	// when t.indexGatewayRing == nil
+	// will make `t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Ring != nil` evaluate to true
+	if t.indexGatewayRing != nil {
+		t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Ring = t.indexGatewayRing
+	}
 
 	var asyncStore bool
 	if config.UsingBoltdbShipper(t.Cfg.SchemaConfig.Configs) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -423,8 +423,8 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 	}
 
 	t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Mode = t.Cfg.IndexGateway.Mode
-	// golang quirk:
-	// Ring is of an interface type ring.ReadRing, indexGatewayRing is of struct type ring.Ring
+	// golang quirk(https://go.dev/doc/faq#nil_error):
+	// Ring is of an interface type ring.ReadRing, indexGatewayRing is of struct reference type *ring.Ring
 	// setting IndexGatewayClientConfig.Ring = t.indexGatewayRing
 	// when t.indexGatewayRing == nil
 	// will make `t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Ring != nil` evaluate to true


### PR DESCRIPTION
…, if they so choose

**What this PR does / why we need it**:
This PR fixes a recently introduced bug. The bug being fixed does not allow loki to run read path components without an index gateway client.

This is due to a nil check in https://github.com/grafana/loki/blob/435391661f4e0f03eb378f77c07aaad5009cd6e9/pkg/storage/store.go#L205 that returns true when a nil struct typed reference is assigned to an interface reference.
