### PR TITLE
Write test that reproduces issue found.

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -265,6 +265,33 @@ func Test_IncrementTimestamp(t *testing.T) {
 				},
 			},
 		},
+		"incrementing enabled, multiple repeated-timestamps": {
+			limits: incrementingEnabled,
+			push: &logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels: "{job=\"foo\"}",
+						Entries: []logproto.Entry{
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 0), Line: "hi"},
+							{Timestamp: time.Unix(123456, 0), Line: "hey there"},
+						},
+					},
+				},
+			},
+			expectedPush: &logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels: "{job=\"foo\"}",
+						Entries: []logproto.Entry{
+							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
+							{Timestamp: time.Unix(123456, 1), Line: "hi"},
+							{Timestamp: time.Unix(123456, 2), Line: "hey there"},
+						},
+					},
+				},
+			},
+		},
 		"incrementing enabled, multiple subsequent increments": {
 			limits: incrementingEnabled,
 			push: &logproto.PushRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a scenario not covered by the current implementation of the `incrementDuplicateTimestamps` configuration.
The scenario is: if multiple entries have the same timestamp, only every-other entry will be fixed.
Ex: `[a, b, c]` entries all with the same timestamp but different log contents, only entry `b` will be fixed, so `a` and `c` will still have the same timestamp.