### PR TITLE
ruler: Add support for alertmanager header authorization

### DIFF
--- a/pkg/ruler/base/notifier.go
+++ b/pkg/ruler/base/notifier.go
@@ -23,13 +23,15 @@ import (
 )
 
 type NotifierConfig struct {
-	TLS       tls.ClientConfig `yaml:",inline"`
-	BasicAuth util.BasicAuth   `yaml:",inline"`
+	TLS        tls.ClientConfig `yaml:",inline"`
+	BasicAuth  util.BasicAuth   `yaml:",inline"`
+	HeaderAuth util.HeaderAuth  `yaml:",inline"`
 }
 
 func (cfg *NotifierConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.TLS.RegisterFlagsWithPrefix("ruler.alertmanager-client", f)
 	cfg.BasicAuth.RegisterFlagsWithPrefix("ruler.alertmanager-client.", f)
+	cfg.HeaderAuth.RegisterFlagsWithPrefix("ruler.alertmanager-client", f)
 }
 
 // rulerNotifier bundles a notifier.Manager together with an associated
@@ -194,6 +196,21 @@ func amConfigFromURL(rulerConfig *Config, url *url.URL, apiVersion config.Alertm
 		amConfig.HTTPClientConfig.BasicAuth = &config_util.BasicAuth{
 			Username: rulerConfig.Notifier.BasicAuth.Username,
 			Password: config_util.Secret(rulerConfig.Notifier.BasicAuth.Password),
+		}
+	}
+
+	if rulerConfig.Notifier.HeaderAuth.IsEnabled() {
+		if rulerConfig.Notifier.HeaderAuth.Credentials != "" {
+			amConfig.HTTPClientConfig.Authorization = &config_util.Authorization{
+				Type:        "Bearer",
+				Credentials: config_util.Secret(rulerConfig.Notifier.HeaderAuth.Credentials),
+			}
+		} else if rulerConfig.Notifier.HeaderAuth.CredentialsFile != "" {
+			amConfig.HTTPClientConfig.Authorization = &config_util.Authorization{
+				Type:            "Bearer",
+				CredentialsFile: rulerConfig.Notifier.HeaderAuth.CredentialsFile,
+			}
+
 		}
 	}
 

--- a/pkg/ruler/base/notifier_test.go
+++ b/pkg/ruler/base/notifier_test.go
@@ -222,6 +222,76 @@ func TestBuildNotifierConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with Header Authorization",
+			cfg: &Config{
+				AlertmanagerURL: "http://alertmanager-0.default.svc.cluster.local/alertmanager",
+				Notifier: NotifierConfig{
+					HeaderAuth: util.HeaderAuth{
+						Credentials: "jacob",
+					},
+				},
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							HTTPClientConfig: config_util.HTTPClientConfig{
+								Authorization: &config_util.Authorization{
+									Type:        "Bearer",
+									Credentials: config_util.Secret("jacob"),
+								},
+							},
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfigs: discovery.Configs{
+								discovery.StaticConfig{
+									{
+										Targets: []model.LabelSet{{"__address__": "alertmanager-0.default.svc.cluster.local"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with Header Authorization and credentials file",
+			cfg: &Config{
+				AlertmanagerURL: "http://alertmanager-0.default.svc.cluster.local/alertmanager",
+				Notifier: NotifierConfig{
+					HeaderAuth: util.HeaderAuth{
+						CredentialsFile: "/path/to/secret/file",
+					},
+				},
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							HTTPClientConfig: config_util.HTTPClientConfig{
+								Authorization: &config_util.Authorization{
+									Type:            "Bearer",
+									CredentialsFile: "/path/to/secret/file",
+								},
+							},
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfigs: discovery.Configs{
+								discovery.StaticConfig{
+									{
+										Targets: []model.LabelSet{{"__address__": "alertmanager-0.default.svc.cluster.local"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "with external labels",
 			cfg: &Config{
 				AlertmanagerURL: "http://alertmanager.default.svc.cluster.local/alertmanager",

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -43,6 +43,23 @@ func (b BasicAuth) IsEnabled() bool {
 	return b.Username != "" || b.Password != ""
 }
 
+// HeaderAuth condigures header based authorization for HTTP clients.
+type HeaderAuth struct {
+	Type            string `yaml:"type,omitempty"`
+	Credentials     string `yaml:"credentials,omitempty"`
+	CredentialsFile string `yaml:"credentials_file,omitempty"`
+}
+
+func (h *HeaderAuth) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&h.Credentials, prefix+"credentials", "", "HTTP Header authentication credentials.")
+	f.StringVar(&h.CredentialsFile, prefix+"credentials-file", "", "HTTP Header authentication credentials file.")
+}
+
+// IsEnabled returns false if header authorization isn't enabled.
+func (h HeaderAuth) IsEnabled() bool {
+	return h.Credentials != "" || h.CredentialsFile != ""
+}
+
 // WriteJSONResponse writes some JSON as a HTTP response.
 func WriteJSONResponse(w http.ResponseWriter, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the base of the ruler is forked from cortex, this PR establishes the missing header authorization capability for the alertmanager client. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
