### PR TITLE
Generate Helm chart README.

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -1,6 +1,9 @@
 ---
 name: helm-ci
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'production/helm/**'
 
 jobs:
   call-lint:

--- a/production/helm/ct.yaml
+++ b/production/helm/ct.yaml
@@ -5,7 +5,7 @@ chart-dirs:
   - production/helm
 chart-repos:
   - grafana=https://grafana.github.io/helm-charts
-  - minio=https://helm.min.io
+  - minio=https://charts.min.io
 helm-extra-args: --timeout 600s
 check-version-increment: false
 validate-maintainers: false

--- a/production/helm/loki/Chart.lock
+++ b/production/helm/loki/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
-  repository: https://helm.min.io/
-  version: 8.0.9
+  repository: https://charts.min.io/
+  version: 4.0.12
 - name: grafana-agent-operator
   repository: https://grafana.github.io/helm-charts
   version: 0.2.3
-digest: sha256:70d9f4b15745de61dab06ba2342c76661c0ac1b14e0419be121a1a95475fcf57
-generated: "2022-07-29T15:38:30.127706509-06:00"
+digest: sha256:74ef214ca08874662ab403a2e5eea39df26ad690962fa19f9ff69cf551550ff2
+generated: "2022-08-31T15:16:16.581500076+02:00"

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -14,8 +14,8 @@ Helm chart for Grafana Loki in simple, scalable mode
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.min.io/ | minio(minio) | 4.0.12 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.3 |
-| https://helm.min.io/ | minio(minio) | 8.0.9 |
 
 ## Chart Repo
 

--- a/production/helm/loki/docs/examples/enterprise/overrides-enterprise-gcs.yaml
+++ b/production/helm/loki/docs/examples/enterprise/overrides-enterprise-gcs.yaml
@@ -1,4 +1,4 @@
-enterprise: 
+enterprise:
   enabled: true
   adminApi:
     enabled: true

--- a/production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml
+++ b/production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml
@@ -1,9 +1,9 @@
-enterprise: 
+enterprise:
   enabled: false
   adminApi:
     enabled: false
   useExternalLicense: false
- 
+
   config: |
     admin_client:
       storage:

--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -40,7 +40,7 @@ spec:
       relabelings:
         - sourceLabels: [job]
           replacement: "{{ $.Release.Namespace }}/$1"
-          targetLabel: job 
+          targetLabel: job
         - replacement: "{{ include "loki.fullname" $ }}"
           targetLabel: cluster
         {{- with .relabelings }}

--- a/production/helm/loki/templates/securitycontextconstraints.yaml
+++ b/production/helm/loki/templates/securitycontextconstraints.yaml
@@ -14,22 +14,22 @@ allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: []
 defaultAddCapabilities: null
-fsGroup: 
+fsGroup:
   type: RunAsAny
 groups: []
 priority: null
 readOnlyRootFilesystem: false
-requiredDropCapabilities: 
+requiredDropCapabilities:
   - ALL
-runAsUser: 
+runAsUser:
   type: RunAsAny
-seLinuxContext: 
+seLinuxContext:
   type: MustRunAs
 seccompProfiles:
   - '*'
-supplementalGroups: 
+supplementalGroups:
   type: RunAsAny
-volumes: 
+volumes:
   - configMap
   - downwardAPI
   - emptyDir

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1059,7 +1059,7 @@ tracing:
 # Configuration for `minio` child chart
 # -------------------------------------
 minio:
-  enabled: false 
+  enabled: false
   accessKey: enterprise-logs
   secretKey: supersecret
   buckets:

--- a/tools/dev/k3d/chartfile.yaml
+++ b/tools/dev/k3d/chartfile.yaml
@@ -5,7 +5,7 @@ repositories:
 - name: prometheus-community
   url: https://prometheus-community.github.io/helm-charts
 - name: minio
-  url: https://helm.min.io
+  url: https://charts.min.io
 requires:
 - chart: grafana/promtail
   version: 3.8.1
@@ -14,7 +14,7 @@ requires:
 - chart: prometheus-community/prometheus
   version: 15.0.1
 - chart: minio/minio
-  version: 8.0.10
+  version: 4.0.12
 - chart: grafana/loki-distributed
   version: 0.42.0
 - chart: grafana/loki-simple-scalable


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm CI would not pass the linting stage.

Summary
* updates the README
* introduces a filter that will only run the Helm CI on changes to the
  Helm chart directory
* removes trailing whitespace
* corrects the Minio chart repository
