### PR TITLE
operator: Write configuration for per-tenant retention

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7201](https://github.com/grafana/loki/pull/7201) **xperimental**: Write configuration for per-tenant retention
 - [7037](https://github.com/grafana/loki/pull/7037) **xperimental**: Skip enforcing matcher for certain tenants on OpenShift
 - [7106](https://github.com/grafana/loki/pull/7106) **xperimental**: Manage global stream-based retention
 - [7092](https://github.com/grafana/loki/pull/7092) **aminesnow**: Configure kube-rbac-proxy sidecar to use Intermediate TLS security profile in OCP

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -209,15 +209,25 @@ var deleteWorkerCountMap = map[lokiv1.LokiStackSizeType]uint{
 }
 
 func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
-	if ls.Limits == nil || ls.Limits.Global == nil || ls.Limits.Global.Retention == nil {
-		return config.RetentionOptions{
-			Enabled: false,
+	if ls.Limits == nil {
+		return config.RetentionOptions{}
+	}
+
+	globalRetention := ls.Limits.Global != nil && ls.Limits.Global.Retention != nil
+	tenantRetention := false
+	for _, t := range ls.Limits.Tenants {
+		if t.Retention != nil {
+			tenantRetention = true
+			break
 		}
+	}
+
+	if !globalRetention && !tenantRetention {
+		return config.RetentionOptions{}
 	}
 
 	return config.RetentionOptions{
 		Enabled:           true,
 		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
-		Globals:           ls.Limits.Global.Retention,
 	}
 }

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/manifests"
+	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -178,5 +179,111 @@ func randomConfigOptions() manifests.Options {
 				},
 			},
 		},
+	}
+}
+
+func TestConfigOptions_RetentionConfig(t *testing.T) {
+	tt := []struct {
+		desc        string
+		spec        lokiv1.LokiStackSpec
+		wantOptions config.RetentionOptions
+	}{
+		{
+			desc: "no retention",
+			spec: lokiv1.LokiStackSpec{},
+			wantOptions: config.RetentionOptions{
+				Enabled: false,
+			},
+		},
+		{
+			desc: "global retention, extra small",
+			spec: lokiv1.LokiStackSpec{
+				Size: lokiv1.SizeOneXExtraSmall,
+				Limits: &lokiv1.LimitsSpec{
+					Global: &lokiv1.LimitsTemplateSpec{
+						Retention: &lokiv1.RetentionLimitSpec{
+							Days: 14,
+						},
+					},
+				},
+			},
+			wantOptions: config.RetentionOptions{
+				Enabled:           true,
+				DeleteWorkerCount: 10,
+			},
+		},
+		{
+			desc: "global and tenant retention, extra small",
+			spec: lokiv1.LokiStackSpec{
+				Size: lokiv1.SizeOneXExtraSmall,
+				Limits: &lokiv1.LimitsSpec{
+					Global: &lokiv1.LimitsTemplateSpec{
+						Retention: &lokiv1.RetentionLimitSpec{
+							Days: 14,
+						},
+					},
+					Tenants: map[string]lokiv1.LimitsTemplateSpec{
+						"development": {
+							Retention: &lokiv1.RetentionLimitSpec{
+								Days: 3,
+							},
+						},
+					},
+				},
+			},
+			wantOptions: config.RetentionOptions{
+				Enabled:           true,
+				DeleteWorkerCount: 10,
+			},
+		},
+		{
+			desc: "tenant retention, extra small",
+			spec: lokiv1.LokiStackSpec{
+				Size: lokiv1.SizeOneXExtraSmall,
+				Limits: &lokiv1.LimitsSpec{
+					Tenants: map[string]lokiv1.LimitsTemplateSpec{
+						"development": {
+							Retention: &lokiv1.RetentionLimitSpec{
+								Days: 3,
+							},
+						},
+					},
+				},
+			},
+			wantOptions: config.RetentionOptions{
+				Enabled:           true,
+				DeleteWorkerCount: 10,
+			},
+		},
+		{
+			desc: "global retention, medium",
+			spec: lokiv1.LokiStackSpec{
+				Size: lokiv1.SizeOneXMedium,
+				Limits: &lokiv1.LimitsSpec{
+					Global: &lokiv1.LimitsTemplateSpec{
+						Retention: &lokiv1.RetentionLimitSpec{
+							Days: 14,
+						},
+					},
+				},
+			},
+			wantOptions: config.RetentionOptions{
+				Enabled:           true,
+				DeleteWorkerCount: 150,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			inOpt := manifests.Options{
+				Stack: tc.spec,
+			}
+			options := manifests.ConfigOptions(inOpt)
+			require.Equal(t, tc.wantOptions, options.Retention)
+		})
 	}
 }

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -119,9 +119,9 @@ limits_config:
   max_query_series: {{ .Stack.Limits.Global.QueryLimits.MaxQuerySeries }}
   cardinality_limit: 100000
   max_streams_matchers_per_query: 1000
-{{- if .Retention.Enabled }}{{- with .Retention }}
-  retention_period: {{.Globals.Days}}d
-{{- with .Globals.Streams }}
+{{- if .Retention.Enabled }}{{- with .Stack.Limits.Global.Retention }}
+  retention_period: {{.Days}}d
+{{- with .Streams }}
   retention_stream:
 {{- range . }}
   - selector: '{{ .Selector }}'

--- a/operator/internal/manifests/internal/config/loki-runtime-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-runtime-config.yaml
@@ -36,4 +36,15 @@ overrides:
     max_query_series: {{ $spec.QueryLimits.MaxQuerySeries }}
     {{- end -}}
   {{- end -}}
+  {{- with $spec.Retention }}
+    retention_period: {{ .Days }}d
+    {{- with .Streams }}
+    retention_stream:
+    {{- range . }}
+    - selector: '{{ .Selector }}'
+      priority: {{ .Priority }}
+      period: {{ .Days }}d
+    {{- end }}
+    {{- end }}
+  {{- end }}
   {{- end -}}

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -162,5 +162,4 @@ func (w WriteAheadLog) ReplayMemoryCeiling() string {
 type RetentionOptions struct {
 	Enabled           bool
 	DeleteWorkerCount uint
-	Globals           *lokiv1.RetentionLimitSpec
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Expanding on #7106 this PR adds per-tenant retention rules into the configuration generator. The per-tenant retention will also work when no global retention rules are defined, falling back to Loki's defaults (currently 31 days of retention).

**Which issue(s) this PR fixes**:

[LOG-2681](https://issues.redhat.com/browse/LOG-2681)

**Special notes for your reviewer**:

**Checklist**

- [x] Tests updated
- [ ] `CHANGELOG.md` updated
