### PR TITLE
Fix pod affinity selector for single binary

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -730,7 +730,7 @@ singleBinary:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              {{- include "loki.readSelectorLabels" . | nindent 10 }}
+              {{- include "loki.singleBinarySelectorLabels" . | nindent 10 }}
           topologyKey: kubernetes.io/hostname
   # -- Node selector for single binary pods
   nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix incorrect selectors for anti-affinity rules for loki single binary.

**Which issue(s) this PR fixes**:
Fixes #7105