### PR TITLE
operator: Allow reduced tenant OIDC authentication requirements

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6362](https://github.com/grafana/loki/pull/6362) **periklis**: Allow reduced tenant OIDC authentication requirements
 - [6288](https://github.com/grafana/loki/pull/6288) **aminesnow**: Expose only an HTTPS gateway when in openshift mode
 - [6195](https://github.com/grafana/loki/pull/6195) **periklis**: Add ruler config support
 - [6198](https://github.com/grafana/loki/pull/6198) **periklis**: Add support for custom S3 CA

--- a/operator/api/v1beta1/lokistack_types.go
+++ b/operator/api/v1beta1/lokistack_types.go
@@ -159,12 +159,20 @@ type OIDCSpec struct {
 	IssuerURL string `json:"issuerURL"`
 	// RedirectURL defines the URL for redirect.
 	//
-	// +required
-	// +kubebuilder:validation:Required
+	// +optional
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redirect URL"
-	RedirectURL   string `json:"redirectURL"`
-	GroupClaim    string `json:"groupClaim"`
-	UsernameClaim string `json:"usernameClaim"`
+	RedirectURL string `json:"redirectURL,omitempty"`
+	// Group claim field from ID Token
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	GroupClaim string `json:"groupClaim,omitempty"`
+	// User claim field from ID Token
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	UsernameClaim string `json:"usernameClaim,omitempty"`
 }
 
 // AuthenticationSpec defines the oidc configuration per tenant for lokiStack Gateway component.

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -838,6 +838,7 @@ spec:
                             authentication.
                           properties:
                             groupClaim:
+                              description: Group claim field from ID Token
                               type: string
                             issuerURL:
                               description: IssuerURL defines the URL for issuer.
@@ -857,13 +858,11 @@ spec:
                               - name
                               type: object
                             usernameClaim:
+                              description: User claim field from ID Token
                               type: string
                           required:
-                          - groupClaim
                           - issuerURL
-                          - redirectURL
                           - secret
-                          - usernameClaim
                           type: object
                         tenantId:
                           description: TenantID defines the id of the tenant.

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -833,6 +833,7 @@ spec:
                             authentication.
                           properties:
                             groupClaim:
+                              description: Group claim field from ID Token
                               type: string
                             issuerURL:
                               description: IssuerURL defines the URL for issuer.
@@ -852,13 +853,11 @@ spec:
                               - name
                               type: object
                             usernameClaim:
+                              description: User claim field from ID Token
                               type: string
                           required:
-                          - groupClaim
                           - issuerURL
-                          - redirectURL
                           - secret
-                          - usernameClaim
                           type: object
                         tenantId:
                           description: TenantID defines the id of the tenant.

--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -69,9 +69,6 @@ func extractSecret(s *corev1.Secret, tenantName string) (*manifests.TenantSecret
 		return nil, kverrors.New("missing clientID field", "field", "clientID")
 	}
 	clientSecret := s.Data["clientSecret"]
-	if len(clientSecret) == 0 {
-		return nil, kverrors.New("missing clientSecret field", "field", "clientSecret")
-	}
 	issuerCAPath := s.Data["issuerCAPath"]
 
 	return &manifests.TenantSecrets{

--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -73,9 +73,6 @@ func extractSecret(s *corev1.Secret, tenantName string) (*manifests.TenantSecret
 		return nil, kverrors.New("missing clientSecret field", "field", "clientSecret")
 	}
 	issuerCAPath := s.Data["issuerCAPath"]
-	if len(issuerCAPath) == 0 {
-		return nil, kverrors.New("missing issuerCAPath field", "field", "issuerCAPath")
-	}
 
 	return &manifests.TenantSecrets{
 		TenantName:   tenantName,

--- a/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
@@ -158,16 +158,6 @@ func TestExtractSecret(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "missing clientSecret",
-			tenantName: "tenant-a",
-			secret: &corev1.Secret{
-				Data: map[string][]byte{
-					"clientID": []byte("test"),
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name:       "all set",
 			tenantName: "tenant-a",
 			secret: &corev1.Secret{

--- a/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets_test.go
@@ -168,17 +168,6 @@ func TestExtractSecret(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:       "missing issuerCAPath",
-			tenantName: "tenant-a",
-			secret: &corev1.Secret{
-				Data: map[string][]byte{
-					"clientID":     []byte("test"),
-					"clientSecret": []byte("test"),
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name:       "all set",
 			tenantName: "tenant-a",
 			secret: &corev1.Secret{

--- a/operator/internal/manifests/internal/gateway/gateway-tenants.yaml
+++ b/operator/internal/manifests/internal/gateway/gateway-tenants.yaml
@@ -19,7 +19,9 @@ tenants:
     {{- end -}}
     {{- end }}
     issuerURL: {{ $spec.OIDC.IssuerURL }}
+    {{ if $spec.OIDC.RedirectURL }}
     redirectURL: {{ $spec.OIDC.RedirectURL }}
+    {{- end -}}
     {{ if $spec.OIDC.UsernameClaim }}
     usernameClaim: {{ $spec.OIDC.UsernameClaim }}
     {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
The present `LokiStack` CR kubebuilder annotations disallow using the gateway OIDC flow by only providing a `clientID` and `issuerURL` in the secret. This makes use cases like using [token-refresher](https://github.com/observatorium/token-refresher) that forwards a valid IDToken impossible.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
