### PR TITLE
fix(querier): Record `result` length after response validation.

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -213,8 +213,12 @@ func (q *QuerierAPI) LabelHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := q.querier.Label(r.Context(), req)
 	queueTime, _ := ctx.Value(httpreq.QueryQueueTimeHTTPHeader).(time.Duration)
 
+	resLength := 0
+	if resp != nil {
+		resLength = len(resp.Values)
+	}
 	// record stats about the label query
-	statResult := statsCtx.Result(time.Since(start), queueTime, len(resp.Values))
+	statResult := statsCtx.Result(time.Since(start), queueTime, resLength)
 	statResult.Log(level.Debug(log))
 
 	status := 200
@@ -381,8 +385,13 @@ func (q *QuerierAPI) SeriesHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := q.querier.Series(r.Context(), req)
 	queueTime, _ := ctx.Value(httpreq.QueryQueueTimeHTTPHeader).(time.Duration)
 
+	resLength := 0
+	if resp != nil {
+		resLength = len(resp.Series)
+	}
+
 	// record stats about the label query
-	statResult := statsCtx.Result(time.Since(start), queueTime, len(resp.Series))
+	statResult := statsCtx.Result(time.Since(start), queueTime, resLength)
 	statResult.Log(level.Debug(log))
 
 	status := 200


### PR DESCRIPTION

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Without this fix, it causes panic, if series or label endpoint returns error.

**Which issue(s) this PR fixes**:
Fixes NA

**Special notes for your reviewer**:
@sandeepsukhani found querier panics in one of our internal Loki cluster because of this bug.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
