### PR TITLE
operator: Add method to get authenticated from GCP

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6125](https://github.com/grafana/loki/pull/6125) **sasagarw**: Add method to get authenticated from GCP
 - [5987](https://github.com/grafana/loki/pull/5987) **Red-GV**: Update logerr to v2.0.0
 - [5907](https://github.com/grafana/loki/pull/5907) **xperimental**: Do not include non-static labels in pod selectors
 - [5893](https://github.com/grafana/loki/pull/5893) **periklis**: Align PVC storage size requests for all lokistack t-shirt sizes

--- a/operator/docs/gcs_object_storage.md
+++ b/operator/docs/gcs_object_storage.md
@@ -1,0 +1,35 @@
+# Storing Objects to Google Cloud Platform
+
+Loki Operator supports [GCS](https://cloud.google.com/) for Loki storage.
+
+### Requirements
+
+* Create a [project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) on Google Cloud Platform.
+* Create a [bucket](https://cloud.google.com/storage/docs/creating-buckets) under same project.
+* Create a [service account](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account) under same project for GCP authentication.
+
+### Installation
+
+* Deploy the loki operator to your cluster.
+
+* Copy the service account credentials received from GCP into a file name `key.json`.
+
+* Create an Object Storage secret with keys `bucketname` and `key.json` as follows:
+
+    ```console
+    kubectl create secret generic test \
+      --from-literal=bucketname="<BUCKET_NAME>" \
+      --from-file=key.json="<PATH/TO/KEY.JSON>"
+    ```
+  
+    where `test` is the secret name, `<BUCKET_NAME>` is the name of bucket created in requirements step and `<PATH/TO/KEY.JSON>` is the file path where the `key.json` was copied to.
+
+* Create an instance of [lokistack](../hack/lokistack_dev.yaml) by referencing the secret name and type as `gcs`:
+
+  ```yaml
+  spec:
+    storage:
+      secret:
+        name: test
+        type: gcs
+  ```

--- a/operator/internal/handlers/internal/secrets/secrets.go
+++ b/operator/internal/handlers/internal/secrets/secrets.go
@@ -91,6 +91,12 @@ func extractGCSConfigSecret(s *corev1.Secret) (*storage.GCSStorageConfig, error)
 		return nil, kverrors.New("missing secret field", "field", "bucketname")
 	}
 
+	// Check if google authentication credentials is provided
+	_, ok = s.Data["key.json"]
+	if !ok {
+		return nil, kverrors.New("missing google authentication credentials", "field", "key.json")
+	}
+
 	return &storage.GCSStorageConfig{
 		Bucket: string(bucket),
 	}, nil

--- a/operator/internal/handlers/internal/secrets/secrets_test.go
+++ b/operator/internal/handlers/internal/secrets/secrets_test.go
@@ -92,10 +92,20 @@ func TestGCSExtract(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "missing key.json",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					"bucketname": []byte("here"),
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "all set",
 			secret: &corev1.Secret{
 				Data: map[string][]byte{
 					"bucketname": []byte("here"),
+					"key.json":   []byte("{\"type\": \"SA\"}"),
 				},
 			},
 		},

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -71,7 +71,7 @@ func CreateOrUpdateLokiStack(
 	storage, err := secrets.ExtractStorageSecret(&storageSecret, stack.Spec.Storage.Secret.Type)
 	if err != nil {
 		return &status.DegradedError{
-			Message: "Invalid object storage secret contents",
+			Message: fmt.Sprintf("Invalid object storage secret contents: %s", err),
 			Reason:  lokiv1beta1.ReasonInvalidObjectStorageSecret,
 			Requeue: false,
 		}

--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -676,7 +676,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidSecret_SetDegraded(t *testing.T) {
 	}
 
 	degradedErr := &status.DegradedError{
-		Message: "Invalid object storage secret contents",
+		Message: "Invalid object storage secret contents: missing secret field",
 		Reason:  lokiv1beta1.ReasonInvalidObjectStorageSecret,
 		Requeue: false,
 	}

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +23,12 @@ func BuildCompactor(opts Options) ([]client.Object, error) {
 		if err := configureCompactorServiceMonitorPKI(statefulSet, opts.Name); err != nil {
 			return nil, err
 		}
+	}
+
+	storageType := opts.Stack.Storage.Secret.Type
+	secretName := opts.Stack.Storage.Secret.Name
+	if err := configureStatefulSetForStorageType(statefulSet, storageType, secretName); err != nil {
+		return nil, err
 	}
 
 	return []client.Object{
@@ -98,10 +103,6 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 	if opts.Stack.Template != nil && opts.Stack.Template.Compactor != nil {
 		podSpec.Tolerations = opts.Stack.Template.Compactor.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.Compactor.NodeSelector
-	}
-
-	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelCompactorComponent, opts.Name)

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -101,23 +101,7 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 	}
 
 	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-			Name: opts.Stack.Storage.Secret.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: opts.Stack.Storage.Secret.Name,
-				},
-			},
-		})
-		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      opts.Stack.Storage.Secret.Name,
-			ReadOnly:  false,
-			MountPath: secretDirectory,
-		})
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-			Name:  EnvGoogleApplicationCredentials,
-			Value: path.Join(secretDirectory, GCSFileName),
-		})
+		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelCompactorComponent, opts.Name)

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -100,23 +100,7 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 	}
 
 	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-			Name: opts.Stack.Storage.Secret.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: opts.Stack.Storage.Secret.Name,
-				},
-			},
-		})
-		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      opts.Stack.Storage.Secret.Name,
-			ReadOnly:  false,
-			MountPath: secretDirectory,
-		})
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-			Name:  EnvGoogleApplicationCredentials,
-			Value: path.Join(secretDirectory, GCSFileName),
-		})
+		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -96,6 +97,26 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 	if opts.Stack.Template != nil && opts.Stack.Template.IndexGateway != nil {
 		podSpec.Tolerations = opts.Stack.Template.IndexGateway.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.IndexGateway.NodeSelector
+	}
+
+	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: opts.Stack.Storage.Secret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: opts.Stack.Storage.Secret.Name,
+				},
+			},
+		})
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      opts.Stack.Storage.Secret.Name,
+			ReadOnly:  false,
+			MountPath: secretDirectory,
+		})
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+			Name:  EnvGoogleApplicationCredentials,
+			Value: path.Join(secretDirectory, GCSFileName),
+		})
 	}
 
 	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +22,12 @@ func BuildIndexGateway(opts Options) ([]client.Object, error) {
 		if err := configureIndexGatewayServiceMonitorPKI(statefulSet, opts.Name); err != nil {
 			return nil, err
 		}
+	}
+
+	storageType := opts.Stack.Storage.Secret.Type
+	secretName := opts.Stack.Storage.Secret.Name
+	if err := configureStatefulSetForStorageType(statefulSet, storageType, secretName); err != nil {
+		return nil, err
 	}
 
 	return []client.Object{
@@ -97,10 +102,6 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 	if opts.Stack.Template != nil && opts.Stack.Template.IndexGateway != nil {
 		podSpec.Tolerations = opts.Stack.Template.IndexGateway.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.IndexGateway.NodeSelector
-	}
-
-	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -106,6 +107,26 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	if opts.Stack.Template != nil && opts.Stack.Template.Ingester != nil {
 		podSpec.Tolerations = opts.Stack.Template.Ingester.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.Ingester.NodeSelector
+	}
+
+	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: opts.Stack.Storage.Secret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: opts.Stack.Storage.Secret.Name,
+				},
+			},
+		})
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      opts.Stack.Storage.Secret.Name,
+			ReadOnly:  false,
+			MountPath: secretDirectory,
+		})
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+			Name:  EnvGoogleApplicationCredentials,
+			Value: path.Join(secretDirectory, GCSFileName),
+		})
 	}
 
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -110,23 +110,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	}
 
 	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-			Name: opts.Stack.Storage.Secret.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: opts.Stack.Storage.Secret.Name,
-				},
-			},
-		})
-		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      opts.Stack.Storage.Secret.Name,
-			ReadOnly:  false,
-			MountPath: secretDirectory,
-		})
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-			Name:  EnvGoogleApplicationCredentials,
-			Value: path.Join(secretDirectory, GCSFileName),
-		})
+		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)

--- a/operator/internal/manifests/object_storage.go
+++ b/operator/internal/manifests/object_storage.go
@@ -1,0 +1,31 @@
+package manifests
+
+import (
+	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
+	"github.com/grafana/loki/operator/internal/manifests/storage"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func configureDeploymentForStorageType(
+	d *appsv1.Deployment,
+	t lokiv1beta1.ObjectStorageSecretType,
+	secretName string) error {
+	switch t {
+	case lokiv1beta1.ObjectStorageSecretGCS:
+		return storage.ConfigureDeployment(d, secretName)
+	default:
+		return nil
+	}
+}
+
+func configureStatefulSetForStorageType(
+	d *appsv1.StatefulSet,
+	t lokiv1beta1.ObjectStorageSecretType,
+	secretName string) error {
+	switch t {
+	case lokiv1beta1.ObjectStorageSecretGCS:
+		return storage.ConfigureStatefulSet(d, secretName)
+	default:
+		return nil
+	}
+}

--- a/operator/internal/manifests/object_storage_test.go
+++ b/operator/internal/manifests/object_storage_test.go
@@ -1,0 +1,380 @@
+package manifests
+
+import (
+	"testing"
+
+	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
+	"github.com/grafana/loki/operator/internal/manifests/internal/config"
+	"github.com/grafana/loki/operator/internal/manifests/storage"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConfigureDeploymentForStorageType(t *testing.T) {
+	type tt struct {
+		desc        string
+		storageType lokiv1beta1.ObjectStorageSecretType
+		secretName  string
+		dpl         *appsv1.Deployment
+		want        *appsv1.Deployment
+	}
+
+	tc := []tt{
+		{
+			desc:        "object storage other than GCS",
+			storageType: lokiv1beta1.ObjectStorageSecretS3,
+			secretName:  "test",
+			dpl: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "object storage GCS",
+			storageType: lokiv1beta1.ObjectStorageSecretGCS,
+			secretName:  "test",
+			dpl: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+										{
+											Name:      "test",
+											ReadOnly:  false,
+											MountPath: secretDirectory,
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  storage.EnvGoogleApplicationCredentials,
+											Value: "/etc/proxy/secrets/key.json",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+								{
+									Name: "test",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tc {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			err := configureDeploymentForStorageType(tc.dpl, tc.storageType, tc.secretName)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, tc.dpl)
+		})
+	}
+}
+
+func TestConfigureStatefulSetForStorageType(t *testing.T) {
+	type tt struct {
+		desc        string
+		storageType lokiv1beta1.ObjectStorageSecretType
+		secretName  string
+		sts         *appsv1.StatefulSet
+		want        *appsv1.StatefulSet
+	}
+
+	tc := []tt{
+		{
+			desc:        "object storage other than GCS",
+			storageType: lokiv1beta1.ObjectStorageSecretS3,
+			secretName:  "test",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "object storage GCS",
+			storageType: lokiv1beta1.ObjectStorageSecretGCS,
+			secretName:  "test",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      configVolumeName,
+											ReadOnly:  false,
+											MountPath: config.LokiConfigMountDir,
+										},
+										{
+											Name:      "test",
+											ReadOnly:  false,
+											MountPath: secretDirectory,
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  storage.EnvGoogleApplicationCredentials,
+											Value: "/etc/proxy/secrets/key.json",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: configVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											DefaultMode: &defaultConfigMapMode,
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: lokiConfigMapName("stack-name"),
+											},
+										},
+									},
+								},
+								{
+									Name: "test",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tc {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			err := configureStatefulSetForStorageType(tc.sts, tc.storageType, tc.secretName)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, tc.sts)
+		})
+	}
+}

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +21,12 @@ func BuildQuerier(opts Options) ([]client.Object, error) {
 		if err := configureQuerierServiceMonitorPKI(deployment, opts.Name); err != nil {
 			return nil, err
 		}
+	}
+
+	storageType := opts.Stack.Storage.Secret.Type
+	secretName := opts.Stack.Storage.Secret.Name
+	if err := configureDeploymentForStorageType(deployment, storageType, secretName); err != nil {
+		return nil, err
 	}
 
 	return []client.Object{
@@ -96,10 +101,6 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 	if opts.Stack.Template != nil && opts.Stack.Template.Querier != nil {
 		podSpec.Tolerations = opts.Stack.Template.Querier.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.Querier.NodeSelector
-	}
-
-	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -99,23 +99,7 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 	}
 
 	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
-		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-			Name: opts.Stack.Storage.Secret.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: opts.Stack.Storage.Secret.Name,
-				},
-			},
-		})
-		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      opts.Stack.Storage.Secret.Name,
-			ReadOnly:  false,
-			MountPath: secretDirectory,
-		})
-		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-			Name:  EnvGoogleApplicationCredentials,
-			Value: path.Join(secretDirectory, GCSFileName),
-		})
+		ensureCredentialsForGCS(&podSpec, opts.Stack.Storage.Secret.Name)
 	}
 
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	lokiv1beta1 "github.com/grafana/loki/operator/api/v1beta1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,6 +96,26 @@ func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 	if opts.Stack.Template != nil && opts.Stack.Template.Querier != nil {
 		podSpec.Tolerations = opts.Stack.Template.Querier.Tolerations
 		podSpec.NodeSelector = opts.Stack.Template.Querier.NodeSelector
+	}
+
+	if opts.Stack.Storage.Secret.Type == lokiv1beta1.ObjectStorageSecretGCS {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: opts.Stack.Storage.Secret.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: opts.Stack.Storage.Secret.Name,
+				},
+			},
+		})
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      opts.Stack.Storage.Secret.Name,
+			ReadOnly:  false,
+			MountPath: secretDirectory,
+		})
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+			Name:  EnvGoogleApplicationCredentials,
+			Value: path.Join(secretDirectory, GCSFileName),
+		})
 	}
 
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)

--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"path"
+
+	"github.com/ViaQ/logerr/v2/kverrors"
+	"github.com/imdario/mergo"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// EnvGoogleApplicationCredentials is the environment variable to specify path to key.json
+	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+	// GCSFileName is the file containing the Google credentials for authentication
+	GCSFileName     = "key.json"
+	secretDirectory = "/etc/proxy/secrets"
+)
+
+// ConfigureDeployment merges a GCS Object Storage volume into the deployment spec.
+// With this, the deployment will expose an environment variable for Google authentication.
+func ConfigureDeployment(d *appsv1.Deployment, secretName string) error {
+	p := ensureCredentialsForGCS(&d.Spec.Template.Spec, secretName)
+
+	if err := mergo.Merge(&d.Spec.Template.Spec, p, mergo.WithOverride); err != nil {
+		return kverrors.Wrap(err, "failed to merge gcs object storage spec ")
+	}
+
+	return nil
+}
+
+// ConfigureStatefulSet merges a GCS Object Storage volume into the statefulset spec.
+// With this, the statefulset will expose an environment variable for Google authentication.
+func ConfigureStatefulSet(s *appsv1.StatefulSet, secretName string) error {
+	p := ensureCredentialsForGCS(&s.Spec.Template.Spec, secretName)
+
+	if err := mergo.Merge(&s.Spec.Template.Spec, p, mergo.WithOverride); err != nil {
+		return kverrors.Wrap(err, "failed to merge gcs object storage spec ")
+	}
+
+	return nil
+}
+
+func ensureCredentialsForGCS(p *corev1.PodSpec, secretName string) corev1.PodSpec {
+	container := p.Containers[0].DeepCopy()
+	volumes := p.Volumes
+
+	volumes = append(volumes, corev1.Volume{
+		Name: secretName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	})
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      secretName,
+		ReadOnly:  false,
+		MountPath: secretDirectory,
+	})
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  EnvGoogleApplicationCredentials,
+		Value: path.Join(secretDirectory, GCSFileName),
+	})
+
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			*container,
+		},
+		Volumes: volumes,
+	}
+}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -62,6 +62,11 @@ const (
 	LabelIndexGatewayComponent string = "index-gateway"
 	// LabelGatewayComponent is the label value for the lokiStack-gateway component
 	LabelGatewayComponent string = "lokistack-gateway"
+
+	// EnvGoogleApplicationCredentials is the environment variable to specify path to key.json
+	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+	// GCSFileName is the file containing the Google credentials for authentication
+	GCSFileName = "key.json"
 )
 
 var (

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -63,11 +62,6 @@ const (
 	LabelIndexGatewayComponent string = "index-gateway"
 	// LabelGatewayComponent is the label value for the lokiStack-gateway component
 	LabelGatewayComponent string = "lokistack-gateway"
-
-	// EnvGoogleApplicationCredentials is the environment variable to specify path to key.json
-	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
-	// GCSFileName is the file containing the Google credentials for authentication
-	GCSFileName = "key.json"
 )
 
 var (
@@ -278,24 +272,4 @@ func lokiReadinessProbe() *corev1.Probe {
 		SuccessThreshold:    1,
 		FailureThreshold:    3,
 	}
-}
-
-func ensureCredentialsForGCS(podSpec *corev1.PodSpec, secretName string) {
-	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-		Name: secretName,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName,
-			},
-		},
-	})
-	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		Name:      secretName,
-		ReadOnly:  false,
-		MountPath: secretDirectory,
-	})
-	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-		Name:  EnvGoogleApplicationCredentials,
-		Value: path.Join(secretDirectory, GCSFileName),
-	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
There isn't an authentication mechanism in the provided Loki configuration. The Loki GCS authentication is handled via the GCS SDK which is typically done with environment variables(For example:GOOGLE_APPLICATION_CREDENTIALS).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
