### PR TITLE
[bugfix] fixes issues sharding series by storageref vs fingerprint in…

### DIFF
--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -169,10 +169,19 @@ func (h *Head) Append(ls labels.Labels, chks index.ChunkMetas) (created bool, re
 // on top of a regular hashmap and holds a slice of series to resolve hash collisions.
 // Its methods require the hash to be submitted with it to avoid re-computations throughout
 // the code.
-type seriesHashmap map[uint64][]*memSeries
+type seriesHashmap struct {
+	sync.RWMutex
+	m map[uint64][]*memSeries
+}
 
-func (m seriesHashmap) get(hash uint64, ls labels.Labels) *memSeries {
-	for _, s := range m[hash] {
+func newSeriesHashmap() *seriesHashmap {
+	return &seriesHashmap{
+		m: map[uint64][]*memSeries{},
+	}
+}
+
+func (m *seriesHashmap) get(hash uint64, ls labels.Labels) *memSeries {
+	for _, s := range m.m[hash] {
 		if labels.Equal(s.ls, ls) {
 			return s
 		}
@@ -180,49 +189,56 @@ func (m seriesHashmap) get(hash uint64, ls labels.Labels) *memSeries {
 	return nil
 }
 
-func (m seriesHashmap) set(hash uint64, s *memSeries) {
-	l := m[hash]
+func (m *seriesHashmap) set(hash uint64, s *memSeries) {
+	l := m.m[hash]
 	for i, prev := range l {
 		if labels.Equal(prev.ls, s.ls) {
 			l[i] = s
 			return
 		}
 	}
-	m[hash] = append(l, s)
+	m.m[hash] = append(l, s)
+}
+
+type memSeriesMap struct {
+	sync.RWMutex
+	m map[uint64]*memSeries
+}
+
+func newMemseriesMap() *memSeriesMap {
+	return &memSeriesMap{
+		m: map[uint64]*memSeries{},
+	}
 }
 
 type stripeSeries struct {
 	shards int
-	locks  []sync.RWMutex
-	hashes []seriesHashmap
+	// Sharded by fingerprint.
+	hashes []*seriesHashmap
 	// Sharded by ref. A series ref is the value of `size` when the series was being newly added.
-	series []map[uint64]*memSeries
+	series []*memSeriesMap
 }
 
 func newStripeSeries() *stripeSeries {
 	s := &stripeSeries{
 		shards: defaultStripeSize,
-		locks:  make([]sync.RWMutex, defaultStripeSize),
-		hashes: make([]seriesHashmap, defaultStripeSize),
-		series: make([]map[uint64]*memSeries, defaultStripeSize),
+		hashes: make([]*seriesHashmap, defaultStripeSize),
+		series: make([]*memSeriesMap, defaultStripeSize),
 	}
 	for i := range s.hashes {
-		s.hashes[i] = seriesHashmap{}
+		s.hashes[i] = newSeriesHashmap()
 	}
 	for i := range s.series {
-		s.series[i] = map[uint64]*memSeries{}
+		s.series[i] = newMemseriesMap()
 	}
 	return s
 }
 
 func (s *stripeSeries) getByID(id uint64) *memSeries {
-	i := id & uint64(s.shards-1)
-
-	s.locks[i].RLock()
-	series := s.series[i][id]
-	s.locks[i].RUnlock()
-
-	return series
+	x := s.series[id&uint64(s.shards-1)]
+	x.RLock()
+	defer x.RUnlock()
+	return x.m[id]
 }
 
 // Append adds chunks to the correct series and returns whether a new series was added
@@ -232,21 +248,22 @@ func (s *stripeSeries) Append(
 	createFn func() *memSeries,
 ) (created bool, refID uint64) {
 	fp := ls.Hash()
-	i := fp & uint64(s.shards-1)
-	mtx := &s.locks[i]
-
-	mtx.Lock()
-	series := s.hashes[i].get(fp, ls)
+	hashes := s.hashes[fp&uint64(s.shards-1)]
+	hashes.Lock()
+	series := hashes.get(fp, ls)
 	if series == nil {
 		series = createFn()
-		s.hashes[i].set(fp, series)
+		hashes.set(fp, series)
 
 		// the series locks are determined by the ref, not fingerprint
-		refIdx := series.ref & uint64(s.shards-1)
-		s.series[refIdx][series.ref] = series
+		seriesMap := s.series[series.ref&uint64(s.shards-1)]
+		seriesMap.Lock()
+		seriesMap.m[series.ref] = series
+		seriesMap.Unlock()
+
 		created = true
 	}
-	mtx.Unlock()
+	hashes.Unlock()
 
 	series.Lock()
 	series.chks = append(series.chks, chks...)


### PR DESCRIPTION
… stripeSeries

I noticed a `concurrent map read/write` panic coming from our `stripeSeries` code at
```
github.com/grafana/loki/pkg/storage/stores/tsdb.(*stripeSeries).getByID(0xc0f7f52a00, 0x2?)
```

Reading over the code, I realized we were using the same lock index during `Append` calls, which is incorrect. To fix this problem and make the code a bit easier to work with, I embedded `RWLock`s in both the `seriesHashmap` and the `memSeriesMap`. This way, we don't reuse the same locks for both purposes, as the `seriesHashmap`s are sharded by `fingerprint` whereas the `memSeriesMap`s are sharded by `StorageRef`.

ref https://github.com/grafana/loki/issues/5428