### PR TITLE
Promtail: Add metrics for journal target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [6105](https://github.com/grafana/loki/pull/6105) **rutgerke** Export metrics for the promtail journal target
 * [6099](https://github.com/grafana/loki/pull/6099/files) **cstyan**: Drop lines with malformed JSON in Promtail JSON pipeline stage
 * [6136](https://github.com/grafana/loki/pull/6136) **periklis**: Add support for alertmanager header authorization
 * [6102](https://github.com/grafana/loki/pull/6102) **timchenko-a**: Add multi-tenancy support to lambda-promtail

--- a/clients/cmd/promtail/promtail-journal.yaml
+++ b/clients/cmd/promtail/promtail-journal.yaml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: journal
+    journal:
+      max_age: 12h
+      labels:
+        job: systemd-journal
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'

--- a/clients/cmd/promtail/promtail-journal.yaml
+++ b/clients/cmd/promtail/promtail-journal.yaml
@@ -6,7 +6,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: http://loki:3100/loki/api/v1/push
+  - url: http://localhost:3100/loki/api/v1/push
 
 scrape_configs:
   - job_name: journal

--- a/clients/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ func TestJournalTarget(t *testing.T) {
 	err = yaml.Unmarshal([]byte(relabelCfg), &relabels)
 	require.NoError(t, err)
 
-	jt, err := journalTargetWithReader(logger, client, ps, "test", relabels,
+	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", relabels,
 		&scrapeconfig.JournalTargetConfig{}, newMockJournalReader, newMockJournalEntry(nil))
 	require.NoError(t, err)
 
@@ -147,7 +148,7 @@ func TestJournalTarget_JSON(t *testing.T) {
 
 	cfg := &scrapeconfig.JournalTargetConfig{JSON: true}
 
-	jt, err := journalTargetWithReader(logger, client, ps, "test", relabels,
+	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", relabels,
 		cfg, newMockJournalReader, newMockJournalEntry(nil))
 	require.NoError(t, err)
 
@@ -197,7 +198,7 @@ func TestJournalTarget_Since(t *testing.T) {
 		MaxAge: "4h",
 	}
 
-	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", nil,
 		&cfg, newMockJournalReader, newMockJournalEntry(nil))
 	require.NoError(t, err)
 
@@ -237,7 +238,7 @@ func TestJournalTarget_Cursor_TooOld(t *testing.T) {
 		RealtimeTimestamp: uint64(entryTs.UnixNano()),
 	})
 
-	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", nil,
 		&cfg, newMockJournalReader, journalEntry)
 	require.NoError(t, err)
 
@@ -277,7 +278,7 @@ func TestJournalTarget_Cursor_NotTooOld(t *testing.T) {
 		RealtimeTimestamp: uint64(entryTs.UnixNano() / int64(time.Microsecond)),
 	})
 
-	jt, err := journalTargetWithReader(logger, client, ps, "test", nil,
+	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", nil,
 		&cfg, newMockJournalReader, journalEntry)
 	require.NoError(t, err)
 

--- a/clients/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget_test.go
@@ -6,12 +6,14 @@ package journal
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,12 +49,11 @@ func newMockJournalEntry(entry *sdjournal.JournalEntry) journalEntryFunc {
 	}
 }
 
-func (r *mockJournalReader) Write(msg string, fields map[string]string) {
+func (r *mockJournalReader) Write(fields map[string]string) {
 	allFields := make(map[string]string, len(fields))
 	for k, v := range fields {
 		allFields[k] = v
 	}
-	allFields["MESSAGE"] = msg
 
 	ts := uint64(time.Now().UnixNano())
 
@@ -96,7 +97,8 @@ func TestJournalTarget(t *testing.T) {
 	err = yaml.Unmarshal([]byte(relabelCfg), &relabels)
 	require.NoError(t, err)
 
-	jt, err := journalTargetWithReader(NewMetrics(prometheus.NewRegistry()), logger, client, ps, "test", relabels,
+	registry := prometheus.NewRegistry()
+	jt, err := journalTargetWithReader(NewMetrics(registry), logger, client, ps, "test", relabels,
 		&scrapeconfig.JournalTargetConfig{}, newMockJournalReader, newMockJournalEntry(nil))
 	require.NoError(t, err)
 
@@ -104,14 +106,93 @@ func TestJournalTarget(t *testing.T) {
 	r.t = t
 
 	for i := 0; i < 10; i++ {
-		r.Write("ping", map[string]string{
+		r.Write(map[string]string{
+			"MESSAGE":   "ping",
 			"CODE_FILE": "journaltarget_test.go",
 		})
 		assert.NoError(t, err)
 	}
 	require.NoError(t, jt.Stop())
 	client.Stop()
+
+	expectedMetrics := `# HELP promtail_journal_target_lines_total Total number of successful journal lines read
+	# TYPE promtail_journal_target_lines_total counter
+	promtail_journal_target_lines_total 10
+	`
+
+	if err := testutil.GatherAndCompare(registry,
+		strings.NewReader(expectedMetrics)); err != nil {
+		t.Fatalf("mismatch metrics: %v", err)
+	}
 	assert.Len(t, client.Received(), 10)
+}
+
+func TestJournalTargetParsingErrors(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	testutils.InitRandom()
+	dirName := "/tmp/" + testutils.RandName()
+	positionsFileName := dirName + "/positions.yml"
+
+	// Set the sync period to a really long value, to guarantee the sync timer
+	// never runs, this way we know everything saved was done through channel
+	// notifications when target.stop() was called.
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Second,
+		PositionsFile: positionsFileName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := fake.New(func() {})
+
+	// We specify no relabel rules, so that we end up with an empty labelset
+	var relabels []*relabel.Config
+
+	registry := prometheus.NewRegistry()
+	jt, err := journalTargetWithReader(NewMetrics(registry), logger, client, ps, "test", relabels,
+		&scrapeconfig.JournalTargetConfig{}, newMockJournalReader, newMockJournalEntry(nil))
+	require.NoError(t, err)
+
+	r := jt.r.(*mockJournalReader)
+	r.t = t
+
+	// No labels but correct message
+	for i := 0; i < 10; i++ {
+		r.Write(map[string]string{
+			"MESSAGE":   "ping",
+			"CODE_FILE": "journaltarget_test.go",
+		})
+		assert.NoError(t, err)
+	}
+
+	// No labels and no message
+	for i := 0; i < 10; i++ {
+		r.Write(map[string]string{
+			"CODE_FILE": "journaltarget_test.go",
+		})
+		assert.NoError(t, err)
+	}
+	require.NoError(t, jt.Stop())
+	client.Stop()
+
+	expectedMetrics := `# HELP promtail_journal_target_lines_total Total number of successful journal lines read
+	# TYPE promtail_journal_target_lines_total counter
+	promtail_journal_target_lines_total 0
+	# HELP promtail_journal_target_parsing_errors_total Total number of parsing errors while reading journal messages
+	# TYPE promtail_journal_target_parsing_errors_total counter
+	promtail_journal_target_parsing_errors_total{error="empty_labels"} 10
+	promtail_journal_target_parsing_errors_total{error="no_message"} 10
+	`
+
+	if err := testutil.GatherAndCompare(registry,
+		strings.NewReader(expectedMetrics)); err != nil {
+		t.Fatalf("mismatch metrics: %v", err)
+	}
+
+	assert.Len(t, client.Received(), 0)
 }
 
 func TestJournalTarget_JSON(t *testing.T) {
@@ -156,7 +237,8 @@ func TestJournalTarget_JSON(t *testing.T) {
 	r.t = t
 
 	for i := 0; i < 10; i++ {
-		r.Write("ping", map[string]string{
+		r.Write(map[string]string{
+			"MESSAGE":     "ping",
 			"CODE_FILE":   "journaltarget_test.go",
 			"OTHER_FIELD": "foobar",
 		})

--- a/clients/pkg/promtail/targets/journal/journaltargetmanager.go
+++ b/clients/pkg/promtail/targets/journal/journaltargetmanager.go
@@ -6,7 +6,6 @@ package journal
 import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/positions"
@@ -21,7 +20,7 @@ type JournalTargetManager struct{}
 // NewJournalTargetManager returns nil as JournalTargets are not supported
 // on this platform.
 func NewJournalTargetManager(
-	reg prometheus.Registerer,
+	metrics *Metrics,
 	logger log.Logger,
 	positions positions.Positions,
 	client api.EntryHandler,

--- a/clients/pkg/promtail/targets/journal/metrics.go
+++ b/clients/pkg/promtail/targets/journal/metrics.go
@@ -1,0 +1,38 @@
+package journal
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics holds a set of journal target metrics.
+type Metrics struct {
+	reg prometheus.Registerer
+
+	journalErrors *prometheus.CounterVec
+	journalLines  prometheus.Counter
+}
+
+// NewMetrics creates a new set of journal target metrics. If reg is non-nil, the
+// metrics will be registered.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	var m Metrics
+	m.reg = reg
+
+	m.journalErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "journal_target_parsing_errors_total",
+		Help:      "Total number of parsing errors while reading journal messages",
+	}, []string{"path"})
+	m.journalLines = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "promtail",
+		Name:      "journal_target_lines_total",
+		Help:      "Total number of successful journal lines read",
+	})
+
+	if reg != nil {
+		reg.MustRegister(
+			m.journalErrors,
+			m.journalLines,
+		)
+	}
+
+	return &m
+}

--- a/clients/pkg/promtail/targets/journal/metrics.go
+++ b/clients/pkg/promtail/targets/journal/metrics.go
@@ -10,6 +10,11 @@ type Metrics struct {
 	journalLines  prometheus.Counter
 }
 
+const (
+	noMessageError   = "no_message"
+	emptyLabelsError = "empty_labels"
+)
+
 // NewMetrics creates a new set of journal target metrics. If reg is non-nil, the
 // metrics will be registered.
 func NewMetrics(reg prometheus.Registerer) *Metrics {
@@ -20,7 +25,7 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		Namespace: "promtail",
 		Name:      "journal_target_parsing_errors_total",
 		Help:      "Total number of parsing errors while reading journal messages",
-	}, []string{"path"})
+	}, []string{"error"})
 	m.journalLines = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "journal_target_lines_total",

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -122,6 +122,7 @@ func NewTargetManagers(
 		gelfMetrics       *gelf.Metrics
 		cloudflareMetrics *cloudflare.Metrics
 		dockerMetrics     *docker.Metrics
+		journalMetrics    *journal.Metrics
 	)
 	if len(targetScrapeConfigs[FileScrapeConfigs]) > 0 {
 		fileMetrics = file.NewMetrics(reg)
@@ -140,6 +141,9 @@ func NewTargetManagers(
 	}
 	if len(targetScrapeConfigs[DockerConfigs]) > 0 || len(targetScrapeConfigs[DockerSDConfigs]) > 0 {
 		dockerMetrics = docker.NewMetrics(reg)
+	}
+	if len(targetScrapeConfigs[JournalScrapeConfigs]) > 0 {
+		journalMetrics = journal.NewMetrics(reg)
 	}
 
 	for target, scrapeConfigs := range targetScrapeConfigs {
@@ -167,7 +171,7 @@ func NewTargetManagers(
 				return nil, err
 			}
 			journalTargetManager, err := journal.NewJournalTargetManager(
-				reg,
+				journalMetrics,
 				logger,
 				pos,
 				client,


### PR DESCRIPTION
**What this PR does / why we need it**:

There are no metrics for the journal target yet, this adds two basic ones:
- Total number of lines processed
- Total number of errors processing lines (with a reason in a label)

Because of the way the journal works, tailing one file with many possible processes writing to it, I chose note to expose counts per unit.

**Which issue(s) this PR fixes**:
Fixes #5554

**Special notes for your reviewer**:
Doing this PR mostly to learn, not because I really need this feature. So all feedback/opinions are welcome!
I looked at the other targets and did not see any tests for the metrics produced/no pattern to copy here, but I'd be happy to figure out how to add them if requested. 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
