### PR TITLE
add metrics for tracking index shipper operations

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/metrics.go
+++ b/pkg/storage/stores/indexshipper/downloads/metrics.go
@@ -1,0 +1,36 @@
+package downloads
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	statusFailure = "failure"
+	statusSuccess = "success"
+)
+
+type metrics struct {
+	queryTimeTableDownloadDurationSeconds  *prometheus.CounterVec
+	tablesSyncOperationTotal               *prometheus.CounterVec
+	tablesDownloadOperationDurationSeconds prometheus.Gauge
+}
+
+func newMetrics(r prometheus.Registerer) *metrics {
+	m := &metrics{
+		queryTimeTableDownloadDurationSeconds: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "query_time_table_download_duration_seconds",
+			Help: "Time (in seconds) spent in downloading of files per table at query time",
+		}, []string{"table"}),
+		tablesSyncOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "tables_sync_operation_total",
+			Help: "Total number of tables sync operations done by status",
+		}, []string{"status"}),
+		tablesDownloadOperationDurationSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "tables_download_operation_duration_seconds",
+			Help: "Time (in seconds) spent in downloading updated files for all the tables",
+		}),
+	}
+
+	return m
+}

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -41,6 +41,7 @@ type table struct {
 	cacheLocation     string
 	storageClient     storage.Client
 	openIndexFileFunc index.OpenIndexFileFunc
+	metrics           *metrics
 
 	baseUserIndexSet, baseCommonIndexSet storage.IndexSet
 
@@ -51,7 +52,7 @@ type table struct {
 
 // NewTable just creates an instance of table without trying to load files from local storage or object store.
 // It is used for initializing table at query time.
-func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc) Table {
+func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics) Table {
 	table := table{
 		name:               name,
 		cacheLocation:      cacheLocation,
@@ -60,6 +61,7 @@ func NewTable(name, cacheLocation string, storageClient storage.Client, openInde
 		baseCommonIndexSet: storage.NewIndexSet(storageClient, false),
 		logger:             log.With(util_log.Logger, "table-name", name),
 		openIndexFileFunc:  openIndexFileFunc,
+		metrics:            metrics,
 		indexSets:          map[string]IndexSet{},
 	}
 
@@ -68,7 +70,7 @@ func NewTable(name, cacheLocation string, storageClient storage.Client, openInde
 
 // LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
 // It is used for loading and initializing table at startup. It would initialize index sets which already had files locally.
-func LoadTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc) (Table, error) {
+func LoadTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics) (Table, error) {
 	err := util.EnsureDirectory(cacheLocation)
 	if err != nil {
 		return nil, err
@@ -88,6 +90,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		logger:             log.With(util_log.Logger, "table-name", name),
 		indexSets:          map[string]IndexSet{},
 		openIndexFileFunc:  openIndexFileFunc,
+		metrics:            metrics,
 	}
 
 	level.Debug(table.logger).Log("msg", fmt.Sprintf("opening locally present files for table %s", name), "files", fmt.Sprint(filesInfo))
@@ -288,6 +291,7 @@ func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying 
 			start := time.Now()
 			defer func() {
 				duration := time.Since(start)
+				t.metrics.queryTimeTableDownloadDurationSeconds.WithLabelValues(t.name).Add(duration.Seconds())
 				logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
 				level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
 			}()

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -42,7 +42,7 @@ func buildTestTableManager(t *testing.T, path string) (*tableManager, stopFunc) 
 	}
 	tblManager, err := NewTableManager(cfg, func(s string) (index.Index, error) {
 		return openMockIndexFile(t, s), nil
-	}, indexStorageClient, nil)
+	}, indexStorageClient, nil, nil)
 	require.NoError(t, err)
 
 	return tblManager.(*tableManager), func() {

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -66,7 +66,7 @@ func buildTestTable(t *testing.T, path string) (*table, stopFunc) {
 
 	table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	}).(*table)
+	}, newMetrics(nil)).(*table)
 	_, usersWithIndex, err := table.storageClient.ListFiles(context.Background(), tableName, false)
 	require.NoError(t, err)
 	require.NoError(t, table.EnsureQueryReadiness(context.Background(), usersWithIndex))
@@ -258,7 +258,7 @@ func TestTable_EnsureQueryReadiness(t *testing.T) {
 			cachePath := t.TempDir()
 			table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
 				return openMockIndexFile(t, path), nil
-			}).(*table)
+			}, newMetrics(nil)).(*table)
 			defer func() {
 				table.Close()
 			}()
@@ -376,7 +376,7 @@ func TestLoadTable(t *testing.T) {
 	// try loading the table.
 	table, err := LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	})
+	}, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
@@ -396,7 +396,7 @@ func TestLoadTable(t *testing.T) {
 	// try loading the table, it should skip loading corrupt file and reload it from storage.
 	table, err = LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	})
+	}, newMetrics(nil))
 	require.NoError(t, err)
 	require.NotNil(t, table)
 

--- a/pkg/storage/stores/indexshipper/uploads/metrics.go
+++ b/pkg/storage/stores/indexshipper/uploads/metrics.go
@@ -1,0 +1,25 @@
+package uploads
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	statusFailure = "failure"
+	statusSuccess = "success"
+)
+
+type metrics struct {
+	tablesUploadOperationTotal *prometheus.CounterVec
+}
+
+func newMetrics(r prometheus.Registerer) *metrics {
+	return &metrics{
+		tablesUploadOperationTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "tables_upload_operation_total",
+			Help:      "Total number of upload operations done by status",
+		}, []string{"status"}),
+	}
+}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -32,7 +32,7 @@ func buildTestTableManager(t *testing.T, testDir string) (TableManager, stopFunc
 	cfg := Config{
 		UploadInterval: time.Hour,
 	}
-	tm, err := NewTableManager(cfg, storageClient)
+	tm, err := NewTableManager(cfg, storageClient, nil)
 	require.NoError(t, err)
 
 	return tm, func() {

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -81,7 +81,8 @@ func NewShipper(cfg Config, storageClient client.ObjectClient, limits downloads.
 
 func (i *indexClient) init(storageClient client.ObjectClient, limits downloads.Limits, ownsTenantFn downloads.IndexGatewayOwnsTenant, registerer prometheus.Registerer) error {
 	var err error
-	i.indexShipper, err = indexshipper.NewIndexShipper(i.cfg.Config, storageClient, limits, ownsTenantFn, indexfile.OpenIndexFile)
+	i.indexShipper, err = indexshipper.NewIndexShipper(i.cfg.Config, storageClient, limits, ownsTenantFn,
+		indexfile.OpenIndexFile, prometheus.WrapRegistererWithPrefix("loki_boltdb_shipper_", registerer))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -27,6 +27,7 @@ func NewStore(indexShipperCfg indexshipper.Config, p config.PeriodConfig, f *fet
 		limits,
 		nil,
 		OpenShippableTSDB,
+		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR #6226, we refactored the code to make the `boltdb-shipper` index client use the generic `indexshipper` to manage the index on object storage. This PR takes care of follow up action to add metrics to `indexshipper`.

I have made sure we have the same metrics exposed as before by using `WrapRegistererWithPrefix`, i.e. when using `indexshipper` for `boltdb-shipper`, metrics would be prefixed with `loki_boltdb_shipper_` while for `tsdb`, the prefix would be `loki_tsdb_shipper_` 