### PR TITLE
[TSDB]  fingerprint offsets is now correctly 16 byte aligned

### DIFF
--- a/pkg/ingester/index/bitprefix.go
+++ b/pkg/ingester/index/bitprefix.go
@@ -107,10 +107,7 @@ func (ii *BitPrefixInvertedIndex) validateShard(shard *astmapper.ShardAnnotation
 		return nil
 	}
 
-	if 1<<(shard.TSDB().RequiredBits()) != shard.Of {
-		return fmt.Errorf("Shard factor must be a power of two, got %d", shard.Of)
-	}
-	return nil
+	return shard.TSDB().Validate()
 }
 
 // Add a fingerprint under the specified labels.

--- a/pkg/querier/queryrange/shard_resolver_test.go
+++ b/pkg/querier/queryrange/shard_resolver_test.go
@@ -11,50 +11,41 @@ import (
 
 func TestGuessShardFactor(t *testing.T) {
 	for _, tc := range []struct {
-		stats          stats.Stats
-		maxParallelism int
-		exp            int
+		stats stats.Stats
+		exp   int
 	}{
 		{
 			// no data == no sharding
-			exp:            0,
-			maxParallelism: 10,
+			exp: 0,
 		},
 		{
-			exp:            4,
-			maxParallelism: 10,
+			exp: 4,
 			stats: stats.Stats{
-				Bytes: 1200 << 20, // 1200MB
+				Bytes: p90BytesPerSecond * 4,
 			},
 		},
 		{
-			exp:            8,
-			maxParallelism: 10,
-			// 1500MB moves us to the next
-			// power of 2 parallelism factor
+			// round up shard factor
+			exp: 16,
 			stats: stats.Stats{
-				Bytes: 1500 << 20,
+				Bytes: p90BytesPerSecond * 15,
 			},
 		},
 		{
-			// Two fully packed parallelism cycles
-			exp:            16,
-			maxParallelism: 8,
+			exp: 2,
 			stats: stats.Stats{
-				Bytes: maxSchedulableBytes * 16,
+				Bytes: p90BytesPerSecond + 1,
 			},
 		},
 		{
-			// increase to next factor of two
-			exp:            32,
-			maxParallelism: 8,
+			exp: 0,
 			stats: stats.Stats{
-				Bytes: maxSchedulableBytes * 17,
+				Bytes: p90BytesPerSecond,
 			},
 		},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc.stats), func(t *testing.T) {
-			require.Equal(t, tc.exp, guessShardFactor(tc.stats, tc.maxParallelism))
+			require.Equal(t, tc.exp, guessShardFactor(tc.stats))
 		})
 	}
 }

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -151,13 +151,12 @@ func (h *splitByInterval) loop(ctx context.Context, ch <-chan *lokiResult, next 
 		data.req.LogToSpan(sp)
 
 		resp, err := next.Do(ctx, data.req)
+		sp.Finish()
 
 		select {
 		case <-ctx.Done():
-			sp.Finish()
 			return
 		case data.ch <- &packedResp{resp, err}:
-			sp.Finish()
 		}
 	}
 }

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -54,6 +54,8 @@ func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, thro
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
 	log.Log(
 		"shortcut", shortcut,
+		"from", from.Time(),
+		"through", through.Time(),
 		"err", err,
 	)
 	if err != nil {

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -52,6 +52,10 @@ func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, thro
 	defer log.Span.Finish()
 
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
+	log.Log(
+		"shortcut", shortcut,
+		"err", err,
+	)
 	if err != nil {
 		return nil, nil, err
 	} else if shortcut {

--- a/pkg/storage/stores/tsdb/index/fingerprint.go
+++ b/pkg/storage/stores/tsdb/index/fingerprint.go
@@ -10,7 +10,6 @@ type FingerprintOffsets [][2]uint64
 
 func (xs FingerprintOffsets) Range(shard ShardAnnotation) (minOffset, maxOffset uint64) {
 	from, through := shard.Bounds()
-
 	lower := sort.Search(len(xs), func(i int) bool {
 		return xs[i][1] >= uint64(from)
 	})

--- a/pkg/storage/stores/tsdb/index/postings.go
+++ b/pkg/storage/stores/tsdb/index/postings.go
@@ -864,7 +864,7 @@ func (sp *ShardedPostings) Next() bool {
 		if ok := sp.p.Next(); !ok {
 			return false
 		}
-		return sp.p.Seek(storage.SeriesRef(sp.minOffset))
+		return sp.Seek(0)
 	}
 	ok := sp.p.Next()
 	if !ok {

--- a/pkg/storage/stores/tsdb/index/postings.go
+++ b/pkg/storage/stores/tsdb/index/postings.go
@@ -871,7 +871,7 @@ func (sp *ShardedPostings) Next() bool {
 		return false
 	}
 
-	if sp.p.At() > storage.SeriesRef(sp.maxOffset) {
+	if sp.p.At() >= storage.SeriesRef(sp.maxOffset) {
 		return false
 	}
 
@@ -881,7 +881,7 @@ func (sp *ShardedPostings) Next() bool {
 // Seek advances the iterator to value v or greater and returns
 // true if a value was found.
 func (sp *ShardedPostings) Seek(v storage.SeriesRef) (res bool) {
-	if v > storage.SeriesRef(sp.maxOffset) {
+	if v >= storage.SeriesRef(sp.maxOffset) {
 		return false
 	}
 	if v < storage.SeriesRef(sp.minOffset) {

--- a/pkg/storage/stores/tsdb/index/postings_test.go
+++ b/pkg/storage/stores/tsdb/index/postings_test.go
@@ -929,3 +929,24 @@ func TestMemPostings_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(expanded), "expected empty postings, got %v", expanded)
 }
+
+func TestShardedPostings(t *testing.T) {
+	offsets := FingerprintOffsets{
+		{0, 0},
+		{5, 0b1 << 62},
+		{10, 0b1 << 63},
+		{15, 0b11 << 62},
+	}
+	shard := NewShard(0, 2)
+	var refs []storage.SeriesRef
+	for i := 0; i < 20; i++ {
+		refs = append(refs, storage.SeriesRef(i))
+	}
+	ps := newListPostings(refs...)
+	shardedPostings := NewShardedPostings(ps, shard, offsets)
+
+	for i := 0; i < 10; i++ {
+		require.Equal(t, true, shardedPostings.Next())
+		require.Equal(t, storage.SeriesRef(i), shardedPostings.At())
+	}
+}

--- a/pkg/storage/stores/tsdb/index/postings_test.go
+++ b/pkg/storage/stores/tsdb/index/postings_test.go
@@ -949,4 +949,5 @@ func TestShardedPostings(t *testing.T) {
 		require.Equal(t, true, shardedPostings.Next())
 		require.Equal(t, storage.SeriesRef(i), shardedPostings.At())
 	}
+	require.Equal(t, false, shardedPostings.Next())
 }

--- a/pkg/storage/stores/tsdb/index/shard.go
+++ b/pkg/storage/stores/tsdb/index/shard.go
@@ -15,7 +15,7 @@ const (
 	ShardLabelFmt = "%d_of_%d"
 )
 
-var errDisallowedIdentityShard = errors.New("shard with factor of 1 is explicitly disallowed. It's equivalent to no sharding.")
+var errDisallowedIdentityShard = errors.New("shard with factor of 1 is explicitly disallowed. It's equivalent to no sharding")
 
 // ShardAnnotation is a convenience struct which holds data from a parsed shard label
 // Of MUST be a power of 2 to ensure sharding logic works correctly.
@@ -70,7 +70,7 @@ func (shard ShardAnnotation) Validate() error {
 }
 
 // Bounds shows the [minimum, maximum) fingerprints. If there is no maximum
-// fingerprint (for example )
+// fingerprint (for example the last shard), math.MaxUint64 is used as the maximum.
 func (shard ShardAnnotation) Bounds() (model.Fingerprint, model.Fingerprint) {
 	requiredBits := model.Fingerprint(shard.RequiredBits())
 	from := model.Fingerprint(shard.Shard) << (64 - requiredBits)

--- a/pkg/storage/stores/tsdb/index/shard.go
+++ b/pkg/storage/stores/tsdb/index/shard.go
@@ -36,10 +36,14 @@ func NewShard(x, of uint32) ShardAnnotation {
 // Inclusion in a shard is calculated by determining the arbitrary bit prefix
 // for a shard, then ensuring the fingerprint has the same prefix
 func (shard ShardAnnotation) Match(fp model.Fingerprint) bool {
+	if shard.Of < 2 {
+		return true
+	}
 	requiredBits := shard.RequiredBits()
 
 	// A shard only matches a fingerprint when they both start with the same prefix
 	prefix := uint64(shard.Shard) << (64 - requiredBits)
+
 	return prefix^uint64(fp) < 1<<(64-requiredBits)
 }
 

--- a/pkg/storage/stores/tsdb/index/shard_test.go
+++ b/pkg/storage/stores/tsdb/index/shard_test.go
@@ -63,6 +63,11 @@ func TestShardBounds(t *testing.T) {
 		from, through uint64
 	}{
 		{
+			shard:   NewShard(0, 1),
+			from:    0,
+			through: math.MaxUint64,
+		},
+		{
 			shard:   NewShard(0, 2),
 			from:    0,
 			through: 1 << 63,

--- a/pkg/storage/stores/tsdb/index/shard_test.go
+++ b/pkg/storage/stores/tsdb/index/shard_test.go
@@ -50,6 +50,11 @@ func TestShardMatch(t *testing.T) {
 			fp:    3 << 62,
 			exp:   false,
 		},
+		{
+			shard: NewShard(0, 1),
+			fp:    5287603155525329,
+			exp:   true,
+		},
 	} {
 		t.Run(fmt.Sprint(tc.shard, tc.fp), func(t *testing.T) {
 			require.Equal(t, tc.exp, tc.shard.Match(model.Fingerprint(tc.fp)))

--- a/pkg/storage/stores/tsdb/index/shard_test.go
+++ b/pkg/storage/stores/tsdb/index/shard_test.go
@@ -22,6 +22,11 @@ func TestShardMatch(t *testing.T) {
 		},
 		{
 			shard: NewShard(0, 2),
+			fp:    5287603155525329,
+			exp:   true,
+		},
+		{
+			shard: NewShard(0, 2),
 			fp:    1 << 63,
 			exp:   false,
 		},

--- a/pkg/storage/stores/tsdb/index/shard_test.go
+++ b/pkg/storage/stores/tsdb/index/shard_test.go
@@ -95,3 +95,33 @@ func TestShardBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestShardValidate(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		factor uint32
+		err    bool
+	}{
+		{
+			factor: 0,
+			err:    false,
+		},
+		{
+			factor: 1,
+			err:    true,
+		},
+		{
+			factor: 2,
+			err:    false,
+		},
+	} {
+		t.Run(fmt.Sprint(tc.factor), func(t *testing.T) {
+			err := NewShard(0, tc.factor).Validate()
+			if tc.err {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -76,6 +76,8 @@ func (c *IndexClient) GetChunkRefs(ctx context.Context, userID string, from, thr
 
 	matchers, shard, err := cleanMatchers(matchers...)
 	kvps = append(kvps,
+		"from", from.Time(),
+		"through", through.Time(),
 		"matchers", syntax.MatchersString(matchers),
 		"shard", shard,
 		"cleanMatcherErr", err,

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -45,6 +45,10 @@ func cleanMatchers(matchers ...*labels.Matcher) ([]*labels.Matcher, *index.Shard
 			Shard: uint32(s.Shard),
 			Of:    uint32(s.Of),
 		}
+
+		if err := shard.Validate(); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if len(matchers) == 0 {


### PR DESCRIPTION
This contains a few fixes I've found over the past few days of debugging TSDB operations (sorry for being all over the place), but the important bits are
1) Correctly calculates `storage.SeriesRef` offsets in the `fingerprintOffsets` table in https://github.com/grafana/loki/commit/7a34b15018d7fd8596f460018ce01cc7b78234d8. This resulted in an incredibly hard to find bug in sharding code because it wasn't:
   * Using section offsets to increase the starting offsets for our series references
   * Using 16 byte offsets of the _file position_ not _series number_

It caused everything but the last shard to be skipped most off the time because the actual references were waaay higher than expected
2) Simplifies the query planning algorithm to consistently prefer smaller units of work.

ref https://github.com/grafana/loki/issues/5428