### PR TITLE
promtail: Fix infinite loop in file target (fixes #5350)

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -168,7 +168,11 @@ func (t *FileTarget) run() {
 
 	for {
 		select {
-		case event := <-t.fileEventWatcher:
+		case event, ok := <-t.fileEventWatcher:
+			if !ok {
+				// fileEventWatcher has been closed
+				return
+			}
 			switch event.Op {
 			case fsnotify.Create:
 				t.startTailing([]string{event.Name})


### PR DESCRIPTION
**What this PR does / why we need it**:

This attempt to fix an issue where promtail consumes 100% CPU on
servers when some pods stop.

**Which issue(s) this PR fixes**:
Fixes #5350

**Special notes for your reviewer**:

This may not be the best fix as a subsequent write to 
quit could block (though if quit where/is buffered, that
may not be a problem).