### PR TITLE
chore(make): reinclude .git dir in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 production/docker/.data
 .cache
-.git


### PR DESCRIPTION
This was removed in #6691, but caused errors in docker builds

```bash
$ make loki-image
docker build -t grafana/loki:main-7f343d2 -f cmd/loki/Dockerfile .
Sending build context to Docker daemon  592.7MB
Step 1/15 : FROM golang:1.17.9 as build
 ---> b6bd03a3a78e
Step 2/15 : COPY . /src/loki
 ---> 0e56c7bfde79
Step 3/15 : WORKDIR /src/loki
 ---> Running in ab8ba59a2684
Removing intermediate container ab8ba59a2684
 ---> a0928aadd596
Step 4/15 : RUN make clean && make BUILD_IN_CONTAINER=false loki
 ---> Running in 0aa8fb6b893a
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
...
```

We use the `.git` dir in the `check-generated-files` Make step.