### PR TITLE
Loki: Add a configurable ability to fudge incoming timestamps for guaranteed query sort order when receiving entries for the same stream that have duplicate timestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 ##### Fixes
 * [5685](https://github.com/grafana/loki/pull/5685) **chaudum**: Assert that push values tuples consist of string values
 ##### Changes
+* [6042](https://github.com/grafana/loki/pull/6042) **slim-bean**: Add a new configuration to allow fudging of ingested timestamps to guarantee sort order of duplicate timestamps at query time.
 * [5777](https://github.com/grafana/loki/pull/5777) **tatchiuleung**: storage: make Azure blobID chunk delimiter configurable
 * [5650](https://github.com/grafana/loki/pull/5650) **cyriltovena**: Remove more chunkstore and schema version below v9
 * [5643](https://github.com/grafana/loki/pull/5643) **simonswine**: Introduce a ChunkRef type as part of logproto

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2100,6 +2100,16 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # CLI flag: -distributor.max-line-size-truncate
 [max_line_size_truncate: <boolean> | default = false ]
 
+# Fudge the log line timestamp during ingestion when it's the same as the previous entry for the same stream
+# When enabled, if a log line in a push request has the same timestamp as the previous line
+# for the same stream, one nanosecond is added to the log line. This will preserve the received
+# order of log lines with the exact same timestamp when they are queried by slightly altering
+# their stored timestamp. NOTE: this is imperfect because Loki accepts out of order writes
+# and another push request for the same stream could contain duplicate timestamps to existing
+# entries and they will not be fudged.
+# CLI flag: -validation.fudge-duplicate-timestamps
+[fudge_duplicate_timestamp: <boolean> | default = false ]
+
 # Maximum number of log entries that will be returned for a query.
 # CLI flag: -validation.max-entries-limit
 [max_entries_limit_per_query: <int> | default = 5000 ]

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -271,7 +271,21 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 				validationErr = err
 				continue
 			}
+
 			stream.Entries[n] = entry
+
+			// If configured for this tenant, fudge duplicate timestamps. Note, this is imperfect
+			// since Loki will accept out of order writes it doesn't account for separate
+			// pushes with overlapping time ranges having entries with duplicate timestamps
+			if validationContext.fudgeDuplicateTimestamps && n != 0 && stream.Entries[n-1].Timestamp.Equal(entry.Timestamp) {
+				// Traditional logic for Loki is that 2 lines with the same timestamp and
+				// exact same content will be de-duplicated, (i.e. only one will be stored, others dropped)
+				// To maintain this behavior, only fudge the timestamp if the log content is different
+				if stream.Entries[n-1].Line != entry.Line {
+					stream.Entries[n].Timestamp = entry.Timestamp.Add(1 * time.Nanosecond)
+				}
+			}
+
 			n++
 			validatedSamplesSize += len(entry.Line)
 			validatedSamplesCount++

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -122,8 +122,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123457, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -133,8 +133,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123457, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -147,8 +147,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -158,8 +158,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -172,8 +172,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 						},
 					},
 				},
@@ -183,8 +183,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 						},
 					},
 				},
@@ -197,8 +197,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123457, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -208,8 +208,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123457, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -222,8 +222,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -233,8 +233,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 1), "heyiiiiiii"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 1), Line: "heyiiiiiii"},
 						},
 					},
 				},
@@ -247,8 +247,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 						},
 					},
 				},
@@ -258,8 +258,8 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 						},
 					},
 				},
@@ -272,9 +272,9 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 0), "hi"},
-							{time.Unix(123456, 1), "hey there"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "hi"},
+							{Timestamp: time.Unix(123456, 1), Line: "hey there"},
 						},
 					},
 				},
@@ -284,9 +284,9 @@ func Test_FudgeTimestamp(t *testing.T) {
 					{
 						Labels: "{job=\"foo\"}",
 						Entries: []logproto.Entry{
-							{time.Unix(123456, 0), "heyooooooo"},
-							{time.Unix(123456, 1), "hi"},
-							{time.Unix(123456, 2), "hey there"},
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 1), Line: "hi"},
+							{Timestamp: time.Unix(123456, 2), Line: "hey there"},
 						},
 					},
 				},

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -14,4 +14,6 @@ type Limits interface {
 	CreationGracePeriod(userID string) time.Duration
 	RejectOldSamples(userID string) bool
 	RejectOldSamplesMaxAge(userID string) time.Duration
+
+	FudgeDuplicateTimestamps(userID string) bool
 }

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -40,20 +40,23 @@ type validationContext struct {
 	maxLabelNameLength     int
 	maxLabelValueLength    int
 
+	fudgeDuplicateTimestamps bool
+
 	userID string
 }
 
 func (v Validator) getValidationContextForTime(now time.Time, userID string) validationContext {
 	return validationContext{
-		userID:                 userID,
-		rejectOldSample:        v.RejectOldSamples(userID),
-		rejectOldSampleMaxAge:  now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
-		creationGracePeriod:    now.Add(v.CreationGracePeriod(userID)).UnixNano(),
-		maxLineSize:            v.MaxLineSize(userID),
-		maxLineSizeTruncate:    v.MaxLineSizeTruncate(userID),
-		maxLabelNamesPerSeries: v.MaxLabelNamesPerSeries(userID),
-		maxLabelNameLength:     v.MaxLabelNameLength(userID),
-		maxLabelValueLength:    v.MaxLabelValueLength(userID),
+		userID:                   userID,
+		rejectOldSample:          v.RejectOldSamples(userID),
+		rejectOldSampleMaxAge:    now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
+		creationGracePeriod:      now.Add(v.CreationGracePeriod(userID)).UnixNano(),
+		maxLineSize:              v.MaxLineSize(userID),
+		maxLineSizeTruncate:      v.MaxLineSizeTruncate(userID),
+		maxLabelNamesPerSeries:   v.MaxLabelNamesPerSeries(userID),
+		maxLabelNameLength:       v.MaxLabelNameLength(userID),
+		maxLabelValueLength:      v.MaxLabelValueLength(userID),
+		fudgeDuplicateTimestamps: v.FudgeDuplicateTimestamps(userID),
 	}
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -46,18 +46,19 @@ const (
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type Limits struct {
 	// Distributor enforced limits.
-	IngestionRateStrategy  string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
-	IngestionRateMB        float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
-	IngestionBurstSizeMB   float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
-	MaxLabelNameLength     int              `yaml:"max_label_name_length" json:"max_label_name_length"`
-	MaxLabelValueLength    int              `yaml:"max_label_value_length" json:"max_label_value_length"`
-	MaxLabelNamesPerSeries int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
-	RejectOldSamples       bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
-	RejectOldSamplesMaxAge model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
-	CreationGracePeriod    model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
-	EnforceMetricName      bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
-	MaxLineSize            flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
-	MaxLineSizeTruncate    bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
+	IngestionRateStrategy   string           `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
+	IngestionRateMB         float64          `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
+	IngestionBurstSizeMB    float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
+	MaxLabelNameLength      int              `yaml:"max_label_name_length" json:"max_label_name_length"`
+	MaxLabelValueLength     int              `yaml:"max_label_value_length" json:"max_label_value_length"`
+	MaxLabelNamesPerSeries  int              `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	RejectOldSamples        bool             `yaml:"reject_old_samples" json:"reject_old_samples"`
+	RejectOldSamplesMaxAge  model.Duration   `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
+	CreationGracePeriod     model.Duration   `yaml:"creation_grace_period" json:"creation_grace_period"`
+	EnforceMetricName       bool             `yaml:"enforce_metric_name" json:"enforce_metric_name"`
+	MaxLineSize             flagext.ByteSize `yaml:"max_line_size" json:"max_line_size"`
+	MaxLineSizeTruncate     bool             `yaml:"max_line_size_truncate" json:"max_line_size_truncate"`
+	FudgeDuplicateTimestamp bool             `yaml:"fudge_duplicate_timestamp" json:"fudge_duplicate_timestamp"`
 
 	// Ingester enforced limits.
 	MaxLocalStreamsPerUser  int              `yaml:"max_streams_per_user" json:"max_streams_per_user"`
@@ -135,6 +136,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
 	f.BoolVar(&l.RejectOldSamples, "validation.reject-old-samples", true, "Reject old samples.")
+	f.BoolVar(&l.FudgeDuplicateTimestamp, "validation.fudge-duplicate-timestamps", false, "Fudge the timestamp of a log line by one nanosecond in the future from a previous entry for the same stream with the same timestamp, guarantees sort order at query time.")
 
 	_ = l.RejectOldSamplesMaxAge.Set("7d")
 	f.Var(&l.RejectOldSamplesMaxAge, "validation.reject-old-samples.max-age", "Maximum accepted sample age before rejecting.")
@@ -535,6 +537,10 @@ func (o *Overrides) PerStreamRateLimit(userID string) RateLimit {
 		Limit: rate.Limit(float64(user.PerStreamRateLimit.Val())),
 		Burst: user.PerStreamRateLimitBurst.Val(),
 	}
+}
+
+func (o *Overrides) FudgeDuplicateTimestamps(userID string) bool {
+	return o.getOverridesForUser(userID).FudgeDuplicateTimestamp
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

Loki will accept entries with duplicate timestamps for the same stream as long as the log content is different. 

Loki stores nanosecond precise timestamps which makes duplicates unlikely if your source system generates timestamps with this precision, however many systems do not have this level of precision, and in some cases may only have second level precision.

This leads to a common enough case where Loki receives multiple entries with the same timestamp.

The problem arises at query time, while Loki can definitely sort entries with different timestamps, in the case where the timestamps are duplicate for the same stream it's currently not possible for Loki to guarantee they will always be displayed exactly as received.

This PR takes a fairly naive approach at solving this problem by intentionally fudging the timestamp of log lines with duplicate timestamps by one nanosecond such that they are no longer duplicate and will always sort correctly at query time.

Two important things to note

1. this obviously changes the timestamp of the log line from how it was originally received which may not be acceptable in all situations which is why it's configurable. The tradeoff here is probably reasonable however, adding a nanosecond to the timestamp of a source stream which likely only has millisecond or second level precision is of minimal impact.
2. this solution is not perfect, Loki will accept out of order writes and a subsequent push request may contain a timestamp which is a duplicate of an entry already recived and processed and it will not be fudged.

I think however this is a reasonable and simple approach to the most common case which is a low precision timestamp source having multiple entries at the same timestamp in which it's more important to have them sort in the received order at query time than it is if the timestamp is fudged by one or a few nanoseconds to accomplish this.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
