### PR TITLE
Docs: Fix default max_chunk_age

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2972,7 +2972,7 @@ configure a runtime configuration file:
 
 How far into the past accepted out-of-order log entries may be
 is configurable with `max_chunk_age`.
-`max_chunk_age` defaults to 1 hour.
+`max_chunk_age` defaults to 2 hour.
 Loki calculates the earliest time that out-of-order entries may have
 and be accepted with
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a doc stating a wrong `max_chunk_age` value.

**Which issue(s) this PR fixes**:
Fixes #6919