### PR TITLE
Do not run helm release on tags matching our version releases

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   call-update-helm-repo:


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't want to run the helm release on tags matching our loki releases. We can add the helm chart to the release process later, but we're not there yet. Right now our flow is ship the updated loki binary, then circle back around and update the helm charts to use that new version is a separate PR/release.
