### PR TITLE
Fix typo in operator/docs/hack_operator_make_run.md

### DIFF
--- a/operator/docs/hack_operator_make_run.md
+++ b/operator/docs/hack_operator_make_run.md
@@ -30,7 +30,7 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
 * Create a minio deployment in the cluster using:
 
   ```console
-  kubectl apply -f config/overlays/development/minio
+  kubectl apply -k config/overlays/development/minio
   ```
 
   This creates minio's  `deployment`, `service`, `pvc` and `secret` in the `default` namespace.


### PR DESCRIPTION
Original command tries to apply kustomization.yaml which gives a validation error.
```
    kubectl apply -f config/overlays/development/minio 
```
Replaced with the -k version, which runs kuztomize:
```
    kubectl apply -k config/overlays/development/minio
```