### PR TITLE
Add sequence num to log output for delete requests

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
@@ -270,6 +270,7 @@ func (d *DeleteRequestsManager) Expired(ref retention.ChunkEntry, _ model.Time) 
 			level.Info(util_log.Logger).Log(
 				"msg", "no chunks to retain: the whole chunk is deleted",
 				"delete_request_id", deleteRequest.RequestID,
+				"sequence num", deleteRequest.SequenceNum,
 				"user", deleteRequest.UserID,
 				"chunkID", string(ref.ChunkID),
 			)
@@ -325,6 +326,7 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 				level.Error(util_log.Logger).Log(
 					"msg", "failed to mark delete request for user as processed",
 					"delete_request_id", deleteRequest.RequestID,
+					"sequence num", deleteRequest.SequenceNum,
 					"user", deleteRequest.UserID,
 					"err", err,
 					"deleted_lines", deleteRequest.DeletedLines,
@@ -333,6 +335,7 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 				level.Info(util_log.Logger).Log(
 					"msg", "delete request for user marked as processed",
 					"delete_request_id", deleteRequest.RequestID,
+					"sequence num", deleteRequest.SequenceNum,
 					"user", deleteRequest.UserID,
 					"deleted_lines", deleteRequest.DeletedLines,
 				)

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager.go
@@ -270,7 +270,7 @@ func (d *DeleteRequestsManager) Expired(ref retention.ChunkEntry, _ model.Time) 
 			level.Info(util_log.Logger).Log(
 				"msg", "no chunks to retain: the whole chunk is deleted",
 				"delete_request_id", deleteRequest.RequestID,
-				"sequence num", deleteRequest.SequenceNum,
+				"sequence_num", deleteRequest.SequenceNum,
 				"user", deleteRequest.UserID,
 				"chunkID", string(ref.ChunkID),
 			)
@@ -326,7 +326,7 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 				level.Error(util_log.Logger).Log(
 					"msg", "failed to mark delete request for user as processed",
 					"delete_request_id", deleteRequest.RequestID,
-					"sequence num", deleteRequest.SequenceNum,
+					"sequence_num", deleteRequest.SequenceNum,
 					"user", deleteRequest.UserID,
 					"err", err,
 					"deleted_lines", deleteRequest.DeletedLines,
@@ -335,7 +335,7 @@ func (d *DeleteRequestsManager) MarkPhaseFinished() {
 				level.Info(util_log.Logger).Log(
 					"msg", "delete request for user marked as processed",
 					"delete_request_id", deleteRequest.RequestID,
-					"sequence num", deleteRequest.SequenceNum,
+					"sequence_num", deleteRequest.SequenceNum,
 					"user", deleteRequest.UserID,
 					"deleted_lines", deleteRequest.DeletedLines,
 				)


### PR DESCRIPTION
Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

**What this PR does / why we need it**:

Print the sequence number of the delete request so the messages are not all the same.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
