### PR TITLE
Tests: Reduce flakiness of GCPLog and integration tests

### DIFF
--- a/clients/pkg/promtail/targets/gcplog/pull_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target_test.go
@@ -25,31 +25,32 @@ import (
 
 func TestPullTarget_Run(t *testing.T) {
 	// Goal: Check message written to pubsub topic is received by the target.
-	tt, apiclient, pubsubClient, teardown := testPullTarget(t)
+	ctx := context.Background()
+	tt, apiclient, pubsubClient, teardown := testPullTarget(ctx, t)
 	defer teardown()
 
 	// seed pubsub
-	ctx := context.Background()
 	tp, err := pubsubClient.CreateTopic(ctx, topic)
 	require.NoError(t, err)
+	defer tp.Stop()
+
 	_, err = pubsubClient.CreateSubscription(ctx, subscription, pubsub.SubscriptionConfig{
 		Topic: tp,
 	})
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
-		_ = tt.run()
+		tt.run()
 	}()
 
-	publishMessage(t, tp)
-
+	publishMessage(ctx, t, tp)
 	// Wait till message is received by the run loop.
 	// NOTE(kavi): sleep is not ideal. but not other way to confirm if api.Handler received messages
-	time.Sleep(1 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	err = tt.Stop()
 	require.NoError(t, err)
@@ -57,6 +58,8 @@ func TestPullTarget_Run(t *testing.T) {
 	// wait till `run` stops.
 	wg.Wait()
 
+	// Sleep one more time before reading from api.Received.
+	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 1, len(apiclient.Received()))
 }
 
@@ -65,7 +68,8 @@ func TestPullTarget_Stop(t *testing.T) {
 
 	errs := make(chan error, 1)
 
-	tt, _, _, teardown := testPullTarget(t)
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
 	defer teardown()
 
 	var wg sync.WaitGroup
@@ -90,30 +94,33 @@ func TestPullTarget_Stop(t *testing.T) {
 }
 
 func TestPullTarget_Type(t *testing.T) {
-	tt, _, _, teardown := testPullTarget(t)
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
 	defer teardown()
 
 	assert.Equal(t, target.TargetType("Gcplog"), tt.Type())
 }
 
 func TestPullTarget_Ready(t *testing.T) {
-	tt, _, _, teardown := testPullTarget(t)
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
 	defer teardown()
 
 	assert.Equal(t, true, tt.Ready())
 }
 
 func TestPullTarget_Labels(t *testing.T) {
-	tt, _, _, teardown := testPullTarget(t)
+	ctx := context.Background()
+	tt, _, _, teardown := testPullTarget(ctx, t)
 	defer teardown()
 
 	assert.Equal(t, model.LabelSet{"job": "test-gcplogtarget"}, tt.Labels())
 }
 
-func testPullTarget(t *testing.T) (*pullTarget, *fake.Client, *pubsub.Client, func()) {
+func testPullTarget(ctx context.Context, t *testing.T) (*pullTarget, *fake.Client, *pubsub.Client, func()) {
 	t.Helper()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	mockSvr := pstest.NewServer()
 	conn, err := grpc.Dial(mockSvr.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -146,11 +153,11 @@ func testPullTarget(t *testing.T) (*pullTarget, *fake.Client, *pubsub.Client, fu
 	}
 }
 
-func publishMessage(t *testing.T, topic *pubsub.Topic) {
+func publishMessage(ctx context.Context, t *testing.T, topic *pubsub.Topic) {
 	t.Helper()
 
-	ctx := context.Background()
 	res := topic.Publish(ctx, &pubsub.Message{Data: []byte(gcpLogEntry)})
+
 	_, err := res.Get(ctx) // wait till message is actully published
 	require.NoError(t, err)
 }

--- a/clients/pkg/promtail/targets/gcplog/pull_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target_test.go
@@ -50,7 +50,7 @@ func TestPullTarget_Run(t *testing.T) {
 	publishMessage(ctx, t, tp)
 	// Wait till message is received by the run loop.
 	// NOTE(kavi): sleep is not ideal. but not other way to confirm if api.Handler received messages
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	err = tt.Stop()
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestPullTarget_Run(t *testing.T) {
 	wg.Wait()
 
 	// Sleep one more time before reading from api.Received.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, 1, len(apiclient.Received()))
 }
 

--- a/clients/pkg/promtail/targets/gcplog/pull_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target_test.go
@@ -44,7 +44,7 @@ func TestPullTarget_Run(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		tt.run()
+		tt.run() //nolint:errcheck
 	}()
 
 	publishMessage(ctx, t, tp)

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -472,7 +472,7 @@ func (c *Client) rangeQueryURL(query string) string {
 }
 
 func (c *Client) LabelNames(ctx context.Context) ([]string, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelFunc()
 
 	url := fmt.Sprintf("%s/loki/api/v1/labels", c.baseURL)
@@ -504,7 +504,7 @@ func (c *Client) LabelNames(ctx context.Context) ([]string, error) {
 
 // LabelValues return a LabelValues query
 func (c *Client) LabelValues(ctx context.Context, labelName string) ([]string, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelFunc()
 
 	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", c.baseURL, url.PathEscape(labelName))

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/weaveworks/common/user"
 )
 
 type roundTripper struct {
@@ -187,7 +190,7 @@ func (c *Client) Metrics() (string, error) {
 
 // Flush all in-memory chunks held by the ingesters to the backing store
 func (c *Client) Flush() error {
-	req, err := c.request("POST", fmt.Sprintf("%s/flush", c.baseURL))
+	req, err := c.request(context.Background(), "POST", fmt.Sprintf("%s/flush", c.baseURL))
 	if err != nil {
 		return err
 	}
@@ -377,8 +380,11 @@ type Rules struct {
 }
 
 // RunRangeQuery runs a query and returns an error if anything went wrong
-func (c *Client) RunRangeQuery(query string) (*Response, error) {
-	buf, statusCode, err := c.run(c.rangeQueryURL(query))
+func (c *Client) RunRangeQuery(ctx context.Context, query string) (*Response, error) {
+	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelFunc()
+
+	buf, statusCode, err := c.run(ctx, c.rangeQueryURL(query))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +393,10 @@ func (c *Client) RunRangeQuery(query string) (*Response, error) {
 }
 
 // RunQuery runs a query and returns an error if anything went wrong
-func (c *Client) RunQuery(query string) (*Response, error) {
+func (c *Client) RunQuery(ctx context.Context, query string) (*Response, error) {
+	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelFunc()
+
 	v := url.Values{}
 	v.Set("query", query)
 	v.Set("time", formatTS(c.Now.Add(time.Second)))
@@ -399,23 +408,27 @@ func (c *Client) RunQuery(query string) (*Response, error) {
 	u.Path = "/loki/api/v1/query"
 	u.RawQuery = v.Encode()
 
-	buf, statusCode, err := c.run(u.String())
+	buf, statusCode, err := c.run(ctx, u.String())
 	if err != nil {
 		return nil, err
 	}
 
 	return c.parseResponse(buf, statusCode)
+
 }
 
 // GetRules returns the loki ruler rules
-func (c *Client) GetRules() (*RulesResponse, error) {
+func (c *Client) GetRules(ctx context.Context) (*RulesResponse, error) {
+	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelFunc()
+
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
 	}
 	u.Path = "/prometheus/api/v1/rules"
 
-	buf, _, err := c.run(u.String())
+	buf, _, err := c.run(ctx, u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -458,10 +471,13 @@ func (c *Client) rangeQueryURL(query string) string {
 	return u.String()
 }
 
-func (c *Client) LabelNames() ([]string, error) {
+func (c *Client) LabelNames(ctx context.Context) ([]string, error) {
+	ctx, cancelFunc := context.WithTimeout(ctx, time.Second)
+	defer cancelFunc()
+
 	url := fmt.Sprintf("%s/loki/api/v1/labels", c.baseURL)
 
-	req, err := c.request("GET", url)
+	req, err := c.request(ctx, "GET", url)
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +489,7 @@ func (c *Client) LabelNames() ([]string, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("Unexpected status code of %d", res.StatusCode)
+		return nil, fmt.Errorf("unexpected status code of %d", res.StatusCode)
 	}
 
 	var values struct {
@@ -487,10 +503,13 @@ func (c *Client) LabelNames() ([]string, error) {
 }
 
 // LabelValues return a LabelValues query
-func (c *Client) LabelValues(labelName string) ([]string, error) {
+func (c *Client) LabelValues(ctx context.Context, labelName string) ([]string, error) {
+	ctx, cancelFunc := context.WithTimeout(ctx, time.Second)
+	defer cancelFunc()
+
 	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", c.baseURL, url.PathEscape(labelName))
 
-	req, err := c.request("GET", url)
+	req, err := c.request(ctx, "GET", url)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +521,7 @@ func (c *Client) LabelValues(labelName string) ([]string, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("Unexpected status code of %d", res.StatusCode)
+		return nil, fmt.Errorf("unexpected status code of %d", res.StatusCode)
 	}
 
 	var values struct {
@@ -515,8 +534,9 @@ func (c *Client) LabelValues(labelName string) ([]string, error) {
 	return values.Data, nil
 }
 
-func (c *Client) request(method string, url string) (*http.Request, error) {
-	req, err := http.NewRequest(method, url, nil)
+func (c *Client) request(ctx context.Context, method string, url string) (*http.Request, error) {
+	ctx = user.InjectOrgID(ctx, c.instanceID)
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -524,8 +544,8 @@ func (c *Client) request(method string, url string) (*http.Request, error) {
 	return req, nil
 }
 
-func (c *Client) run(u string) ([]byte, int, error) {
-	req, err := c.request("GET", u)
+func (c *Client) run(ctx context.Context, u string) ([]byte, int, error) {
+	req, err := c.request(ctx, "GET", u)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/weaveworks/common/user"
 )
 
+const requestTimeout = 30 * time.Second
+
 type roundTripper struct {
 	instanceID    string
 	token         string
@@ -381,7 +383,7 @@ type Rules struct {
 
 // RunRangeQuery runs a query and returns an error if anything went wrong
 func (c *Client) RunRangeQuery(ctx context.Context, query string) (*Response, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, requestTimeout)
 	defer cancelFunc()
 
 	buf, statusCode, err := c.run(ctx, c.rangeQueryURL(query))
@@ -394,7 +396,7 @@ func (c *Client) RunRangeQuery(ctx context.Context, query string) (*Response, er
 
 // RunQuery runs a query and returns an error if anything went wrong
 func (c *Client) RunQuery(ctx context.Context, query string) (*Response, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, requestTimeout)
 	defer cancelFunc()
 
 	v := url.Values{}
@@ -419,7 +421,7 @@ func (c *Client) RunQuery(ctx context.Context, query string) (*Response, error) 
 
 // GetRules returns the loki ruler rules
 func (c *Client) GetRules(ctx context.Context) (*RulesResponse, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, requestTimeout)
 	defer cancelFunc()
 
 	u, err := url.Parse(c.baseURL)
@@ -472,7 +474,7 @@ func (c *Client) rangeQueryURL(query string) string {
 }
 
 func (c *Client) LabelNames(ctx context.Context) ([]string, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, requestTimeout)
 	defer cancelFunc()
 
 	url := fmt.Sprintf("%s/loki/api/v1/labels", c.baseURL)
@@ -504,7 +506,7 @@ func (c *Client) LabelNames(ctx context.Context) ([]string, error) {
 
 // LabelValues return a LabelValues query
 func (c *Client) LabelValues(ctx context.Context, labelName string) ([]string, error) {
-	ctx, cancelFunc := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelFunc := context.WithTimeout(ctx, requestTimeout)
 	defer cancelFunc()
 
 	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", c.baseURL, url.PathEscape(labelName))

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -165,6 +165,17 @@ func New() *Cluster {
 
 func (c *Cluster) Run() error {
 	for _, component := range c.components {
+		var err error
+		component.httpPort, err = getFreePort()
+		if err != nil {
+			panic(fmt.Errorf("error allocating HTTP port: %w", err))
+		}
+
+		component.grpcPort, err = getFreePort()
+		if err != nil {
+			panic(fmt.Errorf("error allocating GRPC port: %w", err))
+		}
+
 		if err := component.run(); err != nil {
 			return err
 		}
@@ -210,17 +221,6 @@ func (c *Cluster) AddComponent(name string, flags ...string) *Component {
 		name:    name,
 		cluster: c,
 		flags:   flags,
-	}
-
-	var err error
-	component.httpPort, err = getFreePort()
-	if err != nil {
-		panic(fmt.Errorf("error allocating HTTP port: %w", err))
-	}
-
-	component.grpcPort, err = getFreePort()
-	if err != nil {
-		panic(fmt.Errorf("error allocating GRPC port: %w", err))
 	}
 
 	c.components = append(c.components, component)

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -165,6 +166,10 @@ func New() *Cluster {
 
 func (c *Cluster) Run() error {
 	for _, component := range c.components {
+		if component.running {
+			continue
+		}
+
 		var err error
 		component.httpPort, err = getFreePort()
 		if err != nil {
@@ -183,6 +188,9 @@ func (c *Cluster) Run() error {
 	return nil
 }
 func (c *Cluster) Cleanup() error {
+	_, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancelFunc()
+
 	var (
 		files []string
 		dirs  []string
@@ -221,6 +229,7 @@ func (c *Cluster) AddComponent(name string, flags ...string) *Component {
 		name:    name,
 		cluster: c,
 		flags:   flags,
+		running: false,
 	}
 
 	c.components = append(c.components, component)
@@ -242,6 +251,8 @@ type Component struct {
 	rulesPath    string
 	RulesTenant  string
 
+	running bool
+
 	RemoteWriteUrls []string
 }
 
@@ -257,6 +268,10 @@ func (c *Component) GRPCURL() *url.URL {
 		Host:   fmt.Sprintf("localhost:%d", c.grpcPort),
 		Scheme: "grpc",
 	}
+}
+
+func (c *Component) AppendFlag(flag string) {
+	c.flags = append(c.flags, flag)
 }
 
 func (c *Component) writeConfig() error {
@@ -325,6 +340,8 @@ func (c *Component) writeConfig() error {
 }
 
 func (c *Component) run() error {
+	c.running = true
+
 	if err := c.writeConfig(); err != nil {
 		return err
 	}
@@ -359,7 +376,7 @@ func (c *Component) run() error {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 200)
-			if c.loki.Server.HTTP == nil {
+			if c.loki == nil || c.loki.Server == nil || c.loki.Server.HTTP == nil {
 				continue
 			}
 

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -270,10 +270,6 @@ func (c *Component) GRPCURL() *url.URL {
 	}
 }
 
-func (c *Component) AppendFlag(flag string) {
-	c.flags = append(c.flags, flag)
-}
-
 func (c *Component) writeConfig() error {
 	var err error
 

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/user"
 
 	"github.com/grafana/loki/integration/client"
 	"github.com/grafana/loki/integration/cluster"
@@ -209,8 +208,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 
 	t.Run("ruler", func(t *testing.T) {
 		// Check rules are read correctly.
-		ctx := user.InjectOrgID(context.Background(), "fake")
-		resp, err := cliRuler.GetRules(ctx)
+		resp, err := cliRuler.GetRules(context.Background())
 
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestSimpleScalableIngestQuery(t *testing.T) {
 	})
 
 	t.Run("query", func(t *testing.T) {
-		resp, err := cliRead.RunRangeQuery(`{job="fake"}`)
+		resp, err := cliRead.RunRangeQuery(context.Background(), `{job="fake"}`)
 		require.NoError(t, err)
 		assert.Equal(t, "streams", resp.Data.ResultType)
 
@@ -62,13 +63,13 @@ func TestSimpleScalableIngestQuery(t *testing.T) {
 	})
 
 	t.Run("label-names", func(t *testing.T) {
-		resp, err := cliRead.LabelNames()
+		resp, err := cliRead.LabelNames(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"job"}, resp)
 	})
 
 	t.Run("label-values", func(t *testing.T) {
-		resp, err := cliRead.LabelValues("job")
+		resp, err := cliRead.LabelValues(context.Background(), "job")
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"fake"}, resp)
 	})

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestSingleBinaryIngestQuery(t *testing.T) {
 	})
 
 	t.Run("query", func(t *testing.T) {
-		resp, err := cli.RunRangeQuery(`{job="fake"}`)
+		resp, err := cli.RunRangeQuery(context.Background(), `{job="fake"}`)
 		require.NoError(t, err)
 		assert.Equal(t, "streams", resp.Data.ResultType)
 
@@ -60,13 +61,13 @@ func TestSingleBinaryIngestQuery(t *testing.T) {
 	})
 
 	t.Run("label-names", func(t *testing.T) {
-		resp, err := cli.LabelNames()
+		resp, err := cli.LabelNames(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"job"}, resp)
 	})
 
 	t.Run("label-values", func(t *testing.T) {
-		resp, err := cli.LabelValues("job")
+		resp, err := cli.LabelValues(context.Background(), "job")
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"fake"}, resp)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reduce flakiness of GCPLog tests by reusing context and stopping GCP topic
- Reduce flakiness of integration tests by:
  - using port as they're assigned
  - reusing context
  - adding timeout to calls (hence, if something get stuck, tests fail earlier)
