### PR TITLE
index-gateway: fix index gateway chunk refs response

### DIFF
--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -307,8 +307,8 @@ func (g *Gateway) GetChunkRef(ctx context.Context, req *indexgatewaypb.GetChunkR
 		Refs: make([]*logproto.ChunkRef, 0, len(chunks)),
 	}
 	for _, cs := range chunks {
-		for _, c := range cs {
-			result.Refs = append(result.Refs, &c.ChunkRef)
+		for i := range cs {
+			result.Refs = append(result.Refs, &cs[i].ChunkRef)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**What this PR does / why we need it**:
While building `GetChunkRefs` response from index gateways, we use the address of loop variable. This causes us to have the same values for all the chunks. Lint somehow missed catching that mistake. This PR fixes the issue by using index for getting the address of the slice item.