### PR TITLE
Improve JSON parser allocations

### DIFF
--- a/pkg/logql/log/json.go
+++ b/pkg/logql/log/json.go
@@ -1,0 +1,165 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/buger/jsonparser"
+	jsoniter "github.com/json-iterator/go"
+)
+
+const (
+	jsonSpacer      = '_'
+	duplicateSuffix = "_extracted"
+	trueString      = "true"
+	falseString     = "false"
+)
+
+var (
+	_                       Stage = &JSONParser{}
+	errUnexpectedJSONObject       = fmt.Errorf("expecting json object(%d), but it is not", jsoniter.ObjectValue)
+)
+
+type JSONParser struct {
+	buf    []byte // buffer used to build json keys
+	prefix []byte
+	lbs    *LabelsBuilder
+
+	keys internedStringSet
+}
+
+// NewJSONParser creates a log stage that can parse a json log line and add properties as labels.
+func NewJSONParser() *JSONParser {
+	return &JSONParser{
+		buf:    make([]byte, 0, 1024),
+		prefix: make([]byte, 0, 1024),
+		keys:   internedStringSet{},
+	}
+}
+
+func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
+	if lbs.ParserLabelHints().NoLabels() {
+		return line, true
+	}
+
+	j.lbs = lbs
+	j.prefix = j.prefix[:0]
+	j.buf = j.buf[:0]
+	if err := jsonparser.ObjectEach(line, j.objectCallback); err != nil {
+		lbs.SetErr(errJSON)
+		return line, true
+	}
+	return line, true
+}
+
+func (j *JSONParser) objectCallback(key, value []byte, dataType jsonparser.ValueType, offset int) error {
+	switch dataType {
+	case jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Null:
+		j.handleValue(key, value, dataType)
+		return nil
+	case jsonparser.Object:
+		var ok bool
+		old := j.prefix
+		j.prefix, ok = j.appendPrefix(j.prefix, key)
+		if !ok {
+			j.prefix = old
+			return nil
+		}
+		err := jsonparser.ObjectEach(value, j.objectCallback)
+		j.prefix = old
+		return err
+	}
+	return nil
+}
+
+func (j *JSONParser) handleValue(field []byte, value []byte, dataType jsonparser.ValueType) {
+	// the first time we use the field as label key.
+	if len(j.prefix) == 0 {
+		key, ok := j.keys.Get(field, func() (string, bool) {
+			j.buf = sanitizeLabelTo(field, j.buf, true)
+			if j.lbs.BaseHas(unsafeGetString(j.buf)) {
+				j.buf = append(j.buf, duplicateSuffix...)
+			}
+			if !j.lbs.ParserLabelHints().ShouldExtract(unsafeGetString(j.buf)) {
+				return "", false
+			}
+
+			return string(j.buf), true
+		})
+		if !ok {
+			return
+		}
+		j.lbs.Set(key, j.valueString(value, dataType))
+		return
+
+	}
+	// otherwise we build the label key using the buffer
+	old := j.prefix
+	defer func() { j.prefix = old }()
+	j.prefix = append(j.prefix, byte(jsonSpacer))
+	j.buf = sanitizeLabelTo(field, j.buf, false)
+	j.prefix = append(j.prefix, j.buf...)
+	key, ok := j.keys.Get(j.prefix, func() (string, bool) {
+		if j.lbs.BaseHas(unsafeGetString(j.prefix)) {
+			j.prefix = append(j.prefix, duplicateSuffix...)
+		}
+		if !j.lbs.ParserLabelHints().ShouldExtract(unsafeGetString(j.prefix)) {
+			return "", false
+		}
+		return string(j.prefix), true
+	})
+	if !ok {
+		return
+	}
+	j.lbs.Set(key, j.valueString(value, dataType))
+}
+
+func (j *JSONParser) valueString(value []byte, dataType jsonparser.ValueType) string {
+	switch dataType {
+	case jsonparser.String:
+		if bytes.ContainsRune(value, utf8.RuneError) {
+			return ""
+		}
+		// todo if j.buf has grown it won't be reused.
+		// unlikely to happen.
+		v, err := jsonparser.Unescape(value, j.buf)
+		if err != nil {
+			return ""
+		}
+		return string(j.buf)
+	case jsonparser.Number:
+		return string(value)
+	case jsonparser.Boolean:
+		if value[0] == 't' || value[0] == 'T' {
+			return trueString
+		}
+		return falseString
+	case jsonparser.Null:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func (j *JSONParser) appendPrefix(prefix, field []byte) ([]byte, bool) {
+	// first time we add return the field as prefix.
+	if len(prefix) == 0 {
+		prefix = sanitizeLabelTo(field, j.prefix, true)
+		if j.lbs.ParserLabelHints().ShouldExtractPrefix(unsafeGetString(prefix)) {
+			return prefix, true
+		}
+		return nil, false
+	}
+	// otherwise we build the prefix and check using the buffer
+	prefix = append(prefix, byte(jsonSpacer))
+	j.buf = sanitizeLabelTo(field, j.buf, false)
+	prefix = append(prefix, j.buf...)
+	// if matches keep going
+	if j.lbs.ParserLabelHints().ShouldExtractPrefix(unsafeGetString(prefix)) {
+		return prefix, true
+	}
+	return nil, false
+}
+
+func (j *JSONParser) RequiredLabelNames() []string { return []string{} }

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/grafana/loki/pkg/logql/log/jsonexpr"
@@ -18,173 +17,12 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const (
-	jsonSpacer      = '_'
-	duplicateSuffix = "_extracted"
-	trueString      = "true"
-	falseString     = "false"
-)
-
 var (
-	_ Stage = &JSONParser{}
 	_ Stage = &RegexpParser{}
 	_ Stage = &LogfmtParser{}
 
-	errUnexpectedJSONObject = fmt.Errorf("expecting json object(%d), but it is not", jsoniter.ObjectValue)
-	errMissingCapture       = errors.New("at least one named capture must be supplied")
+	errMissingCapture = errors.New("at least one named capture must be supplied")
 )
-
-type JSONParser struct {
-	buf []byte // buffer used to build json keys
-	lbs *LabelsBuilder
-
-	keys internedStringSet
-}
-
-// NewJSONParser creates a log stage that can parse a json log line and add properties as labels.
-func NewJSONParser() *JSONParser {
-	return &JSONParser{
-		buf:  make([]byte, 0, 1024),
-		keys: internedStringSet{},
-	}
-}
-
-func (j *JSONParser) Process(line []byte, lbs *LabelsBuilder) ([]byte, bool) {
-	if lbs.ParserLabelHints().NoLabels() {
-		return line, true
-	}
-	it := jsoniter.ConfigFastest.BorrowIterator(line)
-	defer jsoniter.ConfigFastest.ReturnIterator(it)
-
-	// reset the state.
-	j.buf = j.buf[:0]
-	j.lbs = lbs
-
-	if err := j.readObject(it); err != nil {
-		lbs.SetErr(errJSON)
-		return line, true
-	}
-	return line, true
-}
-
-func (j *JSONParser) readObject(it *jsoniter.Iterator) error {
-	// we only care about object and values.
-	if nextType := it.WhatIsNext(); nextType != jsoniter.ObjectValue {
-		return errUnexpectedJSONObject
-	}
-	_ = it.ReadMapCB(j.parseMap(""))
-	if it.Error != nil && it.Error != io.EOF {
-		return it.Error
-	}
-	return nil
-}
-
-func (j *JSONParser) parseMap(prefix string) func(iter *jsoniter.Iterator, field string) bool {
-	return func(iter *jsoniter.Iterator, field string) bool {
-		switch iter.WhatIsNext() {
-		// are we looking at a value that needs to be added ?
-		case jsoniter.StringValue, jsoniter.NumberValue, jsoniter.BoolValue:
-			j.parseLabelValue(iter, prefix, field)
-		// Or another new object based on a prefix.
-		case jsoniter.ObjectValue:
-			if key, ok := j.nextKeyPrefix(prefix, field); ok {
-				return iter.ReadMapCB(j.parseMap(key))
-			}
-			// If this keys is not expected we skip the object
-			iter.Skip()
-		default:
-			iter.Skip()
-		}
-		return true
-	}
-}
-
-func (j *JSONParser) nextKeyPrefix(prefix, field string) (string, bool) {
-	// first time we add return the field as prefix.
-	if len(prefix) == 0 {
-		field = sanitizeLabelKey(field, true)
-		if j.lbs.ParserLabelHints().ShouldExtractPrefix(field) {
-			return field, true
-		}
-		return "", false
-	}
-	// otherwise we build the prefix and check using the buffer
-	j.buf = j.buf[:0]
-	j.buf = append(j.buf, prefix...)
-	j.buf = append(j.buf, byte(jsonSpacer))
-	j.buf = append(j.buf, sanitizeLabelKey(field, false)...)
-	// if matches keep going
-	if j.lbs.ParserLabelHints().ShouldExtractPrefix(unsafeGetString(j.buf)) {
-		return string(j.buf), true
-	}
-	return "", false
-}
-
-func (j *JSONParser) parseLabelValue(iter *jsoniter.Iterator, prefix, field string) {
-	// the first time we use the field as label key.
-	if len(prefix) == 0 {
-		key, ok := j.keys.Get(unsafeGetBytes(field), func() (string, bool) {
-			field = sanitizeLabelKey(field, true)
-			if !j.lbs.ParserLabelHints().ShouldExtract(field) {
-				return "", false
-			}
-			if j.lbs.BaseHas(field) {
-				field = field + duplicateSuffix
-			}
-			return field, true
-		})
-		if !ok {
-			iter.Skip()
-			return
-		}
-		j.lbs.Set(key, readValue(iter))
-		return
-
-	}
-	// otherwise we build the label key using the buffer
-	j.buf = j.buf[:0]
-	j.buf = append(j.buf, prefix...)
-	j.buf = append(j.buf, byte(jsonSpacer))
-	j.buf = append(j.buf, sanitizeLabelKey(field, false)...)
-	key, ok := j.keys.Get(j.buf, func() (string, bool) {
-		if j.lbs.BaseHas(string(j.buf)) {
-			j.buf = append(j.buf, duplicateSuffix...)
-		}
-		if !j.lbs.ParserLabelHints().ShouldExtract(string(j.buf)) {
-			return "", false
-		}
-		return string(j.buf), true
-	})
-	if !ok {
-		iter.Skip()
-		return
-	}
-	j.lbs.Set(key, readValue(iter))
-}
-
-func (j *JSONParser) RequiredLabelNames() []string { return []string{} }
-
-func readValue(iter *jsoniter.Iterator) string {
-	switch iter.WhatIsNext() {
-	case jsoniter.StringValue:
-		v := iter.ReadString()
-		// the rune error replacement is rejected by Prometheus, so we skip it.
-		if strings.ContainsRune(v, utf8.RuneError) {
-			return ""
-		}
-		return v
-	case jsoniter.NumberValue:
-		return iter.ReadNumber().String()
-	case jsoniter.BoolValue:
-		if iter.ReadBool() {
-			return trueString
-		}
-		return falseString
-	default:
-		iter.Skip()
-		return ""
-	}
-}
 
 type RegexpParser struct {
 	regex     *regexp.Regexp

--- a/pkg/logql/log/util.go
+++ b/pkg/logql/log/util.go
@@ -1,7 +1,9 @@
 package log
 
 import (
+	"bytes"
 	"strings"
+	"unicode/utf8"
 )
 
 func uniqueString(s []string) []string {
@@ -35,4 +37,35 @@ func sanitizeLabelKey(key string, isPrefix bool) string {
 		}
 		return '_'
 	}, key)
+}
+
+func sanitizeLabelTo(key, buf []byte, isPrefix bool) []byte {
+	if len(key) == 0 {
+		return buf[:0]
+	}
+	key = bytes.TrimSpace(key)
+	if len(key) == 0 {
+		return buf[:0]
+	}
+	res := buf[:0]
+	if isPrefix && key[0] >= '0' && key[0] <= '9' {
+		res = append(res, '_')
+	}
+	for i := 0; i < len(key); {
+		wid := 1
+		r := rune(key[i])
+		if r >= utf8.RuneSelf {
+			_, wid = utf8.DecodeRune(key[i:])
+			res = append(res, '_')
+			i += wid
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (r >= '0' && r <= '9') {
+			res = append(res, key[i])
+		} else {
+			res = append(res, '_')
+		}
+		i += wid
+	}
+	return res
 }


### PR DESCRIPTION
This is a refactoring of the json parser to avoid a maximun of allocations.

bench so far:

```
❯ benchstat before.txt after.txt
name           old time/op    new time/op    delta
JSONParser-16    1.53µs ± 1%    1.63µs ± 4%   +6.38%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
JSONParser-16      952B ± 0%      872B ± 0%   -8.40%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
JSONParser-16      12.0 ± 0%       6.0 ± 0%  -50.00%  (p=0.008 n=5+5)
```


