### PR TITLE
Fix cache instrumentation

### DIFF
--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -142,7 +142,8 @@ func New(cfg Config, reg prometheus.Registerer, logger log.Logger, cacheType sta
 	}
 
 	if IsGroupCacheSet(cfg) {
-		caches = append(caches, CollectStats(cfg.GroupCache))
+		cacheName := cfg.Prefix + "groupcache"
+		caches = append(caches, CollectStats(Instrument(cacheName, cfg.GroupCache, reg)))
 	}
 
 	cache := NewTiered(caches)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -154,7 +154,7 @@ func (s *store) init() error {
 		if err != nil {
 			return err
 		}
-		f, err := fetcher.New(cache.CollectStats(s.chunksCache), s.storeCfg.ChunkCacheStubs(), s.schemaCfg, chunkClient, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackConcurrency, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackBufferSize)
+		f, err := fetcher.New(s.chunksCache, s.storeCfg.ChunkCacheStubs(), s.schemaCfg, chunkClient, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackConcurrency, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackBufferSize)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Groupcache wasn't instrumented with prometheus metrics and one of the cache was double instrumented with stats collection.
