### PR TITLE
[TSDB] query_frontend_shard_factor uses exponential buckets

### DIFF
--- a/pkg/logql/mapper_metrics.go
+++ b/pkg/logql/mapper_metrics.go
@@ -43,7 +43,7 @@ func newMapperMetrics(registerer prometheus.Registerer, mapper string) *MapperMe
 			Namespace:   "loki",
 			Name:        "query_frontend_shard_factor",
 			Help:        "Number of downstream queries per request",
-			Buckets:     prometheus.LinearBuckets(0, 16, 4),
+			Buckets:     prometheus.ExponentialBuckets(1, 4, 8),
 			ConstLabels: prometheus.Labels{"mapper": mapper},
 		}),
 	}


### PR DESCRIPTION
We dispatch many smaller queries in planning when using TSDB as an index -- this PR updates the underlying metric buckets to use exponential growth to reflect this.

ref https://github.com/grafana/loki/issues/5428