### PR TITLE
Docs: Populate empty index pages

### DIFF
--- a/docs/sources/fundamentals/_index.md
+++ b/docs/sources/fundamentals/_index.md
@@ -4,3 +4,9 @@ weight: 150
 ---
 # Grafana Loki Fundamentals
 
+This section explains fundamental concepts about Grafana Loki:
+
+- [Overview]({{< relref "./overview/" >}})
+- [Architecture]({{< relref "./architecture/" >}})
+- [Labels]({{< relref "./labels/" >}})
+

--- a/docs/sources/fundamentals/_index.md
+++ b/docs/sources/fundamentals/_index.md
@@ -6,7 +6,5 @@ weight: 150
 
 This section explains fundamental concepts about Grafana Loki:
 
-- [Overview]({{< relref "./overview/" >}})
-- [Architecture]({{< relref "./architecture/" >}})
-- [Labels]({{< relref "./labels/" >}})
+{{< section >}}
 

--- a/docs/sources/maintaining/_index.md
+++ b/docs/sources/maintaining/_index.md
@@ -5,3 +5,7 @@ weight: 1200
 # Grafana Loki Maintainers' Guide
 
 This section details information for maintainers of Grafana Loki.
+
+- [Release Loki build images]({{< relref "./release-loki-build-image/" >}})
+- [Release]({{< relref "./release/" >}})
+

--- a/docs/sources/maintaining/_index.md
+++ b/docs/sources/maintaining/_index.md
@@ -6,6 +6,5 @@ weight: 1200
 
 This section details information for maintainers of Grafana Loki.
 
-- [Release Loki build images]({{< relref "./release-loki-build-image/" >}})
-- [Release]({{< relref "./release/" >}})
+{{< section >}}
 

--- a/docs/sources/operations/_index.md
+++ b/docs/sources/operations/_index.md
@@ -4,3 +4,7 @@ weight: 800
 ---
 
 # Operations
+
+This section covers operational topics in Loki:
+
+{{< section >}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Three docs index pages are dead ends - they are either blank or have no links. In lieu of more detailed content, this PR populates these pages with `{{< section >}}` shortcodes that automatically generate TOC-like links to subpages.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

`{{< section >}}` is used in grafana/grafana docs, but I don't see any usage in grafana/loki. If this doesn't work, replace the shortcodes with manual lists of subpages.

**Checklist**
- [X] Reviewed the `CONTRIBUTING.md` guide
- [ ] ~Documentation added~
- [ ] ~Tests updated~
- [ ] ~`CHANGELOG.md` updated~
- [ ] ~Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`~