### PR TITLE
Add prefix for helm-release tags

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -12,6 +12,7 @@ jobs:
       charts_dir: production/helm
       cr_configfile: production/helm/cr.yaml
       ct_configfile: production/helm/ct.yaml
+      helm_tag_prefix: helm
     secrets:
       helm_repo_token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
       # See https://github.com/grafana/helm-charts/blob/main/INTERNAL.md about this key


### PR DESCRIPTION
**What this PR does / why we need it**:

The helm release job creates a tag for each new release. The tags was previously `<chart name>-<chart version>`, which in the case of the loki chart in this repo was `loki-3.0.0`. This is confusing, so we are adding the prefix `helm-` to these  tags.