### PR TITLE
operator: Add support for certificates to allow external S3 storage connections

### DIFF
--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -323,6 +323,14 @@ type LokiTemplateSpec struct {
 
 // ObjectStorageTLSSpec is the TLS configuration for reaching the object storage endpoint.
 type ObjectStorageTLSSpec struct {
+	// Key is the data key of a ConfigMap containing a CA certificate.
+	// It needs to be in the same namespace as the LokiStack custom resource.
+	//
+	// +optional
+	// +kubebuilder:validation:optional
+	// +kubebuilder:default:=service-ca.crt
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMap",displayName="CA ConfigMap Key"
+	Key string `json:"caKey,omitempty"`
 	// CA is the name of a ConfigMap containing a CA certificate.
 	// It needs to be in the same namespace as the LokiStack custom resource.
 	//

--- a/operator/internal/handlers/internal/storage/ca_configmap.go
+++ b/operator/internal/handlers/internal/storage/ca_configmap.go
@@ -3,7 +3,7 @@ package storage
 import corev1 "k8s.io/api/core/v1"
 
 // IsValidCAConfigMap checks if the given CA configMap has an
-// non-empty entry for key `service-ca.crt`
-func IsValidCAConfigMap(cm *corev1.ConfigMap) bool {
-	return cm.Data["service-ca.crt"] != ""
+// non-empty entry for the key
+func IsValidCAConfigMap(cm *corev1.ConfigMap, key string) bool {
+	return cm.Data[key] != ""
 }

--- a/operator/internal/handlers/internal/storage/ca_configmap_test.go
+++ b/operator/internal/handlers/internal/storage/ca_configmap_test.go
@@ -42,7 +42,7 @@ func TestIsValidConfigMap(t *testing.T) {
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
 
-			ok := storage.IsValidCAConfigMap(tst.cm)
+			ok := storage.IsValidCAConfigMap(tst.cm, "service-ca.crt")
 			require.Equal(t, tst.valid, ok)
 		})
 	}

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -110,15 +110,15 @@ func CreateOrUpdateLokiStack(
 			return kverrors.Wrap(err, "failed to lookup lokistack object storage CA config map", "name", key)
 		}
 
-		if !storage.IsValidCAConfigMap(&cm) {
+		if !storage.IsValidCAConfigMap(&cm, stack.Spec.Storage.TLS.Key) {
 			return &status.DegradedError{
-				Message: "Invalid object storage CA configmap contents: missing key `service-ca.crt` or no contents",
+				Message: "Invalid object storage CA configmap contents: missing key or no contents",
 				Reason:  lokiv1.ReasonInvalidObjectStorageCAConfigMap,
 				Requeue: false,
 			}
 		}
 
-		objStore.TLS = &storageoptions.TLSConfig{CA: cm.Name}
+		objStore.TLS = &storageoptions.TLSConfig{CA: cm.Name, Key: stack.Spec.Storage.TLS.Key}
 	}
 
 	var (

--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -961,7 +961,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidCAConfigMap_SetDegraded(t *testing.T
 	}
 
 	degradedErr := &status.DegradedError{
-		Message: "Invalid object storage CA configmap contents: missing key `service-ca.crt` or no contents",
+		Message: "Invalid object storage CA configmap contents: missing key or no contents",
 		Reason:  lokiv1.ReasonInvalidObjectStorageCAConfigMap,
 		Requeue: false,
 	}

--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -34,7 +34,7 @@ func ConfigureDeployment(d *appsv1.Deployment, opts Options) error {
 		if opts.TLS == nil {
 			return nil
 		}
-		return configureDeploymentCA(d, opts.TLS.CA)
+		return configureDeploymentCA(d, opts.TLS)
 	default:
 		return nil
 	}
@@ -52,7 +52,7 @@ func ConfigureStatefulSet(d *appsv1.StatefulSet, opts Options) error {
 		if opts.TLS == nil {
 			return nil
 		}
-		return configureStatefulSetCA(d, opts.TLS.CA)
+		return configureStatefulSetCA(d, opts.TLS)
 	default:
 		return nil
 	}
@@ -71,8 +71,8 @@ func configureDeployment(d *appsv1.Deployment, secretName string) error {
 }
 
 // ConfigureDeploymentCA merges a S3 CA ConfigMap volume into the deployment spec.
-func configureDeploymentCA(d *appsv1.Deployment, cmName string) error {
-	p := ensureCAForS3(&d.Spec.Template.Spec, cmName)
+func configureDeploymentCA(d *appsv1.Deployment, tls *TLSConfig) error {
+	p := ensureCAForS3(&d.Spec.Template.Spec, tls)
 
 	if err := mergo.Merge(&d.Spec.Template.Spec, p, mergo.WithOverride); err != nil {
 		return kverrors.Wrap(err, "failed to merge s3 object storage ca options ")
@@ -94,8 +94,8 @@ func configureStatefulSet(s *appsv1.StatefulSet, secretName string) error {
 }
 
 // ConfigureStatefulSetCA merges a S3 CA ConfigMap volume into the statefulset spec.
-func configureStatefulSetCA(s *appsv1.StatefulSet, cmName string) error {
-	p := ensureCAForS3(&s.Spec.Template.Spec, cmName)
+func configureStatefulSetCA(s *appsv1.StatefulSet, tls *TLSConfig) error {
+	p := ensureCAForS3(&s.Spec.Template.Spec, tls)
 
 	if err := mergo.Merge(&s.Spec.Template.Spec, p, mergo.WithOverride); err != nil {
 		return kverrors.Wrap(err, "failed to merge s3 object storage ca options ")
@@ -136,29 +136,29 @@ func ensureCredentialsForGCS(p *corev1.PodSpec, secretName string) corev1.PodSpe
 	}
 }
 
-func ensureCAForS3(p *corev1.PodSpec, cmName string) corev1.PodSpec {
+func ensureCAForS3(p *corev1.PodSpec, tls *TLSConfig) corev1.PodSpec {
 	container := p.Containers[0].DeepCopy()
 	volumes := p.Volumes
 
 	volumes = append(volumes, corev1.Volume{
-		Name: cmName,
+		Name: tls.CA,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: cmName,
+					Name: tls.CA,
 				},
 			},
 		},
 	})
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      cmName,
+		Name:      tls.CA,
 		ReadOnly:  false,
 		MountPath: caDirectory,
 	})
 
 	container.Args = append(container.Args,
-		fmt.Sprintf("-s3.http.ca-file=%s", path.Join(caDirectory, "service-ca.crt")),
+		fmt.Sprintf("-s3.http.ca-file=%s", path.Join(caDirectory, tls.Key)),
 	)
 
 	return corev1.PodSpec{

--- a/operator/internal/manifests/storage/configure_test.go
+++ b/operator/internal/manifests/storage/configure_test.go
@@ -280,7 +280,8 @@ func TestConfigureDeploymentForStorageCA(t *testing.T) {
 				SecretName:  "test",
 				SharedStore: lokiv1.ObjectStorageSecretS3,
 				TLS: &storage.TLSConfig{
-					CA: "test",
+					CA:  "test",
+					Key: "service-ca.crt",
 				},
 			},
 			dpl: &appsv1.Deployment{
@@ -396,7 +397,8 @@ func TestConfigureStatefulSetForStorageCA(t *testing.T) {
 				SecretName:  "test",
 				SharedStore: lokiv1.ObjectStorageSecretS3,
 				TLS: &storage.TLSConfig{
-					CA: "test",
+					CA:  "test",
+					Key: "service-ca.crt",
 				},
 			},
 			sts: &appsv1.StatefulSet{

--- a/operator/internal/manifests/storage/options.go
+++ b/operator/internal/manifests/storage/options.go
@@ -62,5 +62,6 @@ type SwiftStorageConfig struct {
 // TLSConfig for object storage endpoints. Currently supported only by:
 // - S3
 type TLSConfig struct {
-	CA string
+	CA  string
+	Key string
 }


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

This PR supports bringing up Loki in a cluster that runs behind a proxy
It also adds support to provide proxy certificates to support secure traffic behind a proxy in a cluster. 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

<!--
Note about CHANGELOG entries, if a change adds:
* an important feature
* fixes an issue present in a previous release, 
* causes a change in operation that would be useful for an operator of Loki to know
then please add a CHANGELOG entry.

For documentation changes, build changes, simple fixes etc please skip this step. We are attempting to curate a changelog of the most relevant and important changes to be easier to ingest by end users of Loki.

Note about the upgrade guide, if this changes:
* default configuration values
* metric names or label names
* changes existing log lines such as the metrics.go query output line
* configuration parameters 
* anything to do with any API
* any other change that would require special attention or extra steps to upgrade
Please document clearly what changed AND what needs to be done in the upgrade guide.
-->
**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
