### PR TITLE
Helm: Fix disabling service monitor in monitoring subchart

### DIFF
--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.monitoring.serviceMonitor.enabled }}
 {{- with .Values.monitoring.serviceMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -53,4 +53,5 @@ spec:
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes service monitor template so it respects monitoring.serviceMonitor.enable value
**Which issue(s) this PR fixes**:
Fixes #7066
Fixes #7047

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
