### PR TITLE
[QueryTee] Detects issuer via useragent in querytee reqs

### DIFF
--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,7 +70,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.name, r.Method, p.routeName).Inc()
+	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.name, r.Method, p.routeName, detectIssuer(r)).Inc()
 }
 
 func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *backendResponse) {
@@ -80,6 +81,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 		expectedResponseIdx int
 		responses           = make([]*backendResponse, len(p.backends))
 		query               = r.URL.RawQuery
+		issuer              = detectIssuer(r)
 	)
 
 	if r.Body != nil {
@@ -133,7 +135,13 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 			}
 
 			lvl(p.logger).Log("msg", "Backend response", "path", r.URL.Path, "query", query, "backend", b.name, "status", status, "elapsed", elapsed)
-			p.metrics.requestDuration.WithLabelValues(res.backend.name, r.Method, p.routeName, strconv.Itoa(res.statusCode())).Observe(elapsed.Seconds())
+			p.metrics.requestDuration.WithLabelValues(
+				res.backend.name,
+				r.Method,
+				p.routeName,
+				strconv.Itoa(res.statusCode()),
+				issuer,
+			).Observe(elapsed.Seconds())
 
 			// Keep track of the response if required.
 			if p.comparator != nil {
@@ -170,7 +178,7 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 				result = comparisonFailed
 			}
 
-			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.routeName, result).Inc()
+			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Inc()
 		}
 	}
 }
@@ -249,4 +257,11 @@ func (r *backendResponse) statusCode() int {
 	}
 
 	return r.status
+}
+
+func detectIssuer(r *http.Request) string {
+	if strings.HasPrefix(r.Header.Get("User-Agent"), "loki-canary") {
+		return canaryIssuer
+	}
+	return unknownIssuer
 }

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -8,6 +8,9 @@ import (
 const (
 	comparisonSuccess = "success"
 	comparisonFailed  = "fail"
+
+	unknownIssuer = "unknown"
+	canaryIssuer  = "loki-canary"
 )
 
 type ProxyMetrics struct {
@@ -23,17 +26,17 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Name:      "request_duration_seconds",
 			Help:      "Time (in seconds) spent serving HTTP requests.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 25, 50, 100},
-		}, []string{"backend", "method", "route", "status_code"}),
+		}, []string{"backend", "method", "route", "status_code", "issuer"}),
 		responsesTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_total",
 			Help:      "Total number of responses sent back to the client by the selected backend.",
-		}, []string{"backend", "method", "route"}),
+		}, []string{"backend", "method", "route", "issuer"}),
 		responsesComparedTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_compared_total",
 			Help:      "Total number of responses compared per route and backend name by result.",
-		}, []string{"backend", "route", "result"}),
+		}, []string{"backend", "route", "result", "issuer"}),
 	}
 
 	return m


### PR DESCRIPTION
This will allow us to isolate requests coming from the loki-canaries vs any other source in the query tee. This can be helpful when the canary represents most queries and thus biases the resulting metrics.