### PR TITLE
promtail: Inject tenant ID when receiving X-Scope-OrgID in heroku target

### DIFF
--- a/clients/pkg/promtail/targets/heroku/target.go
+++ b/clients/pkg/promtail/targets/heroku/target.go
@@ -3,7 +3,6 @@ package heroku
 import (
 	"flag"
 	"fmt"
-	lokiClient "github.com/grafana/loki/clients/pkg/promtail/client"
 	"net/http"
 	"strings"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/weaveworks/common/server"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
+	lokiClient "github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In a recent PR, a new promtail target was added for receiving logs from Heroku HTTPS Drains. This target exposes and http server, which receives request from either Heroku's logging service, or from some other source (a proxy for example). To be able to support multitenancy in this new target, and implementing this in a path consistent with the resto of promtail, this PR extracts the `X-Scope-OrgID` header from the incoming request, and injects its value in [promtail's tenant ID reserver label](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go#L420).

In the future, we'd like to use this same approach in other HTTP-exposing targets, for supporting multitenant promtails.

**Which issue(s) this PR fixes**:
Follow up of https://github.com/grafana/loki/commit/0e28452f1f1a9173167640d66abc992c31f23f7b
Related to https://github.com/grafana/cloud-onboarding/issues/1839

**Special notes for your reviewer**:
This is part of this [larger approach](https://github.com/grafana/cloud-onboarding/issues/1839).

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
