### PR TITLE
Support `series|labels` query_type in `logql_query_duration`

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	queryTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	QueryTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "logql",
 		Name:      "query_duration_seconds",
 		Help:      "LogQL query timings",
@@ -190,7 +190,7 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	defer log.Finish()
 
 	rangeType := GetRangeType(q.params)
-	timer := prometheus.NewTimer(queryTime.WithLabelValues(string(rangeType)))
+	timer := prometheus.NewTimer(QueryTime.WithLabelValues(string(rangeType)))
 	defer timer.ObserveDuration()
 
 	// records query statistics

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
@@ -207,6 +208,9 @@ func (q *QuerierAPI) LabelHandler(w http.ResponseWriter, r *http.Request) {
 
 	log, ctx := spanlogger.New(r.Context(), "query.Label")
 
+	timer := prometheus.NewTimer(logql.QueryTime.WithLabelValues("labels"))
+	defer timer.ObserveDuration()
+
 	start := time.Now()
 	statsCtx, ctx := stats.NewContext(ctx)
 
@@ -378,6 +382,9 @@ func (q *QuerierAPI) SeriesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log, ctx := spanlogger.New(r.Context(), "query.Series")
+
+	timer := prometheus.NewTimer(logql.QueryTime.WithLabelValues("series"))
+	defer timer.ObserveDuration()
 
 	start := time.Now()
 	statsCtx, ctx := stats.NewContext(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Support `series|labels` query_type in `logql_query_duration` histogram metric.
So that you can do quantile calculation on metadata queries.

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
