### PR TITLE
Add API delete curl examples

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1126,7 +1126,7 @@ curl -X DELETE \
   -H 'X-Scope-OrgID: <tenant-id>'
 ```
 
-The same example deletion cancellation request for Grafana Enterprise Logs uses Basic Authentication and specifies the tenant name as a user; `Tenant1` is the tenant name in this example. The password in this example is an access policy token that has been defined in the API_TOKEN environment variable:
+The same example deletion cancellation request for Grafana Enterprise Logs uses Basic Authentication and specifies the tenant name as a user; `Tenant1` is the tenant name in this example. The password in this example is an access policy token that has been defined in the API_TOKEN environment variable. The token must be for an access policy with `logs:delete` scope for the tenant specified in the user field.
 
 ```bash
 curl -u "Tenant1:$API_TOKEN" \


### PR DESCRIPTION
This PR updates API delete examples (documentation) in the same way that PR https://github.com/grafana/loki/pull/6530 updated the API query example.  Deletes only work on a single tenant, so the examples distinguish GEL API header from Loki headers.

Reviews:
- Are the cURL commands complete and correct?