### PR TITLE
[jsonnet] only set the consul kvstore configs if memberlist is not being used

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -229,7 +229,7 @@
           ring: {
             heartbeat_timeout: '1m',
             replication_factor: $._config.replication_factor,
-            kvstore: {
+            kvstore: if $._config.memberlist_ring_enabled then {} else {
               store: 'consul',
               consul: {
                 host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
@@ -335,7 +335,7 @@
       distributor: {
         // Creates a ring between distributors, required by the ingestion rate global limit.
         ring: {
-          kvstore: {
+          kvstore: if $._config.memberlist_ring_enabled then {} else {
             store: 'consul',
             consul: {
               host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
@@ -355,7 +355,7 @@
         enable_sharding: true,
         enable_alertmanager_v2: true,
         ring: {
-          kvstore: {
+          kvstore: if $._config.memberlist_ring_enabled then {} else {
             store: 'consul',
             consul: {
               host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -46,9 +46,6 @@
       },
     } else {
       store: 'memberlist',
-      consul: {
-        host: null,
-      },
     },
 
     loki+: if $._config.memberlist_ring_enabled then {


### PR DESCRIPTION
This PR removes the configuration of consul/kvstore configs if memberlist is being used, which it is by default.

I can understand if we don't want to change this configuration/code to avoid potential configuration issues or confusion for OSS users, however for internal use we've run into some confusion as to why (for example) in newly created Loki clusters is there consul configuration if we're only actually using memberlist. 

Note that if OSS users are doing migrations from consul or another kv store to memberlist the memberlist_migration_teardown jsonnet config option will preserve the config of running components at the end of the migration until their rollout is completed.

Signed-off-by: Callum Styan <callumstyan@gmail.com>
