### PR TITLE
operator: Add network tenant for netobserv

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -25,7 +25,7 @@ Do not use this in any production environment.**
 
 #### Sending Logs Directly to the Distributor Component
 
-* The [forwarding logs to LokiStack without LokiStack Gateway](https://github.com/grafana/loki/tree/master/operator/docs/forwarding_logs_without_gateway.md) is used to send application, infrastructure, and audit logs to the Loki Distributor as different tenants using Fluentd or Vector.
+* The [forwarding logs to LokiStack without LokiStack Gateway](https://github.com/grafana/loki/tree/master/operator/docs/forwarding_logs_without_gateway.md) is used to send application, infrastructure, audit and network logs to the Loki Distributor as different tenants using Fluentd or Vector.
 * The guide has a step-by-step guide to connect with OpenShift Logging for forwarding logs to LokiStack.
 
 ### Installation of Storage Size Calculator on OpenShift

--- a/operator/README.md
+++ b/operator/README.md
@@ -26,7 +26,7 @@ Do not use this in any production environment.**
 #### Sending Logs Directly to the Distributor Component
 
 * The [forwarding logs to LokiStack without LokiStack Gateway](https://github.com/grafana/loki/tree/master/operator/docs/forwarding_logs_without_gateway.md) is used to send application, infrastructure, audit and network logs to the Loki Distributor as different tenants using Fluentd or Vector.
-* The guide has a step-by-step guide to connect with OpenShift Logging for forwarding logs to LokiStack.
+* The guide has a step-by-step guide to connect with OpenShift Logging or OpenShift Network for forwarding logs to LokiStack.
 
 ### Installation of Storage Size Calculator on OpenShift
 

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -199,7 +199,7 @@ type AuthenticationSpec struct {
 
 // ModeType is the authentication/authorization mode in which LokiStack Gateway will be configured.
 //
-// +kubebuilder:validation:Enum=static;dynamic;openshift-logging
+// +kubebuilder:validation:Enum=static;dynamic;openshift-logging;openshift-network
 type ModeType string
 
 const (
@@ -208,8 +208,10 @@ const (
 	Static ModeType = "static"
 	// Dynamic mode delegates the authorization to a third-party OPA-compatible endpoint.
 	Dynamic ModeType = "dynamic"
-	// OpenshiftLogging mode provides fully automatic OpenShift in-cluster authentication and authorization support.
+	// OpenshiftLogging mode provides fully automatic OpenShift in-cluster authentication and authorization support for application, infrastructure and audit logs.
 	OpenshiftLogging ModeType = "openshift-logging"
+	// OpenshiftNetwork mode provides fully automatic OpenShift in-cluster authentication and authorization support for network logs only.
+	OpenshiftNetwork ModeType = "openshift-network"
 )
 
 // TenantsSpec defines the mode, authentication and authorization
@@ -220,7 +222,7 @@ type TenantsSpec struct {
 	// +required
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=openshift-logging
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:static","urn:alm:descriptor:com.tectonic.ui:select:dynamic","urn:alm:descriptor:com.tectonic.ui:select:openshift-logging"},displayName="Mode"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:static","urn:alm:descriptor:com.tectonic.ui:select:dynamic","urn:alm:descriptor:com.tectonic.ui:select:openshift-logging","urn:alm:descriptor:com.tectonic.ui:select:openshift-network"},displayName="Mode"
 	Mode ModeType `json:"mode"`
 	// Authentication defines the lokistack-gateway component authentication configuration spec per tenant.
 	//

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -604,6 +604,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:static
         - urn:alm:descriptor:com.tectonic.ui:select:dynamic
         - urn:alm:descriptor:com.tectonic.ui:select:openshift-logging
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift-network
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -1010,6 +1010,7 @@ spec:
                     - static
                     - dynamic
                     - openshift-logging
+                    - openshift-network
                     type: string
                 required:
                 - mode

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -993,6 +993,7 @@ spec:
                     - static
                     - dynamic
                     - openshift-logging
+                    - openshift-network
                     type: string
                 required:
                 - mode

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -459,6 +459,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:static
         - urn:alm:descriptor:com.tectonic.ui:select:dynamic
         - urn:alm:descriptor:com.tectonic.ui:select:openshift-logging
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift-network
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/docs/user-guides/howto_connect_grafana.md
+++ b/operator/docs/user-guides/howto_connect_grafana.md
@@ -46,7 +46,7 @@ An example configuration authenticating to the gateway in this manner is availab
 
 The configuration uses `oauth-proxy` to authenticate the user to the Grafana instance and forwards the token through Grafana to LokiStack's gateway service. This enables the configuration to fully take advantage of the tenancy model, so that users can only see the logs of their applications and only admins can view infrastructure and audit logs.
 
-As the open-source version of Grafana does not support to limit datasources to certain groups of users, all three datasources ("application", "infrastructure" and "audit") will be visible to all users. The infrastructure and audit datasources will not yield any data for non-admin users.
+As the open-source version of Grafana does not support to limit datasources to certain groups of users, all datasources ("application", "infrastructure", "audit" and "network") will be visible to all users. The infrastructure and audit datasources will not yield any data for non-admin users.
 
 ### Using the Gateway With a Static Token
 

--- a/operator/internal/handlers/internal/gateway/modes.go
+++ b/operator/internal/handlers/internal/gateway/modes.go
@@ -43,7 +43,7 @@ func ValidateModes(stack lokiv1.LokiStack) error {
 		}
 	}
 
-	if stack.Spec.Tenants.Mode == lokiv1.OpenshiftLogging {
+	if stack.Spec.Tenants.Mode == lokiv1.OpenshiftLogging || stack.Spec.Tenants.Mode == lokiv1.OpenshiftNetwork {
 		if stack.Spec.Tenants.Authentication != nil {
 			return kverrors.New("incompatible configuration - custom tenants configuration not required")
 		}

--- a/operator/internal/handlers/internal/gateway/tenant_secrets.go
+++ b/operator/internal/handlers/internal/gateway/tenant_secrets.go
@@ -19,7 +19,7 @@ import (
 
 // GetTenantSecrets returns the list to gateway tenant secrets for a tenant mode.
 // For modes static and dynamic the secrets are fetched from external provided
-// secrets. For mode openshift-logging a secret per default tenants are created.
+// secrets. For modes openshift-logging and openshift-network a secret per default tenants are created.
 // All secrets live in the same namespace as the lokistack request.
 func GetTenantSecrets(
 	ctx context.Context,

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -143,15 +143,14 @@ func CreateOrUpdateLokiStack(
 			}
 		}
 
-		if stack.Spec.Tenants.Mode != lokiv1.OpenshiftLogging {
-			tenantSecrets, err = gateway.GetTenantSecrets(ctx, k, req, &stack)
+		switch stack.Spec.Tenants.Mode {
+		case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
+			baseDomain, err = gateway.GetOpenShiftBaseDomain(ctx, k, req)
 			if err != nil {
 				return err
 			}
-		}
-
-		if stack.Spec.Tenants.Mode == lokiv1.OpenshiftLogging {
-			baseDomain, err = gateway.GetOpenShiftBaseDomain(ctx, k, req)
+		default:
+			tenantSecrets, err = gateway.GetTenantSecrets(ctx, k, req, &stack)
 			if err != nil {
 				return err
 			}

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -16,7 +16,8 @@ import (
 )
 
 // ApplyGatewayDefaultOptions applies defaults on the LokiStackSpec depending on selected
-// tenant mode. Currently nothing is applied for modes static and dynamic. For mode openshift-logging
+// tenant mode. Currently nothing is applied for modes static and dynamic.
+// For modes openshift-logging and openshift-network
 // the tenant spec is filled with defaults for authentication and authorization.
 func ApplyGatewayDefaultOptions(opts *Options) error {
 	if opts.Stack.Tenants == nil {
@@ -27,7 +28,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	case lokiv1.Static, lokiv1.Dynamic:
 		return nil // continue using user input
 
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		tenantData := make(map[string]openshift.TenantData)
 		for name, tenant := range opts.Tenants.Configs {
 			tenantData[name] = openshift.TenantData{
@@ -36,6 +37,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 		}
 
 		defaults := openshift.NewOptions(
+			opts.Stack.Tenants.Mode,
 			opts.Name,
 			opts.Namespace,
 			GatewayName(opts.Name),
@@ -47,7 +49,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 		)
 
 		if err := mergo.Merge(&opts.OpenShiftOptions, &defaults, mergo.WithOverride); err != nil {
-			return kverrors.Wrap(err, "failed to merge defaults for mode openshift logging")
+			return kverrors.Wrap(err, "failed to merge defaults for mode openshift")
 		}
 
 	}
@@ -63,13 +65,14 @@ func configureGatewayDeploymentForMode(
 	switch mode {
 	case lokiv1.Static, lokiv1.Dynamic:
 		return nil // nothing to configure
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		caBundleName := signingCABundleName(stackName)
 		serviceName := serviceNameGatewayHTTP(stackName)
 		secretName := signingServiceSecretName(serviceName)
 		serverName := fqdn(serviceName, stackNs)
 		return openshift.ConfigureGatewayDeployment(
 			d,
+			mode,
 			gatewayContainerName,
 			tlsSecretVolume,
 			httpTLSDir,
@@ -95,7 +98,7 @@ func configureGatewayServiceForMode(s *corev1.ServiceSpec, mode lokiv1.ModeType)
 	switch mode {
 	case lokiv1.Static, lokiv1.Dynamic:
 		return nil // nothing to configure
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		return openshift.ConfigureGatewayService(s)
 	}
 
@@ -106,7 +109,7 @@ func configureLokiStackObjsForMode(objs []client.Object, opts Options) []client.
 	switch opts.Stack.Tenants.Mode {
 	case lokiv1.Static, lokiv1.Dynamic:
 		// nothing to configure
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		openShiftObjs := openshift.BuildLokiStackObjects(opts.OpenShiftOptions)
 		objs = append(objs, openShiftObjs...)
 	}
@@ -118,7 +121,7 @@ func configureGatewayObjsForMode(objs []client.Object, opts Options) []client.Ob
 	switch opts.Stack.Tenants.Mode {
 	case lokiv1.Static, lokiv1.Dynamic:
 		// nothing to configure
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		openShiftObjs := openshift.BuildGatewayObjects(opts.OpenShiftOptions)
 
 		var cObjs []client.Object
@@ -144,7 +147,7 @@ func configureGatewayServiceMonitorForMode(sm *monitoringv1.ServiceMonitor, mode
 	switch mode {
 	case lokiv1.Static, lokiv1.Dynamic:
 		return nil // nothing to configure
-	case lokiv1.OpenshiftLogging:
+	case lokiv1.OpenshiftLogging, lokiv1.OpenshiftNetwork:
 		return openshift.ConfigureGatewayServiceMonitor(sm, fg.ServiceMonitorTLSEndpoints)
 	}
 

--- a/operator/internal/manifests/internal/gateway/gateway-tenants.yaml
+++ b/operator/internal/manifests/internal/gateway/gateway-tenants.yaml
@@ -65,7 +65,7 @@ tenants:
     url: {{ $tenant.Authorization.OPA.URL }}
 {{- end -}}
 {{- end -}}
-{{- else if eq $l.Stack.Tenants.Mode "openshift-logging" -}}
+{{- else if (or (eq $l.Stack.Tenants.Mode "openshift-logging") (eq $l.Stack.Tenants.Mode "openshift-network")) -}}
 {{- if $tenant := $l.OpenShiftOptions.Authentication -}}
 {{- range $spec := $l.OpenShiftOptions.Authentication }}
 - name: {{ $spec.TenantName }}

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 func TestBuild_ServiceAccountRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
+	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
 
 	objs := BuildGatewayObjects(opts)
 	sa := objs[1].(*corev1.ServiceAccount)
@@ -24,7 +25,7 @@ func TestBuild_ServiceAccountRefMatches(t *testing.T) {
 }
 
 func TestBuild_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
+	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
 
 	objs := BuildGatewayObjects(opts)
 	cr := objs[2].(*rbacv1.ClusterRole)
@@ -35,7 +36,7 @@ func TestBuild_ClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuild_MonitoringClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
+	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
 
 	objs := BuildGatewayObjects(opts)
 	cr := objs[4].(*rbacv1.Role)
@@ -46,7 +47,7 @@ func TestBuild_MonitoringClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuild_ServiceAccountAnnotationsRouteRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
+	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{})
 
 	objs := BuildGatewayObjects(opts)
 	rt := objs[0].(*routev1.Route)

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -3,10 +3,12 @@ package openshift
 import (
 	"fmt"
 	"math/rand"
+
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 )
 
 // Options is the set of internal template options for rendering
-// the lokistack-gateway tenants configuration file when mode openshift-logging.
+// the lokistack-gateway tenants configuration file when mode openshift-logging or openshift-network.
 type Options struct {
 	BuildOpts      BuildOptions
 	Authentication []AuthenticationSpec
@@ -49,6 +51,7 @@ type TenantData struct {
 
 // NewOptions returns an openshift options struct.
 func NewOptions(
+	mode lokiv1.ModeType,
 	stackName, stackNamespace string,
 	gwName, gwBaseDomain, gwSvcName, gwPortName string,
 	gwLabels map[string]string,
@@ -57,7 +60,9 @@ func NewOptions(
 	host := ingressHost(stackName, stackNamespace, gwBaseDomain)
 
 	var authn []AuthenticationSpec
-	for _, name := range defaultTenants {
+
+	tenants := GetTenants(mode)
+	for _, name := range tenants {
 		cookieSecret := tenantConfigMap[name].CookieSecret
 		if cookieSecret == "" {
 			cookieSecret = newCookieSecret()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `network` tenant in Openshift Gateway component for [netobserv](https://github.com/netobserv) project. This will allow [network-observability-operator](https://github.com/netobserv/network-observability-operator) to configure its components to read and write `loki-operator` logs.

**Which issue(s) this PR fixes**:
/

**Special notes for your reviewer**:
@periklis I feel recommending users to use another lokistack instance is good enough for now but feel free if you feel we should split `ModeType` or add additional guard.

**Checklist**
- [X] Documentation added
- [X] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
