### PR TITLE
do not initialize tsdb index store when using index gateway client for queries

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -485,8 +485,8 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			asyncStore = true
 		case t.Cfg.isModuleEnabled(IndexGateway):
 			// we want to use the actual storage when running the index-gateway, so we remove the Addr from the config
-			// TODO(owen-d): Do the same for TSDB when we add IndexGatewayClientConfig
 			t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
+			t.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 		case t.Cfg.isModuleEnabled(All):
 			// We want ingester to also query the store when using boltdb-shipper but only when running with target All.
 			// We do not want to use AsyncStore otherwise it would start spiraling around doing queries over and over again to the ingesters and store.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -38,6 +38,8 @@ var (
 	indexTypeStats  = usagestats.NewString("store_index_type")
 	objectTypeStats = usagestats.NewString("store_object_type")
 	schemaStats     = usagestats.NewString("store_schema")
+
+	errWritingChunkUnsupported = errors.New("writing chunks is not supported while running store in read-only mode")
 )
 
 // Store is the Loki chunk store to retrieve and save chunks.
@@ -204,25 +206,30 @@ func (s *store) storeForPeriod(p config.PeriodConfig, chunkClient client.Client,
 		prometheus.Labels{"component": "index-store-" + p.From.String()}, s.registerer)
 
 	if p.IndexType == config.TSDBType {
-		objectClient, err := NewObjectClient(s.cfg.TSDBShipperConfig.SharedStoreType, s.cfg, s.clientMetrics)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		// ToDo(Sandeep): Avoid initializing writer when in read only mode
-		writer, idx, err := tsdb.NewStore(s.cfg.TSDBShipperConfig, p, f, objectClient, s.limits, indexClientReg)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
 		if shouldUseIndexGatewayClient(s.cfg.TSDBShipperConfig) {
 			// inject the index-gateway client into the index store
 			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.logger)
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			idx = series.NewIndexGatewayClientStore(gw, idx)
+			idx := series.NewIndexGatewayClientStore(gw, nil)
+
+			return failingChunkWriter{}, idx, func() {
+				f.Stop()
+				gw.Stop()
+			}, nil
 		}
+
+		objectClient, err := NewObjectClient(s.cfg.TSDBShipperConfig.SharedStoreType, s.cfg, s.clientMetrics)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		writer, idx, err := tsdb.NewStore(s.cfg.TSDBShipperConfig, p, f, objectClient, s.limits, indexClientReg)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 
 		return writer, idx,
 			func() {
@@ -491,4 +498,14 @@ func filterChunksByTime(from, through model.Time, chunks []chunk.Chunk) []chunk.
 		filtered = append(filtered, chunk)
 	}
 	return filtered
+}
+
+type failingChunkWriter struct{}
+
+func (f failingChunkWriter) Put(_ context.Context, _ []chunk.Chunk) error {
+	return errWritingChunkUnsupported
+}
+
+func (f failingChunkWriter) PutOne(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
+	return errWritingChunkUnsupported
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
When Loki is configured to run the index gateway client for doing `tsdb` queries, we also initialize `tsdb` index store instance just to satisfy the `IndexStore` interface [here](https://github.com/grafana/loki/blob/a2898295040411e8c375be98ed3e4e167724f45e/pkg/storage/stores/series/series_index_gateway_store.go#L34), which is just a fallback for keeping index gateway client and store backwards compatible.
This causes us to un-necessarily run an instance of `indexshipper` which would try to sync the files locally if query readiness is configured.

This PR changes the code to make the `fallbackStore` for `NewIndexGatewayClientStore` optional and keep it `nil` when initializing it for `tsdb` index store.
