### PR TITLE
redact s3 credential values when printing config to logs

### DIFF
--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -267,8 +267,8 @@ memberlist:
 				assert.Equal(t, false, actual.S3ForcePathStyle)
 				assert.Equal(t, "s3://foo-bucket", actual.Endpoint)
 				assert.Equal(t, "us-east1", actual.Region)
-				assert.Equal(t, "abc123", actual.AccessKeyID)
-				assert.Equal(t, "def789", actual.SecretAccessKey)
+				assert.Equal(t, "abc123", actual.AccessKeyID.Value)
+				assert.Equal(t, "def789", actual.SecretAccessKey.Value)
 				assert.Equal(t, true, actual.Insecure)
 				assert.Equal(t, false, actual.SSEEncryption)
 				assert.Equal(t, 5*time.Minute, actual.HTTPConfig.ResponseHeaderTimeout)
@@ -490,8 +490,8 @@ ruler:
 			assert.Equal(t, "s3", config.Ruler.StoreConfig.Type)
 			assert.Equal(t, "s3://foo-bucket", config.Ruler.StoreConfig.S3.Endpoint)
 			assert.Equal(t, "us-east1", config.Ruler.StoreConfig.S3.Region)
-			assert.Equal(t, "abc123", config.Ruler.StoreConfig.S3.AccessKeyID)
-			assert.Equal(t, "def789", config.Ruler.StoreConfig.S3.SecretAccessKey)
+			assert.Equal(t, "abc123", config.Ruler.StoreConfig.S3.AccessKeyID.Value)
+			assert.Equal(t, "def789", config.Ruler.StoreConfig.S3.SecretAccessKey.Value)
 
 			// should be set by common config
 			assert.EqualValues(t, "foobar", config.StorageConfig.GCSConfig.BucketName)
@@ -520,8 +520,8 @@ storage_config:
 
 			assert.Equal(t, "s3://foo-bucket", config.StorageConfig.AWSStorageConfig.S3Config.Endpoint)
 			assert.Equal(t, "us-east1", config.StorageConfig.AWSStorageConfig.S3Config.Region)
-			assert.Equal(t, "abc123", config.StorageConfig.AWSStorageConfig.S3Config.AccessKeyID)
-			assert.Equal(t, "def789", config.StorageConfig.AWSStorageConfig.S3Config.SecretAccessKey)
+			assert.Equal(t, "abc123", config.StorageConfig.AWSStorageConfig.S3Config.AccessKeyID.Value)
+			assert.Equal(t, "def789", config.StorageConfig.AWSStorageConfig.S3Config.SecretAccessKey.Value)
 
 			// should be set by common config
 			assert.EqualValues(t, "foobar", config.Ruler.StoreConfig.GCS.BucketName)

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -61,6 +63,20 @@ func init() {
 	s3RequestDuration.Register()
 }
 
+type secret struct {
+	Value string
+}
+
+func (secret) MarshalYAML() (interface{}, error) {
+	return "redacted", nil
+}
+
+func (s *secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return unmarshal(&s.Value)
+}
+
+var _ yaml.Marshaler = secret{}
+
 // S3Config specifies config for storing chunks on AWS S3.
 type S3Config struct {
 	S3               flagext.URLValue
@@ -69,8 +85,8 @@ type S3Config struct {
 	BucketNames      string
 	Endpoint         string              `yaml:"endpoint"`
 	Region           string              `yaml:"region"`
-	AccessKeyID      string              `yaml:"access_key_id"`
-	SecretAccessKey  string              `yaml:"secret_access_key"`
+	AccessKeyID      secret              `yaml:"access_key_id"`
+	SecretAccessKey  secret              `yaml:"secret_access_key"`
 	Insecure         bool                `yaml:"insecure"`
 	SSEEncryption    bool                `yaml:"sse_encryption"`
 	HTTPConfig       HTTPConfig          `yaml:"http_config"`
@@ -103,8 +119,8 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 
 	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "S3 Endpoint to connect to.")
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "AWS region to use.")
-	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "AWS Access Key ID")
-	f.StringVar(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
+	f.StringVar(&cfg.AccessKeyID.Value, prefix+"s3.access-key-id", "", "AWS Access Key ID")
+	f.StringVar(&cfg.SecretAccessKey.Value, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 
 	// TODO Remove in Cortex 1.10.0
@@ -237,13 +253,13 @@ func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S
 		s3Config = s3Config.WithRegion(cfg.Region)
 	}
 
-	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" ||
-		cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" {
+	if cfg.AccessKeyID.Value != "" && cfg.SecretAccessKey.Value == "" ||
+		cfg.AccessKeyID.Value == "" && cfg.SecretAccessKey.Value != "" {
 		return nil, errors.New("must supply both an Access Key ID and Secret Access Key or neither")
 	}
 
-	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
-		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey, "")
+	if cfg.AccessKeyID.Value != "" && cfg.SecretAccessKey.Value != "" {
+		creds := credentials.NewStaticCredentials(cfg.AccessKeyID.Value, cfg.SecretAccessKey.Value, "")
 		s3Config = s3Config.WithCredentials(creds)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that we don't commit S3 credential values to logs when using `-print-config-stderr` and `-log-config-reverse-order` flags. 

**Checklist**
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
