### PR TITLE
Docs: Fix template function examples

### DIFF
--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -665,7 +665,7 @@ Example of a query to print a newline per queries stored as a json array in the 
 `date` returns a textual representation of the time value formatted according to the provided [golang datetime layout](https://pkg.go.dev/time#pkg-constants).
 
 ```template
-{ date "2006-01-02" now }}
+{{ date "2006-01-02" now }}
 ```
 
 ## unixEpoch
@@ -673,7 +673,7 @@ Example of a query to print a newline per queries stored as a json array in the 
 `unixEpoch` returns the number of seconds elapsed since January 1, 1970 UTC.
 
 ```template
-{ unixEpoch now }}
+{{ unixEpoch now }}
 ```
 
 Example of a query to filter Loki querier jobs which create time is 1 day before:


### PR DESCRIPTION
Some examples only had a single open brace,
but require two. I added the missing braces.


**What this PR does / why we need it**:
Improves documentation, helps users who are reading docs about template functions.