### PR TITLE
Loki: Implement stream sharding

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -276,6 +276,19 @@ ring:
   # reading and writing.
   # CLI flag: -distributor.ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
+
+# Configures the distributor to shard streams that are too big
+shard_streams:
+  # Whether to enable stream sharding
+  #
+  # CLI flag: -distributor.stream-sharding.enabled
+  [enabled: <boolean> | default = false]
+
+  # Enable debug logging when sharding streams apart from log
+  # levels because logging on the read path may impact performance
+  #
+  # CLI flag: -distributor.stream-sharding.debug-logging-enabled
+  [debug_logging_enabled: <boolean> | default = false]
 ```
 
 ## querier

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -284,11 +284,12 @@ shard_streams:
   # CLI flag: -distributor.stream-sharding.enabled
   [enabled: <boolean> | default = false]
 
-  # Enable debug logging when sharding streams apart from log
-  # levels because logging on the read path may impact performance
+  # Enable logging when sharding streams because logging on the read path may
+  # impact performance. When disabled, stream sharding will emit no logs 
+  # regardless of log level
   #
-  # CLI flag: -distributor.stream-sharding.debug-logging-enabled
-  [debug_logging_enabled: <boolean> | default = false]
+  # CLI flag: -distributor.stream-sharding.logging-enabled
+  [logging_enabled: <boolean> | default = false]
 ```
 
 ## querier

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -439,7 +440,8 @@ func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder
 			continue
 		}
 
-		lbs = append(lbs, labels.Label{Name: ShardLbName, Value: fmt.Sprintf("%d", i)})
+		idx := strconv.Itoa(i)
+		lbs = append(lbs, labels.Label{Name: ShardLbName, Value: idx})
 		streamCopy.Labels = lbs.String()
 		streamCopy.Hash = lbs.Hash()
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -567,7 +567,7 @@ func shardLimitedStream(perStreamErrorMsg string, sharder StreamSharder) {
 		return
 	}
 
-	labels := fmt.Sprintf("{%s}", matches[0][1]) // add curly braces
+	labels := "{" + matches[0][1] + "}"
 
 	lbs, err := syntax.ParseLabels(labels)
 	if err != nil {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -3,8 +3,12 @@ package distributor
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/dskit/limiter"
 	"github.com/grafana/dskit/ring"
@@ -33,6 +37,10 @@ import (
 )
 
 const (
+	// ShardLbName is the internal label to be used by Loki when dividing a stream into smaller pieces.
+	// Possible values are only increasing integers starting from 0.
+	ShardLbName = "__stream_shard__"
+
 	ringKey = "distributor"
 )
 
@@ -385,6 +393,42 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// shardStream shards (divides) the given stream into smaller streams.
+//
+// It will derive N streams (and its entries) from the given stream, where N is the sharding size for the given stream.
+func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder, userID string) ([]uint32, []streamTracker) {
+	logger := util_log.Logger
+	shardsIter := streamSharder.ShardsFor(stream)
+
+	derivedKeys := make([]uint32, 0, shardsIter.NumShards())
+	derivedStreams := make([]streamTracker, 0, shardsIter.NumShards())
+
+	if cfg.ShardStreams.Debug {
+		level.Warn(logger).Log("msg", "sharding request with mode", "mode", cfg.ShardStreams.Mode)
+	}
+
+	for i := 0; i < shardsIter.NumShards(); i++ {
+		idx := shardsIter.NextShardID()
+		streamCopy := stream
+		lbs, err := syntax.ParseLabels(streamCopy.Labels)
+		if err != nil {
+			level.Error(logger).Log("msg", "couldn't extract labels from stream", "stream", streamCopy.Labels)
+			continue
+		}
+		lbs = append(lbs, labels.Label{Name: ShardLbName, Value: fmt.Sprintf("%d", idx)})
+		streamCopy.Labels = lbs.String()
+		streamCopy.Hash = lbs.Hash()
+		if cfg.ShardStreams.Debug {
+			level.Info(logger).Log("msg", "stream derived from sharding", "src-stream", stream.Labels, "derived-stream", streamCopy.Labels)
+		}
+
+		derivedKeys = append(derivedKeys, util.TokenFor(userID, streamCopy.Labels))
+		derivedStreams = append(derivedStreams, streamTracker{stream: streamCopy})
+	}
+
+	return derivedKeys, derivedStreams
 }
 
 // maxT returns the highest between two given timestamps.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -452,7 +452,7 @@ func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, shardNumber
 
 	fIdx := float64(shardNumber)
 	lowerBound := int(fIdx * entriesPerWindow)
-	upperBound := min(int(entriesPerWindow*(1+fIdx)), totalShards)
+	upperBound := min(int(entriesPerWindow*(1+fIdx)), len(stream.Entries))
 
 	if lowerBound > upperBound {
 		if d.cfg.ShardStreams.Debug {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -211,7 +211,7 @@ func New(
 		}),
 		streamSharding: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Namespace: "loki",
-			Name:      "distributor_stream_sharding",
+			Name:      "distributor_streams_sharded_total",
 			Help:      "Counts stream sharding occurrences.",
 		}),
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -420,7 +420,7 @@ func min(x1, x2 int) int {
 func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder, userID string) ([]uint32, []streamTracker) {
 	logger := util_log.Logger
 	shards, ok := streamSharder.ShardsFor(stream)
-	if !ok || shards == 1 {
+	if !ok || shards <= 1 {
 		return []uint32{util.TokenFor(userID, stream.Labels)}, []streamTracker{{stream: stream}}
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -546,11 +546,11 @@ func (d *Distributor) sendSamplesErr(ctx context.Context, ingester ring.Instance
 
 	d.ingesterAppendFailures.WithLabelValues(ingester.Addr).Inc()
 
-	// TODO: look for a better way to recognize a per-stream rate limit.
 	if d.cfg.ShardStreams.Mode == NeverShardMode {
 		return err
 	}
 
+	// TODO: look for a better way to recognize a per-stream rate limit.
 	if errMsg := err.Error(); strings.Contains(errMsg, "Per stream rate limit exceeded (limit") {
 		d.streamSharding.Inc()
 		shardLimitedStream(errMsg, d.streamSharder)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -427,7 +427,7 @@ func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder
 	derivedStreams := make([]streamTracker, 0, shards)
 
 	if cfg.ShardStreams.Debug {
-		level.Warn(logger).Log("msg", "sharding request with mode", "mode", cfg.ShardStreams.Mode)
+		level.Info(logger).Log("msg", "sharding request with mode", "mode", cfg.ShardStreams.Mode)
 	}
 
 	entriesPerWindow := float64(len(stream.Entries)) / float64(shards) // divide and keep decimal value.
@@ -436,6 +436,9 @@ func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder
 		lowerBound := int(fIdx * entriesPerWindow)
 		upperBound := min(int(entriesPerWindow*(1+fIdx)), len(stream.Entries))
 		if lowerBound > upperBound {
+			if cfg.ShardStreams.Debug {
+				level.Warn(logger).Log("msg", "sharding with lowerbound > upperbound", "lowerbound", lowerBound, "upperbound", upperBound, "shards", shards, "labels", stream.Labels)
+			}
 			continue
 		}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -3,7 +3,6 @@ package distributor
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -338,13 +337,13 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		}
 		stream.Entries = stream.Entries[:n]
 
-		if d.cfg.ShardStreams.Mode != NeverShardMode {
+		if d.cfg.ShardStreams.Mode == NeverShardMode {
+			keys = append(keys, util.TokenFor(userID, stream.Labels))
+			streams = append(streams, streamTracker{stream: stream})
+		} else {
 			derivedKeys, derivedStreams := shardStream(stream, d.cfg, d.streamSharder, userID)
 			keys = append(keys, derivedKeys...)
 			streams = append(streams, derivedStreams...)
-		} else {
-			keys = append(keys, util.TokenFor(userID, stream.Labels))
-			streams = append(streams, streamTracker{stream: stream})
 		}
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -403,7 +403,7 @@ func min(x1, x2 int) int {
 func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder, userID string) ([]uint32, []streamTracker) {
 	logger := util_log.Logger
 	shards, ok := streamSharder.ShardsFor(stream)
-	if !ok {
+	if !ok || shards == 1 {
 		return []uint32{util.TokenFor(userID, stream.Labels)}, []streamTracker{{stream: stream}}
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -55,14 +55,16 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.DistributorRing.RegisterFlags(fs)
 }
 
+// StreamSharder manages the state necessary to shard streams.
+type StreamSharder interface {
+	ShardsFor(stream logproto.Stream) ShardIter
+	IncreaseShardsFor(stream string)
+}
+
+// ShardIter provides the information needed to shard a stream in a threadsafe way
 type ShardIter interface {
 	NumShards() int
 	NextShardID() int
-}
-
-type StreamSharder interface {
-	ShardsFor(stream string) ShardIter
-	IncreaseShardsFor(stream string)
 }
 
 // Distributor coordinates replicates and distribution of log streams.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -408,7 +408,7 @@ func TestStreamShard(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		entries           []logproto.Entry
-		shards            int // stub call to ShardsFor.
+		shards            int // stub call to ShardCountFor.
 		wantDerivedStream []streamTracker
 	}{
 		{

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -648,12 +648,8 @@ func BenchmarkShardStream(b *testing.B) {
 	}
 	allEntries := generateEntries(25000)
 
-	cfg := Config{ShardStreams: ShardStreamsConfig{
-		Debug: false,
-	}}
 	b.Run("high number of entries, low number of shards", func(b *testing.B) {
 		d := Distributor{
-			cfg:           cfg,
 			streamSharder: NewStreamSharderMock(1),
 		}
 		stream.Entries = allEntries
@@ -666,7 +662,6 @@ func BenchmarkShardStream(b *testing.B) {
 
 	b.Run("low number of entries, low number of shards", func(b *testing.B) {
 		d := Distributor{
-			cfg:           cfg,
 			streamSharder: NewStreamSharderMock(1),
 		}
 		stream.Entries = nil
@@ -679,7 +674,6 @@ func BenchmarkShardStream(b *testing.B) {
 
 	b.Run("high number of entries, high number of shards", func(b *testing.B) {
 		d := Distributor{
-			cfg:           cfg,
 			streamSharder: NewStreamSharderMock(64),
 		}
 		stream.Entries = allEntries
@@ -692,7 +686,6 @@ func BenchmarkShardStream(b *testing.B) {
 
 	b.Run("low number of entries, high number of shards", func(b *testing.B) {
 		d := Distributor{
-			cfg:           cfg,
 			streamSharder: NewStreamSharderMock(64),
 		}
 		stream.Entries = nil

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -650,7 +650,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 	b.Run("high number of entries, low number of shards", func(b *testing.B) {
 		d := Distributor{
-			streamSharder: NewStreamSharderMock(1),
+			streamSharder: NewStreamSharderMock(2),
 		}
 		stream.Entries = allEntries
 
@@ -662,7 +662,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 	b.Run("low number of entries, low number of shards", func(b *testing.B) {
 		d := Distributor{
-			streamSharder: NewStreamSharderMock(1),
+			streamSharder: NewStreamSharderMock(2),
 		}
 		stream.Entries = nil
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -543,6 +543,76 @@ func TestStreamShard(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "four shards with 2 entries",
+			shards:  4,
+			entries: totalEntries[0:2],
+			wantDerivedStream: []streamTracker{
+				{
+					stream: logproto.Stream{
+						Entries: []logproto.Entry{},
+						Labels:  generateShardLabels(baseLabels, 0).String(),
+						Hash:    generateShardLabels(baseLabels, 0).Hash(),
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Entries: totalEntries[0:1],
+						Labels:  generateShardLabels(baseLabels, 1).String(),
+						Hash:    generateShardLabels(baseLabels, 1).Hash(),
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Entries: []logproto.Entry{},
+						Labels:  generateShardLabels(baseLabels, 2).String(),
+						Hash:    generateShardLabels(baseLabels, 2).Hash(),
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Entries: totalEntries[1:2],
+						Labels:  generateShardLabels(baseLabels, 3).String(),
+						Hash:    generateShardLabels(baseLabels, 3).Hash(),
+					},
+				},
+			},
+		},
+		{
+			name:    "four shards with 1 entry",
+			shards:  4,
+			entries: totalEntries[0:1],
+			wantDerivedStream: []streamTracker{
+				{
+					stream: logproto.Stream{
+						Labels:  generateShardLabels(baseLabels, 0).String(),
+						Hash:    generateShardLabels(baseLabels, 0).Hash(),
+						Entries: []logproto.Entry{},
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Labels:  generateShardLabels(baseLabels, 1).String(),
+						Hash:    generateShardLabels(baseLabels, 1).Hash(),
+						Entries: []logproto.Entry{},
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Labels:  generateShardLabels(baseLabels, 2).String(),
+						Hash:    generateShardLabels(baseLabels, 2).Hash(),
+						Entries: []logproto.Entry{},
+					},
+				},
+				{
+					stream: logproto.Stream{
+						Entries: totalEntries[0:1],
+						Labels:  generateShardLabels(baseLabels, 3).String(),
+						Hash:    generateShardLabels(baseLabels, 3).Hash(),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			streamSharder := NewStreamSharderMock(tc.shards)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -583,7 +583,7 @@ func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory
 		}
 	}
 
-	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil)
+	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -615,10 +615,12 @@ func TestStreamShard(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			streamSharder := NewStreamSharderMock(tc.shards)
+			d := Distributor{
+				streamSharder: NewStreamSharderMock(tc.shards),
+			}
 			baseStream.Entries = tc.entries
 
-			_, derivedStreams := shardStream(baseStream, Config{}, streamSharder, "fake")
+			_, derivedStreams := d.shardStream(baseStream, "fake")
 
 			require.Equal(t, tc.wantDerivedStream, derivedStreams)
 		})
@@ -650,34 +652,54 @@ func BenchmarkShardStream(b *testing.B) {
 		Debug: false,
 	}}
 	b.Run("high number of entries, low number of shards", func(b *testing.B) {
-		streamSharder := NewStreamSharderMock(1)
+		d := Distributor{
+			cfg:           cfg,
+			streamSharder: NewStreamSharderMock(1),
+		}
 		stream.Entries = allEntries
+
+		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			shardStream(stream, cfg, streamSharder, "fake")
+			d.shardStream(stream, "fake")
 		}
 	})
 
 	b.Run("low number of entries, low number of shards", func(b *testing.B) {
-		streamSharder := NewStreamSharderMock(1)
+		d := Distributor{
+			cfg:           cfg,
+			streamSharder: NewStreamSharderMock(1),
+		}
 		stream.Entries = nil
+
+		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			shardStream(stream, cfg, streamSharder, "fake")
+			d.shardStream(stream, "fake")
 		}
 	})
 
 	b.Run("high number of entries, high number of shards", func(b *testing.B) {
-		streamSharder := NewStreamSharderMock(64)
+		d := Distributor{
+			cfg:           cfg,
+			streamSharder: NewStreamSharderMock(64),
+		}
 		stream.Entries = allEntries
+
+		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			shardStream(stream, cfg, streamSharder, "fake")
+			d.shardStream(stream, "fake")
 		}
 	})
 
 	b.Run("low number of entries, high number of shards", func(b *testing.B) {
-		streamSharder := NewStreamSharderMock(64)
+		d := Distributor{
+			cfg:           cfg,
+			streamSharder: NewStreamSharderMock(64),
+		}
 		stream.Entries = nil
+
+		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			shardStream(stream, cfg, streamSharder, "fake")
+			d.shardStream(stream, "fake")
 		}
 	})
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -583,7 +583,7 @@ func prepare(t *testing.T, limits *validation.Limits, kvStore kv.Client, factory
 		}
 	}
 
-	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil, nil)
+	d, err := New(distributorConfig, clientConfig, runtime.DefaultTenantConfigs(), ingestersRing, overrides, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,6 +1,21 @@
 package distributor
 
-import "github.com/grafana/loki/pkg/logproto"
+import (
+	"fmt"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/grafana/loki/pkg/util"
+	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	// ShardLbName is the internal label to be used by Loki when dividing a stream into smaller pieces.
+	// Possible values are only increasing integers starting from 0.
+	ShardLbName = "__stream_shard__"
+)
 
 type NoopStreamSharder struct{}
 
@@ -17,4 +32,40 @@ func (i *NoopShardIter) NumShards() int {
 
 func (i *NoopShardIter) NextShardID() int {
 	return 0
+}
+
+// shardStream shards (divides) the given stream into smaller streams.
+//
+// It will derive N streams (and its entries) from the given stream, where N is the sharding size for the given stream.
+func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder, userID string) ([]uint32, []streamTracker) {
+	logger := util_log.Logger
+	shardsIter := streamSharder.ShardsFor(stream)
+
+	derivedKeys := make([]uint32, 0, shardsIter.NumShards())
+	derivedStreams := make([]streamTracker, 0, shardsIter.NumShards())
+
+	if cfg.ShardStreams.Debug {
+		level.Warn(logger).Log("msg", "sharding request with mode", "mode", cfg.ShardStreams.Mode)
+	}
+
+	for i := 0; i < shardsIter.NumShards(); i++ {
+		idx := shardsIter.NextShardID()
+		streamCopy := stream
+		lbs, err := syntax.ParseLabels(streamCopy.Labels)
+		if err != nil {
+			level.Error(logger).Log("msg", "couldn't extract labels from stream", "stream", streamCopy.Labels)
+			continue
+		}
+		lbs = append(lbs, labels.Label{Name: ShardLbName, Value: fmt.Sprintf("%d", idx)})
+		streamCopy.Labels = lbs.String()
+		streamCopy.Hash = lbs.Hash()
+		if cfg.ShardStreams.Debug {
+			level.Info(logger).Log("msg", "stream derived from sharding", "src-stream", stream.Labels, "derived-stream", streamCopy.Labels)
+		}
+
+		derivedKeys = append(derivedKeys, util.TokenFor(userID, streamCopy.Labels))
+		derivedStreams = append(derivedStreams, streamTracker{stream: streamCopy})
+	}
+
+	return derivedKeys, derivedStreams
 }

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,8 +1,10 @@
 package distributor
 
+import "github.com/grafana/loki/pkg/logproto"
+
 type NoopStreamSharder struct{}
 
-func (s *NoopStreamSharder) ShardsFor(stream string) ShardIter {
+func (s *NoopStreamSharder) ShardsFor(_ logproto.Stream) ShardIter {
 	return &NoopShardIter{}
 }
 func (s *NoopStreamSharder) IncreaseShardsFor(_ string) {}

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,22 +1,83 @@
 package distributor
 
 import (
+	"math"
+	"sync"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-type NoopStreamSharder struct{}
-
-func (s *NoopStreamSharder) ShardsFor(_ logproto.Stream) ShardIter {
-	return &NoopShardIter{}
-}
-func (s *NoopStreamSharder) IncreaseShardsFor(_ string) {}
-
-type NoopShardIter struct{}
-
-func (i *NoopShardIter) NumShards() int {
-	return 0
+type streamSharder struct {
+	mu      sync.Mutex
+	streams map[string]int
 }
 
-func (i *NoopShardIter) NextShardID() int {
-	return 0
+func NewStreamSharder() StreamSharder {
+	return &streamSharder{
+		streams: make(map[string]int),
+	}
+}
+
+func (s *streamSharder) ShardsFor(stream logproto.Stream) (ShardIter, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shards := s.streams[stream.Labels]
+	if shards > 0 {
+		return NewShardIter(stream, shards), true
+	}
+
+	return nil, false
+}
+
+func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shards := s.streams[stream.Labels]
+	s.streams[stream.Labels] = max(shards*2, 2)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type shardIter struct {
+	numShards    int
+	numEntries   int
+	batchSize    int
+	currentIndex int
+}
+
+func NewShardIter(stream logproto.Stream, numShards int) ShardIter {
+	numEntries := len(stream.Entries)
+	batchSize := float64(0)
+	if numShards > 0 {
+		batchSize = math.Ceil(float64(numEntries) / float64(numShards))
+	}
+
+	return &shardIter{
+		numShards:  numShards,
+		numEntries: numEntries,
+		batchSize:  int(batchSize),
+	}
+}
+
+func (s *shardIter) NumShards() int {
+	return s.numShards
+}
+
+func (s *shardIter) NextShardID() (int, bool) {
+	if s.currentIndex < s.numEntries {
+		val := 0
+		if s.batchSize > 0 {
+			val = s.currentIndex / s.batchSize
+		}
+		s.currentIndex++
+		return val, true
+	}
+	return 0, false
 }

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -36,7 +36,8 @@ func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
 
 	shards := s.streams[stream.Labels]
 
-	// Ensure the number of shards is at least 2
+	// Since the number of shards of a stream that is being sharded for the first time is 0,
+	// we assign to it shards = max(shards*2, 2) such that its number of shards will be no less than 2.
 	s.streams[stream.Labels] = max(shards*2, 2)
 }
 

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -17,7 +17,7 @@ func NewStreamSharder() StreamSharder {
 	}
 }
 
-func (s *streamSharder) ShardsFor(stream logproto.Stream) (int, bool) {
+func (s *streamSharder) ShardCountFor(stream logproto.Stream) (int, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -29,11 +29,15 @@ func (s *streamSharder) ShardsFor(stream logproto.Stream) (int, bool) {
 	return 0, false
 }
 
+// IncreaseShardsFor shards the given stream by doubling its number of shards.
 func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	shards := s.streams[stream.Labels]
+
+	// Since the number of shards of a stream that is being sharded for the first time is 0,
+	// we assign to it shards = max(shards*2, 2) such that its number of shards will be no less than 2.
 	s.streams[stream.Labels] = max(shards*2, 2)
 }
 

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,7 +1,6 @@
 package distributor
 
 import (
-	"math"
 	"sync"
 
 	"github.com/grafana/loki/pkg/logproto"
@@ -18,16 +17,16 @@ func NewStreamSharder() StreamSharder {
 	}
 }
 
-func (s *streamSharder) ShardsFor(stream logproto.Stream) (ShardIter, bool) {
+func (s *streamSharder) ShardsFor(stream logproto.Stream) (int, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	shards := s.streams[stream.Labels]
 	if shards > 0 {
-		return NewShardIter(stream, shards), true
+		return shards, true
 	}
 
-	return nil, false
+	return 0, false
 }
 
 func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
@@ -43,41 +42,4 @@ func max(a, b int) int {
 		return a
 	}
 	return b
-}
-
-type shardIter struct {
-	numShards    int
-	numEntries   int
-	batchSize    int
-	currentIndex int
-}
-
-func NewShardIter(stream logproto.Stream, numShards int) ShardIter {
-	numEntries := len(stream.Entries)
-	batchSize := float64(0)
-	if numShards > 0 {
-		batchSize = math.Ceil(float64(numEntries) / float64(numShards))
-	}
-
-	return &shardIter{
-		numShards:  numShards,
-		numEntries: numEntries,
-		batchSize:  int(batchSize),
-	}
-}
-
-func (s *shardIter) NumShards() int {
-	return s.numShards
-}
-
-func (s *shardIter) NextShardID() (int, bool) {
-	if s.currentIndex < s.numEntries {
-		val := 0
-		if s.batchSize > 0 {
-			val = s.currentIndex / s.batchSize
-		}
-		s.currentIndex++
-		return val, true
-	}
-	return 0, false
 }

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,20 +1,7 @@
 package distributor
 
 import (
-	"fmt"
-
-	"github.com/go-kit/log/level"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql/syntax"
-	"github.com/grafana/loki/pkg/util"
-	util_log "github.com/grafana/loki/pkg/util/log"
-	"github.com/prometheus/prometheus/model/labels"
-)
-
-const (
-	// ShardLbName is the internal label to be used by Loki when dividing a stream into smaller pieces.
-	// Possible values are only increasing integers starting from 0.
-	ShardLbName = "__stream_shard__"
 )
 
 type NoopStreamSharder struct{}
@@ -32,40 +19,4 @@ func (i *NoopShardIter) NumShards() int {
 
 func (i *NoopShardIter) NextShardID() int {
 	return 0
-}
-
-// shardStream shards (divides) the given stream into smaller streams.
-//
-// It will derive N streams (and its entries) from the given stream, where N is the sharding size for the given stream.
-func shardStream(stream logproto.Stream, cfg Config, streamSharder StreamSharder, userID string) ([]uint32, []streamTracker) {
-	logger := util_log.Logger
-	shardsIter := streamSharder.ShardsFor(stream)
-
-	derivedKeys := make([]uint32, 0, shardsIter.NumShards())
-	derivedStreams := make([]streamTracker, 0, shardsIter.NumShards())
-
-	if cfg.ShardStreams.Debug {
-		level.Warn(logger).Log("msg", "sharding request with mode", "mode", cfg.ShardStreams.Mode)
-	}
-
-	for i := 0; i < shardsIter.NumShards(); i++ {
-		idx := shardsIter.NextShardID()
-		streamCopy := stream
-		lbs, err := syntax.ParseLabels(streamCopy.Labels)
-		if err != nil {
-			level.Error(logger).Log("msg", "couldn't extract labels from stream", "stream", streamCopy.Labels)
-			continue
-		}
-		lbs = append(lbs, labels.Label{Name: ShardLbName, Value: fmt.Sprintf("%d", idx)})
-		streamCopy.Labels = lbs.String()
-		streamCopy.Hash = lbs.Hash()
-		if cfg.ShardStreams.Debug {
-			level.Info(logger).Log("msg", "stream derived from sharding", "src-stream", stream.Labels, "derived-stream", streamCopy.Labels)
-		}
-
-		derivedKeys = append(derivedKeys, util.TokenFor(userID, streamCopy.Labels))
-		derivedStreams = append(derivedStreams, streamTracker{stream: streamCopy})
-	}
-
-	return derivedKeys, derivedStreams
 }

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -1,0 +1,18 @@
+package distributor
+
+type NoopStreamSharder struct{}
+
+func (s *NoopStreamSharder) ShardsFor(stream string) ShardIter {
+	return &NoopShardIter{}
+}
+func (s *NoopStreamSharder) IncreaseShardsFor(_ string) {}
+
+type NoopShardIter struct{}
+
+func (i *NoopShardIter) NumShards() int {
+	return 0
+}
+
+func (i *NoopShardIter) NextShardID() int {
+	return 0
+}

--- a/pkg/distributor/streamsharder.go
+++ b/pkg/distributor/streamsharder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type streamSharder struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	streams map[string]int
 }
 
@@ -18,8 +18,8 @@ func NewStreamSharder() StreamSharder {
 }
 
 func (s *streamSharder) ShardsFor(stream logproto.Stream) (int, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	shards := s.streams[stream.Labels]
 	if shards > 0 {
@@ -36,8 +36,7 @@ func (s *streamSharder) IncreaseShardsFor(stream logproto.Stream) {
 
 	shards := s.streams[stream.Labels]
 
-	// Since the number of shards of a stream that is being sharded for the first time is 0,
-	// we assign to it shards = max(shards*2, 2) such that its number of shards will be no less than 2.
+	// Ensure the number of shards is at least 2
 	s.streams[stream.Labels] = max(shards*2, 2)
 }
 

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -15,7 +15,7 @@ func TestStreamSharder(t *testing.T) {
 	t.Run("it returns not ok when a stream should not be sharded", func(t *testing.T) {
 		sharder := NewStreamSharder()
 
-		shards, ok := sharder.ShardsFor(stream)
+		shards, ok := sharder.ShardCountFor(stream)
 		require.Equal(t, shards, 0)
 		require.False(t, ok)
 	})
@@ -26,12 +26,12 @@ func TestStreamSharder(t *testing.T) {
 		sharder.IncreaseShardsFor(stream)
 		sharder.IncreaseShardsFor(stream2)
 
-		shards, ok := sharder.ShardsFor(stream)
+		shards, ok := sharder.ShardCountFor(stream)
 		require.True(t, ok)
 
 		require.Equal(t, 4, shards)
 
-		shards, ok = sharder.ShardsFor(stream2)
+		shards, ok = sharder.ShardCountFor(stream2)
 		require.True(t, ok)
 
 		require.Equal(t, 2, shards)
@@ -55,8 +55,8 @@ func (s *StreamSharderMock) IncreaseShardsFor(stream logproto.Stream) {
 	s.increaseCallsFor("IncreaseShardsFor")
 }
 
-func (s *StreamSharderMock) ShardsFor(stream logproto.Stream) (int, bool) {
-	s.increaseCallsFor("ShardsFor")
+func (s *StreamSharderMock) ShardCountFor(stream logproto.Stream) (int, bool) {
+	s.increaseCallsFor("ShardCountFor")
 	if s.wantShards < 0 {
 		return 0, false
 	}

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -1,0 +1,65 @@
+package distributor
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/pkg/logproto"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamSharder(t *testing.T) {
+	stream := logproto.Stream{Entries: make([]logproto.Entry, 11), Labels: "test-stream"}
+	stream2 := logproto.Stream{Entries: make([]logproto.Entry, 11), Labels: "test-stream-2"}
+
+	t.Run("it returns not ok when a stream should not be sharded", func(t *testing.T) {
+		sharder := NewStreamSharder()
+
+		iter, ok := sharder.ShardsFor(stream)
+		require.Nil(t, iter)
+		require.False(t, ok)
+	})
+
+	t.Run("it keeps track of multiple streams", func(t *testing.T) {
+		sharder := NewStreamSharder()
+		sharder.IncreaseShardsFor(stream)
+		sharder.IncreaseShardsFor(stream)
+		sharder.IncreaseShardsFor(stream2)
+
+		iter, ok := sharder.ShardsFor(stream)
+		require.True(t, ok)
+
+		require.Equal(t, 4, iter.NumShards())
+
+		iter, ok = sharder.ShardsFor(stream2)
+		require.True(t, ok)
+
+		require.Equal(t, 2, iter.NumShards())
+	})
+}
+
+func TestShardIter(t *testing.T) {
+	stream := logproto.Stream{Entries: make([]logproto.Entry, 11)}
+
+	t.Run("it returns indices for batching entries in a stream", func(t *testing.T) {
+		iter := NewShardIter(stream, 3)
+
+		var indices []int
+		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
+			indices = append(indices, idx)
+		}
+
+		require.Equal(t, []int{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2}, indices)
+	})
+
+	t.Run("it returns the same index when numShards is 0", func(t *testing.T) {
+		iter := NewShardIter(stream, 0)
+
+		var indices []int
+		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
+			indices = append(indices, idx)
+		}
+
+		require.Equal(t, []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, indices)
+	})
+}

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -15,8 +15,8 @@ func TestStreamSharder(t *testing.T) {
 	t.Run("it returns not ok when a stream should not be sharded", func(t *testing.T) {
 		sharder := NewStreamSharder()
 
-		iter, ok := sharder.ShardsFor(stream)
-		require.Nil(t, iter)
+		shards, ok := sharder.ShardsFor(stream)
+		require.Equal(t, shards, 0)
 		require.False(t, ok)
 	})
 
@@ -26,40 +26,14 @@ func TestStreamSharder(t *testing.T) {
 		sharder.IncreaseShardsFor(stream)
 		sharder.IncreaseShardsFor(stream2)
 
-		iter, ok := sharder.ShardsFor(stream)
+		shards, ok := sharder.ShardsFor(stream)
 		require.True(t, ok)
 
-		require.Equal(t, 4, iter.NumShards())
+		require.Equal(t, 4, shards)
 
-		iter, ok = sharder.ShardsFor(stream2)
+		shards, ok = sharder.ShardsFor(stream2)
 		require.True(t, ok)
 
-		require.Equal(t, 2, iter.NumShards())
-	})
-}
-
-func TestShardIter(t *testing.T) {
-	stream := logproto.Stream{Entries: make([]logproto.Entry, 11)}
-
-	t.Run("it returns indices for batching entries in a stream", func(t *testing.T) {
-		iter := NewShardIter(stream, 3)
-
-		var indices []int
-		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
-			indices = append(indices, idx)
-		}
-
-		require.Equal(t, []int{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2}, indices)
-	})
-
-	t.Run("it returns the same index when numShards is 0", func(t *testing.T) {
-		iter := NewShardIter(stream, 0)
-
-		var indices []int
-		for idx, cont := iter.NextShardID(); cont; idx, cont = iter.NextShardID() {
-			indices = append(indices, idx)
-		}
-
-		require.Equal(t, []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, indices)
+		require.Equal(t, 2, shards)
 	})
 }

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -37,3 +37,34 @@ func TestStreamSharder(t *testing.T) {
 		require.Equal(t, 2, shards)
 	})
 }
+
+type StreamSharderMock struct {
+	calls map[string]int
+
+	ShardsForStub func() (int, bool)
+}
+
+func NewStreamSharderMock(shardsForStub func() (int, bool)) *StreamSharderMock {
+	return &StreamSharderMock{
+		calls:         make(map[string]int),
+		ShardsForStub: shardsForStub,
+	}
+}
+
+func (s *StreamSharderMock) IncreaseShardsFor(stream logproto.Stream) {
+	s.increaseCallsFor("IncreaseShardsFor")
+}
+
+func (s *StreamSharderMock) ShardsFor(stream logproto.Stream) (int, bool) {
+	s.increaseCallsFor("ShardsFor")
+	return s.ShardsForStub()
+}
+
+func (s *StreamSharderMock) increaseCallsFor(funcName string) {
+	if _, ok := s.calls[funcName]; ok {
+		s.calls[funcName]++
+		return
+	}
+
+	s.calls[funcName] = 1
+}

--- a/pkg/distributor/streamsharder_test.go
+++ b/pkg/distributor/streamsharder_test.go
@@ -41,13 +41,13 @@ func TestStreamSharder(t *testing.T) {
 type StreamSharderMock struct {
 	calls map[string]int
 
-	ShardsForStub func() (int, bool)
+	wantShards int
 }
 
-func NewStreamSharderMock(shardsForStub func() (int, bool)) *StreamSharderMock {
+func NewStreamSharderMock(shards int) *StreamSharderMock {
 	return &StreamSharderMock{
-		calls:         make(map[string]int),
-		ShardsForStub: shardsForStub,
+		calls:      make(map[string]int),
+		wantShards: shards,
 	}
 }
 
@@ -57,7 +57,10 @@ func (s *StreamSharderMock) IncreaseShardsFor(stream logproto.Stream) {
 
 func (s *StreamSharderMock) ShardsFor(stream logproto.Stream) (int, bool) {
 	s.increaseCallsFor("ShardsFor")
-	return s.ShardsForStub()
+	if s.wantShards < 0 {
+		return 0, false
+	}
+	return s.wantShards, true
 }
 
 func (s *StreamSharderMock) increaseCallsFor(funcName string) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -259,7 +259,6 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		t.tenantConfigs,
 		t.ring,
 		t.overrides,
-		&distributor.NoopStreamSharder{},
 		prometheus.DefaultRegisterer,
 	)
 	if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -253,7 +253,15 @@ func (t *Loki) initTenantConfigs() (_ services.Service, err error) {
 
 func (t *Loki) initDistributor() (services.Service, error) {
 	var err error
-	t.distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.tenantConfigs, t.ring, t.overrides, prometheus.DefaultRegisterer)
+	t.distributor, err = distributor.New(
+		t.Cfg.Distributor,
+		t.Cfg.IngesterClient,
+		t.tenantConfigs,
+		t.ring,
+		t.overrides,
+		&distributor.NoopStreamSharder{},
+		prometheus.DefaultRegisterer,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement a new feature named `stream sharding`. Distributors with stream sharding enabled will reduce big streams before pushing them to the ingesters by adding a new sharding label. By having a new label, a bigger stream is hence reduced.
This shouldn't impact Loki in any form since it is disabled by default.

This initial implementation contains:
- A sharder interface to be used internally regardless of the implementation
- An initial sharder implementation that supports sharding streams
- A mechanism to recognize per-stream limits and trigger sharding based on it
- Related configurations that dictate if sharding should be enabled or not. We're not documenting these configurations yet as we don't want users to use by mistake since this is far from ready

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
