### PR TITLE
Groupcache performance improvements

### DIFF
--- a/pkg/storage/chunk/cache/groupcache_test.go
+++ b/pkg/storage/chunk/cache/groupcache_test.go
@@ -23,33 +23,25 @@ func TestGroupCache(t *testing.T) {
 	bufs := [][]byte{[]byte("data1"), []byte("data2"), []byte("data3")}
 	miss := []string{"miss1", "miss2"}
 
-	// ensure input correctness
-	nHit := len(keys)
-	require.Len(t, bufs, nHit)
-
-	nMiss := len(miss)
-
-	ctx := context.Background()
-
-	err = c.Store(ctx, keys, bufs)
+	err = c.Store(context.Background(), keys, bufs)
 	require.NoError(t, err)
 
 	// test hits
-	found, data, missed, _ := c.Fetch(ctx, keys)
+	found, data, missed, _ := c.Fetch(context.Background(), keys)
 
-	require.Len(t, found, nHit)
+	require.Len(t, found, len(keys))
 	require.Len(t, missed, 0)
-	for i := 0; i < nHit; i++ {
+	for i := 0; i < len(keys); i++ {
 		require.Equal(t, keys[i], found[i])
 		require.Equal(t, bufs[i], data[i])
 	}
 
 	// test misses
-	found, _, missed, _ = c.Fetch(ctx, miss)
+	found, _, missed, _ = c.Fetch(context.Background(), miss)
 
 	require.Len(t, found, 0)
-	require.Len(t, missed, nMiss)
-	for i := 0; i < nMiss; i++ {
+	require.Len(t, missed, len(miss))
+	for i := 0; i < len(miss); i++ {
 		require.Equal(t, miss[i], missed[i])
 	}
 }


### PR DESCRIPTION
We suspected that we were unnecessarily allocating memory for `Fetch` operations. This brings the allocs down a little but it turns out groupcache is pretty optimized as is.

```
Fetch hits
-------------------------------------------------------------------------------------------------------------------------------
Before: 
tpatterson@pop-os cache (groupcache *%) $ go test -bench BenchmarkGroupCacheFetch -run=^$  -benchmem -memprofile memprofile.out
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/cache
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkGroupCacheFetch-8       1277026               965.6 ns/op           472 B/op         11 allocs/op

After:
tpatterson@pop-os cache (groupcache *%) $ go test -bench BenchmarkGroupCacheFetch -run=^$  -benchmem -memprofile memprofile.out
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/cache
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkGroupCacheFetch-8       1889569               651.0 ns/op           264 B/op          8 allocs/op

Fetch misses
-------------------------------------------------------------------------------------------------------------------------------
tpatterson@pop-os cache (groupcache *%) $ go test -bench BenchmarkGroupCacheFetch -run=^$  -benchmem -memprofile memprofile.out
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/cache
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkGroupCacheFetch-8       1000000              1356 ns/op             504 B/op         15 allocs/op
```

There's not much to be done about cache missed because a miss is the longest path the cache can take.