### PR TITLE
Don't add the memberlist label as a selector to services.

### DIFF
--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -76,6 +76,6 @@
   else {},
 
   compactor_service: if $._config.using_boltdb_shipper then
-    k.util.serviceFor($.compactor_statefulset)
+    k.util.serviceFor($.compactor_statefulset, $._config.service_ignored_labels)
   else {},
 }

--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -30,7 +30,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ],
 
     // This helps ensure we create SRV records starting with _grpclb
-    grpclbServiceFor(deployment):: k.util.serviceFor(deployment, nameFormat='%(port)s'),
+    grpclbServiceFor(deployment):: k.util.serviceFor(deployment, $._config.service_ignored_labels, nameFormat='%(port)s'),
 
 
     readinessProbe::

--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -37,5 +37,5 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 
   distributor_service:
-    k.util.serviceFor($.distributor_deployment),
+    k.util.serviceFor($.distributor_deployment, $._config.service_ignored_labels),
 }

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -109,5 +109,5 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
 
   gateway_service:
-    k.util.serviceFor($.gateway_deployment),
+    k.util.serviceFor($.gateway_deployment, $._config.service_ignored_labels),
 }

--- a/production/ksonnet/loki/index-gateway.libsonnet
+++ b/production/ksonnet/loki/index-gateway.libsonnet
@@ -62,6 +62,6 @@
   else {},
 
   index_gateway_service: if $._config.use_index_gateway then
-    k.util.serviceFor($.index_gateway_statefulset)
+    k.util.serviceFor($.index_gateway_statefulset, $._config.service_ignored_labels)
   else {},
 }

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -77,9 +77,9 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   ingester_service:
     if !$._config.stateful_ingesters then
-      k.util.serviceFor($.ingester_deployment)
+      k.util.serviceFor($.ingester_deployment, $._config.service_ignored_labels)
     else
-      k.util.serviceFor($.ingester_statefulset),
+      k.util.serviceFor($.ingester_statefulset, $._config.service_ignored_labels),
 
   local podDisruptionBudget = k.policy.v1beta1.podDisruptionBudget,
 

--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -17,6 +17,8 @@
 
   _config+:: {
     gossip_member_label: 'loki_gossip_member',
+    service_ignored_labels:: [$._config.gossip_member_label],
+
     // Enables use of memberlist for all rings, instead of consul. If multikv_migration_enabled is true, consul hostname is still configured,
     // but "primary" KV depends on value of multikv_primary.
     memberlist_ring_enabled: false,

--- a/production/ksonnet/loki/overrides-exporter.libsonnet
+++ b/production/ksonnet/loki/overrides-exporter.libsonnet
@@ -33,6 +33,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   else {},
 
   overrides_exporter_service: if $._config.overrides_exporter_enabled then
-    k.util.serviceFor($.overrides_exporter_deployment)
+    k.util.serviceFor($.overrides_exporter_deployment, $._config.service_ignored_labels)
   else {},
 }

--- a/production/ksonnet/loki/querier.libsonnet
+++ b/production/ksonnet/loki/querier.libsonnet
@@ -75,7 +75,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   querier_service:
     if !$._config.stateful_queriers then
-      k.util.serviceFor($.querier_deployment)
+      k.util.serviceFor($.querier_deployment, $._config.service_ignored_labels)
     else
-      k.util.serviceFor($.querier_statefulset),
+      k.util.serviceFor($.querier_statefulset, $._config.service_ignored_labels),
 }

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -56,8 +56,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   then {}
   else
     if $._config.stateful_rulers
-    then k.util.serviceFor($.ruler_statefulset)
-    else k.util.serviceFor($.ruler_deployment),
+    then k.util.serviceFor($.ruler_statefulset, $._config.service_ignored_labels)
+    else k.util.serviceFor($.ruler_deployment, $._config.service_ignored_labels),
 
 
   // PVC for rulers when running as statefulsets

--- a/production/ksonnet/loki/table-manager.libsonnet
+++ b/production/ksonnet/loki/table-manager.libsonnet
@@ -37,5 +37,5 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     k.util.configVolumeMount('loki', '/etc/loki/config'),
 
   table_manager_service:
-    k.util.serviceFor($.table_manager_deployment),
+    k.util.serviceFor($.table_manager_deployment, $._config.service_ignored_labels),
 }


### PR DESCRIPTION
Adding this selector can result in outages caused by all write traffic being routed to only new distributors during initial migrations to memberlists, causing the few new distributors at the start of a rollout to be OOM killed.

cc @JordanRushing @vlad-diachenko @slim-bean 

Signed-off-by: Callum Styan <callumstyan@gmail.com>
