### PR TITLE
Promtail: Change max support compressed line size to be 2MB

### DIFF
--- a/clients/pkg/promtail/targets/file/decompresser.go
+++ b/clients/pkg/promtail/targets/file/decompresser.go
@@ -189,8 +189,9 @@ func (t *decompressor) readLines() {
 
 	level.Info(t.logger).Log("msg", "successfully mounted reader", "path", t.path, "ext", filepath.Ext(t.path))
 
-	maxLoglineSize := 4096
-	buffer := make([]byte, maxLoglineSize)
+	bufferSize := 4096
+	buffer := make([]byte, bufferSize)
+	maxLoglineSize := 2000000 // 2 MB
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(buffer, maxLoglineSize)
 	for line := 1; ; line++ {

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -43,7 +43,7 @@ relies on file extensions. If a discovered file has an expected compression file
 extension, Promtail will **lazily** decompress the compressed file and push the
 parsed data to Loki. Important details are:
 * It relies on the `\n` character to separate the data into different log lines.
-* The max expected log line is 4096 bytes within the compressed file.
+* The max expected log line is 2MB bytes within the compressed file.
 * The data is decompressed in blocks of 4096 bytes. i.e: it first fetches a block of 4096 bytes
   from the compressed file and process it. After processing this block and pushing the data to Loki,
   it fetches the following 4096 bytes, and so on.


### PR DESCRIPTION
**What this PR does / why we need it**:
Change Promtail compression support max line size to 2MB instead of 4096 bytes (~4KB).
This however doesn't change the default buffer size.
4096 bytes means we can't ever have a buffer size bigger than ~4KB but since the default mem page size is 4096 ([source](https://unix.stackexchange.com/questions/128213/how-is-page-size-determined-in-virtual-address-space)), we end up ignoring all lines.