### PR TITLE
[bugfix] fix flush.go nil pointer panic

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -309,8 +309,6 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 			return err
 		}
 
-		i.markChunkAsFlushed(cs[j], chunkMtx)
-
 		reason := func() string {
 			chunkMtx.Lock()
 			defer chunkMtx.Unlock()
@@ -319,6 +317,7 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 		}()
 
 		i.reportFlushedChunkStatistics(&ch, c, sizePerTenant, countPerTenant, reason)
+		i.markChunkAsFlushed(cs[j], chunkMtx)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix panic of flushing a chunk. This fix it by first reporting its statistics and only then marking it as flushed.
 
```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x177d158]

goroutine 14455 [running]:
github.com/grafana/loki/pkg/chunkenc.(*MemChunk).Size(0xc00441c750?)
  /loki@v1.6.2-0.20220816085209-65ed7b60fbd4/pkg/chunkenc/memchunk.go:611 +0x18
github.com/grafana/loki/pkg/ingester.(*Ingester).reportFlushedChunkStatistics(0xc00087a000, 0xc00f8efe80, 0xc0519d0870, {0x36b7008, 0xc01a593860}, {0x36b7008, 0xc01a5938c0}, {0x307e2f9, 0x7})
  /loki@v1.6.2-0.20220816085209-65ed7b60fbd4/pkg/ingester/flush.go:395 +0x2f2
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
