### PR TITLE
Git ignore pkg/loki/wal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ test_results.txt
 .DS_Store
 .aws-sam
 .idea
+pkg/loki/wal
 
 # emacs
 .#*


### PR DESCRIPTION
I noticed that after running `make test` the directory pkg/loki/wal is
created which a bunch of files and data.

I think it would be a good idea to ignore the entire directory with git.