### PR TITLE
always retry syncing index files from indexshipper when the index list cache is stale

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -235,15 +235,6 @@ func (t *table) Sync(ctx context.Context) error {
 
 	for userID, indexSet := range t.indexSets {
 		if err := indexSet.Sync(ctx); err != nil {
-			if errors.Is(err, errIndexListCacheTooStale) {
-				level.Info(t.logger).Log("msg", "we have hit stale list cache, refreshing it and running sync again")
-				t.storageClient.RefreshIndexListCache(ctx)
-
-				err = indexSet.Sync(ctx)
-				if err == nil {
-					continue
-				}
-			}
 			return errors.Wrap(err, fmt.Sprintf("failed to sync index set %s for table %s", userID, t.name))
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
From `indexshipper`, we detect and retry failed sync due to a stale index list cache. However, it is not done in all cases like query readiness or syncing local files on startup, which causes some unexpected problems. This PR updates the code to always refresh the stale list cache and retry sync to keep it consistent.

To keep the code simple, I have made the code retry sync in all failure cases and not just the stale index list cache.

**Checklist**
- [x] Tests updated
