### PR TITLE
fixes nil interface value with non-nil type in cache construction

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/loki/pkg/lokifrontend/frontend/v2/frontendv2pb"
 	"github.com/grafana/loki/pkg/querier"
 	"github.com/grafana/loki/pkg/querier/queryrange"
+	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/ruler"
 	base_ruler "github.com/grafana/loki/pkg/ruler/base"
 	"github.com/grafana/loki/pkg/runtime"
@@ -663,7 +664,7 @@ func (disabledShuffleShardingLimits) MaxQueriersPerUser(userID string) int { ret
 func (t *Loki) initQueryFrontendTripperware() (_ services.Service, err error) {
 	level.Debug(util_log.Logger).Log("msg", "initializing query frontend tripperware")
 
-	var genLoader *generationnumber.GenNumberLoader
+	var genLoader queryrangebase.CacheGenNumberLoader
 	if t.supportIndexDeleteRequest() {
 		cacheGenClient, err := t.cacheGenClient()
 		if err != nil {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/grafana/loki/pull/7013

This will panic when the interface's _value_ is nil because it's been assigned a concrete type already and then passed as an interface. Instead, we treat it as a nil interface with no type bound to it:

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 40570 [running]:
github.com/grafana/loki/pkg/util/server.onPanic({0x2209320, 0x3dfae20})
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/util/server/recovery.go:41 +0x53
github.com/grafana/loki/pkg/util/server.glob..func1.1.1()
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/util/server/recovery.go:29 +0x3a
panic({0x2209320, 0x3dfae20})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber.(*GenNumberLoader).getCacheGenNumber(0x0, {0xc0081e14d7, 0x2})
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber/gennumber_loader.go:120 +0x60
github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber.(*GenNumberLoader).getCacheGenNumbersPerTenants(0x2?, {0xc000e8c4d0?, 0x1, 0x0?})
	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber/gennumber_loader.go:98 +0xe7
github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/generationnumber.(*GenNumberLoader).GetResultsCacheGenNumber(0x2b26298?, {0xc000e8c4d0?, 0xc0050ad080?, 0x2dcdeeb9bcc040e4?})
```