### PR TITLE
Setting sane defaults for ruler in SSD "read" mode

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -742,15 +742,9 @@ func (t *Loki) initRulerStorage() (_ services.Service, err error) {
 	// unfortunately there is no way to generate a "default" config and compare default against actual
 	// to determine if it's unconfigured.  the following check, however, correctly tests this.
 	// Single binary integration tests will break if this ever drifts
-	if t.Cfg.isModuleEnabled(All) && t.Cfg.Ruler.StoreConfig.IsDefaults() {
-		level.Info(util_log.Logger).Log("msg", "RulerStorage is not configured in single binary mode and will not be started.")
+	if (t.Cfg.isModuleEnabled(All) || t.Cfg.isModuleEnabled(Read)) && t.Cfg.Ruler.StoreConfig.IsDefaults() {
+		level.Info(util_log.Logger).Log("msg", "Ruler storage is not configured; ruler will not be started.")
 		return
-	}
-
-	// Loki doesn't support the configdb backend, but without excessive mangling/refactoring
-	// it's hard to enforce this at validation time. Therefore detect this and fail early.
-	if t.Cfg.Ruler.StoreConfig.Type == "configdb" {
-		return nil, errors.New("configdb is not supported as a Loki rules backend type")
 	}
 
 	// Make sure storage directory exists if using filesystem store

--- a/pkg/ruler/base/storage.go
+++ b/pkg/ruler/base/storage.go
@@ -30,8 +30,7 @@ import (
 // RuleStoreConfig configures a rule store.
 // TODO remove this legacy config in Cortex 1.11.
 type RuleStoreConfig struct {
-	Type     string              `yaml:"type"`
-	ConfigDB configClient.Config `yaml:"configdb"`
+	Type string `yaml:"type"`
 
 	// Object Storage Configs
 	Azure azure.BlobStorageConfig   `yaml:"azure"`
@@ -46,14 +45,13 @@ type RuleStoreConfig struct {
 
 // RegisterFlags registers flags.
 func (cfg *RuleStoreConfig) RegisterFlags(f *flag.FlagSet) {
-	cfg.ConfigDB.RegisterFlagsWithPrefix("ruler.", f)
 	cfg.Azure.RegisterFlagsWithPrefix("ruler.storage.", f)
 	cfg.GCS.RegisterFlagsWithPrefix("ruler.storage.", f)
 	cfg.S3.RegisterFlagsWithPrefix("ruler.storage.", f)
 	cfg.Swift.RegisterFlagsWithPrefix("ruler.storage.", f)
 	cfg.Local.RegisterFlagsWithPrefix("ruler.storage.", f)
 	cfg.BOS.RegisterFlagsWithPrefix("ruler.storage.", f)
-	f.StringVar(&cfg.Type, "ruler.storage.type", "configdb", "Method to use for backend rule storage (configdb, azure, gcs, s3, swift, local)")
+	f.StringVar(&cfg.Type, "ruler.storage.type", "", "Method to use for backend rule storage (configdb, azure, gcs, s3, swift, local)")
 }
 
 // Validate config and returns error on failure
@@ -72,7 +70,7 @@ func (cfg *RuleStoreConfig) Validate() error {
 
 // IsDefaults returns true if the storage options have not been set
 func (cfg *RuleStoreConfig) IsDefaults() bool {
-	return cfg.Type == "configdb" && cfg.ConfigDB.ConfigsAPIURL.URL == nil
+	return cfg.Type == ""
 }
 
 // NewLegacyRuleStore returns a rule store backend client based on the provided cfg.
@@ -91,12 +89,6 @@ func NewLegacyRuleStore(cfg RuleStoreConfig, hedgeCfg hedging.Config, clientMetr
 	var client client.ObjectClient
 
 	switch cfg.Type {
-	case "configdb":
-		c, err := configClient.New(cfg.ConfigDB)
-		if err != nil {
-			return nil, err
-		}
-		return configdb.NewConfigRuleStore(c), nil
 	case "azure":
 		client, err = azure.NewBlobStorage(&cfg.Azure, clientMetrics.AzureMetrics, hedgeCfg)
 	case "gcs":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Allows the ruler to fail to start gracefully, if no ruler storage is configured.
Also removes support for `configdb`, since this is not supported but was the default storage type in the ruler code we forked from Cortex.

**Which issue(s) this PR fixes**:
Fixes #5460

**Special notes for your reviewer**:
If Loki SSD is run without ruler storage being configured, you get this nasty error:

```
configdb is not supported as a Loki rules backend type
error initialising module: ruler-storage
github.com/grafana/dskit/modules.(*Manager).initModule
        /home/danny/Code/open-source/loki/vendor/github.com/grafana/dskit/modules/modules.go:122
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
        /home/danny/Code/open-source/loki/vendor/github.com/grafana/dskit/modules/modules.go:92
github.com/grafana/loki/pkg/loki.(*Loki).Run
        /home/danny/Code/open-source/loki/pkg/loki/loki.go:344
main.main
        /home/danny/Code/open-source/loki/cmd/loki/main.go:105
runtime.main
        /home/danny/sdk/go1.17.8/src/runtime/proc.go:255
runtime.goexit
        /home/danny/sdk/go1.17.8/src/runtime/asm_amd64.s:1581
```

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
