### PR TITLE
Evenly spread queriers across available nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* [6415](https://github.com/grafana/loki/pull/6415) **salvacorts** Evenly spread queriers across kubernetes nodes.
 * [6372](https://github.com/grafana/loki/pull/6372) **splitice**: Add support for numbers in JSON fields.
 * [6105](https://github.com/grafana/loki/pull/6105) **rutgerke** Export metrics for the Promtail journal target.
 * [6099](https://github.com/grafana/loki/pull/6099) **cstyan**: Drop lines with malformed JSON in Promtail JSON pipeline stage.

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -36,8 +36,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 #### Evenly spread queriers across kubernetes nodes
 
 We now evenly spread queriers across the available kubernetes nodes, but allowing more than one querier to be scheduled into the same node.
-If you want to keep running up to one querier per node, you will need to revert the changes for `production/ksonnet/loki/querier.libsonnet`
-made at [6415](https://github.com/grafana/loki/pull/6415).
+If you want to keep running up to one querier per node, set `$._config.querier.use_topology_spread` to false.
 
 #### Implementation of unwrapped `rate` aggregation changed
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -33,6 +33,12 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ### Loki
 
+#### Evenly spread queriers across kubernetes nodes
+
+We now evenly spread queriers across the available kubernetes nodes, but allowing more than one querier to be scheduled into the same node.
+If you want to keep running up to one querier per node, you will need to revert the changes for `production/ksonnet/loki/querier.libsonnet`
+made at [6415](https://github.com/grafana/loki/pull/6415).
+
 #### Implementation of unwrapped `rate` aggregation changed
 
 The implementation of the `rate()` aggregation function changed back to the previous implemention prior to [#5013](https://github.com/grafana/loki/pulls/5013).

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -36,7 +36,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 #### Evenly spread queriers across kubernetes nodes
 
 We now evenly spread queriers across the available kubernetes nodes, but allowing more than one querier to be scheduled into the same node.
-If you want to keep running up to one querier per node, set `$._config.querier.use_topology_spread` to false.
+If you want to run at most a single querier per node, set `$._config.querier.use_topology_spread` to false.
 
 #### Implementation of unwrapped `rate` aggregation changed
 

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -47,6 +47,13 @@
       // A higher value will lead to a querier trying to process more requests than there are available
       // cores and will result in scheduling delays.
       concurrency: 4,
+
+      // If use_topology_spread is true, queriers can run on nodes already running queriers but will be
+      // spread through the available nodes using a TopologySpreadConstraints with a max skew
+      // of topology_spread_max_skew.
+      // If use_topology_spread is false, queriers will not be scheduled on nodes already running queriers.
+      use_topology_spread: true,
+      topology_spread_max_skew: 1,
     },
 
     queryFrontend: {

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -51,6 +51,7 @@
       // If use_topology_spread is true, queriers can run on nodes already running queriers but will be
       // spread through the available nodes using a TopologySpreadConstraints with a max skew
       // of topology_spread_max_skew.
+      // See: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
       // If use_topology_spread is false, queriers will not be scheduled on nodes already running queriers.
       use_topology_spread: true,
       topology_spread_max_skew: 1,

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -36,7 +36,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       $._config.overrides_configmap_mount_name,
       $._config.overrides_configmap_mount_path,
     ) +
-    # Evenly spread queriers among available nodes.
+    // Evenly spread queriers among available nodes.
     deployment.spec.template.spec.withTopologySpreadConstraints(
       topologySpreadConstraints.labelSelector.withMatchLabels({ name: 'querier' }) +
       topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, queriers run on different nodes. We do this by using the following anti-affinity rule:

```yaml
affinity:
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchLabels:
          name: querier
      topologyKey: kubernetes.io/hostname
```

The original reasoning behind this is to make our systems more resilient to node failures. For example, if we have 5 queriers, all scheduled in the same node, and the node fails, we would not be able to serve queries until the pods get rescheduled and running on another node.

When new queriers are created, they need to be scheduled into different nodes. If there are not enough nodes in the cluster, new nodes need to be provisioned. This has two implications:
- Cost: Each node has an implicit cost on top of the workload we deploy into the node.
- Latency: It takes longer to allocate a new node into the cluster, and then schedule the pod, than to schedule it right away into an already available node.

This PR uses Kubernetes's `TopologySpreadConstraints` to evenly spread queriers across the available nodes, but allows more than one querier to be scheduled into the same node.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
