### PR TITLE
[Bugfix] TSDB index bucket calculation

### DIFF
--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -291,10 +291,12 @@ func indexBuckets(from, through model.Time, tableRanges config.TableRanges) (res
 	end := through.Time().UnixNano() / int64(config.ObjectStorageIndexRequiredPeriod)
 	for cur := start; cur <= end; cur++ {
 		cfg := tableRanges.ConfigForTableNumber(cur)
-		if cfg == nil {
-			return nil, fmt.Errorf("could not find config for table number %d", cur)
+		if cfg != nil {
+			res = append(res, cfg.IndexTables.Prefix+strconv.Itoa(int(cur)))
 		}
-		res = append(res, cfg.IndexTables.Prefix+strconv.Itoa(int(cur)))
+	}
+	if len(res) == 0 {
+		return nil, fmt.Errorf("could not find config for table(s) fom: %d, through %d", start, end)
 	}
 	return
 }


### PR DESCRIPTION
When calculating the index buckets a chunk belongs to, we shouldn't error when a bucket falls outside the current TSDB store's periodConfig range. This can happen when a chunk is written across the bounds between a previous index type (i.e. boltdb-shipper) and a new tsdb type or vice versa. Instead of erroring when this happens, we'll now correctly return only the buckets matching the TSDB store (the other buckets are handled by their respective stores).

I think we can also remove the error from this function signature, although I left it in as it's conceivably helpful in the case of a chunk range that doesn't overlap at all with the store (which shouldn't happen).


Dependent on https://github.com/grafana/loki/pull/7177
