### PR TITLE
Append .x to the versioned directories for the website sync (#6611)

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -70,4 +70,4 @@ jobs:
           host: "github.com"
           github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
           source_folder: "docs/sources"
-          target_folder: "content/docs/loki/${{ steps.target.outputs.target }}"
+          target_folder: "content/docs/loki/${{ steps.target.outputs.target }}.x"


### PR DESCRIPTION
This ensures documentation backported to this release branch is published to the correct website directory which is "v2.5.x".

Logic in the workflow determines the major and minor versions but we need to append the ".x" part as done for main in #6611.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
