### PR TITLE
Fixes bad initialization for uniqueString

### DIFF
--- a/pkg/logql/log/util.go
+++ b/pkg/logql/log/util.go
@@ -6,7 +6,7 @@ import (
 
 func uniqueString(s []string) []string {
 	unique := make(map[string]bool, len(s))
-	us := make([]string, len(unique))
+	us := make([]string, 0, len(s))
 	for _, elem := range s {
 		if len(elem) != 0 {
 			if !unique[elem] {

--- a/pkg/logql/log/util_test.go
+++ b/pkg/logql/log/util_test.go
@@ -1,6 +1,10 @@
 package log
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func Test_sanitizeLabelKey(t *testing.T) {
 	tests := []struct {
@@ -22,4 +26,11 @@ func Test_sanitizeLabelKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_UniqueStrings(t *testing.T) {
+	in := []string{"foo", "bar", "baz", "foo"}
+	out := uniqueString(in)
+	require.Equal(t, []string{"foo", "bar", "baz"}, out)
+	require.Equal(t, 4, cap(out))
 }


### PR DESCRIPTION
It was always 0 before and then appending, but in fact we wanted to have a pre-allocated size of `len(s)`.