### PR TITLE
Loki: Make DNS resolver configurable in Gateway

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -91,7 +91,7 @@
     dynamodb_access_key: '',
     dynamodb_secret_access_key: '',
     dynamodb_region: error 'must specify dynamodb_region',
-    
+
     // DNS Resolver
     dns_resolver: 'kube-dns.kube-system.svc.cluster.local',
 

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -91,6 +91,9 @@
     dynamodb_access_key: '',
     dynamodb_secret_access_key: '',
     dynamodb_region: error 'must specify dynamodb_region',
+    
+    // DNS Resolver
+    dns_resolver: 'kube-dns.kube-system.svc.cluster.local',
 
     client_configs: {
       dynamo: {

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -39,7 +39,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
           access_log   /dev/stderr  main;
           sendfile     on;
           tcp_nopush   on;
-          resolver kube-dns.kube-system.svc.cluster.local;
+          resolver $(dns_resolver)s;
 
           server {
             listen               80;


### PR DESCRIPTION
Signed-off-by: Ivan Rizzante <i.rizzante@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Currently it's not possible to configure the DNS resolver in [Gateway](https://github.com/grafana/loki/blob/7299e3bdcdae5bd7dacd08be67f706fdbaab8543/production/ksonnet/loki/gateway.libsonnet#L42), which is a problem if `kube-dns` Service does not exists.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [X] Documentation added
- [X] Tests updated
- [X] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
