### PR TITLE
Logcli: Respect quiet flag in logcli tail.go

### DIFF
--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -36,11 +36,11 @@ func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.Lo
 
 	tailResponse := new(loghttp.TailResponse)
 
-	if len(q.IgnoreLabelsKey) > 0 {
+	if len(q.IgnoreLabelsKey) > 0 && !q.Quiet {
 		log.Println("Ignoring labels key:", color.RedString(strings.Join(q.IgnoreLabelsKey, ",")))
 	}
 
-	if len(q.ShowLabelsKey) > 0 {
+	if len(q.ShowLabelsKey) > 0 && !q.Quiet {
 		log.Println("Print only labels key:", color.RedString(strings.Join(q.ShowLabelsKey, ",")))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes logcli tailing to check if the quiet flag is false before logging not critical messages.

**Which issue(s) this PR fixes**:
Fixes #4124

**Special notes for your reviewer**:
N/A\

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
