### PR TITLE
revert stream push error response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,6 @@ require (
 )
 
 require (
-	github.com/gogo/googleapis v1.4.0
 	github.com/grafana/groupcache_exporter v0.0.0-20220629095919-59a8c6428a43
 	github.com/heroku/x v0.0.50
 	github.com/mailgun/groupcache/v2 v2.3.2
@@ -181,6 +180,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/go-zookeeper/zk v1.0.2 // indirect
 	github.com/gofrs/flock v0.7.1 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.0.1 // indirect

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -1,9 +1,14 @@
 package ingester
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"net/http"
 	"sync"
 	"time"
+
+	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/go-kit/log/level"
 
@@ -145,7 +150,7 @@ func (s *stream) Push(
 	// Lock chunkMtx while pushing.
 	// If this is false, chunkMtx must be held outside Push.
 	lockChunk bool,
-) (int, []entryWithError) {
+) (int, error) {
 	if lockChunk {
 		s.chunkMtx.Lock()
 		defer s.chunkMtx.Unlock()
@@ -160,12 +165,12 @@ func (s *stream) Push(
 
 		s.metrics.walReplaySamplesDropped.WithLabelValues(duplicateReason).Add(float64(len(entries)))
 		s.metrics.walReplayBytesDropped.WithLabelValues(duplicateReason).Add(float64(byteCt))
-		return 0, []entryWithError{{entry: &logproto.Entry{}, e: ErrEntriesExist}}
+		return 0, ErrEntriesExist
 	}
 
 	toStore, invalid := s.validateEntries(entries, isReplay)
 	if s.cfg.RateLimitWholeStream && hasRateLimitErr(invalid) {
-		return 0, invalid
+		return 0, errorForFailedEntries(s, invalid, len(entries))
 	}
 
 	prevNumChunks := len(s.chunks)
@@ -184,7 +189,45 @@ func (s *stream) Push(
 		s.metrics.memoryChunks.Add(float64(len(s.chunks) - prevNumChunks))
 	}
 
-	return bytesAdded, append(invalid, entriesWithErr...)
+	return bytesAdded, errorForFailedEntries(s, append(invalid, entriesWithErr...), len(entries))
+}
+
+func errorForFailedEntries(s *stream, failedEntriesWithError []entryWithError, totalEntries int) error {
+	if len(failedEntriesWithError) == 0 {
+		return nil
+	}
+
+	lastEntryWithErr := failedEntriesWithError[len(failedEntriesWithError)-1]
+	_, ok := lastEntryWithErr.e.(*validation.ErrStreamRateLimit)
+	outOfOrder := chunkenc.IsOutOfOrderErr(lastEntryWithErr.e)
+	if !outOfOrder && !ok {
+		return lastEntryWithErr.e
+	}
+	var statusCode int
+	if outOfOrder {
+		statusCode = http.StatusBadRequest
+	}
+	if ok {
+		statusCode = http.StatusTooManyRequests
+	}
+	// Return a http status 4xx request response with all failed entries.
+	buf := bytes.Buffer{}
+	streamName := s.labelsString
+
+	limitedFailedEntries := failedEntriesWithError
+	if maxIgnore := s.cfg.MaxReturnedErrors; maxIgnore > 0 && len(limitedFailedEntries) > maxIgnore {
+		limitedFailedEntries = limitedFailedEntries[:maxIgnore]
+	}
+
+	for _, entryWithError := range limitedFailedEntries {
+		fmt.Fprintf(&buf,
+			"entry with timestamp %s ignored, reason: '%s' for stream: %s,\n",
+			entryWithError.entry.Timestamp.String(), entryWithError.e.Error(), streamName)
+	}
+
+	fmt.Fprintf(&buf, "total ignored: %d out of %d", len(failedEntriesWithError), totalEntries)
+
+	return httpgrpc.Errorf(statusCode, buf.String())
 }
 
 func hasRateLimitErr(errs []entryWithError) bool {

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -64,10 +64,10 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 				NilMetrics,
 			)
 
-			_, entriesWithErrors := s.Push(context.Background(), []logproto.Entry{
+			_, err := s.Push(context.Background(), []logproto.Entry{
 				{Timestamp: time.Unix(int64(numLogs), 0), Line: "log"},
 			}, recordPool.GetRecord(), 0, true)
-			require.Empty(t, entriesWithErrors)
+			require.NoError(t, err)
 
 			newLines := make([]logproto.Entry, numLogs)
 			for i := 0; i < numLogs; i++ {
@@ -86,9 +86,9 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 			fmt.Fprintf(&expected, "total ignored: %d out of %d", numLogs, numLogs)
 			expectErr := httpgrpc.Errorf(http.StatusBadRequest, expected.String())
 
-			_, entriesWithErrors = s.Push(context.Background(), newLines, recordPool.GetRecord(), 0, true)
-			finalErr := errorForFailedEntries(s, entriesWithErrors, len(newLines))
-			require.Equal(t, expectErr.Error(), finalErr.Error())
+			_, err = s.Push(context.Background(), newLines, recordPool.GetRecord(), 0, true)
+			require.Error(t, err)
+			require.Equal(t, expectErr.Error(), err.Error())
 		})
 	}
 }
@@ -110,12 +110,12 @@ func TestPushDeduplication(t *testing.T) {
 		NilMetrics,
 	)
 
-	written, entriesWithErrors := s.Push(context.Background(), []logproto.Entry{
+	written, err := s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "newer, better test"},
 	}, recordPool.GetRecord(), 0, true)
-	require.Empty(t, entriesWithErrors)
+	require.NoError(t, err)
 	require.Len(t, s.chunks, 1)
 	require.Equal(t, s.chunks[0].chunk.Size(), 2,
 		"expected exact duplicate to be dropped and newer content with same timestamp to be appended")
@@ -140,28 +140,27 @@ func TestPushRejectOldCounter(t *testing.T) {
 	)
 
 	// counter should be 2 now since the first line will be deduped
-	_, entriesWithErrors := s.Push(context.Background(), []logproto.Entry{
+	_, err = s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 		{Timestamp: time.Unix(1, 0), Line: "newer, better test"},
 	}, recordPool.GetRecord(), 0, true)
-	require.Empty(t, entriesWithErrors)
+	require.NoError(t, err)
 	require.Len(t, s.chunks, 1)
 	require.Equal(t, s.chunks[0].chunk.Size(), 2,
 		"expected exact duplicate to be dropped and newer content with same timestamp to be appended")
 
 	// fail to push with a counter <= the streams internal counter
-	_, entriesWithErrors = s.Push(context.Background(), []logproto.Entry{
+	_, err = s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 	}, recordPool.GetRecord(), 2, true)
-	require.Len(t, entriesWithErrors, 1)
-	require.Equal(t, entriesWithErrors[0].e, ErrEntriesExist)
+	require.Equal(t, ErrEntriesExist, err)
 
 	// succeed with a greater counter
-	_, entriesWithErrors = s.Push(context.Background(), []logproto.Entry{
+	_, err = s.Push(context.Background(), []logproto.Entry{
 		{Timestamp: time.Unix(1, 0), Line: "test"},
 	}, recordPool.GetRecord(), 3, true)
-	require.Empty(t, entriesWithErrors)
+	require.Nil(t, err)
 
 }
 
@@ -274,11 +273,11 @@ func TestUnorderedPush(t *testing.T) {
 		if x.cutBefore {
 			_ = s.cutChunk(context.Background())
 		}
-		written, entriesWithErrors := s.Push(context.Background(), x.entries, recordPool.GetRecord(), 0, true)
+		written, err := s.Push(context.Background(), x.entries, recordPool.GetRecord(), 0, true)
 		if x.err {
-			require.NotEmpty(t, entriesWithErrors)
+			require.NotNil(t, err)
 		} else {
-			require.Empty(t, entriesWithErrors)
+			require.Nil(t, err)
 		}
 		require.Equal(t, x.written, written)
 	}
@@ -334,11 +333,9 @@ func TestPushRateLimit(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaaa"},
 		{Timestamp: time.Unix(1, 0), Line: "aaaaaaaaab"},
 	}
-
 	// Counter should be 2 now since the first line will be deduped.
-	_, entriesWithErrors := s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
-	require.Len(t, entriesWithErrors, 1)
-	require.Contains(t, entriesWithErrors[0].e.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
+	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
+	require.Contains(t, err.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
 }
 
 func TestPushRateLimitAllOrNothing(t *testing.T) {
@@ -371,9 +368,9 @@ func TestPushRateLimitAllOrNothing(t *testing.T) {
 	}
 
 	// Both entries have errors because rate limiting is done all at once
-	_, entriesWithErrors := s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
-	require.Len(t, entriesWithErrors, 2)
-	require.Contains(t, entriesWithErrors[0].e.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
+	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
+	require.Contains(t, err.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[0].Line))}).Error())
+	require.Contains(t, err.Error(), (&validation.ErrStreamRateLimit{RateLimit: l.PerStreamRateLimit, Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[1].Line))}).Error())
 }
 
 func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
@@ -403,8 +400,8 @@ func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
 	}
 
 	// Push a first entry (it doesn't matter if we look like we're replaying or not)
-	_, entriesWithErrors := s.Push(context.Background(), entries, nil, 1, true)
-	require.Empty(t, entriesWithErrors)
+	_, err = s.Push(context.Background(), entries, nil, 1, true)
+	require.Nil(t, err)
 
 	// Create a sample outside the validity window
 	entries = []logproto.Entry{
@@ -412,12 +409,12 @@ func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
 	}
 
 	// Pretend it's not a replay, ensure we error
-	_, entriesWithErrors = s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
-	require.NotEmpty(t, entriesWithErrors)
+	_, err = s.Push(context.Background(), entries, recordPool.GetRecord(), 0, true)
+	require.NotNil(t, err)
 
 	// Now pretend it's a replay. The same write should succeed.
-	_, entriesWithErrors = s.Push(context.Background(), entries, nil, 2, true)
-	require.Empty(t, entriesWithErrors)
+	_, err = s.Push(context.Background(), entries, nil, 2, true)
+	require.Nil(t, err)
 
 }
 
@@ -458,41 +455,8 @@ func Benchmark_PushStream(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		rec := recordPool.GetRecord()
-		_, entriesWithErrors := s.Push(ctx, e, rec, 0, true)
-		require.Empty(b, entriesWithErrors)
-		recordPool.PutRecord(rec)
-	}
-}
-
-func Benchmark_PushStreamAllOrNothing(b *testing.B) {
-	ls := labels.Labels{
-		labels.Label{Name: "namespace", Value: "loki-dev"},
-		labels.Label{Name: "cluster", Value: "dev-us-central1"},
-		labels.Label{Name: "job", Value: "loki-dev/ingester"},
-		labels.Label{Name: "container", Value: "ingester"},
-	}
-
-	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(b, err)
-	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
-
-	s := newStream(&Config{MaxChunkAge: 24 * time.Hour, RateLimitWholeStream: true}, limiter, "fake", model.Fingerprint(0), ls, true, NilMetrics)
-	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{}, 10)
-	require.NoError(b, err)
-
-	go t.loop()
-	defer t.close()
-
-	s.tailers[1] = t
-	ctx := context.Background()
-	e := entries(100, time.Now())
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for n := 0; n < b.N; n++ {
-		rec := recordPool.GetRecord()
-		_, entriesWithErrors := s.Push(ctx, e, rec, 0, true)
-		require.Empty(b, entriesWithErrors)
+		_, err := s.Push(ctx, e, rec, 0, true)
+		require.NoError(b, err)
 		recordPool.PutRecord(rec)
 	}
 }


### PR DESCRIPTION
We've changed approaches to how we want to do per-stream rate limiting. The new approach will rely on creating an api on the ingester so the distributors can decide how streams should be sharded. As a result, the work to return rate-limited streams in the error body is no longer needed.
