### PR TITLE
run store queries in ingester when using tsdb as index store

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -122,7 +122,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.SyncMinUtilization, "ingester.sync-min-utilization", 0, "Minimum utilization of chunk when doing synchronization.")
 	f.IntVar(&cfg.MaxReturnedErrors, "ingester.max-ignored-stream-errors", 10, "Maximum number of ignored stream errors to return. 0 to return all errors.")
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 2*time.Hour, "Maximum chunk age before flushing.")
-	f.DurationVar(&cfg.QueryStoreMaxLookBackPeriod, "ingester.query-store-max-look-back-period", 0, "How far back should an ingester be allowed to query the store for data, for use only with boltdb-shipper index and filesystem object store. -1 for infinite.")
+	f.DurationVar(&cfg.QueryStoreMaxLookBackPeriod, "ingester.query-store-max-look-back-period", 0, "How far back should an ingester be allowed to query the store for data, for use only with boltdb-shipper/tsdb index and filesystem object store. -1 for infinite.")
 	f.BoolVar(&cfg.AutoForgetUnhealthy, "ingester.autoforget-unhealthy", false, "Enable to remove unhealthy ingesters from the ring after `ring.kvstore.heartbeat_timeout`")
 	f.IntVar(&cfg.IndexShards, "ingester.index-shards", index.DefaultIndexShards, "Shard factor used in the ingesters for the in process reverse index. This MUST be evenly divisible by ALL schema shard factors or Loki will not start.")
 	f.IntVar(&cfg.MaxDroppedStreams, "ingester.tailer.max-dropped-streams", 10, "Maximum number of dropped streams to keep in memory during tailing")
@@ -646,18 +646,20 @@ func (i *Ingester) QuerySample(req *logproto.SampleQueryRequest, queryServer log
 	return sendSampleBatches(ctx, it, queryServer)
 }
 
-// boltdbShipperMaxLookBack returns a max look back period only if active index type is boltdb-shipper.
-// max look back is limited to from time of boltdb-shipper config.
-// It considers previous periodic config's from time if that also has index type set to boltdb-shipper.
-func (i *Ingester) boltdbShipperMaxLookBack() time.Duration {
+// asyncStoreMaxLookBack returns a max look back period only if active index type is one of async index stores like `boltdb-shipper` and `tsdb`.
+// max look back is limited to from time of async store config.
+// It considers previous periodic config's from time if that also has async index type.
+// This is to limit the lookback to only async stores where relevant.
+func (i *Ingester) asyncStoreMaxLookBack() time.Duration {
 	activePeriodicConfigIndex := config.ActivePeriodConfig(i.periodicConfigs)
 	activePeriodicConfig := i.periodicConfigs[activePeriodicConfigIndex]
-	if activePeriodicConfig.IndexType != config.BoltDBShipperType {
+	if activePeriodicConfig.IndexType != config.BoltDBShipperType && activePeriodicConfig.IndexType != config.TSDBType {
 		return 0
 	}
 
 	startTime := activePeriodicConfig.From
-	if activePeriodicConfigIndex != 0 && i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == config.BoltDBShipperType {
+	if activePeriodicConfigIndex != 0 && (i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == config.BoltDBShipperType ||
+		i.periodicConfigs[activePeriodicConfigIndex-1].IndexType == config.TSDBType) {
 		startTime = i.periodicConfigs[activePeriodicConfigIndex-1].From
 	}
 
@@ -665,20 +667,20 @@ func (i *Ingester) boltdbShipperMaxLookBack() time.Duration {
 	return maxLookBack
 }
 
-// GetChunkIDs is meant to be used only when using an async store like boltdb-shipper.
+// GetChunkIDs is meant to be used only when using an async store like boltdb-shipper or tsdb.
 func (i *Ingester) GetChunkIDs(ctx context.Context, req *logproto.GetChunkIDsRequest) (*logproto.GetChunkIDsResponse, error) {
 	orgID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	boltdbShipperMaxLookBack := i.boltdbShipperMaxLookBack()
-	if boltdbShipperMaxLookBack == 0 {
+	asyncStoreMaxLookBack := i.asyncStoreMaxLookBack()
+	if asyncStoreMaxLookBack == 0 {
 		return &logproto.GetChunkIDsResponse{}, nil
 	}
 
 	reqStart := req.Start
-	reqStart = adjustQueryStartTime(boltdbShipperMaxLookBack, reqStart, time.Now())
+	reqStart = adjustQueryStartTime(asyncStoreMaxLookBack, reqStart, time.Now())
 
 	// parse the request
 	start, end := errUtil.RoundToMilliseconds(reqStart, req.End)
@@ -726,9 +728,9 @@ func (i *Ingester) Label(ctx context.Context, req *logproto.LabelRequest) (*logp
 		return resp, nil
 	}
 
-	// Only continue if the active index type is boltdb-shipper or QueryStore flag is true.
-	boltdbShipperMaxLookBack := i.boltdbShipperMaxLookBack()
-	if boltdbShipperMaxLookBack == 0 && !i.cfg.QueryStore {
+	// Only continue if the active index type is one of async index store types or QueryStore flag is true.
+	asyncStoreMaxLookBack := i.asyncStoreMaxLookBack()
+	if asyncStoreMaxLookBack == 0 && !i.cfg.QueryStore {
 		return resp, nil
 	}
 
@@ -739,8 +741,8 @@ func (i *Ingester) Label(ctx context.Context, req *logproto.LabelRequest) (*logp
 	}
 
 	maxLookBackPeriod := i.cfg.QueryStoreMaxLookBackPeriod
-	if boltdbShipperMaxLookBack != 0 {
-		maxLookBackPeriod = boltdbShipperMaxLookBack
+	if asyncStoreMaxLookBack != 0 {
+		maxLookBackPeriod = asyncStoreMaxLookBack
 	}
 	// Adjust the start time based on QueryStoreMaxLookBackPeriod.
 	start := adjustQueryStartTime(maxLookBackPeriod, *req.Start, time.Now())

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -406,7 +406,7 @@ func TestIngester_buildStoreRequest(t *testing.T) {
 	}
 }
 
-func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
+func TestIngester_asyncStoreMaxLookBack(t *testing.T) {
 	now := model.Now()
 
 	for _, tc := range []struct {
@@ -415,7 +415,7 @@ func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
 		expectedMaxLookBack time.Duration
 	}{
 		{
-			name: "not using boltdb-shipper",
+			name: "not using async index store",
 			periodicConfigs: []config.PeriodConfig{
 				{
 					From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
@@ -434,7 +434,17 @@ func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
 			expectedMaxLookBack: time.Since(now.Add(-24 * time.Hour).Time()),
 		},
 		{
-			name: "active config boltdb-shipper, previous config non boltdb-shipper",
+			name: "just one periodic config with tsdb",
+			periodicConfigs: []config.PeriodConfig{
+				{
+					From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
+					IndexType: "tsdb",
+				},
+			},
+			expectedMaxLookBack: time.Since(now.Add(-24 * time.Hour).Time()),
+		},
+		{
+			name: "active config boltdb-shipper, previous config non async index store",
 			periodicConfigs: []config.PeriodConfig{
 				{
 					From:      config.DayTime{Time: now.Add(-48 * time.Hour)},
@@ -448,7 +458,7 @@ func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
 			expectedMaxLookBack: time.Since(now.Add(-24 * time.Hour).Time()),
 		},
 		{
-			name: "current and previous config both using boltdb-shipper",
+			name: "current and previous config both using async index store",
 			periodicConfigs: []config.PeriodConfig{
 				{
 					From:      config.DayTime{Time: now.Add(-48 * time.Hour)},
@@ -456,17 +466,17 @@ func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
 				},
 				{
 					From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
-					IndexType: "boltdb-shipper",
+					IndexType: "tsdb",
 				},
 			},
 			expectedMaxLookBack: time.Since(now.Add(-48 * time.Hour).Time()),
 		},
 		{
-			name: "active config non boltdb-shipper, previous config boltdb-shipper",
+			name: "active config non async index store, previous config tsdb",
 			periodicConfigs: []config.PeriodConfig{
 				{
 					From:      config.DayTime{Time: now.Add(-48 * time.Hour)},
-					IndexType: "boltdb-shipper",
+					IndexType: "tsdb",
 				},
 				{
 					From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
@@ -477,7 +487,7 @@ func TestIngester_boltdbShipperMaxLookBack(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ingester := Ingester{periodicConfigs: tc.periodicConfigs}
-			mlb := ingester.boltdbShipperMaxLookBack()
+			mlb := ingester.asyncStoreMaxLookBack()
 			require.InDelta(t, tc.expectedMaxLookBack, mlb, float64(time.Second))
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
We do local store queries from ingester when running `boltdb-shipper` to include recently flushed data that queriers/index-gateway might not have synced yet. This PR makes it work for `tsdb` index store as well, without which we will see gaps in data due to missing out on recently flushed logs.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [x] Tests updated