### PR TITLE
fix(stats_collector): Do not collect stats for failed requests.

### DIFF
--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -115,6 +115,9 @@ func StatsCollectorMiddleware() queryrangebase.Middleware {
 
 			// execute the request
 			resp, err := next.Do(statsCtx, req)
+			if err != nil {
+				return resp, err
+			}
 
 			// collect stats and status
 			var statistics *stats.Result
@@ -175,9 +178,8 @@ func StatsCollectorMiddleware() queryrangebase.Middleware {
 				case *LokiSeriesRequest:
 					data.match = r.Match
 				}
-
 			}
-			return resp, err
+			return resp, nil
 		})
 	})
 }

--- a/pkg/querier/queryrange/stats_test.go
+++ b/pkg/querier/queryrange/stats_test.go
@@ -2,6 +2,7 @@ package queryrange
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -63,6 +64,18 @@ func TestStatsCollectorMiddleware(t *testing.T) {
 	require.Equal(t, true, data.recorded)
 	require.Equal(t, now, data.params.Start())
 	require.Equal(t, int32(10), data.statistics.Ingester.TotalReached)
+
+	// Do not collect stats if request `next` handler returns error.
+	// Rationale is in that case returned `response` will be nil and there won't be any `response.statistics` to collect.
+	data = &queryData{}
+	ctx = context.WithValue(context.Background(), ctxKey, data)
+	_, _ = StatsCollectorMiddleware().Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		return nil, errors.New("request timedout")
+	})).Do(ctx, &LokiRequest{
+		Query:   "foo",
+		StartTs: now,
+	})
+	require.Equal(t, false, data.recorded)
 }
 
 func Test_StatsHTTP(t *testing.T) {

--- a/pkg/querier/queryrange/stats_test.go
+++ b/pkg/querier/queryrange/stats_test.go
@@ -65,8 +65,8 @@ func TestStatsCollectorMiddleware(t *testing.T) {
 	require.Equal(t, now, data.params.Start())
 	require.Equal(t, int32(10), data.statistics.Ingester.TotalReached)
 
-	// Do not collect stats if request `next` handler returns error.
-	// Rationale is in that case returned `response` will be nil and there won't be any `response.statistics` to collect.
+	// Do not collect stats if the `next` handler returns error.
+	// Rationale being, in that case returned `response` will be nil and there won't be any `response.statistics` to collect.
 	data = &queryData{}
 	ctx = context.WithValue(context.Background(), ctxKey, data)
 	_, _ = StatsCollectorMiddleware().Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {


### PR DESCRIPTION


Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
When any type of query fails, do not collect statistics.
Rationale being when core http handler returns error, it's reponse will be nil and there won't be any statistics
to collect and log.


**Which issue(s) this PR fixes**:
Fixes #6231 

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
