### PR TITLE
Docs: Add changelog entry for configuration parameter name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 * [5685](https://github.com/grafana/loki/pull/5685) **chaudum**: Assert that push values tuples consist of string values
 ##### Changes
 * [6042](https://github.com/grafana/loki/pull/6042) **slim-bean**: Add a new configuration to allow fudging of ingested timestamps to guarantee sort order of duplicate timestamps at query time.
-* [6120](https://github.com/grafana/loki/pull/6120) **KMiller-Grafana**: Rename the fudging of ingested timestamps configuration parameter introduced in PR 6042 to avoid using the slang term "fudge."
+* [6120](https://github.com/grafana/loki/pull/6120) **KMiller-Grafana**: Rename configuration parameter fudge_duplicate_timestamp to be increment_duplicate_timestamp.
 * [5777](https://github.com/grafana/loki/pull/5777) **tatchiuleung**: storage: make Azure blobID chunk delimiter configurable
 * [5650](https://github.com/grafana/loki/pull/5650) **cyriltovena**: Remove more chunkstore and schema version below v9
 * [5643](https://github.com/grafana/loki/pull/5643) **simonswine**: Introduce a ChunkRef type as part of logproto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [5685](https://github.com/grafana/loki/pull/5685) **chaudum**: Assert that push values tuples consist of string values
 ##### Changes
 * [6042](https://github.com/grafana/loki/pull/6042) **slim-bean**: Add a new configuration to allow fudging of ingested timestamps to guarantee sort order of duplicate timestamps at query time.
+* [6120](https://github.com/grafana/loki/pull/6120) **KMiller-Grafana**: Rename the fudging of ingested timestamps configuration parameter introduced in PR 6042 to avoid using the slang term "fudge."
 * [5777](https://github.com/grafana/loki/pull/5777) **tatchiuleung**: storage: make Azure blobID chunk delimiter configurable
 * [5650](https://github.com/grafana/loki/pull/5650) **cyriltovena**: Remove more chunkstore and schema version below v9
 * [5643](https://github.com/grafana/loki/pull/5643) **simonswine**: Introduce a ChunkRef type as part of logproto


### PR DESCRIPTION
PR https://github.com/grafana/loki/pull/6120 renamed a configuration parameter.  I forgot to include a changelog entry with that PR.  This PR adds that changelog entry.