### PR TITLE
highly sharded subqueries are ellided in expr.String

### DIFF
--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1401,15 +1401,14 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 			)`,
 		},
 		{
-			`bytes_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[5m])`,
+			`bytes_over_time({app="foo"}[3m]) + count_over_time({app="foo"}[4m])`,
 			`(sum without (
 				   downstream<bytes_over_time({app="foo"}[1m] offset 2m0s), shard=<nil>>
 				++ downstream<bytes_over_time({app="foo"}[1m] offset 1m0s), shard=<nil>>
 				++ downstream<bytes_over_time({app="foo"}[1m]), shard=<nil>>
 			) +
 			sum without (
-				   downstream<count_over_time({app="foo"}[1m] offset 4m0s), shard=<nil>>
-				++ downstream<count_over_time({app="foo"}[1m] offset 3m0s), shard=<nil>>
+				downstream<count_over_time({app="foo"}[1m] offset 3m0s), shard=<nil>>
 				++ downstream<count_over_time({app="foo"}[1m] offset 2m0s), shard=<nil>>
 				++ downstream<count_over_time({app="foo"}[1m] offset 1m0s), shard=<nil>>
 				++ downstream<count_over_time({app="foo"}[1m]), shard=<nil>>
@@ -1417,7 +1416,7 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 			`,
 		},
 		{
-			`sum(count_over_time({app="foo"}[3m]) * count(sum_over_time({app="foo"} | unwrap bar [5m])))`,
+			`sum(count_over_time({app="foo"}[3m]) * count(sum_over_time({app="foo"} | unwrap bar [4m])))`,
 			`sum(
 				(sum without(
 					   downstream<count_over_time({app="foo"}[1m] offset 2m0s), shard=<nil>>
@@ -1426,8 +1425,7 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 				) *
 				count (
 					sum without(
-						   downstream<sum_over_time({app="foo"} | unwrap bar [1m] offset 4m0s), shard=<nil>>
-						++ downstream<sum_over_time({app="foo"} | unwrap bar [1m] offset 3m0s), shard=<nil>>
+						downstream<sum_over_time({app="foo"} | unwrap bar [1m] offset 3m0s), shard=<nil>>
 						++ downstream<sum_over_time({app="foo"} | unwrap bar [1m] offset 2m0s), shard=<nil>>
 						++ downstream<sum_over_time({app="foo"} | unwrap bar [1m] offset 1m0s), shard=<nil>>
 						++ downstream<sum_over_time({app="foo"} | unwrap bar [1m]), shard=<nil>>


### PR DESCRIPTION
This is mostly a quality of life improvement. Highly sharded subqueries can be burdensome to view and they're logged on every request. This PR will only display the first four subqueries in a `Concat{Log,Sample}Expr`, which is easier on the eyes when viewing logs and is more efficient.