### PR TITLE
Loki: Use Shipper as indexClient for read mode

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -490,7 +490,8 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			// Use AsyncStore to query both ingesters local store and chunk store for store queries.
 			// Only queriers should use the AsyncStore, it should never be used in ingesters.
 			asyncStore = true
-		case t.Cfg.isModuleEnabled(IndexGateway):
+			fallthrough
+		case t.Cfg.isModuleEnabled(IndexGateway) || t.Cfg.isModuleEnabled(Read):
 			// we want to use the actual storage when running the index-gateway, so we remove the Addr from the config
 			t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 			t.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR forces Loki to not use the IndexGatewayClient when running with target=read. Without this, the read mode ends up using an IndexGatewayClient to resolve index queries; however, as IndexGatewayClient doesn't support resolving these queries, any query ends up hanging forever.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
