### PR TITLE
Fix errors loading deletes after force-removing partially-completed delete

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1103,9 +1103,6 @@ curl -u "Tenant1:$API_TOKEN" \
 DELETE /loki/api/v1/delete
 ```
 
-Query Parameters:
-* `force=<boolean>`: When the `force` query parameter is true, partially completed delete requests will be canceled. NOTE: some data from the request may still be deleted.
-
 Remove a delete request for the authenticated tenant.
 The [log entry deletion](../operations/storage/logs-deletion/) documentation has configuration details.
 
@@ -1122,6 +1119,7 @@ DELETE /loki/api/v1/delete
 Query parameters:
 
 * `request_id=<request_id>`: Identifies the delete request to cancel; IDs are found using the `delete` endpoint.
+* `force=<boolean>`: When the `force` query parameter is true, partially completed delete requests will be canceled. NOTE: some data from the request may still be deleted and the deleted request will be listed as 'processed'
 
 A 204 response indicates success.
 

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_store.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -211,6 +212,10 @@ func (ds *deleteRequestsStore) GetDeleteRequestGroup(ctx context.Context, userID
 	if len(deleteRequests) == 0 {
 		return nil, ErrDeleteRequestNotFound
 	}
+
+	sort.Slice(deleteRequests, func(i, j int) bool {
+		return deleteRequests[i].SequenceNum < deleteRequests[j].SequenceNum
+	})
 
 	return deleteRequests, nil
 }

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_store.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_store.go
@@ -238,16 +238,24 @@ func (ds *deleteRequestsStore) GetCacheGenerationNumber(ctx context.Context, use
 
 func (ds *deleteRequestsStore) queryDeleteRequests(ctx context.Context, deleteQuery index.Query) ([]DeleteRequest, error) {
 	var deleteRequests []DeleteRequest
-	err := ds.indexClient.QueryPages(ctx, []index.Query{deleteQuery}, func(query index.Query, batch index.ReadBatchResult) (shouldContinue bool) {
+	var err error
+	err = ds.indexClient.QueryPages(ctx, []index.Query{deleteQuery}, func(query index.Query, batch index.ReadBatchResult) (shouldContinue bool) {
 		// No need to lock inside the callback since we run a single index query.
 		itr := batch.Iterator()
 		for itr.Next() {
-			userID, requestID := splitUserIDAndRequestID(string(itr.RangeValue()))
+			userID, requestID, seqID := splitUserIDAndRequestID(string(itr.RangeValue()))
+
+			var seqNum int64
+			seqNum, err = strconv.ParseInt(seqID, 10, 64)
+			if err != nil {
+				return false
+			}
 
 			deleteRequests = append(deleteRequests, DeleteRequest{
-				UserID:    userID,
-				RequestID: requestID,
-				Status:    DeleteRequestStatus(itr.Value()),
+				UserID:      userID,
+				RequestID:   requestID,
+				SequenceNum: seqNum,
+				Status:      DeleteRequestStatus(itr.Value()),
 			})
 		}
 		return true
@@ -262,8 +270,7 @@ func (ds *deleteRequestsStore) queryDeleteRequests(ctx context.Context, deleteQu
 func (ds *deleteRequestsStore) deleteRequestsWithDetails(ctx context.Context, partialDeleteRequests []DeleteRequest) ([]DeleteRequest, error) {
 	deleteRequests := make([]DeleteRequest, 0, len(partialDeleteRequests))
 	for _, group := range partitionByRequestID(partialDeleteRequests) {
-		for i, deleteRequest := range group {
-			deleteRequest.SequenceNum = int64(i)
+		for _, deleteRequest := range group {
 			requestWithDetails, err := ds.queryDeleteRequestDetails(ctx, deleteRequest)
 			if err != nil {
 				return nil, err
@@ -390,9 +397,13 @@ func encodeUniqueID(t uint32) []byte {
 	return encodedThroughBytes
 }
 
-func splitUserIDAndRequestID(rangeValue string) (userID, requestID string) {
+func splitUserIDAndRequestID(rangeValue string) (userID, requestID, seqID string) {
 	parts := strings.Split(rangeValue, ":")
-	return parts[0], parts[1]
+
+	if len(parts) == 2 {
+		return parts[0], parts[1], "0"
+	}
+	return parts[0], parts[1], parts[2]
 }
 
 // unsafeGetString is like yolostring but with a meaningful name


### PR DESCRIPTION
When sharded deletes that are partially completed are force-removed, everything is removed except the shards that are currently being deleted. The shards being deleted aren't necessarily in numerical order so there's no way to know assume which shards have and haven't been deleted.

The Delete store assumed it could look up requests in sequential order and returned empty requests where there were gaps in the stored data. This change takes the `sequence number` from the stored key of the delete requests it finds and uses that to look up details.

