### PR TITLE
Loki: Remove ring client from the distributor

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -89,7 +89,7 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 // the distributor and as such, no ring status is returned from this function.
 func (d *Distributor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if d.rateLimitStrat == validation.GlobalIngestionRateStrategy {
-		d.distributorsRing.ServeHTTP(w, r)
+		d.distributorsLifecycler.ServeHTTP(w, r)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the ring client from the distributor.

It was originally added on PR https://github.com/grafana/loki/pull/4938/files because it was the only ring implementation with a HTTPHandler support (used for the ring page). Now that DSKit has support for the ring implementations (including the lifecycler) this isn't necessary anymore.

On a side note, I accidentally attached the `IgnoreUnhealthyInstancesReplicationStrategy` to it, which makes no sense to distributors.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
