### PR TITLE
Import memberlist.libsonnet in loki.libsonnet.

### DIFF
--- a/production/ksonnet/loki/loki.libsonnet
+++ b/production/ksonnet/loki/loki.libsonnet
@@ -28,4 +28,7 @@
 (import 'index-gateway.libsonnet') +
 
 // BoltDB Shipper support. This should be the last one to get imported.
-(import 'boltdb_shipper.libsonnet')
+(import 'boltdb_shipper.libsonnet') +
+
+// Memberlist related deployment configuration, mostly migration related
+(import 'memberlist.libsonnet')


### PR DESCRIPTION
This is required so that the memberlist jsonnet code can be used easily. Missed it in my previous PR that added the `memberlist.libonnset` file.

Signed-off-by: Callum Styan <callumstyan@gmail.com>