### PR TITLE
promtail/docker: Update libsystemd-dev from bullseye-backports for arm32 docker images

### DIFF
--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,16 +1,21 @@
-FROM golang:1.17.9 as build
+FROM golang:1.17.9-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki
-RUN apt-get update && apt-get install -qy libsystemd-dev
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
 RUN make clean && make BUILD_IN_CONTAINER=false promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 # tzdata required for the timestamp stage to work
+# Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && \
   apt-get install -qy \
-  tzdata ca-certificates libsystemd-dev && \
+  tzdata ca-certificates
+RUN apt-get install -t bullseye-backports -qy libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY clients/cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes journald parsing for arm32 systems with newer systemd/journald. The same fix was previously accepted for the main promtail Dockerfile.

**Which issue(s) this PR fixes**:
Fixes #5938

