### PR TITLE
Fix typo in flags definitions

### DIFF
--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -70,16 +70,16 @@ type Config struct {
 
 // RegisterFlagsWithPrefix registers flags.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	cfg.IndexGatewayClientConfig.RegisterFlagsWithPrefix(prefix+".shipper.index-gateway-client", f)
+	cfg.IndexGatewayClientConfig.RegisterFlagsWithPrefix(prefix+"shipper.index-gateway-client", f)
 
-	f.StringVar(&cfg.ActiveIndexDirectory, prefix+".shipper.active-index-directory", "", "Directory where ingesters would write index files which would then be uploaded by shipper to configured storage")
-	f.StringVar(&cfg.SharedStoreType, prefix+".shipper.shared-store", "", "Shared store for keeping index files. Supported types: gcs, s3, azure, filesystem")
-	f.StringVar(&cfg.SharedStoreKeyPrefix, prefix+".shipper.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator but should always end with it")
-	f.StringVar(&cfg.CacheLocation, prefix+".shipper.cache-location", "", "Cache location for restoring index files from storage for queries")
-	f.DurationVar(&cfg.CacheTTL, prefix+".shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
-	f.DurationVar(&cfg.ResyncInterval, prefix+".shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
-	f.IntVar(&cfg.QueryReadyNumDays, prefix+".shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
-	f.BoolVar(&cfg.UseBoltDBShipperAsBackup, prefix+".shipper.use-boltdb-shipper-as-backup", false, "Use boltdb-shipper index store as backup for indexing chunks. When enabled, boltdb-shipper needs to be configured under storage_config")
+	f.StringVar(&cfg.ActiveIndexDirectory, prefix+"shipper.active-index-directory", "", "Directory where ingesters would write index files which would then be uploaded by shipper to configured storage")
+	f.StringVar(&cfg.SharedStoreType, prefix+"shipper.shared-store", "", "Shared store for keeping index files. Supported types: gcs, s3, azure, filesystem")
+	f.StringVar(&cfg.SharedStoreKeyPrefix, prefix+"shipper.shared-store.key-prefix", "index/", "Prefix to add to Object Keys in Shared store. Path separator(if any) should always be a '/'. Prefix should never start with a separator but should always end with it")
+	f.StringVar(&cfg.CacheLocation, prefix+"shipper.cache-location", "", "Cache location for restoring index files from storage for queries")
+	f.DurationVar(&cfg.CacheTTL, prefix+"shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
+	f.DurationVar(&cfg.ResyncInterval, prefix+"shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
+	f.IntVar(&cfg.QueryReadyNumDays, prefix+"shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
+	f.BoolVar(&cfg.UseBoltDBShipperAsBackup, prefix+"shipper.use-boltdb-shipper-as-backup", false, "Use boltdb-shipper index store as backup for indexing chunks. When enabled, boltdb-shipper needs to be configured under storage_config")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -33,7 +33,7 @@ type Config struct {
 
 // RegisterFlags registers flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.RegisterFlagsWithPrefix("boltdb", f)
+	cfg.RegisterFlagsWithPrefix("boltdb.", f)
 
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As all flags defined for `TSDBShipperConfig` are already prefixed by a dot, suffixing tsdb with one makes it redundant.

```
  -tsdb..shipper.active-index-directory string
  -tsdb..shipper.cache-location string
  -tsdb..shipper.cache-ttl duration
  -tsdb..shipper.index-gateway-client.grpc.backoff-max-period duration
  -tsdb..shipper.index-gateway-client.grpc.backoff-min-period duration
  -tsdb..shipper.index-gateway-client.grpc.backoff-on-ratelimits
  -tsdb..shipper.index-gateway-client.grpc.backoff-retries int
  -tsdb..shipper.index-gateway-client.grpc.grpc-client-rate-limit float
  -tsdb..shipper.index-gateway-client.grpc.grpc-client-rate-limit-burst int
  -tsdb..shipper.index-gateway-client.grpc.grpc-compression string
  -tsdb..shipper.index-gateway-client.grpc.grpc-max-recv-msg-size int
  -tsdb..shipper.index-gateway-client.grpc.grpc-max-send-msg-size int
  -tsdb..shipper.index-gateway-client.grpc.tls-ca-path string
  -tsdb..shipper.index-gateway-client.grpc.tls-cert-path string
  -tsdb..shipper.index-gateway-client.grpc.tls-enabled
  -tsdb..shipper.index-gateway-client.grpc.tls-insecure-skip-verify
  -tsdb..shipper.index-gateway-client.grpc.tls-key-path string
  -tsdb..shipper.index-gateway-client.grpc.tls-server-name string
  -tsdb..shipper.index-gateway-client.log-gateway-requests
  -tsdb..shipper.index-gateway-client.server-address string
  -tsdb..shipper.query-ready-num-days int
  -tsdb..shipper.resync-interval duration
  -tsdb..shipper.shared-store string
  -tsdb..shipper.shared-store.key-prefix string
  -tsdb..shipper.use-boltdb-shipper-as-backup
  ```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
