### PR TITLE
Do not fail queries if compactor returns unexpected status code

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -122,7 +122,7 @@ func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.Selec
 
 	params.QueryRequest.Deletes, err = q.deletesForUser(ctx, params.Start, params.End)
 	if err != nil {
-		return nil, err
+		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)
 	}
 
 	ingesterQueryInterval, storeQueryInterval := q.buildQueryIntervals(params.Start, params.End)
@@ -417,7 +417,7 @@ func (q *SingleTenantQuerier) Tail(ctx context.Context, req *logproto.TailReques
 
 	deletes, err := q.deletesForUser(ctx, req.Start, time.Now())
 	if err != nil {
-		return nil, err
+		level.Error(spanlogger.FromContext(ctx)).Log("msg", "failed loading deletes for user", "err", err)
 	}
 
 	histReq := logql.SelectLogParams{


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid showing deleted data, the querier originally failed when
deletes were unavailable. If the compactor becomes unavailable this can
cause Loki to stop responding to queries altogether. This PR changes the
querier to log an error but continue servicing the request when it fails
to get deletes.

E.g. when a tenant does not have deletions enabled, the compactor returns 403 (Forbidden) when listing the deletes on `GET /loki/api/v1/deletes`. https://github.com/grafana/loki/blob/k104/pkg/storage/stores/shipper/compactor/deletion/request_handler.go#L223-L233

**Special notes for your reviewer**:

Related PR #6368

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
