### PR TITLE
log addtl info about bytes/shard in planning

### DIFF
--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -120,6 +120,10 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 
 	combined := stats.MergeStats(results...)
 	factor := guessShardFactor(combined, r.maxParallelism)
+	var bytesPerShard = combined.Bytes
+	if factor > 0 {
+		bytesPerShard = combined.Bytes / uint64(factor)
+	}
 	level.Debug(sp).Log(
 		"msg", "queried index",
 		"type", "combined",
@@ -131,6 +135,7 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 		"max_parallelism", r.maxParallelism,
 		"duration", time.Since(start),
 		"factor", factor,
+		"bytes_per_shard", strings.Replace(humanize.Bytes(bytesPerShard), " ", "", 1),
 	)
 	return factor, nil
 }


### PR DESCRIPTION
Extracting metrics for this has proven otherwise difficult because we don't have a `bytes` template and it's a bit inconvenient to add b/c the function returns an error signature.