### PR TITLE
Loki: Log # of unique users involved in query readiness operation

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -246,8 +246,10 @@ func (tm *tableManager) cleanupCache() error {
 // ensureQueryReadiness compares tables required for being query ready with the tables we already have and downloads the missing ones.
 func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 	start := time.Now()
+	distinctUsers := make(map[string]struct{})
+
 	defer func() {
-		level.Info(util_log.Logger).Log("msg", "query readiness setup completed", "duration", time.Since(start))
+		level.Info(util_log.Logger).Log("msg", "query readiness setup completed", "duration", time.Since(start), "distinct_users_len", len(distinctUsers))
 	}()
 
 	activeTableNumber := getActiveTableNumber()
@@ -310,6 +312,10 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 		table, err := tm.getOrCreateTable(tableName)
 		if err != nil {
 			return err
+		}
+
+		for _, u := range usersToBeQueryReadyFor {
+			distinctUsers[u] = struct{}{}
 		}
 
 		perTableStart := time.Now()


### PR DESCRIPTION
**What this PR does / why we need it**:
Log unique users assigned to a queryReadiness call. This will help to understand the correlation between more or fewer users and indexgateway load.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
