### PR TITLE
Fix flaky gRPC server shutdown in tests

### DIFF
--- a/pkg/storage/stores/shipper/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/gateway_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -115,7 +114,7 @@ func createTestGrpcServer(t *testing.T) (func(), string) {
 	indexgatewaypb.RegisterIndexGatewayServer(s, &server)
 	go func() {
 		if err := s.Serve(lis); err != nil {
-			log.Fatalf("Failed to serve: %v", err)
+			t.Logf("Failed to serve: %v", err)
 		}
 	}()
 

--- a/pkg/storage/stores/shipper/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/gateway_client_test.go
@@ -118,16 +118,13 @@ func createTestGrpcServer(t *testing.T) (func(), string) {
 			log.Fatalf("Failed to serve: %v", err)
 		}
 	}()
-	cleanup := func() {
-		s.GracefulStop()
-	}
 
-	return cleanup, lis.Addr().String()
+	return s.GracefulStop, lis.Addr().String()
 }
 
 func TestGatewayClient(t *testing.T) {
 	cleanup, storeAddress := createTestGrpcServer(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	var cfg IndexGatewayClientConfig
 	cfg.Mode = indexgateway.SimpleMode
@@ -313,7 +310,7 @@ func Benchmark_QueriesMatchingLargeNumOfRows(b *testing.B) {
 func TestDoubleRegistration(t *testing.T) {
 	r := prometheus.NewRegistry()
 	cleanup, storeAddress := createTestGrpcServer(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	_, err := NewGatewayClient(IndexGatewayClientConfig{
 		Address: storeAddress,


### PR DESCRIPTION
Do not report an error on shutting down the test gRPC server as test failure.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
