### PR TITLE
[Helm] Make compactor and limits_config configurable

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -65,29 +65,28 @@ loki:
     {{- else }}
     auth_enabled: {{ .Values.loki.auth_enabled }}
     {{- end }}
-
     server:
       http_listen_port: 3100
       grpc_listen_port: 9095
-
     memberlist:
       join_members:
         - {{ include "loki.memberlist" . }}
-
     {{- if .Values.loki.commonConfig}}
     common:
     {{- toYaml .Values.loki.commonConfig | nindent 2}}
       storage:
       {{- include "loki.commonStorageConfig" . | nindent 4}}
     {{- end}}
-
     limits_config:
+    {{- if .Values.loki.limitsConfig}}
+    {{- toYaml .Values.loki.limitsConfig | nindent 2}}
+    {{- else }}
       enforce_metric_name: false
       reject_old_samples: true
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
       split_queries_by_interval: 15m
-
+    {{- end}}
     {{- with .Values.loki.memcached.chunk_cache }}
     {{- if and .enabled .host }}
     chunk_store_config:
@@ -100,7 +99,6 @@ loki:
           service: {{ .service }}
     {{- end }}
     {{- end }}
-
     {{- if .Values.loki.schemaConfig}}
     schema_config:
     {{- toYaml .Values.loki.schemaConfig | nindent 2}}
@@ -121,13 +119,15 @@ loki:
             prefix: loki_index_
             period: 24h
     {{- end }}
-
+    {{- if .Values.loki.compactorConfig}}
+    compactor:
+    {{- toYaml .Values.loki.compactorConfig | nindent 2}}
+    {{- end }}
     {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
     ruler:
       storage:
       {{- include "loki.rulerStorageConfig" . | nindent 4}}
     {{- end -}}
-
     {{- with .Values.loki.memcached.results_cache }}
     query_range:
       align_queries_with_step: true
@@ -142,12 +142,10 @@ loki:
             timeout: {{ .timeout }}
       {{- end }}
     {{- end }}
-
     {{- with .Values.loki.storage_config }}
     storage_config:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
-
     {{- with .Values.loki.query_scheduler }}
     query_scheduler:
       {{- tpl (. | toYaml) $ | nindent 4 }}
@@ -201,6 +199,12 @@ loki:
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig: {}
+  
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#limits_config for more info on how to configure limits
+  limitsConfig: {}
+  
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#compactor for more info on how to configure compactor
+  compactorConfig: {}
 
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -65,18 +65,22 @@ loki:
     {{- else }}
     auth_enabled: {{ .Values.loki.auth_enabled }}
     {{- end }}
+    
     server:
       http_listen_port: 3100
       grpc_listen_port: 9095
+    
     memberlist:
       join_members:
         - {{ include "loki.memberlist" . }}
+    
     {{- if .Values.loki.commonConfig}}
     common:
     {{- toYaml .Values.loki.commonConfig | nindent 2}}
       storage:
       {{- include "loki.commonStorageConfig" . | nindent 4}}
     {{- end}}
+    
     limits_config:
     {{- if .Values.loki.limitsConfig}}
     {{- toYaml .Values.loki.limitsConfig | nindent 2}}
@@ -87,6 +91,7 @@ loki:
       max_cache_freshness_per_query: 10m
       split_queries_by_interval: 15m
     {{- end}}
+    
     {{- with .Values.loki.memcached.chunk_cache }}
     {{- if and .enabled .host }}
     chunk_store_config:
@@ -119,15 +124,18 @@ loki:
             prefix: loki_index_
             period: 24h
     {{- end }}
+    
     {{- if .Values.loki.compactorConfig}}
     compactor:
     {{- toYaml .Values.loki.compactorConfig | nindent 2}}
     {{- end }}
+    
     {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
     ruler:
       storage:
       {{- include "loki.rulerStorageConfig" . | nindent 4}}
     {{- end -}}
+    
     {{- with .Values.loki.memcached.results_cache }}
     query_range:
       align_queries_with_step: true
@@ -142,10 +150,12 @@ loki:
             timeout: {{ .timeout }}
       {{- end }}
     {{- end }}
+    
     {{- with .Values.loki.storage_config }}
     storage_config:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
+    
     {{- with .Values.loki.query_scheduler }}
     query_scheduler:
       {{- tpl (. | toYaml) $ | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the option to configure the limits_config and compactor in order to apply retentions based on the compactor.
Before the helm charts were migrated from the grafana/helm-charts repo there were some open issues about this for the loki-simple-scalable chart. (https://github.com/grafana/helm-charts/issues/1693)

For us the configuration of retentions via compactor is a important feature and i think the changes i applied here are minor.

**Which issue(s) this PR fixes**:
Fixes partially #7068

