### PR TITLE
Remove duplicate deletion_mode entry

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2116,11 +2116,6 @@ compacts index shards to more performant forms.
 # CLI flag: -boltdb.shipper.compactor.delete-request-cancel-period
 [delete_request_cancel_period: <duration> | default = 24h]
 
-# Which deletion mode to use. Supported values are: disabled,
-# whole-stream-deletion, filter-only, and filter-and-delete.
-# CLI flag: -boltdb.shipper.compactor.deletion-mode
-[deletion_mode: <string> | default = "whole-stream-deletion"]
-
 # Maximum number of tables to compact in parallel.
 # While increasing this value, please make sure compactor has enough disk space
 # allocated to be able to store and compact as many tables.


### PR DESCRIPTION
Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

**What this PR does / why we need it**:

Remove the duplicate deletion_mode entry in the 2.6 branch. This change is not needed for the main branch as this setting has been removed from that section there.

**Which issue(s) this PR fixes**:
Fixes #7117 

- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
