### PR TITLE
Only process deletes in batches

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -76,6 +76,7 @@ type Config struct {
 	RetentionEnabled          bool            `yaml:"retention_enabled"`
 	RetentionDeleteDelay      time.Duration   `yaml:"retention_delete_delay"`
 	RetentionDeleteWorkCount  int             `yaml:"retention_delete_worker_count"`
+	DeleteBatchSize           int             `yaml:"delete_batch_size"`
 	DeletionMode              string          `yaml:"deletion_mode"`
 	DeleteRequestCancelPeriod time.Duration   `yaml:"delete_request_cancel_period"`
 	MaxCompactionParallelism  int             `yaml:"max_compaction_parallelism"`
@@ -93,11 +94,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.RetentionDeleteDelay, "boltdb.shipper.compactor.retention-delete-delay", 2*time.Hour, "Delay after which chunks will be fully deleted during retention.")
 	f.BoolVar(&cfg.RetentionEnabled, "boltdb.shipper.compactor.retention-enabled", false, "(Experimental) Activate custom (per-stream,per-tenant) retention.")
 	f.IntVar(&cfg.RetentionDeleteWorkCount, "boltdb.shipper.compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
+	f.IntVar(&cfg.DeleteBatchSize, "boltdb.shipper.compactor.delete-batch-size", 70, "The max number of delete requests to run per compaction cycle.")
 	f.DurationVar(&cfg.DeleteRequestCancelPeriod, "boltdb.shipper.compactor.delete-request-cancel-period", 24*time.Hour, "Allow cancellation of delete request until duration after they are created. Data would be deleted only after delete requests have been older than this duration. Ideally this should be set to at least 24h.")
 	f.IntVar(&cfg.MaxCompactionParallelism, "boltdb.shipper.compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
 	f.StringVar(&cfg.DeletionMode, "boltdb.shipper.compactor.deletion-mode", "disabled", fmt.Sprintf("Deletion mode. Can be one of %v", strings.Join(deletion.AllModes(), "|")))
-	cfg.CompactorRing.RegisterFlagsWithPrefix("boltdb.shipper.compactor.", "collectors/", f)
 	f.BoolVar(&cfg.RunOnce, "boltdb.shipper.compactor.run-once", false, "Run the compactor one time to cleanup and compact index files only (no retention applied)")
+	cfg.CompactorRing.RegisterFlagsWithPrefix("boltdb.shipper.compactor.", "collectors/", f)
 }
 
 // Validate verifies the config does not contain inappropriate values
@@ -278,8 +280,9 @@ func (c *Compactor) initDeletes(r prometheus.Registerer, limits retention.Limits
 	c.deleteRequestsManager = deletion.NewDeleteRequestsManager(
 		c.deleteRequestsStore,
 		c.cfg.DeleteRequestCancelPeriod,
-		r,
 		c.deleteMode,
+		c.cfg.DeleteBatchSize,
+		r,
 	)
 
 	c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits), c.deleteRequestsManager)

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -157,6 +158,12 @@ func (d *DeleteRequestsManager) loadDeleteRequestsToProcess() error {
 		if deleteCount >= d.batchSize {
 			break
 		}
+	}
+
+	if deleteCount < len(deleteRequests) {
+		level.Info(util_log.Logger).Log(
+			"msg", fmt.Sprintf("Processing %d of %d delete requests. More requests will be processed in subsequent compactions", deleteCount, len(deleteRequests)),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
This is a setting to protect the compactor when there are many delete requests. Only process `delete_batch_size` per compaction.

The default of 70 was chosen based on a recent incident where we saw 16-hour delete requests run at a rate of ~28/minute. At that rate, 70 should take ~2.5 minutes. Even if the requests cover 4x the data, this should still keep the deletion phase of compaction to ~10 minutes.
