### PR TITLE
tsdb: build tsdb from tenantheads

### DIFF
--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -31,6 +31,10 @@ func newNoopTSDBManager(dir string) noopTSDBManager {
 	}
 }
 
+func (m noopTSDBManager) BuildFromHead(_ *tenantHeads) error {
+	panic("BuildFromHead not implemented")
+}
+
 func (m noopTSDBManager) BuildFromWALs(_ time.Time, wals []WALIdentifier) error {
 	return recoverHead(m.dir, m.tenantHeads, wals)
 }

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -200,7 +200,7 @@ func (m *tsdbManager) build(heads *tenantHeads) (err error) {
 
 		return nil
 	}); err != nil {
-		level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB from WALs")
+		level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB")
 		return err
 	}
 

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -158,7 +158,7 @@ func (m *tsdbManager) Start() (err error) {
 	return nil
 }
 
-func (m *tsdbManager) build(heads *tenantHeads) (err error) {
+func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 	periods := make(map[string]*Builder)
 
 	if err := heads.forAll(func(user string, ls labels.Labels, chks index.ChunkMetas) error {
@@ -253,7 +253,7 @@ func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 		}
 	}()
 
-	return m.build(heads)
+	return m.buildFromHead(heads)
 }
 
 func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error) {
@@ -272,7 +272,7 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error
 			return errors.Wrap(err, "building TSDB from WALs")
 		}
 
-		err := m.build(tmp)
+		err := m.buildFromHead(tmp)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -28,6 +28,8 @@ type TSDBManager interface {
 	Start() error
 	// Builds a new TSDB file from a set of WALs
 	BuildFromWALs(time.Time, []WALIdentifier) error
+	// Builds a new TSDB file from tenantHeads
+	BuildFromHead(*tenantHeads) error
 }
 
 /*
@@ -156,105 +158,123 @@ func (m *tsdbManager) Start() (err error) {
 	return nil
 }
 
+func (m *tsdbManager) build(heads *tenantHeads) (err error) {
+	periods := make(map[string]*Builder)
+
+	if err := heads.forAll(func(user string, ls labels.Labels, chks index.ChunkMetas) error {
+
+		// chunks may overlap index period bounds, in which case they're written to multiple
+		pds := make(map[string]index.ChunkMetas)
+		for _, chk := range chks {
+			idxBuckets, err := indexBuckets(chk.From(), chk.Through(), m.tableRanges)
+			if err != nil {
+				return err
+			}
+
+			for _, bucket := range idxBuckets {
+				pds[bucket] = append(pds[bucket], chk)
+			}
+		}
+
+		// Embed the tenant label into TSDB
+		lb := labels.NewBuilder(ls)
+		lb.Set(TenantLabel, user)
+		withTenant := lb.Labels()
+
+		// Add the chunks to all relevant builders
+		for pd, matchingChks := range pds {
+			b, ok := periods[pd]
+			if !ok {
+				b = NewBuilder()
+				periods[pd] = b
+			}
+
+			b.AddSeries(
+				withTenant,
+				// use the fingerprint without the added tenant label
+				// so queries route to the chunks which actually exist.
+				model.Fingerprint(ls.Hash()),
+				matchingChks,
+			)
+		}
+
+		return nil
+	}); err != nil {
+		level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB from WALs")
+		return err
+	}
+
+	for p, b := range periods {
+		dstDir := filepath.Join(managerMultitenantDir(m.dir), fmt.Sprint(p))
+		dst := newPrefixedIdentifier(
+			MultitenantTSDBIdentifier{
+				nodeName: m.nodeName,
+				ts:       heads.start,
+			},
+			dstDir,
+			"",
+		)
+
+		level.Debug(m.log).Log("msg", "building tsdb for period", "pd", p, "dst", dst.Path())
+		// build+move tsdb to multitenant dir
+		start := time.Now()
+		_, err = b.Build(
+			context.Background(),
+			managerScratchDir(m.dir),
+			func(from, through model.Time, checksum uint32) Identifier {
+				return dst
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
+
+		loaded, err := NewShippableTSDBFile(dst, false)
+		if err != nil {
+			return err
+		}
+
+		if err := m.shipper.AddIndex(p, "", loaded); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
+	level.Debug(m.log).Log("msg", "building heads")
+	defer func() {
+		m.metrics.tsdbCreationsTotal.WithLabelValues("head").Inc()
+		if err != nil {
+			m.metrics.tsdbCreationsFailedTotal.WithLabelValues("head").Inc()
+		}
+	}()
+
+	return m.build(heads)
+}
+
 func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error) {
 	level.Debug(m.log).Log("msg", "building WALs", "n", len(ids), "ts", t)
-	// get relevant wals
-	// iterate them, build tsdb in scratch dir
 	defer func() {
-		m.metrics.tsdbCreationsTotal.Inc()
+		m.metrics.tsdbCreationsTotal.WithLabelValues("wal").Inc()
 		if err != nil {
-			m.metrics.tsdbCreationFailures.Inc()
+			m.metrics.tsdbCreationsFailedTotal.WithLabelValues("wal").Inc()
 		}
 	}()
 
 	level.Debug(m.log).Log("msg", "recovering tenant heads")
 	for _, id := range ids {
-		tmp := newTenantHeads(t, defaultHeadManagerStripeSize, m.metrics, m.log)
+		tmp := newTenantHeads(id.ts, defaultHeadManagerStripeSize, m.metrics, m.log)
 		if err = recoverHead(m.dir, tmp, []WALIdentifier{id}); err != nil {
 			return errors.Wrap(err, "building TSDB from WALs")
 		}
 
-		periods := make(map[string]*Builder)
-
-		if err := tmp.forAll(func(user string, ls labels.Labels, chks index.ChunkMetas) error {
-
-			// chunks may overlap index period bounds, in which case they're written to multiple
-			pds := make(map[string]index.ChunkMetas)
-			for _, chk := range chks {
-				idxBuckets, err := indexBuckets(chk.From(), chk.Through(), m.tableRanges)
-				if err != nil {
-					return err
-				}
-
-				for _, bucket := range idxBuckets {
-					pds[bucket] = append(pds[bucket], chk)
-				}
-			}
-
-			// Embed the tenant label into TSDB
-			lb := labels.NewBuilder(ls)
-			lb.Set(TenantLabel, user)
-			withTenant := lb.Labels()
-
-			// Add the chunks to all relevant builders
-			for pd, matchingChks := range pds {
-				b, ok := periods[pd]
-				if !ok {
-					b = NewBuilder()
-					periods[pd] = b
-				}
-
-				b.AddSeries(
-					withTenant,
-					// use the fingerprint without the added tenant label
-					// so queries route to the chunks which actually exist.
-					model.Fingerprint(ls.Hash()),
-					matchingChks,
-				)
-			}
-
-			return nil
-		}); err != nil {
-			level.Error(m.log).Log("err", err.Error(), "msg", "building TSDB from WALs")
+		err := m.build(tmp)
+		if err != nil {
 			return err
-		}
-
-		for p, b := range periods {
-
-			dstDir := filepath.Join(managerMultitenantDir(m.dir), fmt.Sprint(p))
-			dst := newPrefixedIdentifier(
-				MultitenantTSDBIdentifier{
-					nodeName: m.nodeName,
-					ts:       id.ts,
-				},
-				dstDir,
-				"",
-			)
-
-			level.Debug(m.log).Log("msg", "building tsdb for period", "pd", p, "dst", dst.Path())
-			// build+move tsdb to multitenant dir
-			start := time.Now()
-			_, err = b.Build(
-				context.Background(),
-				managerScratchDir(m.dir),
-				func(from, through model.Time, checksum uint32) Identifier {
-					return dst
-				},
-			)
-			if err != nil {
-				return err
-			}
-
-			level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
-
-			loaded, err := NewShippableTSDBFile(dst, false)
-			if err != nil {
-				return err
-			}
-
-			if err := m.shipper.AddIndex(p, "", loaded); err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
refactors tsdb manager code to expose a new method `BuildFromHead` which comes in handy for building tsdb from tenant heads after rotation.

Currently we build it by recovering head from WAL even when we have access to the in-mem tenant heads.

**Special notes for your reviewer**:
using `loki_tsdb_head_rotations_*` metric to track loop failures which could be caused either by rotation failures or if rotation is blocked by prev head failing to build

**Checklist**
- [ ] Documentation added
- [x] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
