### PR TITLE
Add string representation of boltdb shipper mode

### DIFF
--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -27,9 +27,11 @@ import (
 	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 
+type Mode int
+
 const (
 	// ModeReadWrite is to allow both read and write
-	ModeReadWrite = iota
+	ModeReadWrite Mode = iota
 	// ModeReadOnly is to allow only read operations
 	ModeReadOnly
 	// ModeWriteOnly is to allow only write operations
@@ -41,6 +43,18 @@ const (
 	// UploadInterval defines interval for when we check if there are new index files to upload.
 	UploadInterval = 1 * time.Minute
 )
+
+func (m Mode) String() string {
+	switch m {
+	case ModeReadWrite:
+		return "read-write"
+	case ModeReadOnly:
+		return "read-only"
+	case ModeWriteOnly:
+		return "write-only"
+	}
+	return "unknown"
+}
 
 type boltDBIndexClient interface {
 	QueryWithCursor(_ context.Context, c *bbolt.Cursor, query index.Query, callback index.QueryPagesCallback) error
@@ -60,7 +74,7 @@ type Config struct {
 	IndexGatewayClientConfig IndexGatewayClientConfig `yaml:"index_gateway_client"`
 	BuildPerTenantIndex      bool                     `yaml:"build_per_tenant_index"`
 	IngesterName             string                   `yaml:"-"`
-	Mode                     int                      `yaml:"-"`
+	Mode                     Mode                     `yaml:"-"`
 	IngesterDBRetainPeriod   time.Duration            `yaml:"-"`
 }
 
@@ -104,7 +118,7 @@ func NewShipper(cfg Config, storageClient client.ObjectClient, limits downloads.
 		return nil, err
 	}
 
-	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("starting boltdb shipper in %d mode", cfg.Mode))
+	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("starting boltdb shipper in %s mode", cfg.Mode))
 
 	return &shipper, nil
 }


### PR DESCRIPTION
Makes the log output significantly more meaningful.

Before:

```
level=info ts=2022-04-21T07:35:01.687187409Z caller=shipper_index_client.go:107 msg="starting boltdb shipper in 0 mode"
```

After:

```
level=info ts=2022-04-21T07:35:01.687187409Z caller=shipper_index_client.go:107 msg="starting boltdb shipper in read-write mode"
```