### PR TITLE
Avoid line copy during LogQL line_format

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -131,10 +131,7 @@ func (lf *LineFormatter) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool)
 		lbs.SetErr(errTemplateFormat)
 		return line, true
 	}
-	// todo(cyriltovena): we might want to reuse the input line or a bytes buffer.
-	res := make([]byte, len(lf.buf.Bytes()))
-	copy(res, lf.buf.Bytes())
-	return res, true
+	return lf.buf.Bytes(), true
 }
 
 func (lf *LineFormatter) RequiredLabelNames() []string {

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -3050,6 +3050,65 @@ func Test_PipelineCombined(t *testing.T) {
 	require.Equal(t, string([]byte(`1.5s|POST|200`)), string(line))
 }
 
+func Benchmark_PipelineCombined(b *testing.B) {
+	query := `{job="cortex-ops/query-frontend"} |= "logging.go" | logfmt | line_format "{{.msg}}" | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)" | (duration > 1s or status==200) and method="POST" | line_format "{{.duration}}|{{.method}}|{{.status}}"`
+
+	expr, err := ParseLogSelector(query, true)
+	require.Nil(b, err)
+
+	p, err := expr.Pipeline()
+	require.Nil(b, err)
+	sp := p.ForStream(labels.Labels{})
+	var (
+		line    []byte
+		lbs     log.LabelsResult
+		matches bool
+	)
+	in := []byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		line, lbs, matches = sp.Process(0, in)
+	}
+	require.True(b, matches)
+	require.Equal(
+		b,
+		labels.Labels{labels.Label{Name: "caller", Value: "logging.go:66"}, labels.Label{Name: "duration", Value: "1.5s"}, labels.Label{Name: "level", Value: "debug"}, labels.Label{Name: "method", Value: "POST"}, labels.Label{Name: "msg", Value: "POST /api/prom/api/v1/query_range (200) 1.5s"}, labels.Label{Name: "path", Value: "/api/prom/api/v1/query_range"}, labels.Label{Name: "status", Value: "200"}, labels.Label{Name: "traceID", Value: "a9d4d8a928d8db1"}, labels.Label{Name: "ts", Value: "2020-10-02T10:10:42.092268913Z"}},
+		lbs.Labels(),
+	)
+	require.Equal(b, string([]byte(`1.5s|POST|200`)), string(line))
+}
+
+func Benchmark_MetricPipelineCombined(b *testing.B) {
+	query := `count_over_time({job="cortex-ops/query-frontend"} |= "logging.go" | logfmt | line_format "{{.msg}}" | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)" | (duration > 1s or status==200) and method="POST" | line_format "{{.duration}}|{{.method}}|{{.status}}"[1m])`
+
+	expr, err := ParseSampleExpr(query)
+	require.Nil(b, err)
+
+	p, err := expr.Extractor()
+	require.Nil(b, err)
+	sp := p.ForStream(labels.Labels{})
+	var (
+		v       float64
+		lbs     log.LabelsResult
+		matches bool
+	)
+	in := []byte(`level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v, lbs, matches = sp.Process(0, in)
+	}
+	require.True(b, matches)
+	require.Equal(
+		b,
+		labels.Labels{labels.Label{Name: "caller", Value: "logging.go:66"}, labels.Label{Name: "duration", Value: "1.5s"}, labels.Label{Name: "level", Value: "debug"}, labels.Label{Name: "method", Value: "POST"}, labels.Label{Name: "msg", Value: "POST /api/prom/api/v1/query_range (200) 1.5s"}, labels.Label{Name: "path", Value: "/api/prom/api/v1/query_range"}, labels.Label{Name: "status", Value: "200"}, labels.Label{Name: "traceID", Value: "a9d4d8a928d8db1"}, labels.Label{Name: "ts", Value: "2020-10-02T10:10:42.092268913Z"}},
+		lbs.Labels(),
+	)
+	require.Equal(b, 1.0, v)
+}
+
 var c []*labels.Matcher
 
 func Benchmark_ParseMatchers(b *testing.B) {


### PR DESCRIPTION
This mostly remove an allocation for each `line_format` specially useful when the result is not used and copied.

This was a todo that was left for a long time.

```
❯ benchstat beforemetric.txt aftermetric.txt
name                        old time/op    new time/op    delta
_MetricPipelineCombined-16    4.94µs ± 1%    4.86µs ± 1%  -1.50%  (p=0.008 n=5+5)

name                        old alloc/op   new alloc/op   delta
_MetricPipelineCombined-16    2.49kB ± 0%    2.42kB ± 0%  -2.63%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
_MetricPipelineCombined-16      33.0 ± 0%      31.0 ± 0%  -6.06%  (p=0.008 n=5+5)

❯ benchstat beforelog.txt afterlog.txt      
name                  old time/op    new time/op    delta
_PipelineCombined-16    4.94µs ± 2%    4.87µs ± 1%  -1.32%  (p=0.040 n=5+5)

name                  old alloc/op   new alloc/op   delta
_PipelineCombined-16    2.49kB ± 0%    2.42kB ± 0%  -2.63%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
_PipelineCombined-16      33.0 ± 0%      31.0 ± 0%  -6.06%  (p=0.008 n=5+5)
```