### PR TITLE
Fix per-tenant delete client

### DIFF
--- a/pkg/storage/stores/shipper/compactor/deletion/tenant_delete_requests_client.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/tenant_delete_requests_client.go
@@ -20,8 +20,14 @@ func NewPerTenantDeleteRequestsClient(c DeleteRequestsClient, l retention.Limits
 
 func (c *perTenantDeleteRequestsClient) GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
 	allLimits := c.limits.AllByUserID()
-	userLimits, ok := allLimits[userID]
-	if ok && userLimits.CompactorDeletionEnabled || c.limits.DefaultLimits().CompactorDeletionEnabled {
+	if userLimits, ok := allLimits[userID]; ok {
+		if userLimits.CompactorDeletionEnabled {
+			return c.client.GetAllDeleteRequestsForUser(ctx, userID)
+		}
+		return nil, nil
+	}
+
+	if c.limits.DefaultLimits().CompactorDeletionEnabled {
 		return c.client.GetAllDeleteRequestsForUser(ctx, userID)
 	}
 

--- a/pkg/storage/stores/shipper/compactor/deletion/tenant_delete_requests_client_test.go
+++ b/pkg/storage/stores/shipper/compactor/deletion/tenant_delete_requests_client_test.go
@@ -27,6 +27,13 @@ func TestTenantDeleteRequestsClient(t *testing.T) {
 		require.Empty(t, reqs)
 	})
 
+	t.Run("tenant disabled but default enabled", func(t *testing.T) {
+		limits.defaultLimit.compactorDeletionEnabled = true
+		reqs, err := perTenantClient.GetAllDeleteRequestsForUser(context.Background(), "2")
+		require.Nil(t, err)
+		require.Empty(t, reqs)
+	})
+
 	t.Run("default is enabled", func(t *testing.T) {
 		limits.defaultLimit.compactorDeletionEnabled = true
 		reqs, err := perTenantClient.GetAllDeleteRequestsForUser(context.Background(), "3")


### PR DESCRIPTION
- Don't make the request for a disabled tenant even if global deletion is allowed
