### PR TITLE
Fix table manger creating invalid tables for expired periodic configs

### DIFF
--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -454,7 +454,7 @@ func (cfg *PeriodicTableConfig) PeriodicTables(from, through model.Time, pCfg Pr
 		actualRetention := retention - outRangePeriod
 		if actualRetention > 0 {
 			//Rounded up, in case only one table left
-			tablesToKeep = int64(actualRetention/time.Second) + periodSecs - 1/periodSecs
+			tablesToKeep = (int64(actualRetention/time.Second) + periodSecs - 1) / periodSecs
 		} else {
 			tablesToKeep = 0
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

This PR add extra judge based on  `schema_config` for table_manager during `expected tables` calculation. Based on `expected tables`,  subsequent CREATE actions will be taken if tables are not exist.

This PR is mainly to fix situation when `schema_config` is appended with new entry,  table manager calculate `expected tables` based on `retention_period` for **each entry**. This results in unexpected table creation behavior, and  these tables before `retention_period` is created but will never be used. 

Table manager works before and after this PR  like below:
```
let's assume retention_period = 2 month
|-------------------------------------------------------
|one month   |one month     |one month   | ...
|-------------------------------------------------------
|<-config A works --------->|<-config B works until now
|-------------------------------------------------------
|<-beforePR: retention for A-|<--retention for B ------->
|-------------------------------------------------------
|-------------------|<-PR: expected retention:two month->

```


besides, this pr fix extreme situation of discontinuous cycles like below:
```
let's assume retention_period = 1 month
beforePR: retain last 1 month for each config entry, which is discontinuous
|-------------------------------------------------------
|one month   |one month     |one month   |one month   | less than one month util now...
|-------------------------------------------------------
|<----config A works ------>|<----config B works----->|<-config C...
|-------------------------------------------------------
|------------｜-before PR:A-| -----------|-before PR:B-|-before PR:C...
|-------------------------------------------------------
|----------------------------------|<-PR: Retention:exactly one month

```



**Which issue(s) this PR fixes**:
Fixes #6336 
test result(using same config in issue above):
numbers of calculated expected tables is downsized and matched with `retention_period`
```
level=info ts=2022-06-08T09:22:17.683364612Z caller=table_manager.go:322 msg="synching tables" expected_tables=23

```
**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
