### PR TITLE
Add integration tests which test happy path

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -150,7 +149,7 @@ func (c *Client) pushLogLine(line string, timestamp time.Time, extraLabelList ..
 		return nil
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("reading request failed with status code %v: %w", res.StatusCode, err)
 	}
@@ -430,7 +429,7 @@ func (c *Client) run(u string) ([]byte, int, error) {
 	}
 	defer res.Body.Close()
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, 0, fmt.Errorf("request failed with status code %v: %w", res.StatusCode, err)
 	}

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -1,0 +1,439 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type roundTripper struct {
+	instanceID    string
+	token         string
+	injectHeaders map[string][]string
+	next          http.RoundTripper
+}
+
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("X-Scope-OrgID", r.instanceID)
+	if r.token != "" {
+		req.SetBasicAuth(r.instanceID, r.token)
+	}
+
+	for key, values := range r.injectHeaders {
+		for _, v := range values {
+			req.Header.Add(key, v)
+		}
+
+		fmt.Println(req.Header.Values(key))
+	}
+
+	return r.next.RoundTrip(req)
+}
+
+type CortexClientOption interface {
+	Type() string
+}
+
+type InjectHeadersOption map[string][]string
+
+func (n InjectHeadersOption) Type() string {
+	return "headerinject"
+}
+
+// Client is a HTTP client that adds basic auth and scope
+type Client struct {
+	Now time.Time
+
+	httpClient *http.Client
+	baseURL    string
+	instanceID string
+}
+
+// NewLogsClient creates a new client
+func New(instanceID, token, baseURL string, opts ...CortexClientOption) *Client {
+	rt := &roundTripper{
+		instanceID: instanceID,
+		token:      token,
+		next:       http.DefaultTransport,
+	}
+
+	for _, opt := range opts {
+		switch opt.Type() {
+		case "headerinject":
+			rt.injectHeaders = opt.(InjectHeadersOption)
+		}
+	}
+
+	return &Client{
+		Now: time.Now(),
+		httpClient: &http.Client{
+			Transport: rt,
+		},
+		baseURL:    baseURL,
+		instanceID: instanceID,
+	}
+}
+
+// PushLogLine creates a new logline with the current time as timestamp
+func (c *Client) PushLogLine(line string, extraLabels ...map[string]string) error {
+	return c.pushLogLine(line, c.Now, extraLabels...)
+}
+
+// PushLogLineWithTimestamp creates a new logline at the given timestamp
+// The timestamp has to be a Unix timestamp (epoch seconds)
+func (c *Client) PushLogLineWithTimestamp(line string, timestamp time.Time, extraLabelList ...map[string]string) error {
+	return c.pushLogLine(line, timestamp, extraLabelList...)
+}
+
+func formatTS(ts time.Time) string {
+	return strconv.FormatInt(ts.UnixNano(), 10)
+}
+
+type stream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}
+
+// pushLogLine creates a new logline
+func (c *Client) pushLogLine(line string, timestamp time.Time, extraLabelList ...map[string]string) error {
+	apiEndpoint := fmt.Sprintf("%s/loki/api/v1/push", c.baseURL)
+
+	s := stream{
+		Stream: map[string]string{
+			"job": "varlog",
+		},
+		Values: [][]string{
+			{
+				formatTS(timestamp),
+				line,
+			},
+		},
+	}
+	// add extra labels
+	for _, labelList := range extraLabelList {
+		for k, v := range labelList {
+			s.Stream[k] = v
+		}
+	}
+
+	data, err := json.Marshal(&struct {
+		Streams []stream `json:"streams"`
+	}{
+		Streams: []stream{s},
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", apiEndpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scope-OrgID", c.instanceID)
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode/100 == 2 {
+		defer res.Body.Close()
+		return nil
+	}
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("reading request failed with status code %v: %w", res.StatusCode, err)
+	}
+
+	return fmt.Errorf("request failed with status code %v: %w", res.StatusCode, errors.New(string(buf)))
+}
+
+func (c *Client) Get(path string) (*http.Response, error) {
+	url := fmt.Sprintf("%s%s", c.baseURL, path)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.httpClient.Do(req)
+}
+
+// Get all the metrics
+func (c *Client) Metrics() (string, error) {
+	url := fmt.Sprintf("%s/metrics", c.baseURL)
+	res, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, res.Body); err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("request failed with status code %d", res.StatusCode)
+	}
+	return sb.String(), nil
+}
+
+// Flush all in-memory chunks held by the ingesters to the backing store
+func (c *Client) Flush() error {
+	req, err := c.request("POST", fmt.Sprintf("%s/flush", c.baseURL))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode/100 == 2 {
+		return nil
+	}
+	return fmt.Errorf("request failed with status code %d", res.StatusCode)
+}
+
+// StreamValues holds a label key value pairs for the Stream and a list of a list of values
+type StreamValues struct {
+	Stream map[string]string
+	Values [][]string
+}
+
+// MatrixValues holds a label key value pairs for the metric and a list of a list of values
+type MatrixValues struct {
+	Metric map[string]string
+	Values [][]interface{}
+}
+
+// VectorValues holds a label key value pairs for the metric and single timestamp and value
+type VectorValues struct {
+	Metric map[string]string `json:"metric"`
+	Time   time.Time
+	Value  string
+}
+
+func (a *VectorValues) UnmarshalJSON(b []byte) error {
+	var s struct {
+		Metric map[string]string `json:"metric"`
+		Value  []interface{}     `json:"value"`
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	a.Metric = s.Metric
+	if len(s.Value) != 2 {
+		return fmt.Errorf("unexpected value length %d", len(s.Value))
+	}
+	if ts, ok := s.Value[0].(int64); ok {
+		a.Time = time.Unix(ts, 0)
+	}
+	if val, ok := s.Value[1].(string); ok {
+		a.Value = val
+	}
+	return nil
+}
+
+// DataType holds the result type and a list of StreamValues
+type DataType struct {
+	ResultType string
+	Stream     []StreamValues
+	Matrix     []MatrixValues
+	Vector     []VectorValues
+}
+
+func (a *DataType) UnmarshalJSON(b []byte) error {
+	// get the result type
+	var s struct {
+		ResultType string          `json:"resultType"`
+		Result     json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	switch s.ResultType {
+	case "streams":
+		if err := json.Unmarshal(s.Result, &a.Stream); err != nil {
+			return err
+		}
+	case "matrix":
+		if err := json.Unmarshal(s.Result, &a.Matrix); err != nil {
+			return err
+		}
+	case "vector":
+		if err := json.Unmarshal(s.Result, &a.Vector); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown result type %s", s.ResultType)
+	}
+	a.ResultType = s.ResultType
+	return nil
+}
+
+// Response holds the status and data
+type Response struct {
+	Status string
+	Data   DataType
+}
+
+// RunRangeQuery runs a query and returns an error if anything went wrong
+func (c *Client) RunRangeQuery(query string) (*Response, error) {
+	buf, statusCode, err := c.run(c.rangeQueryURL(query))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.parseResponse(buf, statusCode)
+}
+
+// RunQuery runs a query and returns an error if anything went wrong
+func (c *Client) RunQuery(query string) (*Response, error) {
+	v := url.Values{}
+	v.Set("query", query)
+	v.Set("time", formatTS(c.Now.Add(time.Second)))
+
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/loki/api/v1/query"
+	u.RawQuery = v.Encode()
+
+	buf, statusCode, err := c.run(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return c.parseResponse(buf, statusCode)
+}
+
+func (c *Client) parseResponse(buf []byte, statusCode int) (*Response, error) {
+	lokiResp := Response{}
+	err := json.Unmarshal(buf, &lokiResp)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response data: %w", err)
+	}
+
+	if statusCode/100 == 2 {
+		return &lokiResp, nil
+	}
+	return nil, fmt.Errorf("request failed with status code %d: %w", statusCode, errors.New(string(buf)))
+}
+
+func (c *Client) rangeQueryURL(query string) string {
+	v := url.Values{}
+	v.Set("query", query)
+	v.Set("start", formatTS(c.Now.Add(-2*time.Hour)))
+	v.Set("end", formatTS(c.Now.Add(time.Second)))
+
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		panic(err)
+	}
+	u.Path = "/loki/api/v1/query_range"
+	u.RawQuery = v.Encode()
+
+	return u.String()
+}
+
+func (c *Client) LabelNames() ([]string, error) {
+	url := fmt.Sprintf("%s/loki/api/v1/labels", c.baseURL)
+
+	req, err := c.request("GET", url)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("Unexpected status code of %d", res.StatusCode)
+	}
+
+	var values struct {
+		Data []string `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&values); err != nil {
+		return nil, err
+	}
+
+	return values.Data, nil
+}
+
+// LabelValues return a LabelValues query
+func (c *Client) LabelValues(labelName string) ([]string, error) {
+	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", c.baseURL, url.PathEscape(labelName))
+
+	req, err := c.request("GET", url)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("Unexpected status code of %d", res.StatusCode)
+	}
+
+	var values struct {
+		Data []string `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&values); err != nil {
+		return nil, err
+	}
+
+	return values.Data, nil
+}
+
+func (c *Client) request(method string, url string) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Scope-OrgID", c.instanceID)
+	return req, nil
+}
+
+func (c *Client) run(u string) ([]byte, int, error) {
+	req, err := c.request("GET", u)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request failed with status code %v: %w", res.StatusCode, err)
+	}
+
+	return buf, res.StatusCode, nil
+}

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -1,0 +1,348 @@
+package cluster
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/grafana/dskit/multierror"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/pkg/loki"
+	"github.com/grafana/loki/pkg/util/cfg"
+)
+
+var wrapRegistryOnce sync.Once
+
+func wrapRegistry() {
+	wrapRegistryOnce.Do(func() {
+		prometheus.DefaultRegisterer = &wrappedRegisterer{Registerer: prometheus.DefaultRegisterer}
+	})
+}
+
+type wrappedRegisterer struct {
+	prometheus.Registerer
+}
+
+func (w *wrappedRegisterer) Register(collector prometheus.Collector) error {
+	if err := w.Registerer.Register(collector); err != nil {
+		var aErr prometheus.AlreadyRegisteredError
+		if errors.As(err, &aErr) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (w *wrappedRegisterer) MustRegister(collectors ...prometheus.Collector) {
+	for _, c := range collectors {
+		if err := w.Register(c); err != nil {
+			panic(err.Error())
+		}
+	}
+}
+
+type Cluster struct {
+	sharedPath string
+	components []*Component
+	waitGroup  sync.WaitGroup
+}
+
+func New() *Cluster {
+	wrapRegistry()
+	sharedPath, err := ioutil.TempDir("", "loki-shared-data")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return &Cluster{
+		sharedPath: sharedPath,
+	}
+}
+
+func (c *Cluster) Run() error {
+	for _, component := range c.components {
+		if err := component.run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (c *Cluster) Cleanup() error {
+	var (
+		files []string
+		dirs  []string
+	)
+	if c.sharedPath != "" {
+		dirs = append(dirs, c.sharedPath)
+	}
+
+	// call all components cleanup
+	errs := multierror.New()
+	for _, component := range c.components {
+		f, d := component.cleanup()
+		files = append(files, f...)
+		dirs = append(dirs, d...)
+	}
+	if err := errs.Err(); err != nil {
+		return err
+	}
+
+	// wait for all process to close
+	c.waitGroup.Wait()
+
+	// cleanup dirs/files
+
+	for _, d := range dirs {
+		errs.Add(os.RemoveAll(d))
+	}
+	for _, f := range files {
+		errs.Add(os.Remove(f))
+	}
+
+	return errs.Err()
+}
+
+func (c *Cluster) AddComponent(name string, flags ...string) *Component {
+	component := &Component{
+		name:    name,
+		cluster: c,
+		flags:   flags,
+	}
+
+	var err error
+	component.httpPort, err = getFreePort()
+	if err != nil {
+		panic(fmt.Errorf("error allocating HTTP port: %w", err))
+	}
+
+	component.grpcPort, err = getFreePort()
+	if err != nil {
+		panic(fmt.Errorf("error allocating GRPC port: %w", err))
+	}
+
+	c.components = append(c.components, component)
+	return component
+}
+
+type Component struct {
+	loki    *loki.Loki
+	name    string
+	cluster *Cluster
+	flags   []string
+
+	httpPort int
+	grpcPort int
+
+	configFile string
+	dataPath   string
+}
+
+func (c *Component) HTTPURL() *url.URL {
+	return &url.URL{
+		Host:   fmt.Sprintf("localhost:%d", c.httpPort),
+		Scheme: "http",
+	}
+}
+
+func (c *Component) GRPCURL() *url.URL {
+	return &url.URL{
+		Host:   fmt.Sprintf("localhost:%d", c.grpcPort),
+		Scheme: "grpc",
+	}
+}
+
+func (c *Component) writeConfig() error {
+	var err error
+
+	configFile, err := ioutil.TempFile("", "loki-config")
+	if err != nil {
+		return fmt.Errorf("error creating config file: %w", err)
+	}
+
+	c.dataPath, err = ioutil.TempDir("", "loki-data")
+	if err != nil {
+		return fmt.Errorf("error creating config file: %w", err)
+	}
+
+	if _, err := configFile.Write([]byte(fmt.Sprintf(`
+auth_enabled: true
+
+server:
+  http_listen_port: %d
+  grpc_listen_port: %d
+
+common:
+  path_prefix: %s
+  storage:
+    filesystem:
+      chunks_directory: %s/chunks
+      rules_directory: %s/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+storage_config:
+  boltdb_shipper:
+    shared_store: filesystem
+    active_index_directory: %s/index
+    cache_location: %s/boltdb-cache
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+compactor:
+  working_directory: %s/retention
+  shared_store: filesystem
+  retention_enabled: true
+
+analytics:
+  reporting_enabled: false
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+ingester:
+  lifecycler:
+    min_ready_duration: 0s
+
+frontend_worker:
+  scheduler_address: localhost:%d
+
+frontend:
+  scheduler_address: localhost:%d
+
+`,
+		c.httpPort,
+		c.grpcPort,
+		c.dataPath,
+		c.cluster.sharedPath,
+		c.cluster.sharedPath,
+		c.dataPath,
+		c.dataPath,
+		c.dataPath,
+		c.grpcPort,
+		c.grpcPort,
+	))); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+	if err := configFile.Close(); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+
+	c.configFile = configFile.Name()
+
+	return nil
+}
+
+func (c *Component) run() error {
+	if err := c.writeConfig(); err != nil {
+		return err
+	}
+
+	var config loki.ConfigWrapper
+
+	var flagset = flag.NewFlagSet("test-flags", flag.ExitOnError)
+
+	if err := cfg.DynamicUnmarshal(&config, append(
+		c.flags,
+		"-config.file",
+		c.configFile,
+	), flagset); err != nil {
+		return err
+	}
+
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	var err error
+	c.loki, err = loki.New(config.Config)
+	if err != nil {
+		return err
+	}
+
+	var (
+		readyCh = make(chan struct{})
+		errCh   = make(chan error, 1)
+	)
+
+	go func() {
+		for {
+			time.Sleep(time.Millisecond * 200)
+			if c.loki.Server.HTTP == nil {
+				continue
+			}
+
+			req := httptest.NewRequest("GET", "http://localhost/ready", nil)
+			w := httptest.NewRecorder()
+			c.loki.Server.HTTP.ServeHTTP(w, req)
+
+			if w.Code == 200 {
+				close(readyCh)
+				return
+			}
+		}
+	}()
+
+	c.cluster.waitGroup.Add(1)
+	go func() {
+		defer c.cluster.waitGroup.Done()
+		err := c.loki.Run(loki.RunOpts{})
+		if err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-readyCh:
+		break
+	case err := <-errCh:
+		return err
+	}
+
+	return nil
+}
+
+// cleanup calls the stop handler and returns files and directories to be cleaned up
+func (c *Component) cleanup() (files []string, dirs []string) {
+	if c.loki != nil {
+		c.loki.SignalHandler.Stop()
+	}
+	if c.configFile != "" {
+		files = append(files, c.configFile)
+	}
+	if c.dataPath != "" {
+		dirs = append(dirs, c.dataPath)
+	}
+	return files, dirs
+}
+
+func getFreePort() (port int, err error) {
+	var a *net.TCPAddr
+	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port, nil
+		}
+	}
+	return
+}

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -29,7 +29,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 		tIngester = clu.AddComponent(
 			"ingester",
 			"-target=ingester",
-			//			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
+			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
 		)
 		tQueryScheduler = clu.AddComponent(
 			"query-scheduler",

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -1,0 +1,106 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/integration/client"
+	"github.com/grafana/loki/integration/cluster"
+)
+
+func TestMicroServicesIngestQuery(t *testing.T) {
+	clu := cluster.New()
+	defer func() {
+		assert.NoError(t, clu.Cleanup())
+	}()
+
+	var (
+		tIndexGateway = clu.AddComponent(
+			"index-gateway",
+			"-target=index-gateway",
+		)
+		tDistributor = clu.AddComponent(
+			"distributor",
+			"-target=distributor",
+		)
+		tIngester = clu.AddComponent(
+			"ingester",
+			"-target=ingester",
+			//			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
+		)
+		tQueryScheduler = clu.AddComponent(
+			"query-scheduler",
+			"-target=query-scheduler",
+			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
+		)
+		tQueryFrontend = clu.AddComponent(
+			"query-frontend",
+			"-target=query-frontend",
+			"-frontend.scheduler-address="+tQueryScheduler.GRPCURL().Host,
+			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
+		)
+		_ = clu.AddComponent(
+			"querier",
+			"-target=querier",
+			"-querier.scheduler-address="+tQueryScheduler.GRPCURL().Host,
+			"-boltdb.shipper.index-gateway-client.server-address="+tIndexGateway.GRPCURL().Host,
+		)
+	)
+
+	require.NoError(t, clu.Run())
+
+	tenantID := randStringRunes(12)
+
+	now := time.Now()
+	cliDistributor := client.New(tenantID, "", tDistributor.HTTPURL().String())
+	cliDistributor.Now = now
+	cliIngester := client.New(tenantID, "", tIngester.HTTPURL().String())
+	cliIngester.Now = now
+	cliQueryFrontend := client.New(tenantID, "", tQueryFrontend.HTTPURL().String())
+	cliQueryFrontend.Now = now
+
+	t.Run("ingest-logs-store", func(t *testing.T) {
+		// ingest some log lines
+		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineA", now.Add(-45*time.Minute), map[string]string{"job": "fake"}))
+		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineB", now.Add(-45*time.Minute), map[string]string{"job": "fake"}))
+
+		// TODO: Flushing is currently causing a panic, as the boltdb shipper is shared using a global variable in:
+		// https://github.com/grafana/loki/blob/66a4692423582ed17cce9bd86b69d55663dc7721/pkg/storage/factory.go#L32-L35
+		//require.NoError(t, cliIngester.Flush())
+	})
+
+	t.Run("ingest-logs-ingester", func(t *testing.T) {
+		// ingest some log lines
+		require.NoError(t, cliDistributor.PushLogLine("lineC", map[string]string{"job": "fake"}))
+		require.NoError(t, cliDistributor.PushLogLine("lineD", map[string]string{"job": "fake"}))
+	})
+
+	t.Run("query", func(t *testing.T) {
+		resp, err := cliQueryFrontend.RunRangeQuery(`{job="fake"}`)
+		require.NoError(t, err)
+		assert.Equal(t, "streams", resp.Data.ResultType)
+
+		var lines []string
+		for _, stream := range resp.Data.Stream {
+			for _, val := range stream.Values {
+				lines = append(lines, val[1])
+			}
+		}
+		assert.ElementsMatch(t, []string{"lineA", "lineB", "lineC", "lineD"}, lines)
+	})
+
+	t.Run("label-names", func(t *testing.T) {
+		resp, err := cliQueryFrontend.LabelNames()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"__name__", "job"}, resp)
+	})
+
+	t.Run("label-values", func(t *testing.T) {
+		resp, err := cliQueryFrontend.LabelValues("job")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"fake"}, resp)
+	})
+}

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/integration/client"
+	"github.com/grafana/loki/integration/cluster"
+)
+
+func TestSingleBinaryIngestQuery(t *testing.T) {
+	clu := cluster.New()
+	defer func() {
+		assert.NoError(t, clu.Cleanup())
+	}()
+
+	var (
+		tAll = clu.AddComponent(
+			"all",
+			"-target=all",
+		)
+	)
+
+	require.NoError(t, clu.Run())
+
+	tenantID := randStringRunes(12)
+	cli := client.New(tenantID, "", tAll.HTTPURL().String())
+
+	t.Run("ingest-logs-store", func(t *testing.T) {
+		// ingest some log lines
+		require.NoError(t, cli.PushLogLineWithTimestamp("lineA", cli.Now.Add(-45*time.Minute), map[string]string{"job": "fake"}))
+		require.NoError(t, cli.PushLogLineWithTimestamp("lineB", cli.Now.Add(-45*time.Minute), map[string]string{"job": "fake"}))
+
+		// TODO: Flushing is currently causing a panic, as the boltdb shipper is shared using a global variable in:
+		// https://github.com/grafana/loki/blob/66a4692423582ed17cce9bd86b69d55663dc7721/pkg/storage/factory.go#L32-L35
+		// require.NoError(t, cli.Flush())
+	})
+
+	t.Run("ingest-logs-ingester", func(t *testing.T) {
+		// ingest some log lines
+		require.NoError(t, cli.PushLogLine("lineC", map[string]string{"job": "fake"}))
+		require.NoError(t, cli.PushLogLine("lineD", map[string]string{"job": "fake"}))
+	})
+
+	t.Run("query", func(t *testing.T) {
+		resp, err := cli.RunRangeQuery(`{job="fake"}`)
+		require.NoError(t, err)
+		assert.Equal(t, "streams", resp.Data.ResultType)
+
+		var lines []string
+		for _, stream := range resp.Data.Stream {
+			for _, val := range stream.Values {
+				lines = append(lines, val[1])
+			}
+		}
+		assert.ElementsMatch(t, []string{"lineA", "lineB", "lineC", "lineD"}, lines)
+	})
+
+	t.Run("label-names", func(t *testing.T) {
+		resp, err := cli.LabelNames()
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"__name__", "job"}, resp)
+	})
+
+	t.Run("label-values", func(t *testing.T) {
+		resp, err := cli.LabelValues("job")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"fake"}, resp)
+	})
+}

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -228,6 +228,7 @@ type Loki struct {
 	ModuleManager *modules.Manager
 	serviceMap    map[string]services.Service
 	deps          map[string][]string
+	SignalHandler *signals.Handler
 
 	Server                   *server.Server
 	ring                     *ring.Ring
@@ -395,9 +396,9 @@ func (t *Loki) Run(opts RunOpts) error {
 	sm.AddListener(services.NewManagerListener(healthy, stopped, serviceFailed))
 
 	// Setup signal handler. If signal arrives, we stop the manager, which stops all the services.
-	handler := signals.NewHandler(t.Server.Log)
+	t.SignalHandler = signals.NewHandler(t.Server.Log)
 	go func() {
-		handler.Loop()
+		t.SignalHandler.Loop()
 		sm.StopAsync()
 	}()
 

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -57,6 +57,7 @@ type Fetcher struct {
 	maxAsyncBufferSize  int
 
 	asyncQueue chan []chunk.Chunk
+	stopOnce   sync.Once
 	stop       chan struct{}
 }
 
@@ -126,10 +127,12 @@ func (c *Fetcher) asyncWriteBackCacheQueueProcessLoop() {
 
 // Stop the ChunkFetcher.
 func (c *Fetcher) Stop() {
-	close(c.decodeRequests)
-	c.wait.Wait()
-	c.cache.Stop()
-	close(c.stop)
+	c.stopOnce.Do(func() {
+		close(c.decodeRequests)
+		c.wait.Wait()
+		c.cache.Stop()
+		close(c.stop)
+	})
 }
 
 func (c *Fetcher) worker() {


### PR DESCRIPTION
This PR adds simple go based integration tests, which can run Loki
in two modes:

- single-binary
- micro-services with index-gateway

After standing up it performs the most basic duties like:
- ingest logs
- run a range query
- query label names and label values

This is meant to catch more significant problem as early as possible in
the PR.

We should aim to keep this as simple as possible.

Note: _`integration/client/client.go` is copied from the closed source Granana Enterprise Logs code based_
