### PR TITLE
Runtime reloadable config; ring migration setup

### DIFF
--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -1,10 +1,18 @@
 package loki
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/loki/pkg/storage"
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/storage/stores/shipper"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_calculateMaxLookBack(t *testing.T) {
@@ -78,6 +86,104 @@ func Test_calculateMaxLookBack(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("calculateMaxLookBack() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func prepareGlobalMetricsRegistry(t *testing.T) {
+	oldReg, oldGat := prometheus.DefaultRegisterer, prometheus.DefaultGatherer
+
+	reg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer, prometheus.DefaultGatherer = reg, reg
+
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer, prometheus.DefaultGatherer = oldReg, oldGat
+	})
+}
+
+func TestMultiKVSetup(t *testing.T) {
+	dir := t.TempDir()
+
+	for target, checkFn := range map[string]func(t *testing.T, c Config){
+		All: func(t *testing.T, c Config) {
+			require.NotNil(t, c.CompactorConfig.CompactorRing.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.Distributor.DistributorRing.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.IndexGateway.Ring.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.QueryScheduler.SchedulerRing.KVStore.Multi.ConfigProvider)
+			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
+		},
+
+		Compactor: func(t *testing.T, c Config) {
+			require.NotNil(t, c.CompactorConfig.CompactorRing.KVStore.Multi.ConfigProvider)
+		},
+
+		Distributor: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider)
+		},
+
+		IndexGateway: func(t *testing.T, c Config) {
+			require.NotNil(t, c.IndexGateway.Ring.KVStore.Multi.ConfigProvider)
+		},
+
+		Ingester: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider)
+		},
+
+		QueryScheduler: func(t *testing.T, c Config) {
+			require.NotNil(t, c.QueryScheduler.SchedulerRing.KVStore.Multi.ConfigProvider)
+		},
+
+		Ruler: func(t *testing.T, c Config) {
+			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
+		},
+	} {
+		t.Run(target, func(t *testing.T) {
+			prepareGlobalMetricsRegistry(t)
+
+			cfg := Config{}
+			cfg.SchemaConfig = config.SchemaConfig{
+				Configs: []config.PeriodConfig{
+					{
+						IndexType:  "inmemory",
+						ObjectType: "filesystem",
+						RowShards:  16,
+						Schema:     "v11",
+						From: config.DayTime{
+							Time: model.Now(),
+						},
+					},
+				},
+			}
+			flagext.DefaultValues(&cfg)
+			// Set to 0 to find any free port.
+			cfg.Server.HTTPListenPort = 0
+			cfg.Server.GRPCListenPort = 0
+			cfg.Target = []string{target}
+
+			// Must be set, otherwise MultiKV config provider will not be set.
+			cfg.RuntimeConfig.LoadPath = filepath.Join(dir, "config.yaml")
+
+			// This would be overwritten by the default values setting.
+			cfg.StorageConfig = storage.Config{
+				FSConfig: local.FSConfig{Directory: dir},
+				BoltDBShipperConfig: shipper.Config{
+					SharedStoreType:      "filesystem",
+					ActiveIndexDirectory: dir,
+					CacheLocation:        dir,
+					Mode:                 shipper.ModeWriteOnly},
+			}
+			cfg.Ruler.Config.StoreConfig.Type = "local"
+			cfg.Ruler.Config.StoreConfig.Local.Directory = dir
+
+			c, err := New(cfg)
+			require.NoError(t, err)
+
+			_, err = c.ModuleManager.InitModuleServices(cfg.Target...)
+			require.NoError(t, err)
+			defer c.Server.Stop()
+
+			checkFn(t, c.Cfg)
 		})
 	}
 }

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -6,13 +6,15 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/shipper"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_calculateMaxLookBack(t *testing.T) {
@@ -145,8 +147,8 @@ func TestMultiKVSetup(t *testing.T) {
 			cfg.SchemaConfig = config.SchemaConfig{
 				Configs: []config.PeriodConfig{
 					{
-						IndexType:  "inmemory",
-						ObjectType: "filesystem",
+						IndexType:  config.StorageTypeInMemory,
+						ObjectType: config.StorageTypeFileSystem,
 						RowShards:  16,
 						Schema:     "v11",
 						From: config.DayTime{
@@ -168,12 +170,12 @@ func TestMultiKVSetup(t *testing.T) {
 			cfg.StorageConfig = storage.Config{
 				FSConfig: local.FSConfig{Directory: dir},
 				BoltDBShipperConfig: shipper.Config{
-					SharedStoreType:      "filesystem",
+					SharedStoreType:      config.StorageTypeFileSystem,
 					ActiveIndexDirectory: dir,
 					CacheLocation:        dir,
 					Mode:                 shipper.ModeWriteOnly},
 			}
-			cfg.Ruler.Config.StoreConfig.Type = "local"
+			cfg.Ruler.Config.StoreConfig.Type = config.StorageTypeLocal
 			cfg.Ruler.Config.StoreConfig.Local.Directory = dir
 
 			c, err := New(cfg)

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -36,6 +36,7 @@ const (
 	StorageTypeGCPColumnKey   = "gcp-columnkey"
 	StorageTypeGCS            = "gcs"
 	StorageTypeGrpc           = "grpc-store"
+	StorageTypeLocal          = "local"
 	StorageTypeS3             = "s3"
 	StorageTypeSwift          = "swift"
 	// BoltDBShipperType holds the index type for using boltdb with shipper which keeps flushing them to a shared storage


### PR DESCRIPTION
This adds the few missing pieces of multi KV runtime reloadable config to loki components that use the ring, based on Peters mimir PR [here](https://github.com/grafana/mimir/issues/996). Note that a lot of config was necessary to get the test to pass (many loki components will fail to start/be registered via the modules setup without things like storage config).

cc @JordanRushing @DylanGuedes @pstibrany 