### PR TITLE
Helm: Fix s3 region in ruler storage config

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -193,12 +193,39 @@ filesystem:
 Storage config for ruler
 */}}
 {{- define "loki.rulerStorageConfig" -}}
-{{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") -}}
+{{- if .Values.minio.enabled -}}
 s3:
   bucketnames: {{ $.Values.loki.storage.bucketNames.ruler }}
+{{- else if eq .Values.loki.storage.type "s3" -}}
+{{- with .Values.loki.storage.s3 }}
+s3:
+  {{- with .s3 }}
+  s3: {{ . }}
+  {{- end }}
+  {{- with .endpoint }}
+  endpoint: {{ . }}
+  {{- end }}
+  {{- with .region }}
+  region: {{ . }}
+  {{- end}}
+  bucketnames: {{ $.Values.loki.storage.bucketNames.ruler }}
+  {{- with .secretAccessKey }}
+  secret_access_key: {{ . }}
+  {{- end }}
+  {{- with .accessKeyId }}
+  access_key_id: {{ . }}
+  {{- end }}
+  s3forcepathstyle: {{ .s3ForcePathStyle }}
+  insecure: {{ .insecure }}
+{{- end -}}
 {{- else if eq .Values.loki.storage.type "gcs" -}}
+{{- with .Values.loki.storage.gcs }}
 gcs:
   bucket_name: {{ $.Values.loki.storage.bucketNames.ruler }}
+  chunk_buffer_size: {{ .chunkBufferSize }}
+  request_timeout: {{ .requestTimeout }}
+  enable_http2: {{ .enableHttp2}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently helm chart helper does not pass region or any other information if s3 storage is configured. This causes issues with connecting to S3 on AWS. This Pr fixes it, by passing all revelant configs to ruler storage config.

**Which issue(s) this PR fixes**:
Fixes #7060

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
