### PR TITLE
[jsonnet] populate the memberlist label by default

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -22,7 +22,7 @@
     // Cluster label and verification flag can be set here or directly to
     // `_config.loki.memberlist.cluster_label` and `_config.loki.memberlist.cluster_label_verification_disabled` respectively.
     // Retaining this config to keep it backwards compatible with 2.6.1 release.
-    memberlist_cluster_label: '',
+    memberlist_cluster_label: '%(cluster)s.%(namespace)s' % self,
     memberlist_cluster_label_verification_disabled: false,
 
     // Migrating from consul to memberlist is a multi-step process:


### PR DESCRIPTION
Sets the memberlist cluster label to `cluster.namespace` by default. Our jsonnet `config.libsonnet` already requires that cluster and namespace values be set.

Signed-off-by: Callum Styan <callumstyan@gmail.com>