### PR TITLE
Fix(query-frontend): `/label/<name>/values` endpoint to use right mid…

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -232,7 +232,7 @@ func getOperation(path string) string {
 		return QueryRangeOp
 	case strings.HasSuffix(path, "/series"):
 		return SeriesOp
-	case strings.HasSuffix(path, "/labels") || strings.HasSuffix(path, "/label"):
+	case strings.HasSuffix(path, "/labels") || strings.HasSuffix(path, "/label") || strings.HasSuffix(path, "/values"):
 		return LabelNamesOp
 	case strings.HasSuffix(path, "/v1/query"):
 		return InstantQueryOp

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/middleware"
@@ -545,6 +546,77 @@ func TestEntriesLimitWithZeroTripperware(t *testing.T) {
 
 	_, err = tpw(rt).RoundTrip(req)
 	require.NoError(t, err)
+}
+
+func Test_getOperation(t *testing.T) {
+	cases := []struct {
+		name       string
+		path       string
+		expectedOp string
+	}{
+		{
+			name:       "instant_query",
+			path:       "/loki/api/v1/query",
+			expectedOp: InstantQueryOp,
+		},
+		{
+			name:       "range_query_prom",
+			path:       "/prom/query",
+			expectedOp: QueryRangeOp,
+		},
+		{
+			name:       "range_query",
+			path:       "/loki/api/v1/query_range",
+			expectedOp: QueryRangeOp,
+		},
+		{
+			name:       "series_query",
+			path:       "/loki/api/v1/series",
+			expectedOp: SeriesOp,
+		},
+		{
+			name:       "series_query_prom",
+			path:       "/prom/series",
+			expectedOp: SeriesOp,
+		},
+		{
+			name:       "labels_query",
+			path:       "/loki/api/v1/labels",
+			expectedOp: LabelNamesOp,
+		},
+		{
+			name:       "labels_query_prom",
+			path:       "/prom/labels",
+			expectedOp: LabelNamesOp,
+		},
+		{
+			name:       "label_query",
+			path:       "/loki/api/v1/label",
+			expectedOp: LabelNamesOp,
+		},
+		{
+			name:       "labels_query_prom",
+			path:       "/prom/label",
+			expectedOp: LabelNamesOp,
+		},
+		{
+			name:       "label_values_query",
+			path:       "/loki/api/v1/label/__name__/values",
+			expectedOp: LabelNamesOp,
+		},
+		{
+			name:       "label_values_query_prom",
+			path:       "/prom/label/__name__/values",
+			expectedOp: LabelNamesOp,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getOperation(tc.path)
+			assert.Equal(t, tc.expectedOp, got)
+		})
+	}
 }
 
 type fakeLimits struct {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

Previously, only `/label/` and `/labels` endpoint were using correct tripperware middleware
on the query frontend(e.g: stats collector middleware)

This PR fixes it for `/label/<name>/values` endpoint as well.

This is useful to support `metrics.go` stats middleware for `label/{name}/values` endpoint as well.

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Related to #5971 

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
