### PR TITLE
Introduce an "enable_groupcache" config to control initialization better

### DIFF
--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -25,7 +25,8 @@ type Cache interface {
 
 // Config for building Caches.
 type Config struct {
-	EnableFifoCache bool `yaml:"enable_fifocache"`
+	EnableFifoCache  bool `yaml:"enable_fifocache"`
+	EnableGroupCache bool `yaml:"enable_groupcache"`
 
 	DefaultValidity time.Duration `yaml:"default_validity"`
 
@@ -61,6 +62,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, description string, f 
 	f.IntVar(&cfg.AsyncCacheWriteBackBufferSize, prefix+"max-async-cache-write-back-buffer-size", 500, "The maximum number of enqueued asynchronous writeback cache allowed.")
 	f.DurationVar(&cfg.DefaultValidity, prefix+"default-validity", time.Hour, description+"The default validity of entries for caches unless overridden.")
 	f.BoolVar(&cfg.EnableFifoCache, prefix+"cache.enable-fifocache", false, description+"Enable in-memory cache (auto-enabled for the chunks & query results cache if no other cache is configured).")
+	f.BoolVar(&cfg.EnableGroupCache, prefix+"cache.enable-groupcache", false, description+"Enable distributed in-memory cache.")
 
 	cfg.Prefix = prefix
 }
@@ -85,7 +87,12 @@ func IsRedisSet(cfg Config) bool {
 }
 
 func IsGroupCacheSet(cfg Config) bool {
-	return cfg.GroupCache != nil
+	return cfg.EnableGroupCache == true
+}
+
+// IsCacheConfigured determines if memcached, redis, or groupcache have been configured
+func IsCacheConfigured(cfg Config) bool {
+	return IsMemcacheSet(cfg) || IsRedisSet(cfg) || IsGroupCacheSet(cfg)
 }
 
 // New creates a new Cache using Config.


### PR DESCRIPTION
We initialize groupcache as a module, which happens after the config is parsed. A function named applyFIFOCacheConfig is called to enable fifocache if no cache is configured, and at the time of its calling the modules have not been initialized. This new "enable_groupcache" value is set if groupcache is configured in common, or this value is set manually. With this setting, we can prevent automatic fifocache settings.

Signed-off-by: Danny Kopping <danny.kopping@grafana.com>
