### PR TITLE
[promtail] stream lag delete fix

### DIFF
--- a/clients/cmd/fluent-bit/dque.go
+++ b/clients/cmd/fluent-bit/dque.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/joncrlsn/dque"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
@@ -153,4 +154,9 @@ func (c *dqueClient) enqueuer() {
 
 func (c *dqueClient) Name() string {
 	return ""
+}
+
+// noop
+func (c *dqueClient) UnregisterLatencyMetric(labels prometheus.Labels) bool {
+	return false
 }

--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -111,10 +111,6 @@ func main() {
 		}
 	}
 
-	// TODO (callum): I really don't understand where we set defaults for various config structs
-	if len(config.Config.Options.StreamLagLabels) == 0 {
-		config.Config.Options.StreamLagLabels = flagext.StringSliceCSV{client.LatencyLabel}
-	}
 	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.Options.StreamLagLabels)
 	p, err := promtail.New(config.Config, clientMetrics, config.dryRun)
 	if err != nil {

--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -111,6 +111,10 @@ func main() {
 		}
 	}
 
+	// TODO (callum): I really don't understand where we set defaults for various config structs
+	if len(config.Config.Options.StreamLagLabels) == 0 {
+		config.Config.Options.StreamLagLabels = flagext.StringSliceCSV{client.LatencyLabel}
+	}
 	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer, config.Config.Options.StreamLagLabels)
 	p, err := promtail.New(config.Config, clientMetrics, config.dryRun)
 	if err != nil {

--- a/clients/pkg/promtail/api/types.go
+++ b/clients/pkg/promtail/api/types.go
@@ -15,9 +15,8 @@ type Entry struct {
 	logproto.Entry
 }
 
-type InstrumentedEntryHandler interface {
-	EntryHandler
-	UnregisterLatencyMetric(prometheus.Labels) bool
+type LatencyMetricHandler interface {
+	UnregisterLatencyMetric(labels prometheus.Labels) bool
 }
 
 // EntryHandler is something that can "handle" entries via a channel.

--- a/clients/pkg/promtail/api/types.go
+++ b/clients/pkg/promtail/api/types.go
@@ -17,7 +17,7 @@ type Entry struct {
 
 type InstrumentedEntryHandler interface {
 	EntryHandler
-	UnregisterLatencyMetric(prometheus.Labels)
+	UnregisterLatencyMetric(prometheus.Labels) bool
 }
 
 // EntryHandler is something that can "handle" entries via a channel.

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -465,6 +465,12 @@ func (c *client) UnregisterLatencyMetric(labels prometheus.Labels) bool {
 		level.Debug(c.logger).Log("msg", "no stream lag metric found", "filename", labels["filename"], "client", c.name, "host", c.cfg.URL.Host)
 		return false
 	}
+	// If we found an entry in the map it's always safe to delete it, this is the
+	// only place we try to look for that entry. This guarantees we don't endlessly
+	// grow the map entries + if the entire labelset is seen again we would just
+	// write this entry back into the map the next time we send a batch for the stream.
+	delete(c.streamLagMetricsMap, key)
+
 	if !c.metrics.streamLag.Delete(lset) {
 		level.Debug(c.logger).Log("msg", "no stream lag metric deleted, mismatch between stored metrics map and client library registered metrics", "filename", labels["filename"], "client", c.name, "host", c.cfg.URL.Host)
 		return false

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -132,6 +132,7 @@ func mustRegisterOrGet(reg prometheus.Registerer, c prometheus.Collector) promet
 // Client pushes entries to Loki and can be stopped
 type Client interface {
 	api.EntryHandler
+	api.LatencyMetricHandler
 	// Stop goroutine sending batch of entries without retries.
 	StopNow()
 	Name() string

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -477,5 +477,5 @@ func (c *client) Name() string {
 }
 
 func (c *client) streamLagMetricsMapKey(labels prometheus.Labels) string {
-	return string(labels["filename"]) + c.name + c.cfg.URL.Host
+	return labels["filename"] + c.name + c.cfg.URL.Host
 }

--- a/clients/pkg/promtail/client/client_test.go
+++ b/clients/pkg/promtail/client/client_test.go
@@ -525,5 +525,5 @@ func Test_UnregisterLatencyMetric(t *testing.T) {
 
 	// Fake setting the metric key in the map, which would be done client.sendBatch
 	c.(*client).streamLagMetricsMap[c.(*client).streamLagMetricsMapKey(ls)] = ls
-	require.True(t, c.(api.InstrumentedEntryHandler).UnregisterLatencyMetric(prometheus.Labels{"filename": "test", "client": c.Name(), "host": cfg.URL.Host}))
+	require.True(t, c.(api.LatencyMetricHandler).UnregisterLatencyMetric(prometheus.Labels{"filename": "test", "client": c.Name(), "host": cfg.URL.Host}))
 }

--- a/clients/pkg/promtail/client/client_test.go
+++ b/clients/pkg/promtail/client/client_test.go
@@ -526,4 +526,5 @@ func Test_UnregisterLatencyMetric(t *testing.T) {
 	// Fake setting the metric key in the map, which would be done client.sendBatch
 	c.(*client).streamLagMetricsMap[c.(*client).streamLagMetricsMapKey(ls)] = ls
 	require.True(t, c.(api.LatencyMetricHandler).UnregisterLatencyMetric(prometheus.Labels{"filename": "test", "client": c.Name(), "host": cfg.URL.Host}))
+	require.Equal(t, 0, len(c.(*client).streamLagMetricsMap))
 }

--- a/clients/pkg/promtail/client/fake/client.go
+++ b/clients/pkg/promtail/client/fake/client.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Client is a fake client used for testing.
@@ -59,4 +60,9 @@ func (c *Client) StopNow() {
 
 func (c *Client) Name() string {
 	return "fake"
+}
+
+// noop
+func (c *Client) UnregisterLatencyMetric(labels prometheus.Labels) bool {
+	return false
 }

--- a/clients/pkg/promtail/client/logger.go
+++ b/clients/pkg/promtail/client/logger.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
@@ -84,4 +85,9 @@ func (l *logger) StopNow() { l.Stop() }
 
 func (l *logger) Name() string {
 	return ""
+}
+
+// noop
+func (l *logger) UnregisterLatencyMetric(_ prometheus.Labels) bool {
+	return true
 }

--- a/clients/pkg/promtail/client/multi.go
+++ b/clients/pkg/promtail/client/multi.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 )
@@ -93,4 +94,14 @@ func (m *MultiClient) Name() string {
 		}
 	}
 	return sb.String()
+}
+
+func (m *MultiClient) UnregisterLatencyMetric(labels prometheus.Labels) bool {
+	var ret bool
+	for _, c := range m.clients {
+		if h, ok := c.(api.LatencyMetricHandler); ok {
+			h.UnregisterLatencyMetric(labels)
+		}
+	}
+	return ret
 }

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -46,6 +46,8 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	c.PositionsConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.TargetConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.LimitsConfig.RegisterFlagsWithPrefix(prefix, f)
+	// Default stream lag labels to "filename"
+	c.Options.StreamLagLabels = []string{client.LatencyLabel}
 }
 
 // RegisterFlags registers flags.
@@ -87,9 +89,5 @@ func (c *Config) Setup(l log.Logger) {
 		for i := range c.ClientConfigs {
 			c.ClientConfigs[i].ExternalLabels = flagext.LabelSet{LabelSet: c.ClientConfig.ExternalLabels.LabelSet.Merge(c.ClientConfigs[i].ExternalLabels.LabelSet)}
 		}
-	}
-
-	if len(c.Options.StreamLagLabels) == 0 {
-		c.Options.StreamLagLabels = dskit_flagext.StringSliceCSV{client.LatencyLabel}
 	}
 }

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -88,4 +88,8 @@ func (c *Config) Setup(l log.Logger) {
 			c.ClientConfigs[i].ExternalLabels = flagext.LabelSet{LabelSet: c.ClientConfig.ExternalLabels.LabelSet.Merge(c.ClientConfigs[i].ExternalLabels.LabelSet)}
 		}
 	}
+
+	if len(c.Options.StreamLagLabels) == 0 {
+		c.Options.StreamLagLabels = dskit_flagext.StringSliceCSV{client.LatencyLabel}
+	}
 }

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -75,7 +75,7 @@ func TestConfig_Setup(t *testing.T) {
 					},
 				},
 				Options: Options{
-					StreamLagLabels: []string{},
+					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 			Config{
@@ -91,7 +91,7 @@ func TestConfig_Setup(t *testing.T) {
 					},
 				},
 				Options: Options{
-					StreamLagLabels: []string{},
+					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestConfig_Setup(t *testing.T) {
 					},
 				},
 				Options: Options{
-					StreamLagLabels: []string{},
+					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 			Config{
@@ -131,7 +131,7 @@ func TestConfig_Setup(t *testing.T) {
 					},
 				},
 				Options: Options{
-					StreamLagLabels: []string{},
+					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 		},

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -74,9 +74,6 @@ func TestConfig_Setup(t *testing.T) {
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
 				},
-				Options: Options{
-					StreamLagLabels: []string{client.LatencyLabel},
-				},
 			},
 			Config{
 				ClientConfig: client.Config{
@@ -89,9 +86,6 @@ func TestConfig_Setup(t *testing.T) {
 					{
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2", "foo": "bar"}},
 					},
-				},
-				Options: Options{
-					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 		},
@@ -108,9 +102,6 @@ func TestConfig_Setup(t *testing.T) {
 					{
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"client2": "2"}},
 					},
-				},
-				Options: Options{
-					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 			Config{
@@ -129,9 +120,6 @@ func TestConfig_Setup(t *testing.T) {
 						ExternalLabels: flagext.LabelSet{LabelSet: model.LabelSet{"foo": "bar"}},
 						URL:            dskitflagext.URLValue{URL: mustURL("http://foo")},
 					},
-				},
-				Options: Options{
-					StreamLagLabels: []string{client.LatencyLabel},
 				},
 			},
 		},

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -81,7 +81,7 @@ func New(cfg config.Config, metrics *client.Metrics, dryRun bool, opts ...Option
 		}
 	}
 
-	tms, err := targets.NewTargetManagers(promtail, promtail.reg, promtail.logger, cfg.PositionsConfig, promtail.client, cfg.ScrapeConfig, &cfg.TargetConfig)
+	tms, err := targets.NewTargetManagers(promtail, promtail.reg, promtail.logger, cfg.PositionsConfig, promtail.client, promtail.client, cfg.ScrapeConfig, &cfg.TargetConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/pkg/promtail/promtail_test.go
+++ b/clients/pkg/promtail/promtail_test.go
@@ -45,7 +45,7 @@ import (
 
 const httpTestPort = 9080
 
-var clientMetrics = client.NewMetrics(prometheus.DefaultRegisterer, nil)
+var clientMetrics = client.NewMetrics(prometheus.DefaultRegisterer, []string{"filename"})
 
 func TestPromtail(t *testing.T) {
 	// Setup.
@@ -564,6 +564,8 @@ func buildTestConfig(t *testing.T, positionsFileName string, logDirName string) 
 	cfg.ServerConfig.HTTPListenPort = httpTestPort
 
 	// Override some of those defaults
+	cfg.Options.StreamLagLabels = flagext.StringSliceCSV{"filename"}
+	// TODO (callum): refactor this to use cfg.ClientConfigs, currently doing so seems to break TestPromtail (writes always context deadline exceeded)
 	cfg.ClientConfig.URL = clientURL
 	cfg.ClientConfig.BatchWait = 10 * time.Millisecond
 	cfg.ClientConfig.BatchSize = 10 * 1024

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -67,7 +67,7 @@ func TestFileTargetSync(t *testing.T) {
 		}
 	}()
 	path := logDir1 + "/*.log"
-	target, err := NewFileTarget(metrics, logger, client, ps, path, nil, nil, &Config{
+	target, err := NewFileTarget(metrics, logger, client, client, ps, path, nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
 	}, nil, fakeHandler)
 	assert.NoError(t, err)
@@ -209,7 +209,7 @@ func TestHandleFileCreationEvent(t *testing.T) {
 		}
 	}()
 
-	target, err := NewFileTarget(metrics, logger, client, ps, path, nil, nil, &Config{
+	target, err := NewFileTarget(metrics, logger, client, client, ps, path, nil, nil, &Config{
 		// To handle file creation event from channel, set enough long time as sync period
 		SyncPeriod: 10 * time.Minute,
 	}, fakeFileHandler, fakeTargetHandler)

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -38,11 +38,11 @@ const (
 // FileTargetManager manages a set of targets.
 // nolint:revive
 type FileTargetManager struct {
-	log            log.Logger
-	quit           context.CancelFunc
-	syncers        map[string]*targetSyncer
-	manager        *discovery.Manager
-	metricsHandler api.LatencyMetricHandler
+	log           log.Logger
+	quit          context.CancelFunc
+	syncers       map[string]*targetSyncer
+	manager       *discovery.Manager
+	metricHandler api.LatencyMetricHandler
 
 	watcher            *fsnotify.Watcher
 	targetEventHandler chan fileTargetEvent
@@ -56,7 +56,7 @@ func NewFileTargetManager(
 	logger log.Logger,
 	positions positions.Positions,
 	client api.EntryHandler,
-	metricsHandler api.LatencyMetricHandler,
+	metricHandler api.LatencyMetricHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *Config,
 ) (*FileTargetManager, error) {
@@ -74,7 +74,7 @@ func NewFileTargetManager(
 		log:                logger,
 		quit:               quit,
 		watcher:            watcher,
-		metricsHandler:     metricsHandler,
+		metricHandler:      metricHandler,
 		targetEventHandler: make(chan fileTargetEvent),
 		syncers:            map[string]*targetSyncer{},
 		manager:            discovery.NewManager(ctx, log.With(logger, "component", "discovery")),
@@ -130,7 +130,7 @@ func NewFileTargetManager(
 			droppedTargets:    []target.Target{},
 			hostname:          hostname,
 			entryHandler:      pipeline.Wrap(client),
-			metricHandler:     metricsHandler,
+			metricHandler:     metricHandler,
 			targetConfig:      targetConfig,
 			fileEventWatchers: map[string]chan fsnotify.Event{},
 		}

--- a/clients/pkg/promtail/targets/file/filetargetmanager_test.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager_test.go
@@ -43,7 +43,7 @@ func newTestPositions(logger log.Logger, filePath string) (positions.Positions, 
 	return pos, nil
 }
 
-func newTestFileTargetManager(logger log.Logger, client api.EntryHandler, positions positions.Positions, observePath string) (*FileTargetManager, error) {
+func newTestFileTargetManager(logger log.Logger, client api.EntryHandler, metricHandler api.LatencyMetricHandler, positions positions.Positions, observePath string) (*FileTargetManager, error) {
 	targetGroup := targetgroup.Group{
 		Targets: []model.LabelSet{{
 			"localhost": "",
@@ -70,7 +70,7 @@ func newTestFileTargetManager(logger log.Logger, client api.EntryHandler, positi
 	}
 
 	metrics := NewMetrics(nil)
-	ftm, err := NewFileTargetManager(metrics, logger, positions, client, []scrapeconfig.Config{sc}, tc)
+	ftm, err := NewFileTargetManager(metrics, logger, positions, client, metricHandler, []scrapeconfig.Config{sc}, tc)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func TestLongPositionsSyncDelayStillSavesCorrectPosition(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, logDirName+"/*")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, logDirName+"/*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestWatchEntireDirectory(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, logDirName+"/*")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, logDirName+"/*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestFileRolls(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, logDirName+"/*.log")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, logDirName+"/*.log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func TestResumesWhereLeftOff(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, logDirName+"/*.log")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, logDirName+"/*.log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestResumesWhereLeftOff(t *testing.T) {
 	}
 
 	// Create a new target manager, keep the same client so we can track what was sent through the handler.
-	ftm2, err := newTestFileTargetManager(logger, client, ps2, logDirName+"/*.log")
+	ftm2, err := newTestFileTargetManager(logger, client, client, ps2, logDirName+"/*.log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestGlobWithMultipleFiles(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, logDirName+"/*.log")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, logDirName+"/*.log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +484,7 @@ func TestDeadlockStartWatchingDuringSync(t *testing.T) {
 	client := fake.New(func() {})
 	defer client.Stop()
 
-	ftm, err := newTestFileTargetManager(logger, client, ps, oldLogDir+"/*")
+	ftm, err := newTestFileTargetManager(logger, client, client, ps, oldLogDir+"/*")
 	assert.NoError(t, err)
 
 	done := make(chan struct{})

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -59,6 +59,7 @@ func NewTargetManagers(
 	logger log.Logger,
 	positionsConfig positions.Config,
 	client api.EntryHandler,
+	metricsHandler api.LatencyMetricHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *file.Config,
 ) (*TargetManagers, error) {
@@ -154,6 +155,7 @@ func NewTargetManagers(
 				logger,
 				pos,
 				client,
+				metricsHandler,
 				scrapeConfigs,
 				targetConfig,
 			)

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -59,7 +59,7 @@ func NewTargetManagers(
 	logger log.Logger,
 	positionsConfig positions.Config,
 	client api.EntryHandler,
-	metricsHandler api.LatencyMetricHandler,
+	metricHandler api.LatencyMetricHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *file.Config,
 ) (*TargetManagers, error) {
@@ -155,7 +155,7 @@ func NewTargetManagers(
 				logger,
 				pos,
 				client,
-				metricsHandler,
+				metricHandler,
 				scrapeConfigs,
 				targetConfig,
 			)


### PR DESCRIPTION
_Note: to reproduce the bug you can run promtail on your laptop and have a single static config that reads a local log file. Delete that file, and then see if the metric still exists on `/metrics`, it should. With the changes in this PR the metric will properly be deleted when you delete that local log file._

So because of the way the metric is registered now we couldn't delete the metric for a file stream that went away in the same way. There's a PR open in the prometheus client_golang that would allow us to do this in a nicer way (delete based on a partial label set), but for now this should work. Alternatively we would refactor the filestream code to track this metric instead of it being part of the client code. 

There was another issue related to the actual `InstrumentedEntryHandler` interface. I had a hard time fully grokking the way the client(s) are passed around between the promtail client code, and then used as `api.EntryHandler` in the file target and target manager code. If I understand correctly, because of another change I made which deprecated the individual `config.Client` and only now allow for multiple clients via `config.Clients`, we now always have a `MultiClient` that's being passed. For some reason `MultiClient`, even with `UnregisterLatencyMetric` implemented, would never match the type assertion for `t.handler.(api.InstrumentedEntryHandler)`, and so we would never call the function to delete the metric. By refactoring the interfaces so that `EntryHandler` and `LatencyMetricHandler` are separate parameters to `NewFileTarget` we shouldn't run into this same bug again.

The commits should be standalone (at least starting from [8d99c61](https://github.com/grafana/loki/pull/5933/commits/8d99c611dfdd39c5e142857ec2da8aa0b140dc76)) and could be read in order for easier reviewing, though some of your comments may be resolved along the way.

CC @MasslessParticle 