### PR TITLE
Use a line-buffered logger to deamplify write syscalls

### DIFF
--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+
 	// embed time zone data
 	_ "time/tzdata"
 

--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-
 	// embed time zone data
 	_ "time/tzdata"
 
@@ -82,7 +81,7 @@ func main() {
 		fmt.Println("Invalid log level")
 		os.Exit(1)
 	}
-	util_log.InitLogger(&config.Config.ServerConfig.Config, prometheus.DefaultRegisterer)
+	util_log.InitLogger(&config.Config.ServerConfig.Config, prometheus.DefaultRegisterer, true, false)
 
 	// Use Stderr instead of files for the klog.
 	klog.SetOutput(os.Stderr)

--- a/clients/pkg/logentry/stages/drop_test.go
+++ b/clients/pkg/logentry/stages/drop_test.go
@@ -40,7 +40,7 @@ func Test_dropStage_Process(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	tests := []struct {

--- a/clients/pkg/logentry/stages/labelallow_test.go
+++ b/clients/pkg/logentry/stages/labelallow_test.go
@@ -16,7 +16,7 @@ func Test_addLabelStage_Process(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	tests := []struct {

--- a/clients/pkg/logentry/stages/labeldrop_test.go
+++ b/clients/pkg/logentry/stages/labeldrop_test.go
@@ -16,7 +16,7 @@ func Test_dropLabelStage_Process(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	tests := []struct {

--- a/clients/pkg/logentry/stages/multiline_test.go
+++ b/clients/pkg/logentry/stages/multiline_test.go
@@ -20,7 +20,7 @@ func Test_multilineStage_Process(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
@@ -52,7 +52,7 @@ func Test_multilineStage_MultiStreams(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	mcfg := &MultilineConfig{Expression: ptrFromString("^START"), MaxWaitTime: ptrFromString("3s")}
@@ -97,7 +97,7 @@ func Test_multilineStage_MaxWaitTime(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	maxWait := 2 * time.Second

--- a/clients/pkg/logentry/stages/pack_test.go
+++ b/clients/pkg/logentry/stages/pack_test.go
@@ -105,7 +105,7 @@ func Test_packStage_Run(t *testing.T) {
 	// Enable debug logging
 	cfg := &ww.Config{}
 	require.Nil(t, cfg.LogLevel.Set("debug"))
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 	Debug = true
 
 	tests := []struct {

--- a/clients/pkg/promtail/targets/lokipush/pushtarget.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtarget.go
@@ -79,7 +79,7 @@ func (t *PushTarget) run() error {
 
 	// The logger registers a metric which will cause a duplicate registry panic unless we provide an empty registry
 	// The metric created is for counting log lines and isn't likely to be missed.
-	util_log.InitLogger(&t.config.Server, prometheus.NewRegistry())
+	util_log.InitLogger(&t.config.Server, prometheus.NewRegistry(), true, false)
 
 	srv, err := server.New(t.config.Server)
 	if err != nil {

--- a/clients/pkg/promtail/targets/windows/target_test.go
+++ b/clients/pkg/promtail/targets/windows/target_test.go
@@ -28,7 +28,7 @@ func init() {
 	// Enable debug logging
 	cfg := &server.Config{}
 	_ = cfg.LogLevel.Set("debug")
-	util_log.InitLogger(cfg, nil)
+	util_log.InitLogger(cfg, nil, true, false)
 }
 
 // Test that you can use to generate event logs locally.

--- a/cmd/logql-analyzer/main.go
+++ b/cmd/logql-analyzer/main.go
@@ -17,7 +17,7 @@ func main() {
 	cfg := getConfig()
 	util_log.InitLogger(&server.Config{
 		LogLevel: cfg.LogLevel,
-	}, prometheus.DefaultRegisterer)
+	}, prometheus.DefaultRegisterer, true, false)
 	s, err := createServer(cfg)
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "error while creating the server", "err", err)

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -43,7 +43,7 @@ func main() {
 		level.Error(util_log.Logger).Log("msg", "invalid log level")
 		os.Exit(1)
 	}
-	util_log.InitLogger(&config.Server, prometheus.DefaultRegisterer)
+	util_log.InitLogger(&config.Server, prometheus.DefaultRegisterer, config.UseBufferedLogger, config.UseSyncLogger)
 
 	// Validate the config once both the config file has been loaded
 	// and CLI flags parsed.

--- a/cmd/querytee/main.go
+++ b/cmd/querytee/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	util_log.InitLogger(&server.Config{
 		LogLevel: cfg.LogLevel,
-	}, prometheus.DefaultRegisterer)
+	}, prometheus.DefaultRegisterer, true, false)
 
 	// Run the instrumentation server.
 	registry := prometheus.NewRegistry()

--- a/go.mod
+++ b/go.mod
@@ -338,4 +338,4 @@ replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-
 
 // Fork containing a line-buffered logger which should improve logging performance.
 // TODO: submit PR to upstream and remove this
-replace github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf
+replace github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d

--- a/go.mod
+++ b/go.mod
@@ -335,3 +335,7 @@ replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet.
 replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
+
+// Fork containing a line-buffered logger which should improve logging performance.
+// TODO: submit PR to upstream and remove this
+replace github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf

--- a/go.mod
+++ b/go.mod
@@ -338,4 +338,4 @@ replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-
 
 // Fork containing a line-buffered logger which should improve logging performance.
 // TODO: submit PR to upstream and remove this
-replace github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d
+replace github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
-github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf h1:3UoaYswoAE/wdexX0p6iVFhYVcLrfVAr8yIjwYZjso8=
-github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d h1:cWYPuIxuMmtFibckYkoH4apJq8UUB0HzWbMyDm5pcZI=
+github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
+github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf h1:3UoaYswoAE/wdexX0p6iVFhYVcLrfVAr8yIjwYZjso8=
+github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -509,10 +511,6 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=
 github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEaizzs=
-github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
 github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d h1:cWYPuIxuMmtFibckYkoH4apJq8UUB0HzWbMyDm5pcZI=
 github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b h1:G8g9mAKEj9O3RsU6Hd/ow6lIcHarlcUl5omV6sFKEOU=
+github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,6 @@ github.com/cznic/ql v1.2.0/go.mod h1:FbpzhyZrqr0PVlK6ury+PoW3T0ODUV22OeWIxcaOrSE
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
 github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
-github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d h1:cWYPuIxuMmtFibckYkoH4apJq8UUB0HzWbMyDm5pcZI=
-github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b h1:G8g9mAKEj9O3RsU6Hd/ow6lIcHarlcUl5omV6sFKEOU=
 github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -64,6 +64,11 @@ type Config struct {
 	HTTPPrefix   string                 `yaml:"http_prefix"`
 	BallastBytes int                    `yaml:"ballast_bytes"`
 
+	// TODO(dannyk): Remove these config options before next release; they don't need to be configurable.
+	// 				 These are only here to allow us to test the new functionality.
+	UseBufferedLogger bool `yaml:"use_buffered_logger"`
+	UseSyncLogger     bool `yaml:"use_sync_logger"`
+
 	Common           common.Config            `yaml:"common,omitempty"`
 	Server           server.Config            `yaml:"server,omitempty"`
 	InternalServer   internalserver.Config    `yaml:"internal_server,omitempty"`
@@ -102,6 +107,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", true, "Set to false to disable auth.")
 	f.IntVar(&c.BallastBytes, "config.ballast-bytes", 0, "The amount of virtual memory to reserve as a ballast in order to optimise "+
 		"garbage collection. Larger ballasts result in fewer garbage collection passes, reducing compute overhead at the cost of memory usage.")
+	f.BoolVar(&c.UseBufferedLogger, "log.use-buffered", true, "Uses a line-buffered logger to improve performance.")
+	f.BoolVar(&c.UseSyncLogger, "log.use-sync", true, "Forces all lines logged to hold a mutex to serialize writes.")
 
 	c.registerServerFlagsWithChangedDefaultValues(f)
 	c.Common.RegisterFlags(f)

--- a/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/util_test.go
@@ -315,7 +315,7 @@ func newTestStore(t testing.TB) *testStore {
 	t.Helper()
 	servercfg := &ww.Config{}
 	require.Nil(t, servercfg.LogLevel.Set("debug"))
-	util_log.InitLogger(servercfg, nil)
+	util_log.InitLogger(servercfg, nil, true, false)
 	workdir := t.TempDir()
 	filepath.Join(workdir, "index")
 	indexDir := filepath.Join(workdir, "index")

--- a/pkg/storage/stores/shipper/index/compactor/util_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/util_test.go
@@ -205,7 +205,7 @@ func newTestStore(t testing.TB, clientMetrics storage.ClientMetrics) *testStore 
 	t.Helper()
 	servercfg := &ww.Config{}
 	require.Nil(t, servercfg.LogLevel.Set("debug"))
-	util_log.InitLogger(servercfg, nil)
+	util_log.InitLogger(servercfg, nil, true, false)
 	workdir := t.TempDir()
 	filepath.Join(workdir, "index")
 	indexDir := filepath.Join(workdir, "index")

--- a/vendor/github.com/go-kit/log/line_buffer.go
+++ b/vendor/github.com/go-kit/log/line_buffer.go
@@ -1,0 +1,116 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// LineBufferedLogger buffers log lines to be flushed periodically. Without a line buffer, Log() will call the write
+// syscall for every log line which is expensive if logging thousands of lines per second.
+type LineBufferedLogger struct {
+	buf     *threadsafeBuffer
+	entries uint32
+	cap     uint32
+	w       io.Writer
+}
+
+// Size returns the number of entries in the buffer.
+func (l *LineBufferedLogger) Size() uint32 {
+	return atomic.LoadUint32(&l.entries)
+}
+
+// Write writes the given bytes to the line buffer, and increments the entries counter.
+// If the buffer is full (entries == cap), it will be flushed, and the entries counter reset.
+func (l *LineBufferedLogger) Write(p []byte) (n int, err error) {
+	// when we've filled the buffer, flush it
+	if l.Size() == l.cap {
+		// Flush resets the size to 0
+		if err := l.Flush(); err != nil {
+			return 0, err
+		}
+	}
+
+	atomic.AddUint32(&l.entries, 1)
+
+	return l.buf.Write(p)
+}
+
+// Flush forces the buffer to be written to the underlying writer.
+func (l *LineBufferedLogger) Flush() error {
+	if l.Size() <= 0 {
+		return nil
+	}
+
+	// reset the counter
+	atomic.StoreUint32(&l.entries, 0)
+
+	_, err := l.buf.WriteTo(l.w)
+	return err
+}
+
+// NewLineBufferedLogger creates a new LineBufferedLogger with a configured capacity and flush period.
+// Lines are flushed when the context is done, the buffer is full, or the flush period is reached.
+func NewLineBufferedLogger(w io.Writer, cap uint32, flushPeriod time.Duration) *LineBufferedLogger {
+	l := &LineBufferedLogger{
+		w:   w,
+		buf: newThreadsafeBuffer(bytes.NewBuffer([]byte{})),
+		cap: cap,
+	}
+
+	// flush periodically
+	go func() {
+		tick := time.NewTicker(flushPeriod)
+		defer tick.Stop()
+
+		for {
+			select {
+			case <-tick.C:
+				l.Flush()
+			}
+		}
+
+	}()
+
+	return l
+}
+
+// threadsafeBuffer wraps the non-threadsafe bytes.Buffer.
+type threadsafeBuffer struct {
+	sync.RWMutex
+
+	buf *bytes.Buffer
+}
+
+// Read returns the contents of the buffer.
+func (t *threadsafeBuffer) Read(p []byte) (n int, err error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	return t.buf.Read(p)
+}
+
+// Write writes the given bytes to the underlying writer.
+func (t *threadsafeBuffer) Write(p []byte) (n int, err error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.buf.Write(p)
+}
+
+// WriteTo writes the buffered lines to the given writer.
+func (t *threadsafeBuffer) WriteTo(w io.Writer) (n int64, err error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.buf.WriteTo(w)
+}
+
+// newThreadsafeBuffer returns a new threadsafeBuffer wrapping the given bytes.Buffer.
+func newThreadsafeBuffer(buf *bytes.Buffer) *threadsafeBuffer {
+	return &threadsafeBuffer{
+		buf: buf,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,7 +359,7 @@ github.com/fsouza/fake-gcs-server/internal/backend
 ## explicit; go 1.17
 github.com/go-kit/kit/log
 github.com/go-kit/kit/log/level
-# github.com/go-kit/log v0.2.1 => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf
+# github.com/go-kit/log v0.2.1 => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d
 ## explicit; go 1.17
 github.com/go-kit/log
 github.com/go-kit/log/level
@@ -1753,4 +1753,4 @@ sigs.k8s.io/yaml
 # google.golang.org/grpc => google.golang.org/grpc v1.45.0
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.36.2-0.20220613200027-59727ab0eb48
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
-# github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf
+# github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,7 +359,7 @@ github.com/fsouza/fake-gcs-server/internal/backend
 ## explicit; go 1.17
 github.com/go-kit/kit/log
 github.com/go-kit/kit/log/level
-# github.com/go-kit/log v0.2.1
+# github.com/go-kit/log v0.2.1 => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf
 ## explicit; go 1.17
 github.com/go-kit/log
 github.com/go-kit/log/level
@@ -1753,3 +1753,4 @@ sigs.k8s.io/yaml
 # google.golang.org/grpc => google.golang.org/grpc v1.45.0
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.36.2-0.20220613200027-59727ab0eb48
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
+# github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220724160234-b7a3543da7cf

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,7 +359,7 @@ github.com/fsouza/fake-gcs-server/internal/backend
 ## explicit; go 1.17
 github.com/go-kit/kit/log
 github.com/go-kit/kit/log/level
-# github.com/go-kit/log v0.2.1 => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d
+# github.com/go-kit/log v0.2.1 => github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b
 ## explicit; go 1.17
 github.com/go-kit/log
 github.com/go-kit/log/level
@@ -1753,4 +1753,4 @@ sigs.k8s.io/yaml
 # google.golang.org/grpc => google.golang.org/grpc v1.45.0
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.36.2-0.20220613200027-59727ab0eb48
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
-# github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20220823062813-c11c260fd86d
+# github.com/go-kit/log => github.com/dannykopping/go-kit-log v0.2.2-0.20221002180827-5591c1641b6b


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
We initialise a global logger in `pkg/util/log/log.go` and use it extensively throughout the Loki codebase. Every time we write a log message, a `write` syscall is invoked. Syscalls are problematic because they transition the process from userspace to kernelspace, which means:

- a context-switch is incurred, which is inherently expensive ([1-2 microseconds](https://eli.thegreenplace.net/2018/measuring-context-switching-and-memory-overheads-for-linux-threads/))
- the goroutine executing the code is **blocked**
- the underlying OS thread (_M_ in the go scheduler model) is **also blocked**
- the goroutine has to be rescheduled once the syscall exits
- the go scheduler may need to spawn additional OS threads if all are blocked in syscalls - which can also be expensive

This change introduces the use of a line-buffered logger. It has a buffer of [256](https://gist.github.com/dannykopping/0704db32c0b08751d1d2494efaa734c2) entries, and once that buffer is filled it will flush to disk. However, a situation will arise in which that buffer remains somewhat empty for a period of time, so there is a periodic flush mechanism, configured to flush every 100ms. There is also a preallocated bytes slice of 10MB which is reused, to avoid excessive slice resizing & garbage collection.

This does mean that we could lose up to 256 log messages in case of an ungraceful termination of the process, but this would need to be precisely timed within the 100ms flushes - in other words, the likelihood is low, and generally we shouldn't `kill -9` any Loki process. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This PR uses my private fork of `go-kit/log`; once we've validated this to work in our environment I will attempt to upstream the change.

[Line-buffering](https://www.gnu.org/software/libc/manual/html_node/Buffering-Concepts.html) is common, and in Linux the `stdout` stream is [line-buffered](https://man7.org/linux/man-pages/man3/stdin.3.html#NOTES) when attached to a terminal.

We also currently make use of the `log.NewSyncWriter` writer, which is totally unnecessary since `write` syscalls are threadsafe by nature, and we also don't need to worry about out-of-order logs anymore. Removing this should also eliminate some contention, and there's a config option to control this separately while we test this out.

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
