### PR TITLE
Add make target to build tarball distribution

### DIFF
--- a/examples/getting-started/local-filesystem.yaml
+++ b/examples/getting-started/local-filesystem.yaml
@@ -1,0 +1,39 @@
+# Minimal config.yaml for single-binary installation using local file system storage.
+# This is not intended for production usage!
+---
+auth_enabled: true
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+schema_config:
+  configs:
+    - from: 2022-01-01
+      store: boltdb
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+common:
+  path_prefix: ./data
+  replication_factor: 1
+  storage:
+    filesystem:
+      chunks_directory: ./data/chunks
+      rules_directory: ./data/rules
+  ring:
+    kvstore:
+      store: memberlist
+
+storage_config:
+  boltdb:
+    directory: ./data/boltdb
+  filesystem:
+    directory: ./data/chunks
+
+memberlist:
+  join_members:
+    - localhost:7946

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -42,7 +42,7 @@ func (c *ConfigWrapper) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.ListTargets, "list-targets", false, "List available targets")
 	f.BoolVar(&c.LogConfig, "log-config-reverse-order", false, "Dump the entire Loki config object at Info log "+
 		"level with the order reversed, reversing the order makes viewing the entries easier in Grafana.")
-	f.StringVar(&c.ConfigFile, "config.file", "", "yaml file to load")
+	f.StringVar(&c.ConfigFile, "config.file", "config.yaml,config/config.yaml", "yaml file to load")
 	f.BoolVar(&c.ConfigExpandEnv, "config.expand-env", false, "Expands ${var} in config according to the values of the environment variables.")
 	c.Config.RegisterFlags(f)
 }

--- a/pkg/util/cfg/cfg.go
+++ b/pkg/util/cfg/cfg.go
@@ -47,7 +47,7 @@ func Unmarshal(dst Cloneable, sources ...Source) error {
 func DefaultUnmarshal(dst Cloneable, args []string, fs *flag.FlagSet) error {
 	return Unmarshal(dst,
 		Defaults(fs),
-		YAMLFlag(args, "config.file"),
+		ConfigFileLoader(args, "config.file"),
 		Flags(args, fs),
 	)
 }

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -20,16 +20,16 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),
 		// Next populate the config from the config file, we do this to populate the `common`
-		// section of the config file by taking advantage of the code in YAMLFlag which will load
+		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		YAMLFlag(args, "config.file"),
+		ConfigFileLoader(args, "config.file"),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
 		// config files so that values from a common, or shared, section can be used in
 		// the dynamic evaluation
 		dst.ApplyDynamicConfig(),
 		// Load configs from the config file a second time, this will supersede anything set by the common
 		// config with values specified in the config file.
-		YAMLFlag(args, "config.file"),
+		ConfigFileLoader(args, "config.file"),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 	)

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -66,7 +66,7 @@ func dYAML(y []byte) Source {
 	}
 }
 
-func YAMLFlag(args []string, name string) Source {
+func ConfigFileLoader(args []string, name string) Source {
 
 	return func(dst Cloneable) error {
 		freshFlags := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/drone/envsubst"
 	"github.com/pkg/errors"
@@ -92,13 +93,18 @@ func YAMLFlag(args []string, name string) Source {
 		if f == nil || f.Value.String() == "" {
 			return nil
 		}
-		expandEnv := false
-		expandEnvFlag := freshFlags.Lookup("config.expand-env")
-		if expandEnvFlag != nil {
-			expandEnv, _ = strconv.ParseBool(expandEnvFlag.Value.String()) // Can ignore error as false returned
+
+		for _, val := range strings.Split(f.Value.String(), ",") {
+			val := strings.TrimSpace(val)
+			expandEnv := false
+			expandEnvFlag := freshFlags.Lookup("config.expand-env")
+			if expandEnvFlag != nil {
+				expandEnv, _ = strconv.ParseBool(expandEnvFlag.Value.String()) // Can ignore error as false returned
+			}
+			if _, err := os.Stat(val); err == nil {
+				return YAML(val, expandEnv)(dst)
+			}
 		}
-
-		return YAML(f.Value.String(), expandEnv)(dst)
-
+		return fmt.Errorf("%s does not exist", f.Value.String())
 	}
 }

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -22,9 +22,9 @@ func (cfg *testCfg) Clone() flagext.Registerer {
 	}(*cfg)
 }
 
-func TestYAMLFlagDoesNotMutate(t *testing.T) {
+func TestConfigFileLoaderDoesNotMutate(t *testing.T) {
 	cfg := &testCfg{}
-	err := YAMLFlag(nil, "something")(cfg)
+	err := ConfigFileLoader(nil, "something")(cfg)
 	require.Nil(t, err)
 	require.Equal(t, 0, cfg.v)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

This PR adds a `make` target to build .tar.gz distributions of Loki that contain both the Loki binary, LogCLI binary, and a config.yaml file that configures to use local filesystem storage.
This allows users to quickly test out Loki by downloading the tarball for the appropriate architecture, extract the archive and run Loki by simply invoking `./bin/loki`.

After running `make tarball`, the contents of the folder `dist/` looks like this:
```console
$ ll dist 
total 209M
-rw-r--r-- 1 christian christian 32M May 13 13:54 loki-chaudum-tarball-distribution-bad32d2-darwin-amd64.tar.gz
-rw-r--r-- 1 christian christian 32M May 13 13:54 loki-chaudum-tarball-distribution-bad32d2-darwin-arm64.tar.gz
-rw-r--r-- 1 christian christian 31M May 13 13:54 loki-chaudum-tarball-distribution-bad32d2-freebsd-amd64.tar.gz
-rw-r--r-- 1 christian christian 30M May 13 13:53 loki-chaudum-tarball-distribution-bad32d2-linux-amd64.tar.gz
-rw-r--r-- 1 christian christian 28M May 13 13:53 loki-chaudum-tarball-distribution-bad32d2-linux-arm64.tar.gz
-rw-r--r-- 1 christian christian 28M May 13 13:53 loki-chaudum-tarball-distribution-bad32d2-linux-arm.tar.gz
-rw-r--r-- 1 christian christian 31M May 13 13:54 loki-chaudum-tarball-distribution-bad32d2-windows-amd64.tar.gz
```

The file name convention is as follows:

```
loki-${version}-${os}-${arch}.tar.gz
```

where `${version}` is the output of `./tools/image-tag`, that is either a version (`v2.5.0`) or a commit hash.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
