### PR TITLE
Add timeouts to deletions 

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2105,6 +2105,15 @@ compacts index shards to more performant forms.
 # CLI flag: -boltdb.shipper.compactor.delete-request-cancel-period
 [delete_request_cancel_period: <duration> | default = 24h]
 
+# The max number of delete requests to run per compaction cycle.
+# CLI flag: -boltdb.shipper.compactor.delete-batch-size
+[delete_batch_size: <duration> | default = 70]
+
+# The maximum amount of time to spend on deletion during a retention compaction.
+# 0 is no timeout
+# CLI flag: -boltdb.shipper.compactor.delete-timeout
+[delete_timeout: <duration> | default = 0]
+
 # Maximum number of tables to compact in parallel.
 # While increasing this value, please make sure compactor has enough disk space
 # allocated to be able to store and compact as many tables.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2109,10 +2109,14 @@ compacts index shards to more performant forms.
 # CLI flag: -boltdb.shipper.compactor.delete-batch-size
 [delete_batch_size: <duration> | default = 70]
 
-# The maximum amount of time to spend on deletion during a retention compaction.
-# 0 is no timeout
-# CLI flag: -boltdb.shipper.compactor.delete-timeout
-[delete_timeout: <duration> | default = 0]
+# The maximum amount of time to spend running retention and deletion
+# on any given table in the index. 0 is no timeout
+#
+# NOTE: This timeout prioritizes runtime over completeness of retention/deletion.
+# It may take several compaction runs to fully perform retention and process
+# all outstanding delete requests
+# CLI flag: -boltdb.shipper.compactor.retention-table-timeout
+[retention_table_timeout: <duration> | default = 0]
 
 # Maximum number of tables to compact in parallel.
 # While increasing this value, please make sure compactor has enough disk space

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -78,9 +78,9 @@ type Config struct {
 	RetentionEnabled          bool            `yaml:"retention_enabled"`
 	RetentionDeleteDelay      time.Duration   `yaml:"retention_delete_delay"`
 	RetentionDeleteWorkCount  int             `yaml:"retention_delete_worker_count"`
+	RetentionTableTimeout     time.Duration   `yaml:"retention_table_timeout"`
 	DeleteBatchSize           int             `yaml:"delete_batch_size"`
 	DeleteRequestCancelPeriod time.Duration   `yaml:"delete_request_cancel_period"`
-	DeleteTimeout             time.Duration   `yaml:"delete_timeout"`
 	MaxCompactionParallelism  int             `yaml:"max_compaction_parallelism"`
 	CompactorRing             util.RingConfig `yaml:"compactor_ring,omitempty"`
 	RunOnce                   bool            `yaml:"-"`
@@ -98,7 +98,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.RetentionDeleteWorkCount, "boltdb.shipper.compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
 	f.IntVar(&cfg.DeleteBatchSize, "boltdb.shipper.compactor.delete-batch-size", 70, "The max number of delete requests to run per compaction cycle.")
 	f.DurationVar(&cfg.DeleteRequestCancelPeriod, "boltdb.shipper.compactor.delete-request-cancel-period", 24*time.Hour, "Allow cancellation of delete request until duration after they are created. Data would be deleted only after delete requests have been older than this duration. Ideally this should be set to at least 24h.")
-	f.DurationVar(&cfg.DeleteTimeout, "boltdb.shipper.compactor.delete-timeout", 0, "The maximum amount of time to spend on deletion during a retention compaction.")
+	f.DurationVar(&cfg.RetentionTableTimeout, "boltdb.shipper.compactor.retention-table-timeout", 0, "The maximum amount of time to spend running retention and deletion on any given table in the index.")
 	f.IntVar(&cfg.MaxCompactionParallelism, "boltdb.shipper.compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
 	f.BoolVar(&cfg.RunOnce, "boltdb.shipper.compactor.run-once", false, "Run the compactor one time to cleanup and compact index files only (no retention applied)")
 	cfg.CompactorRing.RegisterFlagsWithPrefix("boltdb.shipper.compactor.", "collectors/", f)
@@ -235,7 +235,7 @@ func (c *Compactor) init(objectClient client.ObjectClient, schemaConfig config.S
 			return err
 		}
 
-		c.tableMarker, err = retention.NewMarker(retentionWorkDir, c.expirationChecker, c.cfg.DeleteTimeout, chunkClient, r)
+		c.tableMarker, err = retention.NewMarker(retentionWorkDir, c.expirationChecker, c.cfg.RetentionTableTimeout, chunkClient, r)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -637,6 +637,11 @@ func (e *expirationChecker) MarkPhaseFinished() {
 	e.deletionExpiryChecker.MarkPhaseFinished()
 }
 
+func (e *expirationChecker) MarkPhaseTimedOut() {
+	e.retentionExpiryChecker.MarkPhaseTimedOut()
+	e.deletionExpiryChecker.MarkPhaseTimedOut()
+}
+
 func (e *expirationChecker) IntervalMayHaveExpiredChunks(interval model.Interval, userID string) bool {
 	return e.retentionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID) || e.deletionExpiryChecker.IntervalMayHaveExpiredChunks(interval, userID)
 }

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
@@ -289,6 +289,15 @@ func (d *DeleteRequestsManager) MarkPhaseFailed() {
 	d.deleteRequestsToProcessMtx.Lock()
 	defer d.deleteRequestsToProcessMtx.Unlock()
 
+	d.metrics.deletionFailures.WithLabelValues("error").Inc()
+	d.deleteRequestsToProcess = map[string]*userDeleteRequests{}
+}
+
+func (d *DeleteRequestsManager) MarkPhaseTimedOut() {
+	d.deleteRequestsToProcessMtx.Lock()
+	defer d.deleteRequestsToProcessMtx.Unlock()
+
+	d.metrics.deletionFailures.WithLabelValues("timeout").Inc()
 	d.deleteRequestsToProcess = map[string]*userDeleteRequests{}
 }
 

--- a/pkg/storage/stores/indexshipper/compactor/deletion/metrics.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/metrics.go
@@ -48,6 +48,7 @@ type deleteRequestsManagerMetrics struct {
 	deleteRequestsProcessedTotal         *prometheus.CounterVec
 	deleteRequestsChunksSelectedTotal    *prometheus.CounterVec
 	loadPendingRequestsAttemptsTotal     *prometheus.CounterVec
+	deletionFailures                     *prometheus.CounterVec
 	oldestPendingDeleteRequestAgeSeconds prometheus.Gauge
 	pendingDeleteRequestsCount           prometheus.Gauge
 	deletedLinesTotal                    *prometheus.CounterVec
@@ -66,6 +67,11 @@ func newDeleteRequestsManagerMetrics(r prometheus.Registerer) *deleteRequestsMan
 		Name:      "compactor_delete_requests_chunks_selected_total",
 		Help:      "Number of chunks selected while building delete plans per user",
 	}, []string{"user"})
+	m.deletionFailures = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "loki",
+		Name:      "compactor_delete_processing_fails_total",
+		Help:      "Number times the delete phase of compaction has failed",
+	}, []string{"cause"})
 	m.loadPendingRequestsAttemptsTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Namespace: "loki",
 		Name:      "compactor_load_pending_requests_attempts_total",

--- a/pkg/storage/stores/indexshipper/compactor/index_set.go
+++ b/pkg/storage/stores/indexshipper/compactor/index_set.go
@@ -97,6 +97,10 @@ func newIndexSet(ctx context.Context, tableName, userID string, baseIndexSet sto
 		logger:       logger,
 	}
 
+	if userID != "" {
+		ui.logger = log.With(logger, "user-id", userID)
+	}
+
 	var err error
 	ui.sourceObjects, err = ui.baseIndexSet.ListFiles(ui.ctx, ui.tableName, ui.userID, false)
 	if err != nil {

--- a/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
@@ -26,6 +26,7 @@ type ExpirationChecker interface {
 	IntervalMayHaveExpiredChunks(interval model.Interval, userID string) bool
 	MarkPhaseStarted()
 	MarkPhaseFailed()
+	MarkPhaseTimedOut()
 	MarkPhaseFinished()
 	DropFromIndex(ref ChunkEntry, tableEndTime model.Time, now model.Time) bool
 }
@@ -71,6 +72,7 @@ func (e *expirationChecker) MarkPhaseStarted() {
 }
 
 func (e *expirationChecker) MarkPhaseFailed()   {}
+func (e *expirationChecker) MarkPhaseTimedOut() {}
 func (e *expirationChecker) MarkPhaseFinished() {}
 
 func (e *expirationChecker) IntervalMayHaveExpiredChunks(interval model.Interval, userID string) bool {
@@ -105,6 +107,7 @@ func (e *neverExpiringExpirationChecker) IntervalMayHaveExpiredChunks(interval m
 }
 func (e *neverExpiringExpirationChecker) MarkPhaseStarted()  {}
 func (e *neverExpiringExpirationChecker) MarkPhaseFailed()   {}
+func (e *neverExpiringExpirationChecker) MarkPhaseTimedOut() {}
 func (e *neverExpiringExpirationChecker) MarkPhaseFinished() {}
 func (e *neverExpiringExpirationChecker) DropFromIndex(ref ChunkEntry, tableEndTime model.Time, now model.Time) bool {
 	return false

--- a/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
@@ -192,11 +192,11 @@ func Test_EmptyTable(t *testing.T) {
 
 	tables := store.indexTables()
 	require.Len(t, tables, 1)
-	empty, _, err := markForDelete(context.Background(), time.Hour, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil)
+	empty, _, err := markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil)
 	require.NoError(t, err)
 	require.True(t, empty)
 
-	_, _, err = markForDelete(context.Background(), time.Hour, tables[0].name, noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil)
+	_, _, err = markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil)
 	require.Equal(t, err, errNoChunksFound)
 }
 
@@ -668,7 +668,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				seriesCleanRecorder := newSeriesCleanRecorder(table)
 
 				cr := newChunkRewriter(store.chunkClient, table.name, table)
-				empty, isModified, err := markForDelete(context.Background(), time.Hour, table.name, noopWriter{}, seriesCleanRecorder,
+				empty, isModified, err := markForDelete(context.Background(), 0, table.name, noopWriter{}, seriesCleanRecorder,
 					expirationChecker, cr)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedEmpty[i], empty)
@@ -746,7 +746,7 @@ func TestMarkForDelete_DropChunkFromIndex(t *testing.T) {
 	require.Len(t, tables, 8)
 
 	for i, table := range tables {
-		empty, _, err := markForDelete(context.Background(), time.Hour, table.name, noopWriter{}, table,
+		empty, _, err := markForDelete(context.Background(), 0, table.name, noopWriter{}, table,
 			NewExpirationChecker(fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: retentionPeriod}}}), nil)
 		require.NoError(t, err)
 		if i == 7 {

--- a/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
@@ -456,6 +456,10 @@ func (m *mockExpirationChecker) DropFromIndex(ref ChunkEntry, tableEndTime model
 	return false
 }
 
+func (m *mockExpirationChecker) MarkPhaseTimedOut() {
+
+}
+
 func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 	now := model.Now()
 	schema := allSchemas[2]

--- a/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
@@ -192,11 +192,11 @@ func Test_EmptyTable(t *testing.T) {
 
 	tables := store.indexTables()
 	require.Len(t, tables, 1)
-	empty, _, err := markforDelete(context.Background(), tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil)
+	empty, _, err := markForDelete(context.Background(), time.Hour, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil)
 	require.NoError(t, err)
 	require.True(t, empty)
 
-	_, _, err = markforDelete(context.Background(), tables[0].name, noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil)
+	_, _, err = markForDelete(context.Background(), time.Hour, tables[0].name, noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil)
 	require.Equal(t, err, errNoChunksFound)
 }
 
@@ -658,7 +658,7 @@ func TestMarkForDelete_SeriesCleanup(t *testing.T) {
 				seriesCleanRecorder := newSeriesCleanRecorder(table)
 
 				cr := newChunkRewriter(store.chunkClient, table.name, table)
-				empty, isModified, err := markforDelete(context.Background(), table.name, noopWriter{}, seriesCleanRecorder,
+				empty, isModified, err := markForDelete(context.Background(), time.Hour, table.name, noopWriter{}, seriesCleanRecorder,
 					expirationChecker, cr)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedEmpty[i], empty)
@@ -696,7 +696,7 @@ func TestMarkForDelete_DropChunkFromIndex(t *testing.T) {
 	require.Len(t, tables, 8)
 
 	for i, table := range tables {
-		empty, _, err := markforDelete(context.Background(), table.name, noopWriter{}, table,
+		empty, _, err := markForDelete(context.Background(), time.Hour, table.name, noopWriter{}, table,
 			NewExpirationChecker(fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: retentionPeriod}}}), nil)
 		require.NoError(t, err)
 		if i == 7 {

--- a/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
@@ -121,7 +121,7 @@ type table struct {
 	chunks map[string][]chunk.Chunk
 }
 
-func (t *table) ForEachChunk(callback ChunkEntryCallback) error {
+func (t *table) ForEachChunk(_ context.Context, callback ChunkEntryCallback) error {
 	for userID, chks := range t.chunks {
 		i := 0
 		for _, chk := range chks {

--- a/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
@@ -121,10 +121,11 @@ type table struct {
 	chunks map[string][]chunk.Chunk
 }
 
-func (t *table) ForEachChunk(_ context.Context, callback ChunkEntryCallback) error {
+func (t *table) ForEachChunk(ctx context.Context, callback ChunkEntryCallback) error {
 	for userID, chks := range t.chunks {
 		i := 0
-		for _, chk := range chks {
+		for j := 0; j < len(chks) && ctx.Err() == nil; j++ {
+			chk := chks[j]
 			deleteChunk, err := callback(entryFromChunk(chk))
 			if err != nil {
 				return err
@@ -139,7 +140,7 @@ func (t *table) ForEachChunk(_ context.Context, callback ChunkEntryCallback) err
 		t.chunks[userID] = t.chunks[userID][:i]
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 func (t *table) IndexChunk(chunk chunk.Chunk) (bool, error) {

--- a/pkg/storage/stores/indexshipper/compactor/testutil.go
+++ b/pkg/storage/stores/indexshipper/compactor/testutil.go
@@ -160,7 +160,7 @@ func openCompactedIndex(path string) (*compactedIndex, error) {
 	return &compactedIndex{indexFile: idxFile}, nil
 }
 
-func (c compactedIndex) ForEachChunk(_ retention.ChunkEntryCallback) error {
+func (c compactedIndex) ForEachChunk(_ context.Context, _ retention.ChunkEntryCallback) error {
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/index/compactor/compacted_index.go
+++ b/pkg/storage/stores/shipper/index/compactor/compacted_index.go
@@ -1,6 +1,7 @@
 package compactor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -135,7 +136,7 @@ func (c *CompactedIndex) setupIndexProcessors() error {
 	return nil
 }
 
-func (c *CompactedIndex) ForEachChunk(callback retention.ChunkEntryCallback) error {
+func (c *CompactedIndex) ForEachChunk(ctx context.Context, callback retention.ChunkEntryCallback) error {
 	if err := c.setupIndexProcessors(); err != nil {
 		return err
 	}
@@ -145,7 +146,7 @@ func (c *CompactedIndex) ForEachChunk(callback retention.ChunkEntryCallback) err
 		return fmt.Errorf("required boltdb bucket not found")
 	}
 
-	return ForEachChunk(bucket, c.periodConfig, callback)
+	return ForEachChunk(ctx, bucket, c.periodConfig, callback)
 }
 
 func (c *CompactedIndex) IndexChunk(chunk chunk.Chunk) (bool, error) {

--- a/pkg/storage/stores/shipper/index/compactor/compacted_index_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/compacted_index_test.go
@@ -46,7 +46,7 @@ func TestCompactedIndex_IndexProcessor(t *testing.T) {
 
 			// remove c1, c2 chunk and index c4 with same labels as c2
 			c4 := createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "bar"}, labels.Label{Name: "fizz", Value: "buzz"}}, tt.from, tt.from.Add(30*time.Minute))
-			err := compactedIndex.ForEachChunk(func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+			err := compactedIndex.ForEachChunk(context.Background(), func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 				if entry.Labels.Get("fizz") == "buzz" {
 					chunkIndexed, err := compactedIndex.IndexChunk(c4)
 					require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestCompactedIndex_IndexProcessor(t *testing.T) {
 			}
 			chunkEntriesFound := []retention.ChunkEntry{}
 			err = modifiedBoltDB.View(func(tx *bbolt.Tx) error {
-				return ForEachChunk(tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 					chunkEntriesFound = append(chunkEntriesFound, entry)
 					return false, nil
 				})

--- a/pkg/storage/stores/shipper/index/compactor/iterator_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/iterator_test.go
@@ -42,7 +42,7 @@ func Test_ChunkIterator(t *testing.T) {
 			require.Len(t, tables, 1)
 			var actual []retention.ChunkEntry
 			err := tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 					actual = append(actual, entry)
 					return len(actual) == 2, nil
 				})
@@ -56,7 +56,7 @@ func Test_ChunkIterator(t *testing.T) {
 			// second pass we delete c2
 			actual = actual[:0]
 			err = tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 					actual = append(actual, entry)
 					return false, nil
 				})
@@ -67,6 +67,37 @@ func Test_ChunkIterator(t *testing.T) {
 			}, actual)
 		})
 	}
+}
+
+func Test_ChunkIteratorContextCancelation(t *testing.T) {
+	cm := storage.NewClientMetrics()
+	defer cm.Unregister()
+	store := newTestStore(t, cm)
+
+	from := schemaCfg.Configs[0].From.Time
+	c1 := createChunk(t, "1", labels.Labels{labels.Label{Name: "foo", Value: "bar"}}, from, from.Add(1*time.Hour))
+	c2 := createChunk(t, "2", labels.Labels{labels.Label{Name: "foo", Value: "buzz"}, labels.Label{Name: "bar", Value: "foo"}}, from, from.Add(1*time.Hour))
+
+	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{c1, c2}))
+	store.Stop()
+
+	tables := store.indexTables()
+	require.Len(t, tables, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var actual []retention.ChunkEntry
+	err := tables[0].DB.Update(func(tx *bbolt.Tx) error {
+		return ForEachChunk(ctx, tx.Bucket(local.IndexBucketName), schemaCfg.Configs[0], func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+			actual = append(actual, entry)
+			cancel()
+			return len(actual) == 2, nil
+		})
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, actual, 1)
 }
 
 func Test_SeriesCleaner(t *testing.T) {
@@ -91,7 +122,7 @@ func Test_SeriesCleaner(t *testing.T) {
 			require.Len(t, tables, 1)
 			// remove c1, c2 chunk
 			err := tables[0].DB.Update(func(tx *bbolt.Tx) error {
-				return ForEachChunk(tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+				return ForEachChunk(context.Background(), tx.Bucket(local.IndexBucketName), tt.config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 					return entry.Labels.Get("bar") == "foo", nil
 				})
 			})
@@ -213,7 +244,7 @@ func Benchmark_ChunkIterator(b *testing.B) {
 	_ = store.indexTables()[0].Update(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket(local.IndexBucketName)
 		for n := 0; n < b.N; n++ {
-			err := ForEachChunk(bucket, allSchemas[0].config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
+			err := ForEachChunk(context.Background(), bucket, allSchemas[0].config, func(entry retention.ChunkEntry) (deleteChunk bool, err error) {
 				chunkEntry = entry
 				total++
 				return true, nil

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -269,7 +269,7 @@ func newCompactedIndex(ctx context.Context, tableName, userID, workingDir string
 }
 
 // ForEachChunk iterates over all the chunks in the builder and calls the callback function.
-func (c *compactedIndex) ForEachChunk(callback retention.ChunkEntryCallback) error {
+func (c *compactedIndex) ForEachChunk(ctx context.Context, callback retention.ChunkEntryCallback) error {
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{c.periodConfig},
 	}
@@ -287,7 +287,8 @@ func (c *compactedIndex) ForEachChunk(callback retention.ChunkEntryCallback) err
 		chunkEntry.SeriesID = getUnsafeBytes(seriesID)
 		chunkEntry.Labels = withoutTenantLabel(stream.labels)
 
-		for _, chk := range stream.chunks {
+		for i := 0; i < len(stream.chunks) && ctx.Err() == nil; i++ {
+			chk := stream.chunks[i]
 			logprotoChunkRef.From = chk.From()
 			logprotoChunkRef.Through = chk.Through()
 			logprotoChunkRef.Checksum = chk.Checksum
@@ -308,7 +309,7 @@ func (c *compactedIndex) ForEachChunk(callback retention.ChunkEntryCallback) err
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 // IndexChunk adds the chunk to the list of chunks to index.

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -639,6 +639,198 @@ func chunkMetaToChunkRef(userID string, chunkMeta index.ChunkMeta, lbls labels.L
 }
 
 func TestCompactedIndex(t *testing.T) {
+	testCtx := setupCompactedIndex(t)
+
+	for name, tc := range map[string]struct {
+		deleteChunks map[string]index.ChunkMetas
+		addChunks    []chunk.Chunk
+		deleteSeries []labels.Labels
+
+		shouldErr           bool
+		finalExpectedChunks map[string]index.ChunkMetas
+	}{
+		"no changes": {
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(10)),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"delete some chunks from a stream": {
+			deleteChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): append(buildChunkMetas(testCtx.shiftTableStart(3), testCtx.shiftTableStart(5)), buildChunkMetas(testCtx.shiftTableStart(7), testCtx.shiftTableStart(8))...),
+			},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): append(buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(2)), append(buildChunkMetas(testCtx.shiftTableStart(6), testCtx.shiftTableStart(6)), buildChunkMetas(testCtx.shiftTableStart(9), testCtx.shiftTableStart(10))...)...),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"delete all chunks from a stream": {
+			deleteChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(10)),
+			},
+			deleteSeries: []labels.Labels{testCtx.lbls1},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"add some chunks to a stream": {
+			addChunks: []chunk.Chunk{
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(11), testCtx.shiftTableStart(11))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(12), testCtx.shiftTableStart(12))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+			},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(12)),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"add some chunks out of table interval to a stream": {
+			addChunks: []chunk.Chunk{
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(11), testCtx.shiftTableStart(11))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(12), testCtx.shiftTableStart(12))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				// these chunks should not be added
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(int64(testCtx.tableInterval.End+100), int64(testCtx.tableInterval.End+100))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(int64(testCtx.tableInterval.End+200), int64(testCtx.tableInterval.End+200))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+			},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(12)),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"add and delete some chunks in a stream": {
+			addChunks: []chunk.Chunk{
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(11), testCtx.shiftTableStart(11))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(12), testCtx.shiftTableStart(12))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+			},
+			deleteChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(3), testCtx.shiftTableStart(5)),
+			},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): append(buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(2)), buildChunkMetas(testCtx.shiftTableStart(6), testCtx.shiftTableStart(12))...),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
+		"adding chunk to non-existing stream should error": {
+			addChunks: []chunk.Chunk{
+				{
+					Metric:   labels.NewBuilder(testCtx.lbls1).Set("new", "label").Labels(),
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(11), testCtx.shiftTableStart(11))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+			},
+			shouldErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			compactedIndex := testCtx.buildCompactedIndex()
+
+			foundChunkEntries := map[string][]retention.ChunkEntry{}
+			err := compactedIndex.ForEachChunk(context.Background(), func(chunkEntry retention.ChunkEntry) (deleteChunk bool, err error) {
+				seriesIDStr := string(chunkEntry.SeriesID)
+				foundChunkEntries[seriesIDStr] = append(foundChunkEntries[seriesIDStr], chunkEntry)
+				if chks, ok := tc.deleteChunks[string(chunkEntry.SeriesID)]; ok {
+					for _, chk := range chks {
+						if chk.MinTime == int64(chunkEntry.From) && chk.MaxTime == int64(chunkEntry.Through) {
+							return true, nil
+						}
+					}
+				}
+
+				return false, nil
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, testCtx.expectedChunkEntries, foundChunkEntries)
+
+			for _, lbls := range tc.deleteSeries {
+				require.NoError(t, compactedIndex.CleanupSeries(nil, lbls))
+			}
+
+			for _, chk := range tc.addChunks {
+				_, err := compactedIndex.IndexChunk(chk)
+				require.NoError(t, err)
+			}
+
+			indexFile, err := compactedIndex.ToIndexFile()
+			if tc.shouldErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			foundChunks := map[string]index.ChunkMetas{}
+			err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(context.Background(), nil, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+				foundChunks[lbls.String()] = append(index.ChunkMetas{}, chks...)
+			}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
+			require.NoError(t, err)
+
+			require.Equal(t, tc.finalExpectedChunks, foundChunks)
+		})
+	}
+
+}
+
+func TestIteratorContextCancelation(t *testing.T) {
+	tc := setupCompactedIndex(t)
+	compactedIndex := tc.buildCompactedIndex()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var foundChunkEntries []retention.ChunkEntry
+	err := compactedIndex.ForEachChunk(ctx, func(chunkEntry retention.ChunkEntry) (deleteChunk bool, err error) {
+		foundChunkEntries = append(foundChunkEntries, chunkEntry)
+
+		return false, nil
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+type testContext struct {
+	lbls1                labels.Labels
+	lbls2                labels.Labels
+	userID               string
+	tableInterval        model.Interval
+	shiftTableStart      func(ms int64) int64
+	buildCompactedIndex  func() *compactedIndex
+	expectedChunkEntries map[string][]retention.ChunkEntry
+}
+
+func setupCompactedIndex(t *testing.T) *testContext {
+	t.Helper()
+
 	now := model.Now()
 	periodConfig := config.PeriodConfig{
 		IndexTables: config.PeriodicTableConfig{Period: config.ObjectStorageIndexRequiredPeriod},
@@ -679,164 +871,7 @@ func TestCompactedIndex(t *testing.T) {
 		lbls2.String(): chunkMetasToChunkEntry(schemaCfg, userID, lbls2, buildChunkMetas(shiftTableStart(0), shiftTableStart(20))),
 	}
 
-	for name, tc := range map[string]struct {
-		deleteChunks map[string]index.ChunkMetas
-		addChunks    []chunk.Chunk
-		deleteSeries []labels.Labels
-
-		shouldErr           bool
-		finalExpectedChunks map[string]index.ChunkMetas
-	}{
-		"no changes": {
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls1.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(10)),
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"delete some chunks from a stream": {
-			deleteChunks: map[string]index.ChunkMetas{
-				lbls1.String(): append(buildChunkMetas(shiftTableStart(3), shiftTableStart(5)), buildChunkMetas(shiftTableStart(7), shiftTableStart(8))...),
-			},
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls1.String(): append(buildChunkMetas(shiftTableStart(0), shiftTableStart(2)), append(buildChunkMetas(shiftTableStart(6), shiftTableStart(6)), buildChunkMetas(shiftTableStart(9), shiftTableStart(10))...)...),
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"delete all chunks from a stream": {
-			deleteChunks: map[string]index.ChunkMetas{
-				lbls1.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(10)),
-			},
-			deleteSeries: []labels.Labels{lbls1},
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"add some chunks to a stream": {
-			addChunks: []chunk.Chunk{
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(11), shiftTableStart(11))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(12), shiftTableStart(12))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-			},
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls1.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(12)),
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"add some chunks out of table interval to a stream": {
-			addChunks: []chunk.Chunk{
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(11), shiftTableStart(11))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(12), shiftTableStart(12))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-				// these chunks should not be added
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(int64(tableInterval.End+100), int64(tableInterval.End+100))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(int64(tableInterval.End+200), int64(tableInterval.End+200))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-			},
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls1.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(12)),
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"add and delete some chunks in a stream": {
-			addChunks: []chunk.Chunk{
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(11), shiftTableStart(11))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-				{
-					Metric:   lbls1,
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(12), shiftTableStart(12))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-			},
-			deleteChunks: map[string]index.ChunkMetas{
-				lbls1.String(): buildChunkMetas(shiftTableStart(3), shiftTableStart(5)),
-			},
-			finalExpectedChunks: map[string]index.ChunkMetas{
-				lbls1.String(): append(buildChunkMetas(shiftTableStart(0), shiftTableStart(2)), buildChunkMetas(shiftTableStart(6), shiftTableStart(12))...),
-				lbls2.String(): buildChunkMetas(shiftTableStart(0), shiftTableStart(20)),
-			},
-		},
-		"adding chunk to non-existing stream should error": {
-			addChunks: []chunk.Chunk{
-				{
-					Metric:   labels.NewBuilder(lbls1).Set("new", "label").Labels(),
-					ChunkRef: chunkMetaToChunkRef(userID, buildChunkMetas(shiftTableStart(11), shiftTableStart(11))[0], lbls1),
-					Data:     dummyChunkData{},
-				},
-			},
-			shouldErr: true,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			compactedIndex := buildCompactedIndex()
-
-			foundChunkEntries := map[string][]retention.ChunkEntry{}
-			err := compactedIndex.ForEachChunk(func(chunkEntry retention.ChunkEntry) (deleteChunk bool, err error) {
-				seriesIDStr := string(chunkEntry.SeriesID)
-				foundChunkEntries[seriesIDStr] = append(foundChunkEntries[seriesIDStr], chunkEntry)
-				if chks, ok := tc.deleteChunks[string(chunkEntry.SeriesID)]; ok {
-					for _, chk := range chks {
-						if chk.MinTime == int64(chunkEntry.From) && chk.MaxTime == int64(chunkEntry.Through) {
-							return true, nil
-						}
-					}
-				}
-
-				return false, nil
-			})
-			require.NoError(t, err)
-
-			require.Equal(t, expectedChunkEntries, foundChunkEntries)
-
-			for _, lbls := range tc.deleteSeries {
-				require.NoError(t, compactedIndex.CleanupSeries(nil, lbls))
-			}
-
-			for _, chk := range tc.addChunks {
-				_, err := compactedIndex.IndexChunk(chk)
-				require.NoError(t, err)
-			}
-
-			indexFile, err := compactedIndex.ToIndexFile()
-			if tc.shouldErr {
-				require.NotNil(t, err)
-				return
-			}
-			require.NoError(t, err)
-
-			foundChunks := map[string]index.ChunkMetas{}
-			err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(context.Background(), nil, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
-				foundChunks[lbls.String()] = append(index.ChunkMetas{}, chks...)
-			}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
-			require.NoError(t, err)
-
-			require.Equal(t, tc.finalExpectedChunks, foundChunks)
-		})
-	}
-
+	return &testContext{lbls1, lbls2, userID, tableInterval, shiftTableStart, buildCompactedIndex, expectedChunkEntries}
 }
 
 type dummyChunkData struct {

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	// loads everything into memory.
 	if err := db.View(func(t *bbolt.Tx) error {
-		return compactor.ForEachChunk(t.Bucket([]byte("index")), periodConfig, func(entry retention.ChunkEntry) (bool, error) {
+		return compactor.ForEachChunk(context.Background(), t.Bucket([]byte("index")), periodConfig, func(entry retention.ChunkEntry) (bool, error) {
 			builder.AddSeries(entry.Labels, model.Fingerprint(entry.Labels.Hash()), []index.ChunkMeta{{
 				Checksum: extractChecksumFromChunkID(entry.ChunkID),
 				MinTime:  int64(entry.From),


### PR DESCRIPTION
To help protect the system from a situation where deletes take too long and block compaction, this PR introduces timeouts to the deletion process.

As part of retention, all chunks for an affected timerange are scanned and any active deletion filters are applied. This change adds a context to that loop so that it can time out. 

The timeout may not occur exactly when the context expires. Instead, this change prioritizes changing entire chunks so that progress is made even if the timeout expires.

This change adds a `MarkPhaseTimedOut` method to `Expiration Checkers` so they can take the appropriate actions. In this case, the list of deletes to be processed are cleared which prevents `MarkPhaseFinished` from marking them as `Processed`. This ensures deletes will be retried the next time compaction happens.

There is the chance that a set of deletes will never complete so this change adds a `loki_compactor_delete_processing_fails_total` metric that records how many failures occurred and a `cause` that is either `error` or `timeout`
