### PR TITLE
Call correct method on index store

### DIFF
--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -88,7 +88,7 @@ func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, 
 	})
 	if isUnimplementedCallError(err) {
 		// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-		return c.IndexStore.LabelNamesForMetricName(ctx, userID, from, through, metricName)
+		return c.IndexStore.LabelValuesForMetricName(ctx, userID, from, through, metricName, labelName, matchers...)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

when index gateway does not implement the new API.

This bug did not yield an error but only returned incorrect results
because both functions `c.IndexStore.LabelNamesForMetricName` and
`c.IndexStore.LabelValuesForMetricName` return `([]string, error)`.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
