### PR TITLE
compactor: observe the number of index files that need to be compacted

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -496,7 +496,7 @@ func (c *Compactor) CompactTable(ctx context.Context, tableName string, applyRet
 	}
 
 	table, err := newTable(ctx, filepath.Join(c.cfg.WorkingDirectory, tableName), c.indexStorageClient, indexCompactor,
-		schemaCfg, c.tableMarker, c.expirationChecker)
+		schemaCfg, c.tableMarker, c.expirationChecker, c.metrics)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "failed to initialize table for compaction", "table", tableName, "err", err)
 		return err

--- a/pkg/storage/stores/indexshipper/compactor/metrics.go
+++ b/pkg/storage/stores/indexshipper/compactor/metrics.go
@@ -16,7 +16,7 @@ type metrics struct {
 	compactTablesOperationLastSuccess     prometheus.Gauge
 	applyRetentionLastSuccess             prometheus.Gauge
 	compactorRunning                      prometheus.Gauge
-	indexFilesToCompactForLastCompaction  *prometheus.GaugeVec
+	uncompactedIndexFilesDiscovered       *prometheus.GaugeVec
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -46,10 +46,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "compactor_running",
 			Help:      "Value will be 1 if compactor is currently running on this instance",
 		}),
-		indexFilesToCompactForLastCompaction: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+		uncompactedIndexFilesDiscovered: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "loki_boltdb_shipper",
-			Name:      "compact_tables_operation_index_files_in_last_compaction",
-			Help:      "The number of index files observed by last compaction",
+			Name:      "compact_tables_operation_index_files_discovered",
+			Help:      "The number of uncompacted index files discovered by last compaction",
 		}, []string{"table"}),
 	}
 

--- a/pkg/storage/stores/indexshipper/compactor/metrics.go
+++ b/pkg/storage/stores/indexshipper/compactor/metrics.go
@@ -16,6 +16,7 @@ type metrics struct {
 	compactTablesOperationLastSuccess     prometheus.Gauge
 	applyRetentionLastSuccess             prometheus.Gauge
 	compactorRunning                      prometheus.Gauge
+	indexFilesToCompactForLastCompaction  *prometheus.GaugeVec
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -45,6 +46,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name:      "compactor_running",
 			Help:      "Value will be 1 if compactor is currently running on this instance",
 		}),
+		indexFilesToCompactForLastCompaction: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "loki_boltdb_shipper",
+			Name:      "compact_tables_operation_index_files_in_last_compaction",
+			Help:      "The number of index files observed by last compaction",
+		}, []string{"table"}),
 	}
 
 	return &m

--- a/pkg/storage/stores/indexshipper/compactor/table.go
+++ b/pkg/storage/stores/indexshipper/compactor/table.go
@@ -132,7 +132,7 @@ func (t *table) compact(applyRetention bool) error {
 
 	level.Info(t.logger).Log("msg", "listed files", "count", len(indexFiles))
 	if t.metrics != nil {
-		t.metrics.indexFilesToCompactForLastCompaction.WithLabelValues(t.name).Set(float64(len(indexFiles)))
+		t.metrics.uncompactedIndexFilesDiscovered.WithLabelValues(t.name).Set(float64(len(indexFiles)))
 	}
 	defer func() {
 		for _, is := range t.indexSets {
@@ -144,7 +144,7 @@ func (t *table) compact(applyRetention bool) error {
 		}
 	}()
 
-	t.indexSets[""], err = newCommonIndexSet(t.ctx, t.name, t.baseCommonIndexSet, t.workingDirectory, t.logger, t.metrics)
+	t.indexSets[""], err = newCommonIndexSet(t.ctx, t.name, t.baseCommonIndexSet, t.workingDirectory, t.logger)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (t *table) compact(applyRetention bool) error {
 
 	for _, userID := range t.usersWithPerUserIndex {
 		var err error
-		t.indexSets[userID], err = newUserIndexSet(t.ctx, t.name, userID, t.baseUserIndexSet, filepath.Join(t.workingDirectory, userID), t.logger, t.metrics)
+		t.indexSets[userID], err = newUserIndexSet(t.ctx, t.name, userID, t.baseUserIndexSet, filepath.Join(t.workingDirectory, userID), t.logger)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func (t *table) compact(applyRetention bool) error {
 		defer indexSetsMtx.Unlock()
 
 		var err error
-		t.indexSets[userID], err = newUserIndexSet(t.ctx, t.name, userID, t.baseUserIndexSet, filepath.Join(t.workingDirectory, userID), t.logger, t.metrics)
+		t.indexSets[userID], err = newUserIndexSet(t.ctx, t.name, userID, t.baseUserIndexSet, filepath.Join(t.workingDirectory, userID), t.logger)
 		return t.indexSets[userID], err
 	}, t.periodConfig)
 

--- a/pkg/storage/stores/indexshipper/compactor/table_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/table_test.go
@@ -199,7 +199,7 @@ func TestTable_Compaction(t *testing.T) {
 					require.NoError(t, err)
 
 					table, err := newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-						newTestIndexCompactor(), config.PeriodConfig{}, nil, nil)
+						newTestIndexCompactor(), config.PeriodConfig{}, nil, nil, nil)
 					require.NoError(t, err)
 
 					require.NoError(t, table.compact(false))
@@ -236,7 +236,7 @@ func TestTable_Compaction(t *testing.T) {
 
 					// running compaction again should not do anything.
 					table, err = newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-						newTestIndexCompactor(), config.PeriodConfig{}, nil, nil)
+						newTestIndexCompactor(), config.PeriodConfig{}, nil, nil, nil)
 					require.NoError(t, err)
 
 					require.NoError(t, table.compact(false))
@@ -379,7 +379,7 @@ func TestTable_CompactionRetention(t *testing.T) {
 					newTestIndexCompactor(), config.PeriodConfig{},
 					tt.tableMarker, IntervalMayHaveExpiredChunksFunc(func(interval model.Interval, userID string) bool {
 						return true
-					}))
+					}), nil)
 				require.NoError(t, err)
 
 				require.NoError(t, table.compact(true))
@@ -452,7 +452,7 @@ func TestTable_CompactionFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	table, err := newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-		newTestIndexCompactor(), config.PeriodConfig{}, nil, nil)
+		newTestIndexCompactor(), config.PeriodConfig{}, nil, nil, nil)
 	require.NoError(t, err)
 
 	// compaction should fail due to a non-boltdb file.
@@ -470,7 +470,7 @@ func TestTable_CompactionFailure(t *testing.T) {
 	require.NoError(t, os.Remove(filepath.Join(tablePathInStorage, "fail.gz")))
 
 	table, err = newTable(context.Background(), tableWorkingDirectory, storage.NewIndexStorageClient(objectClient, ""),
-		newTestIndexCompactor(), config.PeriodConfig{}, nil, nil)
+		newTestIndexCompactor(), config.PeriodConfig{}, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, table.compact(false))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When debugging the compactor, I was often looking for the "listed" log
line as well as the "deleting" log lines to determine whether
compactor is making materialized progress.

This change adds a guage so that the number of files that need compaction
can be tracked in a metrics store.

**Which issue(s) this PR fixes**:
This would've helped with #6775 