### PR TITLE
Do not parse string of empty matchers

### DIFF
--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -15,7 +15,11 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
-const errAtleastOneEqualityMatcherRequired = "queries require at least one regexp or equality matcher that does not have an empty-compatible value. For instance, app=~\".*\" does not meet this requirement, but app=~\".+\" will"
+const (
+	EmptyMatchers = "{}"
+
+	errAtleastOneEqualityMatcherRequired = "queries require at least one regexp or equality matcher that does not have an empty-compatible value. For instance, app=~\".*\" does not meet this requirement, but app=~\".+\" will"
+)
 
 var parserPool = sync.Pool{
 	New: func() interface{} {

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -333,9 +333,14 @@ func (g *Gateway) LabelValuesForMetricName(ctx context.Context, req *indexgatewa
 	if err != nil {
 		return nil, err
 	}
-	matchers, err := syntax.ParseMatchers(req.Matchers)
-	if err != nil {
-		return nil, err
+	var matchers []*labels.Matcher
+	// An empty matchers string cannot be parsed,
+	// therefore we check the string representation of the the matchers.
+	if req.Matchers != syntax.EmptyMatchers {
+		matchers, err = syntax.ParseMatchers(req.Matchers)
+		if err != nil {
+			return nil, err
+		}
 	}
 	names, err := g.indexQuerier.LabelValuesForMetricName(ctx, instanceID, req.From, req.Through, req.MetricName, req.LabelName, matchers...)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a bug in the index gateway when querying values for a label.
Since the gRPC handler for LabelValuesForMetricName in the index gateway
allows empty matchers in the LabelValuesForMetricNameRequest, we need to
check if the matchers string is an empty matcher (`{}`) before we parse
the string.

This bug was introduced with the index gateway api refactoring in #5892


Signed-off-by: Christian Haudum <christian.haudum@gmail.com>



**Which issue(s) this PR fixes**:

Fixes: #5965

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
