### PR TITLE
[release-2.6.x] Backport 6703 to release 2.6.x

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -21,10 +21,10 @@ The configuration acquired with these installation instructions run Loki as a si
 Copy and paste the commands below into your command line.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.6.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.6.0 -config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.6.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.0 -config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.6.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.6.1 -config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.6.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.1 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -39,10 +39,10 @@ Copy and paste the commands below into your terminal. Note that you will need to
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v2.6.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.6.0 --config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.6.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.0 --config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.6.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.6.1 --config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.6.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.1 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -54,6 +54,6 @@ Navigate to http://localhost:3100/metrics to view the output.
 Run the following commands in your command line. They work for Windows or Linux systems.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.6.0/production/docker-compose.yaml -O docker-compose.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.6.1/production/docker-compose.yaml -O docker-compose.yaml
 docker-compose -f docker-compose.yaml up
 ```

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   read:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     command: "-config.file=/etc/loki/config.yaml -target=read"
     ports:
       - 3101:3100
@@ -22,7 +22,7 @@ services:
           - loki
 
   write:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     command: "-config.file=/etc/loki/config.yaml -target=write"
     ports:
       - 3102:3100
@@ -36,7 +36,7 @@ services:
       <<: *loki-dns
 
   promtail:
-    image: grafana/promtail:2.6.0
+    image: grafana/promtail:2.6.1
     volumes:
       - ./promtail-local-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.6.0
+    image: grafana/promtail:2.6.1
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml

--- a/production/docker/docker-compose-ha-memberlist.yaml
+++ b/production/docker/docker-compose-ha-memberlist.yaml
@@ -9,7 +9,7 @@ services:
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     user: root
     entrypoint:
       - "chown"
@@ -28,7 +28,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.6.0
+    image: grafana/promtail:2.6.1
     volumes:
       - /var/log:/var/log
       - ./config:/etc/promtail/
@@ -49,7 +49,7 @@ services:
       - loki
 
   loki-frontend:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     volumes:
         - ./config:/etc/loki/
     ports:
@@ -62,7 +62,7 @@ services:
       replicas: 2
 
   loki-1:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     volumes:
       - ./config:/etc/loki/
       - ./loki:/loki
@@ -75,7 +75,7 @@ services:
     restart: on-failure
 
   loki-2:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     volumes:
       - ./config:/etc/loki/
       - ./loki:/loki
@@ -89,7 +89,7 @@ services:
     restart: on-failure
 
   loki-3:
-    image: grafana/loki:2.6.0
+    image: grafana/loki:2.6.1
     volumes:
       - ./config:/etc/loki/
       - ./loki:/loki

--- a/production/ksonnet/loki-canary/config.libsonnet
+++ b/production/ksonnet/loki-canary/config.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    loki_canary: 'grafana/loki-canary:2.6.0',
+    loki_canary: 'grafana/loki-canary:2.6.1',
   },
 }

--- a/production/ksonnet/loki-simple-scalable/example/main.jsonnet
+++ b/production/ksonnet/loki-simple-scalable/example/main.jsonnet
@@ -8,7 +8,7 @@ local k = import 'ksonnet-util/kausal.libsonnet',
 
 loki {
   _images+:: {
-    loki: 'grafana/loki:2.6.0',
+    loki: 'grafana/loki:2.6.1',
   },
 
   _config+:: {

--- a/production/ksonnet/loki-simple-scalable/images.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/images.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    loki: 'grafana/loki:2.6.0',
+    loki: 'grafana/loki:2.6.1',
 
     read: self.loki,
     write: self.loki,

--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -4,7 +4,7 @@
     memcached: 'memcached:1.5.17-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
-    loki: 'grafana/loki:2.6.0',
+    loki: 'grafana/loki:2.6.1',
 
     distributor: self.loki,
     ingester: self.loki,

--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    promtail: 'grafana/promtail:2.6.0',
+    promtail: 'grafana/promtail:2.6.1',
   },
 
   _config+:: {

--- a/production/nomad/loki-distributed/README.md
+++ b/production/nomad/loki-distributed/README.md
@@ -21,7 +21,7 @@ To deploy a different version change `variable.version` default value or
 specify from command line:
 
 ```shell
-nomad job run -var="version=2.6.0" job.nomad.hcl
+nomad job run -var="version=2.6.1" job.nomad.hcl
 ```
 
 ### Scale Loki

--- a/production/nomad/loki-distributed/job.nomad.hcl
+++ b/production/nomad/loki-distributed/job.nomad.hcl
@@ -1,7 +1,7 @@
 variable "version" {
   type        = string
   description = "Loki version"
-  default     = "2.6.0"
+  default     = "2.6.1"
 }
 
 job "loki" {

--- a/production/nomad/loki-simple/README.md
+++ b/production/nomad/loki-simple/README.md
@@ -22,7 +22,7 @@ To deploy a different version change `variable.version` default value or specify
 from command line:
 
 ```shell
-nomad job run -var="version=2.6.0" job.nomad.hcl
+nomad job run -var="version=2.6.1" job.nomad.hcl
 ```
 
 ### Scale Loki

--- a/production/nomad/loki-simple/job.nomad.hcl
+++ b/production/nomad/loki-simple/job.nomad.hcl
@@ -1,7 +1,7 @@
 variable "version" {
   type        = string
   description = "Loki version"
-  default     = "2.6.0"
+  default     = "2.6.1"
 }
 
 job "loki" {

--- a/production/nomad/loki/README.md
+++ b/production/nomad/loki/README.md
@@ -22,7 +22,7 @@ To deploy a different version change `variable.version` default value or
 specify from command line:
 
 ```shell
-nomad job run -var="version=2.6.0" job.nomad.hcl
+nomad job run -var="version=2.6.1" job.nomad.hcl
 ```
 
 ### Scale Loki

--- a/production/nomad/loki/job.nomad.hcl
+++ b/production/nomad/loki/job.nomad.hcl
@@ -1,7 +1,7 @@
 variable "version" {
   type        = string
   description = "Loki version"
-  default     = "2.6.0"
+  default     = "2.6.1"
 }
 
 job "loki" {

--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -6,7 +6,7 @@ INSTANCEURL="${3:-}"
 NAMESPACE="${4:-default}"
 CONTAINERROOT="${5:-/var/lib/docker}"
 PARSER="${6:-- docker:}"
-VERSION="${PROMTAIL_VERSION:-2.6.0}"
+VERSION="${PROMTAIL_VERSION:-2.6.1}"
 
 if [ -z "${INSTANCEID}" ] || [ -z "${APIKEY}" ] || [ -z "${INSTANCEURL}" ] || [ -z "${NAMESPACE}" ] || [ -z "${CONTAINERROOT}" ] || [ -z "${PARSER}" ]; then
     echo "usage: $0 <instanceId> <apiKey> <url> [<namespace>[<container_root_path>[<parser>]]]"


### PR DESCRIPTION
manual backport of https://github.com/grafana/loki/pull/6703