### PR TITLE
keep the memberlist labels jsonnet config backwards compatible with 2.6.1

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -17,6 +17,14 @@
     // but "primary" KV depends on value of multikv_primary.
     memberlist_ring_enabled: false,
 
+    // Configures the memberlist cluster label. When verification is enabled, a memberlist member rejects any packet or stream
+    // with a mismatching cluster label.
+    // Cluster label and verification flag can be set here or directly to
+    // `_config.cluster_label` and `_config.cluster_label_verification_disabled` respectively.
+    // Retaining this config to keep it backwards compatible with 2.6.1 release.
+    memberlist_cluster_label: '',
+    memberlist_cluster_label_verification_disabled: false,
+
     // Migrating from consul to memberlist is a multi-step process:
     // 1) Enable multikv_migration_enabled, with primary=consul, secondary=memberlist, and multikv_mirror_enabled=false, restart components.
     // 2) Set multikv_mirror_enabled=true. This doesn't require restart.
@@ -86,10 +94,8 @@
         max_join_retries: 10,
         min_join_backoff: '1s',
 
-        // Configures the memberlist cluster label. When verification is enabled, a memberlist member rejects any packet or stream
-        // with a mismatching cluster label.
-        cluster_label: '',
-        cluster_label_verification_disabled: false,
+        cluster_label: $._config.memberlist_cluster_label,
+        cluster_label_verification_disabled: $._config.memberlist_cluster_label_verification_disabled,
       },
     } else {},
 

--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -20,7 +20,7 @@
     // Configures the memberlist cluster label. When verification is enabled, a memberlist member rejects any packet or stream
     // with a mismatching cluster label.
     // Cluster label and verification flag can be set here or directly to
-    // `_config.cluster_label` and `_config.cluster_label_verification_disabled` respectively.
+    // `_config.loki.memberlist.cluster_label` and `_config.loki.memberlist.cluster_label_verification_disabled` respectively.
     // Retaining this config to keep it backwards compatible with 2.6.1 release.
     memberlist_cluster_label: '',
     memberlist_cluster_label_verification_disabled: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
We have already released [2.6.1 ](https://github.com/grafana/loki/blob/v2.6.1/production/ksonnet/loki/memberlist.libsonnet#L34-L35)with memberlist labels config being set using an intermediate field instead of setting it directly under `_config`. In PR #6707, I removed the config but it would be a breaking change so this PR adds back those intermediate config options with a suggestion to set the config directly under `_config`.