### PR TITLE
improve index list cache in boltdb-shipper to avoid refreshing cache at query time

### DIFF
--- a/pkg/storage/stores/shipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_test.go
@@ -396,6 +396,9 @@ func TestTable_Sync(t *testing.T) {
 	require.NoError(t, os.Remove(filepath.Join(tablePathInStorage, deleteDB)))
 	testutil.AddRecordsToDB(t, filepath.Join(tablePathInStorage, newDB), boltdbClient, 20, 10, nil)
 
+	// refresh the object list cache to get latest list of files
+	table.storageClient.RefreshCache()
+
 	// sync the table
 	require.NoError(t, table.Sync(context.Background()))
 
@@ -577,6 +580,9 @@ func TestLoadTable(t *testing.T) {
 
 	testutil.SetupDBsAtPath(t, tablePathInStorage, commonDBs, nil)
 	testutil.SetupDBsAtPath(t, filepath.Join(tablePathInStorage, userID), userDBs, nil)
+
+	// refresh the object list cache to get latest list of files
+	storageClient.RefreshCache()
 
 	// try loading the table, it should skip loading corrupt file and reload it from storage.
 	table, err = LoadTable(tableName, tablePathInCache, storageClient, boltDBIndexClient, newMetrics(nil))

--- a/pkg/storage/stores/shipper/storage/cached_client_test.go
+++ b/pkg/storage/stores/shipper/storage/cached_client_test.go
@@ -46,6 +46,8 @@ func (m *mockObjectClient) List(_ context.Context, _, _ string) ([]client.Storag
 	return m.storageObjects, []client.StorageCommonPrefix{}, nil
 }
 
+func (m *mockObjectClient) Stop() {}
+
 func TestCachedObjectClient(t *testing.T) {
 	objectsInStorage := []string{
 		// table with just common dbs
@@ -147,37 +149,133 @@ func TestCachedObjectClient_errors(t *testing.T) {
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table1"}, commonPrefixes)
 
-	// timeout the cache and call List concurrently with objectClient throwing an error
-	// objectClient must receive just one request and all the cachedObjectClient.List calls should get an error
-	wg := sync.WaitGroup{}
-	cachedObjectClient.cacheBuiltAt = time.Now().Add(-(cacheTimeout + time.Second))
+	// Refresh the cache and call List concurrently with objectClient throwing an error.
+	// All the cachedObjectClient.List calls should get an error.
 	objectClient.listDelay = time.Millisecond * 100
 	objectClient.errResp = errors.New("fake error")
+	cachedObjectClient.RefreshCache()
+	require.Equal(t, 2, objectClient.listCallsCount)
+
+	wg := sync.WaitGroup{}
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			_, _, err := cachedObjectClient.List(context.Background(), "", "")
 			require.Error(t, err)
-			require.Equal(t, 2, objectClient.listCallsCount)
 		}()
 	}
 
 	wg.Wait()
 
-	// clear the error and call the List concurrently again
-	// objectClient must receive just one request and all the calls should not get any error
+	require.Equal(t, 2, objectClient.listCallsCount)
+
+	// Clear the error and refresh the cache.
+	// objectClient must receive just one request from cache refresh and all the calls should not get any error
 	objectClient.errResp = nil
+	cachedObjectClient.RefreshCache()
+
+	require.Equal(t, 3, objectClient.listCallsCount)
+
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "")
 			require.NoError(t, err)
-			require.Equal(t, 3, objectClient.listCallsCount)
 			require.Equal(t, []client.StorageObject{}, objects)
 			require.Equal(t, []client.StorageCommonPrefix{"table1"}, commonPrefixes)
 		}()
 	}
 	wg.Wait()
+
+	require.Equal(t, 3, objectClient.listCallsCount)
+}
+
+func TestCachedObjectClient_AutoRefresh(t *testing.T) {
+	objectsInStorage := []string{
+		// table with just common dbs
+		"table1/db1.gz",
+		"table1/db2.gz",
+	}
+
+	objectClient := newMockObjectClient(objectsInStorage)
+	cachedObjectClient := newCachedObjectClient(objectClient)
+
+	// initial cache should have been built already
+	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, 1, objectClient.listCallsCount)
+	require.Equal(t, []client.StorageObject{}, objects)
+	require.Equal(t, []client.StorageCommonPrefix{"table1"}, commonPrefixes)
+
+	// add a new table to the storage
+	objectClient.storageObjects = append(objectClient.storageObjects, client.StorageObject{
+		Key: "table2/db1.gz",
+	})
+
+	// see that without enabling cache auto refresh, we do not get back the new table name in response
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, 1, objectClient.listCallsCount)
+	require.Equal(t, []client.StorageObject{}, objects)
+	require.Equal(t, []client.StorageCommonPrefix{"table1"}, commonPrefixes)
+
+	// enable auto refresh and see that it got refreshed already
+	cachedObjectClient.EnableCacheAutoRefresh()
+
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, 2, objectClient.listCallsCount)
+	require.Equal(t, []client.StorageObject{}, objects)
+	require.Equal(t, []client.StorageCommonPrefix{"table1", "table2"}, commonPrefixes)
+
+	// disable the auto refresh
+	cachedObjectClient.DisableCacheAutoRefresh()
+	require.Equal(t, 0, cachedObjectClient.cacheAutoRefreshEnabledCount)
+	require.Nil(t, cachedObjectClient.cacheAutoRefresher)
+
+	// concurrently enable the auto refresh
+	wg := sync.WaitGroup{}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cachedObjectClient.EnableCacheAutoRefresh()
+		}()
+	}
+
+	wg.Wait()
+
+	// see that the cache is refreshed only once
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, 3, objectClient.listCallsCount)
+	require.Equal(t, []client.StorageObject{}, objects)
+	require.Equal(t, []client.StorageCommonPrefix{"table1", "table2"}, commonPrefixes)
+
+	cachedObjectClient.Stop()
+}
+
+func TestCacheAutoRefresher(t *testing.T) {
+	cacheRefreshCount := 0
+	cacheAutoRefresher := newCacheAutoRefresher(func() {
+		cacheRefreshCount++
+	}, time.Second/2)
+
+	// sleep for some time and stop the timer to ensure cache refresh func is called
+	time.Sleep(time.Second + 100*time.Millisecond)
+	cacheAutoRefresher.stop()
+	require.Equal(t, 2, cacheRefreshCount)
+
+	// sleep again to ensure cache refresh func is not called anymore and ensure things are cleaned up
+	time.Sleep(time.Second)
+	require.Equal(t, 2, cacheRefreshCount)
+	cacheAutoRefresher.wg.Wait()
+	select {
+	case _, ok := <-cacheAutoRefresher.stopChan:
+		require.False(t, ok)
+	default:
+		t.Fatal("stopChan should be closed")
+	}
 }

--- a/pkg/storage/stores/shipper/storage/client_test.go
+++ b/pkg/storage/stores/shipper/storage/client_test.go
@@ -36,6 +36,9 @@ func TestIndexStorageClient(t *testing.T) {
 	indexStorageClient := NewIndexStorageClient(objectClient, storageKeyPrefix)
 
 	verifyFiles := func() {
+		// refresh the object list cache to get latest list of files
+		indexStorageClient.RefreshCache()
+
 		tables, err := indexStorageClient.ListTables(context.Background())
 		require.NoError(t, err)
 		require.Len(t, tables, len(tablesToSetup))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
To reduce the number of list calls we make to the object store when using `boltdb-shipper`, we have a cache in place. The cache stays valid for 1 min and is refreshed when a list call is made and it finds that cache needs to be rebuilt. The list call could take a couple of seconds to finish in a large cluster which can add up to the query latency when downloading index at query time.

This PR improves it by doing the cache auto refreshing in the background and the list call returning whatever we have in cache without worrying about its validity. The cache auto refreshing is only necessary for background operations like sync and compaction. For query time index download, it is okay to use the listing built by last sync operation. So the caching layer now exposes 2 new methods for enabling/disabling cache auto sync by background operations:
```
	EnableCacheAutoRefresh()
	DisableCacheAutoRefresh()
```
The implementation takes care of multiple simultaneous requests that can come in to enable/disable cache auto refresh when running multiple Loki services in a single process.

**Special notes for your reviewer**:
I also realized that caching can be also used with `filesystem` object store due to it now supporting flat object listing so I have enabled it for that as well. I have also added `RefreshCache` to let the tests refresh the cache without which they would fail to see updates done in the storage since they use `filesystem` for storing index and it now supports caching of index list.

**Checklist**
- [x] Tests updated
