### PR TITLE
operator: Use default interface_names for lokistack clusters

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6531](https://github.com/grafana/loki/pull/6531) **periklis**: Use default interface_names for lokistack clusters (IPv6 Support)
 - [6411](https://github.com/grafana/loki/pull/6478) **aminesnow**: Support TLS enabled lokistack-gateway for vanilla kubernetes deployments
 - [6504](https://github.com/grafana/loki/pull/6504) **periklis**: Disable usage report on OpenShift
 - [6411](https://github.com/grafana/loki/pull/6411) **Red-GV**: Extend schema validation in LokiStack webhook

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -49,8 +49,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:
@@ -280,8 +278,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:
@@ -596,8 +592,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:
@@ -928,8 +922,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:
@@ -1261,8 +1253,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -68,8 +68,6 @@ ingester:
   lifecycler:
     final_sleep: 0s
     heartbeat_period: 5s
-    interface_names:
-      - eth0
     join_after: 30s
     num_tokens: 512
     ring:


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the hardcoded list of (`eth0`) in the Loki Lifecycle `interface_names` config to use the upstream defaults, i.e. all private network interfaces. According to dskit:
```go
cfg.InfNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
```
This enables out-of-the-box support for IPv6 kubernetes/OpenShift clusers.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
