### PR TITLE
[jsonnet] don't deploy consul if we're using memberlist

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -142,4 +142,8 @@
         { [$._config.gossip_member_label]: 'true' },  // point to all gossip members
         ports,
       ) + service.mixin.spec.withClusterIp('None'),  // headless service
+
+  // Disable the consul deployment if not migrating and using memberlist
+  consul_deployment:: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then null,
+  consul_service:: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then null,
 }


### PR DESCRIPTION
This PR changes our jsonnet code so that we don't deploy consul if we're using memberlist and not actively migrating from consul to memberlist.

Signed-off-by: Callum Styan <callumstyan@gmail.com>
