### PR TITLE
[helm loki] add support for custom analytics config

### DIFF
--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -254,8 +254,8 @@ monitoring:
 | kubectlImage.registry | string | `"docker.io"` | The Docker registry |
 | kubectlImage.repository | string | `"bitnami/kubectl"` | Docker image repository |
 | kubectlImage.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
-| loki.auth_enabled | bool | `true` |  |
 | loki.analytics | object | `{}` | Optional analytics configuration |
+| loki.auth_enabled | bool | `true` |  |
 | loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":3}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
 | loki.compactor | object | `{}` | Optional compactor configuration |
 | loki.config | string | See values.yaml | Config file contents for Loki |

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -255,6 +255,7 @@ monitoring:
 | kubectlImage.repository | string | `"bitnami/kubectl"` | Docker image repository |
 | kubectlImage.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
 | loki.auth_enabled | bool | `true` |  |
+| loki.analytics | object | `{}` | Optional analytics configuration |
 | loki.commonConfig | object | `{"path_prefix":"/var/loki","replication_factor":3}` | Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration |
 | loki.compactor | object | `{}` | Optional compactor configuration |
 | loki.config | string | See values.yaml | Config file contents for Loki |

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -170,6 +170,11 @@ loki:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
 
+    {{- with .Values.loki.analytics }}
+    analytics:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
+
   # Should authentication be enabled
   auth_enabled: true
 
@@ -252,6 +257,9 @@ loki:
 
   # --  Optional compactor configuration
   compactor: {}
+
+  # --  Optional analytics configuration
+  analytics: {}
 
 enterprise:
   # Enable enterprise features, license must be provided


### PR DESCRIPTION
**What this PR does / why we need it**:
I want to disable usage reporting to Grafana. On clusters that don't have access to Internet it generates error logs.
And without this patch, the only way is to have the whole `loki.config` section in my custom values file.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
