### PR TITLE
Fix helm release name template

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,9 +1,6 @@
 name: helm-release
 
 on:
-  pull_request:
-    paths:
-      - 'production/helm/**'
   push:
     branches:
       - main

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,6 +1,9 @@
 name: helm-release
 
 on:
+  pull_request:
+    paths:
+      - 'production/helm/**'
   push:
     branches:
       - main

--- a/production/helm/cr.yaml
+++ b/production/helm/cr.yaml
@@ -3,3 +3,4 @@ key: Grafana Loki
 owner: grafana
 sign: true
 skip-existing: true
+release-name-template-string: "helm-{{ .Name }}-{{ .Version }}"

--- a/production/helm/cr.yaml
+++ b/production/helm/cr.yaml
@@ -3,4 +3,4 @@ key: Grafana Loki
 owner: grafana
 sign: true
 skip-existing: true
-release-name-template-string: "helm-{{ .Name }}-{{ .Version }}"
+release-name-template: "helm-{{ .Name }}-{{ .Version }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The helm release job is failing because it's looking for the wrong release name. This is an attempt to fix it.

**Special notes for your reviewer**:

The addition of `on: pull_request` to the github action is a temporary hack so I can test if this fixes the issue. Please don't merge until we have a chance to remove that.
