### PR TITLE
Return Querier/QueryTimeout YAML configuration

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -496,6 +496,12 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 
 			// Enforce the query timeout while querying backends
 			queryTimeout := q.limits.QueryTimeout(userID)
+			// TODO: remove this clause once we remove the deprecated query-timeout flag.
+			if q.cfg.QueryTimeout != 0 { // querier YAML configuration.
+				level.Warn(log).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "WrapQuerySpanAndTimeout")
+				queryTimeout = q.cfg.QueryTimeout
+			}
+
 			_, cancel := context.WithDeadline(ctx, time.Now().Add(queryTimeout))
 			defer cancel()
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletion"
 	listutil "github.com/grafana/loki/pkg/util"
+	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 	util_validation "github.com/grafana/loki/pkg/util/validation"
 	"github.com/grafana/loki/pkg/validation"
@@ -53,6 +54,7 @@ type Config struct {
 	QueryStoreOnly                bool             `yaml:"query_store_only"`
 	QueryIngesterOnly             bool             `yaml:"query_ingester_only"`
 	MultiTenantQueriesEnabled     bool             `yaml:"multi_tenant_queries_enabled"`
+	QueryTimeout                  time.Duration    `yaml:"query_timeout"`
 }
 
 // RegisterFlags register flags.
@@ -354,6 +356,11 @@ func (q *SingleTenantQuerier) Label(ctx context.Context, req *logproto.LabelRequ
 
 	// Enforce the query timeout while querying backends
 	queryTimeout := q.limits.QueryTimeout(userID)
+	// TODO: remove this clause once we remove the deprecated query-timeout flag.
+	if q.cfg.QueryTimeout != 0 { // querier YAML configuration.
+		level.Warn(util_log.Logger).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "err", err, "call", "Label")
+		queryTimeout = q.cfg.QueryTimeout
+	}
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(queryTimeout))
 	defer cancel()
 
@@ -443,6 +450,11 @@ func (q *SingleTenantQuerier) Tail(ctx context.Context, req *logproto.TailReques
 		return nil, errors.Wrap(err, "failed to load tenant")
 	}
 	queryTimeout := q.limits.QueryTimeout(tenantID)
+	// TODO: remove this clause once we remove the deprecated query-timeout flag.
+	if q.cfg.QueryTimeout != 0 { // querier YAML configuration.
+		level.Warn(util_log.Logger).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "SingleTenantQuerier/Tail")
+		queryTimeout = q.cfg.QueryTimeout
+	}
 	queryCtx, cancelQuery := context.WithDeadline(ctx, time.Now().Add(queryTimeout))
 	defer cancelQuery()
 
@@ -487,6 +499,11 @@ func (q *SingleTenantQuerier) Series(ctx context.Context, req *logproto.SeriesRe
 
 	// Enforce the query timeout while querying backends
 	queryTimeout := q.limits.QueryTimeout(userID)
+	// TODO: remove this clause once we remove the deprecated query-timeout flag.
+	if q.cfg.QueryTimeout != 0 { // querier YAML configuration.
+		level.Warn(util_log.Logger).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "SingleTenantQuerier/Series")
+		queryTimeout = q.cfg.QueryTimeout
+	}
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(queryTimeout))
 	defer cancel()
 
@@ -710,6 +727,11 @@ func (q *SingleTenantQuerier) IndexStats(ctx context.Context, req *loghttp.Range
 
 	// Enforce the query timeout while querying backends
 	queryTimeout := q.limits.QueryTimeout(userID)
+	// TODO: remove this clause once we remove the deprecated query-timeout flag.
+	if q.cfg.QueryTimeout != 0 { // querier YAML configuration.
+		level.Warn(util_log.Logger).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "SingleTenantQuerier/IndexStats")
+		queryTimeout = q.cfg.QueryTimeout
+	}
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(queryTimeout))
 	defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On PR #6835 I mistakenly removed the `querier:query_timeout` YAML configuration. This PR returns it and uses it if it is still configured, while logging a warning message to alert users of the upcoming changes.
