### PR TITLE
Allow fifocache to be configured with groupcache

### DIFF
--- a/pkg/storage/chunk/cache/cache.go
+++ b/pkg/storage/chunk/cache/cache.go
@@ -90,12 +90,12 @@ func IsRedisSet(cfg Config) bool {
 }
 
 func IsGroupCacheSet(cfg Config) bool {
-	return cfg.EnableGroupCache && !cfg.EnableFifoCache
+	return cfg.GroupCache != nil
 }
 
 // IsCacheConfigured determines if memcached, redis, or groupcache have been configured
 func IsCacheConfigured(cfg Config) bool {
-	return IsMemcacheSet(cfg) || IsRedisSet(cfg) || IsGroupCacheSet(cfg)
+	return IsMemcacheSet(cfg) || IsRedisSet(cfg) || cfg.EnableGroupCache
 }
 
 // New creates a new Cache using Config.


### PR DESCRIPTION
We stopped the panic, but it made it so a user can't configure both fifocache and groupcache together. This solves the issue differentiating if groupcache is set for a particular cache based on `cache != nil` and whether it's globally configured via `cfg.GroupCacheEnabled`
