### PR TITLE
fix(chore): Fix "send to closed channel" bug with memcache package.

### DIFF
--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -180,6 +180,9 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk, keys []
 
 	var fromStorage []chunk.Chunk
 	if len(missing) > 0 {
+		if c.storage == nil {
+			return nil, errors.New("nil storage cannot get chunks")
+		}
 		fromStorage, err = c.storage.GetChunks(ctx, missing)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```bash
bash-5.1$ go test -v ./pkg/storage/chunk/cache/... -run TestMemcached_fetchKeysBatched
=== RUN   TestMemcached_fetchKeysBatched
panic: send on closed channel

goroutine 70 [running]:
github.com/grafana/loki/pkg/storage/chunk/cache.(*Memcached).fetchKeysBatched.func1()
        /Users/kaviraj/src/loki/pkg/storage/chunk/cache/memcached.go:167 +0x87
created by github.com/grafana/loki/pkg/storage/chunk/cache.(*Memcached).fetchKeysBatched
        /Users/kaviraj/src/loki/pkg/storage/chunk/cache/memcached.go:164 +0x165
FAIL    github.com/grafana/loki/pkg/storage/chunk/cache 0.384s
```

Try to fix the "send to closed" panic

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
