### PR TITLE
Update loki's default port to 3100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 * [5777](https://github.com/grafana/loki/pull/5777) **tatchiuleung**: storage: make Azure blobID chunk delimiter configurable
 * [5650](https://github.com/grafana/loki/pull/5650) **cyriltovena**: Remove more chunkstore and schema version below v9
 * [5643](https://github.com/grafana/loki/pull/5643) **simonswine**: Introduce a ChunkRef type as part of logproto
+* [6349](https://github.com/grafana/loki/pull/6349) **simonswine**: Updates default HTTP listen port from 80 to 3100, make sure to configure the port explicitly if you are using port 80.
 #### Promtail
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 * [5777](https://github.com/grafana/loki/pull/5777) **tatchiuleung**: storage: make Azure blobID chunk delimiter configurable
 * [5650](https://github.com/grafana/loki/pull/5650) **cyriltovena**: Remove more chunkstore and schema version below v9
 * [5643](https://github.com/grafana/loki/pull/5643) **simonswine**: Introduce a ChunkRef type as part of logproto
-* [6349](https://github.com/grafana/loki/pull/6349) **simonswine**: Updates default HTTP listen port from 80 to 3100, make sure to configure the port explicitly if you are using port 80.
+* [6349](https://github.com/grafana/loki/pull/6349) **simonswine**: Update the default HTTP listen port from 80 to 3100. Make sure to configure the port explicitly if you are using port 80.
 #### Promtail
 
 ##### Enhancements

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -40,7 +40,7 @@ This value now defaults to `loki`, it was previously set to `cortex`. If you are
 
 #### Default value for `server.http-listen-port` changed
 
-This value now defaults to `3100` so the Loki process doesn't require special privileges anymore (before it had been set to port `80`, which is a privileged port). In case you need Loki to listen on port `80` you can set it back to the previous default using `-server.http-listen-port=80`.
+This value now defaults to 3100, so the Loki process doesn't require special privileges. Previously, it had been set to port 80, which is a privileged port. If you need Loki to listen on port 80, you can set it back to the previous default using `-server.http-listen-port=80`.
 
 ## 2.5.0
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -38,6 +38,10 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 This value now defaults to `loki`, it was previously set to `cortex`. If you are relying on this container name for your chunks or ruler storage, you will have to manually specify `-azure.container-name=cortex` or `-ruler.storage.azure.container-name=cortex` respectively.
 
+#### Default value for `server.http-listen-port` changed
+
+This value now defaults to `3100` so the Loki process doesn't require special privileges anymore (before it had been set to port `80`, which is a privileged port). In case you need Loki to listen on port `80` you can set it back to the previous default using `-server.http-listen-port=80`.
+
 ## 2.5.0
 
 ### Loki

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -969,7 +969,7 @@ func TestDefaultUnmarshal(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, config.AuthEnabled)
-		assert.Equal(t, 80, config.Server.HTTPListenPort)
+		assert.Equal(t, 3100, config.Server.HTTPListenPort)
 		assert.Equal(t, 9095, config.Server.GRPCListenPort)
 	})
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -137,6 +137,9 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 
 		case "server.grpc.keepalive.ping-without-stream-allowed":
 			_ = f.Value.Set("true")
+
+		case "server.http-listen-port":
+			_ = f.Value.Set("3100")
 		}
 
 		fs.Var(f.Value, f.Name, f.Usage)

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -57,6 +57,11 @@ func TestFlagDefaults(t *testing.T) {
 	require.Contains(t, gotFlags, flagToCheck)
 	require.Equal(t, c.Server.GRPCServerPingWithoutStreamAllowed, true)
 	require.Contains(t, gotFlags[flagToCheck], "(default true)")
+
+	flagToCheck = "-server.http-listen-port"
+	require.Contains(t, gotFlags, flagToCheck)
+	require.Equal(t, c.Server.HTTPListenPort, 3100)
+	require.Contains(t, gotFlags[flagToCheck], "(default 3100)")
 }
 
 func TestLoki_isModuleEnabled(t1 *testing.T) {


### PR DESCRIPTION
I was suprised this was not already the case. I think it would be a good change to make, but I am also contious of the breaking nature of this.
