### PR TITLE
docs: fix typo in layout

### DIFF
--- a/operator/website/layouts/index.html
+++ b/operator/website/layouts/index.html
@@ -28,7 +28,7 @@
       </div>
       <div class="col-lg-5">
         <h2 class="h4">Recording rules</h2>
-        <p>Push recorded metrics by declarative kuberentes native Recording Rules</p>
+        <p>Push recorded metrics by declarative kubernetes native Recording Rules</p>
       </div>
     </div>
     <div class="row justify-content-center text-center">


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a typo in the layout: `kuberentes` instead of `kubernetes`


