### PR TITLE
[Memcache] use owen-d gomemcache fork for connection sharding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -310,7 +310,7 @@ replace github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915
 
 // Same as Cortex
 // Using a 3rd-party branch for custom dialer - see https://github.com/bradfitz/gomemcache/pull/86
-replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
+replace github.com/bradfitz/gomemcache => github.com/owen-d/gomemcache v0.0.0-20220719101501-ce4268ea75ae
 
 // We only pin this version to avoid problems with running go get: github.com/thanos-io/thanos@main. That
 // currently fails because Thanos isn't merging release branches to main branch, and Go modules system is then

--- a/go.sum
+++ b/go.sum
@@ -1324,6 +1324,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/openzipkin/zipkin-go-opentracing v0.3.4/go.mod h1:js2AbwmHW0YD9DwIw2JhQWmbfFi/UnWyYwdVhqbCDOE=
 github.com/ory/dockertest v3.3.4+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
+github.com/owen-d/gomemcache v0.0.0-20220719101501-ce4268ea75ae h1:NkG2GIrREfX6FfB8D1QCLcFqpE5xHL7rbUGwXB9pvwM=
+github.com/owen-d/gomemcache v0.0.0-20220719101501-ce4268ea75ae/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1542,8 +1544,6 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.31/go.mod h1:4E4+bQ2gBVJcgEC9Cufwylio4m
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
 github.com/thanos-io/thanos v0.19.1-0.20211126105533-c5505f5eaa7d h1:jkXuBsvBkxxDwATzwwho08Xvd/jCu7+E+maw8wrknWk=
 github.com/thanos-io/thanos v0.19.1-0.20211126105533-c5505f5eaa7d/go.mod h1:sfnKJG7cDA41ixNL4gsTJEa3w9Qt8lwAjw+dqRMSDG0=
-github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
-github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,8 +200,8 @@ github.com/beorn7/perks/quantile
 # github.com/bmatcuk/doublestar v1.2.2
 ## explicit; go 1.12
 github.com/bmatcuk/doublestar
-# github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
-## explicit
+# github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b => github.com/owen-d/gomemcache v0.0.0-20220719101501-ce4268ea75ae
+## explicit; go 1.12
 github.com/bradfitz/gomemcache/memcache
 # github.com/buger/jsonparser v1.1.1
 ## explicit; go 1.13
@@ -1729,7 +1729,7 @@ sigs.k8s.io/yaml
 # k8s.io/apimachinery => k8s.io/apimachinery v0.23.6
 # github.com/hashicorp/consul => github.com/hashicorp/consul v1.5.1
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
-# github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
+# github.com/bradfitz/gomemcache => github.com/owen-d/gomemcache v0.0.0-20220719101501-ce4268ea75ae
 # github.com/cloudflare/cloudflare-go => github.com/cyriltovena/cloudflare-go v0.27.1-0.20211118103540-ff77400bcb93
 # k8s.io/client-go => k8s.io/client-go v0.23.6
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65


### PR DESCRIPTION
While profiling TSDB which uses many smaller queries, I've noticed that as much as 45% of our mutex lock contention delay is caused by the memcached client, particularly as we push higher query throughputs (more accesses+cache nodes). As an experiment, I forked gomemcached and added a new commit(https://github.com/owen-d/gomemcache/commit/3b901ce25fe5001e8ebe08b519aee72df46d8176) and striped lock accesses, which improved the problem, reducing acquisition delay by ~90% if I recall correctly (I forgot to save the actual profiles to include in this PR).

This PR moves the gomemcached fork we use to my own.