### PR TITLE
Improve labels computation during LogQL pipeline

### DIFF
--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -127,7 +127,7 @@ func (lf *LineFormatter) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool)
 	lf.buf.Reset()
 	lf.currentLine = line
 
-	if err := lf.Template.Execute(lf.buf, lbs.Labels().Map()); err != nil {
+	if err := lf.Template.Execute(lf.buf, lbs.Map()); err != nil {
 		lbs.SetErr(errTemplateFormat)
 		return line, true
 	}
@@ -286,7 +286,7 @@ func (lf *LabelsFormatter) Process(l []byte, lbs *LabelsBuilder) ([]byte, bool) 
 		}
 		lf.buf.Reset()
 		if data == nil {
-			data = lbs.Labels().Map()
+			data = lbs.Map()
 		}
 		if err := f.tmpl.Execute(lf.buf, data); err != nil {
 			lbs.SetErr(errTemplateFormat)

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -274,7 +274,7 @@ func Test_lineFormatter_Format(t *testing.T) {
 			builder.Reset()
 			outLine, _ := tt.fmter.Process(tt.in, builder)
 			require.Equal(t, tt.want, outLine)
-			require.Equal(t, tt.wantLbs, builder.Labels())
+			require.Equal(t, tt.wantLbs, builder.LabelsResult().Labels())
 		})
 	}
 }
@@ -333,7 +333,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			builder.Reset()
 			_, _ = tt.fmter.Process(nil, builder)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, builder.Labels())
+			require.Equal(t, tt.want, builder.LabelsResult().Labels())
 		})
 	}
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestBinary_Filter(t *testing.T) {
-
 	tests := []struct {
 		f   LabelFilterer
 		lbs labels.Labels
@@ -158,7 +157,7 @@ func TestBinary_Filter(t *testing.T) {
 			_, got := tt.f.Process(nil, b)
 			require.Equal(t, tt.want, got)
 			sort.Sort(tt.wantLbs)
-			require.Equal(t, tt.wantLbs, b.Labels())
+			require.Equal(t, tt.wantLbs, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -192,7 +191,7 @@ func TestBytes_Filter(t *testing.T) {
 			_, got := f.Process(nil, b)
 			require.Equal(t, tt.want, got)
 			wantLbs := labels.Labels{{Name: "bar", Value: tt.wantLabel}}
-			require.Equal(t, wantLbs, b.Labels())
+			require.Equal(t, wantLbs, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -221,7 +220,6 @@ func TestErrorFiltering(t *testing.T) {
 			},
 		},
 		{
-
 			NewStringLabelFilter(labels.MustNewMatcher(labels.MatchNotRegexp, logqlmodel.ErrorLabel, ".+")),
 			labels.Labels{
 				{Name: "status", Value: "200"},
@@ -236,7 +234,6 @@ func TestErrorFiltering(t *testing.T) {
 			},
 		},
 		{
-
 			NewStringLabelFilter(labels.MustNewMatcher(labels.MatchNotRegexp, logqlmodel.ErrorLabel, ".+")),
 			labels.Labels{
 				{Name: "status", Value: "200"},
@@ -250,7 +247,6 @@ func TestErrorFiltering(t *testing.T) {
 			},
 		},
 		{
-
 			NewStringLabelFilter(labels.MustNewMatcher(labels.MatchNotEqual, logqlmodel.ErrorLabel, errJSON)),
 			labels.Labels{
 				{Name: "status", Value: "200"},
@@ -273,7 +269,7 @@ func TestErrorFiltering(t *testing.T) {
 			_, got := tt.f.Process(nil, b)
 			require.Equal(t, tt.want, got)
 			sort.Sort(tt.wantLbs)
-			require.Equal(t, tt.wantLbs, b.Labels())
+			require.Equal(t, tt.wantLbs, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -286,14 +282,16 @@ func TestReduceAndLabelFilter(t *testing.T) {
 	}{
 		{"empty", nil, NoopLabelFilter},
 		{"1", []LabelFilterer{NewBytesLabelFilter(LabelFilterEqual, "foo", 5)}, NewBytesLabelFilter(LabelFilterEqual, "foo", 5)},
-		{"2",
+		{
+			"2",
 			[]LabelFilterer{
 				NewBytesLabelFilter(LabelFilterEqual, "foo", 5),
 				NewBytesLabelFilter(LabelFilterGreaterThanOrEqual, "bar", 6),
 			},
 			NewAndLabelFilter(NewBytesLabelFilter(LabelFilterEqual, "foo", 5), NewBytesLabelFilter(LabelFilterGreaterThanOrEqual, "bar", 6)),
 		},
-		{"3",
+		{
+			"3",
 			[]LabelFilterer{
 				NewBytesLabelFilter(LabelFilterEqual, "foo", 5),
 				NewBytesLabelFilter(LabelFilterGreaterThanOrEqual, "bar", 6),

--- a/pkg/logql/log/labels_test.go
+++ b/pkg/logql/log/labels_test.go
@@ -38,7 +38,7 @@ func TestLabelsBuilder_LabelsError(t *testing.T) {
 	b := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
 	b.Reset()
 	b.SetErr("err")
-	lbsWithErr := b.Labels()
+	lbsWithErr := b.LabelsResult().Labels()
 	require.Equal(
 		t,
 		labels.Labels{
@@ -143,7 +143,6 @@ func TestLabelsBuilder_GroupedLabelsResult(t *testing.T) {
 	}
 	sort.Sort(expected)
 	assertLabelResult(t, expected, b.GroupedLabels())
-
 }
 
 func assertLabelResult(t *testing.T, lbs labels.Labels, res LabelsResult) {

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -105,7 +105,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 			b.Reset()
 			_, _ = j.Process(tt.line, b)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -355,7 +355,7 @@ func TestJSONExpressionParser(t *testing.T) {
 			b.Reset()
 			_, _ = j.Process(tt.line, b)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -550,7 +550,7 @@ func Test_regexpParser_Parse(t *testing.T) {
 			b.Reset()
 			_, _ = tt.parser.Process(tt.line, b)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -715,7 +715,7 @@ func Test_logfmtParser_Parse(t *testing.T) {
 			b.Reset()
 			_, _ = p.Process(tt.line, b)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
 		})
 	}
 }
@@ -809,7 +809,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 			copy := string(tt.line)
 			l, _ := j.Process(tt.line, b)
 			sort.Sort(tt.wantLbs)
-			require.Equal(t, tt.wantLbs, b.Labels())
+			require.Equal(t, tt.wantLbs, b.LabelsResult().Labels())
 			require.Equal(t, tt.wantLine, l)
 			require.Equal(t, string(tt.wantLine), string(l))
 			require.Equal(t, copy, string(tt.line), "the original log line should not be mutated")
@@ -877,7 +877,7 @@ func Test_PatternParser(t *testing.T) {
 			require.NoError(t, err)
 			_, _ = pp.Process(tt.line, b)
 			sort.Sort(tt.want)
-			require.Equal(t, tt.want, b.Labels())
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
 		})
 	}
 }


### PR DESCRIPTION
This does two things:

- Introduce a buffer for computing labels and the buffer is only copied if we never seen that label set before.
- Add a Map function to the label builders used for `label_format` and `line_format` that avoids slice allocations and sorting.

```
❯ benchstat before.txt after.txt
name                                 old time/op    new time/op    delta
_Pipeline/pipeline_bytes-16            10.6µs ± 0%     6.9µs ± 1%  -34.85%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16           10.6µs ± 0%     6.9µs ± 0%  -35.16%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16      10.6µs ± 0%     6.9µs ± 1%  -34.98%  (p=0.008 n=5+5)
_Pipeline/line_extractor_string-16     10.7µs ± 1%     6.9µs ± 0%  -35.27%  (p=0.016 n=5+4)
_Pipeline/label_extractor_bytes-16     10.7µs ± 1%     7.1µs ± 4%  -33.97%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16    10.8µs ± 1%     7.0µs ± 0%  -34.90%  (p=0.016 n=5+4)

name                                 old alloc/op   new alloc/op   delta
_Pipeline/pipeline_bytes-16            9.46kB ± 0%    3.26kB ± 0%  -65.58%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16           9.46kB ± 0%    3.26kB ± 0%  -65.57%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16      9.46kB ± 0%    3.26kB ± 0%  -65.58%  (p=0.008 n=5+5)
_Pipeline/line_extractor_string-16     9.46kB ± 0%    3.26kB ± 0%  -65.58%  (p=0.008 n=5+5)
_Pipeline/label_extractor_bytes-16     9.46kB ± 0%    3.26kB ± 0%  -65.58%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16    9.46kB ± 0%    3.26kB ± 0%  -65.58%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
_Pipeline/pipeline_bytes-16              44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
_Pipeline/pipeline_string-16             44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
_Pipeline/line_extractor_bytes-16        44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
_Pipeline/line_extractor_string-16       44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
_Pipeline/label_extractor_bytes-16       44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
_Pipeline/label_extractor_string-16      44.0 ± 0%      33.0 ± 0%  -25.00%  (p=0.008 n=5+5)
```