### PR TITLE
During query readiness, log duration of all object-store operations

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -296,10 +296,12 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 		}
 
 		// list the users that have dedicated index files for this table
+		operationStart := time.Now()
 		_, usersWithIndex, err := tm.indexStorageClient.ListFiles(ctx, tableName, false)
 		if err != nil {
 			return err
 		}
+		listFilesDuration := time.Since(operationStart)
 
 		// find the users whos index we need to keep ready for querying from this table
 		usersToBeQueryReadyFor := tm.findUsersInTableForQueryReadiness(tableNumber, usersWithIndex, queryReadinessNumByUserID)
@@ -309,20 +311,30 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 			continue
 		}
 
+		operationStart = time.Now()
 		table, err := tm.getOrCreateTable(tableName)
 		if err != nil {
 			return err
 		}
+		createTableDuration := time.Now()
 
 		for _, u := range usersToBeQueryReadyFor {
 			distinctUsers[u] = struct{}{}
 		}
 
-		perTableStart := time.Now()
+		operationStart = time.Now()
 		if err := table.EnsureQueryReadiness(ctx, usersToBeQueryReadyFor); err != nil {
 			return err
 		}
-		level.Info(util_log.Logger).Log("msg", "index pre-download for query readiness completed", "users_len", len(usersToBeQueryReadyFor), "duration", time.Since(perTableStart), "table", tableName)
+		ensureQueryReadinessDuration := time.Since(operationStart)
+		level.Info(util_log.Logger).Log(
+			"msg", "index pre-download for query readiness completed",
+			"users_len", len(usersToBeQueryReadyFor),
+			"query_readiness_duration", ensureQueryReadinessDuration,
+			"table", tableName,
+			"create_table_duration", createTableDuration,
+			"list_files_duration", listFilesDuration,
+		)
 	}
 
 	return nil

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -316,7 +316,7 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		createTableDuration := time.Now()
+		createTableDuration := time.Since(operationStart)
 
 		for _, u := range usersToBeQueryReadyFor {
 			distinctUsers[u] = struct{}{}
@@ -327,6 +327,7 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 			return err
 		}
 		ensureQueryReadinessDuration := time.Since(operationStart)
+
 		level.Info(util_log.Logger).Log(
 			"msg", "index pre-download for query readiness completed",
 			"users_len", len(usersToBeQueryReadyFor),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies one of the query readiness log messages to also include how long it took to create a new table and for listing files. This will help debugging what are the slowest things of the query readiness operation.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
