### PR TITLE
docs: describe ordering in http query results

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -151,6 +151,8 @@ And `<stream value>` is:
 }
 ```
 
+The items in the `values` array are sorted by their timestamp in a descending (when using `direction=backward`) or ascending (when using `direction=forward`) order.
+
 See [statistics](#statistics) for information about the statistics returned by Loki.
 
 ### Examples
@@ -273,11 +275,16 @@ Where `<matrix value>` is:
     <label key-value pairs>
   },
   "values": [
-    <number: second unix epoch>,
-    <string: value>
+    [
+      <number: second unix epoch>,
+      <string: value>
+    ],
+    ...
   ]
 }
 ```
+
+The items in the `values` array are sorted by their timestamp in an ascending order.
 
 And `<stream value>` is:
 
@@ -295,6 +302,8 @@ And `<stream value>` is:
   ]
 }
 ```
+
+The items in the `values` array are sorted by their timestamp in a descending (when using `direction=backward`) or ascending (when using `direction=forward`) order.
 
 See [statistics](#statistics) for information about the statistics returned by Loki.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -286,7 +286,7 @@ Where `<matrix value>` is:
 }
 ```
 
-The items in the `values` array are sorted by their timestamp in an ascending order.
+The items in the `values` array are sorted by timestamp, and the oldest item is first.
 
 And `<stream value>` is:
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -151,7 +151,9 @@ And `<stream value>` is:
 }
 ```
 
-The items in the `values` array are sorted by their timestamp in a descending (when using `direction=backward`) or ascending (when using `direction=forward`) order.
+The items in the `values` array are sorted by timestamp.
+The most recent item is first when using `direction=backward`.
+The oldest item is first when using `direction=forward`.
 
 See [statistics](#statistics) for information about the statistics returned by Loki.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -305,7 +305,9 @@ And `<stream value>` is:
 }
 ```
 
-The items in the `values` array are sorted by their timestamp in a descending (when using `direction=backward`) or ascending (when using `direction=forward`) order.
+The items in the `values` array are sorted by timestamp.
+The most recent item is first when using `direction=backward`.
+The oldest item is first when using `direction=forward`.
 
 See [statistics](#statistics) for information about the statistics returned by Loki.
 


### PR DESCRIPTION
this pull-request describes the ordering of results when using `/query` and `/query_range` HTTP endpoints.
it is important to know whether one can rely on the results being ordered or not (for example, in the grafana loki datasource, if we cannot rely on the ordering of results, we have to sort the data)

NOTE: i do not know if what i described here is guaranteed or not. i made some tests, and it seems to work this way. it would be great if a Loki developer could also verify this info. (if it is not guaranteed, i can update the pull-request so that the docs will mention that the ordering is not guaranteed)

also, there was an error in the query-range-matrix-results format description, i fixed that.