### PR TITLE
Revert "Loki Prometheus mixin: templatize cluster label"

### DIFF
--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -8,6 +8,5 @@
 
     // The label used to differentiate between different nodes (i.e. servers).
     per_node_label: 'instance',
-    per_cluster_label: 'cluster',
   },
 }

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -29,15 +29,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
       addCluster(multi=false)::
         if multi then
-          self.addMultiTemplate('cluster', 'loki_build_info', $._config.per_cluster_label)
+          self.addMultiTemplate('cluster', 'loki_build_info', 'cluster')
         else
-          self.addTemplate('cluster', 'loki_build_info', $._config.per_cluster_label),
+          self.addTemplate('cluster', 'loki_build_info', 'cluster'),
 
       addNamespace(multi=false)::
         if multi then
-          self.addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          self.addMultiTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace')
         else
-          self.addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          self.addTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace'),
 
       addTag()::
         self + {
@@ -74,18 +74,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
         };
 
         if multi then
-          d.addMultiTemplate('cluster', 'loki_build_info', $._config.per_cluster_label)
-          .addMultiTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace')
+          d.addMultiTemplate('cluster', 'loki_build_info', 'cluster')
+          .addMultiTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace')
         else
-          d.addTemplate('cluster', 'loki_build_info', $._config.per_cluster_label)
-          .addTemplate('namespace', 'loki_build_info{' + $._config.per_cluster_label + '=~"$cluster"}', 'namespace'),
+          d.addTemplate('cluster', 'loki_build_info', 'cluster')
+          .addTemplate('namespace', 'loki_build_info{cluster=~"$cluster"}', 'namespace'),
     },
 
   jobMatcher(job)::
-    $._config.per_cluster_label + '=~"$cluster", job=~"($namespace)/%s"' % job,
+    'cluster=~"$cluster", job=~"($namespace)/%s"' % job,
 
   namespaceMatcher()::
-    $._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"',
+    'cluster=~"$cluster", namespace=~"$namespace"',
 
   containerLabelMatcher(containerName)::
     'label_name=~"%s.*"' % containerName,

--- a/production/loki-mixin/dashboards/loki-chunks.libsonnet
+++ b/production/loki-mixin/dashboards/loki-chunks.libsonnet
@@ -6,7 +6,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local dashboards = self,
     'loki-chunks.json': {
                           local cfg = self,
-                          labelsSelector:: $._config.per_cluster_label + '="$cluster", job="$namespace/ingester"',
+                          labelsSelector:: 'cluster="$cluster", job="$namespace/ingester"',
                         } +
                         $.dashboard('Loki / Chunks', uid='chunks')
                         .addCluster()

--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -7,7 +7,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'deployment',
       '$datasource',
-      'label_values(kube_deployment_created{' + $._config.per_cluster_label + '="$cluster", namespace="$namespace"}, deployment)',
+      'label_values(kube_deployment_created{cluster="$cluster", namespace="$namespace"}, deployment)',
       sort=1,
     ),
 
@@ -15,7 +15,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'pod',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", namespace="$namespace", pod=~"$deployment.*"}, pod)',
+      'label_values(kube_pod_container_info{cluster="$cluster", namespace="$namespace", pod=~"$deployment.*"}, pod)',
       sort=1,
     ),
 
@@ -23,7 +23,7 @@ local template = import 'grafonnet/template.libsonnet';
     template.new(
       'container',
       '$datasource',
-      'label_values(kube_pod_container_info{' + $._config.per_cluster_label + '="$cluster", namespace="$namespace", pod=~"$pod", pod=~"$deployment.*"}, container)',
+      'label_values(kube_pod_container_info{cluster="$cluster", namespace="$namespace", pod=~"$pod", pod=~"$deployment.*"}, container)',
       sort=1,
     ),
 
@@ -48,7 +48,7 @@ local template = import 'grafonnet/template.libsonnet';
                         local cfg = self,
 
                         showMultiCluster:: true,
-                        clusterLabel:: $._config.per_cluster_label,
+                        clusterLabel:: 'cluster',
 
                       } + lokiLogs +
                       $.dashboard('Loki / Logs', uid='logs')
@@ -62,7 +62,7 @@ local template = import 'grafonnet/template.libsonnet';
                             targets: [
                               e {
                                 expr: if dashboards['loki-logs.json'].showMultiCluster then super.expr
-                                else std.strReplace(super.expr, $._config.per_cluster_label + '="$cluster", ', ''),
+                                else std.strReplace(super.expr, 'cluster="$cluster", ', ''),
                               }
                               for e in p.targets
                             ],

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                showAnnotations:: true,
                                showLinks:: true,
                                showMultiCluster:: true,
-                               clusterLabel:: $._config.per_cluster_label,
+                               clusterLabel:: 'cluster',
 
                                matchers:: {
                                  cortexgateway: [utils.selector.re('job', '($namespace)/cortex-gw')],
@@ -44,13 +44,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                      std.strReplace(
                                        std.strReplace(
                                          expr,
-                                         ', ' + $._config.per_cluster_label + '="$cluster"',
+                                         ', cluster="$cluster"',
                                          ''
                                        ),
-                                       ', ' + $._config.per_cluster_label + '=~"$cluster"',
+                                       ', cluster=~"$cluster"',
                                        ''
                                      ),
-                                     $._config.per_cluster_label + '="$cluster",',
+                                     'cluster="$cluster",',
                                      ''
                                    ),
 

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                          local cfg = self,
 
                          showMultiCluster:: true,
-                         clusterLabel:: $._config.per_cluster_label,
+                         clusterLabel:: 'cluster',
                          clusterMatchers::
                            if cfg.showMultiCluster then
                              [utils.selector.re(cfg.clusterLabel, '$cluster')]

--- a/production/loki-mixin/dashboards/loki-writes.libsonnet
+++ b/production/loki-mixin/dashboards/loki-writes.libsonnet
@@ -8,7 +8,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                           local cfg = self,
 
                           showMultiCluster:: true,
-                          clusterLabel:: $._config.per_cluster_label,
+                          clusterLabel:: 'cluster',
                           clusterMatchers::
                             if cfg.showMultiCluster then
                               [utils.selector.re(cfg.clusterLabel, '$cluster')]

--- a/production/promtail-mixin/jsonnetfile.json
+++ b/production/promtail-mixin/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "production/loki-mixin"
         }
       },
-      "version": "main"
+      "version": "aed11c25e"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
Reverts grafana/loki#6353

@hervenicol Reverting the PR, because it breaks the `main` branch. (it passed on your original branch, but suspect that CI may be bit flaky. But when tried in local `make lint-jsonnet` it fails as well)

```
Linting ./production/promtail-mixin/mixin.libsonnet
RUNTIME ERROR: Field does not exist: per_cluster_label
	production/promtail-mixin/vendor/loki-mixin/dashboards/dashboard-utils.libsonnet:34:58-85	thunk from <function <anonymous>>
	production/promtail-mixin/vendor/grafana-builder/grafana.libsonnet:31:57-67	thunk from <object <anonymous>>
	<std>:715:15-22	thunk <val> from <function <format_codes_arr>>
	<std>:722:27-30	thunk from <thunk <s> from <function <format_codes_arr>>>
	<std>:592:22-25	thunk from <function <format_code>>
	<std>:592:9-26	function <format_code>
	<std>:722:15-60	thunk <s> from <function <format_codes_arr>>
	<std>:727:24-25	thunk from <thunk <s_padded> from <function <format_codes_arr>>>
	<std>:480:30-33	thunk from <thunk from <function <pad_left>>>
	<std>:480:19-34	thunk from <function <pad_left>>
	...
	<std>:733:11-64	function <format_codes_arr>
	<std>:777:7-46	function <anonymous>
	<std>:237:7-23	function <anonymous>
	production/promtail-mixin/vendor/grafana-builder/grafana.libsonnet:31:18-68	
	Field "query"	
	Array element 1	
	Field "list"	
	Field "templating"	
	Field "promtail.json"	
	During manifestation	
```

to me it looks like it's failing to lint promtail-mixin because promtail-mixin unable to find this new label `per_cluster_label` when used with called with `addCluster()` where `multi=false` by default.

Will be happy to merge it again, once the CI linter is fixed. :) may be in separate PR. 