### PR TITLE
Docs: Revise location of some LogQL examples; improve prose

### DIFF
--- a/docs/sources/logql/log_queries.md
+++ b/docs/sources/logql/log_queries.md
@@ -225,16 +225,16 @@ This means that all the following expressions are equivalent:
 
 ```
 
-By default the precedence of multiple predicates is right to left. You can wrap predicates with parenthesis to force a different precedence left to right.
+The precedence for evaluation of multiple predicates is left to right. You can wrap predicates with parenthesis to force a different precedence.
 
-For example the following are equivalent.
+These examples are equivalent:
 
 ```logql
 | duration >= 20ms or method="GET" and size <= 20KB
 | ((duration >= 20ms or method="GET") and size <= 20KB)
 ```
 
-It will evaluate first `duration >= 20ms or method="GET"`. To evaluate first `method="GET" and size <= 20KB`, make sure to use proper parenthesis as shown below.
+To evaluate the logical `and` first, use parenthesis, as in this example:
 
 ```logql
 | duration >= 20ms or (method="GET" and size <= 20KB)
@@ -533,58 +533,3 @@ In both cases, if the destination label doesn't exist, then a new one is created
 The renaming form `dst=src` will _drop_ the `src` label after remapping it to the `dst` label. However, the _template_ form will preserve the referenced labels, such that  `dst="{{.src}}"` results in both `dst` and `src` having the same value.
 
 > A single label name can only appear once per expression. This means `| label_format foo=bar,foo="new"` is not allowed but you can use two expressions for the desired effect: `| label_format foo=bar | label_format foo="new"`
-
-## Log queries examples
-
-### Multiple filtering
-
-Filtering should be done first using label matchers, then line filters (when possible) and finally using label filters. The following query demonstrate this.
-
-```logql
-{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"} |= "metrics.go" !="out of order" | logfmt | duration > 30s or status_code!="200"
-```
-
-### Multiple parsers
-
-To extract the method and the path of the following logfmt log line:
-
-```log
-level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"
-```
-
-You can use multiple parsers (logfmt and regexp) like this.
-
-```logql
-{job="loki-ops/query-frontend"} | logfmt | line_format "{{.msg}}" | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)"
-```
-
-This is possible because the `| line_format` reformats the log line to become `POST /api/prom/api/v1/query_range (200) 1.5s` which can then be parsed with the `| regexp ...` parser.
-
-### Formatting
-
-The following query shows how you can reformat a log line to make it easier to read on screen.
-
-```logql
-{cluster="ops-tools1", name="querier", namespace="loki-dev"}
-  |= "metrics.go" != "loki-canary"
-  | logfmt
-  | query != ""
-  | label_format query="{{ Replace .query \"\\n\" \"\" -1 }}"
-  | line_format "{{ .ts}}\t{{.duration}}\ttraceID = {{.traceID}}\t{{ printf \"%-100.100s\" .query }} "
-```
-
-Label formatting is used to sanitize the query while the line format reduce the amount of information and creates a tabular output.
-
-For these given log lines:
-
-```log
-level=info ts=2020-10-23T20:32:18.094668233Z caller=metrics.go:81 org_id=29 traceID=1980d41501b57b68 latency=fast query="{cluster=\"ops-tools1\", job=\"loki-ops/query-frontend\"} |= \"query_range\"" query_type=filter range_type=range length=15m0s step=7s duration=650.22401ms status=200 throughput_mb=1.529717 total_bytes_mb=0.994659
-level=info ts=2020-10-23T20:32:18.068866235Z caller=metrics.go:81 org_id=29 traceID=1980d41501b57b68 latency=fast query="{cluster=\"ops-tools1\", job=\"loki-ops/query-frontend\"} |= \"query_range\"" query_type=filter range_type=range length=15m0s step=7s duration=624.008132ms status=200 throughput_mb=0.693449 total_bytes_mb=0.432718
-```
-
-The result would be:
-
-```log
-2020-10-23T20:32:18.094668233Z	650.22401ms	    traceID = 1980d41501b57b68	{cluster="ops-tools1", job="loki-ops/query-frontend"} |= "query_range"
-2020-10-23T20:32:18.068866235Z	624.008132ms	traceID = 1980d41501b57b68	{cluster="ops-tools1", job="loki-ops/query-frontend"} |= "query_range"
-```

--- a/docs/sources/logql/metric_queries.md
+++ b/docs/sources/logql/metric_queries.md
@@ -91,29 +91,7 @@ Which can be used to aggregate over distinct labels dimensions by including a `w
 
 `without` removes the listed labels from the result vector, while all other labels are preserved the output. `by` does the opposite and drops labels that are not listed in the `by` clause, even if their label values are identical between all elements of the vector.
 
-### Unwrapped examples
-
-```logql
-quantile_over_time(0.99,
-  {cluster="ops-tools1",container="ingress-nginx"}
-    | json
-    | __error__ = ""
-    | unwrap request_time [1m]) by (path)
-```
-
-This example calculates the p99 of the nginx-ingress latency by path.
-
-```logql
-sum by (org_id) (
-  sum_over_time(
-  {cluster="ops-tools1",container="loki-dev"}
-      |= "metrics.go"
-      | logfmt
-      | unwrap bytes_processed [1m])
-  )
-```
-
-This calculates the amount of bytes processed per organization ID.
+See [Unwrap examples](../query_examples/#unwrap-examples) for query examples that use the unwrap expression.
 
 ## Built-in aggregation operators
 
@@ -142,24 +120,4 @@ The aggregation operators can either be used to aggregate over all label values 
 The `without` clause removes the listed labels from the resulting vector, keeping all others.
 The `by` clause does the opposite, dropping labels that are not listed in the clause, even if their label values are identical between all elements of the vector.
 
-### Vector aggregation examples
-
-Get the top 10 applications by the highest log throughput:
-
-```logql
-topk(10,sum(rate({region="us-east1"}[5m])) by (name))
-```
-
-Get the count of log lines for the last five minutes for a specified job, grouping
-by level:
-
-```logql
-sum(count_over_time({job="mysql"}[5m])) by (level)
-```
-
-Get the rate of HTTP GET requests to the `/home` endpoint for NGINX logs by region:
-
-```logql
-avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)
-```
-
+See [vector aggregation examples](../query_examples/#vector-aggregation-examples) for query examples that use the vector aggregation.

--- a/docs/sources/logql/metric_queries.md
+++ b/docs/sources/logql/metric_queries.md
@@ -120,4 +120,4 @@ The aggregation operators can either be used to aggregate over all label values 
 The `without` clause removes the listed labels from the resulting vector, keeping all others.
 The `by` clause does the opposite, dropping labels that are not listed in the clause, even if their label values are identical between all elements of the vector.
 
-See [vector aggregation examples](../query_examples/#vector-aggregation-examples) for query examples that use the vector aggregation.
+See [vector aggregation examples](../query_examples/#vector-aggregation-examples) for query examples that use vector aggregation expressions.

--- a/docs/sources/logql/query_examples.md
+++ b/docs/sources/logql/query_examples.md
@@ -94,6 +94,9 @@ the query results
 include only those log lines that contain the string "metrics.go"
 and do not contain the string "out of order".
 
+The `logfmt` parser produces the `duration` and `status_code` labels,
+such that they can be used by a label filter.
+
 The label filter 
 `| duration > 30s or status_code!="200"`
 further filters out log lines.

--- a/docs/sources/logql/query_examples.md
+++ b/docs/sources/logql/query_examples.md
@@ -78,7 +78,7 @@ order the filtering stages left to right:
 Consider the query:
 
 ```logql
-{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"} |= "metrics.go" !="out of order" | logfmt | duration > 30s or status_code!="200"
+{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"} |= "metrics.go" != "out of order" | logfmt | duration > 30s or status_code != "200"
 ```
 Within this query, the stream selector is
 

--- a/docs/sources/logql/query_examples.md
+++ b/docs/sources/logql/query_examples.md
@@ -1,13 +1,15 @@
 ---
 title: Query examples
+menuTitle: Query examples
+description: LogQL query examples with explanations on what those queries accomplish.
 weight: 50
 ---
 
 # Query examples
 
-Some useful query examples here.
+These LogQL query examples have explanations of what the queries accomplish.
 
-## Log Query examples
+## Log query examples
 
 ### Examples that filter on IP address 
 
@@ -50,7 +52,7 @@ Some useful query examples here.
         | line_format "USER = {{.user}}"
     ```
 
-## Metrics Query examples
+## Metrics query examples
 
 - Return the per-second rate of all non-timeout errors
 within the last minutes per host for the MySQL job,
@@ -62,3 +64,136 @@ and only include errors whose duration is above ten seconds.
         | json
         | duration > 10s [1m]))
     ```
+
+## Multiple filtering stages examples
+
+Query results are gathered by successive evaluation of parts of the query from left to right.
+To make querying efficient,
+order the filtering stages left to right:
+
+1. stream selector
+2. line filters
+3. label filters
+
+Consider the query:
+
+```logql
+{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"} |= "metrics.go" !="out of order" | logfmt | duration > 30s or status_code!="200"
+```
+Within this query, the stream selector is
+
+```
+{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"}
+```
+
+There are two line filters: 
+`|= "metrics.go"`
+and `!="out of order"`.
+Of the log lines identified with the stream selector,
+the query results
+include only those log lines that contain the string "metrics.go"
+and do not contain the string "out of order".
+
+The label filter 
+`| duration > 30s or status_code!="200"`
+further filters out log lines.
+It includes those log lines that contain a `status_code` label
+with any value other than the value 200,
+as well as log lines that contain a `duration` label
+with a value greater than 30 sections,
+
+While every query will have a stream selector,
+not all queries will have line and label filters.
+
+## Examples that use multiple parsers
+
+Consider this logfmt log line.
+To extract the method and the path of this logfmt log line,
+
+```log
+level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"
+```
+
+To extract the method and the path,
+use multiple parsers (logfmt and regexp):
+
+```logql
+{job="loki-ops/query-frontend"} | logfmt | line_format "{{.msg}}" | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)"
+```
+
+This is possible because the `| line_format` reformats the log line to become `POST /api/prom/api/v1/query_range (200) 1.5s` which can then be parsed with the `| regexp ...` parser.
+
+## Log line formatting examples
+
+The following query shows how you can reformat a log line to make it easier to read on screen.
+
+```logql
+{cluster="ops-tools1", name="querier", namespace="loki-dev"}
+  |= "metrics.go" != "loki-canary"
+  | logfmt
+  | query != ""
+  | label_format query="{{ Replace .query \"\\n\" \"\" -1 }}"
+  | line_format "{{ .ts}}\t{{.duration}}\ttraceID = {{.traceID}}\t{{ printf \"%-100.100s\" .query }} "
+```
+
+Label formatting is used to sanitize the query while the line format reduce the amount of information and creates a tabular output.
+
+For these given log lines:
+
+```log
+level=info ts=2020-10-23T20:32:18.094668233Z caller=metrics.go:81 org_id=29 traceID=1980d41501b57b68 latency=fast query="{cluster=\"ops-tools1\", job=\"loki-ops/query-frontend\"} |= \"query_range\"" query_type=filter range_type=range length=15m0s step=7s duration=650.22401ms status=200 throughput_mb=1.529717 total_bytes_mb=0.994659
+level=info ts=2020-10-23T20:32:18.068866235Z caller=metrics.go:81 org_id=29 traceID=1980d41501b57b68 latency=fast query="{cluster=\"ops-tools1\", job=\"loki-ops/query-frontend\"} |= \"query_range\"" query_type=filter range_type=range length=15m0s step=7s duration=624.008132ms status=200 throughput_mb=0.693449 total_bytes_mb=0.432718
+```
+
+The result would be:
+
+```log
+2020-10-23T20:32:18.094668233Z	650.22401ms	    traceID = 1980d41501b57b68	{cluster="ops-tools1", job="loki-ops/query-frontend"} |= "query_range"
+2020-10-23T20:32:18.068866235Z	624.008132ms	traceID = 1980d41501b57b68	{cluster="ops-tools1", job="loki-ops/query-frontend"} |= "query_range"
+```
+
+## Unwrap examples
+
+- Calculate the p99 of the nginx-ingress latency by path:
+
+    ```logql
+    quantile_over_time(0.99,
+      {cluster="ops-tools1",container="ingress-nginx"}
+        | json
+        | __error__ = ""
+        | unwrap request_time [1m]) by (path)
+    ```
+
+- Calculate the quantity of bytes processed per organization ID:
+
+    ```logql
+    sum by (org_id) (
+      sum_over_time(
+      {cluster="ops-tools1",container="loki-dev"}
+          |= "metrics.go"
+          | logfmt
+          | unwrap bytes_processed [1m])
+      )
+    ```
+
+## Vector aggregation examples
+
+Get the top 10 applications by the highest log throughput:
+
+```logql
+topk(10,sum(rate({region="us-east1"}[5m])) by (name))
+```
+
+Get the count of log lines for the last five minutes for a specified job, grouping
+by level:
+
+```logql
+sum(count_over_time({job="mysql"}[5m])) by (level)
+```
+
+Get the rate of HTTP GET requests to the `/home` endpoint for NGINX logs by region:
+
+```logql
+avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)
+```
+


### PR DESCRIPTION
This docs-only revision relocates some existing examples.  It also updates prose about the examples and about evaluation precedence for logical operators in the label filtering explanation.

Future PRs will better address the organization of the examples. This PR aims only to gather examples in a single location.