### PR TITLE
compactor: prefetch existing compacted user index files in parallel

### DIFF
--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -70,12 +70,14 @@ const (
 type compactedIndexSet struct {
 	compactor.IndexSet
 	compactedIndex *CompactedIndex
+	needsUpload bool
 }
 
-func newCompactedIndexSet(indexSet compactor.IndexSet, compactedIndex *CompactedIndex) *compactedIndexSet {
+func newCompactedIndexSet(indexSet compactor.IndexSet, compactedIndex *CompactedIndex, needsUpload bool) *compactedIndexSet {
 	return &compactedIndexSet{
 		IndexSet:       indexSet,
 		compactedIndex: compactedIndex,
+		needsUpload:    needsUpload,
 	}
 }
 
@@ -109,6 +111,11 @@ func newTableCompactor(
 
 func (t *tableCompactor) CompactTable() error {
 	commonIndexes := t.commonIndexSet.ListSourceFiles()
+	// prefetch existing user compacted index files to avoid serializing batches of records being re-written
+	err := t.prefetchUserIndexFiles()
+	if err != nil {
+		return err
+	}
 
 	// we need to perform compaction if we have more than 1 files in the storage or the only file we have is not a compaction file.
 	// if the files are already compacted we need to see if we need to recreate the compacted DB to reduce its space.
@@ -150,32 +157,24 @@ func (t *tableCompactor) CompactTable() error {
 		}
 	}
 
-	for userID, indexSet := range t.existingUserIndexSet {
-		if _, ok := t.userCompactedIndexSet[userID]; ok {
-			continue
-		}
-
+	for _, userCompactedIndexSet := range t.userCompactedIndexSet {
+		indexSet := userCompactedIndexSet.IndexSet
 		// We did not have any updates for this indexSet during compaction.
 		// Now see if it has more than one files to compact it down to a single file or if it requires recreation to save space.
 		sourceFiles := indexSet.ListSourceFiles()
-		if len(sourceFiles) > 1 || mustRecreateCompactedDB(sourceFiles) {
-			userCompactedIndexSet, err := t.getOrCreateUserCompactedIndexSet(userID)
-			if err != nil {
+		if mustRecreateCompactedDB(sourceFiles) {
+			if err := userCompactedIndexSet.compactedIndex.recreateCompactedDB(); err != nil {
 				return err
-			}
-			if len(sourceFiles) == 1 {
-				if err := userCompactedIndexSet.compactedIndex.recreateCompactedDB(); err != nil {
-					return err
-				}
 			}
 
-			if err := userCompactedIndexSet.SetCompactedIndex(userCompactedIndexSet.compactedIndex, true); err != nil {
-				return err
-			}
+			userCompactedIndexSet.needsUpload = true
 		}
 	}
 
 	for _, userCompactedIndexSet := range t.userCompactedIndexSet {
+		if !userCompactedIndexSet.needsUpload {
+			continue
+		}
 		if err := userCompactedIndexSet.SetCompactedIndex(userCompactedIndexSet.compactedIndex, true); err != nil {
 			return err
 		}
@@ -184,11 +183,71 @@ func (t *tableCompactor) CompactTable() error {
 	return nil
 }
 
+func (t *tableCompactor) prefetchUserIndexFiles() error {
+	existingUsers := make([]string, 0, len(t.existingUserIndexSet))
+	for userId, _ := range t.existingUserIndexSet {
+		existingUsers = append(existingUsers, userId)
+	}
+
+	return concurrency.ForEachJob(t.ctx, len(existingUsers), readDBsConcurrency, func (ctx context.Context, idx int) error {
+		userID := existingUsers[idx]
+		compactedIndex, err := t.fetchUserCompactedIndexSet(userID)
+		if err != nil {
+			return err
+		}
+
+		t.userCompactedIndexSetMtx.Lock()
+		defer t.userCompactedIndexSetMtx.Unlock()
+
+		t.userCompactedIndexSet[userID] = compactedIndex
+		return nil
+
+	})
+}
+
+func (t *tableCompactor) fetchUserCompactedIndexSet(userID string) (*compactedIndexSet, error) {
+	userIndexSet, ok := t.existingUserIndexSet[userID]
+	if !ok {
+		return nil, errors.New("requested non-existing compacted tenant index")
+	}
+
+	sourceFiles := userIndexSet.ListSourceFiles()
+	if len(sourceFiles) > 1 {
+		compactedIndex, err := compactIndexes(t.ctx, t.periodConfig, userIndexSet, func(userID string) (*CompactedIndex, error) {
+			return nil, errors.New("compacted user index set should not be requested while compacting user index")
+		})
+		if err != nil {
+			return nil, err
+		}
+		return newCompactedIndexSet(userIndexSet, compactedIndex, true), nil
+	} else if len(sourceFiles) == 1 {
+		indexFile, err := userIndexSet.GetSourceFile(sourceFiles[0])
+		if err != nil {
+			return nil, err
+		}
+		boltdb, err := openBoltdbFileWithNoSync(indexFile)
+		if err != nil {
+			return nil, err
+		}
+
+		return newCompactedIndexSet(userIndexSet, newCompactedIndex(boltdb, userIndexSet.GetTableName(), userIndexSet.GetWorkingDir(), t.periodConfig, userIndexSet.GetLogger()), false), nil
+	}
+	return nil, errors.New("attempted to fetch empty index set")
+
+}
+
 func (t *tableCompactor) getOrCreateUserCompactedIndexSet(userID string) (*compactedIndexSet, error) {
 	t.userCompactedIndexSetMtx.RLock()
 	indexSet, ok := t.userCompactedIndexSet[userID]
+	needsUpload := ok && indexSet.needsUpload
 	t.userCompactedIndexSetMtx.RUnlock()
 	if ok {
+		if !needsUpload {
+			t.userCompactedIndexSetMtx.Lock()
+			defer t.userCompactedIndexSetMtx.Unlock()
+			indexSet.needsUpload = true
+
+		}
 		return indexSet, nil
 	}
 
@@ -213,15 +272,14 @@ func (t *tableCompactor) getOrCreateUserCompactedIndexSet(userID string) (*compa
 			return nil, err
 		}
 		compactedIndex := newCompactedIndex(compactedFile, userIndexSet.GetTableName(), userIndexSet.GetWorkingDir(), t.periodConfig, userIndexSet.GetLogger())
-		t.userCompactedIndexSet[userID] = newCompactedIndexSet(userIndexSet, compactedIndex)
+		t.userCompactedIndexSet[userID] = newCompactedIndexSet(userIndexSet, compactedIndex, true)
 	} else {
-		compactedIndex, err := compactIndexes(t.ctx, t.periodConfig, userIndexSet, func(userID string) (*CompactedIndex, error) {
-			return nil, errors.New("compacted user index set should not be requested while compacting user index")
-		})
+		compactedIndex, err := t.fetchUserCompactedIndexSet(userID)
+		compactedIndex.needsUpload = true
 		if err != nil {
 			return nil, err
 		}
-		t.userCompactedIndexSet[userID] = newCompactedIndexSet(userIndexSet, compactedIndex)
+		t.userCompactedIndexSet[userID] = compactedIndex
 	}
 
 	return t.userCompactedIndexSet[userID], nil

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -274,12 +274,7 @@ func (t *tableCompactor) getOrCreateUserCompactedIndexSet(userID string) (*compa
 		compactedIndex := newCompactedIndex(compactedFile, userIndexSet.GetTableName(), userIndexSet.GetWorkingDir(), t.periodConfig, userIndexSet.GetLogger())
 		t.userCompactedIndexSet[userID] = newCompactedIndexSet(userIndexSet, compactedIndex, true)
 	} else {
-		compactedIndex, err := t.fetchUserCompactedIndexSet(userID)
-		compactedIndex.needsUpload = true
-		if err != nil {
-			return nil, err
-		}
-		t.userCompactedIndexSet[userID] = compactedIndex
+		return nil, errors.New("an existing user index was not prefetched before starting compaction")
 	}
 
 	return t.userCompactedIndexSet[userID], nil

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -185,8 +185,8 @@ func (t *tableCompactor) CompactTable() error {
 
 func (t *tableCompactor) prefetchUserIndexFiles() error {
 	existingUsers := make([]string, 0, len(t.existingUserIndexSet))
-	for userId := range t.existingUserIndexSet {
-		existingUsers = append(existingUsers, userId)
+	for userID := range t.existingUserIndexSet {
+		existingUsers = append(existingUsers, userID)
 	}
 
 	return concurrency.ForEachJob(t.ctx, len(existingUsers), readDBsConcurrency, func(ctx context.Context, idx int) error {

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -185,7 +185,7 @@ func (t *tableCompactor) CompactTable() error {
 
 func (t *tableCompactor) prefetchUserIndexFiles() error {
 	existingUsers := make([]string, 0, len(t.existingUserIndexSet))
-	for userId, _ := range t.existingUserIndexSet {
+	for userId := range t.existingUserIndexSet {
 		existingUsers = append(existingUsers, userId)
 	}
 

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -70,7 +70,7 @@ const (
 type compactedIndexSet struct {
 	compactor.IndexSet
 	compactedIndex *CompactedIndex
-	needsUpload bool
+	needsUpload    bool
 }
 
 func newCompactedIndexSet(indexSet compactor.IndexSet, compactedIndex *CompactedIndex, needsUpload bool) *compactedIndexSet {
@@ -189,7 +189,7 @@ func (t *tableCompactor) prefetchUserIndexFiles() error {
 		existingUsers = append(existingUsers, userId)
 	}
 
-	return concurrency.ForEachJob(t.ctx, len(existingUsers), readDBsConcurrency, func (ctx context.Context, idx int) error {
+	return concurrency.ForEachJob(t.ctx, len(existingUsers), readDBsConcurrency, func(ctx context.Context, idx int) error {
 		userID := existingUsers[idx]
 		compactedIndex, err := t.fetchUserCompactedIndexSet(userID)
 		if err != nil {

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -172,10 +172,11 @@ func (t *tableCompactor) CompactTable() error {
 	}
 
 	for _, userCompactedIndexSet := range t.userCompactedIndexSet {
-		if !userCompactedIndexSet.needsUpload {
-			continue
-		}
-		if err := userCompactedIndexSet.SetCompactedIndex(userCompactedIndexSet.compactedIndex, true); err != nil {
+		// Inform higher level abstraction of the index files
+		// that were fetched/parsed. The index set is going to
+		// call cleanup even if it doesn't upload the contents of
+		// the compacted index
+		if err := userCompactedIndexSet.SetCompactedIndex(userCompactedIndexSet.compactedIndex, nil, userCompactedIndexSet.needsUpload); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -430,7 +430,7 @@ func (t *tableCompactor) compactCommonIndexes(ctx context.Context) (*CompactedIn
 	}
 
 	tenantIdsSlice := make([]string, 0, len(tenantsToFetch))
-	for tenant, _ := range tenantsToFetch {
+	for tenant := range tenantsToFetch {
 		tenantIdsSlice = append(tenantIdsSlice, tenant)
 	}
 

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor_test.go
@@ -446,7 +446,13 @@ func TestTable_RecreateCompactedDB(t *testing.T) {
 				compareCompactedTable(t, tablePathInStorage, tCompactor)
 			} else if tt.dbCount <= 1 {
 				require.Nil(t, tCompactor.commonIndexSet.(*mockIndexSet).compactedIndex)
-				require.Len(t, tCompactor.userCompactedIndexSet, 0)
+				uploadedCompactedIndexSets := make([]*compactedIndexSet, 0, len(tCompactor.userCompactedIndexSet))
+				for _, is := range tCompactor.userCompactedIndexSet {
+					if is.needsUpload {
+						uploadedCompactedIndexSets = append(uploadedCompactedIndexSets, is)
+					}
+				}
+				require.Len(t, uploadedCompactedIndexSets, 0)
 			} else {
 				require.False(t, tCompactor.commonIndexSet.(*mockIndexSet).compactedIndex.(*CompactedIndex).compactedFileRecreated)
 				for _, userCompactedIndexSet := range tCompactor.userCompactedIndexSet {
@@ -493,6 +499,9 @@ func compareCompactedTable(t *testing.T, srcTable string, tableCompactor *tableC
 	}
 
 	for userID, compactedIndex := range tableCompactor.userCompactedIndexSet {
+		if !compactedIndex.needsUpload {
+			continue
+		}
 		for _, userRecords := range readDB(t, compactedIndex.IndexSet.(*mockIndexSet).compactedIndex.(*CompactedIndex).compactedFile) {
 			if _, ok := compactedRecords[userID]; !ok {
 				compactedRecords[userID] = make(map[string]string)

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor_test.go
@@ -448,9 +448,7 @@ func TestTable_RecreateCompactedDB(t *testing.T) {
 				require.Nil(t, tCompactor.commonIndexSet.(*mockIndexSet).compactedIndex)
 				uploadedCompactedIndexSets := make([]*compactedIndexSet, 0, len(tCompactor.userCompactedIndexSet))
 				for _, is := range tCompactor.userCompactedIndexSet {
-					if is.needsUpload {
-						uploadedCompactedIndexSets = append(uploadedCompactedIndexSets, is)
-					}
+					uploadedCompactedIndexSets = append(uploadedCompactedIndexSets, is)
 				}
 				require.Len(t, uploadedCompactedIndexSets, 0)
 			} else {
@@ -499,9 +497,6 @@ func compareCompactedTable(t *testing.T, srcTable string, tableCompactor *tableC
 	}
 
 	for userID, compactedIndex := range tableCompactor.userCompactedIndexSet {
-		if !compactedIndex.needsUpload {
-			continue
-		}
 		for _, userRecords := range readDB(t, compactedIndex.IndexSet.(*mockIndexSet).compactedIndex.(*CompactedIndex).compactedFile) {
 			if _, ok := compactedRecords[userID]; !ok {
 				compactedRecords[userID] = make(map[string]string)


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change, these files are fetched while [holding a table global lock](https://github.com/grafana/loki/blob/a1e75da9707d4fe5bacf5d3aea947225c5781d09/pkg/storage/stores/shipper/index/compactor/table_compactor.go#L195), serializing fetches.

I chose the approach of prefetching index files over attempting to change the locking pattern to allow parallel, on-demand fetches because the complexity of parallelizing on-demand fetches outweighed the benefits of avoiding extra fetches. More specifically, this patch trades off fetching idle, non-compactable index files in favor of avoiding blocking during compactions. The extra fetches are parallelized and so should incur a negligible wall clock penalty even for large numbers of tenants(e.g. 1k idle tenants at 50 threads and 500ms to fetch is ~10s).

**Which issue(s) this PR fixes**:
This should help with #6775, without completely resolving it.

**Checklist**
This change does not introduce any settings, metrics etc. It should be transparent from a user perspective. Therefore, I don't believe it merits documentation/changelog updates.

- [x] Tests updated

