### PR TITLE
Implement all-or-nothing stream ingestion

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -107,7 +107,7 @@ type Config struct {
 	MaxDroppedStreams int `yaml:"max_dropped_streams"`
 
 	// Whether nor not to ingest all at once or not. Comes from distributor StreamShards Enabled
-	AllOrNothingStreamIngest bool `yaml:"-"`
+	RateLimitWholeStream bool `yaml:"-"`
 }
 
 // RegisterFlags registers the flags.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -105,6 +105,9 @@ type Config struct {
 	IndexShards int `yaml:"index_shards"`
 
 	MaxDroppedStreams int `yaml:"max_dropped_streams"`
+
+	// Whether nor not to ingest all at once or not. Comes from distributor StreamShards Enabled
+	AllOrNothingStreamIngest bool `yaml:"-"`
 }
 
 // RegisterFlags registers the flags.

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -262,7 +262,8 @@ func errorForFailedEntries(s *stream, failedEntriesWithError []entryWithError, t
 			entryWithError.entry.Timestamp.String(), entryWithError.e.Error(), streamName)
 	}
 
-	fmt.Fprintf(&buf, "total ignored: %d out of %d", len(failedEntriesWithError), totalEntries)
+	// If it's a 400 or 429, the whole stream was rejected
+	fmt.Fprintf(&buf, "total ignored: %d out of %d", totalEntries, totalEntries)
 
 	var details []*types.Any
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -262,8 +262,7 @@ func errorForFailedEntries(s *stream, failedEntriesWithError []entryWithError, t
 			entryWithError.entry.Timestamp.String(), entryWithError.e.Error(), streamName)
 	}
 
-	// If it's a 400 or 429, the whole stream was rejected
-	fmt.Fprintf(&buf, "total ignored: %d out of %d", totalEntries, totalEntries)
+	fmt.Fprintf(&buf, "total ignored: %d out of %d", len(failedEntriesWithError), totalEntries)
 
 	var details []*types.Any
 

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -160,7 +160,7 @@ func (s *stream) Push(
 
 		s.metrics.walReplaySamplesDropped.WithLabelValues(duplicateReason).Add(float64(len(entries)))
 		s.metrics.walReplayBytesDropped.WithLabelValues(duplicateReason).Add(float64(byteCt))
-		return 0, []entryWithError{{e: ErrEntriesExist}}
+		return 0, []entryWithError{{entry: &logproto.Entry{}, e: ErrEntriesExist}}
 	}
 
 	toStore, invalid := s.validateEntries(entries, isReplay)

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -235,10 +235,11 @@ func TestUnorderedPush(t *testing.T) {
 	)
 
 	for _, x := range []struct {
-		cutBefore bool
-		entries   []logproto.Entry
-		err       bool
-		written   int
+		cutBefore    bool
+		entries      []logproto.Entry
+		err          bool
+		written      int
+		allOrNothing bool
 	}{
 		{
 			entries: []logproto.Entry{
@@ -258,7 +259,17 @@ func TestUnorderedPush(t *testing.T) {
 				{Timestamp: time.Unix(9, 0), Line: "x"},
 			},
 			err:     true,
-			written: 0, // Reject whole stream when any error
+			written: 2, // 1 ignored // Reject whole stream when any error
+		},
+		{ //unwritten entries don't track highest
+			entries: []logproto.Entry{
+				{Timestamp: time.Unix(4, 0), Line: "x"}, // ordering err, too far
+				{Timestamp: time.Unix(12, 0), Line: "x"},
+				{Timestamp: time.Unix(13, 0), Line: "x"},
+			},
+			err:          true,
+			written:      0, // Reject whole stream when any error
+			allOrNothing: true,
 		},
 		// force a chunk cut and then push data overlapping with previous chunk.
 		// This ultimately ensures the iterators implementation respects unordered chunks.
@@ -271,6 +282,8 @@ func TestUnorderedPush(t *testing.T) {
 			written: 2,
 		},
 	} {
+		s.cfg.AllOrNothingStreamIngest = x.allOrNothing
+
 		if x.cutBefore {
 			_ = s.cutChunk(context.Background())
 		}
@@ -289,6 +302,8 @@ func TestUnorderedPush(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "x"},
 		{Timestamp: time.Unix(2, 0), Line: "x"},
 		{Timestamp: time.Unix(7, 0), Line: "x"},
+		{Timestamp: time.Unix(8, 0), Line: "x"},
+		{Timestamp: time.Unix(9, 0), Line: "x"},
 		{Timestamp: time.Unix(10, 0), Line: "x"},
 		{Timestamp: time.Unix(11, 0), Line: "x"},
 	}
@@ -318,6 +333,41 @@ func TestPushRateLimit(t *testing.T) {
 
 	s := newStream(
 		defaultConfig(),
+		limiter,
+		"fake",
+		model.Fingerprint(0),
+		labels.Labels{
+			{Name: "foo", Value: "bar"},
+		},
+		true,
+		NilMetrics,
+	)
+
+	entries := []logproto.Entry{
+		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaaa"},
+		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},
+	}
+
+	// Counter should be 2 now since the first line will be deduped.
+	_, entriesWithErrors := s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
+	require.Len(t, entriesWithErrors, 1)
+	require.Contains(t, entriesWithErrors[0].e.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
+}
+
+func TestPushRateLimitAllOrNothing(t *testing.T) {
+	l := validation.Limits{
+		PerStreamRateLimit:      10,
+		PerStreamRateLimitBurst: 10,
+	}
+	limits, err := validation.NewOverrides(l, nil)
+	require.NoError(t, err)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
+
+	cfg := defaultConfig()
+	cfg.AllOrNothingStreamIngest = true
+
+	s := newStream(
+		cfg,
 		limiter,
 		"fake",
 		model.Fingerprint(0),
@@ -407,6 +457,39 @@ func Benchmark_PushStream(b *testing.B) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	s := newStream(&Config{MaxChunkAge: 24 * time.Hour}, limiter, "fake", model.Fingerprint(0), ls, true, NilMetrics)
+	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{}, 10)
+	require.NoError(b, err)
+
+	go t.loop()
+	defer t.close()
+
+	s.tailers[1] = t
+	ctx := context.Background()
+	e := entries(100, time.Now())
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		rec := recordPool.GetRecord()
+		_, entriesWithErrors := s.Push(ctx, e, rec, 0, true)
+		require.Empty(b, entriesWithErrors)
+		recordPool.PutRecord(rec)
+	}
+}
+
+func Benchmark_PushStreamAllOrNothing(b *testing.B) {
+	ls := labels.Labels{
+		labels.Label{Name: "namespace", Value: "loki-dev"},
+		labels.Label{Name: "cluster", Value: "dev-us-central1"},
+		labels.Label{Name: "job", Value: "loki-dev/ingester"},
+		labels.Label{Name: "container", Value: "ingester"},
+	}
+
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(b, err)
+	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
+
+	s := newStream(&Config{MaxChunkAge: 24 * time.Hour, AllOrNothingStreamIngest: true}, limiter, "fake", model.Fingerprint(0), ls, true, NilMetrics)
 	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{}, 10)
 	require.NoError(b, err)
 

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -258,7 +258,7 @@ func TestUnorderedPush(t *testing.T) {
 				{Timestamp: time.Unix(9, 0), Line: "x"},
 			},
 			err:     true,
-			written: 2, // 1 ignored
+			written: 0, // Reject whole stream when any error
 		},
 		// force a chunk cut and then push data overlapping with previous chunk.
 		// This ultimately ensures the iterators implementation respects unordered chunks.
@@ -289,8 +289,6 @@ func TestUnorderedPush(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "x"},
 		{Timestamp: time.Unix(2, 0), Line: "x"},
 		{Timestamp: time.Unix(7, 0), Line: "x"},
-		{Timestamp: time.Unix(8, 0), Line: "x"},
-		{Timestamp: time.Unix(9, 0), Line: "x"},
 		{Timestamp: time.Unix(10, 0), Line: "x"},
 		{Timestamp: time.Unix(11, 0), Line: "x"},
 	}

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -333,7 +333,7 @@ func TestPushRateLimit(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},
 	}
 
-	// Both entries have errors because rate limiting is does all at once
+	// Both entries have errors because rate limiting is done all at once
 	_, entriesWithErrors := s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
 	require.Len(t, entriesWithErrors, 2)
 	require.Contains(t, entriesWithErrors[0].e.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -258,7 +258,7 @@ func TestUnorderedPush(t *testing.T) {
 				{Timestamp: time.Unix(9, 0), Line: "x"},
 			},
 			err:     true,
-			written: 2, // 1 ignored // Reject whole stream when any error
+			written: 2, // 1 ignored
 		},
 		// force a chunk cut and then push data overlapping with previous chunk.
 		// This ultimately ensures the iterators implementation respects unordered chunks.

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -332,9 +332,10 @@ func TestPushRateLimit(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaaa"},
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},
 	}
-	// Counter should be 2 now since the first line will be deduped.
+
+	// Both entries have errors because rate limiting is does all at once
 	_, entriesWithErrors := s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
-	require.Len(t, entriesWithErrors, 1)
+	require.Len(t, entriesWithErrors, 2)
 	require.Contains(t, entriesWithErrors[0].e.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -427,7 +427,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 
 func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.Cfg.Ingester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-	t.Cfg.Ingester.AllOrNothingStreamIngest = t.Cfg.Distributor.ShardStreams.Enabled
+	t.Cfg.Ingester.RateLimitWholeStream = t.Cfg.Distributor.ShardStreams.Enabled
 
 	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Cfg.IngesterClient, t.Store, t.overrides, t.tenantConfigs, prometheus.DefaultRegisterer)
 	if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -427,6 +427,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 
 func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.Cfg.Ingester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
+	t.Cfg.Ingester.AllOrNothingStreamIngest = t.Cfg.Distributor.ShardStreams.Enabled
 
 	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Cfg.IngesterClient, t.Store, t.overrides, t.tenantConfigs, prometheus.DefaultRegisterer)
 	if err != nil {


### PR DESCRIPTION
Per-stream sharding will introduce automatic stream sharding on rate-limited streams. The ingester's current line-by-line behavior may result in duplicates when a partially-accepted stream is resharded and sent to other ingesters. This PR makes the ingester either rate limit the entire stream before attempting to write lines to a chunk. The PR

1. Separates validation, storage, and wal replay into their own functions
2. Implements a flag to rate limit the whole stream or not
3. Checks rate limits for the whole stream rather than line-by-line
4. Returns an error with information on the whole stream when rate limited

