### PR TITLE
Docs: Fix Helm Chart links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Notice: `go get` return `package github.com/grafana/loki: no Go files in /go/src
 
 ## Contribute to helm
 
-Please follow the [Loki Helm Chart](./production/helm/README.md).
+Please follow the [Loki Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md#loki-helm-chart).
 
 ### Dependency management
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Notice: `go get` return `package github.com/grafana/loki: no Go files in /go/src
 
 ## Contribute to helm
 
-Please follow the [Loki Helm Chart](https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md#loki-helm-chart).
+Please follow the [Loki Helm Chart](./production/helm/loki/README.md).
 
 ### Dependency management
 

--- a/production/README.md
+++ b/production/README.md
@@ -52,7 +52,7 @@ orchestrator from HashiCorp.
 
 ## Using Helm to deploy on Kubernetes
 
-Helm charts used to deploy Loki and Promtail to Kubernetes:
+Here are the Helm charts used to deploy Loki and Promtail to Kubernetes:
 - [Loki](https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md#loki-helm-chart) 
 - [Promtail](https://github.com/grafana/helm-charts/blob/main/charts/promtail/README.md#promtail) 
 

--- a/production/README.md
+++ b/production/README.md
@@ -52,7 +52,9 @@ orchestrator from HashiCorp.
 
 ## Using Helm to deploy on Kubernetes
 
-There is a [Helm chart](helm) to deploy Loki and Promtail to Kubernetes.
+Helm charts used to deploy Loki and Promtail to Kubernetes:
+- [Loki](https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md#loki-helm-chart) 
+- [Promtail](https://github.com/grafana/helm-charts/blob/main/charts/promtail/README.md#promtail) 
 
 ## Build and run from source
 

--- a/production/README.md
+++ b/production/README.md
@@ -53,7 +53,7 @@ orchestrator from HashiCorp.
 ## Using Helm to deploy on Kubernetes
 
 Here are the Helm charts used to deploy Loki and Promtail to Kubernetes:
-- [Loki](https://github.com/grafana/helm-charts/blob/main/charts/loki/README.md#loki-helm-chart) 
+- [Loki](./production/helm/loki/README.md) 
 - [Promtail](https://github.com/grafana/helm-charts/blob/main/charts/promtail/README.md#promtail) 
 
 ## Build and run from source


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix the link pointing to a Loki Helm chart, found in the [Contribute to Helm](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md#contribute-to-helm) section of the [CONTRIBUTING.MD](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) file.
- Fix the link pointing to a Promtail Helm chart, found in the [Using Helm to deploy on Kubernetes](https://github.com/grafana/loki/blob/main/production/README.md#using-helm-to-deploy-on-kubernetes) section of the [production/README.md](https://github.com/grafana/loki/tree/main/production) file.

The previous links used were pointing to a [deprecated file](https://github.com/grafana/loki/tree/main/production/helm).


**Special notes for your reviewer**:

None.
<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
