### PR TITLE
Fix inconsistent coverage in the distributor package

### DIFF
--- a/pkg/distributor/ingestion_rate_strategy_test.go
+++ b/pkg/distributor/ingestion_rate_strategy_test.go
@@ -46,6 +46,20 @@ func TestIngestionRateStrategy(t *testing.T) {
 			expectedLimit: 0.5 * float64(bytesInMB),
 			expectedBurst: int(2.0 * float64(bytesInMB)),
 		},
+		"global rate limiter should share nothing when there aren't any distributors": {
+			limits: validation.Limits{
+				IngestionRateStrategy: validation.GlobalIngestionRateStrategy,
+				IngestionRateMB:       1.0,
+				IngestionBurstSizeMB:  2.0,
+			},
+			ring: func() ReadLifecycler {
+				ring := newReadLifecyclerMock()
+				ring.On("HealthyInstancesCount").Return(0)
+				return ring
+			}(),
+			expectedLimit: 1.0 * float64(bytesInMB),
+			expectedBurst: int(2.0 * float64(bytesInMB)),
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
We have a handy code coverage tool that lets us know our change's impacts on code coverage. Something strange that's been happening is the distributor package has been consistently providing non-deterministic results:

![coverage](https://user-images.githubusercontent.com/1413241/178039555-3d67bab2-9406-470b-a17f-20a3334b02b4.png)

Turns out [this line](https://github.com/grafana/loki/blob/e7fb10f4567f191a8dbc2344b1e62c8072dd695e/pkg/distributor/ingestion_rate_strategy.go#L48) wasn't explicitly tested in it's unit test and was being accidentally tested as part of another test in the same package. As a result, code coverage was inconsistent. 

This PR explicitly tests this code path so the coverage results of our tests are always consistent.
