### PR TITLE
fix auth header env variable usage help

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -244,7 +244,7 @@ func newQueryClient(app *kingpin.Application) client.Client {
 	app.Flag("bearer-token", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN env var.").Default("").Envar("LOKI_BEARER_TOKEN").StringVar(&client.BearerToken)
 	app.Flag("bearer-token-file", "adds the Authorization header to API requests for authentication purposes. Can also be set using LOKI_BEARER_TOKEN_FILE env var.").Default("").Envar("LOKI_BEARER_TOKEN_FILE").StringVar(&client.BearerTokenFile)
 	app.Flag("retries", "How many times to retry each query when getting an error response from Loki. Can also be set using LOKI_CLIENT_RETRIES").Default("0").Envar("LOKI_CLIENT_RETRIES").IntVar(&client.Retries)
-	app.Flag("auth-header", "The authorization header used.").Default("Authorization").Envar("LOKI_AUTH_HEADER").StringVar(&client.AuthHeader)
+	app.Flag("auth-header", "The authorization header used. Can also be set using LOKI_AUTH_HEADER").Default("Authorization").Envar("LOKI_AUTH_HEADER").StringVar(&client.AuthHeader)
 
 	return client
 }


### PR DESCRIPTION
Fix logcli  auth-header env variable LOKI_AUTH_HEADER.

What this PR does / why we need it:
Makes the help consistent with other help. I'm sorry to not have spotted it earlier.

Which issue(s) this PR fixes:
Fixes https://github.com/grafana/loki/issues/6143

Special notes for your reviewer:
Sorry for the small pr... @kavirajk  

Checklist

Documentation added
Tests updated
Is this an important fix or new feature? Add an entry in the CHANGELOG.md.
Changes that require user attention or interaction to upgrade are documented in docs/sources/upgrading/_index.md