### PR TITLE
Disable index gateway client on read target.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -490,8 +490,13 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			// Use AsyncStore to query both ingesters local store and chunk store for store queries.
 			// Only queriers should use the AsyncStore, it should never be used in ingesters.
 			asyncStore = true
-			fallthrough
-		case t.Cfg.isModuleEnabled(IndexGateway) || t.Cfg.isModuleEnabled(Read):
+
+			if t.Cfg.isModuleEnabled(Read) {
+				// we want to use the actual storage when running the index-gateway, so we remove the Addr from the config
+				t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
+				t.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true
+			}
+		case t.Cfg.isModuleEnabled(IndexGateway):
 			// we want to use the actual storage when running the index-gateway, so we remove the Addr from the config
 			t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 			t.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -218,7 +218,7 @@ func TestIndexGatewayRingMode_when_TargetIsRead(t *testing.T) {
 	})
 }
 
-func TestIndexGatewayClientConfig_when_TargetIsQuerier(t *testing.T) {
+func TestIndexGatewayClientConfig_when_TargetIsQuerierOrRead(t *testing.T) {
 	dir := t.TempDir()
 
 	t.Run("IndexGateway client is disabled when running querier target", func(t *testing.T) {
@@ -236,8 +236,8 @@ func TestIndexGatewayClientConfig_when_TargetIsQuerier(t *testing.T) {
 		}()
 
 		require.NoError(t, err)
-		assert.Equal(t, false, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
-		assert.Equal(t, false, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.False(t, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.False(t, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
 	})
 
 	t.Run("IndexGateway client is endabled when running read target", func(t *testing.T) {
@@ -257,8 +257,8 @@ func TestIndexGatewayClientConfig_when_TargetIsQuerier(t *testing.T) {
 		}()
 
 		require.NoError(t, err)
-		assert.Equal(t, true, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
-		assert.Equal(t, true, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.True(t, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.True(t, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
 	})
 }
 

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -216,7 +216,50 @@ func TestIndexGatewayRingMode_when_TargetIsRead(t *testing.T) {
 		})
 
 	})
+}
 
+func TestIndexGatewayClientConfig_when_TargetIsQuerier(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("IndexGateway client is disabled when running querier target", func(t *testing.T) {
+		cfg := minimalWorkingConfig(t, dir, Querier)
+		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
+		c, err := New(cfg)
+		require.NoError(t, err)
+
+		services, err := c.ModuleManager.InitModuleServices(Querier)
+		defer func() {
+			for _, service := range services {
+				service.StopAsync()
+			}
+		}()
+
+		require.NoError(t, err)
+		assert.Equal(t, false, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.Equal(t, false, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
+	})
+
+	t.Run("IndexGateway client is endabled when running read target", func(t *testing.T) {
+		cfg := minimalWorkingConfig(t, dir, Read)
+		cfg.SchemaConfig.Configs[0].IndexType = config.BoltDBShipperType
+		cfg.SchemaConfig.Configs[0].IndexTables.Period = 24 * time.Hour
+		cfg.CompactorConfig.SharedStoreType = config.StorageTypeFileSystem
+		cfg.CompactorConfig.WorkingDirectory = dir
+		c, err := New(cfg)
+		require.NoError(t, err)
+
+		services, err := c.ModuleManager.InitModuleServices(Read)
+		defer func() {
+			for _, service := range services {
+				service.StopAsync()
+			}
+		}()
+
+		require.NoError(t, err)
+		assert.Equal(t, true, c.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled)
+		assert.Equal(t, true, c.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled)
+	})
 }
 
 func minimalWorkingConfig(t *testing.T, dir, target string) Config {
@@ -251,6 +294,7 @@ func minimalWorkingConfig(t *testing.T, dir, target string) Config {
 				ActiveIndexDirectory: dir,
 				CacheLocation:        dir,
 				Mode:                 indexshipper.ModeWriteOnly,
+				ResyncInterval:       24 * time.Hour,
 			},
 		},
 	}


### PR DESCRIPTION
Summary:
PR #6461 introduced a fix for the read target that was supposed to
disable the index gateway clients. However, `fallthrough` does not
behave as expected. Thus we are using a nested if statement here.