### PR TITLE
[jsonnet] Fix conditional for deploying consul when not using memberlist

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -144,6 +144,6 @@
       ) + service.mixin.spec.withClusterIp('None'),  // headless service
 
   // Disable the consul deployment if not migrating and using memberlist
-  consul_deployment: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then null else super.consul_deployment,
-  consul_service: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then null else super.consul_service,
+  consul_deployment: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_deployment,
+  consul_service: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_service,
 }


### PR DESCRIPTION
PR #6888 broke some additional jsonnet we use internally to extend the `consul_deployment`, although the changes in that PR were necessary for OSS users who do want to use consul. 

What we need to do is use {} instead of null since `{} + null` is invalid and will result in an error. Then we can modify our internal extensions to the same conditional we have in this `memberlist.jsonnet` file to only add on to the consul deployment if we are not using memberlist.

Signed-off-by: Callum Styan <callumstyan@gmail.com>