### PR TITLE
Add jsonnet tools to build image

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -359,7 +359,7 @@ local manifest(apps) = pipeline('manifest') {
           dockerfile: 'loki-build-image/Dockerfile',
           username: { from_secret: docker_username_secret.name },
           password: { from_secret: docker_password_secret.name },
-          tags: ['0.20.4'],
+          tags: ['0.21.0'],
           dry_run: false,
         },
       },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -12,7 +12,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.20.4
+    - 0.21.0
     username:
       from_secret: docker_username
   when:
@@ -1167,6 +1167,6 @@ kind: secret
 name: deploy_config
 ---
 kind: signature
-hmac: e3f0cead040a655e51244d5d71377a4ba506d7f63fae440593f6e7d14018a1e3
+hmac: cb6f2957ccaf19841b99a76ec820fe1d3b32df4f20ea34b651afda4d27c9f1a6
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -62,6 +62,12 @@ RUN GO111MODULE=on go get github.com/tcnksm/ghr
 FROM golang:1.17.9 as nfpm
 RUN GO111MODULE=on go get github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
+# Install tools used to compile jsonnet.
+FROM golang:1.17.9 as jsonnet
+RUN GO111MODULE=on go get \
+    github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 \
+    github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
+
 FROM golang:1.17.9-buster
 RUN apt-get update && \
     apt-get install -qy \
@@ -81,6 +87,8 @@ COPY --from=faillint /go/bin/faillint /usr/bin/faillint
 COPY --from=delve /go/bin/dlv /usr/bin/dlv
 COPY --from=ghr /go/bin/ghr /usr/bin/ghr
 COPY --from=nfpm /go/bin/nfpm /usr/bin/nfpm
+COPY --from=jsonnet /go/bin/jb /usr/bin/jb
+COPY --from=jsonnet /go/bin/mixtool /usr/bin/mixtool
 
 # Install some necessary dependencies.
 # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/loki/pull/6254 I'm proposing to publish a compiled version of the mixin. To make it run in CI, we need to add some jsonnet tools to build image, which is what I'm doing in this PR. I've bumped the build image minor version (from `0.20` to `0.21`) because I guess you follow semver.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Changes have been tested in https://github.com/grafana/loki/pull/6254

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
