### PR TITLE
Revert "Configure ingester PDB to have max_unavailable=0"

### DIFF
--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -88,5 +88,5 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     podDisruptionBudget.mixin.metadata.withName('loki-ingester-pdb') +
     podDisruptionBudget.mixin.metadata.withLabels({ name: 'loki-ingester-pdb' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: name }) +
-    podDisruptionBudget.mixin.spec.withMaxUnavailable(0),
+    podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
 }


### PR DESCRIPTION
Reverts grafana/loki#6589

As discussed internally, setting `max_unavailable` to `0` would block the nodes from draining. Investigating the root cause behind what caused us to change this value, it looks like the cause was not the rollout or pod disruption; it was a panic in ingester causing multiple ingesters to go down.