### PR TITLE
Implement the stream sharder and shard iter

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -583,7 +583,7 @@ func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory
 		}
 	}
 
-	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil, nil)
+	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,22 +1,83 @@
 package distributor
 
 import (
+	"math"
+	"sync"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-type NoopStreamSharder struct{}
-
-func (s *NoopStreamSharder) ShardsFor(_ logproto.Stream) ShardIter {
-	return &NoopShardIter{}
-}
-func (s *NoopStreamSharder) IncreaseShardsFor(_ string) {}
-
-type NoopShardIter struct{}
-
-func (i *NoopShardIter) NumShards() int {
-	return 0
+type streamSharder struct {
+	mu      sync.Mutex
+	streams map[string]int
 }
 
-func (i *NoopShardIter) NextShardID() int {
-	return 0
+func NewStreamSharder() StreamSharder {
+	return &streamSharder{
+		streams: make(map[string]int),
+	}
+}
+
+func (s *streamSharder) ShardsFor(stream logproto.Stream) (ShardIter, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shards := s.streams[stream.Labels]
+	if shards > 0 {
+		return NewShardIter(stream, shards), true
+	}
+
+	return nil, false
+}
+
+func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shards := s.streams[stream.Labels]
+	s.streams[stream.Labels] = max(shards*2, 2)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type shardIter struct {
+	numShards    int
+	numEntries   int
+	batchSize    int
+	currentIndex int
+}
+
+func NewShardIter(stream logproto.Stream, numShards int) ShardIter {
+	numEntries := len(stream.Entries)
+	batchSize := float64(0)
+	if numShards > 0 {
+		batchSize = math.Ceil(float64(numEntries) / float64(numShards))
+	}
+
+	return &shardIter{
+		numShards:  numShards,
+		numEntries: numEntries,
+		batchSize:  int(batchSize),
+	}
+}
+
+func (s *shardIter) NumShards() int {
+	return s.numShards
+}
+
+func (s *shardIter) NextShardID() (int, bool) {
+	if s.currentIndex < s.numEntries {
+		val := 0
+		if s.batchSize > 0 {
+			val = s.currentIndex / s.batchSize
+		}
+		s.currentIndex++
+		return val, true
+	}
+	return 0, false
 }

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -1,0 +1,65 @@
+package distributor
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/pkg/logproto"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamSharder(t *testing.T) {
+	stream := logproto.Stream{Entries: make([]logproto.Entry, 11), Labels: "test-stream"}
+	stream2 := logproto.Stream{Entries: make([]logproto.Entry, 11), Labels: "test-stream-2"}
+
+	t.Run("it returns not ok when a stream should not be sharded", func(t *testing.T) {
+		sharder := NewStreamSharder()
+
+		iter, ok := sharder.ShardsFor(stream)
+		require.Nil(t, iter)
+		require.False(t, ok)
+	})
+
+	t.Run("it keeps track of multiple streams", func(t *testing.T) {
+		sharder := NewStreamSharder()
+		sharder.IncreaseShardsFor(stream)
+		sharder.IncreaseShardsFor(stream)
+		sharder.IncreaseShardsFor(stream2)
+
+		iter, ok := sharder.ShardsFor(stream)
+		require.True(t, ok)
+
+		require.Equal(t, 4, iter.NumShards())
+
+		iter, ok = sharder.ShardsFor(stream2)
+		require.True(t, ok)
+
+		require.Equal(t, 2, iter.NumShards())
+	})
+}
+
+func TestShardIter(t *testing.T) {
+	stream := logproto.Stream{Entries: make([]logproto.Entry, 11)}
+
+	t.Run("it returns indices for batching entries in a stream", func(t *testing.T) {
+		iter := NewShardIter(stream, 3)
+
+		var indices []int
+		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
+			indices = append(indices, idx)
+		}
+
+		require.Equal(t, []int{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2}, indices)
+	})
+
+	t.Run("it returns the same index when numShards is 0", func(t *testing.T) {
+		iter := NewShardIter(stream, 0)
+
+		var indices []int
+		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
+			indices = append(indices, idx)
+		}
+
+		require.Equal(t, []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, indices)
+	})
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -259,7 +259,6 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		t.tenantConfigs,
 		t.ring,
 		t.overrides,
-		&distributor.NoopStreamSharder{},
 		prometheus.DefaultRegisterer,
 	)
 	if err != nil {


### PR DESCRIPTION
This PR is the first-pass implementation of the component that manages the state for sharded streams.

Todo after this:
- Expire streams so we don't grow without bound
- Cache values so not every distributor has to calculate the cost of every stream