### PR TITLE
Ingester stream api stop

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -310,6 +310,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, record *WALR
 
 // removeStream removes a stream from the instance.
 func (i *instance) removeStream(s *stream) {
+	s.Stop()
 	if i.streams.Delete(s) {
 		i.index.Delete(s.labels, s.fp)
 		i.streamsRemovedTotal.Inc()

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -310,7 +310,6 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, record *WALR
 
 // removeStream removes a stream from the instance.
 func (i *instance) removeStream(s *stream) {
-	s.Stop()
 	if i.streams.Delete(s) {
 		i.index.Delete(s.labels, s.fp)
 		i.streamsRemovedTotal.Inc()

--- a/pkg/ingester/rate_calculator_test.go
+++ b/pkg/ingester/rate_calculator_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestRateCalculator(t *testing.T) {
 	c := NewRateCalculator()
+	defer c.Stop()
 
 	for i := 0; i < 100; i++ {
 		c.Record(50)
@@ -20,5 +21,5 @@ func TestRateCalculator(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return c.Rate() == 0
-	}, time.Second*2, time.Second)
+	}, time.Second*3, time.Second)
 }

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -574,6 +574,10 @@ func (s *stream) resetCounter() {
 	s.entryCt = 0
 }
 
+func (s *stream) Stop() {
+	s.rateCalculator.Stop()
+}
+
 func headBlockType(unorderedWrites bool) chunkenc.HeadBlockFmt {
 	if unorderedWrites {
 		return chunkenc.UnorderedHeadBlockFmt

--- a/pkg/ingester/streams_map.go
+++ b/pkg/ingester/streams_map.go
@@ -45,6 +45,7 @@ func (m *streamsMap) StoreByFP(fp model.Fingerprint, s *stream) {
 
 // Delete must be called inside WithLock
 func (m *streamsMap) Delete(s *stream) bool {
+	s.Stop()
 	_, loaded := m.streams.LoadAndDelete(s.labelsString)
 	if loaded {
 		m.streamsByFP.Delete(s.fp)

--- a/pkg/logproto/logproto.proto
+++ b/pkg/logproto/logproto.proto
@@ -49,7 +49,7 @@ message StreamRatesResponse {
 message StreamRate {
   uint64 streamHash = 1;
   uint64 streamHashNoShard = 2;
-  int64 rate = 3;
+  int64 rate = 3; // rate in plain bytes.
 }
 
 message PushRequest {


### PR DESCRIPTION
**What this PR does / why we need it**:
Stop the rateCalculator timer when stream is about to be removed.

**Which issue(s) this PR fixes**:
N/A
