### PR TITLE
Remove unnecessary spin up of mock

### DIFF
--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client_test.go
@@ -296,11 +296,9 @@ func Benchmark_QueriesMatchingLargeNumOfRows(b *testing.B) {
 
 func TestDoubleRegistration(t *testing.T) {
 	r := prometheus.NewRegistry()
-	cleanup, storeAddress := createTestGrpcServer(t)
-	t.Cleanup(cleanup)
 
 	clientCfg := IndexGatewayClientConfig{
-		Address: storeAddress,
+		Address: "my-store-address:1234",
 	}
 
 	client, err := NewGatewayClient(clientCfg, r, util_log.Logger)


### PR DESCRIPTION
This removes the unnecessary spinning up of a mock for `TestDoubleRegistration`. The client itself is not used at all and that
causes it to be stopped before it is actually started.

Example flake: https://drone.grafana.net/grafana/loki/14724/2/5
