### PR TITLE
docs: Fix broken link from unpack parser to pack stage

### DIFF
--- a/docs/sources/clients/promtail/stages/pack.md
+++ b/docs/sources/clients/promtail/stages/pack.md
@@ -57,7 +57,7 @@ This would create a log line
 }
 ```
 
-**Loki 2.2 also includes a new [`unpack`](../../../../logql/log_queries/#unpack) parser to work with the pack stage.**
+**Loki 2.2 also includes a new [`unpack` parser]({{< relref "../../../logql/log_queries.md#unpack" >}}) to work with the pack stage.**
 
 For example:
 

--- a/docs/sources/logql/log_queries.md
+++ b/docs/sources/logql/log_queries.md
@@ -476,7 +476,7 @@ those labels:
 
 #### unpack
 
-The `unpack` parser parses a JSON log line, unpacking all embedded labels in the [`pack`](../clients/promtail/stages/pack/) stage.
+The `unpack` parser parses a JSON log line, unpacking all embedded labels from Promtail's [`pack` stage]({{< relref "../clients/promtail/stages/pack.md" >}}).
 **A special property `_entry` will also be used to replace the original log line**.
 
 For example, using `| unpack` with the log line:


### PR DESCRIPTION
### What this PR does / why we need it

**before**:
![2022-05-20_10-17](https://user-images.githubusercontent.com/281260/169485613-eaf9cc9e-0f33-4e2f-bf70-45da4aebc960.png)

**after**:
![2022-05-20_10-18](https://user-images.githubusercontent.com/281260/169485620-c0f0f627-ffd3-4703-85b8-817cb57b0f21.png)

