### PR TITLE
Fix setting name in documentation

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2161,7 +2161,7 @@ compacts index shards to more performant forms.
 # Constrain the size of a delete request. When a delete request that spans > delete_max_interval
 # is input, the request is sharded into smaller requests of no more than delete_max_interval.
 #
-# 0 means no max_query_period.
+# 0 means no delete_max_interval.
 # CLI flag: -boltdb.shipper.compactor.delete-max-interval
 [delete_max_interval: <duration> | default = 0]
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2158,8 +2158,8 @@ compacts index shards to more performant forms.
 # CLI flag: -boltdb.shipper.compactor.delete-request-cancel-period
 [delete_request_cancel_period: <duration> | default = 24h]
 
-# Constrain the size a delete request. When a delete request that spans > delete_max_query_range
-# is input, the request is sharded into smaller requests of no more than delete_max_query_range.
+# Constrain the size of a delete request. When a delete request that spans > delete_max_interval
+# is input, the request is sharded into smaller requests of no more than delete_max_interval.
 #
 # 0 means no max_query_period.
 # CLI flag: -boltdb.shipper.compactor.delete-max-interval


### PR DESCRIPTION
Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

**What this PR does / why we need it**:

The delete_max_interval was previously named delete_max_query_range. This rename was not done in the documentation,

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
