### PR TITLE
Fix internal server initialization

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -378,6 +378,9 @@ func (t *Loki) Run(opts RunOpts) error {
 	t.bindConfigEndpoint(opts)
 
 	// Each component serves its version.
+	if t.Cfg.InternalServer.Enable {
+		t.InternalServer.HTTP.Path("/loki/api/v1/status/buildinfo").Methods("GET").HandlerFunc(versionHandler())
+	}
 	t.Server.HTTP.Path("/loki/api/v1/status/buildinfo").Methods("GET").HandlerFunc(versionHandler())
 
 	t.Server.HTTP.Path("/debug/fgprof").Methods("GET", "POST").Handler(fgprof.Handler())

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -152,13 +152,13 @@ func (t *Loki) initInternalServer() (services.Service, error) {
 		return nil, err
 	}
 
-	t.Server = serv
+	t.InternalServer = serv
 
 	servicesToWaitFor := func() []services.Service {
 		svs := []services.Service(nil)
 		for m, s := range t.serviceMap {
 			// Server should not wait for itself.
-			if m != Server {
+			if m != InternalServer {
 				svs = append(svs, s)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up on #7069. Fix server instance assignment in modules. Adds missing `buildinfo` handler to internal server listener for k8s liveness checks

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
