### PR TITLE
loki-canary: Fix resource leak when using client-side certs

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -119,8 +119,13 @@ func main() {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 
+		var err error
 		c.writer = writer.NewWriter(os.Stdout, sentChan, *interval, *outOfOrderMin, *outOfOrderMax, *outOfOrderPercentage, *size)
-		c.reader = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval)
+		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Unable to create reader for Loki querier, check config: %s", err)
+			os.Exit(1)
+		}
 		c.comparator = comparator.NewComparator(os.Stderr, *wait, *maxWait, *pruneInterval, *spotCheckInterval, *spotCheckMax, *spotCheckQueryRate, *spotCheckWait, *metricTestInterval, *metricTestQueryRange, *interval, *buckets, sentChan, receivedChan, c.reader, true)
 	}
 

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -91,7 +91,7 @@ func NewReader(writer io.Writer,
 	streamName string,
 	streamValue string,
 	interval time.Duration,
-) *Reader {
+) (*Reader, error) {
 	h := http.Header{}
 
 	// http.DefaultClient will be used in the case that the connection to Loki is http or TLS without client certs.
@@ -102,7 +102,7 @@ func NewReader(writer io.Writer,
 			return &http.Transport{TLSClientConfig: tls}, nil
 		})
 		if err != nil {
-			panic(fmt.Sprintf("Failed to create HTTPS transport with TLS config: %v", err))
+			return nil, errors.Wrapf(err, "Failed to create HTTPS transport with TLS config")
 		}
 		httpClient = &http.Client{Transport: rt}
 	}
@@ -157,7 +157,7 @@ func NewReader(writer io.Writer,
 		}
 	}()
 
-	return &rd
+	return &rd, nil
 }
 
 func (r *Reader) Stop() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When running canary with client side certificates (introduced in #6310), a new `http.Transport` is being created for each request 🤦‍♂️. As a result, connections are left open until they timeout an hour later. This quickly causes resource exhaustion and errors like `dial tcp 1.1.1.1:1111: connect: cannot assign requested address`. 

This change will reuse the same transport for all requests just like `http.DefaultClient` is reused when not using client certs.

Tested by running loki-canary for 5 days and observing with netstat a constant number of TCP connections to the querier.