### PR TITLE
query-tee: support for multi backend response comparison and disabling query proxy for select backends

### DIFF
--- a/cmd/querytee/main.go
+++ b/cmd/querytee/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Run the proxy.
-	proxy, err := querytee.NewProxy(cfg.ProxyConfig, util_log.Logger, lokiReadRoutes(cfg), registry)
+	proxy, err := querytee.NewProxy(cfg.ProxyConfig, util_log.Logger, lokiReadRoutes(cfg), lokiWriteRoutes(), registry)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "Unable to initialize the proxy", "err", err.Error())
 		os.Exit(1)
@@ -77,6 +77,12 @@ func lokiReadRoutes(cfg Config) []querytee.Route {
 		{Path: "/api/prom/label", RouteName: "api_prom_label", Methods: []string{"GET"}, ResponseComparator: nil},
 		{Path: "/api/prom/label/{name}/values", RouteName: "api_prom_label_name_values", Methods: []string{"GET"}, ResponseComparator: nil},
 		{Path: "/api/prom/series", RouteName: "api_prom_series", Methods: []string{"GET"}, ResponseComparator: nil},
+	}
+}
+
+func lokiWriteRoutes() []querytee.Route {
+	return []querytee.Route{
 		{Path: "/loki/api/v1/push", RouteName: "api_v1_push", Methods: []string{"POST"}, ResponseComparator: nil},
+		{Path: "/api/prom/push", RouteName: "api_prom_push", Methods: []string{"POST"}, ResponseComparator: nil},
 	}
 }

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -28,6 +28,7 @@ type ProxyConfig struct {
 	PreferredBackend               string
 	BackendReadTimeout             time.Duration
 	CompareResponses               bool
+	DisableBackendReadProxy        string
 	ValueComparisonTolerance       float64
 	UseRelativeError               bool
 	PassThroughNonRegisteredRoutes bool
@@ -40,6 +41,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client. If no preferred backend is configured then the query-tee will send back to the client the first successful response received without waiting for other backends.")
 	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 90*time.Second, "The timeout when reading the response from a backend.")
 	f.BoolVar(&cfg.CompareResponses, "proxy.compare-responses", false, "Compare responses between preferred and secondary endpoints for supported routes.")
+	f.StringVar(&cfg.DisableBackendReadProxy, "proxy.disable-backend-read", "", "Comma separated list of non-primary backend hostnames to disable their read proxy. Typically used for temporarily not passing any read requests to specified backends.")
 	f.Float64Var(&cfg.ValueComparisonTolerance, "proxy.value-comparison-tolerance", 0.000001, "The tolerance to apply when comparing floating point values in the responses. 0 to disable tolerance and require exact match (not recommended).")
 	f.BoolVar(&cfg.UseRelativeError, "proxy.compare-use-relative-error", false, "Use relative error tolerance when comparing floating point values.")
 	f.DurationVar(&cfg.SkipRecentSamples, "proxy.compare-skip-recent-samples", 60*time.Second, "The window from now to skip comparing samples. 0 to disable.")
@@ -54,11 +56,12 @@ type Route struct {
 }
 
 type Proxy struct {
-	cfg      ProxyConfig
-	backends []*ProxyBackend
-	logger   log.Logger
-	metrics  *ProxyMetrics
-	routes   []Route
+	cfg         ProxyConfig
+	backends    []*ProxyBackend
+	logger      log.Logger
+	metrics     *ProxyMetrics
+	readRoutes  []Route
+	writeRoutes []Route
 
 	// The HTTP server used to run the proxy service.
 	srv         *http.Server
@@ -68,7 +71,7 @@ type Proxy struct {
 	done sync.WaitGroup
 }
 
-func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer prometheus.Registerer) (*Proxy, error) {
+func NewProxy(cfg ProxyConfig, logger log.Logger, readRoutes, writeRoutes []Route, registerer prometheus.Registerer) (*Proxy, error) {
 	if cfg.CompareResponses && cfg.PreferredBackend == "" {
 		return nil, fmt.Errorf("when enabling comparison of results -backend.preferred flag must be set to hostname of preferred backend")
 	}
@@ -78,10 +81,11 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	}
 
 	p := &Proxy{
-		cfg:     cfg,
-		logger:  logger,
-		metrics: NewProxyMetrics(registerer),
-		routes:  routes,
+		cfg:         cfg,
+		logger:      logger,
+		metrics:     NewProxyMetrics(registerer),
+		readRoutes:  readRoutes,
+		writeRoutes: writeRoutes,
 	}
 
 	// Parse the backend endpoints (comma separated).
@@ -142,6 +146,15 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 		level.Warn(p.logger).Log("msg", "The proxy is running with only 1 backend. At least 2 backends are required to fulfil the purpose of the proxy and compare results.")
 	}
 
+	if cfg.DisableBackendReadProxy != "" {
+		readDisabledBackendHosts := strings.Split(p.cfg.DisableBackendReadProxy, ",")
+		for _, host := range readDisabledBackendHosts {
+			if host == cfg.PreferredBackend {
+				return nil, fmt.Errorf("the preferred backend cannot be disabled for reading")
+			}
+		}
+	}
+
 	return p, nil
 }
 
@@ -159,13 +172,17 @@ func (p *Proxy) Start() error {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// register routes
-	for _, route := range p.routes {
+	// register read routes
+	for _, route := range p.readRoutes {
 		var comparator ResponsesComparator
 		if p.cfg.CompareResponses {
 			comparator = route.ResponseComparator
 		}
-		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, comparator))
+		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(filterReadDisabledBackends(p.backends, p.cfg.DisableBackendReadProxy), route.RouteName, p.metrics, p.logger, comparator))
+	}
+
+	for _, route := range p.writeRoutes {
+		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, nil))
 	}
 
 	if p.cfg.PassThroughNonRegisteredRoutes {
@@ -217,4 +234,26 @@ func (p *Proxy) Endpoint() string {
 	}
 
 	return p.srvListener.Addr().String()
+}
+
+func filterReadDisabledBackends(backends []*ProxyBackend, disableReadProxyCfg string) []*ProxyBackend {
+	readEnabledBackends := make([]*ProxyBackend, 0, len(backends))
+	readDisabledBackendNames := strings.Split(disableReadProxyCfg, ",")
+	for _, b := range backends {
+		if !b.preferred {
+			readDisabled := false
+			for _, h := range readDisabledBackendNames {
+				if strings.TrimSpace(h) == b.name {
+					readDisabled = true
+					break
+				}
+			}
+			if readDisabled {
+				continue
+			}
+		}
+		readEnabledBackends = append(readEnabledBackends, b)
+	}
+
+	return readEnabledBackends
 }

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -138,7 +138,7 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, readRoutes, writeRoutes []Rout
 	}
 
 	if cfg.CompareResponses && len(p.backends) < 2 {
-		return nil, fmt.Errorf("when enabling comparison of results number of backends should be 2 exactly")
+		return nil, fmt.Errorf("when enabling comparison of results number of backends should be at least 2")
 	}
 
 	// At least 2 backends are suggested

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -133,7 +133,7 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 		}
 	}
 
-	if cfg.CompareResponses && len(p.backends) != 2 {
+	if cfg.CompareResponses && len(p.backends) < 2 {
 		return nil, fmt.Errorf("when enabling comparison of results number of backends should be 2 exactly")
 	}
 

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -32,8 +32,8 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 		responsesComparedTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_compared_total",
-			Help:      "Total number of responses compared per route name by result.",
-		}, []string{"route", "result"}),
+			Help:      "Total number of responses compared per route and backend name by result.",
+		}, []string{"backend", "route", "result"}),
 	}
 
 	return m

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,9 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testRoutes = []Route{
+var testReadRoutes = []Route{
 	{Path: "/api/v1/query", RouteName: "api_v1_query", Methods: []string{"GET"}, ResponseComparator: &testComparator{}},
 }
+
+var testWriteRoutes = []Route{}
 
 type testComparator struct{}
 
@@ -27,7 +30,7 @@ func (testComparator) Compare(expected, actual []byte) error { return nil }
 func Test_NewProxy(t *testing.T) {
 	cfg := ProxyConfig{}
 
-	p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, nil)
+	p, err := NewProxy(cfg, log.NewNopLogger(), testReadRoutes, testWriteRoutes, nil)
 	assert.Equal(t, errMinBackends, err)
 	assert.Nil(t, p)
 }
@@ -164,7 +167,7 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 				cfg.CompareResponses = true
 			}
 
-			p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, nil)
+			p, err := NewProxy(cfg, log.NewNopLogger(), testReadRoutes, testWriteRoutes, nil)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 			defer p.Stop() //nolint:errcheck
@@ -313,7 +316,7 @@ func TestProxy_Passthrough(t *testing.T) {
 				PassThroughNonRegisteredRoutes: true,
 			}
 
-			p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, nil)
+			p, err := NewProxy(cfg, log.NewNopLogger(), testReadRoutes, testWriteRoutes, nil)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 			defer p.Stop() //nolint:errcheck
@@ -350,5 +353,49 @@ func mockQueryResponse(path string, status int, res string) http.HandlerFunc {
 		if status == http.StatusOK {
 			_, _ = w.Write([]byte(res))
 		}
+	}
+}
+
+func TestFilterReadDisabledBackend(t *testing.T) {
+	urlMustParse := func(urlStr string) *url.URL {
+		u, err := url.Parse(urlStr)
+		require.NoError(t, err)
+		return u
+	}
+
+	backends := []*ProxyBackend{
+		NewProxyBackend("test1", urlMustParse("http:/test1"), time.Second, true),
+		NewProxyBackend("test2", urlMustParse("http:/test2"), time.Second, false),
+		NewProxyBackend("test3", urlMustParse("http:/test3"), time.Second, false),
+		NewProxyBackend("test4", urlMustParse("http:/test4"), time.Second, false),
+	}
+	for name, tc := range map[string]struct {
+		disableReadProxyCfg string
+		expectedBackends    []*ProxyBackend
+	}{
+		"nothing disabled": {
+			expectedBackends: backends,
+		},
+		"test2 disabled": {
+			disableReadProxyCfg: "test2",
+			expectedBackends:    []*ProxyBackend{backends[0], backends[2], backends[3]},
+		},
+		"test2 and test4 disabled": {
+			disableReadProxyCfg: "test2, test4",
+			expectedBackends:    []*ProxyBackend{backends[0], backends[2]},
+		},
+		"all secondary disabled": {
+			disableReadProxyCfg: "test2, test4,test3",
+			expectedBackends:    []*ProxyBackend{backends[0]},
+		},
+		"disabling primary should not be filtered out": {
+			disableReadProxyCfg: "test1",
+			expectedBackends:    backends,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filteredBackends := filterReadDisabledBackends(backends, tc.disableReadProxyCfg)
+			require.Equal(t, tc.expectedBackends, filteredBackends)
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
It contains the following 2 changes for query-tee:
1. query-tee enables query response comparison between a preferred backend and a secondary backend. However, it did not allow multiple secondary backends to query and compare their responses. This PR updates the code where it would compare responses from all the secondary backends with the primary backend. I have also added a `name` label to the metric, which records the result of query response comparison.
2. Add a flag to disable just the query proxy for select secondary backends. This would allow us to temporarily disable read queries for one of the secondary backends while continuing to keep writing logs to it.

I think we should rename it to `tee` instead of `query-tee` :D

**Checklist**
- [x] Tests updated
