### PR TITLE
Documentation: Explain --config.expand-env=true double slash with slash substitution

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -60,6 +60,11 @@ ${VAR:default_value}
 
 Where default_value is the value to use if the environment variable is undefined.
 
+**Note**: With `expand-env=true` the configuration will first run through
+[envsubst](https://linux.die.net/man/1/envsubst) which will replace double
+slashes with single slashes. Because of this every use of a slash `\` needs to
+be replaced with a double slash `\\`
+
 ### Generic placeholders:
 
 - `<boolean>`: a boolean that can take the values `true` or `false`

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -61,7 +61,7 @@ ${VAR:default_value}
 Where default_value is the value to use if the environment variable is undefined.
 
 **Note**: With `expand-env=true` the configuration will first run through
-[envsubst](https://linux.die.net/man/1/envsubst) which will replace double
+[envsubst](https://pkg.go.dev/github.com/drone/envsubst) which will replace double
 slashes with single slashes. Because of this every use of a slash `\` needs to
 be replaced with a double slash `\\`
 

--- a/docs/sources/clients/promtail/stages/regex.md
+++ b/docs/sources/clients/promtail/stages/regex.md
@@ -38,6 +38,16 @@ But these are not:
 - `expression: '\\w*'` (only escape backslashes when using double quotes)
 - `expression: "\w*"` (backslash must be escaped)
 
+
+If you run Promtail with the `--config.expand-env=true` flag the configuration
+will run through [envsubst](https://linux.die.net/man/1/envsubst) which will
+replace double slashes with single slashes. Because of this when using
+`expand-env=true` you need to use double slashes for each single slash. For
+example:
+
+- `expression: '\w*'` must be `expression: '\\w*'`
+- `expression: "\\w*"` must be `expression: "\\\\w*"`
+
 ## Example
 
 ### Without `source`

--- a/docs/sources/clients/promtail/stages/regex.md
+++ b/docs/sources/clients/promtail/stages/regex.md
@@ -40,7 +40,7 @@ But these are not:
 
 
 If you run Promtail with the `--config.expand-env=true` flag the configuration
-will run through [envsubst](https://linux.die.net/man/1/envsubst) which will
+will run through [envsubst](https://pkg.go.dev/github.com/drone/envsubst)  which will
 replace double slashes with single slashes. Because of this when using
 `expand-env=true` you need to use double slashes for each single slash. For
 example:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

When I was configuring Promtail to use a regex stage I escaped slashes in regular expressions when using double quotes in yaml files. But no where did it explain that when using the option `--config.expand-env=true` the program `envsubst` would replace double slashes with slashes. I found the issue #3635 to find out this is behavior as expected. While I accept this, I thought it would be useful to warn the next person about just this case.

Adds two paragraphs to the Promtail configuration docs:
- in `docs/sources/clients/promtail/configuration.md`: use double slashes for single slashes when using `expand-env=true`
- in `docs/sources/clients/promtail/stages/regex.md`: explained again as it's more likely to use back slashes in regex

**Which issue(s) this PR fixes**:

Although already closed it's related to the following: Fixes #3635

**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
