### PR TITLE
tsdb: build rotated heads asynchronously

### DIFF
--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -61,6 +61,8 @@ type Metrics struct {
 	tsdbCreationFailures          prometheus.Counter
 	tsdbManagerUpdatesTotal       prometheus.Counter
 	tsdbManagerUpdatesFailedTotal prometheus.Counter
+	tsdbHeadRotationsTotal        prometheus.Counter
+	tsdbHeadRotationsFailedTotal  prometheus.Counter
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -84,6 +86,14 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		tsdbManagerUpdatesFailedTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_tsdb_manager_updates_failed_total",
 			Help: "Total number of tsdb manager update failures (loading/rotating tsdbs in mem)",
+		}),
+		tsdbHeadRotationsTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_tsdb_head_rotations_total",
+			Help: "Total number of tsdb head rotations",
+		}),
+		tsdbHeadRotationsFailedTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "loki_tsdb_head_rotations_failed_total",
+			Help: "Total number of tsdb head rotations failed",
 		}),
 	}
 }

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -186,6 +186,7 @@ func (m *HeadManager) loop() {
 				if err := m.Rotate(now); err != nil {
 					level.Error(m.log).Log(
 						"msg", "failed rotating tsdb head",
+						"period", m.period.PeriodFor(m.prev.initialized),
 						"err", err,
 					)
 					continue

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -174,6 +174,7 @@ func (m *HeadManager) loop() {
 			if err := buildPrev(); err != nil {
 				level.Error(m.log).Log(
 					"msg", "failed building tsdb head",
+					"period", m.period.PeriodFor(m.prev.initialized),
 					"err", err,
 				)
 				// rotating head without building prev would result in loss of index for that period (until restart)

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -166,7 +166,7 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 		},
 	}
 
-	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, newNoopTSDBManager(dir))
+	mgr := NewHeadManager(log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(dir))
 	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 	// so ensure our dirs exist
 	for _, d := range managerRequiredDirs(dir) {
@@ -249,7 +249,7 @@ func Test_HeadManager_Lifecycle(t *testing.T) {
 		},
 	}
 
-	mgr := NewHeadManager(log.NewNopLogger(), dir, nil, newNoopTSDBManager(dir))
+	mgr := NewHeadManager(log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(dir))
 	w, err := newHeadWAL(log.NewNopLogger(), walPath(mgr.dir, curPeriod), curPeriod)
 	require.Nil(t, err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:
Currently `Append` call to the head has to wait for block creation to complete when rotating head.
And since we rotate head every 15m (default period), this would result in latency spikes at these times.
This PR moves the TSDB build step to an async routine.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
