### PR TITLE
fixed typo in API host

### DIFF
--- a/docs/sources/logql/analyzer/script.js
+++ b/docs/sources/logql/analyzer/script.js
@@ -1,4 +1,4 @@
-let host = "https://logql-analyzer.grafana.com/2-6-x";
+let host = "https://logql-analyzer.grafana.net/2-6-x";
 Handlebars.registerHelper("inc", (val) => parseInt(val) + 1);
 let streamSelector = `{job="analyze"}`;
 const logsSourceInputElement = document.getElementById("logs-source-input");


### PR DESCRIPTION
we have to use logql-analyzer.grafana.net instead of using logql-analyzer.grafana.com