### PR TITLE
[jsonnet] port some common jsonnet for statefulset and ingester creation

### DIFF
--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -39,4 +39,39 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       container.mixin.readinessProbe.withInitialDelaySeconds(15) +
       container.mixin.readinessProbe.withTimeoutSeconds(1),
   },
+
+  // functions for k8s objects
+  newLokiPdb(deploymentName, maxUnavailable=1)::
+    local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget;
+    local pdbName = '%s-pdb' % deploymentName;
+
+    podDisruptionBudget.new() +
+    podDisruptionBudget.mixin.metadata.withName(pdbName) +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: pdbName }) +
+    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: deploymentName }) +
+    podDisruptionBudget.mixin.spec.withMaxUnavailable(maxUnavailable),
+
+  newIngesterPdb(ingesterName)::
+    $.newLokiPdb(ingesterName),
+
+  newLokiStatefulSet(name, replicas, container, pvc, podManagementPolicy='Parallel')::
+    local statefulSet = $.apps.v1.statefulSet;
+
+    statefulSet.new(name, replicas, [container], pvc) +
+    statefulSet.mixin.spec.withServiceName(name) +
+    // statefulSet.mixin.metadata.withNamespace($._config.namespace) +
+    // statefulSet.mixin.metadata.withLabels({ name: name }) +
+    statefulSet.mixin.spec.template.metadata.withLabels({ name: name }) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: name }) +
+    // statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
+    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
+    $.config_hash_mixin +
+    (if podManagementPolicy != null then statefulSet.mixin.spec.withPodManagementPolicy(podManagementPolicy) else {}) +
+    (if !std.isObject($._config.node_selector) then {} else statefulSet.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
+    k.util.configVolumeMount('loki', '/etc/loki/config') +
+    k.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ),
 }

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -3,6 +3,7 @@
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
     http_listen_port: 3100,
+    node_selector: null,
 
     create_service_monitor: false,
 
@@ -81,6 +82,10 @@
       use_topology_spread: true,
       topology_spread_max_skew: 1,
     },
+
+    ingester_allow_multiple_replicas_on_same_node: false,
+    ingester_data_disk_size: '10Gi',
+    ingester_data_disk_class: 'fast',
 
     // Bigtable variables
     bigtable_instance: error 'must specify bigtable instance',

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -5,6 +5,28 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local volumeMount = k.core.v1.volumeMount,
   local statefulSet = k.apps.v1.statefulSet,
 
+  // The ingesters should persist TSDB blocks and WAL on a persistent
+  // volume in order to be crash resilient.
+  local ingester_data_pvc =
+    pvc.new() +
+    pvc.mixin.spec.resources.withRequests({ storage: $._config.ingester_data_disk_size }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName($._config.ingester_data_disk_class) +
+    pvc.mixin.metadata.withName('ingester-data'),
+
+  newIngesterStatefulSet(name, container, with_anti_affinity=true)::
+    // local ingesterContainer = container + $.core.v1.container.withVolumeMountsMixin([
+    //   volumeMount.new('ingester-data', '/data'),
+    // ]);
+
+    $.newLokiStatefulSet(name, 3, container, ingester_data_pvc) +
+    // When the ingester needs to flush blocks to the storage, it may take quite a lot of time.
+    // For this reason, we grant an high termination period (80 minutes).
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    // $.lokiVolumeMounts +
+    $.util.podPriority('high') +
+    (if with_anti_affinity then $.util.antiAffinity else {}),
+
   ingester_args::
     $._config.commonArgs {
       target: 'ingester',
@@ -59,21 +81,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     pvc.mixin.spec.withStorageClassName($._config.ingester_pvc_class)
   else {},
 
-  ingester_statefulset: if $._config.stateful_ingesters then
-    statefulSet.new('ingester', 3, [$.ingester_container], $.ingester_data_pvc) +
-    statefulSet.mixin.spec.withServiceName('ingester') +
-    statefulSet.mixin.spec.withPodManagementPolicy('Parallel') +
-    $.config_hash_mixin +
-    k.util.configVolumeMount('loki', '/etc/loki/config') +
-    k.util.configVolumeMount(
-      $._config.overrides_configmap_mount_name,
-      $._config.overrides_configmap_mount_path,
-    ) +
-    k.util.antiAffinity +
-    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800)
-  else {},
+  ingester_statefulset: self.newIngesterStatefulSet('ingester', $.ingester_container, !$._config.ingester_allow_multiple_replicas_on_same_node),
 
   ingester_service:
     if !$._config.stateful_ingesters then


### PR DESCRIPTION
The mimir team turned a lot of jsonnet deployment code/config into functions. The functions make common config across deployments/statefulsets easier, and also creation of new similar but slightly different deployments/statefulsets of exsting components simpler as well. For example, it will make zone aware ingester creation simpler. 

The current changeset should (as in I tested it via `tk diff`) result in no diff for our own environments.

Note that this is just ingester related, there's plenty of other nice jsonnet things the mimir team is doing that we could also copy.

Signed-off-by: Callum Styan <callumstyan@gmail.com>