### PR TITLE
docs: update the labels timespan info

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -387,8 +387,9 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode '
 
 ## `GET /loki/api/v1/labels`
 
-`/loki/api/v1/labels` retrieves the list of known labels within a given time span. It
-accepts the following query parameters in the URL:
+`/loki/api/v1/labels` retrieves the list of known labels within a given time span
+(NOTE: in some cases Loki may use a larger time span than the one specified).
+It accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
@@ -424,8 +425,8 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/labels" | jq
 ## `GET /loki/api/v1/label/<name>/values`
 
 `/loki/api/v1/label/<name>/values` retrieves the list of known values for a given
-label within a given time span. It accepts the following query parameters in
-the URL:
+label within a given time span. (NOTE: in some cases Loki may use a larger time span than the one specified)
+It accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.


### PR DESCRIPTION
When using the `/loki/api/v1/labels` and `/loki/api/v1/label/$label_name/values` HTTP endpoints, the time-range specified int the query is not always respected. in some cases a larger-than-specified time-range will be used. this pull request adds this into to the documentation.