### PR TITLE
Update docs for xk6-loki log formats

### DIFF
--- a/docs/sources/clients/k6/log-generation.md
+++ b/docs/sources/clients/k6/log-generation.md
@@ -65,7 +65,8 @@ is used.
 
 ## Log format
 
-`xk6-loki` can emit log lines in six distinct formats. The label `format` of a stream defines the format of its log lines.
+`xk6-loki` can emit log lines in seven distinct formats. The label `format` of
+a stream defines the format of its log lines.
 
 * Apache common (`apache_common`)
 * Apache combined (`apache_combined`)
@@ -73,8 +74,10 @@ is used.
 * [BSD syslog](https://datatracker.ietf.org/doc/html/rfc3164) (`rfc3164`)
 * [Syslog](https://datatracker.ietf.org/doc/html/rfc5424) (`rfc5424`)
 * JSON (`json`)
+* [logfmt](https://pkg.go.dev/github.com/kr/logfmt) (`logfmt`)
 
-Under the hood, the extension uses the library [flog](https://github.com/mingrammer/flog) for generating log lines.
+Under the hood, the extension uses a fork the library
+[flog](https://github.com/mingrammer/flog) for generating log lines.
 
 ## Labels
 
@@ -83,7 +86,7 @@ Under the hood, the extension uses the library [flog](https://github.com/mingram
 | name      | type     | cardinality     |
 | --------- | -------- | --------------- |
 | instance  | fixed    | 1 per k6 worker |
-| format    | fixed    | 6               |
+| format    | fixed    | 7               |
 | os        | fixed    | 3               |
 | namespace | variable | >100            |
 | app       | variable | >100            |


### PR DESCRIPTION
**What this PR does / why we need it**:

Support for `logfmt` log format has been merged into `main` with https://github.com/grafana/xk6-loki/commit/717a1332b4bff56e1e822527d0eca78bd76f2176

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
