### PR TITLE
[helm] Mimic loki service account with canary account

### DIFF
--- a/production/helm/loki/templates/loki-canary/_helpers.tpl
+++ b/production/helm/loki/templates/loki-canary/_helpers.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/component: canary
 Docker image name for loki-canary
 */}}
 {{- define "loki-canary.image" -}}
-{{- $dict := dict "service" .Values.monitoring.selfMonitoring.lokiCanary.image "global" .Values.global.image "defaultVersion" "latest" -}}
+{{- $dict := dict "service" .Values.monitoring.selfMonitoring.lokiCanary.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
 {{- include "loki.baseImage" $dict -}}
 {{- end -}}
 

--- a/production/helm/loki/templates/loki-canary/serviceaccount.yaml
+++ b/production/helm/loki/templates/loki-canary/serviceaccount.yaml
@@ -7,8 +7,12 @@ metadata:
   labels:
     {{- include "loki-canary.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
   {{- with .Values.monitoring.selfMonitoring.lokiCanary.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bring the Loki Canary service account in line with the Loki service account, removing the post install hook, and sharing the top level properties for `automountServiceAccountToken` and `imagePullSecrets`. I'm open to creating canary specific values for these setting if needed, but want to start by sharing the top level values to reduce config if possible.

Also default canary to Appversion to be in sync with default Loki version

**Which issue(s) this PR fixes**:
Fixes two issues raised in comments from @towolf (thanks!) on this [PR](https://github.com/grafana/loki/pull/7173#issuecomment-1256410181).

Fixes #7237