### PR TITLE
Define a reason why the fifocache has evicted an item

### DIFF
--- a/pkg/storage/chunk/cache/fifo_cache.go
+++ b/pkg/storage/chunk/cache/fifo_cache.go
@@ -95,7 +95,7 @@ type FifoCache struct {
 }
 
 const (
-	expiredReason string = "expired"
+	expiredReason string = "expired" //nolint:staticcheck
 	fullReason           = "full"
 	tooBigReason         = "too big"
 	stoppedReason        = "stopped"

--- a/pkg/storage/chunk/cache/fifo_cache.go
+++ b/pkg/storage/chunk/cache/fifo_cache.go
@@ -97,7 +97,7 @@ type FifoCache struct {
 const (
 	expiredReason string = "expired" //nolint:staticcheck
 	fullReason           = "full"
-	tooBigReason         = "too big"
+	tooBigReason         = "object too big"
 	stoppedReason        = "stopped"
 )
 

--- a/pkg/storage/chunk/cache/fifo_cache.go
+++ b/pkg/storage/chunk/cache/fifo_cache.go
@@ -98,7 +98,6 @@ const (
 	expiredReason string = "expired" //nolint:staticcheck
 	fullReason           = "full"
 	tooBigReason         = "object too big"
-	stoppedReason        = "stopped"
 )
 
 type cacheEntry struct {
@@ -284,8 +283,6 @@ func (c *FifoCache) Stop() {
 	defer c.lock.Unlock()
 
 	close(c.done)
-
-	c.entriesEvicted.WithLabelValues(stoppedReason).Add(float64(c.lru.Len()))
 
 	c.entries = make(map[string]*list.Element)
 	c.lru.Init()

--- a/pkg/storage/chunk/cache/fifo_cache_test.go
+++ b/pkg/storage/chunk/cache/fifo_cache_test.go
@@ -55,9 +55,11 @@ func TestFifoCacheEviction(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, c.entries, cnt)
 
+		reason := fullReason
+
 		assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(1))
 		assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(cnt))
-		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(0))
+		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted.WithLabelValues(reason)), float64(0))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(cnt))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(len(c.entries)))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(c.lru.Len()))
@@ -98,7 +100,7 @@ func TestFifoCacheEviction(t *testing.T) {
 
 		assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(2))
 		assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(cnt+evicted))
-		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(evicted))
+		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted.WithLabelValues(reason)), float64(evicted))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(cnt))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(len(c.entries)))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(c.lru.Len()))
@@ -119,7 +121,7 @@ func TestFifoCacheEviction(t *testing.T) {
 
 		assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(2))
 		assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(cnt+evicted))
-		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(evicted))
+		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted.WithLabelValues(reason)), float64(evicted))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(cnt))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(len(c.entries)))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(c.lru.Len()))
@@ -149,7 +151,7 @@ func TestFifoCacheEviction(t *testing.T) {
 
 		assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(3))
 		assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(cnt+evicted))
-		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(evicted))
+		assert.Equal(t, testutil.ToFloat64(c.entriesEvicted.WithLabelValues(reason)), float64(evicted))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(cnt))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(len(c.entries)))
 		assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(c.lru.Len()))
@@ -208,7 +210,8 @@ func TestFifoCacheExpiry(t *testing.T) {
 
 			assert.Equal(t, float64(1), testutil.ToFloat64(c.entriesAdded))
 			assert.Equal(t, float64(4), testutil.ToFloat64(c.entriesAddedNew))
-			assert.Equal(t, float64(1), testutil.ToFloat64(c.entriesEvicted))
+			assert.Equal(t, float64(0), testutil.ToFloat64(c.entriesEvicted.WithLabelValues(expiredReason)))
+			assert.Equal(t, float64(1), testutil.ToFloat64(c.entriesEvicted.WithLabelValues(fullReason)))
 			assert.Equal(t, float64(3), testutil.ToFloat64(c.entriesCurrent))
 			assert.Equal(t, float64(len(c.entries)), testutil.ToFloat64(c.entriesCurrent))
 			assert.Equal(t, float64(c.lru.Len()), testutil.ToFloat64(c.entriesCurrent))
@@ -223,7 +226,8 @@ func TestFifoCacheExpiry(t *testing.T) {
 
 			assert.Equal(t, float64(1), testutil.ToFloat64(c.entriesAdded))
 			assert.Equal(t, float64(4), testutil.ToFloat64(c.entriesAddedNew))
-			assert.Equal(t, float64(4), testutil.ToFloat64(c.entriesEvicted))
+			assert.Equal(t, float64(3), testutil.ToFloat64(c.entriesEvicted.WithLabelValues(expiredReason)))
+			assert.Equal(t, float64(1), testutil.ToFloat64(c.entriesEvicted.WithLabelValues(fullReason)))
 			assert.Equal(t, float64(0), testutil.ToFloat64(c.entriesCurrent))
 			assert.Equal(t, float64(len(c.entries)), testutil.ToFloat64(c.entriesCurrent))
 			assert.Equal(t, float64(c.lru.Len()), testutil.ToFloat64(c.entriesCurrent))


### PR DESCRIPTION
Signed-off-by: Danny Kopping <danny.kopping@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
This PR adds an eviction reason for the fifocache, which will help an operator know if an entry was evicted because the TTL expired vs the cache is full.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
We use a fifocache when running boltdb-shipper for storing ingesters' index caches locally. We do this because we cannot share the cache between ingesters, to prevent missing out chunks that may not exist in other ingesters.
https://github.com/grafana/loki/blob/main/pkg/loki/modules.go#L414-L425

The cache is configured with a fixed size of 200MB, and is currently not configurable; we could consider making this configurable however even in our biggest clusters we're only seeing ~11MB of use currently.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
