### PR TITLE
ignores reporting cancellations as errors in the usage-reporter module

### DIFF
--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -3,6 +3,7 @@ package usagestats
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"io"
 	"math"
@@ -254,7 +255,10 @@ func (rep *Reporter) running(ctx context.Context) error {
 
 	if rep.cluster == nil {
 		<-ctx.Done()
-		return ctx.Err()
+		if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
 	}
 	// check every minute if we should report.
 	ticker := time.NewTicker(reportCheckInterval)
@@ -281,7 +285,10 @@ func (rep *Reporter) running(ctx context.Context) error {
 			rep.lastReport = next
 			next = next.Add(reportInterval)
 		case <-ctx.Done():
-			return ctx.Err()
+			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+			return nil
 		}
 	}
 }

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -97,7 +97,7 @@ func Test_ReportLoop(t *testing.T) {
 		<-time.After(6*time.Second + (stabilityCheckInterval * time.Duration(stabilityMinimunRequired+1)))
 		cancel()
 	}()
-	require.Equal(t, context.Canceled, r.running(ctx))
+	require.Equal(t, nil, r.running(ctx))
 	require.GreaterOrEqual(t, totalReport, 5)
 	first := clusterIDs[0]
 	for _, uid := range clusterIDs {
@@ -156,5 +156,5 @@ func TestWrongKV(t *testing.T) {
 		<-time.After(1 * time.Second)
 		cancel()
 	}()
-	require.Equal(t, context.Canceled, r.running(ctx))
+	require.Equal(t, nil, r.running(ctx))
 }


### PR DESCRIPTION
After noticing some unexpected module failures, I realized the usage reporter is returning context cancellation as errors. This doesn't work well with the service code which [cancels](https://github.com/grafana/loki/blob/main/vendor/github.com/grafana/dskit/services/basic_service.go#L242-L246) the context itself. I've adjusted the code to ignore cancellations for this reason.