### PR TITLE
[logql] don't try to execute a modified function that is not allowed by the AST

### DIFF
--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -199,7 +199,12 @@ func (m RangeMapper) sumOverFullRange(expr *syntax.RangeAggregationExpr, overrid
 			Grouping:  overrideDownstream.Grouping,
 			Operation: overrideDownstream.Operation,
 		}
+		// Ensure our modified expression is still valid.
+		if downstreamExpr.(*syntax.VectorAggregationExpr).Left.(*syntax.RangeAggregationExpr).Validate() != nil {
+			return expr
+		}
 	}
+
 	return &syntax.BinOpExpr{
 		SampleExpr: &syntax.VectorAggregationExpr{
 			Left: m.mapConcatSampleExpr(downstreamExpr, rangeInterval, recorder),

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1500,6 +1500,10 @@ func Test_SplitRangeVectorMapping_Noop(t *testing.T) {
 			`sum(avg_over_time({app="foo"} | unwrap bar[3m]))`,
 			`sum(avg_over_time({app="foo"} | unwrap bar[3m]))`,
 		},
+		{ // this query caused a panic in ops
+			`topk(10,sum by (cluster,org_id) (rate({container="query-frontend",namespace="loki-prod",cluster="prod-us-central-0"} |= "metrics.go" | logfmt | unwrap bytes(total_bytes) | __error__=""[1h])))`,
+			`topk(10,sum by (cluster,org_id) (rate({container="query-frontend",namespace="loki-prod",cluster="prod-us-central-0"} |= "metrics.go" | logfmt | unwrap bytes(total_bytes) | __error__=""[1h])))`,
+		},
 
 		// should be noop if range interval is lower or equal to split interval (1m)
 		{

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -777,6 +777,10 @@ func (e RangeAggregationExpr) validate() error {
 	}
 }
 
+func (e RangeAggregationExpr) Validate() error {
+	return e.validate()
+}
+
 // impls Stringer
 func (e *RangeAggregationExpr) String() string {
 	var sb strings.Builder


### PR DESCRIPTION
The original panic was not useful, the change to the `clone` function and it's usage will ensure that in future cases we at least get an error message along with the panic stack trace. This PR also calls the `validate` function on the modified range query to ensure it's still allowed. In the case of the panic we saw, `unwrap` is not allowed with `count_over_time`, when in the original query we had `rate` with `unwrap` which is allowed.