### PR TITLE
tsdb: clean-up metrics

### DIFF
--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -62,30 +62,40 @@ guaranteeing we maintain querying consistency for the entire data lifecycle.
 
 // TODO(owen-d)
 type Metrics struct {
-	seriesNotFound prometheus.Counter
-	headRotations  *prometheus.CounterVec
-	walTruncations *prometheus.CounterVec
-	tsdbCreations  *prometheus.CounterVec
+	seriesNotFound      prometheus.Counter
+	walTruncations      *prometheus.CounterVec
+	tsdbCreations       *prometheus.CounterVec
+	headRotations       *prometheus.CounterVec
+	rotationLastSuccess prometheus.Gauge
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	return &Metrics{
 		seriesNotFound: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_tsdb_head_series_not_found_total",
-			Help: "Total number of requests for series that were not found",
+			Namespace: "loki_tsdb",
+			Name:      "head_series_not_found_total",
+			Help:      "Total number of requests for series that were not found",
 		}),
-		headRotations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_tsdb_head_rotations_total",
-			Help: "Total number of tsdb head rotations partitioned by status",
-		}, []string{statusLabel}),
 		walTruncations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_tsdb_wal_truncations_total",
-			Help: "Total number of WAL truncations partitioned by status",
+			Namespace: "loki_tsdb",
+			Name:      "wal_truncations_total",
+			Help:      "Total number of WAL truncations partitioned by status",
 		}, []string{statusLabel}),
 		tsdbCreations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_tsdb_creations_total",
-			Help: "Total number of tsdb creations partitioned by status",
+			Namespace: "loki_tsdb",
+			Name:      "creations_total",
+			Help:      "Total number of tsdb creations partitioned by status",
 		}, []string{statusLabel, tsdbBuildSourceLabel}),
+		headRotations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki_tsdb",
+			Name:      "head_rotations_total",
+			Help:      "Total number of tsdb head rotations partitioned by status",
+		}, []string{statusLabel}),
+		rotationLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_tsdb",
+			Name:      "head_rotation_last_successful_run_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful tsdb head rotation",
+		}),
 	}
 }
 

--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -66,7 +66,7 @@ type Metrics struct {
 	walTruncations      *prometheus.CounterVec
 	tsdbCreations       *prometheus.CounterVec
 	headRotations       *prometheus.CounterVec
-	rotationLastSuccess prometheus.Gauge
+	creationLastSuccess prometheus.Gauge
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -91,10 +91,10 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Name:      "head_rotations_total",
 			Help:      "Total number of tsdb head rotations partitioned by status",
 		}, []string{statusLabel}),
-		rotationLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		creationLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki_tsdb",
-			Name:      "head_rotation_last_successful_run_timestamp_seconds",
-			Help:      "Unix timestamp of the last successful tsdb head rotation",
+			Name:      "last_successful_creation_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful tsdb creation",
 		}),
 	}
 }

--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -62,11 +62,11 @@ guaranteeing we maintain querying consistency for the entire data lifecycle.
 
 // TODO(owen-d)
 type Metrics struct {
-	seriesNotFound      prometheus.Counter
-	walTruncations      *prometheus.CounterVec
-	tsdbCreations       *prometheus.CounterVec
-	headRotations       *prometheus.CounterVec
-	creationLastSuccess prometheus.Gauge
+	seriesNotFound       prometheus.Counter
+	headRotations        *prometheus.CounterVec
+	walTruncations       *prometheus.CounterVec
+	tsdbBuilds           *prometheus.CounterVec
+	tsdbBuildLastSuccess prometheus.Gauge
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -76,25 +76,25 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Name:      "head_series_not_found_total",
 			Help:      "Total number of requests for series that were not found",
 		}),
-		walTruncations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki_tsdb",
-			Name:      "wal_truncations_total",
-			Help:      "Total number of WAL truncations partitioned by status",
-		}, []string{statusLabel}),
-		tsdbCreations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki_tsdb",
-			Name:      "creations_total",
-			Help:      "Total number of tsdb creations partitioned by status",
-		}, []string{statusLabel, tsdbBuildSourceLabel}),
 		headRotations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_tsdb",
-			Name:      "head_rotations_total",
+			Name:      "head_rotation_attempts_total",
 			Help:      "Total number of tsdb head rotations partitioned by status",
 		}, []string{statusLabel}),
-		creationLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		walTruncations: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki_tsdb",
-			Name:      "last_successful_creation_timestamp_seconds",
-			Help:      "Unix timestamp of the last successful tsdb creation",
+			Name:      "wal_truncation_attempts_total",
+			Help:      "Total number of WAL truncations partitioned by status",
+		}, []string{statusLabel}),
+		tsdbBuilds: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki_tsdb",
+			Name:      "build_index_attempts_total",
+			Help:      "Total number of tsdb index builds partitioned by status",
+		}, []string{statusLabel, tsdbBuildSourceLabel}),
+		tsdbBuildLastSuccess: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_tsdb",
+			Name:      "build_index_last_successful_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful tsdb index build",
 		}),
 	}
 }

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -193,7 +193,6 @@ func (m *HeadManager) loop() {
 					continue
 				}
 				m.metrics.headRotations.WithLabelValues(statusSuccess).Inc()
-				m.metrics.rotationLastSuccess.SetToCurrentTime()
 			}
 
 			// build tsdb from rotated-out period

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -247,9 +247,10 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 	level.Debug(m.log).Log("msg", "building heads")
 	defer func() {
-		m.metrics.tsdbCreationsTotal.WithLabelValues("head").Inc()
-		if err != nil {
-			m.metrics.tsdbCreationsFailedTotal.WithLabelValues("head").Inc()
+		if err == nil {
+			m.metrics.tsdbCreations.WithLabelValues(statusSuccess, "head").Inc()
+		} else {
+			m.metrics.tsdbCreations.WithLabelValues(statusFailure, "head").Inc()
 		}
 	}()
 
@@ -259,9 +260,10 @@ func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error) {
 	level.Debug(m.log).Log("msg", "building WALs", "n", len(ids), "ts", t)
 	defer func() {
-		m.metrics.tsdbCreationsTotal.WithLabelValues("wal").Inc()
-		if err != nil {
-			m.metrics.tsdbCreationsFailedTotal.WithLabelValues("wal").Inc()
+		if err == nil {
+			m.metrics.tsdbCreations.WithLabelValues(statusSuccess, "wal").Inc()
+		} else {
+			m.metrics.tsdbCreations.WithLabelValues(statusFailure, "wal").Inc()
 		}
 	}()
 

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -241,6 +241,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 		}
 	}
 
+	m.metrics.creationLastSuccess.SetToCurrentTime()
 	return nil
 }
 

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -247,11 +247,12 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 	level.Debug(m.log).Log("msg", "building heads")
 	defer func() {
-		if err == nil {
-			m.metrics.tsdbCreations.WithLabelValues(statusSuccess, "head").Inc()
-		} else {
-			m.metrics.tsdbCreations.WithLabelValues(statusFailure, "head").Inc()
+		status := statusSuccess
+		if err != nil {
+			status = statusFailure
 		}
+
+		m.metrics.tsdbCreations.WithLabelValues(status, "head").Inc()
 	}()
 
 	return m.buildFromHead(heads)
@@ -260,11 +261,12 @@ func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error) {
 	level.Debug(m.log).Log("msg", "building WALs", "n", len(ids), "ts", t)
 	defer func() {
-		if err == nil {
-			m.metrics.tsdbCreations.WithLabelValues(statusSuccess, "wal").Inc()
-		} else {
-			m.metrics.tsdbCreations.WithLabelValues(statusFailure, "wal").Inc()
+		status := statusSuccess
+		if err != nil {
+			status = statusFailure
 		}
+
+		m.metrics.tsdbCreations.WithLabelValues(status, "wal").Inc()
 	}()
 
 	level.Debug(m.log).Log("msg", "recovering tenant heads")

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -241,7 +241,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 		}
 	}
 
-	m.metrics.creationLastSuccess.SetToCurrentTime()
+	m.metrics.tsdbBuildLastSuccess.SetToCurrentTime()
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (m *tsdbManager) BuildFromHead(heads *tenantHeads) (err error) {
 			status = statusFailure
 		}
 
-		m.metrics.tsdbCreations.WithLabelValues(status, "head").Inc()
+		m.metrics.tsdbBuilds.WithLabelValues(status, "head").Inc()
 	}()
 
 	return m.buildFromHead(heads)
@@ -267,7 +267,7 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier) (err error
 			status = statusFailure
 		}
 
-		m.metrics.tsdbCreations.WithLabelValues(status, "wal").Inc()
+		m.metrics.tsdbBuilds.WithLabelValues(status, "wal").Inc()
 	}()
 
 	level.Debug(m.log).Log("msg", "recovering tenant heads")


### PR DESCRIPTION
Signed-off-by: Ashwanth Goli <iamashwanth@gmail.com>

**What this PR does / why we need it**:
clean-up unused metrics and refactor others to use a `CounterVec`

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Is this an important fix or new feature? Add an entry in the `CHANGELOG.md`.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
