### PR TITLE
chore(fix): set log level for GetChunkRefs log

### DIFF
--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -52,7 +52,7 @@ func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, thro
 	defer log.Span.Finish()
 
 	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
-	log.Log(
+	level.Debug(log).Log(
 		"shortcut", shortcut,
 		"from", from.Time(),
 		"through", through.Time(),


### PR DESCRIPTION
This log line was being written without a log level