### PR TITLE
deletion: add client type as label

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -241,7 +241,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	// Querier worker's max concurrent requests must be the same as the querier setting
 	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.MaxConcurrent
 
-	deleteStore, err := t.deleteRequestsClient()
+	deleteStore, err := t.deleteRequestsClient("querier")
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +769,7 @@ func (t *Loki) initRuler() (_ services.Service, err error) {
 
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 
-	deleteStore, err := t.deleteRequestsClient()
+	deleteStore, err := t.deleteRequestsClient("ruler")
 	if err != nil {
 		return nil, err
 	}
@@ -982,7 +982,7 @@ func (t *Loki) initUsageReport() (services.Service, error) {
 	return ur, nil
 }
 
-func (t *Loki) deleteRequestsClient() (deletion.DeleteRequestsClient, error) {
+func (t *Loki) deleteRequestsClient(clientType string) (deletion.DeleteRequestsClient, error) {
 	// TODO(owen-d): enable delete request storage in tsdb
 	if config.UsingTSDB(t.Cfg.SchemaConfig.Configs) {
 		return deletion.NewNoOpDeleteRequestsStore(), nil
@@ -1002,7 +1002,7 @@ func (t *Loki) deleteRequestsClient() (deletion.DeleteRequestsClient, error) {
 		return nil, err
 	}
 
-	return deletion.NewDeleteRequestsClient(compactorAddress, &http.Client{Timeout: 5 * time.Second}, t.deleteClientMetrics)
+	return deletion.NewDeleteRequestsClient(compactorAddress, &http.Client{Timeout: 5 * time.Second}, t.deleteClientMetrics, clientType)
 }
 
 func calculateMaxLookBack(pc config.PeriodConfig, maxLookBackConfig, minDuration time.Duration) (time.Duration, error) {

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/pkg/util/log"
 )
@@ -32,7 +33,8 @@ type deleteRequestsClient struct {
 	cache         map[string][]DeleteRequest
 	cacheDuration time.Duration
 
-	metrics *DeleteRequestClientMetrics
+	metrics    *DeleteRequestClientMetrics
+	clientType string
 
 	stopChan chan struct{}
 }
@@ -49,7 +51,7 @@ func WithRequestClientCacheDuration(d time.Duration) DeleteRequestsStoreOption {
 	}
 }
 
-func NewDeleteRequestsClient(addr string, c httpClient, deleteClientMetrics *DeleteRequestClientMetrics, opts ...DeleteRequestsStoreOption) (DeleteRequestsClient, error) {
+func NewDeleteRequestsClient(addr string, c httpClient, deleteClientMetrics *DeleteRequestClientMetrics, clientType string, opts ...DeleteRequestsStoreOption) (DeleteRequestsClient, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		level.Error(log.Logger).Log("msg", "error parsing url", "err", err)
@@ -62,6 +64,7 @@ func NewDeleteRequestsClient(addr string, c httpClient, deleteClientMetrics *Del
 		httpClient:    c,
 		cacheDuration: 5 * time.Minute,
 		cache:         make(map[string][]DeleteRequest),
+		clientType:    clientType,
 		metrics:       deleteClientMetrics,
 		stopChan:      make(chan struct{}),
 	}
@@ -79,10 +82,10 @@ func (c *deleteRequestsClient) GetAllDeleteRequestsForUser(ctx context.Context, 
 		return cachedRequests, nil
 	}
 
-	c.metrics.deleteRequestsLookupsTotal.Inc()
+	c.metrics.deleteRequestsLookupsTotal.With(prometheus.Labels{"client_type": c.clientType}).Inc()
 	requests, err := c.getRequestsFromServer(ctx, userID)
 	if err != nil {
-		c.metrics.deleteRequestsLookupsFailedTotal.Inc()
+		c.metrics.deleteRequestsLookupsFailedTotal.With(prometheus.Labels{"client_type": c.clientType}).Inc()
 		return nil, err
 	}
 

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client_test.go
@@ -17,7 +17,7 @@ func TestGetCacheGenNumberForUser(t *testing.T) {
 
 	t.Run("it requests results from the api", func(t *testing.T) {
 		httpClient := &mockHTTPClient{ret: `[{"request_id":"test-request"}]`}
-		client, err := NewDeleteRequestsClient("http://test-server", httpClient, deleteClientMetrics)
+		client, err := NewDeleteRequestsClient("http://test-server", httpClient, deleteClientMetrics, "test_client")
 		require.Nil(t, err)
 
 		deleteRequests, err := client.GetAllDeleteRequestsForUser(context.Background(), "userID")
@@ -33,7 +33,7 @@ func TestGetCacheGenNumberForUser(t *testing.T) {
 
 	t.Run("it caches the results", func(t *testing.T) {
 		httpClient := &mockHTTPClient{ret: `[{"request_id":"test-request"}]`}
-		client, err := NewDeleteRequestsClient("http://test-server", httpClient, deleteClientMetrics, WithRequestClientCacheDuration(100*time.Millisecond))
+		client, err := NewDeleteRequestsClient("http://test-server", httpClient, deleteClientMetrics, "test_client", WithRequestClientCacheDuration(100*time.Millisecond))
 		require.Nil(t, err)
 
 		deleteRequests, err := client.GetAllDeleteRequestsForUser(context.Background(), "userID")

--- a/pkg/storage/stores/shipper/compactor/deletion/metrics.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/metrics.go
@@ -6,24 +6,24 @@ import (
 )
 
 type DeleteRequestClientMetrics struct {
-	deleteRequestsLookupsTotal       prometheus.Counter
-	deleteRequestsLookupsFailedTotal prometheus.Counter
+	deleteRequestsLookupsTotal       *prometheus.CounterVec
+	deleteRequestsLookupsFailedTotal *prometheus.CounterVec
 }
 
 func NewDeleteRequestClientMetrics(r prometheus.Registerer) *DeleteRequestClientMetrics {
 	m := DeleteRequestClientMetrics{}
 
-	m.deleteRequestsLookupsTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+	m.deleteRequestsLookupsTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "delete_request_lookups_total",
 		Help:      "Number times the client has looked up delete requests",
-	})
+	}, []string{"client_type"})
 
-	m.deleteRequestsLookupsFailedTotal = promauto.With(r).NewCounter(prometheus.CounterOpts{
+	m.deleteRequestsLookupsFailedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "delete_request_lookups_failed_total",
 		Help:      "Number times the client has failed to look up delete requests",
-	})
+	}, []string{"client_type"})
 
 	return &m
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The delete request counters do not differentiate between the clients. This PR adds a client type label.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>