### PR TITLE
[TSDB] store uncompressed chunk size in index

### DIFF
--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -81,7 +81,7 @@ func (f Facade) Size() int {
 		return 0
 	}
 	// Note this is an estimation (which is OK)
-	return f.c.CompressedSize()
+	return f.c.UncompressedSize()
 }
 
 func (f Facade) Entries() int {

--- a/pkg/chunkenc/facade.go
+++ b/pkg/chunkenc/facade.go
@@ -81,6 +81,13 @@ func (f Facade) Size() int {
 		return 0
 	}
 	// Note this is an estimation (which is OK)
+	return f.c.CompressedSize()
+}
+
+func (f Facade) UncompressedSize() int {
+	if f.c == nil {
+		return 0
+	}
 	return f.c.UncompressedSize()
 }
 

--- a/pkg/storage/chunk/bigchunk.go
+++ b/pkg/storage/chunk/bigchunk.go
@@ -172,6 +172,9 @@ func (b *bigchunk) Len() int {
 	return sum
 }
 
+// Unused, but for compatibility
+func (b *bigchunk) UncompressedSize() int { return b.Size() }
+
 func (b *bigchunk) Size() int {
 	sum := 2 // For the number of sub chunks.
 	for _, c := range b.chunks {

--- a/pkg/storage/chunk/interface.go
+++ b/pkg/storage/chunk/interface.go
@@ -52,6 +52,8 @@ type Data interface {
 	Rebound(start, end model.Time, filter filter.Func) (Data, error)
 	// Size returns the approximate length of the chunk in bytes.
 	Size() int
+	// UncompressedSize returns the length of uncompressed bytes.
+	UncompressedSize() int
 	// Entries returns the number of entries in a chunk
 	Entries() int
 	Utilization() float64

--- a/pkg/storage/stores/tsdb/chunkwriter.go
+++ b/pkg/storage/stores/tsdb/chunkwriter.go
@@ -78,7 +78,7 @@ func (w *ChunkWriter) PutOne(ctx context.Context, from, through model.Time, chk 
 	}
 
 	// Always write the index to benefit durability via replication factor.
-	approxKB := math.Round(float64(chk.Data.Size()) / float64(1<<10))
+	approxKB := math.Round(float64(chk.Data.UncompressedSize()) / float64(1<<10))
 	metas := index.ChunkMetas{
 		{
 			Checksum: chk.ChunkRef.Checksum,


### PR DESCRIPTION
Uncompressed size is more intuitive for both understanding throughput on streams via the index sampling endpoint and query planning -- this fixes an earlier oversight which used compressed size.

ref https://github.com/grafana/loki/issues/5428