### PR TITLE
TSDB indexBuckets helper logs instead of errors

### DIFF
--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -230,8 +230,7 @@ func TestCompactor_Compact(t *testing.T) {
 		IndexTables: config.PeriodicTableConfig{Period: config.ObjectStorageIndexRequiredPeriod},
 		Schema:      "v12",
 	}
-	indexBkts, err := indexBuckets(now, now, []config.TableRange{periodConfig.GetIndexTableNumberRange(config.DayTime{Time: now})})
-	require.NoError(t, err)
+	indexBkts := indexBuckets(now, now, []config.TableRange{periodConfig.GetIndexTableNumberRange(config.DayTime{Time: now})})
 
 	tableName := indexBkts[0]
 	lbls1 := mustParseLabels(`{foo="bar", a="b"}`)
@@ -839,8 +838,7 @@ func setupCompactedIndex(t *testing.T) *testContext {
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{periodConfig},
 	}
-	indexBuckets, err := indexBuckets(now, now, []config.TableRange{periodConfig.GetIndexTableNumberRange(config.DayTime{Time: now})})
-	require.NoError(t, err)
+	indexBuckets := indexBuckets(now, now, []config.TableRange{periodConfig.GetIndexTableNumberRange(config.DayTime{Time: now})})
 	tableName := indexBuckets[0]
 	tableInterval := retention.ExtractIntervalFromTableName(tableName)
 	// shiftTableStart shift tableInterval.Start by the given amount of milliseconds.

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -30,10 +30,7 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 	var indices []Index
 
 	// Ensure we query both per tenant and multitenant TSDBs
-	idxBuckets, err := indexBuckets(from, through, i.tableRanges)
-	if err != nil {
-		return nil, err
-	}
+	idxBuckets := indexBuckets(from, through, i.tableRanges)
 	for _, bkt := range idxBuckets {
 		if err := i.shipper.ForEach(ctx, bkt, user, func(multitenant bool, idx shipper_index.Index) error {
 			impl, ok := idx.(Index)

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -294,7 +294,7 @@ func indexBuckets(from, through model.Time, tableRanges config.TableRanges) (res
 		}
 	}
 	if len(res) == 0 {
-		level.Warn(util_log.Logger).Log("err", "could not find config for table(s) fom: %d, through %d", start, end)
+		level.Warn(util_log.Logger).Log("err", "could not find config for table(s) from: %d, through %d", start, end)
 	}
 	return
 }


### PR DESCRIPTION
indexBuckets will return the list of overlapping TSDB buckets for a time range. Historically, this errored when there was no overlap, which is generally impossible. While mutating period configurations as a test (which should never be done in production), I realized this would preemptively error us when there were old TSDB WALs from a bucket that no longer belonged to a TSDB period (i.e. by replacing a `tsdb` index with a `boltdb-shipper` one).

This PR changes this to a log line instead as we don't need to error and stop computation; it's better to return an empty overlap instead.