### PR TITLE
fix(loki): allow global and per tenant sigv4 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [6317](https://github.com/grafana/loki/pull/6317/files) **dannykoping**: General: add cache usage statistics
 
 ##### Fixes
+* [6358](https://github.com/grafana/loki/pull/6358) **taharah**: Fixes sigv4 authentication for the Ruler's remote write configuration by allowing both a global and per tenant configuration.
 * [6152](https://github.com/grafana/loki/pull/6152) **slim-bean**: Fixes unbounded ingester memory growth when live tailing under specific circumstances.
 * [5685](https://github.com/grafana/loki/pull/5685) **chaudum**: Assert that push values tuples consist of string values
 ##### Changes

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -562,21 +562,7 @@ remote_write:
     # Optionally configures AWS's Signature Verification 4 signing process to
     # sign requests. Cannot be set at the same time as basic_auth, authorization, or oauth2.
     # To use the default credentials from the AWS SDK, use `sigv4: {}`.
-    sigv4:
-      # The AWS region. If blank, the region from the default credentials chain
-      # is used.
-      [region: <string>]
-
-      # The AWS API keys. If blank, the environment variables `AWS_ACCESS_KEY_ID`
-      # and `AWS_SECRET_ACCESS_KEY` are used.
-      [access_key: <string>]
-      [secret_key: <secret>]
-
-      # Named AWS profile used to authenticate.
-      [profile: <string>]
-
-      # AWS Role ARN, an alternative to using AWS API keys.
-      [role_arn: <string>]
+    [sigv4: <sigv4_config>]
 
     # Configures the remote write request's TLS settings.
     tls_config:
@@ -2362,6 +2348,10 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # This is experimental and might change in the future.
 [ruler_remote_write_queue_retry_on_ratelimit: <boolean>]
 
+# Configures AWS's Signature Verification 4 signing process to
+# sign every remote write request.
+[ruler_remote_write_sigv4_config:  <sigv4_config>]
+
 # Limit queries that can be sharded.
 # Queries within the time range of now and now minus this sharding lookback
 # are not sharded. The default value of 0s disables the lookback, causing
@@ -2373,6 +2363,28 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # This also determines how cache keys are chosen when result caching is enabled
 # CLI flag: -querier.split-queries-by-interval
 [split_queries_by_interval: <duration> | default = 30m]
+```
+
+## sigv4_config
+
+The `sigv4_config` block configures AWS's Signature Verification 4 signing process to
+sign every remote write request.
+
+```yaml
+# The AWS region. If blank, the region from the default credentials chain
+# is used.
+[region: <string>]
+
+# The AWS API keys. If blank, the environment variables `AWS_ACCESS_KEY_ID`
+# and `AWS_SECRET_ACCESS_KEY` are used.
+[access_key: <string>]
+[secret_key: <secret>]
+
+# Named AWS profile used to authenticate.
+[profile: <string>]
+
+# AWS Role ARN, an alternative to using AWS API keys.
+[role_arn: <string>]
 ```
 
 ### grpc_client_config

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,10 @@ require (
 	k8s.io/klog v1.0.0
 )
 
-require github.com/willf/bloom v2.0.3+incompatible
+require (
+	github.com/prometheus/common/sigv4 v0.1.0
+	github.com/willf/bloom v2.0.3+incompatible
+)
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
@@ -228,7 +231,6 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/alertmanager v0.23.1-0.20210914172521-e35efbddb66a // indirect
-	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/sigv4"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -49,6 +50,7 @@ type RulesLimits interface {
 	RulerRemoteWriteQueueMinBackoff(userID string) time.Duration
 	RulerRemoteWriteQueueMaxBackoff(userID string) time.Duration
 	RulerRemoteWriteQueueRetryOnRateLimit(userID string) bool
+	RulerRemoteWriteSigV4Config(userID string) *sigv4.SigV4Config
 }
 
 // engineQueryFunc returns a new query function using the rules.EngineQueryFunc function

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -229,7 +229,6 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 	// TODO(dannyk): configure HTTP client overrides
 	// metadata is only used by prometheus scrape configs
 	overrides.Client.MetadataConfig = config.MetadataConfig{Send: false}
-	overrides.Client.SigV4Config = nil
 
 	if r.overrides.RulerRemoteWriteDisabled(tenant) {
 		overrides.Enabled = false
@@ -294,6 +293,10 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 
 	if v := r.overrides.RulerRemoteWriteQueueRetryOnRateLimit(tenant); v {
 		overrides.Client.QueueConfig.RetryOnRateLimit = v
+	}
+
+	if v := r.overrides.RulerRemoteWriteSigV4Config(tenant); v != nil {
+		overrides.Client.SigV4Config = v
 	}
 
 	return overrides, nil

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/sigv4"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v2"
@@ -108,6 +109,7 @@ type Limits struct {
 	RulerRemoteWriteQueueMinBackoff        time.Duration                `yaml:"ruler_remote_write_queue_min_backoff" json:"ruler_remote_write_queue_min_backoff"`
 	RulerRemoteWriteQueueMaxBackoff        time.Duration                `yaml:"ruler_remote_write_queue_max_backoff" json:"ruler_remote_write_queue_max_backoff"`
 	RulerRemoteWriteQueueRetryOnRateLimit  bool                         `yaml:"ruler_remote_write_queue_retry_on_ratelimit" json:"ruler_remote_write_queue_retry_on_ratelimit"`
+	RulerRemoteWriteSigV4Config            *sigv4.SigV4Config           `yaml:"ruler_remote_write_sigv4_config" json:"ruler_remote_write_sigv4_config"`
 
 	// Global and per tenant retention
 	RetentionPeriod model.Duration    `yaml:"retention_period" json:"retention_period"`
@@ -510,6 +512,10 @@ func (o *Overrides) RulerRemoteWriteQueueMaxBackoff(userID string) time.Duration
 // RulerRemoteWriteQueueRetryOnRateLimit returns whether to retry failed remote-write requests (429 response) for a given user.
 func (o *Overrides) RulerRemoteWriteQueueRetryOnRateLimit(userID string) bool {
 	return o.getOverridesForUser(userID).RulerRemoteWriteQueueRetryOnRateLimit
+}
+
+func (o *Overrides) RulerRemoteWriteSigV4Config(userID string) *sigv4.SigV4Config {
+	return o.getOverridesForUser(userID).RulerRemoteWriteSigV4Config
 }
 
 // RetentionPeriod returns the retention period for a given user.

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -63,6 +63,8 @@ split_queries_by_interval: 190s
 ruler_evaluation_delay_duration: 200s
 ruler_max_rules_per_rule_group: 210
 ruler_max_rule_groups_per_tenant: 220
+ruler_remote_write_sigv4_config:
+  region: us-east-1
 per_tenant_override_config: ""
 per_tenant_override_period: 230s
 `
@@ -96,6 +98,9 @@ per_tenant_override_period: 230s
   "ruler_evaluation_delay_duration": "200s",
   "ruler_max_rules_per_rule_group": 210,
   "ruler_max_rule_groups_per_tenant":220,
+  "ruler_remote_write_sigv4_config": {
+    "region": "us-east-1"
+  },
   "per_tenant_override_config": "",
   "per_tenant_override_period": "230s"
  }


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Fixes an issue that prevented the sigv4 authentication configuration from being set during the resolution of the per tenant overrides. This fixes the issue by allowing the global value to be properly propagated as well as enables setting the sigv4 authentication on a per tenant basis. 

**Which issue(s) this PR fixes**:
Fixes #6293

**Special notes for your reviewer**:
N/A

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
