### PR TITLE
Compactor: add per tenant compaction delete enabled flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [6410](https://github.com/grafana/loki/pull/6410) **MichelHollands**: Add support for per tenant delete API access enabling.
 * [6372](https://github.com/grafana/loki/pull/6372) **splitice**: Add support for numbers in JSON fields.
 * [6105](https://github.com/grafana/loki/pull/6105) **rutgerke** Export metrics for the Promtail journal target.
 * [6099](https://github.com/grafana/loki/pull/6099) **cstyan**: Drop lines with malformed JSON in Promtail JSON pipeline stage.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2373,9 +2373,9 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # CLI flag: -querier.split-queries-by-interval
 [split_queries_by_interval: <duration> | default = 30m]
 
-# When true, access to the deletion API on the compactor is enabled.
-# CLI flag: -compactor.deletion-enabled
-[compactor_deletion_enabled: <boolean> | default = false]
+# When true, access to the deletion API is enabled.
+# CLI flag: -compactor.allow_deletes
+[allow_deletes: <boolean> | default = false]
 ```
 
 ## sigv4_config

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2372,6 +2372,10 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # This also determines how cache keys are chosen when result caching is enabled
 # CLI flag: -querier.split-queries-by-interval
 [split_queries_by_interval: <duration> | default = 30m]
+
+# When true, access to the deletion API on the compactor is enabled.
+# CLI flag: -compactor.deletion-enabled
+[compactor_deletion_enabled: <boolean> | default = false]
 ```
 
 ## sigv4_config

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -24,8 +24,9 @@ With `whole-stream-deletion`, all the log entries matching the query given in th
 With `filter-only`, log lines matching the query in the delete request are filtered out when querying Loki. They are not removed from the on-disk chunks.
 With `filter-and-delete`, log lines matching the query in the delete request are filtered out when querying Loki, and they are also removed from the on-disk chunks.
 
-
 A delete request may be canceled within a configurable cancellation period. Set the `delete_request_cancel_period` in the Compactor's YAML configuration or on the command line when invoking Loki. Its default value is 24h.
+
+Access to the deletion API can be enabled per tenant via the `compactor_deletion_enabled` setting.
 
 ## Compactor endpoints
 

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -26,7 +26,7 @@ With `filter-and-delete`, log lines matching the query in the delete request are
 
 A delete request may be canceled within a configurable cancellation period. Set the `delete_request_cancel_period` in the Compactor's YAML configuration or on the command line when invoking Loki. Its default value is 24h.
 
-Access to the deletion API can be enabled per tenant via the `compactor_deletion_enabled` setting.
+Access to the deletion API can be enabled per tenant via the `allow_deletes` setting.
 
 ## Compactor endpoints
 

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -26,7 +26,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 			"-boltdb.shipper.compactor.deletion-mode=filter-and-delete",
 			// By default a minute is added to the delete request start time. This compensates for that.
 			"-boltdb.shipper.compactor.delete-request-cancel-period=-60s",
-			"-compactor.deletion-enabled=true",
+			"-compactor.allow-deletes=true",
 		)
 		tIndexGateway = clu.AddComponent(
 			"index-gateway",

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -26,6 +26,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 			"-boltdb.shipper.compactor.deletion-mode=filter-and-delete",
 			// By default a minute is added to the delete request start time. This compensates for that.
 			"-boltdb.shipper.compactor.delete-request-cancel-period=-60s",
+			"-compactor.deletion-enabled=true",
 		)
 		tIndexGateway = clu.AddComponent(
 			"index-gateway",

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -873,10 +873,10 @@ func (t *Loki) initCompactor() (services.Service, error) {
 	if t.Cfg.CompactorConfig.RetentionEnabled {
 		switch t.compactor.DeleteMode() {
 		case deletion.WholeStreamDeletion, deletion.FilterOnly, deletion.FilterAndDelete:
-			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler)))
-			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler)))
-			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler)))
-			t.Server.HTTP.Path("/loki/api/v1/cache/generation_numbers").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler)))
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("PUT", "POST").Handler(t.HTTPAuthMiddleware.Wrap(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler()))
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler()))
+			t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler()))
+			t.Server.HTTP.Path("/loki/api/v1/cache/generation_numbers").Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler()))
 		default:
 			break
 		}

--- a/pkg/storage/stores/shipper/compactor/compactor.go
+++ b/pkg/storage/stores/shipper/compactor/compactor.go
@@ -265,6 +265,7 @@ func (c *Compactor) initDeletes(r prometheus.Registerer, limits retention.Limits
 	c.DeleteRequestsHandler = deletion.NewDeleteRequestHandler(
 		c.deleteRequestsStore,
 		c.cfg.DeleteRequestCancelPeriod,
+		limits,
 		r,
 	)
 

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
@@ -218,9 +218,16 @@ func (dm *DeleteRequestHandler) deletionMiddleware(next http.Handler) http.Handl
 
 		allLimits := dm.limits.AllByUserID()
 		userLimits, ok := allLimits[userID]
-		if ok && !userLimits.CompactorDeletionEnabled {
-			http.Error(w, "access denied", http.StatusForbidden)
-			return
+		if ok {
+			if !userLimits.CompactorDeletionEnabled {
+				http.Error(w, "access denied", http.StatusForbidden)
+				return
+			}
+		} else {
+			if !dm.limits.DefaultLimits().CompactorDeletionEnabled {
+				http.Error(w, "access denied", http.StatusForbidden)
+				return
+			}
 		}
 
 		next.ServeHTTP(w, r)

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler.go
@@ -17,6 +17,8 @@ import (
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
+const deletionNotAvailableMsg = "deletion is not available for this tenant"
+
 // DeleteRequestHandler provides handlers for delete requests
 type DeleteRequestHandler struct {
 	deleteRequestsStore       DeleteRequestsStore
@@ -220,12 +222,12 @@ func (dm *DeleteRequestHandler) deletionMiddleware(next http.Handler) http.Handl
 		userLimits, ok := allLimits[userID]
 		if ok {
 			if !userLimits.CompactorDeletionEnabled {
-				http.Error(w, "access denied", http.StatusForbidden)
+				http.Error(w, deletionNotAvailableMsg, http.StatusForbidden)
 				return
 			}
 		} else {
 			if !dm.limits.DefaultLimits().CompactorDeletionEnabled {
-				http.Error(w, "access denied", http.StatusForbidden)
+				http.Error(w, deletionNotAvailableMsg, http.StatusForbidden)
 				return
 			}
 		}

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
@@ -103,6 +103,26 @@ func TestDeleteRequestHandlerDeletionMiddleware(t *testing.T) {
 
 	require.Equal(t, http.StatusForbidden, res.Result().StatusCode)
 
+	// User without override, this should use the default value which is false
+	req = httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
+	req = req.WithContext(user.InjectOrgID(req.Context(), "3"))
+
+	res = httptest.NewRecorder()
+	middle.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusForbidden, res.Result().StatusCode)
+
+	// User without override, after the default value is set to true
+	fl.defaultLimit.compactorDeletionEnabled = true
+
+	req = httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
+	req = req.WithContext(user.InjectOrgID(req.Context(), "3"))
+
+	res = httptest.NewRecorder()
+	middle.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Result().StatusCode)
+
 	// User header is not given
 	req = httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
 

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/storage/chunk/client/local"
-	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
-	"github.com/grafana/loki/pkg/validation"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	"github.com/grafana/loki/pkg/validation"
 )
 
 type retentionLimit struct {

--- a/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/request_handler_test.go
@@ -1,0 +1,112 @@
+package deletion
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/storage/chunk/client/local"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/storage"
+	"github.com/grafana/loki/pkg/validation"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+)
+
+type retentionLimit struct {
+	compactorDeletionEnabled bool
+	retentionPeriod          time.Duration
+	streamRetention          []validation.StreamRetention
+}
+
+func (r retentionLimit) convertToValidationLimit() *validation.Limits {
+	return &validation.Limits{
+		CompactorDeletionEnabled: r.compactorDeletionEnabled,
+		RetentionPeriod:          model.Duration(r.retentionPeriod),
+		StreamRetention:          r.streamRetention,
+	}
+}
+
+type fakeLimits struct {
+	defaultLimit retentionLimit
+	perTenant    map[string]retentionLimit
+}
+
+func (f fakeLimits) RetentionPeriod(userID string) time.Duration {
+	return f.perTenant[userID].retentionPeriod
+}
+
+func (f fakeLimits) StreamRetention(userID string) []validation.StreamRetention {
+	return f.perTenant[userID].streamRetention
+}
+
+func (f fakeLimits) CompactorDeletionEnabled(userID string) bool {
+	return f.perTenant[userID].compactorDeletionEnabled
+}
+
+func (f fakeLimits) DefaultLimits() *validation.Limits {
+	return f.defaultLimit.convertToValidationLimit()
+}
+
+func (f fakeLimits) AllByUserID() map[string]*validation.Limits {
+	res := make(map[string]*validation.Limits)
+	for userID, ret := range f.perTenant {
+		res[userID] = ret.convertToValidationLimit()
+	}
+	return res
+}
+
+func TestDeleteRequestHandlerDeletionMiddleware(t *testing.T) {
+	// build the store
+	tempDir := t.TempDir()
+
+	workingDir := filepath.Join(tempDir, "working-dir")
+	objectStorePath := filepath.Join(tempDir, "object-store")
+
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{
+		Directory: objectStorePath,
+	})
+	require.NoError(t, err)
+	testDeleteRequestsStore, err := NewDeleteStore(workingDir, storage.NewIndexStorageClient(objectClient, ""))
+	require.NoError(t, err)
+
+	// limits
+	fl := &fakeLimits{
+		perTenant: map[string]retentionLimit{
+			"1": {compactorDeletionEnabled: true},
+			"2": {compactorDeletionEnabled: false},
+		},
+	}
+
+	// Setup handler
+	drh := NewDeleteRequestHandler(testDeleteRequestsStore, 10*time.Second, fl, nil)
+	middle := drh.deletionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	// User that has deletion enabled
+	req := httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
+	req = req.WithContext(user.InjectOrgID(req.Context(), "1"))
+
+	res := httptest.NewRecorder()
+	middle.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Result().StatusCode)
+
+	// User that does not have deletion enabled
+	req = httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
+	req = req.WithContext(user.InjectOrgID(req.Context(), "2"))
+
+	res = httptest.NewRecorder()
+	middle.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusForbidden, res.Result().StatusCode)
+
+	// User header is not given
+	req = httptest.NewRequest(http.MethodGet, "http://www.your-domain.com", nil)
+
+	res = httptest.NewRecorder()
+	middle.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Result().StatusCode)
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -92,7 +92,6 @@ type Limits struct {
 
 	// Compactor.
 	CompactorBlocksRetentionPeriod model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
-	CompactorDeletionEnabled       bool           `yaml:"compactor_deletion_enabled" json:"compactor_deletion_enabled"`
 
 	// This config doesn't have a CLI flag registered here because they're registered in
 	// their own original config struct.
@@ -168,7 +167,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. 0 to disable.")
-	f.BoolVar(&l.CompactorDeletionEnabled, "compactor.deletion-enabled", false, "Enable deletion")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used. Must be set when the store-gateway sharding is enabled with the shuffle-sharding strategy. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
@@ -495,11 +493,6 @@ func (o *Overrides) EvaluationDelay(userID string) time.Duration {
 // CompactorBlocksRetentionPeriod returns the retention period for a given user.
 func (o *Overrides) CompactorBlocksRetentionPeriod(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).CompactorBlocksRetentionPeriod)
-}
-
-// CompactorDeletionEnabled returns whether or not deletion is enabled for a given user.
-func (o *Overrides) CompactorDeletionEnabled(userID string) bool {
-	return o.getOverridesForUser(userID).CompactorDeletionEnabled
 }
 
 // MetricRelabelConfigs returns the metric relabel configs for a given user.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -92,6 +92,7 @@ type Limits struct {
 
 	// Compactor.
 	CompactorBlocksRetentionPeriod model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
+	CompactorDeletionEnabled       bool           `yaml:"compactor_deletion_enabled" json:"compactor_deletion_enabled"`
 
 	// This config doesn't have a CLI flag registered here because they're registered in
 	// their own original config struct.
@@ -167,6 +168,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. 0 to disable.")
+	f.BoolVar(&l.CompactorDeletionEnabled, "compactor.deletion-enabled", false, "Enable deletion")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used. Must be set when the store-gateway sharding is enabled with the shuffle-sharding strategy. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
@@ -493,6 +495,11 @@ func (o *Overrides) EvaluationDelay(userID string) time.Duration {
 // CompactorBlocksRetentionPeriod returns the retention period for a given user.
 func (o *Overrides) CompactorBlocksRetentionPeriod(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).CompactorBlocksRetentionPeriod)
+}
+
+// CompactorDeletionEnabled returns whether or not deletion is enabled for a given user.
+func (o *Overrides) CompactorDeletionEnabled(userID string) bool {
+	return o.getOverridesForUser(userID).CompactorDeletionEnabled
 }
 
 // MetricRelabelConfigs returns the metric relabel configs for a given user.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -111,6 +111,8 @@ type Limits struct {
 	RulerRemoteWriteQueueRetryOnRateLimit  bool                         `yaml:"ruler_remote_write_queue_retry_on_ratelimit" json:"ruler_remote_write_queue_retry_on_ratelimit"`
 	RulerRemoteWriteSigV4Config            *sigv4.SigV4Config           `yaml:"ruler_remote_write_sigv4_config" json:"ruler_remote_write_sigv4_config"`
 
+	CompactorDeletionEnabled bool `yaml:"compactor_deletion_enabled" json:"compactor_deletion_enabled"`
+
 	// Global and per tenant retention
 	RetentionPeriod model.Duration    `yaml:"retention_period" json:"retention_period"`
 	StreamRetention []StreamRetention `yaml:"retention_stream,omitempty" json:"retention_stream,omitempty"`
@@ -530,6 +532,10 @@ func (o *Overrides) StreamRetention(userID string) []StreamRetention {
 
 func (o *Overrides) UnorderedWrites(userID string) bool {
 	return o.getOverridesForUser(userID).UnorderedWrites
+}
+
+func (o *Overrides) CompactorDeletionEnabled(userID string) bool {
+	return o.getOverridesForUser(userID).CompactorDeletionEnabled
 }
 
 func (o *Overrides) DefaultLimits() *Limits {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -195,6 +195,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	_ = l.QuerySplitDuration.Set("30m")
 	f.Var(&l.QuerySplitDuration, "querier.split-queries-by-interval", "Split queries by an interval and execute in parallel, 0 disables it. This also determines how cache keys are chosen when result caching is enabled")
+
+	f.BoolVar(&l.CompactorDeletionEnabled, "compactor.deletion-enabled", false, "Enable access to deletion API.")
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -111,7 +111,7 @@ type Limits struct {
 	RulerRemoteWriteQueueRetryOnRateLimit  bool                         `yaml:"ruler_remote_write_queue_retry_on_ratelimit" json:"ruler_remote_write_queue_retry_on_ratelimit"`
 	RulerRemoteWriteSigV4Config            *sigv4.SigV4Config           `yaml:"ruler_remote_write_sigv4_config" json:"ruler_remote_write_sigv4_config"`
 
-	CompactorDeletionEnabled bool `yaml:"compactor_deletion_enabled" json:"compactor_deletion_enabled"`
+	CompactorDeletionEnabled bool `yaml:"allow_deletes" json:"allow_deletes"`
 
 	// Global and per tenant retention
 	RetentionPeriod model.Duration    `yaml:"retention_period" json:"retention_period"`
@@ -196,7 +196,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	_ = l.QuerySplitDuration.Set("30m")
 	f.Var(&l.QuerySplitDuration, "querier.split-queries-by-interval", "Split queries by an interval and execute in parallel, 0 disables it. This also determines how cache keys are chosen when result caching is enabled")
 
-	f.BoolVar(&l.CompactorDeletionEnabled, "compactor.deletion-enabled", false, "Enable access to deletion API.")
+	f.BoolVar(&l.CompactorDeletionEnabled, "compactor.allow-deletes", false, "Enable access to the deletion API.")
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.


### PR DESCRIPTION
Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

**What this PR does / why we need it**:

This PR adds a per tenant compaction delete enabled flag called `compactor_deletion_enabled`. A unit test was added for the http middleware that checks access.

This was also manually tested. The following snippet was added in the Loki config file:

``` yaml
limits_config:
  compactor_deletion_enabled: false
```

The runtime config contained the following:

``` yaml
overrides:
  tenant1:
    compactor_deletion_enabled: true
  tenant2:
    compactor_deletion_enabled: false
```

Running curl commands against the API gives the expected results: 

``` sh
% curl  http://localhost:3100/loki/api/v1/delete
no org id
% curl -H "X-Scope-OrgID: tenant1"  http://localhost:3100/loki/api/v1/delete
[]
% curl -H "X-Scope-OrgID: tenant2"  http://localhost:3100/loki/api/v1/delete
access denied
% curl -H "X-Scope-OrgID: tenant3"  http://localhost:3100/loki/api/v1/delete
[]
```

**Checklist**
- [x] Documentation added
- [X] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
