### PR TITLE
[new feature] logql engine support exec `vector(0)` grama

### DIFF
--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -595,6 +595,14 @@ func TestEngine_LogsInstantQuery(t *testing.T) {
 			promql.Scalar{T: 60 * 1000, V: 2},
 		},
 		{
+			// vector instant
+			`vector(2)`,
+			time.Unix(60, 0), logproto.FORWARD, 100,
+			nil,
+			nil,
+			promql.Scalar{T: 60 * 1000, V: 2},
+		},
+		{
 			// single comparison
 			`1 == 1`,
 			time.Unix(60, 0), logproto.FORWARD, 100,
@@ -1911,6 +1919,18 @@ func TestEngine_RangeQuery(t *testing.T) {
 		},
 		{
 			`2`,
+			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
+			nil,
+			nil,
+			promql.Matrix{
+				promql.Series{
+					Points: []promql.Point{{T: 60 * 1000, V: 2}, {T: 90 * 1000, V: 2}, {T: 120 * 1000, V: 2}, {T: 150 * 1000, V: 2}, {T: 180 * 1000, V: 2}},
+				},
+			},
+		},
+		// vector query range
+		{
+			`vector(2)`,
 			time.Unix(60, 0), time.Unix(180, 0), 30 * time.Second, 0, logproto.FORWARD, 100,
 			nil,
 			nil,

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -1535,11 +1535,10 @@ func TestEngine_RangeQuery(t *testing.T) {
 				promql.Series{
 					//vector result
 					Metric: labels.Labels(nil),
-					Points: []promql.Point{promql.Point{T: 60000, V: 0}, promql.Point{T: 80000, V: 0}, promql.Point{T: 100000, V: 0}, promql.Point{T: 120000, V: 0}, promql.Point{T: 140000, V: 0}, promql.Point{T: 160000, V: 0}, promql.Point{T: 180000, V: 0}}},
+					Points: []promql.Point{{T: 60000, V: 0}, {T: 80000, V: 0}, {T: 100000, V: 0}, {T: 120000, V: 0}, {T: 140000, V: 0}, {T: 160000, V: 0}, {T: 180000, V: 0}}},
 				promql.Series{
 					Metric: labels.Labels{labels.Label{Name: "app", Value: "foo"}},
-					Points: []promql.Point{promql.Point{T: 60000, V: 0.03333333333333333}, promql.Point{T: 80000, V: 0.06666666666666667}, promql.Point{T: 100000, V: 0.06666666666666667}, promql.Point{T: 120000, V: 0.03333333333333333}, promql.Point{T: 180000, V: 0.03333333333333333}},
-				},
+					Points: []promql.Point{{T: 60000, V: 0.03333333333333333}, {T: 80000, V: 0.06666666666666667}, {T: 100000, V: 0.06666666666666667}, {T: 120000, V: 0.03333333333333333}, {T: 180000, V: 0.03333333333333333}}},
 			},
 		},
 		{

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -153,6 +153,7 @@ func Test_SampleExpr_String(t *testing.T) {
 		)
 		`,
 		`10 / (5/2)`,
+		`(count_over_time({job="postgres"}[5m])/2) or vector(2)`,
 		`10 / (count_over_time({job="postgres"}[5m])/2)`,
 		`{app="foo"} | json response_status="response.status.code", first_param="request.params[0]"`,
 		`label_replace(

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -2855,6 +2855,10 @@ func TestParse(t *testing.T) {
 			err: logqlmodel.NewParseError("syntax error: unexpected IDENTIFIER, expecting NUMBER or { or (", 1, 20),
 		},
 		{
+			in:  `vector(abc)`,
+			err: logqlmodel.NewParseError("syntax error: unexpected IDENTIFIER, expecting NUMBER", 1, 8),
+		},
+		{
 			in: `{app="foo"}
 					# |= "bar"
 					| json`,


### PR DESCRIPTION
**What this PR does / why we need it**:
logql engine support exec `vector(0)` grama.
new PR of :https://github.com/grafana/loki/pull/7007
**Which issue(s) this PR fixes**:
Fixes #6946

**Special notes for your reviewer**:
test passed.
test1: vectorExpr only
![image](https://user-images.githubusercontent.com/9583245/187871060-2ce63f01-5613-4a1e-9a52-59712f32cc7c.png)

test2: binExpr and vectorExpr
![image](https://user-images.githubusercontent.com/9583245/188090201-702c1ec4-7c37-41cb-9f2f-8f137a39dadf.png)

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
