### PR TITLE
Wait to close `Memcached.inputCh` until the `Memcached.wg` counter is zero in `Memcached.Stop()`

### DIFF
--- a/pkg/storage/chunk/cache/memcached.go
+++ b/pkg/storage/chunk/cache/memcached.go
@@ -225,8 +225,8 @@ func (c *Memcached) Stop() {
 		return
 	}
 
-	close(c.inputCh)
 	c.wg.Wait()
+	close(c.inputCh)
 }
 
 func (c *Memcached) GetCacheType() stats.CacheType {


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>

**What this PR does / why we need it**:

Currently, it's possible for Loki to panic via "send on closed channel" because we close a channel prematurely in our Memached chunk cache implementation. This PR updates our order of operations to only close the related channel *after* the WaitGroup counter reaches 0.

e.g.

<img width="797" alt="Screen Shot 2022-09-20 at 17 43 10" src="https://user-images.githubusercontent.com/3335605/191377828-883e6977-384d-4952-927c-a2e15449351e.png">



**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
