### PR TITLE
Add lokistack prefix to role and rolebinding names.

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -130,7 +130,7 @@ generate: $(CONTROLLER_GEN) ## Generate controller and crd code
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=lokistack-manager crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: test
 test: deps generate go-generate lint lint-prometheus manifests ## Run tests

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: lokistack-manager
 rules:
 - apiGroups:
   - ""

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: lokistack-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: lokistack-manager
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
The ClusterRole and ClusterRoleBinding are global resources.
The former names "manager-role" and "manager-rolebinding" may clash.
Renamed both to "lokistack-manager".
- incudes lokistack prefix for uniqueness.
- dropped "-role" and "-rolebinding" suffix to follow common usage.