### PR TITLE
[TSDB] disables bloom filters for tsdb index on ingesters

### DIFF
--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -1,7 +1,7 @@
 package logproto
 
 import (
-	"sync/atomic"
+	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -1,6 +1,12 @@
 package logproto
 
-import "github.com/prometheus/prometheus/model/labels"
+import (
+	"sync/atomic"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
 
 // Note, this is not very efficient and use should be minimized as it requires label construction on each comparison
 type SeriesIdentifiers []SeriesIdentifier
@@ -21,3 +27,19 @@ func (xs Streams) Less(i, j int) bool { return xs[i].Labels <= xs[j].Labels }
 func (s Series) Len() int           { return len(s.Samples) }
 func (s Series) Swap(i, j int)      { s.Samples[i], s.Samples[j] = s.Samples[j], s.Samples[i] }
 func (s Series) Less(i, j int) bool { return s.Samples[i].Timestamp < s.Samples[j].Timestamp }
+
+// Safe for concurrent use
+func (m *IndexStatsResponse) AddStream(_ model.Fingerprint) {
+	atomic.AddUint64(&m.Streams, 1)
+}
+
+// Safe for concurrent use
+func (m *IndexStatsResponse) AddChunk(_ model.Fingerprint, chk index.ChunkMeta) {
+	atomic.AddUint64(&m.Chunks, 1)
+	atomic.AddUint64(&m.Bytes, uint64(chk.KB<<10))
+	atomic.AddUint64(&m.Entries, uint64(chk.Entries))
+}
+
+func (m *IndexStatsResponse) Stats() IndexStatsResponse {
+	return *m
+}

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -3,9 +3,10 @@ package logproto
 import (
 	"sync/atomic"
 
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 // Note, this is not very efficient and use should be minimized as it requires label construction on each comparison

--- a/pkg/storage/stores/index/stats/stats.go
+++ b/pkg/storage/stores/index/stats/stats.go
@@ -45,7 +45,7 @@ func (p *PoolBloom) Get() *Blooms {
 func (p *PoolBloom) Put(x *Blooms) {
 	x.Streams.ClearAll()
 	x.Chunks.ClearAll()
-	x.stats = Stats{}
+	x.stats = &Stats{}
 	p.pool.Put(x)
 }
 
@@ -75,6 +75,7 @@ func newBlooms() *Blooms {
 	return &Blooms{
 		Streams: streams,
 		Chunks:  chunks,
+		stats:   &Stats{},
 	}
 }
 
@@ -86,16 +87,16 @@ func newBlooms() *Blooms {
 type Blooms struct {
 	sync.RWMutex
 	Streams, Chunks *bloom.BloomFilter
-	stats           Stats
+	stats           *Stats
 }
 
-func (b *Blooms) Stats() Stats { return b.stats }
+func (b *Blooms) Stats() Stats { return b.stats.Stats() }
 
 func (b *Blooms) AddStream(fp model.Fingerprint) {
 	key := make([]byte, 8)
 	binary.BigEndian.PutUint64(key, uint64(fp))
 	b.add(b.Streams, key, func() {
-		b.stats.Streams++
+		b.stats.AddStream(fp)
 	})
 }
 
@@ -108,9 +109,7 @@ func (b *Blooms) AddChunk(fp model.Fingerprint, chk index.ChunkMeta) {
 	binary.BigEndian.PutUint64(key[16:], uint64(chk.MaxTime))
 	binary.BigEndian.PutUint32(key[24:], chk.Checksum)
 	b.add(b.Chunks, key, func() {
-		b.stats.Chunks++
-		b.stats.Bytes += uint64(chk.KB << 10)
-		b.stats.Entries += uint64(chk.Entries)
+		b.stats.AddChunk(fp, chk)
 	})
 }
 

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/client/util"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/grafana/loki/pkg/util/wal"
 )
@@ -624,12 +623,12 @@ func (t *tenantHeads) LabelValues(ctx context.Context, userID string, from, thro
 
 }
 
-func (t *tenantHeads) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
+func (t *tenantHeads) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
 	idx, ok := t.tenantIndex(userID, from, through)
 	if !ok {
-		return blooms, nil
+		return nil
 	}
-	return idx.Stats(ctx, userID, from, through, blooms, shard, matchers...)
+	return idx.Stats(ctx, userID, from, through, acc, shard, matchers...)
 }
 
 // helper only used in building TSDBs

--- a/pkg/storage/stores/tsdb/index.go
+++ b/pkg/storage/stores/tsdb/index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -51,7 +50,7 @@ type Index interface {
 	Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error)
 	LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error)
 	LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error)
-	Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error)
+	Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error
 }
 
 type NoopIndex struct{}
@@ -73,8 +72,8 @@ func (NoopIndex) LabelValues(ctx context.Context, userID string, from, through m
 	return nil, nil
 }
 
-func (NoopIndex) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
-	return nil, nil
+func (NoopIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
+	return nil
 }
 
 func (NoopIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {}

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper"
 	shipper_index "github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
@@ -116,11 +115,11 @@ func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, fr
 	return idx.LabelValues(ctx, userID, from, through, name, matchers...)
 }
 
-func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
+func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
-		return blooms, err
+		return err
 	}
 
-	return idx.Stats(ctx, userID, from, through, blooms, shard, matchers...)
+	return idx.Stats(ctx, userID, from, through, acc, shard, matchers...)
 }

--- a/pkg/storage/stores/tsdb/lazy_index.go
+++ b/pkg/storage/stores/tsdb/lazy_index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -66,10 +65,10 @@ func (f LazyIndex) LabelValues(ctx context.Context, userID string, from, through
 	return i.LabelValues(ctx, userID, from, through, name, matchers...)
 }
 
-func (f LazyIndex) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
+func (f LazyIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
 	i, err := f()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return i.Stats(ctx, userID, from, through, blooms, shard, matchers...)
+	return i.Stats(ctx, userID, from, through, acc, shard, matchers...)
 }

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -237,13 +236,9 @@ func (i *MultiIndex) LabelValues(ctx context.Context, userID string, from, throu
 	return results, nil
 }
 
-func (i *MultiIndex) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
-	if blooms == nil {
-		blooms = stats.BloomPool.Get()
-	}
-
+func (i *MultiIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
 	_, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.Stats(ctx, userID, from, through, blooms, shard, matchers...)
+		return nil, idx.Stats(ctx, userID, from, through, acc, shard, matchers...)
 	})
-	return blooms, err
+	return err
 }

--- a/pkg/storage/stores/tsdb/multitenant.go
+++ b/pkg/storage/stores/tsdb/multitenant.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -90,6 +89,6 @@ func (m *MultiTenantIndex) LabelValues(ctx context.Context, userID string, from,
 	return m.idx.LabelValues(ctx, userID, from, through, name, withTenantLabelMatcher(userID, matchers)...)
 }
 
-func (m *MultiTenantIndex) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
-	return m.idx.Stats(ctx, userID, from, through, blooms, shard, withTenantLabelMatcher(userID, matchers)...)
+func (m *MultiTenantIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
+	return m.idx.Stats(ctx, userID, from, through, acc, shard, withTenantLabelMatcher(userID, matchers)...)
 }

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	index_shipper "github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
@@ -264,10 +263,7 @@ func (i *TSDBIndex) Identifier(string) SingleTenantTSDBIdentifier {
 	}
 }
 
-func (i *TSDBIndex) Stats(ctx context.Context, userID string, from, through model.Time, blooms *stats.Blooms, shard *index.ShardAnnotation, matchers ...*labels.Matcher) (*stats.Blooms, error) {
-	if blooms == nil {
-		blooms = stats.BloomPool.Get()
-	}
+func (i *TSDBIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, matchers ...*labels.Matcher) error {
 	queryBounds := newBounds(from, through)
 
 	if err := i.forSeries(ctx, shard,
@@ -277,16 +273,16 @@ func (i *TSDBIndex) Stats(ctx context.Context, userID string, from, through mode
 			for _, chk := range chks {
 				if Overlap(queryBounds, chk) {
 					if !addedStream {
-						blooms.AddStream(fp)
+						acc.AddStream(fp)
 						addedStream = true
 					}
-					blooms.AddChunk(fp, chk)
+					acc.AddChunk(fp, chk)
 				}
 			}
 		},
 		matchers...); err != nil {
-		return blooms, err
+		return err
 	}
 
-	return blooms, nil
+	return nil
 }


### PR DESCRIPTION
Refactors the TSDB Index sampling to take an interface which uses bloom filters on the index gateways but bypasses them on the ingesters. This doesn't seem worth the cost in ingesters as it's relevant for deduplicating across index bucket boundaries (less likely with 15m shipping periods in the ingester index-shipper) and deduplicating due to replication factor (not valid in ingesters either).