### PR TITLE
Fix Promtail dashboard

### DIFF
--- a/production/promtail-mixin/dashboards.libsonnet
+++ b/production/promtail-mixin/dashboards.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local dashboards = self,
 
     // local labelsSelector = 'cluster=~"$cluster", namespace=~"$namespace"',
-    local labelsSelector = dashboard._config.per_cluster_label + '~"$cluster", namespace=~"$namespace"',
+    local labelsSelector = dashboard._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"',
     local quantileLabelSelector = dashboard._config.per_cluster_label + '=~"$cluster", job=~"$namespace/promtail"',
 
     'promtail.json': {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Promtail production dashboard/panels. Error message: `bad_data: 1:40: parse error: unexpected character inside braces: '~'`.