### PR TITLE
[Mixin] Rename `logs` template variable to `loki_datasource`.

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-logs.json
@@ -719,7 +719,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "$logs",
+            "datasource": "$loki_datasources",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -820,7 +820,7 @@
             }
          },
          {
-            "datasource": "$logs",
+            "datasource": "$loki_datasources",
             "gridPos": {
                "h": 19,
                "w": 24,
@@ -919,7 +919,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
@@ -2040,7 +2040,7 @@
                   "bars": true,
                   "dashLength": 10,
                   "dashes": false,
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "fill": 1,
                   "fillGradient": 0,
                   "gridPos": {
@@ -2128,7 +2128,7 @@
                   }
                },
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "gridPos": {
                      "h": 18,
                      "w": 12,
@@ -3247,7 +3247,7 @@
                   "bars": true,
                   "dashLength": 10,
                   "dashes": false,
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "fill": 1,
                   "fillGradient": 0,
                   "gridPos": {
@@ -3335,7 +3335,7 @@
                   }
                },
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "gridPos": {
                      "h": 18,
                      "w": 18,
@@ -6178,7 +6178,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-retention.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-retention.json
@@ -1401,7 +1401,7 @@
             "height": "250px",
             "panels": [
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "id": 17,
                   "span": 12,
                   "targets": [
@@ -1492,7 +1492,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin-compiled/dashboards/loki-logs.json
+++ b/production/loki-mixin-compiled/dashboards/loki-logs.json
@@ -719,7 +719,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "$logs",
+            "datasource": "$loki_datasources",
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -820,7 +820,7 @@
             }
          },
          {
-            "datasource": "$logs",
+            "datasource": "$loki_datasources",
             "gridPos": {
                "h": 19,
                "w": 24,
@@ -919,7 +919,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -2040,7 +2040,7 @@
                   "bars": true,
                   "dashLength": 10,
                   "dashes": false,
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "fill": 1,
                   "fillGradient": 0,
                   "gridPos": {
@@ -2128,7 +2128,7 @@
                   }
                },
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "gridPos": {
                      "h": 18,
                      "w": 12,
@@ -2713,7 +2713,7 @@
                   "bars": true,
                   "dashLength": 10,
                   "dashes": false,
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "fill": 1,
                   "fillGradient": 0,
                   "gridPos": {
@@ -2801,7 +2801,7 @@
                   }
                },
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "gridPos": {
                      "h": 18,
                      "w": 18,
@@ -3653,7 +3653,7 @@
                   "bars": true,
                   "dashLength": 10,
                   "dashes": false,
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "fill": 1,
                   "fillGradient": 0,
                   "gridPos": {
@@ -3741,7 +3741,7 @@
                   }
                },
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "gridPos": {
                      "h": 18,
                      "w": 18,
@@ -6584,7 +6584,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin-compiled/dashboards/loki-retention.json
+++ b/production/loki-mixin-compiled/dashboards/loki-retention.json
@@ -1401,7 +1401,7 @@
             "height": "250px",
             "panels": [
                {
-                  "datasource": "$logs",
+                  "datasource": "$loki_datasources",
                   "id": 17,
                   "span": 12,
                   "targets": [
@@ -1492,7 +1492,7 @@
             {
                "hide": 0,
                "label": null,
-               "name": "logs",
+               "name": "loki_datasource",
                "options": [ ],
                "query": "loki",
                "refresh": 1,

--- a/production/loki-mixin/dashboards/dashboard-loki-logs.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-logs.json
@@ -715,7 +715,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$logs",
+      "datasource": "$loki_datasources",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -816,7 +816,7 @@
       }
     },
     {
-      "datasource": "$logs",
+      "datasource": "$loki_datasources",
       "gridPos": {
         "h": 19,
         "w": 24,

--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -11,7 +11,7 @@
         "type": "dashboard"
       },
       {
-        "datasource": "$logs",
+        "datasource": "$loki_datasources",
         "enable": true,
         "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"$namespace\"",
         "hide": true,
@@ -2076,7 +2076,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2163,7 +2163,7 @@
           }
         },
         {
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "gridPos": {
             "h": 18,
             "w": 12,
@@ -2740,7 +2740,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2827,7 +2827,7 @@
           }
         },
         {
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "gridPos": {
             "h": 18,
             "w": 18,
@@ -3666,7 +3666,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -3753,7 +3753,7 @@
           }
         },
         {
-          "datasource": "$logs",
+          "datasource": "$loki_datasources",
           "gridPos": {
             "h": 18,
             "w": 18,

--- a/production/loki-mixin/dashboards/dashboard-utils.libsonnet
+++ b/production/loki-mixin/dashboards/dashboard-utils.libsonnet
@@ -10,7 +10,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         if condition
         then self.addRow(row)
         else self,
-      addLog(name='logs'):: self {
+      addLog(name='loki_datasource'):: self {
         templating+: {
           list+: [
             {
@@ -90,7 +90,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerLabelMatcher(containerName)::
     'label_name=~"%s.*"' % containerName,
 
-  logPanel(title, selector, datasource='$logs'):: {
+  logPanel(title, selector, datasource='$loki_datasources'):: {
     title: title,
     type: 'logs',
     datasource: datasource,

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -142,7 +142,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                local selectDatasource(ds) =
                                  if ds == null || ds == '' then ds
                                  else if ds == '$datasource' then '$datasource'
-                                 else '$logs',
+                                 else '$loki_datasources',
 
                                local isRowHidden(row) =
                                  std.member(dashboards['loki-operational.json'].hiddenRows, row),
@@ -190,7 +190,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                ],
                              } +
                              $.dashboard('Loki / Operational', uid='operational')
-                             // The queries in this dashboard don't make use of the cluster tempalte label selector
+                             // The queries in this dashboard don't make use of the cluster template label selector
                              // but we keep it here to allow selecting a namespace specific to a certain cluster, the
                              // namespace template variable selectors query uses the cluster value.
                              .addLog()


### PR DESCRIPTION
**What this PR does / why we need it**:
Grafana Cloud integration have the convention to name data source variables after `<type>_datasource`. That means `$logs` should become `loki_datasource`.
