### PR TITLE
Loki/Tests: Replicates QF duplicating logs

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -584,6 +584,9 @@ func (c *Client) run(u string) ([]byte, int, error) {
 	if err != nil {
 		return nil, 0, fmt.Errorf("request failed with status code %v: %w", res.StatusCode, err)
 	}
+	if res.StatusCode != 200 {
+		return nil, 0, fmt.Errorf("request failed with status code %v: %s", res.Status, buf)
+	}
 
 	return buf, res.StatusCode, nil
 }

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -317,49 +317,12 @@ func (a *VectorValues) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// StatsReport wraps the stats summary of a query execution.
-type StatsReport struct {
-	Summary SummaryReport `json:"summary"`
-}
-
-// SummaryReport holds statistics of a query execution.
-type SummaryReport struct {
-	BytesProcessedPersecond int
-	LinesProcessedPersecond int
-	TotalLinesProcessed     int
-	TotalEntriesReturned    int
-	Subqueries              int
-}
-
-func (s *SummaryReport) UnmarshalJSON(b []byte) error {
-	var r struct {
-		BytesProcessedPersecond int `json:"bytesProcessedPerSecond"`
-		LinesProcessedPersecond int `json:"linesProcessedPerSecond"`
-		TotalLinesProcessed     int `json:"totalLinesProcessed"`
-		TotalEntriesReturned    int `json:"totalEntriesReturned"`
-		Subqueries              int `json:"subqueries"`
-	}
-
-	if err := json.Unmarshal(b, &r); err != nil {
-		return err
-	}
-
-	s.BytesProcessedPersecond = r.BytesProcessedPersecond
-	s.LinesProcessedPersecond = r.LinesProcessedPersecond
-	s.TotalLinesProcessed = r.TotalLinesProcessed
-	s.TotalEntriesReturned = r.TotalEntriesReturned
-	s.Subqueries = r.Subqueries
-
-	return nil
-}
-
 // DataType holds the result type and a list of StreamValues
 type DataType struct {
 	ResultType string
 	Stream     []StreamValues
 	Matrix     []MatrixValues
 	Vector     []VectorValues
-	Stats      StatsReport
 }
 
 func (a *DataType) UnmarshalJSON(b []byte) error {
@@ -367,14 +330,9 @@ func (a *DataType) UnmarshalJSON(b []byte) error {
 	var s struct {
 		ResultType string          `json:"resultType"`
 		Result     json.RawMessage `json:"result"`
-		Stats      json.RawMessage `json:"stats"`
 	}
 
 	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(s.Stats, &a.Stats); err != nil {
 		return err
 	}
 

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -317,12 +317,43 @@ func (a *VectorValues) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// StatsReport wraps the stats summary of a query execution.
+type StatsReport struct {
+	Summary SummaryReport `json:"summary"`
+}
+
+// SummaryReport holds statistics of a query execution.
+type SummaryReport struct {
+	BytesProcessedPersecond int
+	LinesProcessedPersecond int
+	TotalLinesProcessed     int
+}
+
+func (s *SummaryReport) UnmarshalJSON(b []byte) error {
+	var r struct {
+		BytesProcessedPersecond int `json:"bytesProcessedPerSecond"`
+		LinesProcessedPersecond int `json:"linesProcessedPerSecond"`
+		TotalLinesProcessed     int `json:"totalLinesProcessed"`
+	}
+
+	if err := json.Unmarshal(b, &r); err != nil {
+		return err
+	}
+
+	s.BytesProcessedPersecond = r.BytesProcessedPersecond
+	s.LinesProcessedPersecond = r.LinesProcessedPersecond
+	s.TotalLinesProcessed = r.TotalLinesProcessed
+
+	return nil
+}
+
 // DataType holds the result type and a list of StreamValues
 type DataType struct {
 	ResultType string
 	Stream     []StreamValues
 	Matrix     []MatrixValues
 	Vector     []VectorValues
+	Stats      StatsReport
 }
 
 func (a *DataType) UnmarshalJSON(b []byte) error {
@@ -330,8 +361,14 @@ func (a *DataType) UnmarshalJSON(b []byte) error {
 	var s struct {
 		ResultType string          `json:"resultType"`
 		Result     json.RawMessage `json:"result"`
+		Stats      json.RawMessage `json:"stats"`
 	}
+
 	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(s.Stats, &a.Stats); err != nil {
 		return err
 	}
 

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -327,6 +327,8 @@ type SummaryReport struct {
 	BytesProcessedPersecond int
 	LinesProcessedPersecond int
 	TotalLinesProcessed     int
+	TotalEntriesReturned    int
+	Subqueries              int
 }
 
 func (s *SummaryReport) UnmarshalJSON(b []byte) error {
@@ -334,6 +336,8 @@ func (s *SummaryReport) UnmarshalJSON(b []byte) error {
 		BytesProcessedPersecond int `json:"bytesProcessedPerSecond"`
 		LinesProcessedPersecond int `json:"linesProcessedPerSecond"`
 		TotalLinesProcessed     int `json:"totalLinesProcessed"`
+		TotalEntriesReturned    int `json:"totalEntriesReturned"`
+		Subqueries              int `json:"subqueries"`
 	}
 
 	if err := json.Unmarshal(b, &r); err != nil {
@@ -343,6 +347,8 @@ func (s *SummaryReport) UnmarshalJSON(b []byte) error {
 	s.BytesProcessedPersecond = r.BytesProcessedPersecond
 	s.LinesProcessedPersecond = r.LinesProcessedPersecond
 	s.TotalLinesProcessed = r.TotalLinesProcessed
+	s.TotalEntriesReturned = r.TotalEntriesReturned
+	s.Subqueries = r.Subqueries
 
 	return nil
 }

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -59,6 +59,10 @@ schema_config:
         prefix: index_
         period: 24h
 
+query_range:
+  align_queries_with_step: true
+  parallelise_shardable_queries: true
+
 compactor:
   working_directory: {{.dataPath}}/retention
   shared_store: filesystem

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -64,6 +64,9 @@ query_range:
   align_queries_with_step: true
   parallelise_shardable_queries: true
 
+query_scheduler:
+  max_outstanding_requests_per_tenant: 1024
+
 compactor:
   working_directory: {{.dataPath}}/retention
   shared_store: filesystem

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -33,6 +33,7 @@ server:
 
 common:
   path_prefix: {{.dataPath}}
+  compactor_address: 127.0.0.1
   storage:
     filesystem:
       chunks_directory: {{.sharedDataPath}}/chunks


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new functional test scenario that simulates/replicates https://github.com/grafana/loki/issues/6929.
How to replicate the issue:
- Run Loki on SSD
- Run a query-frontend with downstream pointing to SSD read node
- Execute a query that has a filter against the frontend
Two things might happen:
- If your `outstanding_requests` isn't big, you'll receive a 429. If it's big enough, you'll receive duplicated logs.

**Which issue(s) this PR fixes**:
Not a fix to https://github.com/grafana/loki/issues/6929 but it replicates it

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
