### PR TITLE
operator: Add shellcheck disables

### DIFF
--- a/operator/quickstart.sh
+++ b/operator/quickstart.sh
@@ -2,13 +2,15 @@
 
 set -eou pipefail
 
+# shellcheck disable=SC1091
 source .bingo/variables.env
 
 setup() {
     echo "-------------------------------------------"
     echo "- Creating Kind cluster...                -"
     echo "-------------------------------------------"
-    $KIND create cluster --config=hack/kind_config.yaml
+    # shellcheck disable=SC2154
+    ${KIND} create cluster --config=hack/kind_config.yaml
 }
 
 deps() {
@@ -70,7 +72,8 @@ certificates() {
 }
 
 check() {
-    $LOGCLI --addr "http://localhost/token-refresher/api/logs/v1/test-oidc" labels
+    # shellcheck disable=SC2154
+    ${LOGCLI} --addr "http://localhost/token-refresher/api/logs/v1/test-oidc" labels
 }
 
 case ${1:-"*"} in


### PR DESCRIPTION
**What this PR does / why we need it**:

The CI is currently failing due to shellcheck errors in operator/quickstart.sh. This PR adds disable directives so it doesn't error anymore.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
