### PR TITLE
strips out tenant label from LabelNames queries

### DIFF
--- a/pkg/storage/stores/tsdb/multitenant.go
+++ b/pkg/storage/stores/tsdb/multitenant.go
@@ -26,7 +26,7 @@ func NewMultiTenantIndex(idx Index) *MultiTenantIndex {
 	return &MultiTenantIndex{idx: idx}
 }
 
-func withTenantLabel(userID string, matchers []*labels.Matcher) []*labels.Matcher {
+func withTenantLabelMatcher(userID string, matchers []*labels.Matcher) []*labels.Matcher {
 	cpy := make([]*labels.Matcher, len(matchers))
 	copy(cpy, matchers)
 	cpy = append(cpy, labels.MustNewMatcher(labels.MatchEqual, TenantLabel, userID))
@@ -52,11 +52,11 @@ func (m *MultiTenantIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilter
 func (m *MultiTenantIndex) Close() error { return m.idx.Close() }
 
 func (m *MultiTenantIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	return m.idx.GetChunkRefs(ctx, userID, from, through, res, shard, withTenantLabel(userID, matchers)...)
+	return m.idx.GetChunkRefs(ctx, userID, from, through, res, shard, withTenantLabelMatcher(userID, matchers)...)
 }
 
 func (m *MultiTenantIndex) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
-	xs, err := m.idx.Series(ctx, userID, from, through, res, shard, withTenantLabel(userID, matchers)...)
+	xs, err := m.idx.Series(ctx, userID, from, through, res, shard, withTenantLabelMatcher(userID, matchers)...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (m *MultiTenantIndex) Series(ctx context.Context, userID string, from, thro
 }
 
 func (m *MultiTenantIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	res, err := m.idx.LabelNames(ctx, userID, from, through, withTenantLabel(userID, matchers)...)
+	res, err := m.idx.LabelNames(ctx, userID, from, through, withTenantLabelMatcher(userID, matchers)...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,5 +82,9 @@ func (m *MultiTenantIndex) LabelNames(ctx context.Context, userID string, from, 
 }
 
 func (m *MultiTenantIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	return m.idx.LabelValues(ctx, userID, from, through, name, withTenantLabel(userID, matchers)...)
+	// Prevent queries for the internal tenant label
+	if name == TenantLabel {
+		return nil, nil
+	}
+	return m.idx.LabelValues(ctx, userID, from, through, name, withTenantLabelMatcher(userID, matchers)...)
 }


### PR DESCRIPTION
This PR prevents sending the internal tenant label used in `LabelNames` queries. This label is only used to pack multiple tenants into a single TSDB index until we compact to multitenant ones.

ref https://github.com/grafana/loki/issues/5428