### PR TITLE
chore(groupcache): Groupcache doesn't need global server handler anymore

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -161,7 +161,7 @@ func (t *Loki) initGroupcache() (_ services.Service, err error) {
 	t.groupcacheRingManager = rm
 	t.Server.HTTP.Path("/groupcache/ring").Methods("GET", "POST").Handler(t.groupcacheRingManager)
 
-	gc, err := cache.NewGroupCache(rm, t.Cfg.Common.GroupCacheConfig, t.Server, util_log.Logger, prometheus.DefaultRegisterer)
+	gc, err := cache.NewGroupCache(rm, t.Cfg.Common.GroupCacheConfig, util_log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/chunk/cache/groupcache.go
+++ b/pkg/storage/chunk/cache/groupcache.go
@@ -21,7 +21,6 @@ import (
 	"github.com/mailgun/groupcache/v2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaveworks/common/server"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -89,7 +88,7 @@ type ringManager interface {
 	Ring() ring.ReadRing
 }
 
-func NewGroupCache(rm ringManager, config GroupCacheConfig, server *server.Server, logger log.Logger, reg prometheus.Registerer) (*GroupCache, error) {
+func NewGroupCache(rm ringManager, config GroupCacheConfig, logger log.Logger, reg prometheus.Registerer) (*GroupCache, error) {
 	addr := fmt.Sprintf("http://%s", rm.Addr())
 	level.Info(logger).Log("msg", "groupcache local address set to", "addr", addr)
 

--- a/pkg/storage/chunk/cache/groupcache_test.go
+++ b/pkg/storage/chunk/cache/groupcache_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/gorilla/mux"
-	"github.com/weaveworks/common/server"
 
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +62,7 @@ func setupGroupCache() (*GroupCache, error) {
 	return NewGroupCache(&mockRingManager{}, GroupCacheConfig{
 		Enabled:    true,
 		CapacityMB: 1,
-	}, &server.Server{HTTP: mux.NewRouter()}, log.NewNopLogger(), nil)
+	}, log.NewNopLogger(), nil)
 }
 
 type mockRingManager struct{}


### PR DESCRIPTION

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

[Now groupcache runs it's own server.](https://github.com/grafana/loki/pull/6752) Fix the constructor of the groupcache to the same.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
