### PR TITLE
prevents sharding avg and avg_over_time for unshardable children

### DIFF
--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -255,6 +255,14 @@ func TestMappingStrings(t *testing.T) {
 				)
 			)`,
 		},
+		{
+			in:  `avg(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]))`,
+			out: `avg(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]))`,
+		},
+		{
+			in:  `avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m])`,
+			out: `avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m])`,
+		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)


### PR DESCRIPTION
This fixes a bug in query planning which didn't check if the child-expressions of `avg` were shardable, which led to some `unimplemented` errors on the frontend. It's pretty unlikely to run into this (i.e. `avg(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]))`).

I've run this in a dev cluster as well, everything looking :+1: .

In the future, we can consider mapping `avg_over_time` -> `sum_over_time / count_over_time` :thinking: 

Closes https://github.com/grafana/loki/issues/6202