### PR TITLE
boltdb shipper index list cache improvements

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -284,7 +284,7 @@ func (t *indexSet) checkStorageForUpdates(ctx context.Context, lock bool) (toDow
 	// listing tables from store
 	var files []storage.IndexFile
 
-	files, err = t.baseIndexSet.ListFiles(ctx, t.tableName, t.userID)
+	files, err = t.baseIndexSet.ListFiles(ctx, t.tableName, t.userID, false)
 	if err != nil {
 		return
 	}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -263,7 +263,7 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 		}
 
 		// list the users that have dedicated index files for this table
-		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName)
+		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -322,6 +322,6 @@ func (m *mockIndexStorageClient) ListTables(ctx context.Context) ([]string, erro
 	return m.tablesInStorage, nil
 }
 
-func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
+func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string, bypassCache bool) ([]storage.IndexFile, []string, error) {
 	return []storage.IndexFile{}, m.userIndexesInTables[tableName], nil
 }

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -32,8 +32,8 @@ func newStorageClientWithFakeObjectsInList(storageClient storage.Client) storage
 	return storageClientWithFakeObjectsInList{storageClient}
 }
 
-func (o storageClientWithFakeObjectsInList) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
-	files, userIDs, err := o.Client.ListFiles(ctx, tableName)
+func (o storageClientWithFakeObjectsInList) ListFiles(ctx context.Context, tableName string, bypassCache bool) ([]storage.IndexFile, []string, error) {
+	files, userIDs, err := o.Client.ListFiles(ctx, tableName, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,6 +46,20 @@ func (o storageClientWithFakeObjectsInList) ListFiles(ctx context.Context, table
 	return files, userIDs, nil
 }
 
+func (o storageClientWithFakeObjectsInList) ListUserFiles(ctx context.Context, tableName, userID string, _ bool) ([]storage.IndexFile, error) {
+	files, err := o.Client.ListUserFiles(ctx, tableName, userID, true)
+	if err != nil {
+		return nil, err
+	}
+
+	files = append(files, storage.IndexFile{
+		Name:       "fake-object",
+		ModifiedAt: time.Now(),
+	})
+
+	return files, nil
+}
+
 func buildTestTable(t *testing.T, path string) (*table, stopFunc) {
 	storageClient := buildTestStorageClient(t, path)
 	cachePath := filepath.Join(path, cacheDirName)
@@ -53,7 +67,7 @@ func buildTestTable(t *testing.T, path string) (*table, stopFunc) {
 	table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
 	}).(*table)
-	_, usersWithIndex, err := table.storageClient.ListFiles(context.Background(), tableName)
+	_, usersWithIndex, err := table.storageClient.ListFiles(context.Background(), tableName, false)
 	require.NoError(t, err)
 	require.NoError(t, table.EnsureQueryReadiness(context.Background(), usersWithIndex))
 
@@ -301,6 +315,7 @@ func TestTable_Sync(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(filepath.Join(tablePathInStorage, newDB), []byte(newDB), 0755))
 
 	// sync the table
+	table.storageClient.RefreshIndexListCache(context.Background())
 	require.NoError(t, table.Sync(context.Background()))
 
 	// check that table got the new index and dropped the deleted index

--- a/pkg/storage/stores/shipper/compactor/index_set.go
+++ b/pkg/storage/stores/shipper/compactor/index_set.go
@@ -94,7 +94,7 @@ func (is *indexSet) initUserIndexSet(workingDir string) {
 	ctx, cancelFunc := context.WithTimeout(is.ctx, userIndexReadinessTimeout)
 	defer cancelFunc()
 
-	is.sourceObjects, is.err = is.baseIndexSet.ListFiles(is.ctx, is.tableName, is.userID)
+	is.sourceObjects, is.err = is.baseIndexSet.ListFiles(is.ctx, is.tableName, is.userID, false)
 	if is.err != nil {
 		return
 	}

--- a/pkg/storage/stores/shipper/compactor/table.go
+++ b/pkg/storage/stores/shipper/compactor/table.go
@@ -123,7 +123,7 @@ func newTable(ctx context.Context, workingDirectory string, indexStorageClient s
 }
 
 func (t *table) compact(applyRetention bool) error {
-	indexFiles, usersWithPerUserIndex, err := t.indexStorageClient.ListFiles(t.ctx, t.name)
+	indexFiles, usersWithPerUserIndex, err := t.indexStorageClient.ListFiles(t.ctx, t.name, false)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (t *table) done() error {
 			continue
 		}
 
-		indexFiles, err := t.baseUserIndexSet.ListFiles(t.ctx, t.name, userID)
+		indexFiles, err := t.baseUserIndexSet.ListFiles(t.ctx, t.name, userID, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/downloads/index_set.go
@@ -25,6 +25,8 @@ import (
 	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 
+var errIndexListCacheTooStale = fmt.Errorf("index list cache too stale")
+
 type IndexSet interface {
 	Init(forQuerying bool) error
 	Close()
@@ -300,6 +302,14 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {
 		return err
+	}
+
+	// if we did not bypass list cache and skipped downloading all the new files due to them being removed by compaction,
+	// it means the cache is not valid anymore since compaction would have happened after last index list cache refresh.
+	// Let us return error to ask the caller to re-run the sync after the list cache refresh.
+	if !bypassListCache && len(downloadedFiles) == 0 && len(toDownload) > 0 {
+		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownload)
+		return errIndexListCacheTooStale
 	}
 
 	if lock {

--- a/pkg/storage/stores/shipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/downloads/index_set_test.go
@@ -26,7 +26,7 @@ func buildTestIndexSet(t *testing.T, userID, path string) (*indexSet, stopFunc) 
 		boltDBIndexClient, util_log.Logger, newMetrics(nil))
 	require.NoError(t, err)
 
-	require.NoError(t, idxSet.Init())
+	require.NoError(t, idxSet.Init(false))
 
 	return idxSet.(*indexSet), func() {
 		idxSet.Close()

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -114,7 +114,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 			return nil, err
 		}
 
-		err = userIndexSet.Init()
+		err = userIndexSet.Init(false)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 		return nil, err
 	}
 
-	err = commonIndexSet.Init()
+	err = commonIndexSet.Init(false)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying 
 			}()
 		}
 
-		err := indexSet.Init()
+		err := indexSet.Init(forQuerying)
 		if err != nil {
 			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
 		}

--- a/pkg/storage/stores/shipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager.go
@@ -297,7 +297,7 @@ func (tm *TableManager) ensureQueryReadiness(ctx context.Context) error {
 		}
 
 		// list the users that have dedicated index files for this table
-		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName)
+		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/downloads/table_manager_test.go
@@ -328,6 +328,6 @@ func (m *mockIndexStorageClient) ListTables(ctx context.Context) ([]string, erro
 	return m.tablesInStorage, nil
 }
 
-func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string) ([]storage.IndexFile, []string, error) {
+func (m *mockIndexStorageClient) ListFiles(ctx context.Context, tableName string, bypassCache bool) ([]storage.IndexFile, []string, error) {
 	return []storage.IndexFile{}, m.userIndexesInTables[tableName], nil
 }

--- a/pkg/storage/stores/shipper/storage/cached_client.go
+++ b/pkg/storage/stores/shipper/storage/cached_client.go
@@ -50,7 +50,7 @@ func newCachedObjectClient(downstreamClient client.ObjectClient) *cachedObjectCl
 // We have a buffered channel here with a capacity of 1 to make sure only one concurrent call makes it through.
 // We also have a sync.WaitGroup to make sure all the concurrent calls to buildCacheOnce wait until the cache gets rebuilt since
 // we are doing read-through cache, and we do not want to serve stale results.
-func (c *cachedObjectClient) buildCacheOnce(ctx context.Context) {
+func (c *cachedObjectClient) buildCacheOnce(ctx context.Context, forceRefresh bool) {
 	c.buildCacheWg.Add(1)
 	defer c.buildCacheWg.Done()
 
@@ -59,7 +59,7 @@ func (c *cachedObjectClient) buildCacheOnce(ctx context.Context) {
 	select {
 	case c.buildCacheChan <- struct{}{}:
 		c.err = nil
-		c.err = c.buildCache(ctx)
+		c.err = c.buildCache(ctx, forceRefresh)
 		<-c.buildCacheChan
 		if c.err != nil {
 			level.Error(util_log.Logger).Log("msg", "failed to build cache", "err", c.err)
@@ -68,7 +68,16 @@ func (c *cachedObjectClient) buildCacheOnce(ctx context.Context) {
 	}
 }
 
-func (c *cachedObjectClient) List(ctx context.Context, prefix, _ string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
+func (c *cachedObjectClient) RefreshIndexListCache(ctx context.Context) {
+	c.buildCacheOnce(ctx, true)
+	c.buildCacheWg.Wait()
+}
+
+func (c *cachedObjectClient) List(ctx context.Context, prefix, objectDelimiter string, bypassCache bool) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
+	if bypassCache {
+		return c.ObjectClient.List(ctx, prefix, objectDelimiter)
+	}
+
 	prefix = strings.TrimSuffix(prefix, delimiter)
 	ss := strings.Split(prefix, delimiter)
 	if len(ss) > 2 {
@@ -76,7 +85,7 @@ func (c *cachedObjectClient) List(ctx context.Context, prefix, _ string) ([]clie
 	}
 
 	if time.Since(c.cacheBuiltAt) >= cacheTimeout {
-		c.buildCacheOnce(ctx)
+		c.buildCacheOnce(ctx, false)
 	}
 
 	// wait for cache build operation to finish, if running
@@ -120,8 +129,8 @@ func (c *cachedObjectClient) List(ctx context.Context, prefix, _ string) ([]clie
 }
 
 // buildCache builds the cache if expired
-func (c *cachedObjectClient) buildCache(ctx context.Context) error {
-	if time.Since(c.cacheBuiltAt) < cacheTimeout {
+func (c *cachedObjectClient) buildCache(ctx context.Context, forceRefresh bool) error {
+	if !forceRefresh && time.Since(c.cacheBuiltAt) < cacheTimeout {
 		return nil
 	}
 

--- a/pkg/storage/stores/shipper/storage/cached_client_test.go
+++ b/pkg/storage/stores/shipper/storage/cached_client_test.go
@@ -65,14 +65,14 @@ func TestCachedObjectClient(t *testing.T) {
 	cachedObjectClient := newCachedObjectClient(objectClient)
 
 	// list tables
-	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "")
+	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table1", "table2", "table3"}, commonPrefixes)
 
 	// list objects in all 3 tables
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table1/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table1/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{
@@ -81,7 +81,7 @@ func TestCachedObjectClient(t *testing.T) {
 	}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{
@@ -89,14 +89,14 @@ func TestCachedObjectClient(t *testing.T) {
 	}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table2/user1"}, commonPrefixes)
 
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{"table3/user1"}, commonPrefixes)
 
 	// list user objects from table2 and table3
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/user1/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table2/user1/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{
@@ -106,7 +106,7 @@ func TestCachedObjectClient(t *testing.T) {
 	}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user1/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user1/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{
@@ -116,14 +116,14 @@ func TestCachedObjectClient(t *testing.T) {
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 
 	// list non-existent table
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table4/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table4/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{}, objects)
 	require.Equal(t, []client.StorageCommonPrefix{}, commonPrefixes)
 
 	// list non-existent user
-	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user2/", "")
+	objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "table3/user2/", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{}, objects)
@@ -141,7 +141,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 	cachedObjectClient := newCachedObjectClient(objectClient)
 
 	// do the initial listing
-	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "")
+	objects, commonPrefixes, err := cachedObjectClient.List(context.Background(), "", "", false)
 	require.NoError(t, err)
 	require.Equal(t, 1, objectClient.listCallsCount)
 	require.Equal(t, []client.StorageObject{}, objects)
@@ -157,7 +157,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _, err := cachedObjectClient.List(context.Background(), "", "")
+			_, _, err := cachedObjectClient.List(context.Background(), "", "", false)
 			require.Error(t, err)
 			require.Equal(t, 2, objectClient.listCallsCount)
 		}()
@@ -172,7 +172,7 @@ func TestCachedObjectClient_errors(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "")
+			objects, commonPrefixes, err = cachedObjectClient.List(context.Background(), "", "", false)
 			require.NoError(t, err)
 			require.Equal(t, 3, objectClient.listCallsCount)
 			require.Equal(t, []client.StorageObject{}, objects)

--- a/pkg/storage/stores/shipper/storage/client_test.go
+++ b/pkg/storage/stores/shipper/storage/client_test.go
@@ -36,6 +36,7 @@ func TestIndexStorageClient(t *testing.T) {
 	indexStorageClient := NewIndexStorageClient(objectClient, storageKeyPrefix)
 
 	verifyFiles := func() {
+		indexStorageClient.RefreshIndexListCache(context.Background())
 		tables, err := indexStorageClient.ListTables(context.Background())
 		require.NoError(t, err)
 		require.Len(t, tables, len(tablesToSetup))
@@ -43,7 +44,7 @@ func TestIndexStorageClient(t *testing.T) {
 			expectedFiles, ok := tablesToSetup[table]
 			require.True(t, ok)
 
-			filesInStorage, _, err := indexStorageClient.ListFiles(context.Background(), table)
+			filesInStorage, _, err := indexStorageClient.ListFiles(context.Background(), table, false)
 			require.NoError(t, err)
 			require.Len(t, filesInStorage, len(expectedFiles))
 

--- a/pkg/storage/stores/shipper/table_client.go
+++ b/pkg/storage/stores/shipper/table_client.go
@@ -18,6 +18,7 @@ func NewBoltDBShipperTableClient(objectClient client.ObjectClient, storageKeyPre
 }
 
 func (b *boltDBShipperTableClient) ListTables(ctx context.Context) ([]string, error) {
+	b.indexStorageClient.RefreshIndexListCache(ctx)
 	return b.indexStorageClient.ListTables(ctx)
 }
 
@@ -30,7 +31,7 @@ func (b *boltDBShipperTableClient) Stop() {
 }
 
 func (b *boltDBShipperTableClient) DeleteTable(ctx context.Context, tableName string) error {
-	files, _, err := b.indexStorageClient.ListFiles(ctx, tableName)
+	files, _, err := b.indexStorageClient.ListFiles(ctx, tableName, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
To reduce the number of list calls we make to the object store when using boltdb-shipper, we have a cache in place. The cache stays valid for 1 min and is refreshed when a list call is made and it finds that cache needs to be rebuilt. The list call could take a couple of seconds to finish in a large cluster which can add up to the query latency when downloading index at query time.

This PR adds a parameter to list calls to skip the list cache and directly load the objects list from the object store. We will skip the cache only while doing query time download of index which is not too common, we see just up to 8k query time download operations in a day in our largest Loki cluster.

The other change this PR does is to detect the staleness of the list cache. Before explaining the problem, let us keep few things in mind:
* While running compaction, it would first upload the newly created(compacted) file and then remove the source files. So it is possible that a list call can see the newly compacted file with the old source files while the compactor is still removing them.
* When we see a 404 error while downloading the index, we just ignore it assuming the compactor would have removed it during compaction.

Now the problem is if compaction happened just after we cached the list of objects, the sync operation on the recently compacted table would try to download old source files that were compacted away but we would just ignore missing files as mentioned above. This means we won't have downloaded either of source index files and the new compacted file, still not know too us due to stale cache. This PR adds a check in sync code to see if we skipped downloading all the files, if so then we would retry the sync after force refreshing the index list cache.

**Checklist**
- [x] Tests updated
