### PR TITLE
log query which causes panic in logql.clone

### DIFF
--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -450,7 +450,9 @@ func isSplittableByRange(expr syntax.SampleExpr) bool {
 func clone(expr syntax.SampleExpr) syntax.SampleExpr {
 	e, err := syntax.ParseSampleExpr(expr.String())
 	if err != nil {
-		panic(err)
+		panic(
+			errors.Wrapf(err, "error cloning query: %s", expr.String()),
+		)
 	}
 	return e
 }


### PR DESCRIPTION
Found a panic in one of our clusters and wasn't sure the query which caused it. This PR tries to log the offending query during mapping prior to the panic.