### PR TITLE
Helm-Chart: Make PVCs in Statefulsets optional

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,9 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.0.9
+- [ENHANCEMENT] Make PVC for Statefulsets optional but enabled as default
+  
 ## 3.0.4
 
 - [CHANGE] Default minio replicas to 1 node with 2 drives. The old config used the default, which was 16 nodes with 1 drive each.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.0.8
+version: 3.0.9
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -330,8 +330,15 @@ monitoring:
 | read.image.repository | string | `nil` | Docker image repository for the read image. Overrides `loki.image.repository` |
 | read.image.tag | string | `nil` | Docker image tag for the read image. Overrides `loki.image.tag` |
 | read.nodeSelector | object | `{}` | Node selector for read pods |
+| read.persistence.enabled | bool | `true` | Enable Persistence for Read Statefulset |
 | read.persistence.size | string | `"10Gi"` | Size of persistent disk |
 | read.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| read.persistence.accessModes | list | `[ReadWriteOnce]` | Persistence AccessModes |
+| read.persistence.annotations | object | `{}` | Persistence Annotations |
+| read.persistence.labels | object | `{}` | Persistence Labels |
+| read.persistence.existingClaim | string | `nil` | Name of existing Claim |
+| read.persistence.selector | object | `{}` | PVC Selector |
+| read.persistence.persistentVolumeClaimRetentionPolicy | object | `{}` | Retention Policies for PVC |
 | read.podAnnotations | object | `{}` | Annotations for read pods |
 | read.priorityClassName | string | `nil` | The name of the PriorityClass for read pods |
 | read.replicas | int | `3` | Number of replicas for the read |
@@ -380,8 +387,15 @@ monitoring:
 | write.image.repository | string | `nil` | Docker image repository for the write image. Overrides `loki.image.repository` |
 | write.image.tag | string | `nil` | Docker image tag for the write image. Overrides `loki.image.tag` |
 | write.nodeSelector | object | `{}` | Node selector for write pods |
+| write.persistence.enabled | bool | `true` | Enable Persistence for Write Statefulset |
 | write.persistence.size | string | `"10Gi"` | Size of persistent disk |
 | write.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| write.persistence.accessModes | list | `[ReadWriteOnce]` | Persistence AccessModes |
+| write.persistence.annotations | object | `{}` | Persistence Annotations |
+| write.persistence.labels | object | `{}` | Persistence Labels |
+| write.persistence.existingClaim | string | `nil` | Name of existing Claim |
+| write.persistence.selector | object | `{}` | PVC Selector |
+| write.persistence.persistentVolumeClaimRetentionPolicy | object | `{}` | Retention Policies for PVC |
 | write.podAnnotations | object | `{}` | Annotations for write pods |
 | write.priorityClassName | string | `nil` | The name of the PriorityClass for write pods |
 | write.replicas | int | `3` | Number of replicas for the write |

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -54,6 +54,10 @@ spec:
       securityContext:
         {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.read.terminationGracePeriodSeconds }}
+      {{- with .Values.read.persistence.persistentVolumeClaimRetentionPolicy }}
+      persistentVolumeClaimRetentionPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: read
           image: {{ include "loki.image" . }}
@@ -137,16 +141,33 @@ spec:
         {{- with .Values.read.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+  {{- if not .Values.read.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else if .Values.read.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.read.persistence.existingClaim }}
+  {{- else }}
   volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        {{- with .Values.read.persistence.storageClass }}
-        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.read.persistence.size | quote }}
+  - metadata:
+      name: data
+      labels:
+        {{- toYaml .Values.read.persistence.labels | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.read.persistence.annotations | nindent 8 }}
+    spec:
+      accessModes:
+        {{- toYaml .Values.read.persistence.accessModes | nindent 8 }}
+      resources:
+        requests:
+          storage: {{ .Values.read.persistence.size | quote }}
+      {{- with .Values.read.persistence.storageClass }}
+      storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+      {{- end }}
+      {{- if .Values.read.persistence.selector }}
+      selector:
+        {{- toYaml .Values.read.persistence.selector | nindent 8 }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -46,6 +46,10 @@ spec:
       securityContext:
         {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.write.terminationGracePeriodSeconds }}
+      {{- with .Values.write.persistence.persistentVolumeClaimRetentionPolicy }}
+      persistentVolumeClaimRetentionPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: write
           image: {{ include "loki.image" . }}
@@ -125,16 +129,33 @@ spec:
         {{- with .Values.write.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+  {{- if not .Values.write.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else if .Values.write.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.write.persistence.existingClaim }}
+  {{- else }}
   volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        {{- with .Values.write.persistence.storageClass }}
-        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.write.persistence.size | quote }}
+  - metadata:
+      name: data
+      labels:
+        {{- toYaml .Values.write.persistence.labels | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.write.persistence.annotations | nindent 8 }}
+    spec:
+      accessModes:
+        {{- toYaml .Values.write.persistence.accessModes | nindent 8 }}
+      resources:
+        requests:
+          storage: {{ .Values.write.persistence.size | quote }}
+      {{- with .Values.write.persistence.storageClass }}
+      storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+      {{- end }}
+      {{- if .Values.write.persistence.selector }}
+      selector:
+        {{- toYaml .Values.write.persistence.selector | nindent 8 }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -628,15 +628,31 @@ write:
   nodeSelector: {}
   # -- Tolerations for write pods
   tolerations: []
+
   persistence:
+    enabled: true
+    accessModes:
+    - ReadWriteOnce
     # -- Size of persistent disk
     size: 10Gi
+    labels: {}
+    annotations: {}
+    # selector:
+    #   matchLabels:
+    #     app.kubernetes.io/name: loki
+    # subPath: ""
+    # existingClaim:
     # -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
     # If set to "-", storageClassName: "", which disables dynamic provisioning.
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Delete
+    #   whenScaled: Delete
+
+
 
 # Configuration for the read node(s)
 read:
@@ -696,14 +712,27 @@ read:
   # -- Tolerations for read pods
   tolerations: []
   persistence:
+    enabled: true
+    accessModes:
+    - ReadWriteOnce
     # -- Size of persistent disk
     size: 10Gi
+    labels: {}
+    annotations: {}
+    # selector:
+    #   matchLabels:
+    #     app.kubernetes.io/name: loki
+    # subPath: ""
+    # existingClaim:
     # -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
     # If set to "-", storageClassName: "", which disables dynamic provisioning.
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Delete
+    #   whenScaled: Delete
 
 # Configuration for the single binary node(s)
 singleBinary:


### PR DESCRIPTION
Signed-off-by: atze234 <schorsus@gmx.de>

**What this PR does / why we need it**:
Make PVCs of Statefulsets optional as of the old loki Chart

**Which issue(s) this PR fixes**:
Fixes #7068 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
