### PR TITLE
Add support for custom internal server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Loki
 
 ##### Enhancements
+* [7069](https://github.com/grafana/loki/pull/7069) **periklis**: Add support for custom internal server listener for readiness probes.
 * [7023](https://github.com/grafana/loki/pull/7023) **liguozhong**: logql engine support exec `vector(0)` grammar.
 * [6983](https://github.com/grafana/loki/pull/6983) **slim-bean**: `__timestamp__` and `__line__` are now available in the logql `label_format` query stage.
 * [6821](https://github.com/grafana/loki/pull/6821) **kavirajk**: Introduce new cache type `embedded-cache` which is an in-process cache system that runs loki without the need for an external cache (like memcached, redis, etc). It can be run in two modes `distributed: false` (default, and same as old `fifocache`) and `distributed: true` which runs cache in distributed fashion sharding keys across peers if Loki is run in microservices or SSD mode.

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -369,9 +369,8 @@ func (t *Loki) Run(opts RunOpts) error {
 	// before starting servers, register /ready handler. It should reflect entire Loki.
 	if t.Cfg.InternalServer.Enable {
 		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
-	} else {
-		t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
 	}
+	t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
 
 	grpc_health_v1.RegisterHealthServer(t.Server.GRPC, grpcutil.NewHealthCheck(sm))
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/loki/pkg/ruler/rulestore"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/scheduler"
+	internalserver "github.com/grafana/loki/pkg/server"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
@@ -65,6 +66,7 @@ type Config struct {
 
 	Common           common.Config            `yaml:"common,omitempty"`
 	Server           server.Config            `yaml:"server,omitempty"`
+	InternalServer   internalserver.Config    `yaml:"internal_server,omitempty"`
 	Distributor      distributor.Config       `yaml:"distributor,omitempty"`
 	Querier          querier.Config           `yaml:"querier,omitempty"`
 	IngesterClient   client.Config            `yaml:"ingester_client,omitempty"`
@@ -131,6 +133,7 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	// Register to throwaway flags first. Default values are remembered during registration and cannot be changed,
 	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
 	c.Server.RegisterFlags(throwaway)
+	c.InternalServer.RegisterFlags(throwaway)
 
 	throwaway.VisitAll(func(f *flag.Flag) {
 		// Ignore errors when setting new values. We have a test to verify that it works.
@@ -232,6 +235,7 @@ type Loki struct {
 	SignalHandler *signals.Handler
 
 	Server                   *server.Server
+	InternalServer           *server.Server
 	ring                     *ring.Ring
 	overrides                *validation.Overrides
 	tenantConfigs            *runtime.TenantConfigs
@@ -363,7 +367,11 @@ func (t *Loki) Run(opts RunOpts) error {
 	}
 
 	// before starting servers, register /ready handler. It should reflect entire Loki.
-	t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
+	if t.Cfg.InternalServer.Enable {
+		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
+	} else {
+		t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm))
+	}
 
 	grpc_health_v1.RegisterHealthServer(t.Server.GRPC, grpcutil.NewHealthCheck(sm))
 
@@ -473,6 +481,11 @@ func (t *Loki) setupModuleManager() error {
 	mm := modules.NewManager(util_log.Logger)
 
 	mm.RegisterModule(Server, t.initServer, modules.UserInvisibleModule)
+
+	if t.Cfg.InternalServer.Enable {
+		mm.RegisterModule(InternalServer, t.initInternalServer, modules.UserInvisibleModule)
+	}
+
 	mm.RegisterModule(RuntimeConfig, t.initRuntimeConfig, modules.UserInvisibleModule)
 	mm.RegisterModule(MemberlistKV, t.initMemberlistKV, modules.UserInvisibleModule)
 	mm.RegisterModule(Ring, t.initRing, modules.UserInvisibleModule)
@@ -542,6 +555,26 @@ func (t *Loki) setupModuleManager() error {
 	// first to initialize the ring that will also be used by the query frontend
 	if (t.Cfg.isModuleEnabled(QueryFrontend) && t.Cfg.isModuleEnabled(QueryScheduler)) || t.Cfg.isModuleEnabled(Read) || t.Cfg.isModuleEnabled(All) {
 		deps[QueryFrontend] = append(deps[QueryFrontend], QueryScheduler)
+	}
+
+	if t.Cfg.InternalServer.Enable {
+		depsToUpdate := []string{Distributor, Ingester, Querier, QueryFrontend, QueryScheduler, Ruler, TableManager, Compactor, IndexGateway}
+
+		for _, dep := range depsToUpdate {
+			var idx int
+			for i, v := range deps[dep] {
+				if v == Server {
+					idx = i
+					break
+				}
+			}
+
+			lhs := deps[dep][0:idx]
+			rhs := deps[dep][idx+1:]
+
+			deps[dep] = append(lhs, InternalServer)
+			deps[dep] = append(deps[dep], rhs...)
+		}
 	}
 
 	for mod, targets := range deps {

--- a/pkg/server/internal_server.go
+++ b/pkg/server/internal_server.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"flag"
+	"time"
+
+	serverww "github.com/weaveworks/common/server"
+)
+
+// Config extends weaveworks server config
+type Config struct {
+	serverww.Config `yaml:",inline"`
+	Enable          bool `yaml:"enable"`
+}
+
+// RegisterFlags add internal server flags to flagset
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cfg.Config.HTTPListenAddress, "internal-server.http-listen-address", "", "HTTP internal server listen address.")
+	f.StringVar(&cfg.Config.HTTPListenNetwork, "internal-server.http-listen-network", serverww.DefaultNetwork, "HTTP internal server listen network, default tcp")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSCertPath, "internal-server.http-tls-cert-path", "", "HTTP internal server cert path.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSKeyPath, "internal-server.http-tls-key-path", "", "HTTP internal server key path.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientAuth, "internal-server.http-tls-client-auth", "", "HTTP TLS Client Auth type.")
+	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientCAs, "internal-server.http-tls-ca-path", "", "HTTP TLS Client CA path.")
+	f.IntVar(&cfg.Config.HTTPListenPort, "internal-server.http-listen-port", 8080, "HTTP internal server listen port.")
+	f.IntVar(&cfg.Config.HTTPConnLimit, "internal-server.http-conn-limit", 0, "Maximum number of simultaneous http connections, <=0 to disable")
+	f.DurationVar(&cfg.Config.ServerGracefulShutdownTimeout, "internal-server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
+	f.DurationVar(&cfg.Config.HTTPServerReadTimeout, "internal-server.http-read-timeout", 30*time.Second, "Read timeout for HTTP server")
+	f.DurationVar(&cfg.Config.HTTPServerWriteTimeout, "internal-server.http-write-timeout", 30*time.Second, "Write timeout for HTTP server")
+	f.DurationVar(&cfg.Config.HTTPServerIdleTimeout, "internal-server.http-idle-timeout", 120*time.Second, "Idle timeout for HTTP server")
+	f.BoolVar(&cfg.Enable, "internal-server.enable", false, "Disable the internal http server.")
+}

--- a/pkg/server/internal_server.go
+++ b/pkg/server/internal_server.go
@@ -21,7 +21,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSKeyPath, "internal-server.http-tls-key-path", "", "HTTP internal server key path.")
 	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientAuth, "internal-server.http-tls-client-auth", "", "HTTP TLS Client Auth type.")
 	f.StringVar(&cfg.Config.HTTPTLSConfig.ClientCAs, "internal-server.http-tls-ca-path", "", "HTTP TLS Client CA path.")
-	f.IntVar(&cfg.Config.HTTPListenPort, "internal-server.http-listen-port", 8080, "HTTP internal server listen port.")
+	f.IntVar(&cfg.Config.HTTPListenPort, "internal-server.http-listen-port", 3101, "HTTP internal server listen port.")
 	f.IntVar(&cfg.Config.HTTPConnLimit, "internal-server.http-conn-limit", 0, "Maximum number of simultaneous http connections, <=0 to disable")
 	f.DurationVar(&cfg.Config.ServerGracefulShutdownTimeout, "internal-server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
 	f.DurationVar(&cfg.Config.HTTPServerReadTimeout, "internal-server.http-read-timeout", 30*time.Second, "Read timeout for HTTP server")

--- a/pkg/server/internal_server.go
+++ b/pkg/server/internal_server.go
@@ -15,7 +15,7 @@ type Config struct {
 
 // RegisterFlags add internal server flags to flagset
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.Config.HTTPListenAddress, "internal-server.http-listen-address", "", "HTTP internal server listen address.")
+	f.StringVar(&cfg.Config.HTTPListenAddress, "internal-server.http-listen-address", "localhost", "HTTP internal server listen address.")
 	f.StringVar(&cfg.Config.HTTPListenNetwork, "internal-server.http-listen-network", serverww.DefaultNetwork, "HTTP internal server listen network, default tcp")
 	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSCertPath, "internal-server.http-tls-cert-path", "", "HTTP internal server cert path.")
 	f.StringVar(&cfg.Config.HTTPTLSConfig.TLSKeyPath, "internal-server.http-tls-key-path", "", "HTTP internal server key path.")


### PR DESCRIPTION
**What this PR does / why we need it**:
The following PR adds support for a custom internal server listener dedicated for the start to serve the ready handler on a separate port and optionally TLS configuration. The key purpose for this one is to serve the Loki HTTP API via mTLS while serving the readiness endpoints without (i.e. kubernetes readiness/liveness probes do not support authentication)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [x] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
