### PR TITLE
operator: Expose only an HTTPS gateway when in openshift-logging mode

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main
 
 - [6195](https://github.com/grafana/loki/pull/6195) **periklis**: Add ruler config support
+- [6288](https://github.com/grafana/loki/pull/6288) **aminesnow**: Expose only an HTTPS gateway when in openshift mode
 - [6198](https://github.com/grafana/loki/pull/6198) **periklis**: Add support for custom S3 CA
 - [6199](https://github.com/grafana/loki/pull/6199) **Red-GV**: Update GCP secret volume path
 - [6125](https://github.com/grafana/loki/pull/6125) **sasagarw**: Add method to get authenticated from GCP

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Main
 
-- [6195](https://github.com/grafana/loki/pull/6195) **periklis**: Add ruler config support
 - [6288](https://github.com/grafana/loki/pull/6288) **aminesnow**: Expose only an HTTPS gateway when in openshift mode
+- [6195](https://github.com/grafana/loki/pull/6195) **periklis**: Add ruler config support
 - [6198](https://github.com/grafana/loki/pull/6198) **periklis**: Add support for custom S3 CA
 - [6199](https://github.com/grafana/loki/pull/6199) **Red-GV**: Update GCP secret volume path
 - [6125](https://github.com/grafana/loki/pull/6125) **sasagarw**: Add method to get authenticated from GCP

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -37,12 +37,12 @@ spec:
             - name: LOKI_ORG_ID
               value: application
             - name: LOKI_ADDR
-              value: http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application
+              value: https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application
             - name: LOKI_BEARER_TOKEN_FILE
               value: /var/run/secrets/kubernetes.io/serviceaccount/token
           args:
             - -c
-            - while true; do logcli query '{job="systemd-journal"}'; sleep 30; done
+            - while true; do logcli --ca-cert="/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" query '{job="systemd-journal"}'; sleep 30; done
       serviceAccountName: lokistack-dev-addons-logcli
 ---
 apiVersion: apps/v1
@@ -118,7 +118,9 @@ metadata:
 data:
   promtail.yaml: |
     clients:
-      - url: http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application/loki/api/v1/push
+      - url: https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application/loki/api/v1/push
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         tenant_id: application
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         backoff_config:

--- a/operator/hack/lokistack_gateway_ocp.yaml
+++ b/operator/hack/lokistack_gateway_ocp.yaml
@@ -2,6 +2,7 @@ apiVersion: loki.grafana.com/v1beta1
 kind: LokiStack
 metadata:
   name: lokistack-dev
+  namespace: openshift-logging
 spec:
   size: 1x.extra-small
   storage:

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -263,7 +263,7 @@ func TestBuildAll_WithFeatureFlags_EnableTLSServiceMonitorConfig(t *testing.T) {
 			continue
 		}
 
-		secretName := fmt.Sprintf("%s-http-metrics", name)
+		secretName := fmt.Sprintf("%s-http-tls", name)
 		expVolume := corev1.Volume{
 			Name: secretName,
 			VolumeSource: corev1.VolumeSource{

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	tlsMetricsSercetVolume = "tls-metrics-secret"
+	tlsSercetVolume = "tls-secret"
 )
 
 // BuildGateway returns a list of k8s objects for Loki Stack Gateway
@@ -49,7 +49,7 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 
 	if opts.Stack.Tenants != nil {
 		mode := opts.Stack.Tenants.Mode
-		if err := configureDeploymentForMode(dpl, mode, opts.Flags); err != nil {
+		if err := configureDeploymentForMode(dpl, mode, opts.Flags, opts.Name, opts.Namespace); err != nil {
 			return nil, err
 		}
 
@@ -58,6 +58,9 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 		}
 
 		objs = configureGatewayObjsForMode(objs, opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return objs, nil
@@ -356,7 +359,7 @@ func configureGatewayMetricsPKI(podSpec *corev1.PodSpec, serviceName string) err
 	secretVolumeSpec := corev1.PodSpec{
 		Volumes: []corev1.Volume{
 			{
-				Name: tlsMetricsSercetVolume,
+				Name: tlsSercetVolume,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: secretName,
@@ -368,7 +371,7 @@ func configureGatewayMetricsPKI(podSpec *corev1.PodSpec, serviceName string) err
 	secretContainerSpec := corev1.Container{
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      tlsMetricsSercetVolume,
+				Name:      tlsSercetVolume,
 				ReadOnly:  true,
 				MountPath: gateway.LokiGatewayTLSDir,
 			},

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -356,7 +356,7 @@ func configureGatewayMetricsPKI(podSpec *corev1.PodSpec, serviceName string) err
 	secretVolumeSpec := corev1.PodSpec{
 		Volumes: []corev1.Volume{
 			{
-				Name: tlsSercetVolume,
+				Name: tlsSecretVolume,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: secretName,
@@ -368,7 +368,7 @@ func configureGatewayMetricsPKI(podSpec *corev1.PodSpec, serviceName string) err
 	secretContainerSpec := corev1.Container{
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      tlsSercetVolume,
+				Name:      tlsSecretVolume,
 				ReadOnly:  true,
 				MountPath: gateway.LokiGatewayTLSDir,
 			},

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -58,9 +58,6 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 		}
 
 		objs = configureGatewayObjsForMode(objs, opts)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return objs, nil

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -56,15 +56,18 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	return nil
 }
 
-func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags) error {
+func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags, name, ns string) error {
 	switch mode {
 	case lokiv1beta1.Static, lokiv1beta1.Dynamic:
 		return nil // nothing to configure
 	case lokiv1beta1.OpenshiftLogging:
+		serviceName := serviceNameGatewayHTTP(name)
+		secretName := signingServiceSecretName(serviceName)
+		serverName := fqdn(serviceName, ns)
 		return openshift.ConfigureGatewayDeployment(
 			d,
 			gatewayContainerName,
-			tlsMetricsSercetVolume,
+			tlsSercetVolume,
 			gateway.LokiGatewayTLSDir,
 			gateway.LokiGatewayCertFile,
 			gateway.LokiGatewayKeyFile,
@@ -72,6 +75,10 @@ func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType,
 			gateway.LokiGatewayCAFile,
 			flags.EnableTLSServiceMonitorConfig,
 			flags.EnableCertificateSigningService,
+			secretName,
+			serviceName,
+			serverName,
+			gatewayHTTPPort,
 		)
 	}
 

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -56,14 +56,14 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	return nil
 }
 
-func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags, name, ns string) error {
+func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags, stackName, stackNs string) error {
 	switch mode {
 	case lokiv1beta1.Static, lokiv1beta1.Dynamic:
 		return nil // nothing to configure
 	case lokiv1beta1.OpenshiftLogging:
-		serviceName := serviceNameGatewayHTTP(name)
+		serviceName := serviceNameGatewayHTTP(stackName)
 		secretName := signingServiceSecretName(serviceName)
-		serverName := fqdn(serviceName, ns)
+		serverName := fqdn(serviceName, stackNs)
 		return openshift.ConfigureGatewayDeployment(
 			d,
 			gatewayContainerName,

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -76,7 +76,6 @@ func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType,
 			flags.EnableTLSServiceMonitorConfig,
 			flags.EnableCertificateSigningService,
 			secretName,
-			serviceName,
 			serverName,
 			gatewayHTTPPort,
 		)

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -67,7 +67,7 @@ func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType,
 		return openshift.ConfigureGatewayDeployment(
 			d,
 			gatewayContainerName,
-			tlsSercetVolume,
+			tlsSecretVolume,
 			gateway.LokiGatewayTLSDir,
 			gateway.LokiGatewayCertFile,
 			gateway.LokiGatewayKeyFile,

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"fmt"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -184,6 +185,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 		dpl   *appsv1.Deployment
 		want  *appsv1.Deployment
 	}
+	name := "test"
+	ns := "test-ns"
 
 	tc := []tt{
 		{
@@ -199,9 +202,13 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			want: &appsv1.Deployment{},
 		},
 		{
+
 			desc: "openshift-logging mode",
 			mode: lokiv1beta1.OpenshiftLogging,
 			dpl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -220,6 +227,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 				},
 			},
 			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -230,6 +240,32 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										"--tls.server.cert-file=/var/run/tls/tls.crt",
+										"--tls.server.key-file=/var/run/tls/tls.key",
+										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
+										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      tlsSercetVolume,
+											ReadOnly:  true,
+											MountPath: gateway.LokiGatewayTLSDir,
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
 									},
 								},
 								{
@@ -284,6 +320,16 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 								},
 							},
+							Volumes: []corev1.Volume{
+								{
+									Name: tlsSercetVolume,
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test-gateway-http-tls",
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -296,6 +342,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 				EnableTLSServiceMonitorConfig: true,
 			},
 			dpl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -307,6 +356,23 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      tlsSercetVolume,
+											ReadOnly:  true,
+											MountPath: gateway.LokiGatewayTLSDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: tlsSercetVolume,
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test-gateway-http-tls",
+										},
+									},
 								},
 							},
 						},
@@ -314,6 +380,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 				},
 			},
 			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -324,6 +393,32 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										"--tls.server.cert-file=/var/run/tls/tls.crt",
+										"--tls.server.key-file=/var/run/tls/tls.key",
+										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
+										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      tlsSercetVolume,
+											ReadOnly:  true,
+											MountPath: gateway.LokiGatewayTLSDir,
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
 									},
 								},
 								{
@@ -380,9 +475,19 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsMetricsSercetVolume,
+											Name:      tlsSercetVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: tlsSercetVolume,
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test-gateway-http-tls",
 										},
 									},
 								},
@@ -401,7 +506,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 			dpl: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gateway",
+					Name:      "gateway",
+					Namespace: ns,
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -435,7 +541,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gateway",
+					Name:      "gateway",
+					Namespace: ns,
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -450,6 +557,11 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.tail.endpoint=https://example.com",
 										"--logs.write.endpoint=https://example.com",
 										"--logs.tls.ca-file=/var/run/ca/service-ca.crt",
+										"--tls.server.cert-file=/var/run/tls/tls.crt",
+										"--tls.server.key-file=/var/run/tls/tls.key",
+										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
+										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -461,6 +573,20 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 											Name:      "gateway-ca-bundle",
 											ReadOnly:  true,
 											MountPath: "/var/run/ca",
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTPS,
+											},
 										},
 									},
 								},
@@ -518,7 +644,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsMetricsSercetVolume,
+											Name:      tlsSercetVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},
@@ -551,7 +677,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			err := configureDeploymentForMode(tc.dpl, tc.mode, tc.flags)
+			err := configureDeploymentForMode(tc.dpl, tc.mode, tc.flags, name, ns)
 			require.NoError(t, err)
 			require.Equal(t, tc.want, tc.dpl)
 		})

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -250,7 +250,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsSercetVolume,
+											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},
@@ -324,7 +324,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
-									Name: tlsSercetVolume,
+									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName: "test-gateway-http-metrics",
@@ -362,7 +362,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsSercetVolume,
+											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},
@@ -371,7 +371,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
-									Name: tlsSercetVolume,
+									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName: "test-gateway-http-metrics",
@@ -405,7 +405,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsSercetVolume,
+											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},
@@ -479,7 +479,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsSercetVolume,
+											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},
@@ -488,7 +488,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
-									Name: tlsSercetVolume,
+									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName: "test-gateway-http-metrics",
@@ -650,7 +650,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      tlsSercetVolume,
+											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
 										},

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -179,14 +179,14 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 
 func TestConfigureDeploymentForMode(t *testing.T) {
 	type tt struct {
-		desc  string
-		mode  lokiv1beta1.ModeType
-		flags FeatureFlags
-		dpl   *appsv1.Deployment
-		want  *appsv1.Deployment
+		desc      string
+		mode      lokiv1beta1.ModeType
+		stackName string
+		stackNs   string
+		flags     FeatureFlags
+		dpl       *appsv1.Deployment
+		want      *appsv1.Deployment
 	}
-	name := "test"
-	ns := "test-ns"
 
 	tc := []tt{
 		{
@@ -203,11 +203,13 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 		},
 		{
 
-			desc: "openshift-logging mode",
-			mode: lokiv1beta1.OpenshiftLogging,
+			desc:      "openshift-logging mode",
+			mode:      lokiv1beta1.OpenshiftLogging,
+			stackName: "test",
+			stackNs:   "test-ns",
 			dpl: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -228,7 +230,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -325,7 +327,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSercetVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-tls",
+											SecretName: "test-gateway-http-metrics",
 										},
 									},
 								},
@@ -336,14 +338,16 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 		},
 		{
-			desc: "openshift-logging mode with-tls-service-monitor-config",
-			mode: lokiv1beta1.OpenshiftLogging,
+			desc:      "openshift-logging mode with-tls-service-monitor-config",
+			mode:      lokiv1beta1.OpenshiftLogging,
+			stackName: "test",
+			stackNs:   "test-ns",
 			flags: FeatureFlags{
 				EnableTLSServiceMonitorConfig: true,
 			},
 			dpl: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -370,7 +374,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSercetVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-tls",
+											SecretName: "test-gateway-http-metrics",
 										},
 									},
 								},
@@ -381,7 +385,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -487,7 +491,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSercetVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-tls",
+											SecretName: "test-gateway-http-metrics",
 										},
 									},
 								},
@@ -498,8 +502,10 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			},
 		},
 		{
-			desc: "openshift-logging mode with-cert-signing-service",
-			mode: lokiv1beta1.OpenshiftLogging,
+			desc:      "openshift-logging mode with-cert-signing-service",
+			mode:      lokiv1beta1.OpenshiftLogging,
+			stackName: "test",
+			stackNs:   "test-ns",
 			flags: FeatureFlags{
 				EnableTLSServiceMonitorConfig:   true,
 				EnableCertificateSigningService: true,
@@ -507,7 +513,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			dpl: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gateway",
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -542,7 +548,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gateway",
-					Namespace: ns,
+					Namespace: "test-ns",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -677,7 +683,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			err := configureDeploymentForMode(tc.dpl, tc.mode, tc.flags, name, ns)
+			err := configureDeploymentForMode(tc.dpl, tc.mode, tc.flags, "test", "test-ns")
 			require.NoError(t, err)
 			require.Equal(t, tc.want, tc.dpl)
 		})

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -221,6 +221,21 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										fmt.Sprintf("--web.healthchecks.url=http://localhost:%d", gatewayHTTPPort),
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
 									},
 								},
 							},
@@ -242,11 +257,11 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--tls.server.cert-file=/var/run/tls/tls.crt",
 										"--tls.server.key-file=/var/run/tls/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
 										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
-										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -327,7 +342,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-metrics",
+											SecretName: "test-gateway-http-tls",
 										},
 									},
 								},
@@ -359,12 +374,27 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										fmt.Sprintf("--web.healthchecks.url=http://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      tlsSecretVolume,
 											ReadOnly:  true,
 											MountPath: gateway.LokiGatewayTLSDir,
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
 										},
 									},
 								},
@@ -374,7 +404,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-metrics",
+											SecretName: "test-gateway-http-tls",
 										},
 									},
 								},
@@ -397,11 +427,11 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--tls.server.cert-file=/var/run/tls/tls.crt",
 										"--tls.server.key-file=/var/run/tls/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
 										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
-										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -491,7 +521,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Name: tlsSecretVolume,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "test-gateway-http-metrics",
+											SecretName: "test-gateway-http-tls",
 										},
 									},
 								},
@@ -526,12 +556,27 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=http://example.com",
 										"--logs.tail.endpoint=http://example.com",
 										"--logs.write.endpoint=http://example.com",
+										fmt.Sprintf("--web.healthchecks.url=http://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "tls-secret",
 											ReadOnly:  true,
 											MountPath: "/var/run/tls",
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Scheme: corev1.URISchemeHTTP,
+											},
 										},
 									},
 								},
@@ -562,12 +607,12 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.read.endpoint=https://example.com",
 										"--logs.tail.endpoint=https://example.com",
 										"--logs.write.endpoint=https://example.com",
+										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--logs.tls.ca-file=/var/run/ca/service-ca.crt",
 										"--tls.server.cert-file=/var/run/tls/tls.crt",
 										"--tls.server.key-file=/var/run/tls/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
 										fmt.Sprintf("--tls.healthchecks.server-name=%s", "test-gateway-http.test-ns.svc.cluster.local"),
-										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -19,7 +19,7 @@ const (
 	opaDefaultLabelMatcher = "kubernetes_namespace_name"
 )
 
-func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile string, withTLS bool) corev1.Container {
+func newOPAOpenShiftContainer(secretVolumeName, tlsDir, certFile, keyFile string, withTLS bool) corev1.Container {
 	var (
 		image        string
 		args         []string
@@ -55,7 +55,7 @@ func newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile strin
 
 		volumeMounts = []corev1.VolumeMount{
 			{
-				Name:      sercretVolumeName,
+				Name:      secretVolumeName,
 				ReadOnly:  true,
 				MountPath: tlsDir,
 			},

--- a/operator/internal/manifests/openshift/route.go
+++ b/operator/internal/manifests/openshift/route.go
@@ -29,6 +29,9 @@ func BuildRoute(opts Options) client.Object {
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString(opts.BuildOpts.GatewaySvcTargetPort),
 			},
+			TLS: &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationReencrypt,
+			},
 			WildcardPolicy: routev1.WildcardPolicyNone,
 		},
 	}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -223,7 +223,7 @@ func serviceMonitorName(componentName string) string {
 }
 
 func signingServiceSecretName(serviceName string) string {
-	return fmt.Sprintf("%s-metrics", serviceName)
+	return fmt.Sprintf("%s-tls", serviceName)
 }
 
 func fqdn(serviceName, namespace string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
This PR configures LokiStack gateway to exclusively use the HTTPS protocol when using the openshift-logging mode. In addition, traffic to the gateway k8s service is re-encrypted using a reencrypt termination policy while using the openshift-logging mode.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [X] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
