### PR TITLE
Jsonnet: fix overrides exporter to use correct CPU limits

### DIFF
--- a/production/ksonnet/loki/overrides-exporter.libsonnet
+++ b/production/ksonnet/loki/overrides-exporter.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.mixin.readinessProbe.withInitialDelaySeconds(15) +
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     k.util.resourcesRequests('100m', '128Mi') +
-    k.util.resourcesLimits('200', '512Mi'),
+    k.util.resourcesLimits('200m', '512Mi'),
 
   local deployment = k.apps.v1.deployment,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the overrides exporter uses 200 vCPUs due to a missing `m` unit indicating "milli-CPUs".

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
