### PR TITLE
creates a single tsdb for entire wal recovery

### DIFF
--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -176,51 +176,36 @@ func (m *HeadManager) Start() error {
 	}
 
 	now := time.Now()
-	curPeriod := m.period.PeriodFor(now)
-
 	walsByPeriod, err := walsByPeriod(m.dir, m.period)
 	if err != nil {
 		return err
 	}
 	level.Info(m.log).Log("msg", "loaded wals by period", "groups", len(walsByPeriod))
 
-	m.activeHeads = newTenantHeads(now, m.shards, m.metrics, m.log)
-
 	// Load the shipper with any previously built TSDBs
 	if err := m.tsdbManager.Start(); err != nil {
 		return errors.Wrap(err, "failed to start tsdb manager")
 	}
 
-	// Build any old WALs into TSDBs for the shipper
+	// Build any old WALs into a TSDB for the shipper
+	var allWALs []WALIdentifier
 	for _, group := range walsByPeriod {
-		if group.period < curPeriod {
-			if err := m.tsdbManager.BuildFromWALs(
-				m.period.TimeForPeriod(group.period),
-				group.wals,
-			); err != nil {
-				return errors.Wrap(err, "building tsdb")
-			}
-			// Now that we've built tsdbs of this data, we can safely remove the WALs
-			if err := m.removeWALGroup(group); err != nil {
-				return errors.Wrapf(err, "removing wals for period %d", group.period)
-			}
-		}
-
-		if group.period >= curPeriod {
-			if err := recoverHead(m.dir, m.activeHeads, group.wals); err != nil {
-				return errors.Wrap(err, "recovering tsdb head from wal")
-			}
-		}
+		allWALs = append(allWALs, group.wals...)
 	}
 
-	nextWALPath := walPath(m.dir, now)
-	nextWAL, err := newHeadWAL(m.log, nextWALPath, now)
-	if err != nil {
-		return errors.Wrapf(err, "creating tsdb wal: %s", nextWALPath)
+	curPeriod := m.period.PeriodFor(now)
+	if err := m.tsdbManager.BuildFromWALs(
+		m.period.TimeForPeriod(curPeriod),
+		allWALs,
+	); err != nil {
+		return errors.Wrap(err, "building tsdb")
 	}
-	m.active = nextWAL
 
-	return nil
+	if err := os.RemoveAll(managerWalDir(m.dir)); err != nil {
+		return errors.New("cleaning (removing) wal dir")
+	}
+
+	return m.Rotate(now)
 }
 
 func managerRequiredDirs(parent string) []string {

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -175,7 +175,6 @@ func (m *HeadManager) Start() error {
 		}
 	}
 
-	now := time.Now()
 	walsByPeriod, err := walsByPeriod(m.dir, m.period)
 	if err != nil {
 		return err
@@ -193,9 +192,9 @@ func (m *HeadManager) Start() error {
 		allWALs = append(allWALs, group.wals...)
 	}
 
-	curPeriod := m.period.PeriodFor(now)
+	now := time.Now()
 	if err := m.tsdbManager.BuildFromWALs(
-		m.period.TimeForPeriod(curPeriod),
+		now,
 		allWALs,
 	); err != nil {
 		return errors.Wrap(err, "building tsdb")

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -19,10 +19,22 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
-type noopTSDBManager struct{ NoopIndex }
+type noopTSDBManager struct {
+	dir string
+	*tenantHeads
+}
 
-func (noopTSDBManager) BuildFromWALs(_ time.Time, _ []WALIdentifier) error { return nil }
-func (noopTSDBManager) Start() error                                       { return nil }
+func newNoopTSDBManager(dir string) noopTSDBManager {
+	return noopTSDBManager{
+		dir:         dir,
+		tenantHeads: newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger()),
+	}
+}
+
+func (m noopTSDBManager) BuildFromWALs(_ time.Time, wals []WALIdentifier) error {
+	return recoverHead(m.dir, m.tenantHeads, wals)
+}
+func (m noopTSDBManager) Start() error { return nil }
 
 func chunkMetasToChunkRefs(user string, fp uint64, xs index.ChunkMetas) (res []ChunkRef) {
 	for _, x := range xs {
@@ -154,7 +166,7 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 		},
 	}
 
-	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, noopTSDBManager{})
+	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, newNoopTSDBManager(dir))
 	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 	// so ensure our dirs exist
 	for _, d := range managerRequiredDirs(dir) {
@@ -237,7 +249,7 @@ func Test_HeadManager_Lifecycle(t *testing.T) {
 		},
 	}
 
-	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, noopTSDBManager{})
+	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, newNoopTSDBManager(dir))
 	w, err := newHeadWAL(log.NewNopLogger(), walPath(mgr.dir, curPeriod), curPeriod)
 	require.Nil(t, err)
 


### PR DESCRIPTION
This simplifies our TSDB WAL replay to build a single TSDB rather than a TSDB per rotation period (15m) on restart. It also fixes a bug during replay where the WALs for a new rotation period didn't include the series reference (likely in a previous period).

It also builds TSDBs during replay with un-rounded timestamps to avoid clobbering in the case of multiple replays (crashlooping) in the same rotation period (15m)

ref https://github.com/grafana/loki/issues/5428