### PR TITLE
tsdb supports data deletion, this PR takes care of todo to enable delete request client for tsdb

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -690,11 +690,7 @@ func (t *Loki) initQueryFrontendTripperware() (_ services.Service, err error) {
 }
 
 func (t *Loki) supportIndexDeleteRequest() bool {
-	// TODO(owen-d): enable delete request storage in tsdb
-	if config.UsingTSDB(t.Cfg.SchemaConfig.Configs) {
-		return false
-	}
-	return config.UsingBoltdbShipper(t.Cfg.SchemaConfig.Configs)
+	return config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs)
 }
 
 func (t *Loki) cacheGenClient() (generationnumber.CacheGenClient, error) {

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -253,23 +253,6 @@ func UsingObjectStorageIndex(configs []PeriodConfig) bool {
 	return usingForPeriodConfigs(configs, fn)
 }
 
-// UsingBoltdbShipper checks whether current or the next index type is boltdb-shipper, returns true if yes.
-func UsingBoltdbShipper(configs []PeriodConfig) bool {
-	fn := func(cfg PeriodConfig) bool {
-		return cfg.IndexType == BoltDBShipperType
-	}
-
-	return usingForPeriodConfigs(configs, fn)
-}
-
-func UsingTSDB(configs []PeriodConfig) bool {
-	fn := func(cfg PeriodConfig) bool {
-		return cfg.IndexType == TSDBType
-	}
-
-	return usingForPeriodConfigs(configs, fn)
-}
-
 func defaultRowShards(schema string) uint32 {
 	switch schema {
 	case "v1", "v2", "v3", "v4", "v5", "v6", "v9":

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -592,7 +592,7 @@ store: boltdb-shipper
 	require.Equal(t, expected, cfg)
 }
 
-func TestUsingBoltdbShipper(t *testing.T) {
+func TestUsingObjectStorageIndex(t *testing.T) {
 	var cfg SchemaConfig
 
 	// just one PeriodConfig in the past using boltdb-shipper
@@ -600,18 +600,18 @@ func TestUsingBoltdbShipper(t *testing.T) {
 		From:      DayTime{Time: model.Now().Add(-24 * time.Hour)},
 		IndexType: "boltdb-shipper",
 	}}
-	assert.Equal(t, true, UsingBoltdbShipper(cfg.Configs))
+	assert.Equal(t, true, UsingObjectStorageIndex(cfg.Configs))
 
-	// just one PeriodConfig in the past not using boltdb-shipper
+	// just one PeriodConfig in the past not using object storge index
 	cfg.Configs[0].IndexType = "boltdb"
-	assert.Equal(t, false, UsingBoltdbShipper(cfg.Configs))
+	assert.Equal(t, false, UsingObjectStorageIndex(cfg.Configs))
 
-	// add a newer PeriodConfig in the future using boltdb-shipper
+	// add a newer PeriodConfig in the future using tsdb
 	cfg.Configs = append(cfg.Configs, PeriodConfig{
 		From:      DayTime{Time: model.Now().Add(time.Hour)},
-		IndexType: "boltdb-shipper",
+		IndexType: "tsdb",
 	})
-	assert.Equal(t, true, UsingBoltdbShipper(cfg.Configs))
+	assert.Equal(t, true, UsingObjectStorageIndex(cfg.Configs))
 }
 
 func TestActiveIndexType(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`tsdb` index store supports deletion of data, but we had missed enabling the creation of delete requests client, which is required for query time filtering of data requested for deletion. This PR takes care of it.
I have also removed some unused code and adjusted the tests accordingly.

**Checklist**
- [x] Tests updated