### PR TITLE
[TSDB] 600MB max per shard in query planning

### DIFF
--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -142,14 +142,14 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 
 const (
 	// Just some observed values to get us started on better query planning.
-	p90BytesPerSecond = 300 << 20 // 300MB/s/core
+	maxBytesPerShard = 600 << 20 // 600MB/s/core
 )
 
 func guessShardFactor(stats stats.Stats) int {
-	expectedSeconds := float64(stats.Bytes) / float64(p90BytesPerSecond)
-	power := math.Ceil(math.Log2(expectedSeconds)) // round up to nearest power of 2
+	minShards := float64(stats.Bytes) / float64(maxBytesPerShard)
 
-	// Parallelize down to 1s queries
+	power := math.Ceil(math.Log2(minShards)) // round up to nearest power of 2
+
 	// Since x^0 == 1 and we only support factors of 2
 	// reset this edge case manually
 	factor := int(math.Pow(2, power))

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -148,8 +148,8 @@ const (
 // Since we shard by powers of two and we increase shard factor
 // once each shard surpasses maxBytesPerShard, if the shard factor
 // is at least two, the range of data per shard is (maxBytesPerShard/2, maxBytesPerShard]
-// For instance, for a maxBytesPerShard of 500MB and a query touching 1000MB, we split into two shards off 500MB.
-// If there are 10004MB, we split into four shards of 251MB
+// For instance, for a maxBytesPerShard of 500MB and a query touching 1000MB, we split into two shards of 500MB.
+// If there are 1004MB, we split into four shards of 251MB.
 func guessShardFactor(stats stats.Stats) int {
 	minShards := float64(stats.Bytes) / float64(maxBytesPerShard)
 

--- a/pkg/querier/queryrange/shard_resolver_test.go
+++ b/pkg/querier/queryrange/shard_resolver_test.go
@@ -21,26 +21,26 @@ func TestGuessShardFactor(t *testing.T) {
 		{
 			exp: 4,
 			stats: stats.Stats{
-				Bytes: p90BytesPerSecond * 4,
+				Bytes: maxBytesPerShard * 4,
 			},
 		},
 		{
 			// round up shard factor
 			exp: 16,
 			stats: stats.Stats{
-				Bytes: p90BytesPerSecond * 15,
+				Bytes: maxBytesPerShard * 15,
 			},
 		},
 		{
 			exp: 2,
 			stats: stats.Stats{
-				Bytes: p90BytesPerSecond + 1,
+				Bytes: maxBytesPerShard + 1,
 			},
 		},
 		{
 			exp: 0,
 			stats: stats.Stats{
-				Bytes: p90BytesPerSecond,
+				Bytes: maxBytesPerShard,
 			},
 		},
 	} {


### PR DESCRIPTION
This PR gives a little better understanding into shard query planning and targets a range of `(300MB,600MB]` per shard. Doubling this also allows us to halve query parallelism configs and still schedule the same amount of work in parallel, which should make for easier schema upgrades as the parallelism differences between TSDB and prior period configs will be less.