### PR TITLE
Make TSDB store singleton resettable

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -40,6 +40,9 @@ var boltDBIndexClientWithShipper index.Client
 // ResetBoltDBIndexClientWithShipper allows to reset the singleton.
 // MUST ONLY BE USED IN TESTS
 func ResetBoltDBIndexClientWithShipper() {
+	if boltDBIndexClientWithShipper == nil {
+		return
+	}
 	boltDBIndexClientWithShipper.Stop()
 	boltDBIndexClientWithShipper = nil
 }

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -26,6 +26,18 @@ type store struct {
 	stopOnce     sync.Once
 }
 
+var storeInstance *store
+
+// This must only be called in test cases where a new store instances
+// cannot be explicitly created.
+func ResetStoreInstance() {
+	if storeInstance == nil {
+		return
+	}
+	storeInstance.Stop()
+	storeInstance = nil
+}
+
 type newStoreFactoryFunc func(
 	indexShipperCfg indexshipper.Config,
 	p config.PeriodConfig,
@@ -50,7 +62,6 @@ type newStoreFactoryFunc func(
 // If we do need to do schema specific handling, it would be a good idea to abstract away the handling since
 // running multiple head managers would be complicated and wasteful.
 var NewStore = func() newStoreFactoryFunc {
-	var storeInstance *store
 	return func(
 		indexShipperCfg indexshipper.Config,
 		p config.PeriodConfig,


### PR DESCRIPTION
This changes allows downstream projects to reset the TSDB store singleton. This must only be called in test cases where a new store instances cannot be explicitly created.

Also add a `nil` check to the reset function for the BoltDB shipper singleton instance.