### PR TITLE
Decrease log level for "failed to put to memcached"

### DIFF
--- a/pkg/storage/chunk/cache/memcached.go
+++ b/pkg/storage/chunk/cache/memcached.go
@@ -217,7 +217,7 @@ func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) err
 			return c.memcache.Set(&item)
 		})
 		if cacheErr != nil {
-			level.Error(c.logger).Log("msg", "failed to put to memcached", "name", c.name, "err", err)
+			level.Warn(c.logger).Log("msg", "failed to put to memcached", "name", c.name, "err", err)
 			err = cacheErr
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since failing to put to memcached does not have an operational impact on
the write path, this log message should not be an error. Make it a
warning instead.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->


**Special notes for your reviewer**:

Do people rely on log messages being at a specific log level?

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
