### PR TITLE
do not increment sync operation count metric on per index set

### DIFF
--- a/pkg/storage/stores/shipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/downloads/index_set_test.go
@@ -22,8 +22,7 @@ func buildTestIndexSet(t *testing.T, userID, path string) (*indexSet, stopFunc) 
 	cachePath := filepath.Join(path, cacheDirName)
 
 	baseIndexSet := storage.NewIndexSet(storageClient, userID != "")
-	idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet,
-		boltDBIndexClient, util_log.Logger, newMetrics(nil))
+	idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet, boltDBIndexClient, util_log.Logger)
 	require.NoError(t, err)
 
 	require.NoError(t, idxSet.Init(false))

--- a/pkg/storage/stores/shipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/downloads/table.go
@@ -108,8 +108,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 		}
 
 		userID := fileInfo.Name()
-		userIndexSet, err := NewIndexSet(name, userID, filepath.Join(cacheLocation, userID),
-			table.baseUserIndexSet, boltDBIndexClient, loggerWithUserID(table.logger, userID), metrics)
+		userIndexSet, err := NewIndexSet(name, userID, filepath.Join(cacheLocation, userID), table.baseUserIndexSet, boltDBIndexClient, loggerWithUserID(table.logger, userID))
 		if err != nil {
 			return nil, err
 		}
@@ -122,8 +121,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, boltDBI
 		table.indexSets[userID] = userIndexSet
 	}
 
-	commonIndexSet, err := NewIndexSet(name, "", cacheLocation, table.baseCommonIndexSet,
-		boltDBIndexClient, table.logger, metrics)
+	commonIndexSet, err := NewIndexSet(name, "", cacheLocation, table.baseCommonIndexSet, boltDBIndexClient, table.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -298,8 +296,7 @@ func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying 
 	}
 
 	// instantiate the index set, add it to the map
-	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.boltDBIndexClient,
-		loggerWithUserID(t.logger, id), t.metrics)
+	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.boltDBIndexClient, loggerWithUserID(t.logger, id))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Do not increment index sync operation count metric from index set since we already track it on the overall sync operation in table manager [here](https://github.com/grafana/loki/blob/2758dc659acbf5682a9655422b43396a1fed5a83/pkg/storage/stores/shipper/downloads/table_manager.go#L206).

This would also fix unexpected increases in failure counts due to stale index list cache which we handle already by checking if the error is `errIndexListCacheTooStale` and retry the sync.
