### PR TITLE
fixes azure client secret duplicate CLI registration

### DIFF
--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -119,7 +119,7 @@ func (c *BlobStorageConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagS
 	f.BoolVar(&c.UseServicePrincipal, prefix+"azure.use-service-principal", false, "Use Service Principal to authenticate through Azure OAuth.")
 	f.StringVar(&c.TenantID, prefix+"azure.tenant-id", "", "Azure Tenant ID is used to authenticate through Azure OAuth.")
 	f.StringVar(&c.ClientID, prefix+"azure.client-id", "", "Azure Service Principal ID(GUID).")
-	f.Var(&c.ClientSecret, prefix+"azure.client-id", "Azure Service Principal secret key.")
+	f.Var(&c.ClientSecret, prefix+"azure.client-secret", "Azure Service Principal secret key.")
 }
 
 type BlobStorageMetrics struct {


### PR DESCRIPTION
Fixes duplicate key registration from https://github.com/grafana/loki/pull/7179/files#diff-665c7ce7ef736bdf9f9da76a8e389d5b6fcdc90099db913ce36b4c0da2a97ef2R121-R122