### PR TITLE
Only consider an interval to have possible expired chunks if it overlaps a delete.

### DIFF
--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -203,13 +203,15 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 	}
 }
 
-func (d *DeleteRequestsManager) IntervalMayHaveExpiredChunks(_ model.Interval, userID string) bool {
+func (d *DeleteRequestsManager) IntervalMayHaveExpiredChunks(interval model.Interval, userID string) bool {
 	d.deleteRequestsToProcessMtx.Lock()
 	defer d.deleteRequestsToProcessMtx.Unlock()
 
 	if userID != "" {
 		for _, deleteRequest := range d.deleteRequestsToProcess {
-			if deleteRequest.UserID == userID {
+			if deleteRequest.UserID == userID &&
+				deleteRequest.StartTime <= interval.End &&
+				deleteRequest.EndTime >= interval.Start {
 				return true
 			}
 		}


### PR DESCRIPTION
Before, we considered any interval to potentially have an expired chunk if the passed userID matched a user on a DeleteRequest. This PR adds the requirement that an interval must also overlap a delete request to count as having a potential expired chunk.
