### PR TITLE
Deletion: use correct counter when deleting lines

### DIFF
--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager.go
@@ -119,7 +119,7 @@ func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
 		if deleteRequest.CreatedAt.Add(d.deleteRequestCancelPeriod).Add(time.Minute).After(model.Now()) {
 			continue
 		}
-		deleteRequest.deletedLinesTotal = d.metrics.deleteRequestsProcessedTotal.WithLabelValues(deleteRequest.UserID)
+		deleteRequest.deletedLinesTotal = d.metrics.deletedLinesTotal.WithLabelValues(deleteRequest.UserID)
 		d.deleteRequestsToProcess = append(d.deleteRequestsToProcess, deleteRequest)
 	}
 

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_manager_test.go
@@ -293,6 +293,10 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, nil, tc.deletionMode)
 			require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
+			for _, dr := range mgr.deleteRequestsToProcess {
+				require.Contains(t, dr.deletedLinesTotal.Desc().String(), "loki_compactor_deleted_lines")
+			}
+
 			isExpired, nonDeletedIntervals := mgr.Expired(chunkEntry, model.Now())
 			require.Equal(t, tc.expectedResp.isExpired, isExpired)
 			for idx, interval := range nonDeletedIntervals {


### PR DESCRIPTION
**What this PR does / why we need it**:

An incorrect counter was used when deleting lines. A test to check the counter is added as well.

**Checklist**
- [ ] Documentation added
- [X] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
