### PR TITLE
operator: Use docker build context for root make targets

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -87,6 +87,7 @@ local docker_operator(arch, operator) = {
   image: 'plugins/docker',
   settings: {
     repo: 'grafana/%s' % operator,
+    context: 'operator',
     dockerfile: 'operator/Dockerfile',
     username: { from_secret: docker_username_secret.name },
     password: { from_secret: docker_password_secret.name },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -707,6 +707,7 @@ steps:
   image: plugins/docker
   name: build-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: true
     password:
@@ -722,6 +723,7 @@ steps:
   image: plugins/docker
   name: publish-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: false
     password:
@@ -759,6 +761,7 @@ steps:
   image: plugins/docker
   name: build-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: true
     password:
@@ -774,6 +777,7 @@ steps:
   image: plugins/docker
   name: publish-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: false
     password:
@@ -811,6 +815,7 @@ steps:
   image: plugins/docker
   name: build-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: true
     password:
@@ -826,6 +831,7 @@ steps:
   image: plugins/docker
   name: publish-loki-operator-image
   settings:
+    context: operator
     dockerfile: operator/Dockerfile
     dry_run: false
     password:
@@ -1409,8 +1415,3 @@ get:
   path: secret/data/common/loki_ci_autodeploy
 kind: secret
 name: deploy_config
----
-kind: signature
-hmac: 2082d23dcc8f69038e55b027f55a8b1fe8bc52b27f07d785db781fc935a434ad
-
-...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1415,3 +1415,8 @@ get:
   path: secret/data/common/loki_ci_autodeploy
 kind: secret
 name: deploy_config
+---
+kind: signature
+hmac: b99e5220d2f2fc15a0bca24bfd3ead78bb6b1ac276fc01ea76a06705fc920190
+
+...

--- a/Makefile
+++ b/Makefile
@@ -581,9 +581,9 @@ endif
 
 # loki-operator
 loki-operator-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG) -f operator/Dockerfile .
+	$(SUDO) docker build -t $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG) -f operator/Dockerfile operator/
 loki-operator-image-cross:
-	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG) -f operator/Dockerfile.cross .
+	$(SUDO) $(BUILD_OCI) -t $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG) -f operator/Dockerfile.cross operator/
 loki-operator-push: loki-operator-image-cross
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/loki-operator:$(IMAGE_TAG)
 	

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,17 +3,17 @@ FROM golang:1.17.9 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY operator/go.mod go.mod
-COPY operator/go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY operator/main.go main.go
-COPY operator/apis/ apis/
-COPY operator/controllers/ controllers/
-COPY operator/internal/ internal/
+COPY main.go main.go
+COPY apis/ apis/
+COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -8,17 +8,17 @@ FROM --platform=linux/amd64 $BUILD_IMAGE as builder
 COPY --from=goenv /goarch /goarm /
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY operator/go.mod go.mod
-COPY operator/go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY operator/main.go main.go
-COPY operator/apis/ apis/
-COPY operator/controllers/ controllers/
-COPY operator/internal/ internal/
+COPY main.go main.go
+COPY apis/ apis/
+COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(cat /goarch) GOARM=$(cat /goarm) go build -a -o manager main.go


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up PR on #6086 to use build context on root make targets and unblock `make oci-build` in `operator/` subfolder.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
