### PR TITLE
fluent-bit: clarify docs, use 1.9.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ fluent-bit-plugin:
 	go build $(DYN_GO_FLAGS) -buildmode=c-shared -o clients/cmd/fluent-bit/out_grafana_loki.so ./clients/cmd/fluent-bit/
 
 fluent-bit-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/fluent-bit-plugin-loki:$(IMAGE_TAG) -f clients/cmd/fluent-bit/Dockerfile .
+	$(SUDO) docker build -t $(IMAGE_PREFIX)/fluent-bit-plugin-loki:$(IMAGE_TAG) --build-arg LDFLAGS="-s -w $(GO_LDFLAGS)" -f clients/cmd/fluent-bit/Dockerfile .
 
 fluent-bit-push:
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/fluent-bit-plugin-loki:$(IMAGE_TAG)

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,10 +1,24 @@
-FROM golang:1.19.2 as build
-COPY . /src/loki
-WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin
+FROM golang:1.19.2@sha256:b850621230956a6d960d6d7cfaba6a8a2e8e245b230a928ef66aa0cfd065e229 AS builder
 
-FROM fluent/fluent-bit:1.8
-COPY --from=build /src/loki/clients/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/bin
+COPY . /src
+
+WORKDIR /src
+
+ARG LDFLAGS
+ENV CGO_ENABLED=1
+
+RUN go build \
+    -trimpath -ldflags "${LDFLAGS}" \
+    -tags netgo \
+    -buildmode=c-shared \
+    -o clients/cmd/fluent-bit/out_grafana_loki.so \
+    /src/clients/cmd/fluent-bit
+
+FROM fluent/fluent-bit:1.9.9@sha256:3045036b2ef35eae09a5f40273a0f1fbd70ca4d67e80918bfd0676b16ba43a29
+
+COPY --from=builder /src/clients/cmd/fluent-bit/out_grafana_loki.so /fluent-bit/bin
 COPY clients/cmd/fluent-bit/fluent-bit.conf /fluent-bit/etc/fluent-bit.conf
+
 EXPOSE 2020
+
 CMD ["/fluent-bit/bin/fluent-bit", "-e","/fluent-bit/bin/out_grafana_loki.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/clients/cmd/fluent-bit/README.md
+++ b/clients/cmd/fluent-bit/README.md
@@ -40,4 +40,4 @@ Issue the following command to send `/var/log` logs to your `http://localhost:31
 $ make fluent-bit-test
 ```
 
-You can easily override the address by setting `$LOKI_URL` environment variable.
+You can easily override the address by setting  the `$LOKI_URL` environment variable.

--- a/clients/cmd/fluent-bit/README.md
+++ b/clients/cmd/fluent-bit/README.md
@@ -4,25 +4,40 @@
 
 This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/fluent/fluent-bit-go) interface. It pushes logs to Loki using a GRPC connection.
 
-> syslog and systemd input plugin have not been tested yet, feedback appreciated.
+> **Warning**
+> `syslog` and `systemd` input plugins have not been tested yet. Feedback appreciated, file [an issue](https://github.com/grafana/loki/issues/new?template=bug_report.md) if you encounter any misbehaviors.
 
 ## Building
 
-Prerequisites:
+**Prerequisites**
 
 * Go 1.16+
 * gcc (for cgo)
 
-To build the output plugin library file (`out_grafana_loki.so`), you can use:
+To [build](https://docs.fluentbit.io/manual/development/golang-output-plugins#build-a-go-plugin) the output plugin library file `out_grafana_loki.so`, in the root directory of Loki source code, you can use:
 
 ```bash
-make fluent-bit-plugin
+$ make fluent-bit-plugin
 ```
 
-You can also build the docker image with the plugin pre-installed using:
+You can also build the Docker image with the plugin pre-installed using:
 
 ```bash
-make fluent-bit-image
+$ make fluent-bit-image
 ```
 
-Finally if you want to test you can use `make fluent-bit-test` to send some logs to your local Loki instance.
+## Running
+
+```bash
+$ fluent-bit -e out_grafana_loki.so -c /etc/fluent-bit.conf
+```
+
+**Testing**
+
+Issue the following command to send `/var/log` logs to your `http://localhost:3100/loki/api/` Loki instance for testing:
+
+```bash
+$ make fluent-bit-test
+```
+
+You can easily override the address by setting `$LOKI_URL` environment variable.


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

* Pins digests for security enhancements
* Pass `-ldflags` using `--build-args`
* Use fluent-bit image `1.9.9`
* Use golang image `1.19.2`
* Clarify fluent-bit readme

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
