### PR TITLE
correct heartbeat timeout to distributor lifecycler for ring page

### DIFF
--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -79,6 +79,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	lc.InfNames = cfg.InstanceInterfaceNames
 	lc.UnregisterOnShutdown = true
 	lc.HeartbeatPeriod = cfg.HeartbeatPeriod
+	lc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	lc.ObservePeriod = 0
 	lc.NumTokens = 1
 	lc.JoinAfter = 0


### PR DESCRIPTION
Passes the correct `heartbeat_timeout` to the created lifecycler config in distributor ring construction. When we didn't include this, it would create a visual bug incorrectly marking many distributors as unhealthy when in fact they were in fine condition. Including 

The _lifecycler_ `heartbeat_timeout` is _only_ referenced in the status page [here](https://github.com/grafana/loki/blob/74c8cf03ba4fb2abd979a9af05bb945813a4505c/vendor/github.com/grafana/dskit/ring/lifecycler.go#L892-L894). The _ring_ `heartbeat_timeout` continues to be updated correctly.