### PR TITLE
operator: Allow optional installation of webhooks

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6363](https://github.com/grafana/loki/pull/6363) **periklis**: Allow optional installation of webhooks (Kind)
 - [6362](https://github.com/grafana/loki/pull/6362) **periklis**: Allow reduced tenant OIDC authentication requirements
 - [6288](https://github.com/grafana/loki/pull/6288) **aminesnow**: Expose only an HTTPS gateway when in openshift mode
 - [6195](https://github.com/grafana/loki/pull/6195) **periklis**: Add ruler config support

--- a/operator/config/overlays/development/kustomization.yaml
+++ b/operator/config/overlays/development/kustomization.yaml
@@ -18,5 +18,6 @@ labels:
     app.kubernetes.io/version: "0.0.1"
 
 patchesStrategicMerge:
+- manager_run_flags_patch.yaml
 - manager_related_image_patch.yaml
 - manager_image_pull_policy_patch.yaml

--- a/operator/config/overlays/development/manager_run_flags_patch.yaml
+++ b/operator/config/overlays/development/manager_run_flags_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          args:
+          - "--with-alerting-rule-webhooks=false"
+          - "--with-recording-rule-webhooks=false"

--- a/operator/main.go
+++ b/operator/main.go
@@ -75,7 +75,7 @@ func main() {
 	flag.BoolVar(&enableAlertingRuleWebhooks, "with-alerting-rule-webhooks", true,
 		"Enables AlertingRule validation webhooks.")
 	flag.BoolVar(&enableRecordingRuleWebhooks, "with-recording-rule-webhooks", true,
-		"Enables RecordingRule Validation Webhooks.")
+		"Enables RecordingRule validation webhooks.")
 	flag.Parse()
 
 	logger := log.NewLogger("loki-operator")

--- a/operator/main.go
+++ b/operator/main.go
@@ -73,7 +73,7 @@ func main() {
 	flag.BoolVar(&enableGrafanaLabsAnalytics, "with-grafana-labs-analytics", true,
 		"Enables Grafana Labs analytics.\nMore info: https://grafana.com/docs/loki/latest/configuration/#analytics")
 	flag.BoolVar(&enableAlertingRuleWebhooks, "with-alerting-rule-webhooks", true,
-		"Enables AlertigRule Validation Webhooks.")
+		"Enables AlertingRule validation webhooks.")
 	flag.BoolVar(&enableRecordingRuleWebhooks, "with-recording-rule-webhooks", true,
 		"Enables RecordingRule Validation Webhooks.")
 	flag.Parse()

--- a/operator/main.go
+++ b/operator/main.go
@@ -41,16 +41,18 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr                string
-		enableLeaderElection       bool
-		probeAddr                  string
-		enableCertSigning          bool
-		enableServiceMonitors      bool
-		enableTLSServiceMonitors   bool
-		enableGateway              bool
-		enableGatewayRoute         bool
-		enablePrometheusAlerts     bool
-		enableGrafanaLabsAnalytics bool
+		metricsAddr                 string
+		enableLeaderElection        bool
+		probeAddr                   string
+		enableCertSigning           bool
+		enableServiceMonitors       bool
+		enableTLSServiceMonitors    bool
+		enableGateway               bool
+		enableGatewayRoute          bool
+		enablePrometheusAlerts      bool
+		enableGrafanaLabsAnalytics  bool
+		enableAlertingRuleWebhooks  bool
+		enableRecordingRuleWebhooks bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -70,6 +72,10 @@ func main() {
 	flag.BoolVar(&enablePrometheusAlerts, "with-prometheus-alerts", false, "Enables prometheus alerts.")
 	flag.BoolVar(&enableGrafanaLabsAnalytics, "with-grafana-labs-analytics", true,
 		"Enables Grafana Labs analytics.\nMore info: https://grafana.com/docs/loki/latest/configuration/#analytics")
+	flag.BoolVar(&enableAlertingRuleWebhooks, "with-alerting-rule-webhooks", true,
+		"Enables AlertigRule Validation Webhooks.")
+	flag.BoolVar(&enableRecordingRuleWebhooks, "with-recording-rule-webhooks", true,
+		"Enables RecordingRule Validation Webhooks.")
 	flag.Parse()
 
 	logger := log.NewLogger("loki-operator")
@@ -132,9 +138,11 @@ func main() {
 		logger.Error(err, "unable to create controller", "controller", "AlertingRule")
 		os.Exit(1)
 	}
-	if err = (&lokiv1beta1.AlertingRule{}).SetupWebhookWithManager(mgr); err != nil {
-		logger.Error(err, "unable to create webhook", "webhook", "AlertingRule")
-		os.Exit(1)
+	if enableAlertingRuleWebhooks {
+		if err = (&lokiv1beta1.AlertingRule{}).SetupWebhookWithManager(mgr); err != nil {
+			logger.Error(err, "unable to create webhook", "webhook", "AlertingRule")
+			os.Exit(1)
+		}
 	}
 	if err = (&controllers.RecordingRuleReconciler{
 		Client: mgr.GetClient(),
@@ -144,9 +152,11 @@ func main() {
 		logger.Error(err, "unable to create controller", "controller", "RecordingRule")
 		os.Exit(1)
 	}
-	if err = (&lokiv1beta1.RecordingRule{}).SetupWebhookWithManager(mgr); err != nil {
-		logger.Error(err, "unable to create webhook", "webhook", "RecordingRule")
-		os.Exit(1)
+	if enableRecordingRuleWebhooks {
+		if err = (&lokiv1beta1.RecordingRule{}).SetupWebhookWithManager(mgr); err != nil {
+			logger.Error(err, "unable to create webhook", "webhook", "RecordingRule")
+			os.Exit(1)
+		}
 	}
 	if err = (&controllers.RulerConfigReconciler{
 		Client: mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Using webhooks for `AlertingRule` and `RecordingRule` requires TLS by default and we cannot use this with kind on local development yet.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
