### PR TITLE
Docs: Add doc-validator tool to lint technical documentation

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -1,0 +1,21 @@
+name: "doc-validator"
+on:
+  pull_request:
+    paths: ["docs/sources/**"]
+  workflow_dispatch:
+jobs:
+  doc-validator:
+    runs-on: "ubuntu-latest"
+    container:
+      image: "grafana/doc-validator:53w6qa25dqyiv9h3pscylb7yvyyj8vdh"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+      - name: "Run doc-validator tool"
+        run: >
+          doc-validator
+          --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
+          ./docs/sources
+          /docs/loki/latest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,25 +1,26 @@
+PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
 BUILD_IN_CONTAINER ?= true
 
 .PHONY: pull
 pull:
-	docker pull ${IMAGE}
+	$(PODMAN) pull ${IMAGE}
 
 .PHONY: docs
 docs: pull
-	docker run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/latest -p 3002:3002 $(IMAGE)
+	$(PODMAN) run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/latest -p 3002:3002 $(IMAGE)
 
 .PHONY: docs-next
 docs-next: pull
-	docker run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/next -p 3002:3002 $(IMAGE)
+	$(PODMAN) run  --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/next -p 3002:3002 $(IMAGE)
 
 .PHONY: docs-test
 docs-test: pull
-	docker run --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/latest -p 3002:3002 $(IMAGE) /bin/bash -c 'make prod'
+	$(PODMAN) run --rm -it -v ${PWD}/sources:/hugo/content/docs/loki/latest -p 3002:3002 $(IMAGE) /bin/bash -c 'make prod'
 
 sources/installation/helm/reference.md: ../production/helm/loki/reference.md.gotmpl
 ifeq ($(BUILD_IN_CONTAINER),true)
-	docker run --rm --volume "$(realpath ..):/helm-docs:z" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
+	$(PODMAN) run --rm --volume "$(realpath ..):/helm-docs:z" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
 		-c /helm-docs/production/helm/ \
 		-t reference.md.gotmpl \
 		-o reference.md

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Grafana Loki
+title: Grafana Loki documentation
 aliases:
   - /docs/loki/
 ---

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Grafana Loki documentation
+description: "Technical documentation for Grafana Loki"
 aliases:
   - /docs/loki/
 ---

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1,5 +1,5 @@
 ---
-title: HTTP API
+title: Grafana Loki HTTP API
 menuTitle: "HTTP API"
 description: "Loki exposes REST endpoints for operating on a Loki cluster. This section details the endpoints."
 weight: 900

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -590,8 +590,6 @@ JSON post body can be sent in the following format:
 
 You can set `Content-Encoding: gzip` request header and post gzipped JSON.
 
-Loki can be configured to [accept out-of-order writes](../configuration/#accept-out-of-order-writes).
-
 In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
 
 ### Examples
@@ -1384,8 +1382,6 @@ JSON post body can be sent in the following format:
   ]
 }
 ```
-
-Loki can be configured to [accept out-of-order writes](../configuration/#accept-out-of-order-writes).
 
 In microservices mode, `/api/prom/push` is exposed by the distributor.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -175,6 +175,7 @@ See [statistics](#statistics) for information about the statistics returned by L
 ### Examples
 
 This example query
+
 ```bash
 curl -G -s  "http://localhost:3100/loki/api/v1/query" \
   --data-urlencode \
@@ -270,8 +271,8 @@ accepts the following query parameters in the URL:
 - `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
 - `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
-- `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`.  Only applies to query types which produce a matrix response.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
+- `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`. Only applies to query types which produce a matrix response.
 - `interval`: <span style="background-color:#f3f973;">This parameter is experimental; see the explanation under Step versus interval.</span> Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
@@ -279,13 +280,11 @@ In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and 
 
 ### Step versus interval
 
-Use the `step` parameter when making metric queries to Loki, or queries which return a matrix response.  It is evaluated in exactly the same way Prometheus evaluates `step`.  First the query will be evaluated at `start` and then evaluated again at `start + step` and again at `start + step + step` until `end` is reached.  The result will be a matrix of the query result evaluated at each step.
+Use the `step` parameter when making metric queries to Loki, or queries which return a matrix response. It is evaluated in exactly the same way Prometheus evaluates `step`. First the query will be evaluated at `start` and then evaluated again at `start + step` and again at `start + step + step` until `end` is reached. The result will be a matrix of the query result evaluated at each step.
 
-Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached.  It does not fill missing entries.
+Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached. It does not fill missing entries.
 
-<span style="background-color:#f3f973;">Note about the experimental nature of the interval parameter:</span> This flag may be removed in the future, if so it will likely be in favor of a LogQL expression to perform similar behavior, however that is uncertain at this time.  [Issue 1779](https://github.com/grafana/loki/issues/1779) was created to track the discussion, if you are using `interval` please go add your use case and thoughts to that issue.
-
-
+<span style="background-color:#f3f973;">Note about the experimental nature of the interval parameter:</span> This flag may be removed in the future, if so it will likely be in favor of a LogQL expression to perform similar behavior, however that is uncertain at this time. [Issue 1779](https://github.com/grafana/loki/issues/1779) was created to track the discussion, if you are using `interval` please go add your use case and thoughts to that issue.
 
 Response:
 
@@ -441,7 +440,7 @@ It accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 
 In microservices mode, `/loki/api/v1/labels` is exposed by the querier.
 
@@ -483,7 +482,7 @@ It accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 
 In microservices mode, `/loki/api/v1/label/<name>/values` is exposed by the querier.
 
@@ -524,7 +523,7 @@ a query. It accepts the following query parameters in the URL:
 
 - `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
-    loggers catch up. Defaults to 0 and cannot be larger than 5.
+  loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return. It defaults to `100`.
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 
@@ -602,7 +601,6 @@ $ curl -v -H "Content-Type: application/json" -XPOST -s "http://localhost:3100/l
   '{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}'
 ```
 
-
 ## Identify ready Loki instance
 
 ```
@@ -639,11 +637,11 @@ It accepts three URL query parameters `flush`, `delete_ring_tokens`, and `termin
 
 **URL query parameters:**
 
-* `flush=<bool>`:
+- `flush=<bool>`:
   Flag to control whether to flush any in-memory chunks the ingester holds. Defaults to `true`.
-* `delete_ring_tokens=<bool>`:
+- `delete_ring_tokens=<bool>`:
   Flag to control whether to delete the file that contains the ingester ring tokens of the instance if the `-ingester.token-file-path` is specified. Defaults to `false.
-* `terminate=<bool>`:
+- `terminate=<bool>`:
   Flag to control whether to terminate the Loki process after service shutdown. Defaults to `true`.
 
 This handler, in contrast to the deprecated `/ingester/flush_shutdown` handler, terminates the Loki process by default.
@@ -716,6 +714,7 @@ POST /loki/api/v1/format_query
 ```
 
 Params:
+
 - `query`: A LogQL query string. Can be passed as URL param (`?query=<query>`) in case of both `GET` and `POST`. Or as form value in case of `POST`.
 
 The `/loki/api/v1/format_query` endpoint allows to format LogQL queries. It returns an error if the passed LogQL is invalid. It is exposed by all Loki components and helps to improve readability and the debugging experience of LogQL queries.
@@ -723,6 +722,7 @@ The `/loki/api/v1/format_query` endpoint allows to format LogQL queries. It retu
 ## List series
 
 The Series API is available under the following:
+
 - `GET /loki/api/v1/series`
 - `POST /loki/api/v1/series`
 - `GET /api/prom/series`
@@ -735,7 +735,7 @@ URL query parameters:
 - `match[]=<series_selector>`: Repeated log stream selector argument that selects the streams to return. At least one `match[]` argument must be provided.
 - `start=<nanosecond Unix epoch>`: Start timestamp.
 - `end=<nanosecond Unix epoch>`: End timestamp.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 
 You can URL-encode these parameters directly in the request body by using the POST method and `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large or dynamic number of stream selectors that may breach server-side URL character limits.
 
@@ -743,7 +743,7 @@ In microservices mode, these endpoints are exposed by the querier.
 
 ### Examples
 
-``` bash
+```console
 $ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match[]={container_name=~"prometheus.*", component="server"}' --data-urlencode 'match[]={app="loki"}' | jq '.'
 {
   "status": "success",
@@ -793,7 +793,6 @@ $ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match[]={
 }
 ```
 
-
 ## Index Stats
 
 The `/loki/api/v1/index/stats` endpoint can be used to query the index for the number of `streams`, `chunks`, `entries`, and `bytes` that a query resolves to.
@@ -807,23 +806,24 @@ URL query parameters:
 You can URL-encode these parameters directly in the request body by using the POST method and `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large or dynamic number of stream selectors that may breach server-side URL character limits.
 
 Response:
+
 ```json
 {
   "streams": 100,
   "chunks": 1000,
   "entries": 5000,
-  "bytes": 100000,
+  "bytes": 100000
 }
 ```
 
 It is an approximation with the following caveats:
-  * It does not include data from the ingesters
-  * It is a probabilistic technique
-  * streams/chunks which span multiple period configurations may be counted twice.
+
+- It does not include data from the ingesters
+- It is a probabilistic technique
+- streams/chunks which span multiple period configurations may be counted twice.
 
 These make it generally more helpful for larger queries.
 It can be used for better understanding the throughput requirements and data topology for a list of matchers over a period of time.
-
 
 ## Statistics
 
@@ -838,7 +838,7 @@ The example belows show all possible statistics returned with their respective d
     "resultType": "streams",
     "result": [],
     "stats": {
-     "ingester" : {
+      "ingester": {
         "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by ingesters
         "decompressedBytes": 0, // Total bytes decompressed and processed by ingesters
         "decompressedLines": 0, // Total lines decompressed and processed by ingesters
@@ -852,7 +852,7 @@ The example belows show all possible statistics returned with their respective d
       },
       "store": {
         "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by the store
-        "decompressedBytes": 0,  // Total bytes decompressed and processed by the store
+        "decompressedBytes": 0, // Total bytes decompressed and processed by the store
         "decompressedLines": 0, // Total lines decompressed and processed by the store
         "chunksDownloadTime": 0, // Total time spent downloading chunks in seconds (float)
         "totalChunksRef": 0, // Total chunks found in the index for the current query
@@ -864,8 +864,8 @@ The example belows show all possible statistics returned with their respective d
         "execTime": 0, // Total execution time in seconds (float)
         "linesProcessedPerSecond": 0, // Total lines processed per second
         "queueTime": 0, // Total queue time in seconds (float)
-        "totalBytesProcessed":0, // Total amount of bytes processed overall for this request
-        "totalLinesProcessed":0 // Total amount of lines processed overall for this request
+        "totalBytesProcessed": 0, // Total amount of bytes processed overall for this request
+        "totalLinesProcessed": 0 // Total amount of lines processed overall for this request
       }
     }
   }
@@ -885,7 +885,6 @@ GET /ruler/ring
 Displays a web page with the ruler hash ring status, including the state, healthy and last heartbeat time of each ruler.
 
 ### List rule groups
-
 
 ```
 GET /loki/api/v1/rules
@@ -973,6 +972,7 @@ Creates or updates a rule group. This endpoint expects a request with `Content-T
 #### Example request
 
 Request headers:
+
 - `Content-Type: application/yaml`
 
 Request body:
@@ -1051,10 +1051,10 @@ Log entry deletion is supported _only_ when the BoltDB Shipper is configured for
 
 Query parameters:
 
-* `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters.
-* `start=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. This parameter is required.
-* `end=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
-* `max_interval=<duration>`: The maximum time period the delete request can span. If the request is larger than this value, it is split into several requests of <= `max_interval`. Valid time units are `s`, `m`, and `h`.
+- `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters.
+- `start=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. This parameter is required.
+- `end=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
+- `max_interval=<duration>`: The maximum time period the delete request can span. If the request is larger than this value, it is split into several requests of <= `max_interval`. Valid time units are `s`, `m`, and `h`.
 
 A 204 response indicates success.
 
@@ -1136,8 +1136,8 @@ DELETE /loki/api/v1/delete
 
 Query parameters:
 
-* `request_id=<request_id>`: Identifies the delete request to cancel; IDs are found using the `delete` endpoint.
-* `force=<boolean>`: When the `force` query parameter is true, partially completed delete requests will be canceled. NOTE: some data from the request may still be deleted and the deleted request will be listed as 'processed'
+- `request_id=<request_id>`: Identifies the delete request to cancel; IDs are found using the `delete` endpoint.
+- `force=<boolean>`: When the `force` query parameter is true, partially completed delete requests will be canceled. NOTE: some data from the request may still be deleted and the deleted request will be listed as 'processed'
 
 A 204 response indicates success.
 
@@ -1171,7 +1171,7 @@ a query. It accepts the following query parameters in the URL:
 
 - `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
-    loggers catch up. Defaults to 0 and cannot be larger than 5.
+  loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 
@@ -1222,7 +1222,7 @@ support the following values:
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 - `regexp`: a regex to filter the returned results
 
@@ -1290,7 +1290,7 @@ the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 
 In microservices mode, `/api/prom/label/<name>/values` is exposed by the querier.
 
@@ -1327,7 +1327,7 @@ accepts the following query parameters in the URL:
 
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now.  Any value specified for `start` supersedes this parameter.
+- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 
 In microservices mode, `/api/prom/label` is exposed by the querier.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -75,12 +75,13 @@ These endpoints are exposed by the ruler:
 - [`GET /prometheus/api/v1/alerts`](#list-alerts)
 
 These endpoints are exposed by the compactor:
+
 - [`GET /compactor/ring`](#compactor-ring-status)
 - [`POST /loki/api/v1/delete`](#request-log-deletion)
 - [`GET /loki/api/v1/delete`](#list-log-deletion-requests)
 - [`DELETE /loki/api/v1/delete`](#request-cancellation-of-a-delete-request)
 
-A [list of clients](../clients) can be found in the clients documentation.
+A [list of clients]({{< relref "../clients" >}}) can be found in the clients documentation.
 
 ## Matrix, vector, and streams
 
@@ -114,7 +115,7 @@ GET /loki/api/v1/query
 `/loki/api/v1/query` allows for doing queries against a single point in time. The URL
 query parameters support the following values:
 
-- `query`: The [LogQL](../logql/) query to perform
+- `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
 - `time`: The evaluation time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward`.
@@ -222,7 +223,7 @@ gave this response:
 ```
 
 If your cluster has
-[Grafana Loki Multi-Tenancy](../operations/multi-tenancy/) enabled,
+[Grafana Loki Multi-Tenancy]({{< relref "../operations/multi-tenancy/" >}}) enabled,
 set the `X-Scope-OrgID` header to identify the tenant you want to query.
 Here is the same example query for the single tenant called `Tenant1`:
 
@@ -265,7 +266,7 @@ GET /loki/api/v1/query_range
 `/loki/api/v1/query_range` is used to do a query over a range of time and
 accepts the following query parameters in the URL:
 
-- `query`: The [LogQL](../logql/) query to perform
+- `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
 - `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
@@ -521,7 +522,7 @@ GET /loki/api/v1/tail
 `/loki/api/v1/tail` is a WebSocket endpoint that will stream log messages based on
 a query. It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL](../logql/) query to perform
+- `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
     loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return. It defaults to `100`.
@@ -665,7 +666,7 @@ GET /metrics
 ```
 
 `/metrics` returns exposed Prometheus metrics. See
-[Observing Loki](../operations/observability/)
+[Observing Loki]({{< relref "../operations/observability/" >}})
 for a list of exported metrics.
 
 In microservices mode, the `/metrics` endpoint is exposed by all components.
@@ -799,7 +800,7 @@ The `/loki/api/v1/index/stats` endpoint can be used to query the index for the n
 
 URL query parameters:
 
-- `query`: The [LogQL](../logql/) matchers to check (i.e. `{job="foo", env!="dev"}`)
+- `query`: The [LogQL]({{< relref "../logql/" >}}) matchers to check (i.e. `{job="foo", env!="dev"}`)
 - `start=<nanosecond Unix epoch>`: Start timestamp.
 - `end=<nanosecond Unix epoch>`: End timestamp.
 
@@ -1044,7 +1045,7 @@ PUT /loki/api/v1/delete
 ```
 
 Create a new delete request for the authenticated tenant.
-The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
@@ -1084,7 +1085,7 @@ GET /loki/api/v1/delete
 ```
 
 List the existing delete requests for the authenticated tenant.
-The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
@@ -1121,7 +1122,7 @@ DELETE /loki/api/v1/delete
 ```
 
 Remove a delete request for the authenticated tenant.
-The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
 
 Loki allows cancellation of delete requests until the requests are picked up for processing. It is controlled by the `delete_request_cancel_period` YAML configuration or the equivalent command line option when invoking Loki. To cancel a delete request that has been picked up for processing or is partially complete, pass the `force=true` query parameter to the API.
 
@@ -1168,7 +1169,7 @@ curl -u "Tenant1:$API_TOKEN" \
 `/api/prom/tail` is a WebSocket endpoint that will stream log messages based on
 a query. It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL](../logql/) query to perform
+- `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
     loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return
@@ -1217,7 +1218,7 @@ will be sent over the WebSocket multiple times.
 `/api/prom/query` supports doing general queries. The URL query parameters
 support the following values:
 
-- `query`: The [LogQL](../logql/) query to perform
+- `query`: The [LogQL]({{< relref "../logql/" >}}) query to perform
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -594,7 +594,7 @@ In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
 
 ### Examples
 
-```bash
+```console
 $ curl -v -H "Content-Type: application/json" -XPOST -s "http://localhost:3100/loki/api/v1/push" --data-raw \
   '{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}'
 ```
@@ -1254,7 +1254,7 @@ See [statistics](#statistics) for information about the statistics returned by L
 
 #### Examples
 
-```bash
+```console
 $ curl -G -s "http://localhost:3100/api/prom/query" --data-urlencode 'query={foo="bar"}' | jq
 {
   "streams": [
@@ -1305,7 +1305,7 @@ Response:
 
 #### Examples
 
-```bash
+```console
 $ curl -G -s  "http://localhost:3100/api/prom/label/foo/values" | jq
 {
   "values": [
@@ -1342,7 +1342,7 @@ Response:
 
 #### Examples
 
-```bash
+```console
 $ curl -G -s  "http://localhost:3100/api/prom/label" | jq
 {
   "values": [
@@ -1387,7 +1387,7 @@ In microservices mode, `/api/prom/push` is exposed by the distributor.
 
 #### Examples
 
-```bash
+```console
 $ curl -H "Content-Type: application/json" -XPOST -s "https://localhost:3100/api/prom/push" --data-raw \
   '{"streams": [{ "labels": "{foo=\"bar\"}", "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "fizzbuzz" }] }]}'
 ```


### PR DESCRIPTION
Source code:
https://github.com/grafana/technical-documentation/tree/main/tools/doc-validator

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**What this PR does / why we need it**:

Adds a CI step for pull requests that validates links in technical documentation and performs linting of technical documentation source files.

**Special notes for your reviewer**:

- Lots of issues will need to be fixed before we can merge this.
- The tool is still in early development so each error should be scrutinized for validity.

**Checklist**
- [ ] Documentation added
- [na] Tests updated
- [na] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [na] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
