### PR TITLE
Disable distributed cache for the default loki local config

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -21,7 +21,7 @@ query_range:
     cache:
       embedded_cache:
         enabled: true
-        distributed: true
+        distributed: false
         max_size_mb: 100
 
 schema_config:


### PR DESCRIPTION
It breaks if there's not a ring setup
