### PR TITLE
Evenly spread distributors across available nodes

### DIFF
--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -44,10 +44,18 @@ Currently `embedded-cache` with `distributed: true` can be enabled only for resu
 We now evenly spread distributors across the available kubernetes nodes, but allowing more than one distributors to be scheduled into the same node.
 If you want to run at most a single distributors per node, set `$._config.distributors.use_topology_spread` to false.
 
+While we attempt to schedule at most 1 distributor per Kubernetes node with the `topology_spread_max_skew: 1` field,
+if no more nodes are available then multiple distributors will be scheduled on the same node.
+This can potentially impact your service's reliability so consider tuning these values according to your risk tolerance.
+
 #### Evenly spread queriers across kubernetes nodes
 
 We now evenly spread queriers across the available kubernetes nodes, but allowing more than one querier to be scheduled into the same node.
 If you want to run at most a single querier per node, set `$._config.querier.use_topology_spread` to false.
+
+While we attempt to schedule at most 1 querier per Kubernetes node with the `topology_spread_max_skew: 1` field,
+if no more nodes are available then multiple queriers will be scheduled on the same node.
+This can potentially impact your service's reliability so consider tuning these values according to your risk tolerance.
 
 #### Default value for `server.http-listen-port` changed
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -39,6 +39,11 @@ We introduced a new cache called `embedded-cache` which is an in-process cache s
 
 Currently `embedded-cache` with `distributed: true` can be enabled only for results cache.
 
+#### Evenly spread distributors across kubernetes nodes
+
+We now evenly spread distributors across the available kubernetes nodes, but allowing more than one distributors to be scheduled into the same node.
+If you want to run at most a single distributors per node, set `$._config.distributors.use_topology_spread` to false.
+
 #### Evenly spread queriers across kubernetes nodes
 
 We now evenly spread queriers across the available kubernetes nodes, but allowing more than one querier to be scheduled into the same node.

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -77,6 +77,11 @@
 
     ruler_enabled: false,
 
+    distributor: {
+      use_topology_spread: true,
+      topology_spread_max_skew: 1,
+    },
+
     // Bigtable variables
     bigtable_instance: error 'must specify bigtable instance',
     bigtable_project: error 'must specify bigtable project',

--- a/production/ksonnet/loki/distributor.libsonnet
+++ b/production/ksonnet/loki/distributor.libsonnet
@@ -23,6 +23,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.withEnvMixin($._config.commonEnvs),
 
   local deployment = k.apps.v1.deployment,
+  local topologySpreadConstraints = k.core.v1.topologySpreadConstraint,
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container]) +
@@ -32,9 +33,18 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       $._config.overrides_configmap_mount_name,
       $._config.overrides_configmap_mount_path,
     ) +
-    k.util.antiAffinity +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(5) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    if $._config.distributor.use_topology_spread then
+      deployment.spec.template.spec.withTopologySpreadConstraints(
+        // Evenly spread queriers among available nodes.
+        topologySpreadConstraints.labelSelector.withMatchLabels({ name: 'distributor' }) +
+        topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +
+        topologySpreadConstraints.withWhenUnsatisfiable('ScheduleAnyway') +
+        topologySpreadConstraints.withMaxSkew($._config.distributor.topology_spread_max_skew),
+      )
+    else
+      k.util.antiAffinity,
 
   distributor_service:
     k.util.serviceFor($.distributor_deployment, $._config.service_ignored_labels),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
-->

**What this PR does / why we need it**:

This is equivalent to https://github.com/grafana/loki/pull/6415 but for distributors.
Why only distributors?
- Ingesters are critical and stateful, so we cannot risk losing multiple ingesters on a node failure.
- Other workloads do not typically have a high number of replicas, therefore, the risk of losing multiple replicas on a node failure outweighs the benefits.


**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [x] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
