### PR TITLE
Add chart-tools and chart-releaser for helm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,8 @@
             golangci-lint
             helm-docs
             faillint
+            chart-testing
+            chart-releaser
           ];
 
           shellHook = ''

--- a/nix/chart-releaser.nix
+++ b/nix/chart-releaser.nix
@@ -1,0 +1,37 @@
+{ pkgs, lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "chart-releaser";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1x3r4cyzk4p9shbg2xzgvfbfk9kc12hqy9xzpd6l0fbyhdh91qxw";
+  };
+
+  vendorSha256 = "GYsP5LXZA/swgg7xsOkOAITj/E7euEpP0Uk2KzUzBbI=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/cr\"," "\"$out/etc/cr\","
+  '';
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${version}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  # tests require git to be available
+  nativeBuildInputs = with pkgs; [ git installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd cr \
+      --bash <($out/bin/cr completion bash) \
+      --zsh <($out/bin/cr completion zsh) \
+      --fish <($out/bin/cr completion fish) \
+  '';
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -37,5 +37,9 @@ in {
     faillint = prev.callPackage ./faillint.nix {
       inherit (prev) lib buildGoModule fetchFromGitHub;
     };
+
+    chart-releaser = prev.callPackage ./chart-releaser.nix {
+      inherit (prev) pkgs lib buildGoModule fetchFromGitHub;
+    };
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `chart-tools` and `chart-releaser` binaries to the nix shell for doing helm releases/testing.