### PR TITLE
operator: Reconcile owner reference for existing objects

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6923](https://github.com/grafana/loki/pull/6923) **xperimental**: Reconcile owner reference for existing objects
 - [6907](https://github.com/grafana/loki/pull/6907) **Red-GV**: Adding valid subscription annotation to operator metadata
 - [6479](https://github.com/grafana/loki/pull/6749) **periklis**: Update Loki operand to v2.6.1
 - [6748](https://github.com/grafana/loki/pull/6748) **periklis**: Update go4.org/unsafe/assume-no-moving-gc to latest

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1096,6 +1096,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - get
           - list
           - update
@@ -1131,6 +1132,7 @@ spec:
           - routes
           verbs:
           - create
+          - delete
           - get
           - list
           - update

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -178,6 +178,7 @@ rules:
   - servicemonitors
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -213,6 +214,7 @@ rules:
   - routes
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -80,11 +80,11 @@ type LokiStackReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -37,6 +37,10 @@ func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
 		}
 		existing.SetLabels(existingLabels)
 
+		if ownerRefs := desired.GetOwnerReferences(); len(ownerRefs) > 0 {
+			existing.SetOwnerReferences(ownerRefs)
+		}
+
 		switch existing.(type) {
 		case *corev1.ConfigMap:
 			cm := existing.(*corev1.ConfigMap)

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -18,17 +18,6 @@ import (
 )
 
 func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
-	got := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"test": "test",
-			},
-			Annotations: map[string]string{
-				"test": "test",
-			},
-		},
-	}
-
 	want := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -37,9 +26,20 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 			Annotations: map[string]string{
 				"test": "test",
 			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "loki.grafana.com/v1",
+					BlockOwnerDeletion: pointer.Bool(true),
+					Controller:         pointer.Bool(true),
+					Kind:               "LokiStack",
+					Name:               "lokistack-testing",
+					UID:                "6128aa83-de7f-47c0-abf2-4a380713b599",
+				},
+			},
 		},
 	}
 
+	got := &corev1.ConfigMap{}
 	f := manifests.MutateFuncFor(got, want)
 	err := f()
 	require.NoError(t, err)
@@ -47,6 +47,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 	// Partial mutation checks
 	require.Exactly(t, got.Labels, want.Labels)
 	require.Exactly(t, got.Annotations, want.Annotations)
+	require.Exactly(t, got.OwnerReferences, want.OwnerReferences)
 }
 
 func TestGetMutateFunc_ReturnErrOnNotSupportedType(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

Currently the `ownerReferences` of creates resources are only set when the resource is created and not included in the check when reconciliation happens. During normal operation this is not a big issue, because the reference to `LokiStack` should not change.

We recently changed the CRD version of `LokiStack` from `v1beta1` to `v1` and stopped serving the old version. This causes references to the old `v1beta1` LokiStack to become stale. This PR fixes this issue by also looking at the `ownerReferences` field during reconciliation and updating it with the current reference.

The additional privileges are needed because the apiserver will only allow an update of the `ownerReferences` field for `ServiceAccounts` that are also able to delete the object.

**Which issue(s) this PR fixes**:

[LOG-2945](https://issues.redhat.com/browse/LOG-2945)

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**

- [x] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
