### PR TITLE
Only release helm for helm paths

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'production/helm/**'
 
 jobs:
   call-update-helm-repo:


### PR DESCRIPTION
**What this PR does / why we need it**:

Only need to run the helm release action when helm paths were changed