### PR TITLE
Automatically label Helm realted pull requests.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,3 +5,5 @@ sig/operator:
 - 'operator/**/*'
 kind/feature:
 - 'operator/docs/enhancements/*'
+aread/helm:
+- 'production/helm/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@ sig/operator:
 - 'operator/**/*'
 kind/feature:
 - 'operator/docs/enhancements/*'
-aread/helm:
+area/helm:
 - 'production/helm/**/*'


### PR DESCRIPTION
**What this PR does / why we need it**:
Labelling Helm related pull requests with `area/helm` will ease discovery.