### PR TITLE
[helm] Storage: Read support for Azure Object Storage

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -299,7 +299,7 @@ Create the service endpoint including port for MinIO.
 
 {{/* Determine if deployment is using object storage */}}
 {{- define "loki.isUsingObjectStorage" -}}
-{{- or (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "s3") -}}
+{{- or (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "azure") -}}
 {{- end -}}
 
 {{/* Configure the correct name for the memberlist service */}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Using Azure Object Storage worked before Helm chart version 3.0.

**Which issue(s) this PR fixes**:
Fixes #7090 