### PR TITLE
[release-2.6.x] Fix TIME_WAIT connection leak from queriers to compactor

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -991,7 +991,10 @@ func (t *Loki) deleteRequestsClient(clientType string, limits retention.Limits) 
 		return nil, err
 	}
 
-	client, err := deletion.NewDeleteRequestsClient(compactorAddress, &http.Client{Timeout: 5 * time.Second}, t.deleteClientMetrics, clientType)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 250
+	transport.MaxIdleConnsPerHost = 250
+	client, err := deletion.NewDeleteRequestsClient(compactorAddress, &http.Client{Timeout: 5 * time.Second, Transport: transport}, t.deleteClientMetrics, clientType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/delete_requests_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -164,7 +166,10 @@ func (c *deleteRequestsClient) getRequestsFromServer(ctx context.Context, userID
 		level.Error(log.Logger).Log("msg", "error getting delete requests from the store", "err", err)
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode/100 != 2 {
 		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)


### PR DESCRIPTION
backport of https://github.com/grafana/loki/pull/6681