### PR TITLE
Loki: Fix flaky IndexGatewayClient test

### DIFF
--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
@@ -103,11 +103,8 @@ func createTestGrpcServer(t *testing.T) (func(), string) {
 			t.Logf("Failed to serve: %v", err)
 		}
 	}()
-	cleanup := func() {
-		s.GracefulStop()
-	}
 
-	return cleanup, lis.Addr().String()
+	return s.GracefulStop, lis.Addr().String()
 }
 
 func TestGatewayClient(t *testing.T) {

--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
@@ -106,9 +106,6 @@ func createTestGrpcServer(t *testing.T) (func(), string) {
 	}()
 	cleanup := func() {
 		s.GracefulStop()
-		// if err := lis.Close(); err != nil {
-		// 	panic(err)
-		// }
 	}
 
 	return cleanup, lis.Addr().String()

--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"testing"
 
@@ -101,7 +100,7 @@ func createTestGrpcServer(t *testing.T) (func(), string) {
 	indexgatewaypb.RegisterIndexGatewayServer(s, &server)
 	go func() {
 		if err := s.Serve(lis); err != nil {
-			log.Fatalf("Failed to serve: %v", err)
+			t.Logf("Failed to serve: %v", err)
 		}
 	}()
 	cleanup := func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a flaky test by deferring the stop of gRPC clients used. You can see an example of it failing [here](https://drone.grafana.net/grafana/loki/13014/2/5). 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
