### PR TITLE
fix the issue of overwriting tsdb files during rollouts

### DIFF
--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -168,91 +168,93 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error
 	}()
 
 	level.Debug(m.log).Log("msg", "recovering tenant heads")
-	tmp := newTenantHeads(t, defaultHeadManagerStripeSize, m.metrics, m.log)
-	if err = recoverHead(m.dir, tmp, ids); err != nil {
-		return errors.Wrap(err, "building TSDB from WALs")
-	}
+	for _, id := range ids {
+		tmp := newTenantHeads(t, defaultHeadManagerStripeSize, m.metrics, m.log)
+		if err = recoverHead(m.dir, tmp, []WALIdentifier{id}); err != nil {
+			return errors.Wrap(err, "building TSDB from WALs")
+		}
 
-	periods := make(map[string]*Builder)
+		periods := make(map[string]*Builder)
 
-	if err := tmp.forAll(func(user string, ls labels.Labels, chks index.ChunkMetas) error {
+		if err := tmp.forAll(func(user string, ls labels.Labels, chks index.ChunkMetas) error {
 
-		// chunks may overlap index period bounds, in which case they're written to multiple
-		pds := make(map[string]index.ChunkMetas)
-		for _, chk := range chks {
-			idxBuckets, err := indexBuckets(chk.From(), chk.Through(), m.tableRanges)
+			// chunks may overlap index period bounds, in which case they're written to multiple
+			pds := make(map[string]index.ChunkMetas)
+			for _, chk := range chks {
+				idxBuckets, err := indexBuckets(chk.From(), chk.Through(), m.tableRanges)
+				if err != nil {
+					return err
+				}
+
+				for _, bucket := range idxBuckets {
+					pds[bucket] = append(pds[bucket], chk)
+				}
+			}
+
+			// Embed the tenant label into TSDB
+			lb := labels.NewBuilder(ls)
+			lb.Set(TenantLabel, user)
+			withTenant := lb.Labels()
+
+			// Add the chunks to all relevant builders
+			for pd, matchingChks := range pds {
+				b, ok := periods[pd]
+				if !ok {
+					b = NewBuilder()
+					periods[pd] = b
+				}
+
+				b.AddSeries(
+					withTenant,
+					// use the fingerprint without the added tenant label
+					// so queries route to the chunks which actually exist.
+					model.Fingerprint(ls.Hash()),
+					matchingChks,
+				)
+			}
+
+			return nil
+		}); err != nil {
+			level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB from WALs")
+			return err
+		}
+
+		for p, b := range periods {
+
+			dstDir := filepath.Join(managerMultitenantDir(m.dir), fmt.Sprint(p))
+			dst := newPrefixedIdentifier(
+				MultitenantTSDBIdentifier{
+					nodeName: m.nodeName,
+					ts:       id.ts,
+				},
+				dstDir,
+				"",
+			)
+
+			level.Debug(m.log).Log("msg", "building tsdb for period", "pd", p, "dst", dst.Path())
+			// build+move tsdb to multitenant dir
+			start := time.Now()
+			_, err = b.Build(
+				context.Background(),
+				managerScratchDir(m.dir),
+				func(from, through model.Time, checksum uint32) Identifier {
+					return dst
+				},
+			)
 			if err != nil {
 				return err
 			}
 
-			for _, bucket := range idxBuckets {
-				pds[bucket] = append(pds[bucket], chk)
-			}
-		}
+			level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
 
-		// Embed the tenant label into TSDB
-		lb := labels.NewBuilder(ls)
-		lb.Set(TenantLabel, user)
-		withTenant := lb.Labels()
-
-		// Add the chunks to all relevant builders
-		for pd, matchingChks := range pds {
-			b, ok := periods[pd]
-			if !ok {
-				b = NewBuilder()
-				periods[pd] = b
+			loaded, err := NewShippableTSDBFile(dst, false)
+			if err != nil {
+				return err
 			}
 
-			b.AddSeries(
-				withTenant,
-				// use the fingerprint without the added tenant label
-				// so queries route to the chunks which actually exist.
-				model.Fingerprint(ls.Hash()),
-				matchingChks,
-			)
-		}
-
-		return nil
-	}); err != nil {
-		level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB from WALs")
-		return err
-	}
-
-	for p, b := range periods {
-
-		dstDir := filepath.Join(managerMultitenantDir(m.dir), fmt.Sprint(p))
-		dst := newPrefixedIdentifier(
-			MultitenantTSDBIdentifier{
-				nodeName: m.nodeName,
-				ts:       t,
-			},
-			dstDir,
-			"",
-		)
-
-		level.Debug(m.log).Log("msg", "building tsdb for period", "pd", p, "dst", dst.Path())
-		// build+move tsdb to multitenant dir
-		start := time.Now()
-		_, err = b.Build(
-			context.Background(),
-			managerScratchDir(m.dir),
-			func(from, through model.Time, checksum uint32) Identifier {
-				return dst
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
-
-		loaded, err := NewShippableTSDBFile(dst, false)
-		if err != nil {
-			return err
-		}
-
-		if err := m.shipper.AddIndex(p, "", loaded); err != nil {
-			return err
+			if err := m.shipper.AddIndex(p, "", loaded); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
During startup, we load all the index from the `wal` from previous session and build tsdb index out of it and upload the files with timestamp [now](https://github.com/grafana/loki/blob/f18edcf9d8199619a9b63d48a217948078ba6f24/pkg/storage/stores/tsdb/head_manager.go#L196). We also create a new `wal` with timestamp [now](https://github.com/grafana/loki/blob/f18edcf9d8199619a9b63d48a217948078ba6f24/pkg/storage/stores/tsdb/head_manager.go#L206). While rotating the `wal` we build and upload the index out of it with the same timestamp as the `wal` from which it was built [here](https://github.com/grafana/loki/blob/f18edcf9d8199619a9b63d48a217948078ba6f24/pkg/storage/stores/tsdb/head_manager.go#L288). This means the index built from `wal` created at startup would overwrite index build from previous session's `wal`. This PR fixes the issue by building index files with same timestamp as the `wal` from which it was built.


<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->