### PR TITLE
Add IndexGateway Query Readiness Duration panel to `Loki - Reads Resources` dashboard in production/loki-mixin

### DIFF
--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -103,6 +103,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           .addPanel(
             $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', 'index-gateway'),
           )
+          .addPanel(
+            $.panel('Query Readiness Duration') +
+            $.queryPanel(
+              'sum by (pod) (rate(loki_boltdb_shipper_query_readiness_duration_seconds{%s,container=%s}[$__rate_interval]))' % [$.namespaceMatcher(), 'index-gateway']
+            ) + { yaxes: $.yaxes('s') },
+          )
         )
         .addRow(
           $.row('Ingester')

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -106,8 +106,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
           .addPanel(
             $.panel('Query Readiness Duration') +
             $.queryPanel(
-              'sum by (pod) (rate(loki_boltdb_shipper_query_readiness_duration_seconds{%s,container=%s}[$__rate_interval]))' % [$.namespaceMatcher(), 'index-gateway']
-            ) + { yaxes: $.yaxes('s') },
+              ['loki_boltdb_shipper_query_readiness_duration_seconds{%s}' % $.namespaceMatcher()], ['duration']
+            ) +
+            { yaxes: $.yaxes('s') },
           )
         )
         .addRow(


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

re: https://github.com/grafana/loki/pull/5946

This PR adds a new dashboard panel in the `Loki - Reads Resources` dashboard to visualize query readiness duration for IndexGateways.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
