### PR TITLE
Fix certain binary expression queries by optimizing through push down

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -132,14 +132,19 @@ func TestRangeMappingEquivalence(t *testing.T) {
 
 		// sum
 		{`sum(bytes_over_time({a=~".+"}[2s]))`, time.Second},
+		{`sum(bytes_over_time({a=~".+"} | logfmt | line > 5 [2s]))`, time.Second},
 		{`sum(count_over_time({a=~".+"}[2s]))`, time.Second},
+		{`sum(count_over_time({a=~".+"} | logfmt | line > 5 [2s]))`, time.Second},
 		{`sum(sum_over_time({a=~".+"} | unwrap b [2s]))`, time.Second},
+		{`sum(sum_over_time({a=~".+"} | logfmt | unwrap line [2s]))`, time.Second},
 		{`sum(max_over_time({a=~".+"} | unwrap b [2s]))`, time.Second},
 		{`sum(max_over_time({a=~".+"} | unwrap b [2s]) by (a))`, time.Second},
 		{`sum(max_over_time({a=~".+"} | logfmt | unwrap line [2s]) by (a))`, time.Second},
+		{`sum(max_over_time({a=~".+"} | logfmt | unwrap line [2s]))`, time.Second},
 		{`sum(min_over_time({a=~".+"} | unwrap b [2s]))`, time.Second},
 		{`sum(min_over_time({a=~".+"} | unwrap b [2s]) by (a))`, time.Second},
 		{`sum(min_over_time({a=~".+"} | logfmt | unwrap line [2s]) by (a))`, time.Second},
+		{`sum(min_over_time({a=~".+"} | logfmt | unwrap line [2s]))`, time.Second},
 		{`sum(rate({a=~".+"}[2s]))`, time.Second},
 		{`sum(bytes_rate({a=~".+"}[2s]))`, time.Second},
 
@@ -215,9 +220,11 @@ func TestRangeMappingEquivalence(t *testing.T) {
 		{`min(max_over_time({a=~".+"} | unwrap b [2s]))`, time.Second},
 		{`min(max_over_time({a=~".+"} | unwrap b [2s]) by (a))`, time.Second},
 		{`min(max_over_time({a=~".+"} | logfmt | unwrap line [2s]) by (a))`, time.Second},
+		{`min(max_over_time({a=~".+"} | logfmt | unwrap line [2s]))`, time.Second},
 		{`min(min_over_time({a=~".+"} | unwrap b [2s]))`, time.Second},
 		{`min(min_over_time({a=~".+"} | unwrap b [2s]) by (a))`, time.Second},
 		{`min(min_over_time({a=~".+"} | logfmt | unwrap line [2s]) by (a))`, time.Second},
+		{`min(min_over_time({a=~".+"} | logfmt | unwrap line [2s]))`, time.Second},
 		{`min(rate({a=~".+"}[2s]))`, time.Second},
 		{`min(bytes_rate({a=~".+"}[2s]))`, time.Second},
 
@@ -237,6 +244,7 @@ func TestRangeMappingEquivalence(t *testing.T) {
 		// Binary operations
 		{`bytes_over_time({a=~".+"}[3s]) + count_over_time({a=~".+"}[5s])`, time.Second},
 		{`sum(count_over_time({a=~".+"}[3s]) * count(sum_over_time({a=~".+"} | unwrap b [5s])))`, time.Second},
+		{`sum(count_over_time({a=~".+"} | logfmt | b > 2 [3s])) / sum(count_over_time({a=~".+"} [3s]))`, time.Second},
 
 		// Multi vector aggregator layer queries
 		{`sum(max(bytes_over_time({a=~".+"}[3s])))`, time.Second},

--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -343,7 +343,7 @@ func (m RangeMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 
 	// We cannot execute downstream queries that would potentially produce a huge amount of series
 	// and therefore would very likely fail.
-	if expr.Grouping == nil && hasLabelExtractionStage(expr) {
+	if expr.Grouping == nil && vectorAggrPushdown == nil && hasLabelExtractionStage(expr) {
 		return expr
 	}
 	switch expr.Operation {

--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -128,9 +128,21 @@ func (m RangeMapper) Map(expr syntax.SampleExpr, vectorAggrPushdown *syntax.Vect
 		if err != nil {
 			return nil, err
 		}
+		// if left hand side is a noop, we need to return the original expression
+		// so the whole expression is a noop and thus not executed using the
+		// downstream engine
+		if e.SampleExpr.String() == lhsMapped.String() {
+			return e, nil
+		}
 		rhsMapped, err := m.Map(e.RHS, vectorAggrPushdown, recorder)
 		if err != nil {
 			return nil, err
+		}
+		// if right hand side is a noop, we need to return the original expression
+		// so the whole expression is a noop and thus not executed using the
+		// downstream engine
+		if e.RHS.String() == rhsMapped.String() {
+			return e, nil
 		}
 		e.SampleExpr = lhsMapped
 		e.RHS = rhsMapped

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -932,6 +932,26 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 				)
 			)`,
 		},
+		{
+			`sum (count_over_time({app="foo"} | logfmt | duration > 10s [3m])) / sum (count_over_time({app="foo"} [3m]))`,
+			`(
+				sum (
+					sum without (
+						   downstream<sum (count_over_time({app="foo"} | logfmt | duration > 10s [1m] offset 2m0s)), shard=<nil>>
+						++ downstream<sum (count_over_time({app="foo"} | logfmt | duration > 10s [1m] offset 1m0s)), shard=<nil>>
+						++ downstream<sum (count_over_time({app="foo"} | logfmt | duration > 10s [1m])), shard=<nil>>
+					)
+				)
+				/
+				sum (
+					sum without (
+						   downstream<sum (count_over_time({app="foo"} [1m] offset 2m0s)), shard=<nil>>
+						++ downstream<sum (count_over_time({app="foo"} [1m] offset 1m0s)), shard=<nil>>
+						++ downstream<sum (count_over_time({app="foo"} [1m])), shard=<nil>>
+					)
+				)
+			)`,
+		},
 
 		// Multi vector aggregator layer queries
 		{
@@ -956,6 +976,98 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 					   downstream<count_over_time({app="foo"}[1m] offset 2m0s), shard=<nil>>
 					++ downstream<count_over_time({app="foo"}[1m] offset 1m0s), shard=<nil>>
 					++ downstream<count_over_time({app="foo"}[1m]), shard=<nil>>
+				)
+			)`,
+		},
+
+		// outer vector aggregation is pushed down
+		{
+			`sum(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`sum(
+				min without(
+					   downstream<sum(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<sum(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<sum(min_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`sum(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`sum(
+				max without(
+					   downstream<sum(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<sum(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<sum(max_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`sum(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`sum(
+				sum without(
+					   downstream<sum(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<sum(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<sum(sum_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`min(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`min(
+				min without(
+					   downstream<min(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<min(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<min(min_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`min(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`min(
+				max without(
+					   downstream<min(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<min(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<min(max_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`min(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`min(
+				sum without(
+					   downstream<min(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<min(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<min(sum_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`max(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`max(
+				min without(
+					   downstream<max(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<max(min_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<max(min_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`max(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`max(
+				max without(
+					   downstream<max(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<max(max_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<max(max_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
+				)
+			)`,
+		},
+		{
+			`max(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
+			`max(
+				sum without(
+					   downstream<max(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 2m0s)), shard=<nil>>
+					++ downstream<max(sum_over_time({app="foo"} | logfmt | unwrap bar [1m] offset 1m0s)), shard=<nil>>
+					++ downstream<max(sum_over_time({app="foo"} | logfmt | unwrap bar [1m])), shard=<nil>>
 				)
 			)`,
 		},
@@ -997,42 +1109,6 @@ func Test_SplitRangeVectorMapping_Noop(t *testing.T) {
 
 		// should be noop if inner range aggregation includes a stage for label extraction such as `| json` or `| logfmt`
 		// because otherwise the downstream queries would result in too many series
-		{
-			`sum(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`sum(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`sum(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`sum(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`sum(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`sum(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`min(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`min(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`min(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`min(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`min(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`min(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`max(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`max(min_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`max(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`max(max_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
-		{
-			`max(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-			`max(sum_over_time({app="foo"} | logfmt | unwrap bar [3m]))`,
-		},
 		{
 			`max_over_time({app="foo"} | json | unwrap bar [3m])`,
 			`max_over_time({app="foo"} | json | unwrap bar [3m])`,

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1113,6 +1113,12 @@ func Test_SplitRangeVectorMapping_Noop(t *testing.T) {
 			`max_over_time({app="foo"} | json | unwrap bar [3m])`,
 			`max_over_time({app="foo"} | json | unwrap bar [3m])`,
 		},
+
+		// if one side of a binary expression is a noop, the full query is a noop as well
+		{
+			`sum by (foo) (sum_over_time({app="foo"} | json | unwrap bar [3m])) / sum_over_time({app="foo"} | json | unwrap bar [6m])`,
+			`sum by (foo) (sum_over_time({app="foo"} | json | unwrap bar [3m])) / sum_over_time({app="foo"} | json | unwrap bar [6m])`,
+		},
 	} {
 		tc := tc
 		t.Run(tc.expr, func(t *testing.T) {

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1117,7 +1117,7 @@ func Test_SplitRangeVectorMapping_Noop(t *testing.T) {
 		// if one side of a binary expression is a noop, the full query is a noop as well
 		{
 			`sum by (foo) (sum_over_time({app="foo"} | json | unwrap bar [3m])) / sum_over_time({app="foo"} | json | unwrap bar [6m])`,
-			`sum by (foo) (sum_over_time({app="foo"} | json | unwrap bar [3m])) / sum_over_time({app="foo"} | json | unwrap bar [6m])`,
+			`(sum by (foo) (sum_over_time({app="foo"} | json | unwrap bar [3m])) / sum_over_time({app="foo"} | json | unwrap bar [6m]))`,
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR optimizes instant queries that use a vector aggregation around a range aggregation with log extraction stage (`json`, `logfmt`), such as `sum(count_over_time({foo="bar"} | logfmt | duration > 30s [24h]))`.

Since the vector aggregation can be pushed down to the downstream query, the downstream query does not create a massive amount of streams, even though it contains a generic label extraction stage.

This would also fix binary expression queries that use said aggregation on one of its leave nodes, such as:

```
sum(count_over_time({foo="bar"} | logfmt | duration > 2s [3s]))
/
sum(count_over_time({foo="bar"} [3s]))
```

If either the left hand side or the right hand side of a binary expression is a noop, we need to return the original expression so the whole expression is a noop as well, and thus not executed using the downstream engine.
Otherwise, a binary expression that has a noop on either side, results in an `unimplemented` error when executed using the downstream engine.


**Which issue(s) this PR fixes**:

Fixes #6130 

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
