### PR TITLE
Helm: add support for configuring ruler

### DIFF
--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -254,6 +254,7 @@ monitoring:
 | loki.readinessProbe.initialDelaySeconds | int | `30` |  |
 | loki.readinessProbe.timeoutSeconds | int | `1` |  |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
+| loki.rulerConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#ruler for more info on configuring ruler |
 | loki.schemaConfig | object | `{}` | Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas |
 | loki.server | object | `{"grpc_listen_port":9095,"http_listen_port":3100}` | Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration. |
 | loki.storage | object | `{"bucketNames":{"admin":"admin","chunks":"chunks","ruler":"ruler"},"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"},"gcs":{"chunkBufferSize":0,"enableHttp2":true,"requestTimeout":"0s"},"s3":{"accessKeyId":null,"endpoint":null,"http_config":{},"insecure":false,"region":null,"s3":null,"s3ForcePathStyle":false,"secretAccessKey":null},"type":"s3"}` | Storage config. Providing this will automatically populate all necessary storage configs in the templated config. |

--- a/production/helm/loki/README.md.gotmpl
+++ b/production/helm/loki/README.md.gotmpl
@@ -29,7 +29,7 @@ As a result of this major change, upgrades from the charts this replaces might b
 
 ### Upgrading from `grafana/loki`
 
-The default installation of `grafana/loki` is a single instance backed by `filesystem` storage that is not highly available. As a result, this upgrade method will involve downtime. The upgrade will involve deleting the previously deployed loki stateful set, the running the `helm upgrade` which will create the new one with the same name, which should attach to the existing PVC or ephemeral storage, thus preserving you data. Will still highly recommend backing up all data before conducting the upgrade.
+The default installation of `grafana/loki` is a single instance backed by `filesystem` storage that is not highly available. As a result, this upgrade method will involve downtime. The upgrade will involve deleting the previously deployed loki stateful set, the running the `helm upgrade` which will create the new one with the same name, which should attach to the existing PVC or ephemeral storage, thus preserving your data. Will still highly recommend backing up all data before conducting the upgrade.
 
 To upgrade, you will need at least the following in your `values.yaml`:
 
@@ -41,7 +41,7 @@ loki:
     type: 'filesystem'
 ```
 
-You will need to 1. Update the grafana helm repo, 2. delete the exsiting stateful set, and 3. updgrade making sure to have the values above included in your `values.yaml`. If you installed `grafana/loki` as `loki` in namespace `loki`, the commands would be:
+You will need to 1. Update the grafana helm repo, 2. delete the exsiting stateful set, and 3. upgrade making sure to have the values above included in your `values.yaml`. If you installed `grafana/loki` as `loki` in namespace `loki`, the commands would be:
 
 ```console
 helm repo update grafana

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -121,11 +121,14 @@ loki:
             period: 24h
     {{- end }}
 
-    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+    {{- if .Values.loki.rulerConfig}}
     ruler:
       storage:
+      {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
       {{- include "loki.rulerStorageConfig" . | nindent 4}}
-    {{- end -}}
+      {{- end }}
+    {{- toYaml .Values.loki.rulerConfig | nindent 2}}
+    {{- end }}
 
     {{- with .Values.loki.memcached.results_cache }}
     query_range:
@@ -220,6 +223,12 @@ loki:
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig: {}
+
+  # -- Check https://grafana.com/docs/loki/latest/configuration/#ruler for more info on configuring ruler
+  rulerConfig:
+    alertmanager_url: ""
+    enable_alertmanager_v2: false
+    enable_api: true
 
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -121,13 +121,13 @@ loki:
             period: 24h
     {{- end }}
 
-    {{- if .Values.loki.rulerConfig}}
     ruler:
       storage:
       {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
       {{- include "loki.rulerStorageConfig" . | nindent 4}}
       {{- end }}
-    {{- toYaml .Values.loki.rulerConfig | nindent 2}}
+    {{- with .Values.loki.rulerConfig}}
+    {{- toYaml . | nindent 2}}
     {{- end }}
 
     {{- with .Values.loki.memcached.results_cache }}
@@ -225,10 +225,7 @@ loki:
   schemaConfig: {}
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#ruler for more info on configuring ruler
-  rulerConfig:
-    alertmanager_url: ""
-    enable_alertmanager_v2: false
-    enable_api: true
+  rulerConfig: {}
 
   # -- Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig`
   structuredConfig: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables configuring various `ruler` options like alertmanager url.
`rulerConfig` is added second in the template so users can override the `storage` config if necessary.
Have seen questions in community Slack asking how to get filesystem support and alertmanager back when migrating from the old loki helm which should now be possible.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
