### PR TITLE
Promote policyRule to v1

### DIFF
--- a/production/ksonnet/promtail/promtail.libsonnet
+++ b/production/ksonnet/promtail/promtail.libsonnet
@@ -14,8 +14,7 @@ config + scrape_config {
     _config+:: { namespace: $._config.namespace },
   },
 
-  local policyRule = k.rbac.v1beta1.policyRule,
-
+  local policyRule = k.rbac.v1.policyRule,
 
   promtail_rbac:
     namespaced_k.util.rbac($._config.promtail_cluster_role_name, [


### PR DESCRIPTION
**What this PR does / why we need it**:

In Kubernetes 1.22, policyRule is promoted to v1 and out of v1beta.  Here we make the adjustment to the jsonnet call to reflect that change and allow users on 1.22 to make use of this jsonnet.  It looks like this was available at least back to 1.18.

https://jsonnet-libs.github.io/k8s-libsonnet/1.18/rbac/v1/policyRule/

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
