### PR TITLE
Bring addition of server config into existing style

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.0.6
+version: 3.0.7
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.0.6](https://img.shields.io/badge/Version-3.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.0.7](https://img.shields.io/badge/Version-3.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 
@@ -255,7 +255,7 @@ monitoring:
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | loki.schemaConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
-| loki.serverConfig | object | `{"grpc_listen_port":9095,"http_listen_port":3100}` | Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration. |
+| loki.server | object | `{"grpc_listen_port":9095,"http_listen_port":3100}` | Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration. |
 | loki.storage | object | `{"bucketNames":{"admin":"admin","chunks":"chunks","ruler":"ruler"},"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"},"gcs":{"chunkBufferSize":0,"enableHttp2":true,"requestTimeout":"0s"},"s3":{"accessKeyId":null,"endpoint":null,"http_config":{},"insecure":false,"region":null,"s3":null,"s3ForcePathStyle":false,"secretAccessKey":null},"type":"s3"}` | Storage config. Providing this will automatically populate all necessary storage configs in the templated config. |
 | loki.storage_config | object | `{"hedging":{"at":"250ms","max_per_second":20,"up_to":3}}` | Additional storage config |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -66,9 +66,9 @@ loki:
     auth_enabled: {{ .Values.loki.auth_enabled }}
     {{- end }}
 
+    {{- with .Values.loki.server }}
     server:
-    {{- if .Values.loki.serverConfig}}
-    {{- toYaml .Values.loki.serverConfig | nindent 2}}
+      {{- toYaml . | nindent 2}}
     {{- end}}
 
     memberlist:
@@ -161,7 +161,7 @@ loki:
   auth_enabled: true
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration.
-  serverConfig:
+  server:
     http_listen_port: 3100
     grpc_listen_port: 9095
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent PR (https://github.com/grafana/loki/pull/7137) was merged to make the server settings more configurable in the helm chart. This PR fixes a few style nits with that PR, mainly:

* Name the config block the same as the header in the actual loki config file (in this case, `server` not `serverConfig`)
* Use `with`, and wrap around the header in the config file so the entire section is omitted if empty, rather than setting an empty object under the header.