### PR TITLE
operator: Disable report on overlay openshift

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6504](https://github.com/grafana/loki/pull/6504) **periklis**: Disable usage report on OpenShift
 - [6411](https://github.com/grafana/loki/pull/6411) **Red-GV**: Extend schema validation in LokiStack webhook
 - [6334](https://github.com/grafana/loki/pull/6433) **periklis**: Move operator cli flags to component config
 - [6224](https://github.com/grafana/loki/pull/6224) **periklis**: Add support for GRPC over TLS for Loki components

--- a/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -22,7 +22,7 @@ data:
       enableLokiStackAlerts: true
       enableLokiStackGateway: true
       enableLokiStackGatewayRoute: true
-      enableGrafanaLabsStats: true
+      enableGrafanaLabsStats: false
       enableLokiStackWebhook: true
       enableAlertingRuleWebhook: true
       enableRecordingRuleWebhook: true

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -19,7 +19,7 @@ featureFlags:
   enableLokiStackAlerts: true
   enableLokiStackGateway: true
   enableLokiStackGatewayRoute: true
-  enableGrafanaLabsStats: true
+  enableGrafanaLabsStats: false
   enableLokiStackWebhook: true
   enableAlertingRuleWebhook: true
   enableRecordingRuleWebhook: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This provides a fix introduced by #6433 as per usage report not always available on OpenShift clusters (e.g. air-gapped environments) and leaving it per default open spams the distributor logs when a custom S3 CA is used (e.g. OpenShift Data Foundation, Minio)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
