### PR TITLE
Refactor pushing and validation into their own functions

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -275,6 +275,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	}
 }
 
+// nolint:error-return
 func (d *Distributor) validateStreams(streams []logproto.Stream, userID string) ([]uint32, []streamTracker, error, bool) {
 	// First we flatten out the request into a list of samples.
 	// We use the heuristic of 1 sample per TS to size the array.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -275,7 +275,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	}
 }
 
-// nolint:error-return
+// nolint
 func (d *Distributor) validateStreams(streams []logproto.Stream, userID string) ([]uint32, []streamTracker, error, bool) {
 	// First we flatten out the request into a list of samples.
 	// We use the heuristic of 1 sample per TS to size the array.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -363,7 +363,7 @@ func (d *Distributor) validateStreams(streams []logproto.Stream, userID string) 
 	return keys, validStreams, validationErr, true
 }
 
-func (d *Distributor) pushStreams(ctx context.Context, keys []uint32, streams []streamTracker, userID string) (pushTracker, error) {
+func (d *Distributor) pushStreams(ctx context.Context, keys []uint32, streams []streamTracker, userID string) (*pushTracker, error) {
 	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck
 	var descs [maxExpectedReplicationSet]ring.InstanceDesc
 
@@ -372,7 +372,7 @@ func (d *Distributor) pushStreams(ctx context.Context, keys []uint32, streams []
 	for i, key := range keys {
 		replicationSet, err := d.ingestersRing.Get(key, ring.Write, descs[:0], nil, nil)
 		if err != nil {
-			return pushTracker{}, err
+			return nil, err
 		}
 
 		streams[i].minSuccess = len(replicationSet.Instances) - replicationSet.MaxErrors
@@ -402,7 +402,7 @@ func (d *Distributor) pushStreams(ctx context.Context, keys []uint32, streams []
 		}(ingesterDescs[ingester], samples)
 	}
 
-	return tracker, nil
+	return &tracker, nil
 }
 
 func min(x1, x2 int) int {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -415,7 +415,7 @@ func TestStreamShard(t *testing.T) {
 			name:              "one shard with no entries",
 			entries:           nil,
 			shards:            1,
-			wantDerivedStream: []streamTracker{{stream: baseStream}},
+			wantDerivedStream: []streamTracker{{key: 0x544903, stream: baseStream}},
 		},
 		{
 			name:    "one shard with one entry",
@@ -423,6 +423,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:1],
 			wantDerivedStream: []streamTracker{
 				{
+					key: 0x544903,
 					stream: logproto.Stream{
 						Entries: []logproto.Entry{totalEntries[0]},
 						Labels:  baseStream.Labels,
@@ -437,6 +438,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:3],
 			wantDerivedStream: []streamTracker{
 				{ // shard 1.
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:1],
 						Labels:  generateShardLabels(baseLabels, 0).String(),
@@ -444,6 +446,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				}, // shard 2.
 				{
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Entries: totalEntries[1:3],
 						Labels:  generateShardLabels(baseLabels, 1).String(),
@@ -458,6 +461,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:5],
 			wantDerivedStream: []streamTracker{
 				{ // shard 1.
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:2],
 						Labels:  generateShardLabels(baseLabels, 0).String(),
@@ -465,6 +469,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				}, // shard 2.
 				{
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Entries: totalEntries[2:5],
 						Labels:  generateShardLabels(baseLabels, 1).String(),
@@ -479,6 +484,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:20],
 			wantDerivedStream: []streamTracker{
 				{ // shard 1.
+					key: 0x544903,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:20],
 						Labels:  baseStream.Labels,
@@ -493,6 +499,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:20],
 			wantDerivedStream: []streamTracker{
 				{ // shard 1.
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:10],
 						Labels:  generateShardLabels(baseLabels, 0).String(),
@@ -500,6 +507,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				}, // shard 2.
 				{
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Entries: totalEntries[10:20],
 						Labels:  generateShardLabels(baseLabels, 1).String(),
@@ -514,6 +522,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:20],
 			wantDerivedStream: []streamTracker{
 				{ // shard 1.
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:5],
 						Labels:  generateShardLabels(baseLabels, 0).String(),
@@ -521,6 +530,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{ // shard 2.
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Entries: totalEntries[5:10],
 						Labels:  generateShardLabels(baseLabels, 1).String(),
@@ -528,6 +538,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{ // shard 3.
+					key: 0x87ff5c63,
 					stream: logproto.Stream{
 						Entries: totalEntries[10:15],
 						Labels:  generateShardLabels(baseLabels, 2).String(),
@@ -535,6 +546,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{ // shard 4.
+					key: 0xaa01d046,
 					stream: logproto.Stream{
 						Entries: totalEntries[15:20],
 						Labels:  generateShardLabels(baseLabels, 3).String(),
@@ -549,6 +561,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:2],
 			wantDerivedStream: []streamTracker{
 				{
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Entries: []logproto.Entry{},
 						Labels:  generateShardLabels(baseLabels, 0).String(),
@@ -556,6 +569,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:1],
 						Labels:  generateShardLabels(baseLabels, 1).String(),
@@ -563,6 +577,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0x87ff5c63,
 					stream: logproto.Stream{
 						Entries: []logproto.Entry{},
 						Labels:  generateShardLabels(baseLabels, 2).String(),
@@ -570,6 +585,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0xaa01d046,
 					stream: logproto.Stream{
 						Entries: totalEntries[1:2],
 						Labels:  generateShardLabels(baseLabels, 3).String(),
@@ -584,6 +600,7 @@ func TestStreamShard(t *testing.T) {
 			entries: totalEntries[0:1],
 			wantDerivedStream: []streamTracker{
 				{
+					key: 0x9003e599,
 					stream: logproto.Stream{
 						Labels:  generateShardLabels(baseLabels, 0).String(),
 						Hash:    generateShardLabels(baseLabels, 0).Hash(),
@@ -591,6 +608,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0xfa06cb24,
 					stream: logproto.Stream{
 						Labels:  generateShardLabels(baseLabels, 1).String(),
 						Hash:    generateShardLabels(baseLabels, 1).Hash(),
@@ -598,6 +616,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0x87ff5c63,
 					stream: logproto.Stream{
 						Labels:  generateShardLabels(baseLabels, 2).String(),
 						Hash:    generateShardLabels(baseLabels, 2).Hash(),
@@ -605,6 +624,7 @@ func TestStreamShard(t *testing.T) {
 					},
 				},
 				{
+					key: 0xaa01d046,
 					stream: logproto.Stream{
 						Entries: totalEntries[0:1],
 						Labels:  generateShardLabels(baseLabels, 3).String(),
@@ -620,7 +640,7 @@ func TestStreamShard(t *testing.T) {
 			}
 			baseStream.Entries = tc.entries
 
-			_, derivedStreams := d.shardStream(baseStream, "fake")
+			derivedStreams := d.shardStream(baseStream, "fake")
 
 			require.Equal(t, tc.wantDerivedStream, derivedStreams)
 		})


### PR DESCRIPTION
Upcoming work on the per-stream-rate limit project will require us to push new sets of streams without revalidation. To support that work, this PR:

1. separates validation and pushing into two functions so
    - Stream sharding can happen in between while retaining readability
    - `pushStreams` can be called with different sets of streams for a single `Push` as streams are sharded.
2. Adds the ingester keys to `streamTracker` so they don't need to be managed separately.
3. Includes some renaming of things that were pulled from cortex