### PR TITLE
support custom label selector in kubernetes_sd_configs

### DIFF
--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -112,10 +112,7 @@ func NewFileTargetManager(
 		// download metadata for all pods running on a cluster, which may be a long operation.
 		for _, kube := range cfg.ServiceDiscoveryConfig.KubernetesSDConfigs {
 			if kube.Role == kubernetes.RolePod {
-				selector := fmt.Sprintf("%s=%s", kubernetesPodNodeField, hostname)
-				kube.Selectors = []kubernetes.SelectorConfig{
-					{Role: kubernetes.RolePod, Field: selector},
-				}
+				kube.Selectors = tm.fulfillKubePodSelector(kube.Selectors, hostname)
 			}
 		}
 
@@ -243,6 +240,24 @@ func (tm *FileTargetManager) AllTargets() map[string][]target.Target {
 		result[jobName] = append(result[jobName], syncer.DroppedTargets()...)
 	}
 	return result
+}
+
+func (tm *FileTargetManager) fulfillKubePodSelector(selectors []kubernetes.SelectorConfig, host string) []kubernetes.SelectorConfig {
+	nodeSelector := fmt.Sprintf("%s=%s", kubernetesPodNodeField, host)
+	if len(selectors) == 0 {
+		return []kubernetes.SelectorConfig{{Role: kubernetes.RolePod, Field: nodeSelector}}
+	}
+
+	for _, selector := range selectors {
+		if selector.Field == "" {
+			selector.Field = nodeSelector
+		} else if !strings.Contains(selector.Field, nodeSelector) {
+			selector.Field += "," + nodeSelector
+		}
+		selector.Role = kubernetes.RolePod
+	}
+
+	return selectors
 }
 
 // targetSyncer sync targets based on service discovery changes.

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1547,18 +1547,20 @@ namespaces:
   names:
     [ - <string> ]
 
-# Optional label and field selectors to limit the discovery process to a subset of available resources.
-# See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
-# and https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ to learn more about the possible
-# filters that can be used. The endpoints role supports pod, service and endpoints selectors.
-# Roles only support selectors matching the role itself (e.g. node role can only contain node selectors).
-
-# Note: When making decision about using field/label selector make sure that this
-# is the best approach - it will prevent Promtail from reusing single list/watch
-# for all scrape configs. This might result in a bigger load on the Kubernetes API,
-# because per each selector combination there will be additional LIST/WATCH. On the other hand,
-# if you just want to monitor small subset of pods in large cluster it's recommended to use selectors.
-# Decision, if selectors should be used or not depends on the particular situation.
+# Optional label and field selectors to limit the discovery process to a subset of available
+#  resources. See
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+# and https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ to learn
+# more about the possible filters that can be used. The endpoints role supports pod,
+# service, and endpoint selectors. Roles only support selectors matching the role itself;
+# for example, the node role can only contain node selectors.
+# Note: When making decisions about using field/label selectors, make sure that this
+# is the best approach. It will prevent Promtail from reusing single list/watch
+# for all scrape configurations. This might result in a bigger load on the Kubernetes API,
+# because for each selector combination, there will be additional LIST/WATCH.
+# On the other hand, if you want to monitor a small subset of pods of a large cluster,
+# we recommend using selectors. The decision on the use of selectors or not depends
+# on the particular situation.
 [ selectors:
           [ - role: <string>
                   [ label: <string> ]

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1546,6 +1546,23 @@ tls_config:
 namespaces:
   names:
     [ - <string> ]
+
+# Optional label and field selectors to limit the discovery process to a subset of available resources.
+# See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+# and https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ to learn more about the possible
+# filters that can be used. The endpoints role supports pod, service and endpoints selectors.
+# Roles only support selectors matching the role itself (e.g. node role can only contain node selectors).
+
+# Note: When making decision about using field/label selector make sure that this
+# is the best approach - it will prevent Promtail from reusing single list/watch
+# for all scrape configs. This might result in a bigger load on the Kubernetes API,
+# because per each selector combination there will be additional LIST/WATCH. On the other hand,
+# if you just want to monitor small subset of pods in large cluster it's recommended to use selectors.
+# Decision, if selectors should be used or not depends on the particular situation.
+[ selectors:
+          [ - role: <string>
+                  [ label: <string> ]
+                  [ field: <string> ] ]]
 ```
 
 Where `<role>` must be `endpoints`, `service`, `pod`, `node`, or


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:

make promtail scrape logs of pod with speciifc field or label selector, so that it will watch less logs and make fewer calculations and get a better performance in some scenarios.

for example, we only want to scape the pods in a specific namespace or with specific label in other namespaces

```
      - job_name: lcc-system-pods
        pipeline_stages:
          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
        kubernetes_sd_configs:
          - role: pod
            selectors:
            - role: pod
              field: metadata.namespace=lcc-system
        relabel_configs: ....
     -  job_name: lcc-pods-not-in-lcc-system
        pipeline_stages:
          {{- toYaml .Values.config.snippets.pipelineStages | nindent 4 }}
        kubernetes_sd_configs:
          - role: pod
            selectors:
            - role: pod
              field: metadata.namespace!=lcc-system
              label: app.lccomputing.com/product=lcc
        relabel_configs: ....
```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
