### PR TITLE
Use fake credentials in storage/chunk/storage tests

### DIFF
--- a/pkg/storage/chunk/client/gcp/fixtures.go
+++ b/pkg/storage/chunk/client/gcp/fixtures.go
@@ -83,7 +83,10 @@ func (f *fixture) Clients() (
 
 	if f.gcsObjectClient {
 		var c *GCSObjectClient
-		c, err = newGCSObjectClient(ctx, GCSConfig{BucketName: "chunks"}, hedging.Config{}, func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
+		c, err = newGCSObjectClient(ctx, GCSConfig{
+			BucketName: "chunks",
+			Insecure:   true,
+		}, hedging.Config{}, func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
 			return f.gcssrv.Client(), nil
 		})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the storage tests to pass when building loki 2.5.0 for Arch Linux.

**Which issue(s) this PR fixes**:
Fixes #6185

**Special notes for your reviewer**:
Please double check that this only affects tests and doesn't have any unintentional side effects.

**Checklist**
- [N/A] Documentation added
- [N/A] Tests updated
- [N/A] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [N/A] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
