### PR TITLE
Docs: Fix bad links in the API section

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1,5 +1,7 @@
 ---
 title: HTTP API
+menuTitle: "HTTP API"
+description: "Loki exposes REST endpoints for operating on a Loki cluster. This section details the endpoints."
 weight: 900
 ---
 
@@ -1024,7 +1026,8 @@ POST /loki/api/v1/delete
 PUT /loki/api/v1/delete
 ```
 
-Create a new delete request for the authenticated tenant. More details can be found in the [logs deletion documentation](../operations/storage/logs-deletion.md#request-log-entry-deletion).
+Create a new delete request for the authenticated tenant.
+The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1065,7 +1065,8 @@ curl -u "Tenant1:$API_TOKEN" \
 GET /loki/api/v1/delete
 ```
 
-List the existing delete requests for the authenticated tenant. More details can be found in the [logs deletion documentation](../operations/storage/logs-deletion.md#list-delete-requests).
+List the existing delete requests for the authenticated tenant.
+The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
@@ -1101,7 +1102,8 @@ curl -u "Tenant1:$API_TOKEN" \
 DELETE /loki/api/v1/delete
 ```
 
-Remove a delete request for the authenticated tenant. More details can be found in the [logs deletion documentation](../operations/storage/logs-deletion.md#request-cancellation-of-a-delete-request).
+Remove a delete request for the authenticated tenant.
+The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
 
 Loki allows cancellation of delete requests until the requests are picked up for processing. It is controlled by the `delete_request_cancel_period` YAML configuration or the equivalent command line option when invoking Loki.
 

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -1,8 +1,10 @@
 ---
-title: Log Entry Deletion
+title: Log entry deletion
+menuTitle: "Log entry deletion"
+description: "Log entries from a specified stream may be deleted."
 weight: 60
 ---
-# Log Entry Deletion
+# Log entry deletion
 
 Grafana Loki supports the deletion of log entries from a specified stream.
 Log entries that fall within a specified time window and match an optional line filter are those that will be deleted.


### PR DESCRIPTION
There were bad links named "logs deletion documentation" in the section on compactor endpoints.  This PR fixes those bad links.  Also updated the YAML file frontmatter to better conform to style guidelines since I was changing the files.