### PR TITLE
operator: Set minimum TLS version to 1.2 to support FIPS

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6669](https://github.com/grafana/loki/pull/6669) **xperimental**: Set minimum TLS version to 1.2 to support FIPS
 - [6663](https://github.com/grafana/loki/pull/6663) **aminesnow**: Generalize live tail fix to all clusters using TLS
 - [6443](https://github.com/grafana/loki/pull/6443) **aminesnow**: Fix live tail of logs not working on OpenShift-based clusters
 - [6646](https://github.com/grafana/loki/pull/6646) **periklis**: Update Loki operand to v2.6.0

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -259,6 +259,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.write.endpoint=http://example.com",
 										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--tls.client-auth-type=NoClientCert",
+										"--tls.min-version=VersionTLS12",
 										"--tls.server.cert-file=/var/run/tls/http/tls.crt",
 										"--tls.server.key-file=/var/run/tls/http/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
@@ -291,6 +292,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Image: "quay.io/observatorium/opa-openshift:latest",
 									Args: []string{
 										"--log.level=warn",
+										"--tls.min-version=VersionTLS12",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
@@ -431,6 +433,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--logs.write.endpoint=http://example.com",
 										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--tls.client-auth-type=NoClientCert",
+										"--tls.min-version=VersionTLS12",
 										"--tls.server.cert-file=/var/run/tls/http/tls.crt",
 										"--tls.server.key-file=/var/run/tls/http/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
@@ -463,6 +466,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Image: "quay.io/observatorium/opa-openshift:latest",
 									Args: []string{
 										"--log.level=warn",
+										"--tls.min-version=VersionTLS12",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
@@ -616,6 +620,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										fmt.Sprintf("--web.healthchecks.url=https://localhost:%d", gatewayHTTPPort),
 										"--logs.tls.ca-file=/var/run/ca/service-ca.crt",
 										"--tls.client-auth-type=NoClientCert",
+										"--tls.min-version=VersionTLS12",
 										"--tls.server.cert-file=/var/run/tls/http/tls.crt",
 										"--tls.server.key-file=/var/run/tls/http/tls.key",
 										"--tls.healthchecks.server-ca-file=/var/run/ca/service-ca.crt",
@@ -653,6 +658,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Image: "quay.io/observatorium/opa-openshift:latest",
 									Args: []string{
 										"--log.level=warn",
+										"--tls.min-version=VersionTLS12",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -99,6 +99,7 @@ func ConfigureGatewayDeployment(
 	caFilePath := path.Join(caDir, caFile)
 	gwArgs = append(gwArgs,
 		"--tls.client-auth-type=NoClientCert",
+		"--tls.min-version=VersionTLS12",
 		fmt.Sprintf("--tls.server.cert-file=%s", certFilePath),
 		fmt.Sprintf("--tls.server.key-file=%s", keyFilePath),
 		fmt.Sprintf("--tls.healthchecks.server-ca-file=%s", caFilePath),

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -35,6 +35,7 @@ func newOPAOpenShiftContainer(secretVolumeName, tlsDir, certFile, keyFile string
 	uriScheme = corev1.URISchemeHTTP
 	args = []string{
 		"--log.level=warn",
+		"--tls.min-version=VersionTLS12",
 		fmt.Sprintf("--opa.package=%s", opaDefaultPackage),
 		fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatcher),
 		fmt.Sprintf("--web.listen=:%d", GatewayOPAHTTPPort),


### PR DESCRIPTION
**What this PR does / why we need it**:

This change downgrades the minimum TLS version supported by the two gateway components to TLS 1.2 for OpenShift. This is, so that clusters which need to be FIPS-compliant can be supported by the loki-operator.

Currently this only modifies the configuration of the gateway deployment, one open question would be if we need to _force_ all components to use TLS 1.2 if running on a FIPS cluster for compliance.

**Which issue(s) this PR fixes**:

[LOG-2546](https://issues.redhat.com/browse/LOG-2546)

**Special notes for your reviewer**:

- [ ] Question: Do we need to force all TLS-based communication to use TLS 1.2?

**Checklist**

- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
