### PR TITLE
Expose tenant ID through relabel in push promtail targets

### DIFF
--- a/clients/pkg/promtail/targets/gcplog/push_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target_test.go
@@ -275,7 +275,7 @@ func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := gcplog.NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, []*relabel.Config{
+	tenantIDRelabelConfig := []*relabel.Config{
 		{
 			SourceLabels: model.LabelNames{"__tenant_id__"},
 			Regex:        relabel.MustNewRegexp("(.*)"),
@@ -283,7 +283,8 @@ func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 			TargetLabel:  "tenant_id",
 			Action:       relabel.Replace,
 		},
-	}, "test_job", config)
+	}
+	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, tenantIDRelabelConfig, "test_job", config)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()

--- a/clients/pkg/promtail/targets/gcplog/push_translation.go
+++ b/clients/pkg/promtail/targets/gcplog/push_translation.go
@@ -57,6 +57,8 @@ func translate(m PushMessage, other model.LabelSet, useIncomingTimestamp bool, r
 	// If the incoming request carries the tenant id, inject it as the reserved label, so it's used by the
 	// remote write client.
 	if xScopeOrgID != "" {
+		// Expose tenant ID through relabel to use as logs or metrics label
+		lbs.Set(lokiClient.ReservedLabelTenantID, xScopeOrgID)
 		fixedLabels[lokiClient.ReservedLabelTenantID] = model.LabelValue(xScopeOrgID)
 	}
 

--- a/clients/pkg/promtail/targets/heroku/target_test.go
+++ b/clients/pkg/promtail/targets/heroku/target_test.go
@@ -297,7 +297,7 @@ func TestHerokuDrainTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := NewTarget(metrics, logger, eh, "test_job", config, []*relabel.Config{
+	tenantIDRelabelConfig := []*relabel.Config{
 		{
 			SourceLabels: model.LabelNames{"__tenant_id__"},
 			TargetLabel:  "tenant_id",
@@ -305,7 +305,8 @@ func TestHerokuDrainTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 			Action:       relabel.Replace,
 			Regex:        relabel.MustNewRegexp("(.*)"),
 		},
-	})
+	}
+	pt, err := NewTarget(metrics, logger, eh, "test_job", config, tenantIDRelabelConfig)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()


### PR DESCRIPTION
**What this PR does / why we need it**:

Some Promtail targets that support pushing logs through HTTP, allow using a specific header for writing logs for multiple tenants. This log is propagated through a Promtail internal label, that is then consumed by the remote write client.

If Promtail is used in a multi-tenant manner, it'd be nice to somehow be able to track how much is each tenant's share from the logs received. This PR exposes the received tenant id value through relabeling. 

This allows for example, keeping it as a label and exposing a metric though the `metrics` pipeline stage, which can be segregated by tenant.

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/cloud-onboarding/issues/2067

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
