### PR TITLE
Remove __name__ from label calls

### DIFF
--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -95,7 +95,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 	t.Run("label-names", func(t *testing.T) {
 		resp, err := cliQueryFrontend.LabelNames()
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"__name__", "job"}, resp)
+		assert.ElementsMatch(t, []string{"job"}, resp)
 	})
 
 	t.Run("label-values", func(t *testing.T) {

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -62,7 +62,7 @@ func TestSingleBinaryIngestQuery(t *testing.T) {
 	t.Run("label-names", func(t *testing.T) {
 		resp, err := cli.LabelNames()
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"__name__", "job"}, resp)
+		assert.ElementsMatch(t, []string{"job"}, resp)
 	})
 
 	t.Run("label-values", func(t *testing.T) {

--- a/pkg/storage/stores/series/series_index_store.go
+++ b/pkg/storage/stores/series/series_index_store.go
@@ -551,7 +551,6 @@ func (c *indexStore) lookupLabelNamesBySeries(ctx context.Context, from, through
 	level.Debug(log).Log("entries", len(entries))
 
 	var result util.UniqueStrings
-	result.Add(model.MetricNameLabel)
 	for _, entry := range entries {
 		lbs := []string{}
 		err := jsoniter.ConfigFastest.Unmarshal(entry.Value, &lbs)

--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -252,11 +252,11 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 	}{
 		{
 			`foo`,
-			[]string{labels.MetricName, "bar", "flip", "toms"},
+			[]string{"bar", "flip", "toms"},
 		},
 		{
 			`bar`,
-			[]string{labels.MetricName, "bar", "toms"},
+			[]string{"bar", "toms"},
 		},
 	} {
 		for _, schema := range schemas {

--- a/pkg/storage/stores/series/series_store_utils.go
+++ b/pkg/storage/stores/series/series_store_utils.go
@@ -38,6 +38,10 @@ func labelNamesFromChunks(chunks []chunk.Chunk) []string {
 	var result util.UniqueStrings
 	for _, c := range chunks {
 		for _, l := range c.Metric {
+			if l.Name == model.MetricNameLabel {
+				continue
+			}
+
 			result.Add(l.Name)
 		}
 	}


### PR DESCRIPTION
`__name__` wasn't being being applied to `Label` calls when it's not meaningful for user. This PR always filters `__name__` from Label calls.