### PR TITLE
store: fix bug in getting chunk ids from ingesters when using boltdb-shipper

### DIFF
--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -23,7 +23,8 @@ type IngesterQuerier interface {
 }
 
 type AsyncStoreCfg struct {
-	IngesterQuerier      IngesterQuerier
+	IngesterQuerier IngesterQuerier
+	// QueryIngestersWithin defines maximum lookback beyond which ingesters are not queried for chunk ids.
 	QueryIngestersWithin time.Duration
 }
 

--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/storage/stores"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -21,23 +22,28 @@ type IngesterQuerier interface {
 	GetChunkIDs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 }
 
+type AsyncStoreCfg struct {
+	IngesterQuerier      IngesterQuerier
+	QueryIngestersWithin time.Duration
+}
+
 // AsyncStore does querying to both ingesters and chunk store and combines the results after deduping them.
 // This should be used when using an async store like boltdb-shipper.
 // AsyncStore is meant to be used only in queriers or any other service other than ingesters.
 // It should never be used in ingesters otherwise it would start spiraling around doing queries over and over again to other ingesters.
 type AsyncStore struct {
-	Store
+	stores.Store
 	scfg                 config.SchemaConfig
 	ingesterQuerier      IngesterQuerier
 	queryIngestersWithin time.Duration
 }
 
-func NewAsyncStore(store Store, scfg config.SchemaConfig, querier IngesterQuerier, queryIngestersWithin time.Duration) *AsyncStore {
+func NewAsyncStore(cfg AsyncStoreCfg, store stores.Store, scfg config.SchemaConfig) *AsyncStore {
 	return &AsyncStore{
 		Store:                store,
 		scfg:                 scfg,
-		ingesterQuerier:      querier,
-		queryIngestersWithin: queryIngestersWithin,
+		ingesterQuerier:      cfg.IngesterQuerier,
+		queryIngestersWithin: cfg.QueryIngestersWithin,
 	}
 }
 

--- a/pkg/storage/async_store_test.go
+++ b/pkg/storage/async_store_test.go
@@ -211,7 +211,8 @@ func TestAsyncStore_mergeIngesterAndStoreChunks(t *testing.T) {
 			ingesterQuerier := newIngesterQuerierMock()
 			ingesterQuerier.On("GetChunkIDs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.ingesterChunkIDs, nil)
 
-			asyncStore := NewAsyncStore(store, config.SchemaConfig{}, ingesterQuerier, 0)
+			asyncStoreCfg := AsyncStoreCfg{IngesterQuerier: ingesterQuerier}
+			asyncStore := NewAsyncStore(asyncStoreCfg, store, config.SchemaConfig{})
 
 			chunks, fetchers, err := asyncStore.GetChunkRefs(context.Background(), "fake", model.Now(), model.Now(), nil)
 			require.NoError(t, err)
@@ -268,7 +269,11 @@ func TestAsyncStore_QueryIngestersWithin(t *testing.T) {
 			ingesterQuerier := newIngesterQuerierMock()
 			ingesterQuerier.On("GetChunkIDs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 
-			asyncStore := NewAsyncStore(store, config.SchemaConfig{}, ingesterQuerier, tc.queryIngestersWithin)
+			asyncStoreCfg := AsyncStoreCfg{
+				IngesterQuerier:      ingesterQuerier,
+				QueryIngestersWithin: tc.queryIngestersWithin,
+			}
+			asyncStore := NewAsyncStore(asyncStoreCfg, store, config.SchemaConfig{})
 
 			_, _, err := asyncStore.GetChunkRefs(context.Background(), "fake", tc.queryFrom, tc.queryThrough, nil)
 			require.NoError(t, err)

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -63,6 +63,11 @@ type Config struct {
 
 	MaxChunkBatchSize   int            `yaml:"max_chunk_batch_size"`
 	BoltDBShipperConfig shipper.Config `yaml:"boltdb_shipper"`
+
+	// Config for using AsyncStore when using async index stores like `boltdb-shipper`.
+	// It is required for getting chunk ids of recently flushed chunks from the ingesters.
+	EnableAsyncStore bool          `yaml:"-"`
+	AsyncStoreConfig AsyncStoreCfg `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -159,6 +159,10 @@ func (s *store) init() error {
 		}
 		s.composite.AddStore(p.From.Time, f, idx, w, stop)
 	}
+
+	if s.cfg.EnableAsyncStore {
+		s.Store = NewAsyncStore(s.cfg.AsyncStoreConfig, s.Store, s.schemaCfg)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have a [ChunkStore](https://github.com/grafana/loki/blob/8f024954539b5eb706ab3ef967c4b1696ad04fd6/pkg/storage/stores/composite_store.go#L16) type which has a `GetChunkRefs` method and [LokiStore](https://github.com/grafana/loki/blob/5ea1951c6e3e2690bdfb993e6a71dc4e8d8efe50/pkg/storage/store.go#L41) type which is actually a wrapper on top of `ChunkStore` type, providing methods like `SelectLogs`, `SelectSamples` etc.
We also have a [AsyncStore](https://github.com/grafana/loki/blob/5ea1951c6e3e2690bdfb993e6a71dc4e8d8efe50/pkg/storage/async_store.go#L34) type which is used when `boltdb-shipper` is used as an index store so that we can get chunk ids of recently flushed chunks from ingesters. However, it only implements the `GetChunkRefs` method, which gets chunk ids from both `ChunkStore` and Ingesters.

Previously all 3 had separate factory functions, but in PR #5833, we merged factory functions for `ChunkStore` and `LokiStore`. The problem now is `AsyncStore` now embeds `LokiStore` instead of `ChunkStore`. So when any of the `LokiStore` methods are called, control shifts to `LokiStore`, which calls `ChunkStore` methods since it has no idea about the presence of `AsyncStore`. Unfortunately, this causes us not to query ingesters for recently flushed chunk ids, so we miss some of the data from queries until the index gets synced.

This PR fixes the issue by making the factory function for `LokiStore` initialise `AsyncStore` as well so that it can query chunk ids from ingesters.
