### PR TITLE
LogQL: add the `default` sprig template function to logql label/line formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging
 * [4865](https://github.com/grafana/loki/pull/4865) **taisho6339**: Fix duplicate registry.MustRegister call in Promtail Kafka
 * [4845](https://github.com/grafana/loki/pull/4845) **chaudum** Return error responses consistently as JSON
-* [](https://github.com/grafana/loki/pull/) **jburnham**: Add `default` sprig template function in logql label/line formatter
+* [](https://github.com/grafana/loki/pull/) **jburnham**: LogQL: add `default` sprig template function in logql label/line formatter
 ## Unreleased
 
 ### All Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [4860](https://github.com/grafana/loki/pull/4860) **cyriltovena**: Add rate limiting and metrics to hedging
 * [4865](https://github.com/grafana/loki/pull/4865) **taisho6339**: Fix duplicate registry.MustRegister call in Promtail Kafka
 * [4845](https://github.com/grafana/loki/pull/4845) **chaudum** Return error responses consistently as JSON
+* [](https://github.com/grafana/loki/pull/) **jburnham**: Add `default` sprig template function in logql label/line formatter
 ## Unreleased
 
 ### All Changes

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -666,3 +666,17 @@ Example of a query to filter Loki querier jobs which create time is 1 day before
 ```logql
 {job="loki/querier"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff="{{sub .nowEpoch .createDateEpoch}}" | dateTimeDiff > 86400
 ```
+
+## default
+
+`default` checks whether the string is set, and returns default if not set.
+
+Signature: `default(d string,src string) string`
+
+Examples:
+
+```template
+{{ .http_request_headers_x_forwarded_for | default "-" }}
+{{ default "-" "" }} // output: -
+{{ default "-" "foo" }} // output: foo
+```

--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -84,6 +84,7 @@ var (
 		"toDate",
 		"now",
 		"unixEpoch",
+		"default",
 	}
 )
 

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -265,6 +265,14 @@ func Test_lineFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "bar", Value: "2"}},
 			[]byte("1"),
 		},
+		{
+			"default",
+			newMustLineFormatter(`{{.foo | default "-" }}{{.bar | default "-"}}{{.unknown | default "-"}}`),
+			labels.Labels{{Name: "foo", Value: "blip"}, {Name: "bar", Value: ""}},
+			[]byte("blip--"),
+			labels.Labels{{Name: "foo", Value: "blip"}, {Name: "bar", Value: ""}},
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -324,6 +332,14 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("status", "{{div .status 100 }}")}),
 			labels.Labels{{Name: "status", Value: "200"}},
 			labels.Labels{{Name: "status", Value: "2"}},
+		},
+		{
+			"default",
+			mustNewLabelsFormatter([]LabelFmt{
+				NewTemplateLabelFmt("blip", `{{.foo | default "-" }} and {{.bar}}`),
+			}),
+			labels.Labels{{Name: "bar", Value: "blop"}},
+			labels.Labels{{Name: "blip", Value: "- and blop"}, {Name: "bar", Value: "blop"}},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**:
With the `default` sprig template function, we will be able to make it easier to output a default value if the source string is otherwise empty. Useful for json fields that can be missing, like HTTP headers in a log line that aren't required as in the following:

```
{job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`
```

Previously this could only be done (that I found) with the much more verbose
```
{{regexReplaceAllLiteral "^$" .http_request_headers_x_forwarded_for "-"}}
```

**Checklist**
- [X] Documentation added
- [X] Tests updated
- [X] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.

