### PR TITLE
Add deleted lines panel to deletion dashboard

### DIFF
--- a/production/loki-mixin-compiled/dashboards/loki-deletion.json
+++ b/production/loki-mixin-compiled/dashboards/loki-deletion.json
@@ -437,6 +437,94 @@
             "showTitle": true,
             "title": "Failures",
             "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 12,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(loki_compactor_deleted_lines{cluster=~\"$cluster\",job=~\"$namespace/compactor\"}[$__rate_interval])) by (user)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{user}}",
+                        "legendLink": null,
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Lines Deleted / Sec",
+                  "tooltip": {
+                     "shared": true,
+                     "sort": 2,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Deleted lines",
+            "titleSize": "h6"
          }
       ],
       "schemaVersion": 14,

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -44,7 +44,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           g.row('Deleted lines')
           .addPanel(
             g.panel('Lines Deleted / Sec') +
-            g.queryPanel('sum(rate(loki_compactor_deleted_lines{cluster=~"$cluster",job=~"$namespace/compactor"}[$__rate_interval])) by (user)', '{{user}}'),
+            g.queryPanel('sum(rate(loki_compactor_deleted_lines{' + $._config.per_cluster_label + '=~"$cluster",job=~"$namespace/compactor"}[$__rate_interval])) by (user)', '{{user}}'),
           )
         ),
     },

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -40,6 +40,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
             g.panel('Failures in Loading Delete Requests / Hour') +
             g.queryPanel('sum(increase(loki_compactor_load_pending_requests_attempts_total{status="fail", %s}[1h]))' % $.namespaceMatcher(), 'failures'),
           )
+        ).addRow(
+          g.row('Deleted lines')
+          .addPanel(
+            g.panel('Lines Deleted / Sec') +
+            g.queryPanel('sum(rate(loki_compactor_deleted_lines{cluster=~"$cluster",job=~"$namespace/compactor"}[$__rate_interval])) by (user)', '{{user}}') +
+          )
         ),
     },
 }

--- a/production/loki-mixin/dashboards/loki-deletion.libsonnet
+++ b/production/loki-mixin/dashboards/loki-deletion.libsonnet
@@ -44,7 +44,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           g.row('Deleted lines')
           .addPanel(
             g.panel('Lines Deleted / Sec') +
-            g.queryPanel('sum(rate(loki_compactor_deleted_lines{cluster=~"$cluster",job=~"$namespace/compactor"}[$__rate_interval])) by (user)', '{{user}}') +
+            g.queryPanel('sum(rate(loki_compactor_deleted_lines{cluster=~"$cluster",job=~"$namespace/compactor"}[$__rate_interval])) by (user)', '{{user}}'),
           )
         ),
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a panel for deleted lines to the Deletion dashboard. The new delete functionality has a counter for the deleted lines.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
