### PR TITLE
Add better observability to queryReadiness

### DIFF
--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -28,7 +28,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		ensureQueryReadinessDurationSeconds: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "query_readiness_duration_seconds",
-			Help:      "Time (in seconds) spent making an index gateway ready to be queried",
+			Help:      "Time (in seconds) spent making this instance ready to be queried",
 			Buckets:   instrument.DefBuckets,
 		}),
 		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{

--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -16,7 +16,6 @@ type metrics struct {
 	tablesSyncOperationTotal               *prometheus.CounterVec
 	tablesDownloadOperationDurationSeconds prometheus.Gauge
 	ensureQueryReadinessDurationSeconds    prometheus.Histogram
-	usersToBeQueryReadyForTotal            prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -31,11 +30,6 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "query_readiness_duration_seconds",
 			Help:      "Time (in seconds) spent making an index gateway ready to be queried",
 			Buckets:   instrument.DefBuckets,
-		}),
-		usersToBeQueryReadyForTotal: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_boltdb_shipper",
-			Name:      "users_to_be_query_ready_for_total",
-			Help:      "Total number of users an index gateway instance has to be query ready for.",
 		}),
 		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",

--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -3,6 +3,7 @@ package downloads
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/instrument"
 )
 
 const (
@@ -14,6 +15,8 @@ type metrics struct {
 	queryTimeTableDownloadDurationSeconds  *prometheus.CounterVec
 	tablesSyncOperationTotal               *prometheus.CounterVec
 	tablesDownloadOperationDurationSeconds prometheus.Gauge
+	ensureQueryReadinessDurationSeconds    prometheus.Histogram
+	usersToBeQueryReadyForTotal            prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -23,6 +26,17 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "query_time_table_download_duration_seconds",
 			Help:      "Time (in seconds) spent in downloading of files per table at query time",
 		}, []string{"table"}),
+		ensureQueryReadinessDurationSeconds: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "query_readiness_duration_seconds",
+			Help:      "Time (in seconds) spent making an index gateway ready to be queried",
+			Buckets:   instrument.DefBuckets,
+		}),
+		usersToBeQueryReadyForTotal: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "users_to_be_query_ready_for_total",
+			Help:      "Total number of users an index gateway instance has to be query ready for.",
+		}),
 		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "tables_sync_operation_total",

--- a/pkg/storage/stores/shipper/downloads/metrics.go
+++ b/pkg/storage/stores/shipper/downloads/metrics.go
@@ -3,7 +3,6 @@ package downloads
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/weaveworks/common/instrument"
 )
 
 const (
@@ -15,7 +14,6 @@ type metrics struct {
 	queryTimeTableDownloadDurationSeconds  *prometheus.CounterVec
 	tablesSyncOperationTotal               *prometheus.CounterVec
 	tablesDownloadOperationDurationSeconds prometheus.Gauge
-	ensureQueryReadinessDurationSeconds    prometheus.Histogram
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -25,12 +23,6 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "query_time_table_download_duration_seconds",
 			Help:      "Time (in seconds) spent in downloading of files per table at query time",
 		}, []string{"table"}),
-		ensureQueryReadinessDurationSeconds: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loki_boltdb_shipper",
-			Name:      "query_readiness_duration_seconds",
-			Help:      "Time (in seconds) spent making this instance ready to be queried",
-			Buckets:   instrument.DefBuckets,
-		}),
 		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_boltdb_shipper",
 			Name:      "tables_sync_operation_total",

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -241,6 +241,14 @@ func (tm *TableManager) cleanupCache() error {
 
 // ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
 func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
+	start := time.Now()
+	usersToBeQueryReadyLen := 0
+	defer func() {
+		duration := time.Since(start)
+		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(duration.Seconds())
+		tm.metrics.usersToBeQueryReadyForTotal.Set(float64(usersToBeQueryReadyLen))
+	}()
+
 	activeTableNumber := getActiveTableNumber()
 
 	// find the largest query readiness number
@@ -309,6 +317,9 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 			return err
 		}
 
+		usersToBeQueryReadyLen += len(usersToBeQueryReadyFor)
+
+		level.Debug(util_log.Logger).Log("msg", "instance should be query ready for users", "users", usersToBeQueryReadyFor)
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -315,7 +315,7 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 			return err
 		}
 
-		level.Debug(util_log.Logger).Log("msg", "instance should be query ready for users", "users", usersToBeQueryReadyFor)
+		level.Debug(util_log.Logger).Log("msg", "instance should be query ready for users", "users", usersToBeQueryReadyFor, "query_readiness_duration", time.Since(start))
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -242,11 +242,9 @@ func (tm *TableManager) cleanupCache() error {
 // ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
 func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 	start := time.Now()
-	usersToBeQueryReadyLen := 0
 	defer func() {
 		duration := time.Since(start)
 		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(duration.Seconds())
-		tm.metrics.usersToBeQueryReadyForTotal.Set(float64(usersToBeQueryReadyLen))
 	}()
 
 	activeTableNumber := getActiveTableNumber()
@@ -316,8 +314,6 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
-		usersToBeQueryReadyLen += len(usersToBeQueryReadyFor)
 
 		level.Debug(util_log.Logger).Log("msg", "instance should be query ready for users", "users", usersToBeQueryReadyFor)
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -243,8 +243,7 @@ func (tm *TableManager) cleanupCache() error {
 func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
-		duration := time.Since(start)
-		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(duration.Seconds())
+		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 
 	activeTableNumber := getActiveTableNumber()
@@ -315,10 +314,11 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 			return err
 		}
 
-		level.Debug(util_log.Logger).Log("msg", "instance should be query ready for users", "users", usersToBeQueryReadyFor, "query_readiness_duration", time.Since(start))
+		perTableStart := time.Now()
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}
+		level.Debug(util_log.Logger).Log("msg", "instance query ready for users", "users", usersToBeQueryReadyFor, "query_readiness_duration", time.Since(perTableStart), "table", tableName)
 	}
 
 	return nil

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -318,7 +319,8 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}
-		level.Debug(util_log.Logger).Log("msg", "instance query ready for users", "users", usersToBeQueryReadyFor, "query_readiness_duration", time.Since(perTableStart), "table", tableName)
+		joinedUsers := strings.Join(usersToBeQueryReadyFor, ",")
+		level.Debug(util_log.Logger).Log("msg", "instance query ready for users", "users", joinedUsers, "query_readiness_duration", time.Since(perTableStart), "table", tableName)
 	}
 
 	return nil

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -245,7 +245,6 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		level.Info(util_log.Logger).Log("msg", "query readiness setup completed", "duration", time.Since(start))
-		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 
 	activeTableNumber := getActiveTableNumber()

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -244,6 +244,7 @@ func (tm *TableManager) cleanupCache() error {
 func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
+		level.Info(util_log.Logger).Log("msg", "query readiness setup completed", "duration", time.Since(start))
 		tm.metrics.ensureQueryReadinessDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 
@@ -320,7 +321,7 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 			return err
 		}
 		joinedUsers := strings.Join(usersToBeQueryReadyFor, ",")
-		level.Debug(util_log.Logger).Log("msg", "instance query ready for users", "users", joinedUsers, "query_readiness_duration", time.Since(perTableStart), "table", tableName)
+		level.Info(util_log.Logger).Log("msg", "index pre-download for query readiness completed", "users", joinedUsers, "duration", time.Since(perTableStart), "table", tableName)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
~~Adds a new `query_readiness_duration_seconds` metric, that reports query readiness duration of a tablemanager/index gateway instance. We should use it later to report performance against the ring mode.~~ 

~~Adds a new `usersToBeQueryReadyForTotal` metric, that reports number of users involved in the query readiness operation. We should use it later to correlate number of users with the query readiness duration.~~

Logs the users involved in the query readiness operation. Will be especially useful for the ring mode so that we can track down the users assigned to each instance.

Logs the duration spent in the query readiness operation.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
