### PR TITLE
update to alpine:3.6.2

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.0
+    - 0.23.0
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.0
+    - 0.23.0
     username:
       from_secret: docker_username
   when:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.23.0
+    - 0.24.0
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.23.0
+    - 0.24.0
     username:
       from_secret: docker_username
   when:

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false clients/cmd/docker-driver/docker-driver
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/clients/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -9,7 +9,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false promtail-debug
 
 
-FROM       alpine:3.15.6
+FROM       alpine:3.16.2
 RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/clients/cmd/promtail/promtail-debug /usr/bin/promtail-debug
 COPY       --from=build /go/bin/dlv /usr/bin/dlv

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false logcli
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 
 RUN apk add --no-cache ca-certificates libcap
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -8,7 +8,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-debug
 
-FROM       alpine:3.15.6
+FROM       alpine:3.16.2
 RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
 COPY       --from=build /usr/bin/dlv /usr/bin/dlv

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -3,7 +3,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/migrate/migrate /usr/bin/migrate
 #ENTRYPOINT [ "/usr/bin/migrate" ]

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -4,7 +4,7 @@
 # tag of the Docker image in `../.drone/drone.jsonnet` and run `make drone`.
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
-FROM alpine:3.15.6 as helm
+FROM alpine:3.16.2 as helm
 ARG HELM_VER="v3.2.3"
 
 RUN apk add --no-cache curl && \
@@ -13,7 +13,7 @@ RUN apk add --no-cache curl && \
     mv /tmp/linux-amd64/helm /usr/bin/helm && \
     rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
 
-FROM alpine:3.15.6 as lychee
+FROM alpine:3.16.2 as lychee
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/lychee-$LYCHEE_VER.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-x86_64-unknown-linux-gnu.tar.gz && \
@@ -21,18 +21,18 @@ RUN apk add --no-cache curl && \
     mv /tmp/lychee /usr/bin/lychee && \
     rm -rf /tmp/linux-amd64 /tmp/lychee-$LYCHEE_VER.tgz
 
-FROM alpine:3.15.6 as golangci
+FROM alpine:3.16.2 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.45.2
 
-FROM alpine:3.15.6 as buf
+FROM alpine:3.16.2 as buf
 
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$(uname -s)-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"
 
-FROM alpine:3.15.6 as docker
+FROM alpine:3.16.2 as docker
 RUN apk add --no-cache docker-cli
 
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above

--- a/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18.5
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 
 RUN     mkdir /loki
 WORKDIR /loki

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 RUN go build -o ./main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 
 
-FROM alpine:3.15.6
+FROM alpine:3.16.2
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates the alpine image version we use to 3.16.2 and will also build/publish a new loki build image

Signed-off-by: Callum Styan <callumstyan@gmail.com>
