### PR TITLE
specify logcli authorization header name by flag

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -244,6 +244,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
 	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("0").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
+	app.Flag("auth-header", "The authorization header used.").Default("Authorization").Envar("AUTH_HEADER").StringVar(&client.AuthHeader)
 
 	return client
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -55,6 +55,7 @@ type DefaultClient struct {
 	OrgID           string
 	Tripperware     Tripperware
 	BearerToken     string
+	AuthHeader      string
 	BearerTokenFile string
 	Retries         int
 	QueryTags       string
@@ -261,7 +262,11 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	}
 
 	if c.BearerToken != "" {
-		h.Set("Authorization", "Bearer "+c.BearerToken)
+		if c.AuthHeader != "" {
+			h.Set(c.AuthHeader, "Bearer "+c.BearerToken)
+		} else {
+			h.Set("Authorization", "Bearer "+c.BearerToken)
+		}
 	}
 
 	if c.BearerTokenFile != "" {
@@ -270,7 +275,11 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", c.BearerTokenFile, err)
 		}
 		bearerToken := strings.TrimSpace(string(b))
-		h.Set("Authorization", "Bearer "+bearerToken)
+		if c.AuthHeader != "" {
+			h.Set(c.AuthHeader, "Bearer "+bearerToken)
+		} else {
+			h.Set("Authorization", "Bearer "+bearerToken)
+		}
 	}
 	return h, nil
 }


### PR DESCRIPTION
Add logcli flag `auth-header` to be able to specify authorization header name.

**What this PR does / why we need it**:
Adds a flag auth-header which defaults to Authorization.

**Which issue(s) this PR fixes**:
Fixes #6143 

**Special notes for your reviewer**:
Change has no side effects on existing users unless they use the new flag auth-header.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
