### PR TITLE
reintroduces now deprecated+noop deletion configs for compatibility

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
@@ -84,6 +85,9 @@ type Config struct {
 	MaxCompactionParallelism  int             `yaml:"max_compaction_parallelism"`
 	CompactorRing             util.RingConfig `yaml:"compactor_ring,omitempty"`
 	RunOnce                   bool            `yaml:"-"`
+
+	// Deprecated
+	DeletionMode string `yaml:"deletion_mode"`
 }
 
 // RegisterFlags registers flags.
@@ -101,6 +105,10 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.RetentionTableTimeout, "boltdb.shipper.compactor.retention-table-timeout", 0, "The maximum amount of time to spend running retention and deletion on any given table in the index.")
 	f.IntVar(&cfg.MaxCompactionParallelism, "boltdb.shipper.compactor.max-compaction-parallelism", 1, "Maximum number of tables to compact in parallel. While increasing this value, please make sure compactor has enough disk space allocated to be able to store and compact as many tables.")
 	f.BoolVar(&cfg.RunOnce, "boltdb.shipper.compactor.run-once", false, "Run the compactor one time to cleanup and compact index files only (no retention applied)")
+
+	// Deprecated
+	flagext.DeprecatedFlag(f, "boltdb.shipper.compactor.deletion-mode", "Deprecated. This has been moved to the deletion_mode per tenant configuration.", util_log.Logger)
+
 	cfg.CompactorRing.RegisterFlagsWithPrefix("boltdb.shipper.compactor.", "collectors/", f)
 }
 

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -121,7 +121,15 @@ func (cfg *Config) Validate() error {
 		return errors.New("interval for applying retention should either be set to a 0 or a multiple of compaction interval")
 	}
 
-	return shipper_storage.ValidateSharedStoreKeyPrefix(cfg.SharedStoreKeyPrefix)
+	if err := shipper_storage.ValidateSharedStoreKeyPrefix(cfg.SharedStoreKeyPrefix); err != nil {
+		return err
+	}
+
+	if cfg.DeletionMode != "" {
+		level.Warn(util_log.Logger).Log("msg", "boltdb.shipper.compactor.deletion-mode has been deprecated and will be ignored. This has been moved to the deletion_mode per tenant configuration.")
+	}
+
+	return nil
 }
 
 type Compactor struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
 
 	dskit_flagext "github.com/grafana/dskit/flagext"
@@ -248,6 +249,10 @@ func (l *Limits) Validate() error {
 
 	if _, err := deletionmode.ParseMode(l.DeletionMode); err != nil {
 		return err
+	}
+
+	if l.CompactorDeletionEnabled {
+		level.Warn(util_log.Logger).Log("msg", "The compactor.allow-deletes configuration option has been deprecated and will be ignored. Instead, use deletion_mode in the limits_configs to adjust deletion functionality")
 	}
 
 	return nil

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -7,9 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
-
+	"github.com/go-kit/log/level"
 	dskit_flagext "github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -20,6 +18,7 @@ import (
 
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/ruler/util"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
 	"github.com/grafana/loki/pkg/util/flagext"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
 
+	dskit_flagext "github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/sigv4"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/ruler/util"
 	"github.com/grafana/loki/pkg/util/flagext"
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 const (
@@ -123,6 +125,9 @@ type Limits struct {
 	// Config for overrides, convenient if it goes here.
 	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
 	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
+
+	// Deprecated
+	CompactorDeletionEnabled bool `yaml:"allow_deletes" json:"allow_deletes"`
 }
 
 type StreamRetention struct {
@@ -200,6 +205,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.QuerySplitDuration, "querier.split-queries-by-interval", "Split queries by an interval and execute in parallel, 0 disables it. This also determines how cache keys are chosen when result caching is enabled")
 
 	f.StringVar(&l.DeletionMode, "compactor.deletion-mode", "filter-and-delete", "Set the deletion mode for the user. Options are: disabled, filter-only, and filter-and-delete")
+
+	// Deprecated
+	dskit_flagext.DeprecatedFlag(f, "compactor.allow-deletes", "Deprecated. Instead, see compactor.deletion-mode which is another per tenant configuration", util_log.Logger)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.


### PR DESCRIPTION
This reintroduces a few recently deleted configurations to retain backwards compatibility for old fields, even though their behavior is now a no-op:

 * `boltdb.shipper.compactor.deletion-mode` (compactor config)
 *  `compactor.allow-deletes` (limits config)