### PR TITLE
specify logcli authorization header by flag

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -244,7 +244,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
 	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("0").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
-	app.Flag("auth-header", "The authorization header used.").Default("Authorization").Envar("AUTH_HEADER").StringVar(&client.AuthHeader)
+	app.Flag("auth-header", "The authorization header used.").Default("Authorization").Envar("LOKI_AUTH_HEADER").StringVar(&client.AuthHeader)
 
 	return client
 }

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -244,6 +244,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
 	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("0").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
+	app.Flag("auth-header", "The authorization header used.").Default("Authorization").Envar("AUTH_HEADER").StringVar(&client.AuthHeader)
 
 	return client
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	queryPath       = "/loki/api/v1/query"
-	queryRangePath  = "/loki/api/v1/query_range"
-	labelsPath      = "/loki/api/v1/labels"
-	labelValuesPath = "/loki/api/v1/label/%s/values"
-	seriesPath      = "/loki/api/v1/series"
-	tailPath        = "/loki/api/v1/tail"
+	queryPath         = "/loki/api/v1/query"
+	queryRangePath    = "/loki/api/v1/query_range"
+	labelsPath        = "/loki/api/v1/labels"
+	labelValuesPath   = "/loki/api/v1/label/%s/values"
+	seriesPath        = "/loki/api/v1/series"
+	tailPath          = "/loki/api/v1/tail"
+	defaultAuthHeader = "Authorization"
 )
 
 var userAgent = fmt.Sprintf("loki-logcli/%s", build.Version)
@@ -238,7 +239,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 
 	if c.Username != "" && c.Password != "" {
 		if c.AuthHeader == "" {
-			c.AuthHeader = "Authorization"
+			c.AuthHeader = defaultAuthHeader
 		}
 		h.Set(
 			c.AuthHeader,
@@ -266,7 +267,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 
 	if c.BearerToken != "" {
 		if c.AuthHeader == "" {
-			c.AuthHeader = "Authorization"
+			c.AuthHeader = defaultAuthHeader
 		}
 
 		h.Set(c.AuthHeader, "Bearer "+c.BearerToken)
@@ -279,7 +280,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 		}
 		bearerToken := strings.TrimSpace(string(b))
 		if c.AuthHeader == "" {
-			c.AuthHeader = "Authorization"
+			c.AuthHeader = defaultAuthHeader
 		}
 		h.Set(c.AuthHeader, "Bearer "+bearerToken)
 	}

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -237,6 +237,9 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	h := make(http.Header)
 
 	if c.Username != "" && c.Password != "" {
+		if c.AuthHeader == "" {
+			c.AuthHeader = "Authorization"
+		}
 		h.Set(
 			c.AuthHeader,
 			"Basic "+base64.StdEncoding.EncodeToString([]byte(c.Username+":"+c.Password)),
@@ -262,6 +265,10 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	}
 
 	if c.BearerToken != "" {
+		if c.AuthHeader == "" {
+			c.AuthHeader = "Authorization"
+		}
+
 		h.Set(c.AuthHeader, "Bearer "+c.BearerToken)
 	}
 
@@ -271,6 +278,9 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", c.BearerTokenFile, err)
 		}
 		bearerToken := strings.TrimSpace(string(b))
+		if c.AuthHeader == "" {
+			c.AuthHeader = "Authorization"
+		}
 		h.Set(c.AuthHeader, "Bearer "+bearerToken)
 	}
 	return h, nil

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -58,6 +58,7 @@ type DefaultClient struct {
 	BearerTokenFile string
 	Retries         int
 	QueryTags       string
+	AuthHeader      string
 }
 
 // Query uses the /api/v1/query endpoint to execute an instant query
@@ -237,7 +238,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 
 	if c.Username != "" && c.Password != "" {
 		h.Set(
-			"Authorization",
+			c.AuthHeader,
 			"Basic "+base64.StdEncoding.EncodeToString([]byte(c.Username+":"+c.Password)),
 		)
 	}
@@ -261,7 +262,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	}
 
 	if c.BearerToken != "" {
-		h.Set("Authorization", "Bearer "+c.BearerToken)
+		h.Set(c.AuthHeader, "Bearer "+c.BearerToken)
 	}
 
 	if c.BearerTokenFile != "" {
@@ -270,7 +271,7 @@ func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", c.BearerTokenFile, err)
 		}
 		bearerToken := strings.TrimSpace(string(b))
-		h.Set("Authorization", "Bearer "+bearerToken)
+		h.Set(c.AuthHeader, "Bearer "+bearerToken)
 	}
 	return h, nil
 }


### PR DESCRIPTION
Add logcli flag auth-header to be able to specify authorization header name.

What this PR does / why we need it:
Adds a flag auth-header which defaults to Authorization.

Which issue(s) this PR fixes:
Fixes https://github.com/grafana/loki/issues/6143

Special notes for your reviewer:
Change has no side effects on existing users unless they use the new flag auth-header.

Checklist

Documentation added
Tests updated
Is this an important fix or new feature? Add an entry in the CHANGELOG.md.
Changes that require user attention or interaction to upgrade are documented in docs/sources/upgrading/_index.md