### PR TITLE
Revert "Docs: fix pic location in `sources/fundamentals/architecture/deployme…"

### DIFF
--- a/docs/sources/fundamentals/architecture/deployment-modes.md
+++ b/docs/sources/fundamentals/architecture/deployment-modes.md
@@ -28,7 +28,7 @@ This is monolithic mode;
 it runs all of Loki’s microservice components inside a single process
 as a single binary or Docker image.
 
-![monolithic mode diagram](./monolithic-mode.png)
+![monolithic mode diagram](../monolithic-mode.png)
 
 Monolithic mode is useful for getting started quickly to experiment with Loki,
 as well as for small read/write volumes of up to approximately 100GB per day.
@@ -54,7 +54,7 @@ Loki provides the simple scalable deployment mode.
 This deployment mode can scale to several TBs of logs per day and more.
 Consider the microservices mode approach for very large Loki installations.
 
-![simple scalable deployment mode diagram](./simple-scalable.png)
+![simple scalable deployment mode diagram](../simple-scalable.png)
 
 In this mode the component microservices of Loki are bundled into two targets:
 `-target=read` and `-target=write`.
@@ -89,7 +89,7 @@ Each process is invoked specifying its `target`:
 * ruler
 * compactor
 
-![microservices mode diagram](./microservices-mode.png)
+![microservices mode diagram](../microservices-mode.png)
 
 Running components as individual microservices allows scaling up
 by increasing the quantity of microservices.


### PR DESCRIPTION
Reverts grafana/loki#6089

i think it's break https://grafana.com/docs/loki/next/fundamentals/architecture/deployment-modes/ pic

and i see the desc at `https://github.com/grafana/loki/tree/main/docs`

> `The files in this directory are used to generate it but consequently the links don't work in Github.`

so reverts that pr