### PR TITLE
chore(groupcache): Support per cache group capacity

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -173,9 +173,11 @@ func (t *Loki) initGroupcache() (_ services.Service, err error) {
 	)
 	t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.GroupCache = gc.NewGroup(
 		t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Prefix+"groupcache",
-		&t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Groupcache,
+		&t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Groupcache,
 		stats.ResultCache,
 	)
+
+	// The index cache generates too much traffic to be used. Make it a fifo cache
 	t.Cfg.StorageConfig.IndexQueriesCacheConfig.EnableFifoCache = true
 	t.Cfg.StorageConfig.IndexQueriesCacheConfig.Fifocache.MaxSizeBytes = fmt.Sprint(t.Cfg.Common.GroupCacheConfig.CapacityMB * 1e6)
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -168,12 +168,12 @@ func (t *Loki) initGroupcache() (_ services.Service, err error) {
 
 	t.Cfg.ChunkStoreConfig.ChunkCacheConfig.GroupCache = gc.NewGroup(
 		t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Prefix+"groupcache",
-		&t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Groupcache,
+		&t.Cfg.ChunkStoreConfig.ChunkCacheConfig.GroupCacheConfig,
 		stats.ChunkCache,
 	)
 	t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.GroupCache = gc.NewGroup(
 		t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Prefix+"groupcache",
-		&t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Groupcache,
+		&t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.GroupCacheConfig,
 		stats.ResultCache,
 	)
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -166,10 +166,16 @@ func (t *Loki) initGroupcache() (_ services.Service, err error) {
 		return nil, err
 	}
 
-	t.Cfg.ChunkStoreConfig.ChunkCacheConfig.GroupCache = gc.NewGroup(t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Prefix+"groupcache", stats.ChunkCache)
-	t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.GroupCache = gc.NewGroup(t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Prefix+"groupcache", stats.ResultCache)
-
-	// The index cache generates too much traffic to be used. Make it a fifo cache
+	t.Cfg.ChunkStoreConfig.ChunkCacheConfig.GroupCache = gc.NewGroup(
+		t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Prefix+"groupcache",
+		&t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Groupcache,
+		stats.ChunkCache,
+	)
+	t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.GroupCache = gc.NewGroup(
+		t.Cfg.QueryRange.ResultsCacheConfig.CacheConfig.Prefix+"groupcache",
+		&t.Cfg.ChunkStoreConfig.ChunkCacheConfig.Groupcache,
+		stats.ResultCache,
+	)
 	t.Cfg.StorageConfig.IndexQueriesCacheConfig.EnableFifoCache = true
 	t.Cfg.StorageConfig.IndexQueriesCacheConfig.Fifocache.MaxSizeBytes = fmt.Sprint(t.Cfg.Common.GroupCacheConfig.CapacityMB * 1e6)
 

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -35,6 +35,7 @@ type Config struct {
 	MemcacheClient MemcachedClientConfig `yaml:"memcached_client"`
 	Redis          RedisConfig           `yaml:"redis"`
 	Fifocache      FifoCacheConfig       `yaml:"fifocache"`
+	Groupcache     GroupConfig           `yaml:"groupcache"` // TODO(kavi): consider resolving conflict with `GroupCache` field in same struct.
 
 	// This is to name the cache metrics properly.
 	Prefix string `yaml:"prefix" doc:"hidden"`

--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -35,7 +35,9 @@ type Config struct {
 	MemcacheClient MemcachedClientConfig `yaml:"memcached_client"`
 	Redis          RedisConfig           `yaml:"redis"`
 	Fifocache      FifoCacheConfig       `yaml:"fifocache"`
-	Groupcache     GroupConfig           `yaml:"groupcache"` // TODO(kavi): consider resolving conflict with `GroupCache` field in same struct.
+
+	// GroupcacheConfig is a local GroupCache config per cache
+	GroupCacheConfig GroupConfig `yaml:"groupcache"`
 
 	// This is to name the cache metrics properly.
 	Prefix string `yaml:"prefix" doc:"hidden"`

--- a/pkg/storage/chunk/cache/groupcache.go
+++ b/pkg/storage/chunk/cache/groupcache.go
@@ -69,7 +69,7 @@ type GroupCacheConfig struct {
 	Cache Cache `yaml:"-"`
 }
 
-// GroupGconfig represents config per Group.
+// Groupconfig represents config per Group.
 type GroupConfig struct {
 	CapacityMB int64 `yaml:"capacity_mb,omitempty"`
 }

--- a/pkg/storage/chunk/cache/groupcache.go
+++ b/pkg/storage/chunk/cache/groupcache.go
@@ -101,7 +101,6 @@ func NewGroupCache(rm ringManager, config GroupCacheConfig, server *server.Serve
 			},
 		},
 	)
-	server.HTTP.PathPrefix("/_groupcache/").Handler(pool)
 
 	startCtx, cancel := context.WithCancel(context.Background())
 	cache := &GroupCache{

--- a/pkg/storage/chunk/cache/groupcache.go
+++ b/pkg/storage/chunk/cache/groupcache.go
@@ -52,7 +52,7 @@ type GroupCache struct {
 	wg                   sync.WaitGroup
 	reg                  prometheus.Registerer
 	startWaitingForClose context.CancelFunc
-	capacity             int64
+	cacheBytes           int64
 }
 
 // RingCfg is a wrapper for the Groupcache ring configuration plus the replication factor.
@@ -112,7 +112,7 @@ func NewGroupCache(rm ringManager, config GroupCacheConfig, server *server.Serve
 		wg:                   sync.WaitGroup{},
 		startWaitingForClose: cancel,
 		reg:                  reg,
-		capacity:             config.CapacityMB * 1e6, // MB => B
+		cacheBytes:           config.CapacityMB * 1e6, // MB => B
 	}
 
 	go cache.serveGroupcache(config.ListenPort)
@@ -224,7 +224,7 @@ func (c *GroupCache) NewGroup(name string, cfg *GroupConfig, ct stats.CacheType)
 	c.wg.Add(1)
 	c.startWaitingForClose()
 
-	cap := c.capacity
+	cap := c.cacheBytes
 	if cfg.CapacityMB != 0 {
 		cap = cfg.CapacityMB * 1e6 // MB into bytes
 	}

--- a/pkg/storage/chunk/cache/groupcache_test.go
+++ b/pkg/storage/chunk/cache/groupcache_test.go
@@ -52,7 +52,7 @@ func TestGroupCache(t *testing.T) {
 
 	assert.Equal(t, c1.(*group).cacheBytes, int64(1*1e6))
 
-	// pass explicity capacity per group should take preference.
+	// pass explicitly capacity per group should take preference.
 	c2 := gc.NewGroup("test-group2", &GroupConfig{CapacityMB: 6}, "test2")
 	defer c.Stop()
 


### PR DESCRIPTION
Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Support per cache group capacity. 

With this individual group in groupcache can have own memory threshold.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/grafana/loki/issues/6786

**Special notes for your reviewer**:
1. Will add per group ballast config in separate PR after testing
2. Will replace `/groupcache/` with generic name also in different PR.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
