### PR TITLE
Add delete api validations

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1034,8 +1034,8 @@ Log entry deletion is supported _only_ when the BoltDB Shipper is configured for
 Query parameters:
 
 * `query=<series_selector>`: query argument that identifies the streams from which to delete with optional line filters.
-* `start=<rfc3339 | unix_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. If not specified, defaults to 0, the Unix Epoch time.
-* `end=<rfc3339 | unix_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
+* `start=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the start of the time window within which entries will be deleted. This parameter is required.
+* `end=<rfc3339 | unix_seconds_timestamp>`: A timestamp that identifies the end of the time window within which entries will be deleted. If not specified, defaults to the current time.
 
 A 204 response indicates success.
 

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -107,7 +107,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 	})
 
 	t.Run("add-delete-request", func(t *testing.T) {
-		params := client.DeleteRequestParams{Query: `{job="fake"} |= "lineB"`}
+		params := client.DeleteRequestParams{Start: "0000000000", Query: `{job="fake"} |= "lineB"`}
 		require.NoError(t, cliCompactor.AddDeleteRequest(params))
 	})
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -52,7 +52,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletion"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber"
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	shipper_index "github.com/grafana/loki/pkg/storage/stores/shipper/index"
 	boltdb_shipper_compactor "github.com/grafana/loki/pkg/storage/stores/shipper/index/compactor"
@@ -1040,7 +1039,7 @@ func (t *Loki) initUsageReport() (services.Service, error) {
 	return ur, nil
 }
 
-func (t *Loki) deleteRequestsClient(clientType string, limits retention.Limits) (deletion.DeleteRequestsClient, error) {
+func (t *Loki) deleteRequestsClient(clientType string, limits *validation.Overrides) (deletion.DeleteRequestsClient, error) {
 	// TODO(owen-d): enable delete request storage in tsdb
 	if config.UsingTSDB(t.Cfg.SchemaConfig.Configs) {
 		return deletion.NewNoOpDeleteRequestsStore(), nil

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/loki/pkg/validation"
+
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
@@ -139,7 +141,7 @@ type Compactor struct {
 	subservicesWatcher *services.FailureWatcher
 }
 
-func NewCompactor(cfg Config, objectClient client.ObjectClient, schemaConfig config.SchemaConfig, limits retention.Limits, r prometheus.Registerer) (*Compactor, error) {
+func NewCompactor(cfg Config, objectClient client.ObjectClient, schemaConfig config.SchemaConfig, limits *validation.Overrides, r prometheus.Registerer) (*Compactor, error) {
 	retentionEnabledStats.Set("false")
 	if cfg.RetentionEnabled {
 		retentionEnabledStats.Set("true")
@@ -205,7 +207,7 @@ func NewCompactor(cfg Config, objectClient client.ObjectClient, schemaConfig con
 	return compactor, nil
 }
 
-func (c *Compactor) init(objectClient client.ObjectClient, schemaConfig config.SchemaConfig, limits retention.Limits, r prometheus.Registerer) error {
+func (c *Compactor) init(objectClient client.ObjectClient, schemaConfig config.SchemaConfig, limits *validation.Overrides, r prometheus.Registerer) error {
 	err := chunk_util.EnsureDirectory(c.cfg.WorkingDirectory)
 	if err != nil {
 		return err
@@ -240,7 +242,7 @@ func (c *Compactor) init(objectClient client.ObjectClient, schemaConfig config.S
 	return nil
 }
 
-func (c *Compactor) initDeletes(r prometheus.Registerer, limits retention.Limits) error {
+func (c *Compactor) initDeletes(r prometheus.Registerer, limits *validation.Overrides) error {
 	deletionWorkDir := filepath.Join(c.cfg.WorkingDirectory, "deletion")
 
 	store, err := deletion.NewDeleteStore(deletionWorkDir, c.indexStorageClient)

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -251,7 +251,7 @@ func (c *Compactor) initDeletes(r prometheus.Registerer, limits retention.Limits
 
 	c.DeleteRequestsHandler = deletion.NewDeleteRequestHandler(
 		c.deleteRequestsStore,
-		limits,
+		c.cfg.DeleteRequestCancelPeriod,
 		r,
 	)
 

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
@@ -40,10 +40,10 @@ type DeleteRequestsManager struct {
 	wg                         sync.WaitGroup
 	done                       chan struct{}
 	batchSize                  int
-	limits                     retention.Limits
+	limits                     Limits
 }
 
-func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeriod time.Duration, batchSize int, limits retention.Limits, registerer prometheus.Registerer) *DeleteRequestsManager {
+func NewDeleteRequestsManager(store DeleteRequestsStore, deleteRequestCancelPeriod time.Duration, batchSize int, limits Limits, registerer prometheus.Registerer) *DeleteRequestsManager {
 	dm := &DeleteRequestsManager{
 		deleteRequestsStore:       store,
 		deleteRequestCancelPeriod: deleteRequestCancelPeriod,

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
@@ -433,7 +433,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, tc.batchSize, deleteLimits(tc.deletionMode), nil)
+			mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, tc.batchSize, &fakeLimits{mode: tc.deletionMode.String()}, nil)
 			require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
 			for _, deleteRequests := range mgr.deleteRequestsToProcess {
@@ -475,7 +475,7 @@ func TestDeleteRequestsManager_IntervalMayHaveExpiredChunks(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, 70, deleteLimits(deletionmode.FilterAndDelete), nil)
+		mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, 70, &fakeLimits{mode: deletionmode.FilterAndDelete.String()}, nil)
 		require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
 		interval := model.Interval{Start: 300, End: 600}
@@ -503,12 +503,4 @@ func (m *mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID s
 	m.addedEndTime = endTime
 	m.addedQuery = query
 	return m.addErr
-}
-
-func deleteLimits(mode deletionmode.Mode) *fakeLimits {
-	return &fakeLimits{
-		defaultLimit: retentionLimit{
-			compactorDeletionEnabled: mode.String(),
-		},
-	}
 }

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
@@ -433,7 +433,7 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, tc.batchSize, deleteLimits(tc.deletionMode), nil)
+			mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, tc.batchSize, deleteLimits(tc.deletionMode), nil)
 			require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
 			for _, deleteRequests := range mgr.deleteRequestsToProcess {
@@ -475,7 +475,7 @@ func TestDeleteRequestsManager_IntervalMayHaveExpiredChunks(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		mgr := NewDeleteRequestsManager(mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, 70, deleteLimits(deletionmode.FilterAndDelete), nil)
+		mgr := NewDeleteRequestsManager(&mockDeleteRequestsStore{deleteRequests: tc.deleteRequestsFromStore}, time.Hour, 70, deleteLimits(deletionmode.FilterAndDelete), nil)
 		require.NoError(t, mgr.loadDeleteRequestsToProcess())
 
 		interval := model.Interval{Start: 300, End: 600}
@@ -486,10 +486,23 @@ func TestDeleteRequestsManager_IntervalMayHaveExpiredChunks(t *testing.T) {
 type mockDeleteRequestsStore struct {
 	DeleteRequestsStore
 	deleteRequests []DeleteRequest
+	addedUser      string
+	addedStartTime model.Time
+	addedEndTime   model.Time
+	addedQuery     string
+	addErr         error
 }
 
-func (m mockDeleteRequestsStore) GetDeleteRequestsByStatus(_ context.Context, _ DeleteRequestStatus) ([]DeleteRequest, error) {
+func (m *mockDeleteRequestsStore) GetDeleteRequestsByStatus(_ context.Context, _ DeleteRequestStatus) ([]DeleteRequest, error) {
 	return m.deleteRequests, nil
+}
+
+func (m *mockDeleteRequestsStore) AddDeleteRequest(ctx context.Context, userID string, startTime, endTime model.Time, query string) error {
+	m.addedUser = userID
+	m.addedStartTime = startTime
+	m.addedEndTime = endTime
+	m.addedQuery = query
+	return m.addErr
 }
 
 func deleteLimits(mode deletionmode.Mode) *fakeLimits {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
@@ -19,8 +19,6 @@ import (
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
-const deletionNotAvailableMsg = "deletion is not available for this tenant"
-
 // DeleteRequestHandler provides handlers for delete requests
 type DeleteRequestHandler struct {
 	deleteRequestsStore       DeleteRequestsStore

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
@@ -194,18 +194,13 @@ func startTime(params url.Values) (int64, error) {
 
 func endTime(params url.Values, startTime int64) (int64, error) {
 	endParam := params.Get("end")
+	endTime, err := parseTime(endParam)
+	if err != nil {
+		return 0, errors.New("invalid end time: require unix seconds or RFC3339 format")
+	}
 
-	endTime := int64(model.Now())
-	if endParam != "" {
-		var err error
-		endTime, err = parseTime(endParam)
-		if err != nil {
-			return 0, errors.New("invalid start time: require unix seconds or RFC3339 format")
-		}
-
-		if endTime > int64(model.Now()) {
-			return 0, errors.New("deletes in the future are not allowed")
-		}
+	if endTime > int64(model.Now()) {
+		return 0, errors.New("deletes in the future are not allowed")
 	}
 
 	if startTime > endTime {
@@ -216,6 +211,10 @@ func endTime(params url.Values, startTime int64) (int64, error) {
 }
 
 func parseTime(in string) (int64, error) {
+	if in == "" {
+		return int64(model.Now()), nil
+	}
+
 	t, err := time.Parse(time.RFC3339, in)
 	if err != nil {
 		return timeFromInt(in)

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/grafana/loki/pkg/util"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/util"
 
 	"github.com/weaveworks/common/user"
 )

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
@@ -86,11 +86,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, time.Second, nil)
 
 		for _, tc := range []struct {
-			orgID     string
-			query     string
-			startTime string
-			endTime   string
-			error     string
+			orgID, query, startTime, endTime, error string
 		}{
 			{"", `{foo="bar"}`, "0000000000", "0000000001", "no org id\n"},
 			{"org-id", "", "0000000000", "0000000001", "query not set\n"},

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
@@ -1,0 +1,179 @@
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaveworks/common/user"
+)
+
+func TestAddDeleteRequestHandler(t *testing.T) {
+	t.Run("it adds the delete request to the store", func(t *testing.T) {
+		store := &mockDeleteRequestsStore{}
+		h := NewDeleteRequestHandler(store, time.Second, nil)
+
+		req := buildRequest("org-id", `{foo="bar"}`, "0000000000", "0000000001")
+
+		w := httptest.NewRecorder()
+		h.AddDeleteRequestHandler(w, req)
+
+		require.Equal(t, "org-id", store.addedUser)
+		require.Equal(t, `{foo="bar"}`, store.addedQuery)
+		require.Equal(t, toTime("0000000000"), store.addedStartTime)
+		require.Equal(t, toTime("0000000001"), store.addedEndTime)
+
+		require.Equal(t, w.Code, http.StatusNoContent)
+	})
+
+	t.Run("it works with RFC3339", func(t *testing.T) {
+		store := &mockDeleteRequestsStore{}
+		h := NewDeleteRequestHandler(store, time.Second, nil)
+
+		req := buildRequest("org-id", `{foo="bar"}`, "2006-01-02T15:04:05Z", "2006-01-03T15:04:05Z")
+
+		w := httptest.NewRecorder()
+		h.AddDeleteRequestHandler(w, req)
+
+		require.Equal(t, w.Code, http.StatusNoContent)
+
+		require.Equal(t, "org-id", store.addedUser)
+		require.Equal(t, `{foo="bar"}`, store.addedQuery)
+		require.Equal(t, toTime("1136214245"), store.addedStartTime)
+		require.Equal(t, toTime("1136300645"), store.addedEndTime)
+	})
+
+	t.Run("it returns 500 when the delete store errors", func(t *testing.T) {
+		store := &mockDeleteRequestsStore{addErr: errors.New("something bad")}
+		h := NewDeleteRequestHandler(store, time.Second, nil)
+
+		req := buildRequest("org-id", `{foo="bar"}`, "0000000000", "0000000001")
+
+		w := httptest.NewRecorder()
+		h.AddDeleteRequestHandler(w, req)
+		require.Equal(t, w.Code, http.StatusInternalServerError)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, time.Second, nil)
+
+		t.Run("userid", func(t *testing.T) {
+			req := buildRequest("", `{foo="bar"}`, "0000000000", "0000000001")
+
+			w := httptest.NewRecorder()
+			h.AddDeleteRequestHandler(w, req)
+
+			require.Equal(t, w.Code, http.StatusBadRequest)
+			require.Equal(t, w.Body.String(), "no org id\n")
+		})
+
+		t.Run("query", func(t *testing.T) {
+			t.Run("doesn't exist", func(t *testing.T) {
+				req := buildRequest("org-id", "", "0000000000", "0000000001")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "query not set\n")
+			})
+
+			t.Run("unparsable", func(t *testing.T) {
+				req := buildRequest("org-id", `not a query`, "0000000000", "0000000001")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "invalid query expression\n")
+			})
+		})
+
+		t.Run("start time", func(t *testing.T) {
+			t.Run("exists", func(t *testing.T) {
+				req := buildRequest("org-id", `{foo="bar"}`, "", "0000000001")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "start time not set\n")
+			})
+
+			t.Run("is parsable", func(t *testing.T) {
+				req := buildRequest("org-id", `{foo="bar"}`, "0000000000000", "0000000001")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "invalid start time: require unix seconds or RFC3339 format\n")
+			})
+		})
+
+		t.Run("end time", func(t *testing.T) {
+			t.Run("is parsable", func(t *testing.T) {
+				req := buildRequest("org-id", `{foo="bar"}`, "0000000000", "0000000000001")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "invalid start time: require unix seconds or RFC3339 format\n")
+			})
+
+			t.Run("is <= now", func(t *testing.T) {
+				startTime := fmt.Sprint(time.Now().Add(time.Hour).Unix())[:10]
+				req := buildRequest("org-id", `{foo="bar"}`, startTime, "0000000000")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "start time can't be greater than end time\n")
+			})
+
+			t.Run("is > start", func(t *testing.T) {
+				req := buildRequest("org-id", `{foo="bar"}`, "0000000001", "0000000000")
+
+				w := httptest.NewRecorder()
+				h.AddDeleteRequestHandler(w, req)
+
+				require.Equal(t, w.Code, http.StatusBadRequest)
+				require.Equal(t, w.Body.String(), "start time can't be greater than end time\n")
+			})
+		})
+	})
+}
+
+func buildRequest(orgID, query, start, end string) *http.Request {
+	var req *http.Request
+	if orgID == "" {
+		req, _ = http.NewRequest(http.MethodGet, "", nil)
+	} else {
+		ctx := user.InjectOrgID(context.Background(), orgID)
+		req, _ = http.NewRequestWithContext(ctx, http.MethodGet, "", nil)
+	}
+
+	q := req.URL.Query()
+	q.Set("query", query)
+	q.Set("start", start)
+	q.Set("end", end)
+	req.URL.RawQuery = q.Encode()
+
+	return req
+}
+
+func toTime(t string) model.Time {
+	modelTime, _ := util.ParseTime(t)
+	return model.Time(modelTime)
+}

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client.go
@@ -6,6 +6,8 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 )
 
+const deletionNotAvailableMsg = "deletion is not available for this tenant"
+
 type perTenantDeleteRequestsClient struct {
 	client DeleteRequestsClient
 	limits retention.Limits

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client.go
@@ -2,18 +2,20 @@ package deletion
 
 import (
 	"context"
-
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 )
 
 const deletionNotAvailableMsg = "deletion is not available for this tenant"
 
-type perTenantDeleteRequestsClient struct {
-	client DeleteRequestsClient
-	limits retention.Limits
+type Limits interface {
+	DeletionMode(userID string) string
 }
 
-func NewPerTenantDeleteRequestsClient(c DeleteRequestsClient, l retention.Limits) DeleteRequestsClient {
+type perTenantDeleteRequestsClient struct {
+	client DeleteRequestsClient
+	limits Limits
+}
+
+func NewPerTenantDeleteRequestsClient(c DeleteRequestsClient, l Limits) DeleteRequestsClient {
 	return &perTenantDeleteRequestsClient{
 		client: c,
 		limits: l,

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_delete_requests_client_test.go
@@ -26,27 +26,6 @@ func TestTenantDeleteRequestsClient(t *testing.T) {
 		require.Nil(t, err)
 		require.Empty(t, reqs)
 	})
-
-	t.Run("tenant disabled but default enabled", func(t *testing.T) {
-		limits.defaultLimit.compactorDeletionEnabled = "filter-only"
-		reqs, err := perTenantClient.GetAllDeleteRequestsForUser(context.Background(), "2")
-		require.Nil(t, err)
-		require.Empty(t, reqs)
-	})
-
-	t.Run("default is enabled", func(t *testing.T) {
-		limits.defaultLimit.compactorDeletionEnabled = "filter-and-delete"
-		reqs, err := perTenantClient.GetAllDeleteRequestsForUser(context.Background(), "3")
-		require.Nil(t, err)
-		require.Equal(t, []DeleteRequest{{RequestID: "test-request"}}, reqs)
-	})
-
-	t.Run("default is disabled", func(t *testing.T) {
-		limits.defaultLimit.compactorDeletionEnabled = "disabled"
-		reqs, err := perTenantClient.GetAllDeleteRequestsForUser(context.Background(), "3")
-		require.Nil(t, err)
-		require.Empty(t, reqs)
-	})
 }
 
 type fakeRequestsClient struct {
@@ -61,9 +40,9 @@ func (c *fakeRequestsClient) GetAllDeleteRequestsForUser(_ context.Context, user
 
 var (
 	limits = &fakeLimits{
-		perTenant: map[string]retentionLimit{
-			"1": {compactorDeletionEnabled: "filter-only"},
-			"2": {compactorDeletionEnabled: "disabled"},
+		limits: map[string]string{
+			"1": "filter-only",
+			"2": "disabled",
 		},
 	}
 )

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler.go
@@ -3,12 +3,10 @@ package deletion
 import (
 	"net/http"
 
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
-
 	"github.com/grafana/dskit/tenant"
 )
 
-func TenantMiddleware(limits retention.Limits, next http.Handler) http.Handler {
+func TenantMiddleware(limits Limits, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		userID, err := tenant.TenantID(ctx)

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler.go
@@ -1,0 +1,36 @@
+package deletion
+
+import (
+	"net/http"
+
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
+
+	"github.com/grafana/dskit/tenant"
+)
+
+func TenantMiddleware(limits retention.Limits, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userID, err := tenant.TenantID(ctx)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		allLimits := limits.AllByUserID()
+		userLimits, ok := allLimits[userID]
+		if ok {
+			if !userLimits.CompactorDeletionEnabled {
+				http.Error(w, deletionNotAvailableMsg, http.StatusForbidden)
+				return
+			}
+		} else {
+			if !limits.DefaultLimits().CompactorDeletionEnabled {
+				http.Error(w, deletionNotAvailableMsg, http.StatusForbidden)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/tenant_request_handler_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/validation"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/validation"
 )
 
 func TestDeleteRequestHandlerDeletionMiddleware(t *testing.T) {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/util.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/util.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
 
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
-
 	"github.com/grafana/loki/pkg/logql/syntax"
 )
 
@@ -24,7 +22,7 @@ func parseDeletionQuery(query string) (syntax.LogSelectorExpr, error) {
 	return logSelectorExpr, nil
 }
 
-func validDeletionLimit(l retention.Limits, userID string) (bool, error) {
+func validDeletionLimit(l Limits, userID string) (bool, error) {
 	mode, err := deleteModeFromLimits(l, userID)
 	if err != nil {
 		return false, err
@@ -33,10 +31,7 @@ func validDeletionLimit(l retention.Limits, userID string) (bool, error) {
 	return mode.DeleteEnabled(), nil
 }
 
-func deleteModeFromLimits(l retention.Limits, userID string) (deletionmode.Mode, error) {
-	allLimits := l.AllByUserID()
-	if userLimits, ok := allLimits[userID]; ok {
-		return deletionmode.ParseMode(userLimits.DeletionMode)
-	}
-	return deletionmode.ParseMode(l.DefaultLimits().DeletionMode)
+func deleteModeFromLimits(l Limits, userID string) (deletionmode.Mode, error) {
+	mode := l.DeletionMode(userID)
+	return deletionmode.ParseMode(mode)
 }


### PR DESCRIPTION
To help protect against pathological delete scenarios, this PR adds the following validation to the Delete API:
- Ensure a start date is present
- Ensure the timestamp format is either 10-digit Unix seconds or RFC3339

Additionally, this PR moves the delete middleware to it's own file. This is just so validation testing could be done without setting up limits.
