### PR TITLE
fixed type of the property in memberlist config

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -87,7 +87,7 @@
         join_members: ['gossip-ring.%s.svc.cluster.local:%d' % [$._config.namespace, gossipRingPort]],
 
         max_join_backoff: '1m',
-        max_join_retries: '10',
+        max_join_retries: 10,
         min_join_backoff: '1s',
       },
     },


### PR DESCRIPTION
if we enable memberlist using the logic from memberlist.libsonnet , the pods are crushed because Loki expects numeric value but it gets string value.
