### PR TITLE
Other: trigger build of loki-build-image:0.20.3

### DIFF
--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -3,17 +3,25 @@ title: Releasing Loki Build Image
 ---
 # Releasing `loki-build-image`
 
-The [`loki-build-image`](https://github.com/grafana/loki/tree/master/loki-build-image) is the Docker image used to run tests and build Grafana Loki binaries in CI.
+The [`loki-build-image`](https://github.com/grafana/loki/tree/master/loki-build-image)
+is the Docker image used to run tests and build Grafana Loki binaries in CI.
 
-The image is released with any change to `./loki-build-image` on `main`.
+The build and publish process of the image is triggered upon a merge to `main`
+if there were made any changes in the folder `./loki-build-image/`.
 
-## How To Use a New Release
+**Building and using the `loki-build-image` is a two-step process.**
 
-1. Update the version tag of the `loki-build-image` pipeline defined in `.drone/drone.jsonnet` (search for `pipeline('loki-build-image')`).
-1. Merge change into `main` and wait for the release.
-1. Update `BUILD_IMAGE_VERSION` in the `Makefile`.
-1. Update the image version in all the other places it exists
-    1. Dockerfiles in `cmd` directory
-    1. .circleci/config.yml
-1. Run `make drone BUILD_IN_CONTAINER=false` to rebuild the drone yml file with the new image version (the image version in the Makefile is used)
-2. Merge change into `main`.
+As a **first step** to build the new image, you need to create a pull
+request with the desired changes to the Dockerfile. To increase the version of
+the image, you also need to update the version tag of the `loki-build-image`
+pipeline defined in `.drone/drone.jsonnet` (search for
+`pipeline('loki-build-image')`) and run `BUILD_IN_CONTAINER=false make drone`
+and commit the changes to the same pull request.
+Once approved and merged to `main`, the image with the new version is built.
+
+The new image can only be used after updating the `BUILD_IMAGE_VERSION` in the
+`Makefile` a **second step**. Once again, run `BUILD_IN_CONTAINER=false make
+drone` after changing the version and submit a PR with the generated changes.
+Also update the image version in all other places where the image is used:
+* Dockerfiles in `cmd` directory
+* `.circleci/config.yml`

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -20,8 +20,11 @@ and commit the changes to the same pull request.
 Once approved and merged to `main`, the image with the new version is built.
 
 The new image can only be used after updating the `BUILD_IMAGE_VERSION` in the
-`Makefile` a **second step**. Once again, run `BUILD_IN_CONTAINER=false make
-drone` after changing the version and submit a PR with the generated changes.
-Also update the image version in all other places where the image is used:
+`Makefile` a **second step**. After changing the version in the Makefile and
+updating it in all other places where the image is used:
+
 * Dockerfiles in `cmd` directory
 * `.circleci/config.yml`
+
+run `BUILD_IN_CONTAINER=false make drone` again and submit a PR with the
+generated changes.

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -1,4 +1,8 @@
-# NOTICE: Change the verion in Makefile if you make a change here. See ../docs/sources/maintaining/release-loki-build-image.md.
+# This is the Dockerfile for the Loki build image that is used by the CI
+# pipelines.
+# If you make changes to this Dockerfile you also need to update the
+# tag of the Docker image in `../.drone/drone.jsonnet` and run `make drone`.
+# See ../docs/sources/maintaining/release-loki-build-image.md
 
 FROM alpine as helm
 ARG HELM_VER="v3.2.3"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Update documentation how to build and use the loki-build-image**

The existing documentation was not clear about the two-step process for
building and using the image. This PR tries to improve that.


**Trigger build for Loki build image version 0.20.3**

In commit 435391661f4e0f03eb378f77c07aaad5009cd6e9 the version was
increased from 0.20.2 to 0.20.3 in the `.drone/drone.jsonnet` file, but
not in the `.drone/drone.yml`, which caused the image not to be built.

In order to trigger the build of 0.20.3, contents of the
`loki-build-image/` folder need to change, therefore the comment in the
Dockerfile.


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
