### PR TITLE
[TSDB] dont skip writing to TSDB index when chunk exists in cache

### DIFF
--- a/pkg/storage/stores/tsdb/chunkwriter.go
+++ b/pkg/storage/stores/tsdb/chunkwriter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores/series"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 )
@@ -58,23 +57,11 @@ func (w *ChunkWriter) PutOne(ctx context.Context, from, through model.Time, chk 
 	// to avoid data loss if we lose an ingester's disk
 	// but we can skip writing the chunk if another replica
 	// has already written it to storage.
-	writeChunk := true
-
-	// If this chunk is in cache it must already be in the database so we don't need to write it again
-	found, _, _, _ := w.fetcher.Cache().Fetch(ctx, []string{w.schemaCfg.ExternalKey(chk.ChunkRef)})
-
-	if len(found) > 0 {
-		writeChunk = false
-		series.DedupedChunksTotal.Inc()
-	}
-
 	chunks := []chunk.Chunk{chk}
 
 	c := w.fetcher.Client()
-	if writeChunk {
-		if err := c.PutChunks(ctx, chunks); err != nil {
-			return errors.Wrap(err, "writing chunk")
-		}
+	if err := c.PutChunks(ctx, chunks); err != nil {
+		return errors.Wrap(err, "writing chunk")
 	}
 
 	// Always write the index to benefit durability via replication factor.
@@ -92,10 +79,8 @@ func (w *ChunkWriter) PutOne(ctx context.Context, from, through model.Time, chk 
 		return errors.Wrap(err, "writing index entry")
 	}
 
-	if writeChunk {
-		if cacheErr := w.fetcher.WriteBackCache(ctx, chunks); cacheErr != nil {
-			level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
-		}
+	if cacheErr := w.fetcher.WriteBackCache(ctx, chunks); cacheErr != nil {
+		level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
 	}
 
 	return nil


### PR DESCRIPTION
Because TSDB indices are accumulated on disks and eventually flushed, we rely on their replication factor, so ensure we don't skip writing index entries when the chunk exists in cache already.

ref https://github.com/grafana/loki/issues/5428