### PR TITLE
Expose limits and compactor config via helm values

### DIFF
--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -236,6 +236,7 @@ monitoring:
 | ingress.paths.write[1] | string | `"/loki/api/v1/push"` |  |
 | loki.auth_enabled | bool | `true` |  |
 | loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":3}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
+| loki.compactor | object | `{}` | Optional compactor configuration |
 | loki.config | string | See values.yaml | Config file contents for Loki |
 | loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
 | loki.existingSecretForConfig | string | `""` | Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config` |
@@ -243,6 +244,7 @@ monitoring:
 | loki.image.registry | string | `"docker.io"` | The Docker registry |
 | loki.image.repository | string | `"grafana/loki"` | Docker image repository |
 | loki.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| loki.limits_config | object | `{"enforce_metric_name":false,"max_cache_freshness_per_query":"10m","reject_old_samples":true,"reject_old_samples_max_age":"168h","split_queries_by_interval":"15m"}` | Limits config |
 | loki.memcached | object | `{"chunk_cache":{"batch_size":256,"enabled":false,"host":"","parallelism":10,"service":"memcached-client"},"results_cache":{"default_validity":"12h","enabled":false,"host":"","service":"memcached-client","timeout":"500ms"}}` | Configure memcached as an external cache for chunk and results cache. Disabled by default must enable and specify a host for each cache you would like to use. |
 | loki.podAnnotations | object | `{}` | Common annotations for all pods |
 | loki.podSecurityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | The SecurityContext for Loki pods |
@@ -253,22 +255,7 @@ monitoring:
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | loki.schemaConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
-| loki.storage.bucketNames.admin | string | `"admin"` |  |
-| loki.storage.bucketNames.chunks | string | `"chunks"` |  |
-| loki.storage.bucketNames.ruler | string | `"ruler"` |  |
-| loki.storage.filesystem.chunks_directory | string | `"/var/loki/chunks"` |  |
-| loki.storage.filesystem.rules_directory | string | `"/var/loki/rules"` |  |
-| loki.storage.gcs.chunkBufferSize | int | `0` |  |
-| loki.storage.gcs.enableHttp2 | bool | `true` |  |
-| loki.storage.gcs.requestTimeout | string | `"0s"` |  |
-| loki.storage.s3.accessKeyId | string | `nil` |  |
-| loki.storage.s3.endpoint | string | `nil` |  |
-| loki.storage.s3.insecure | bool | `false` |  |
-| loki.storage.s3.region | string | `nil` |  |
-| loki.storage.s3.s3 | string | `nil` |  |
-| loki.storage.s3.s3ForcePathStyle | bool | `false` |  |
-| loki.storage.s3.secretAccessKey | string | `nil` |  |
-| loki.storage.type | string | `"s3"` |  |
+| loki.storage | object | `{"bucketNames":{"admin":"admin","chunks":"chunks","ruler":"ruler"},"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"},"gcs":{"chunkBufferSize":0,"enableHttp2":true,"requestTimeout":"0s"},"s3":{"accessKeyId":null,"endpoint":null,"insecure":false,"region":null,"s3":null,"s3ForcePathStyle":false,"secretAccessKey":null},"type":"s3"}` | Storage config. Providing this will automatically populate all necessary storage configs in the templated config. |
 | loki.storage_config | object | `{"hedging":{"at":"250ms","max_per_second":20,"up_to":3}}` | Additional storage config |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
 | minio | object | `{"accessKey":"enterprise-logs","buckets":[{"name":"chunks","policy":"none","purge":false},{"name":"ruler","policy":"none","purge":false},{"name":"admin","policy":"none","purge":false}],"enabled":false,"persistence":{"size":"5Gi"},"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"secretKey":"supersecret"}` | ----------------------------------- |

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -81,12 +81,10 @@ loki:
       {{- include "loki.commonStorageConfig" . | nindent 4}}
     {{- end}}
 
+    {{- with .Values.loki.lmits_config }}
     limits_config:
-      enforce_metric_name: false
-      reject_old_samples: true
-      reject_old_samples_max_age: 168h
-      max_cache_freshness_per_query: 10m
-      split_queries_by_interval: 15m
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
 
     {{- with .Values.loki.memcached.chunk_cache }}
     {{- if and .enabled .host }}
@@ -153,14 +151,28 @@ loki:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
 
+    {{- with .Values.loki.compactor }}
+    compactor:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
+
   # Should authentication be enabled
   auth_enabled: true
+
+  # -- Limits config
+  limits_config:
+    enforce_metric_name: false
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+    max_cache_freshness_per_query: 10m
+    split_queries_by_interval: 15m
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
   commonConfig:
     path_prefix: /var/loki
     replication_factor: 3
 
+  # -- Storage config. Providing this will automatically populate all necessary storage configs in the templated config.
   storage:
     bucketNames:
       chunks: chunks
@@ -214,6 +226,9 @@ loki:
       at: "250ms"
       max_per_second: 20
       up_to: 3
+
+  # --  Optional compactor configuration
+  compactor: {}
 
 enterprise:
   # Enable enterprise features, license must be provided


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes the compactor and limits config in the helm chart via helm values. Replaces https://github.com/grafana/loki/pull/7055 with some minor stylistic changes, and moving default limits into the new `limits_config` value.