### PR TITLE
Fix promtail `metric` stage causing failure when getting extracted metrics

### DIFF
--- a/clients/pkg/logentry/metric/metricvec.go
+++ b/clients/pkg/logentry/metric/metricvec.go
@@ -1,6 +1,7 @@
 package metric
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -52,10 +53,23 @@ func (c *metricVec) With(labels model.LabelSet) prometheus.Metric {
 	var ok bool
 	var metric prometheus.Metric
 	if metric, ok = c.metrics[fp]; !ok {
-		metric = c.factory(util.ModelLabelSetToMap(labels))
+		metric = c.factory(util.ModelLabelSetToMap(cleanLabels(labels)))
 		c.metrics[fp] = metric
 	}
 	return metric
+}
+
+func cleanLabels(set model.LabelSet) model.LabelSet {
+	out := make(model.LabelSet, len(set))
+	for k, v := range set {
+		// Performing the same label validity check the prometheus go client library does.
+		// https://github.com/prometheus/client_golang/blob/618194de6ad3db637313666104533639011b470d/prometheus/labels.go#L85
+		if !k.IsValid() || strings.HasPrefix(string(k), "__") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 func (c *metricVec) Delete(labels model.LabelSet) bool {

--- a/clients/pkg/logentry/metric/metricvec.go
+++ b/clients/pkg/logentry/metric/metricvec.go
@@ -59,6 +59,7 @@ func (c *metricVec) With(labels model.LabelSet) prometheus.Metric {
 	return metric
 }
 
+// cleanLabels removes labels whose label name is not a valid prometheus one, or has the reserved `__` prefix.
 func cleanLabels(set model.LabelSet) model.LabelSet {
 	out := make(model.LabelSet, len(set))
 	for k, v := range set {

--- a/clients/pkg/logentry/stages/metrics_test.go
+++ b/clients/pkg/logentry/stages/metrics_test.go
@@ -246,7 +246,8 @@ pipeline_stages:
         action: inc
 `
 
-var testConfigWithTenantStep = `
+func TestNonPrometheusLabelsShouldBeDropped(t *testing.T) {
+	const counterConfig = `
 pipeline_stages:
 - static_labels:
     good_label: "1"
@@ -262,26 +263,89 @@ pipeline_stages:
         action: inc
 `
 
-func TestNonPrometheusLabelsShouldBeDropped(t *testing.T) {
-	const expected = `# HELP logentry_dropped_lines_total A count of all log lines dropped as a result of a pipeline stage
-# TYPE logentry_dropped_lines_total counter
-logentry_dropped_lines_total{reason="match_stage"} 1
-# HELP promtail_custom_loki_count should only inc on non dropped labels
+	const expectedCounterMetrics = `# HELP promtail_custom_loki_count should count all entries
 # TYPE promtail_custom_loki_count counter
 promtail_custom_loki_count{good_label="1"} 1
 `
+
+	const gaugeConfig = `
+pipeline_stages:
+- regex:
+    expression: 'vehicle=(?P<vehicle>\d+) longitude=(?P<longitude>[-]?\d+\.\d+) latitude=(?P<latitude>\d+\.\d+)'
+- labels:
+    vehicle:
+- metrics:
+    longitude:
+        type: Gauge
+        description: "longitude GPS vehicle"
+        source: longitude
+        config:
+          match_all: true
+          action: set
+`
+
+	const expectedGaugeMetrics = `# HELP promtail_custom_longitude longitude GPS vehicle
+# TYPE promtail_custom_longitude gauge
+promtail_custom_longitude{vehicle="1"} -10.1234
+`
+
+	const histogramConfig = `
+pipeline_stages:
+- json:
+    expressions:
+      payload: payload
+- metrics:
+    payload_size_bytes:
+      type: Histogram
+      description: payload size in bytes
+      source: payload
+      config:
+        buckets: [10, 20]
+`
+
+	const expectedHistogramMetrics = `# HELP promtail_custom_payload_size_bytes payload size in bytes
+# TYPE promtail_custom_payload_size_bytes histogram
+promtail_custom_payload_size_bytes_bucket{test="app",le="10"} 1
+promtail_custom_payload_size_bytes_bucket{test="app",le="20"} 1
+promtail_custom_payload_size_bytes_bucket{test="app",le="+Inf"} 1
+promtail_custom_payload_size_bytes_sum{test="app"} 10
+promtail_custom_payload_size_bytes_count{test="app"} 1
+`
 	for name, tc := range map[string]struct {
-		promtailConfig string
-		labels         model.LabelSet
+		promtailConfig  string
+		labels          model.LabelSet
+		line            string
+		expectedCollect string
 	}{
-		"non-prometheus incoming label": {
+		"counter metric with non-prometheus incoming label": {
 			promtailConfig: testMetricWithNonPromLabel,
 			labels: model.LabelSet{
 				"__bad_label__": "2",
 			},
+			line:            testMetricLogLine1,
+			expectedCollect: expectedCounterMetrics,
 		},
-		"tenant step injected label": {
-			promtailConfig: testConfigWithTenantStep,
+		"counter metric with tenant step injected label": {
+			promtailConfig:  counterConfig,
+			line:            testMetricLogLine1,
+			expectedCollect: expectedCounterMetrics,
+		},
+		"gauge metric with non-prometheus incoming label": {
+			promtailConfig: gaugeConfig,
+			labels: model.LabelSet{
+				"__bad_label__": "2",
+			},
+			line:            `#<13>Jan 28 14:25:52 vehicle=1 longitude=-10.1234 latitude=15.1234`,
+			expectedCollect: expectedGaugeMetrics,
+		},
+		"histogram metric with non-prometheus incoming label": {
+			promtailConfig: histogramConfig,
+			labels: model.LabelSet{
+				"test":          "app",
+				"__bad_label__": "2",
+			},
+			line:            testMetricLogLine1,
+			expectedCollect: expectedHistogramMetrics,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -291,11 +355,11 @@ promtail_custom_loki_count{good_label="1"} 1
 			in := make(chan Entry)
 			out := pl.Run(in)
 
-			in <- newEntry(nil, tc.labels, testMetricLogLine1, time.Now())
+			in <- newEntry(nil, tc.labels, tc.line, time.Now())
 			close(in)
 			<-out
 
-			err = testutil.GatherAndCompare(registry, strings.NewReader(expected))
+			err = testutil.GatherAndCompare(registry, strings.NewReader(tc.expectedCollect))
 			require.NoError(t, err, "gathered metrics are different than expected")
 		})
 	}

--- a/clients/pkg/logentry/stages/metrics_test.go
+++ b/clients/pkg/logentry/stages/metrics_test.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/clients/pkg/logentry/metric"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Promtail allows ingested log entries to be modified before pushing them to Loki with the use of pipelines. One of the available pipeline "stages" is called `metrics`, and allows extracting metrics from incoming logs. These metrics are labeled with the labels available in the processed `Entry`. There's some edge cases in which if either a entry label is invalid, or it starts with the prometheus internal label prefix, `__`, calling the promtail `/metrics` fails.

One way to easily reproduce this is by having the following configuration:
```yaml
pipeline_stages:
- static_labels:
    good_label: "1"
- tenant:
    value: "2"
- metrics:
    loki_count:
      type: Counter
      description: "should count all entries"
      config:
        match_all: true
        action: inc
```
Which exposes a `promtail_custom_loki_count` metrics that counts processed log entries. In this case, the step before the `metrics` one injects an internal label `__tenant_id__` to be used by the remote write client. Since this label starts with the prometheus reserved prefix,  this will make calling the `metrics` endpoint fail with an error like the following:
```
An error has occurred while serving metrics:

1 error(s) occurred:
* "__tenant_id__" is not a valid label name for metric "promtail_custom_loki_count"
```

This PR attempts to fix that by, before creating the corresponding metrics, dropping invalid or internal labels. That way promtail will just use labels that are valid.

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/cloud-onboarding/issues/2067

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
