### PR TITLE
exposes line length hist on distributors 

### DIFF
--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -63,6 +63,7 @@ func (v Validator) getValidationContextForTime(now time.Time, userID string) val
 // ValidateEntry returns an error if the entry is invalid
 func (v Validator) ValidateEntry(ctx validationContext, labels string, entry logproto.Entry) error {
 	ts := entry.Timestamp.UnixNano()
+	validation.LineLengthHist.Observe(float64(len(entry.Line)))
 
 	// Makes time string on the error message formatted consistently.
 	formatedEntryTime := entry.Timestamp.Format(timeFormat)

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/pkg/util/flagext"
 )
@@ -66,7 +67,7 @@ func (e *ErrStreamRateLimit) Error() string {
 }
 
 // MutatedSamples is a metric of the total number of lines mutated, by reason.
-var MutatedSamples = prometheus.NewCounterVec(
+var MutatedSamples = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "mutated_samples_total",
@@ -76,7 +77,7 @@ var MutatedSamples = prometheus.NewCounterVec(
 )
 
 // MutatedBytes is a metric of the total mutated bytes, by reason.
-var MutatedBytes = prometheus.NewCounterVec(
+var MutatedBytes = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "mutated_bytes_total",
@@ -86,7 +87,7 @@ var MutatedBytes = prometheus.NewCounterVec(
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.
-var DiscardedBytes = prometheus.NewCounterVec(
+var DiscardedBytes = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "discarded_bytes_total",
@@ -96,7 +97,7 @@ var DiscardedBytes = prometheus.NewCounterVec(
 )
 
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
-var DiscardedSamples = prometheus.NewCounterVec(
+var DiscardedSamples = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "discarded_samples_total",
@@ -105,6 +106,9 @@ var DiscardedSamples = prometheus.NewCounterVec(
 	[]string{ReasonLabel, "tenant"},
 )
 
-func init() {
-	prometheus.MustRegister(DiscardedSamples, DiscardedBytes)
-}
+var LineLengthHist = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "loki",
+	Name:      "bytes_per_line",
+	Help:      "The total number of bytes per line.",
+	Buckets:   prometheus.ExponentialBuckets(1, 16, 8), // 1B -> 4GB
+})

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -110,5 +110,5 @@ var LineLengthHist = promauto.NewHistogram(prometheus.HistogramOpts{
 	Namespace: "loki",
 	Name:      "bytes_per_line",
 	Help:      "The total number of bytes per line.",
-	Buckets:   prometheus.ExponentialBuckets(1, 16, 8), // 1B -> 4GB
+	Buckets:   prometheus.ExponentialBuckets(1, 8, 8), // 1B -> 16MB
 })


### PR DESCRIPTION
As part of the work to better understand line length limits in Loki, this adds a new histogram for them so we can better understand distributions of line lengths coming in.
Also fixes some metric instantiations that were missed in the `init` function by preferring `promauto`.