### PR TITLE
copy all the fixes/improvements that went into boltdb-shipper that are missing from generic index-shipper

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -3,7 +3,6 @@ package downloads
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/loki/pkg/util/spanlogger"
 	"io/ioutil"
 	"path/filepath"
 	"sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
 	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/grafana/loki/pkg/util/spanlogger"
 )
 
 // timeout for downloading initial files for a table to avoid leaking resources by allowing it to take all the time.

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -3,6 +3,7 @@ package downloads
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/loki/pkg/util/spanlogger"
 	"io/ioutil"
 	"path/filepath"
 	"sync"
@@ -143,7 +144,7 @@ func (t *table) Close() {
 func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	// iterate through both user and common index
 	for _, uid := range []string{userID, ""} {
-		indexSet, err := t.getOrCreateIndexSet(uid, true)
+		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
 		if err != nil {
 			return err
 		}
@@ -191,7 +192,8 @@ func (t *table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string 
 		}
 	}
 
-	if commonIndexSetExpired {
+	// common index set should expire only after all the user index sets have expired.
+	if commonIndexSetExpired && len(expiredIndexSets) == len(t.indexSets)-1 {
 		expiredIndexSets = append(expiredIndexSets, "")
 	}
 
@@ -207,6 +209,13 @@ func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) 
 		t.indexSetsMtx.Lock()
 		defer t.indexSetsMtx.Unlock()
 		for _, userID := range indexSetsToCleanup {
+			// additional check for cleaning up the common index set when it is the only one left.
+			// This is just for safety because the index sets could change between findExpiredIndexSets and the actual cleanup.
+			if userID == "" && len(t.indexSets) != 1 {
+				level.Info(t.logger).Log("msg", "skipping cleanup of common index set because we possibly have unexpired user index sets left")
+				continue
+			}
+
 			level.Info(t.logger).Log("msg", fmt.Sprintf("cleaning up expired index set %s", userID))
 			err := t.indexSets[userID].DropAllDBs()
 			if err != nil {
@@ -243,7 +252,7 @@ func (t *table) Sync(ctx context.Context) error {
 // Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
 // forQuerying must be set to true only getting the index for querying since
 // it captures the amount of time it takes to download the index at query time.
-func (t *table) getOrCreateIndexSet(id string, forQuerying bool) (IndexSet, error) {
+func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying bool) (IndexSet, error) {
 	t.indexSetsMtx.RLock()
 	indexSet, ok := t.indexSets[id]
 	t.indexSetsMtx.RUnlock()
@@ -278,8 +287,9 @@ func (t *table) getOrCreateIndexSet(id string, forQuerying bool) (IndexSet, erro
 		if forQuerying {
 			start := time.Now()
 			defer func() {
-				duration := time.Since(start).Seconds()
-				level.Info(loggerWithUserID(t.logger, id)).Log("msg", "downloaded index set at query time", "duration", duration)
+				duration := time.Since(start)
+				logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
+				level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
 			}()
 		}
 
@@ -295,7 +305,7 @@ func (t *table) getOrCreateIndexSet(id string, forQuerying bool) (IndexSet, erro
 // EnsureQueryReadiness ensures that we have downloaded the common index as well as user index for the provided userIDs.
 // When ensuring query readiness for a table, we will always download common index set because it can include index for one of the provided user ids.
 func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
-	commonIndexSet, err := t.getOrCreateIndexSet("", false)
+	commonIndexSet, err := t.getOrCreateIndexSet(ctx, "", false)
 	if err != nil {
 		return err
 	}
@@ -323,7 +333,7 @@ func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) erro
 // downloadUserIndexes downloads user specific index files concurrently.
 func (t *table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
 	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
-		indexSet, err := t.getOrCreateIndexSet(userIDs[idx], false)
+		indexSet, err := t.getOrCreateIndexSet(ctx, userIDs[idx], false)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -89,27 +89,38 @@ func (tm *tableManager) AddIndex(tableName, userID string, index index.Index) er
 	return tm.getOrCreateTable(tableName).AddIndex(userID, index)
 }
 
-func (tm *tableManager) getOrCreateTable(tableName string) Table {
+func (tm *tableManager) getTable(tableName string) (Table, bool) {
 	tm.tablesMtx.RLock()
+	defer tm.tablesMtx.RUnlock()
+
 	table, ok := tm.tables[tableName]
-	tm.tablesMtx.RUnlock()
+	return table, ok
+}
 
+func (tm *tableManager) getOrCreateTable(tableName string) Table {
+	table, ok := tm.getTable(tableName)
+	if ok {
+		return table
+	}
+
+	tm.tablesMtx.Lock()
+	defer tm.tablesMtx.Unlock()
+
+	table, ok = tm.tables[tableName]
 	if !ok {
-		tm.tablesMtx.Lock()
-		defer tm.tablesMtx.Unlock()
-
-		table, ok = tm.tables[tableName]
-		if !ok {
-			table = NewTable(tableName, tm.storageClient)
-			tm.tables[tableName] = table
-		}
+		table = NewTable(tableName, tm.storageClient)
+		tm.tables[tableName] = table
 	}
 
 	return table
 }
 
 func (tm *tableManager) ForEach(tableName, userID string, callback index.ForEachIndexCallback) error {
-	table := tm.getOrCreateTable(tableName)
+	table, ok := tm.getTable(tableName)
+	if !ok {
+		return nil
+	}
+
 	return table.ForEach(userID, callback)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A couple of fixes/improvements have been made in `boltdb-shipper`, which have not made their way to `index-shipper`.
This PR adds them before I start making `boltdb-shipper` client use `index-shipper`.
