### PR TITLE
allow backup store metrics registration by including backend type in labels

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -206,7 +206,13 @@ func shouldUseIndexGatewayClient(cfg indexshipper.Config) bool {
 
 func (s *store) storeForPeriod(p config.PeriodConfig, chunkClient client.Client, f *fetcher.Fetcher) (stores.ChunkWriter, index.ReaderWriter, func(), error) {
 	indexClientReg := prometheus.WrapRegistererWith(
-		prometheus.Labels{"component": "index-store-" + p.From.String()}, s.registerer)
+		prometheus.Labels{
+			"component": fmt.Sprintf(
+				"index-store-%s-%s",
+				p.IndexType,
+				p.From.String(),
+			),
+		}, s.registerer)
 
 	if p.IndexType == config.TSDBType {
 		if shouldUseIndexGatewayClient(s.cfg.TSDBShipperConfig) {


### PR DESCRIPTION
The refactor [here](https://github.com/grafana/loki/blob/main/pkg/storage/store.go#L237) introduced in https://github.com/grafana/loki/pull/7154 will cause a panic due to duplicate registration via the same store prefix when using a backup index store (for use during tsdb migrations).

This PR adds more granularity to the label value to differentiate these and avoid the problem.