### PR TITLE
docker-compose: Disable auth in Grafana

### DIFF
--- a/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
+++ b/tools/dev/loki-boltdb-storage-s3/docker-compose.yml
@@ -240,6 +240,8 @@ services:
       - querier
     environment:
       - GF_PATHS_PROVISIONING=/etc/config/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
You can access the development Grafana without `admin:admin` and `skip`.