### PR TITLE
Improve index entries deduping and concurrency

### DIFF
--- a/pkg/storage/stores/shipper/util/queries.go
+++ b/pkg/storage/stores/shipper/util/queries.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"sync"
 
-	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
 
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	util_math "github.com/grafana/loki/pkg/util/math"
-	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 
-const maxQueriesPerGoroutine = 100
+const (
+	maxQueriesBatch = 100
+	maxConcurrency  = 10
+)
 
 type TableQuerier interface {
 	MultiQueries(ctx context.Context, queries []index.Query, callback index.QueryPagesCallback) error
@@ -35,121 +37,127 @@ func DoParallelQueries(ctx context.Context, tableQuerier TableQuerier, queries [
 	if len(queries) == 0 {
 		return nil
 	}
-	errs := make(chan error)
-
-	id := NewIndexDeduper(callback)
-	defer func() {
-		logger := spanlogger.FromContext(ctx)
-		level.Debug(logger).Log("msg", "done processing index queries", "table-name", queries[0].TableName,
-			"query-count", len(queries), "num-entries-sent", id.numEntriesSent)
-	}()
-
-	if len(queries) <= maxQueriesPerGoroutine {
-		return tableQuerier.MultiQueries(ctx, queries, id.Callback)
+	if len(queries) <= maxQueriesBatch {
+		return tableQuerier.MultiQueries(ctx, queries, NewCallbackDeduper(callback, len(queries)))
 	}
 
-	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
-		q := queries[i:util_math.Min(i+maxQueriesPerGoroutine, len(queries))]
-		go func(queries []index.Query) {
-			errs <- tableQuerier.MultiQueries(ctx, queries, id.Callback)
-		}(q)
+	jobsCount := len(queries) / maxQueriesBatch
+	if len(queries)%maxQueriesBatch != 0 {
+		jobsCount++
 	}
-
-	var lastErr error
-	for i := 0; i < len(queries); i += maxQueriesPerGoroutine {
-		err := <-errs
-		if err != nil {
-			lastErr = err
-		}
-	}
-
-	return lastErr
-}
-
-// IndexDeduper should always be used on table level not the whole query level because it just looks at range values which can be repeated across tables
-// Cortex anyways dedupes entries across tables
-type IndexDeduper struct {
-	callback        index.QueryPagesCallback
-	seenRangeValues map[string]map[string]struct{}
-	numEntriesSent  int
-	mtx             sync.RWMutex
-}
-
-func NewIndexDeduper(callback index.QueryPagesCallback) *IndexDeduper {
-	return &IndexDeduper{
-		callback:        callback,
-		seenRangeValues: map[string]map[string]struct{}{},
-	}
-}
-
-func (i *IndexDeduper) Callback(query index.Query, batch index.ReadBatchResult) bool {
-	return i.callback(query, &filteringBatch{
-		query:           query,
-		ReadBatchResult: batch,
-		isSeen:          i.isSeen,
+	callback = NewSyncCallbackDeduper(callback, len(queries))
+	return concurrency.ForEachJob(ctx, jobsCount, maxConcurrency, func(ctx context.Context, idx int) error {
+		return tableQuerier.MultiQueries(ctx, queries[idx*maxQueriesBatch:util_math.Min((idx+1)*maxQueriesBatch, len(queries))], callback)
 	})
 }
 
-func (i *IndexDeduper) isSeen(hashValue string, rangeValue []byte) bool {
-	i.mtx.RLock()
+// NewSyncCallbackDeduper should always be used on table level not the whole query level because it just looks at range values which can be repeated across tables
+// NewSyncCallbackDeduper is safe to used by multiple goroutines
+// Cortex anyways dedupes entries across tables
+func NewSyncCallbackDeduper(callback index.QueryPagesCallback, queries int) index.QueryPagesCallback {
+	syncMap := &syncMap{
+		seen: make(map[string]map[string]struct{}, queries),
+	}
+	return func(q index.Query, rbr index.ReadBatchResult) bool {
+		return callback(q, &readBatchDeduperSync{
+			syncMap:           syncMap,
+			hashValue:         q.HashValue,
+			ReadBatchIterator: rbr.Iterator(),
+		})
+	}
+}
 
-	// index entries are never modified during query processing so it should be safe to reference a byte slice as a string.
-	rangeValueStr := GetUnsafeString(rangeValue)
+// NewCallbackDeduper should always be used on table level not the whole query level because it just looks at range values which can be repeated across tables
+// NewCallbackDeduper is safe not to used by multiple goroutines
+// Cortex anyways dedupes entries across tables
+func NewCallbackDeduper(callback index.QueryPagesCallback, queries int) index.QueryPagesCallback {
+	f := &readBatchDeduper{
+		seen: make(map[string]map[string]struct{}, queries),
+	}
+	return func(q index.Query, rbr index.ReadBatchResult) bool {
+		f.hashValue = q.HashValue
+		f.ReadBatchIterator = rbr.Iterator()
+		return callback(q, f)
+	}
+}
 
-	if _, ok := i.seenRangeValues[hashValue][rangeValueStr]; ok {
-		i.mtx.RUnlock()
+type readBatchDeduper struct {
+	index.ReadBatchIterator
+	hashValue string
+	seen      map[string]map[string]struct{}
+}
+
+func (f *readBatchDeduper) Iterator() index.ReadBatchIterator {
+	return f
+}
+
+func (f *readBatchDeduper) Next() bool {
+	for f.ReadBatchIterator.Next() {
+		rangeValue := f.RangeValue()
+		hashes, ok := f.seen[f.hashValue]
+		if !ok {
+			hashes = map[string]struct{}{}
+			hashes[GetUnsafeString(rangeValue)] = struct{}{}
+			f.seen[f.hashValue] = hashes
+			return true
+		}
+		h := GetUnsafeString(rangeValue)
+		if _, loaded := hashes[h]; loaded {
+			continue
+		}
+		hashes[h] = struct{}{}
 		return true
 	}
 
-	i.mtx.RUnlock()
-
-	i.mtx.Lock()
-	defer i.mtx.Unlock()
-
-	// re-check if another concurrent call added the values already, if so do not add it again and return true
-	if _, ok := i.seenRangeValues[hashValue][rangeValueStr]; ok {
-		return true
-	}
-
-	// add the hashValue first if missing
-	if _, ok := i.seenRangeValues[hashValue]; !ok {
-		i.seenRangeValues[hashValue] = map[string]struct{}{}
-	}
-
-	// add the rangeValue
-	i.seenRangeValues[hashValue][rangeValueStr] = struct{}{}
-	i.numEntriesSent++
 	return false
 }
 
-type isSeen func(hashValue string, rangeValue []byte) bool
-
-type filteringBatch struct {
-	query index.Query
-	index.ReadBatchResult
-	isSeen isSeen
+type syncMap struct {
+	seen map[string]map[string]struct{}
+	rw   sync.RWMutex // nolint: structcheck
 }
 
-func (f *filteringBatch) Iterator() index.ReadBatchIterator {
-	return &filteringBatchIter{
-		query:             f.query,
-		ReadBatchIterator: f.ReadBatchResult.Iterator(),
-		isSeen:            f.isSeen,
-	}
-}
-
-type filteringBatchIter struct {
-	query index.Query
+type readBatchDeduperSync struct {
 	index.ReadBatchIterator
-	isSeen isSeen
+	hashValue string
+	*syncMap
 }
 
-func (f *filteringBatchIter) Next() bool {
+func (f *readBatchDeduperSync) Iterator() index.ReadBatchIterator {
+	return f
+}
+
+func (f *readBatchDeduperSync) Next() bool {
 	for f.ReadBatchIterator.Next() {
-		if f.isSeen(f.query.HashValue, f.ReadBatchIterator.RangeValue()) {
+		rangeValue := f.RangeValue()
+		f.rw.RLock()
+		hashes, ok := f.seen[f.hashValue]
+		if ok {
+			h := GetUnsafeString(rangeValue)
+			if _, loaded := hashes[h]; loaded {
+				f.rw.RUnlock()
+				continue
+			}
+			f.rw.RUnlock()
+			f.rw.Lock()
+			if _, loaded := hashes[h]; loaded {
+				f.rw.Unlock()
+				continue
+			}
+			hashes[h] = struct{}{}
+			f.rw.Unlock()
+			return true
+		}
+		f.rw.RUnlock()
+		f.rw.Lock()
+		if _, ok := f.seen[f.hashValue]; ok {
+			f.rw.Unlock()
 			continue
 		}
-
+		f.seen[f.hashValue] = map[string]struct{}{
+			GetUnsafeString(rangeValue): {},
+		}
+		f.rw.Unlock()
 		return true
 	}
 


### PR DESCRIPTION
This PR improves deduping of entries by using different deduper depending if we are running with or without concurrency, but also make sure the concurrency is bounded even for a lot of index queries ( above 100k) maximun 10 goroutine are spawned per query.

Benchmark result:

```
❯ benchstat before.txt after.txt                                                                                                                                  
name                    old time/op    new time/op    delta
_MultiQueries/50-16        102µs ± 3%      45µs ± 2%  -55.39%  (p=0.008 n=5+5)
_MultiQueries/100-16       203µs ± 3%      90µs ± 5%  -55.57%  (p=0.008 n=5+5)
_MultiQueries/1000-16     4.16ms ± 1%    2.44ms ± 1%  -41.35%  (p=0.008 n=5+5)
_MultiQueries/10000-16    43.5ms ± 3%    24.5ms ± 1%  -43.59%  (p=0.008 n=5+5)
_MultiQueries/50000-16     354ms ± 0%     127ms ± 2%  -64.21%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
_MultiQueries/50-16       91.3kB ± 0%    27.8kB ± 0%  -69.52%  (p=0.008 n=5+5)
_MultiQueries/100-16       182kB ± 0%      56kB ± 0%  -69.48%  (p=0.008 n=5+5)
_MultiQueries/1000-16     1.85MB ± 0%    0.76MB ± 0%  -58.87%  (p=0.008 n=5+5)
_MultiQueries/10000-16    18.3MB ± 0%     7.5MB ± 0%  -58.96%  (p=0.008 n=5+5)
_MultiQueries/50000-16    90.6MB ± 0%    37.2MB ± 0%  -58.94%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op  delta
_MultiQueries/50-16        1.12k ± 0%     0.51k ± 0%  -54.74%  (p=0.008 n=5+5)
_MultiQueries/100-16       2.22k ± 0%     1.01k ± 0%  -54.73%  (p=0.008 n=5+5)
_MultiQueries/1000-16      22.1k ± 0%     14.0k ± 0%  -36.47%  (p=0.008 n=5+5)
_MultiQueries/10000-16      221k ± 0%      140k ± 0%  -36.53%  (p=0.016 n=5+4)
_MultiQueries/50000-16     1.10M ± 0%     0.70M ± 0%  -36.51%  (p=0.008 n=5+5)
```