### PR TITLE
Add `multi_kv_config` block to overrides ConfigMap when multi-kv mode is enabled

### DIFF
--- a/production/ksonnet/loki/overrides.libsonnet
+++ b/production/ksonnet/loki/overrides.libsonnet
@@ -36,6 +36,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
           overrides: $._config.overrides,
           configs: $._config.runtimeConfigs,
         }
+        + (if std.length($._config.multi_kv_config) > 0 then { multi_kv_config: $._config.multi_kv_config } else {}),
       ),
     }),
 }


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
This PR adds a correctly-nested `multi_kv_config` block to the overrides configmap when multi kv mode is enabled to support a migration between Consul and Memberlist.

- #6320
- #6321

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
