### PR TITLE
Tsdb/inverted index

### DIFF
--- a/pkg/ingester/index/bitprefix.go
+++ b/pkg/ingester/index/bitprefix.go
@@ -22,7 +22,11 @@ type BitPrefixInvertedIndex struct {
 	shards      []*indexShard
 }
 
-func NewBitPrefixWithShards(totalShards uint32) *BitPrefixInvertedIndex {
+func NewBitPrefixWithShards(totalShards uint32) (*BitPrefixInvertedIndex, error) {
+	if requiredBits := index.NewShard(0, totalShards).RequiredBits(); 1<<requiredBits != totalShards {
+		return nil, fmt.Errorf("Shard factor must be a power of two, got %d", totalShards)
+	}
+
 	shards := make([]*indexShard, totalShards)
 	for i := uint32(0); i < totalShards; i++ {
 		shards[i] = &indexShard{
@@ -33,7 +37,7 @@ func NewBitPrefixWithShards(totalShards uint32) *BitPrefixInvertedIndex {
 	return &BitPrefixInvertedIndex{
 		totalShards: totalShards,
 		shards:      shards,
-	}
+	}, nil
 }
 
 func (ii *BitPrefixInvertedIndex) getShards(shard *astmapper.ShardAnnotation) ([]*indexShard, bool) {

--- a/pkg/ingester/index/bitprefix.go
+++ b/pkg/ingester/index/bitprefix.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 // BitPrefixInvertedIndex is another inverted index implementation

--- a/pkg/ingester/index/bitprefix.go
+++ b/pkg/ingester/index/bitprefix.go
@@ -1,0 +1,235 @@
+package index
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// BitPrefixInvertedIndex is another inverted index implementation
+// that uses the bit prefix sharding algorithm in tsdb/index/shard.go
+// instead of a modulo approach.
+// This is the standard for TSDB compatibility because
+// the same series must resolve to the same shard (for each period config),
+// whether it's resolved on the ingester or via the store.
+type BitPrefixInvertedIndex struct {
+	totalShards uint32
+	shards      []*indexShard
+}
+
+func NewBitPrefixWithShards(totalShards uint32) *BitPrefixInvertedIndex {
+	shards := make([]*indexShard, totalShards)
+	for i := uint32(0); i < totalShards; i++ {
+		shards[i] = &indexShard{
+			idx:   map[string]indexEntry{},
+			shard: i,
+		}
+	}
+	return &BitPrefixInvertedIndex{
+		totalShards: totalShards,
+		shards:      shards,
+	}
+}
+
+func (ii *BitPrefixInvertedIndex) getShards(shard *astmapper.ShardAnnotation) ([]*indexShard, bool) {
+	if shard == nil {
+		return ii.shards, false
+	}
+
+	// When comparing a higher shard factor to a lower inverted index shard factor
+	// we must filter resulting fingerprints as the the lower shard factor in the
+	// inverted index is a superset of the requested factor.
+	//
+	// For instance, the 3_of_4 shard factor maps to the bit prefix 0b11.
+	// If the inverted index only has a factor of 2, we'll need to check the 0b1
+	// prefixed shard (which contains the 0b10 and 0b11 prefixes).
+	// Conversely, if the requested shard is 1_of_2, but the index has a factor of 4,
+	// we can _exactly_ match ob1 => (ob10, ob11) and know all fingerprints in those
+	// resulting shards have the requested ob1 prefix (don't need to filter).
+	var filter bool
+	if shard.Of > len(ii.shards) {
+		filter = true
+	}
+
+	requestedShard := shard.TSDB()
+	minFp, maxFp := requestedShard.Bounds()
+
+	// Determine how many bits we need to take from
+	// the requested shard's min/max fingerprint values
+	// in order to calculate the indices for the inverted index's
+	// shard factor.
+	requiredBits := index.NewShard(0, uint32(len(ii.shards))).RequiredBits()
+	lowerIdx := int(minFp >> (64 - requiredBits))
+	upperIdx := int(maxFp >> (64 - requiredBits))
+
+	// If the upper bound's shard doesn't align exactly
+	// with the maximum fingerprint, we must also
+	// check the subsequent shard.
+	// This happens in two cases:
+	// 1) When requesting the last shard of any factor.
+	// This accounts for zero indexing in our sharding logic
+	// to successfully request `shards[start:len(shards)]`
+	// 2) When requesting the _first_ shard of a larger factor
+	// than the index uses. In this case, the required_bits are not
+	// enough and the requested end prefix gets trimmed.
+	// If confused, comment out this line and see which tests fail.
+	if (upperIdx << (64 - requiredBits)) != int(maxFp) {
+		upperIdx++
+	}
+
+	return ii.shards[lowerIdx:upperIdx], filter
+}
+
+func (ii *BitPrefixInvertedIndex) shardForFP(fp model.Fingerprint) int {
+	localShard := index.NewShard(0, uint32(len(ii.shards)))
+	return int(fp >> (64 - localShard.RequiredBits()))
+}
+
+func (ii *BitPrefixInvertedIndex) validateShard(shard *astmapper.ShardAnnotation) error {
+	if shard == nil {
+		return nil
+	}
+
+	if 1<<(shard.TSDB().RequiredBits()) != shard.Of {
+		return fmt.Errorf("Shard factor must be a power of two, got %d", shard.Of)
+	}
+	return nil
+}
+
+// Add a fingerprint under the specified labels.
+// NOTE: memory for `labels` is unsafe; anything retained beyond the
+// life of this function must be copied
+func (ii *BitPrefixInvertedIndex) Add(labels []logproto.LabelAdapter, fp model.Fingerprint) labels.Labels {
+	// add() returns 'interned' values so the original labels are not retained
+	return ii.shards[ii.shardForFP(fp)].add(labels, fp)
+}
+
+// Lookup all fingerprints for the provided matchers.
+func (ii *BitPrefixInvertedIndex) Lookup(matchers []*labels.Matcher, shard *astmapper.ShardAnnotation) ([]model.Fingerprint, error) {
+	if err := ii.validateShard(shard); err != nil {
+		return nil, err
+	}
+
+	var result []model.Fingerprint
+	shards, filter := ii.getShards(shard)
+
+	// if no matcher is specified, all fingerprints would be returned
+	if len(matchers) == 0 {
+		for i := range shards {
+			fps := shards[i].allFPs()
+			result = append(result, fps...)
+		}
+	} else {
+		for i := range shards {
+			fps := shards[i].lookup(matchers)
+			result = append(result, fps...)
+		}
+	}
+
+	// Because bit prefix order is also ascending order,
+	// the merged fingerprints from ascending shards are also in order.
+	if filter {
+		minFP, maxFP := shard.TSDB().Bounds()
+		minIdx := sort.Search(len(result), func(i int) bool {
+			return result[i] >= minFP
+		})
+
+		maxIdx := sort.Search(len(result), func(i int) bool {
+			return result[i] >= maxFP
+		})
+
+		result = result[minIdx:maxIdx]
+	}
+
+	return result, nil
+}
+
+// LabelNames returns all label names.
+func (ii *BitPrefixInvertedIndex) LabelNames(shard *astmapper.ShardAnnotation) ([]string, error) {
+	if err := ii.validateShard(shard); err != nil {
+		return nil, err
+	}
+
+	var extractor func(unlockIndex) []string
+	shards, filter := ii.getShards(shard)
+
+	// If we need to check shard inclusion, we have to do it the expensive way :(
+	// Therefore it's more performant to request shard factors lower or equal to the
+	// inverted index factor
+	if filter {
+		s := shard.TSDB()
+
+		extractor = func(x unlockIndex) (results []string) {
+
+		outer:
+			for name, entry := range x {
+				for _, valEntry := range entry.fps {
+					for _, fp := range valEntry.fps {
+						if s.Match(fp) {
+							results = append(results, name)
+							continue outer
+						}
+					}
+				}
+			}
+
+			return results
+		}
+	}
+
+	results := make([][]string, 0, len(shards))
+	for i := range shards {
+		shardResult := shards[i].labelNames(extractor)
+		results = append(results, shardResult)
+	}
+
+	return mergeStringSlices(results), nil
+}
+
+// LabelValues returns the values for the given label.
+func (ii *BitPrefixInvertedIndex) LabelValues(name string, shard *astmapper.ShardAnnotation) ([]string, error) {
+	if err := ii.validateShard(shard); err != nil {
+		return nil, err
+	}
+
+	var extractor func(indexEntry) []string
+	shards, filter := ii.getShards(shard)
+	if filter {
+		s := shard.TSDB()
+
+		extractor = func(x indexEntry) []string {
+			results := make([]string, 0, len(x.fps))
+
+		outer:
+			for val, valEntry := range x.fps {
+				for _, fp := range valEntry.fps {
+					if s.Match(fp) {
+						results = append(results, val)
+						continue outer
+					}
+				}
+			}
+			return results
+		}
+	}
+	results := make([][]string, 0, len(shards))
+
+	for i := range shards {
+		shardResult := shards[i].labelValues(name, extractor)
+		results = append(results, shardResult)
+	}
+
+	return mergeStringSlices(results), nil
+}
+
+// Delete a fingerprint with the given label pairs.
+func (ii *BitPrefixInvertedIndex) Delete(labels labels.Labels, fp model.Fingerprint) {
+	localShard := index.NewShard(0, uint32(len(ii.shards)))
+	idx := int(fp >> (64 - localShard.RequiredBits()))
+	ii.shards[idx].delete(labels, fp)
+}

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -5,12 +5,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/querier/astmapper"
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 func Test_BitPrefixGetShards(t *testing.T) {

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -2,50 +2,198 @@ package index
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
+	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBitPrefixGetShards(t *testing.T) {
-	ii := NewBitPrefixWithShards(4)
-	for i, tc := range []struct {
-		shard  *astmapper.ShardAnnotation
-		exp    []*indexShard
-		filter bool
+func Test_BitPrefixGetShards(t *testing.T) {
+	for _, tt := range []struct {
+		total    uint32
+		filter   bool
+		shard    *astmapper.ShardAnnotation
+		expected []uint32
 	}{
-		{
-			shard:  &astmapper.ShardAnnotation{Shard: 0, Of: 2},
-			exp:    ii.shards[:2],
-			filter: false,
-		},
-		{
-			shard:  &astmapper.ShardAnnotation{Shard: 1, Of: 2},
-			exp:    ii.shards[2:],
-			filter: false,
-		},
-		{
-			shard:  &astmapper.ShardAnnotation{Shard: 0, Of: 8},
-			exp:    ii.shards[:1],
-			filter: true,
-		},
-		{
-			shard:  &astmapper.ShardAnnotation{Shard: 1, Of: 8},
-			exp:    ii.shards[:1],
-			filter: true,
-		},
-		{
-			shard:  &astmapper.ShardAnnotation{Shard: 7, Of: 8},
-			exp:    ii.shards[3:],
-			filter: true,
-		},
-	} {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			got, filter := ii.getShards(tc.shard)
-			require.Equal(t, tc.filter, filter)
-			require.Equal(t, tc.exp, got)
+		// equal factors
+		{16, false, &astmapper.ShardAnnotation{Shard: 0, Of: 16}, []uint32{0}},
+		{16, false, &astmapper.ShardAnnotation{Shard: 4, Of: 16}, []uint32{4}},
+		{16, false, &astmapper.ShardAnnotation{Shard: 15, Of: 16}, []uint32{15}},
 
+		// idx factor a larger factor of 2
+		{32, false, &astmapper.ShardAnnotation{Shard: 0, Of: 16}, []uint32{0, 1}},
+		{32, false, &astmapper.ShardAnnotation{Shard: 4, Of: 16}, []uint32{8, 9}},
+		{32, false, &astmapper.ShardAnnotation{Shard: 15, Of: 16}, []uint32{30, 31}},
+		{64, false, &astmapper.ShardAnnotation{Shard: 15, Of: 16}, []uint32{60, 61, 62, 63}},
+
+		// // idx factor a smaller factor of 2
+		{8, true, &astmapper.ShardAnnotation{Shard: 0, Of: 16}, []uint32{0}},
+		{8, true, &astmapper.ShardAnnotation{Shard: 4, Of: 16}, []uint32{2}},
+		{8, true, &astmapper.ShardAnnotation{Shard: 15, Of: 16}, []uint32{7}},
+	} {
+		tt := tt
+		t.Run(tt.shard.String()+fmt.Sprintf("_total_%d", tt.total), func(t *testing.T) {
+			ii, err := NewBitPrefixWithShards(tt.total)
+			require.Nil(t, err)
+			res, filter := ii.getShards(tt.shard)
+			resInt := []uint32{}
+			for _, r := range res {
+				resInt = append(resInt, r.shard)
+			}
+			require.Equal(t, tt.filter, filter)
+			require.Equal(t, tt.expected, resInt)
 		})
 	}
+}
+
+func Test_BitPrefixValidateShards(t *testing.T) {
+	ii, err := NewBitPrefixWithShards(32)
+	require.Nil(t, err)
+	require.NoError(t, ii.validateShard(&astmapper.ShardAnnotation{Shard: 1, Of: 16}))
+	require.Error(t, ii.validateShard(&astmapper.ShardAnnotation{Shard: 1, Of: 15}))
+}
+
+func Test_BitPrefixCreation(t *testing.T) {
+	// non factor of 2 shard factor
+	_, err := NewBitPrefixWithShards(6)
+	require.Error(t, err)
+
+	// valid shard factor
+	_, err = NewBitPrefixWithShards(4)
+	require.Nil(t, err)
+}
+
+func Test_BitPrefixDeleteAddLoopkup(t *testing.T) {
+	index, err := NewBitPrefixWithShards(DefaultIndexShards)
+	require.Nil(t, err)
+	lbs := []logproto.LabelAdapter{
+		{Name: "foo", Value: "foo"},
+		{Name: "bar", Value: "bar"},
+		{Name: "buzz", Value: "buzz"},
+	}
+	sort.Sort(logproto.FromLabelAdaptersToLabels(lbs))
+
+	index.Add(lbs, model.Fingerprint((logproto.FromLabelAdaptersToLabels(lbs).Hash())))
+	index.Delete(logproto.FromLabelAdaptersToLabels(lbs), model.Fingerprint(logproto.FromLabelAdaptersToLabels(lbs).Hash()))
+	ids, err := index.Lookup([]*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "foo", "foo"),
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, ids, 0)
+}
+
+func Test_BitPrefix_hash_mapping(t *testing.T) {
+	lbs := labels.Labels{
+		labels.Label{Name: "compose_project", Value: "loki-boltdb-storage-s3"},
+		labels.Label{Name: "compose_service", Value: "ingester-2"},
+		labels.Label{Name: "container_name", Value: "loki-boltdb-storage-s3_ingester-2_1"},
+		labels.Label{Name: "filename", Value: "/var/log/docker/790fef4c6a587c3b386fe85c07e03f3a1613f4929ca3abaa4880e14caadb5ad1/json.log"},
+		labels.Label{Name: "host", Value: "docker-desktop"},
+		labels.Label{Name: "source", Value: "stderr"},
+	}
+
+	// for _, shard := range []uint32{2, 4, 8, 16, 32, 64, 128} {
+	for _, shard := range []uint32{2} {
+		t.Run(fmt.Sprintf("%d", shard), func(t *testing.T) {
+			ii, err := NewBitPrefixWithShards(shard)
+			require.Nil(t, err)
+
+			requestedFactor := 16
+
+			fp := model.Fingerprint(lbs.Hash())
+			ii.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
+
+			requiredBits := index.NewShard(0, uint32(requestedFactor)).RequiredBits()
+			expShard := uint32(lbs.Hash() >> (64 - requiredBits))
+
+			res, err := ii.Lookup(
+				[]*labels.Matcher{{Type: labels.MatchEqual,
+					Name:  "compose_project",
+					Value: "loki-boltdb-storage-s3"}},
+				&astmapper.ShardAnnotation{
+					Shard: int(expShard),
+					Of:    requestedFactor,
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, res, 1)
+			require.Equal(t, fp, res[0])
+		})
+	}
+}
+
+func Test_BitPrefixNoMatcherLookup(t *testing.T) {
+	lbs := labels.Labels{
+		labels.Label{Name: "foo", Value: "bar"},
+		labels.Label{Name: "hi", Value: "hello"},
+	}
+	// with no shard param
+	ii, err := NewBitPrefixWithShards(16)
+	require.Nil(t, err)
+	fp := model.Fingerprint(lbs.Hash())
+	ii.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
+	ids, err := ii.Lookup(nil, nil)
+	require.Nil(t, err)
+	require.Equal(t, fp, ids[0])
+
+	// with shard param
+	ii, err = NewBitPrefixWithShards(16)
+	require.Nil(t, err)
+	expShard := uint32(fp >> (64 - index.NewShard(0, 16).RequiredBits()))
+	ii.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
+	ids, err = ii.Lookup(nil, &astmapper.ShardAnnotation{Shard: int(expShard), Of: 16})
+	require.Nil(t, err)
+	require.Equal(t, fp, ids[0])
+}
+
+func Test_BitPrefixConsistentMapping(t *testing.T) {
+	a, err := NewBitPrefixWithShards(16)
+	require.Nil(t, err)
+	b, err := NewBitPrefixWithShards(32)
+	require.Nil(t, err)
+
+	for i := 0; i < 100; i++ {
+		lbs := labels.Labels{
+			labels.Label{Name: "foo", Value: "bar"},
+			labels.Label{Name: "hi", Value: fmt.Sprint(i)},
+		}
+
+		fp := model.Fingerprint(lbs.Hash())
+		a.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
+		b.Add(logproto.FromLabelsToLabelAdapters(lbs), fp)
+	}
+
+	shardMax := 8
+	for i := 0; i < shardMax; i++ {
+		shard := &astmapper.ShardAnnotation{
+			Shard: i,
+			Of:    shardMax,
+		}
+
+		aIDs, err := a.Lookup([]*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+		}, shard)
+		require.Nil(t, err)
+
+		bIDs, err := b.Lookup([]*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+		}, shard)
+		require.Nil(t, err)
+
+		sorter := func(xs []model.Fingerprint) {
+			sort.Slice(xs, func(i, j int) bool {
+				return xs[i] < xs[j]
+			})
+		}
+		sorter(aIDs)
+		sorter(bIDs)
+
+		require.Equal(t, aIDs, bIDs, "incorrect shard mapping for shard %v", shard)
+	}
+
 }

--- a/pkg/ingester/index/bitprefix_test.go
+++ b/pkg/ingester/index/bitprefix_test.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/loki/pkg/querier/astmapper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitPrefixGetShards(t *testing.T) {
+	ii := NewBitPrefixWithShards(4)
+	for i, tc := range []struct {
+		shard  *astmapper.ShardAnnotation
+		exp    []*indexShard
+		filter bool
+	}{
+		{
+			shard:  &astmapper.ShardAnnotation{Shard: 0, Of: 2},
+			exp:    ii.shards[:2],
+			filter: false,
+		},
+		{
+			shard:  &astmapper.ShardAnnotation{Shard: 1, Of: 2},
+			exp:    ii.shards[2:],
+			filter: false,
+		},
+		{
+			shard:  &astmapper.ShardAnnotation{Shard: 0, Of: 8},
+			exp:    ii.shards[:1],
+			filter: true,
+		},
+		{
+			shard:  &astmapper.ShardAnnotation{Shard: 1, Of: 8},
+			exp:    ii.shards[:1],
+			filter: true,
+		},
+		{
+			shard:  &astmapper.ShardAnnotation{Shard: 7, Of: 8},
+			exp:    ii.shards[3:],
+			filter: true,
+		},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got, filter := ii.getShards(tc.shard)
+			require.Equal(t, tc.filter, filter)
+			require.Equal(t, tc.exp, got)
+
+		})
+	}
+}

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -45,7 +45,8 @@ func Test_GetShards(t *testing.T) {
 }
 
 func Test_ValidateShards(t *testing.T) {
-	require.NoError(t, validateShard(32, &astmapper.ShardAnnotation{Shard: 1, Of: 16}))
+	ii := NewWithShards(32)
+	require.NoError(t, ii.validateShard(&astmapper.ShardAnnotation{Shard: 1, Of: 16}))
 }
 
 var (

--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -302,6 +303,10 @@ func (shard ShardAnnotation) Label() labels.Label {
 		Name:  ShardLabel,
 		Value: shard.String(),
 	}
+}
+
+func (shard ShardAnnotation) TSDB() index.ShardAnnotation {
+	return index.NewShard(uint32(shard.Shard), uint32(shard.Of))
 }
 
 // ShardFromMatchers extracts a ShardAnnotation and the index it was pulled from in the matcher list

--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 const (


### PR DESCRIPTION
In order to maintain query consistency, we must ensure the same shard (i.e. `1_of_16`) corresponds to the same series. Since TSDB calculates shard inclusion differently (by using bit prefixes instead of modulos), we need to account for this change when resolving streams in the ingester's inverted index.

This is the first PR which doesn't use the new code paths.
Also, because the bit prefixed inverted index will support dynamic sharding of higher _or_ lower shard factors, it occasionally needs to do additional computation when translating higher granularity shard factors to lower granularity ones (i.e. 16 -> 4).

ref https://github.com/grafana/loki/issues/5428