### PR TITLE
[Fix] Furthers gcs latency buckets

### DIFF
--- a/pkg/storage/chunk/client/gcp/instrumentation.go
+++ b/pkg/storage/chunk/client/gcp/instrumentation.go
@@ -30,9 +30,8 @@ var (
 		Name:      "gcs_request_duration_seconds",
 		Help:      "Time spent doing GCS requests.",
 
-		// GCS latency seems to range from a few ms to a few secs and is
-		// important.  So use 6 buckets from 5ms to 5s.
-		Buckets: prometheus.ExponentialBuckets(0.005, 4, 6),
+		// 6 buckets from 5ms to 80s.
+		Buckets: prometheus.ExponentialBuckets(0.005, 4, 8),
 	}, []string{"operation", "status_code"})
 )
 

--- a/pkg/storage/chunk/client/gcp/instrumentation.go
+++ b/pkg/storage/chunk/client/gcp/instrumentation.go
@@ -30,8 +30,8 @@ var (
 		Name:      "gcs_request_duration_seconds",
 		Help:      "Time spent doing GCS requests.",
 
-		// 6 buckets from 5ms to 80s.
-		Buckets: prometheus.ExponentialBuckets(0.005, 4, 8),
+		// 6 buckets from 5ms to 20s.
+		Buckets: prometheus.ExponentialBuckets(0.005, 4, 7),
 	}, []string{"operation", "status_code"})
 )
 


### PR DESCRIPTION
During TSDB testing, I noticed metrics maxxing out at the upper bucket. This adds one more, giving us a 20s measurement upper bound for GCS latencies.