### PR TITLE
Test memory allocations for overwhelmed Tailer.

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -113,7 +113,7 @@ func (t *tailer) send(stream logproto.Stream, lbs labels.Labels) {
 
 	// if we are already dropping streams due to blocked connection, drop new streams directly to save some effort
 	if blockedSince := t.blockedSince(); blockedSince != nil {
-		if blockedSince.Before(time.Now().Add(-time.Second * 15)) {
+		if blockedSince.Before(time.Now().Add(-time.Millisecond * 100)) {
 			t.close()
 			return
 		}


### PR DESCRIPTION
This draft is investigating the memory consumption of the Tailer when the client cannot keep up.

Run tests with
```
go test -mod=vendor ./pkg/ingester/ -run ^Test_Allocations$ -benchmem -memprofile memprofile.out -cpuprofile cpuprofile.out
```

View profile with

```
go tool pprof -source_path=$(pwd) -http :9403 memprofile.out
```

The Source view is interesting:

```
github.com/grafana/loki/pkg/ingester.(*tailer).send

/home/karsten/src/loki/pkg/ingester/tailer.go

  Total:           0   198.01MB (flat, cum)  8.17%
    119            .          .           		} 
    120            .          .           		t.dropStream(stream) 
    121            .          .           		return 
    122            .          .           	} 
    123            .          .            
    124            .   198.01MB           	streams := t.processStream(stream, lbs) 
    125            .          .           	if len(streams) == 0 { 
    126            .          .           		return 
    127            .          .           	} 
    128            .          .           	for _, s := range streams { 
    129            .          .           		select { 

```

Ideally there would be little memory consumed.