### PR TITLE
Tsdb/wal rotate fix

### DIFF
--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -254,14 +254,14 @@ func (m *HeadManager) Rotate(t time.Time) error {
 		}
 	}
 
-	stopPrev("previous cycle") // stop the previous wal if it hasn't been cleaned up yet
 	m.mtx.Lock()
+	stopPrev("previous cycle") // stop the previous wal if it hasn't been cleaned up yet
 	m.prev = m.active
 	m.prevHeads = m.activeHeads
 	m.active = nextWAL
 	m.activeHeads = nextHeads
-	m.mtx.Unlock()
 	stopPrev("freshly rotated") // stop the newly rotated-out wal
+	m.mtx.Unlock()
 
 	// build tsdb from rotated-out period
 	// TODO(owen-d): don't block Append() waiting for tsdb building. Use a work channel/etc


### PR DESCRIPTION
Fixes an issue where we'd optimistically release the lock during tsdb headmanager rotations. Now we'll lock for the entire process and double check conditions.

ref https://github.com/grafana/loki/issues/5428