### PR TITLE
Tests: Improve several tests behavior

### DIFF
--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -295,6 +295,10 @@ func TestFileTargetPathExclusion(t *testing.T) {
 		return receivedStopWatch.Load() == 1
 	}, time.Second*10, time.Millisecond*1, "Expected received stopping watch event to be 1 at this point in the test...")
 
+	require.NoError(t, os.RemoveAll(logDir2))
+	require.NoError(t, os.RemoveAll(logDir3))
+	require.NoError(t, target.sync())
+
 	target.Stop()
 	ps.Stop()
 }

--- a/clients/pkg/promtail/targets/gcplog/pull_target.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target.go
@@ -147,5 +147,6 @@ func (t *pullTarget) Stop() error {
 	t.cancel()
 	t.wg.Wait()
 	t.handler.Stop()
+	t.ps.Close()
 	return nil
 }

--- a/clients/pkg/promtail/targets/gcplog/pull_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target_test.go
@@ -138,7 +138,7 @@ func testPullTarget(ctx context.Context, t *testing.T) (*pullTarget, *fake.Clien
 		handler:       handler,
 		relabelConfig: nil,
 		config:        testConfig,
-		jobName:       "job-test-gcplogtarget",
+		jobName:       t.Name() + "job-test-gcplogtarget",
 		ctx:           ctx,
 		cancel:        cancel,
 		ps:            mockpubsubClient,

--- a/clients/pkg/promtail/targets/gcplog/pull_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target_test.go
@@ -150,6 +150,7 @@ func testPullTarget(ctx context.Context, t *testing.T) (*pullTarget, *fake.Clien
 		cancel()
 		conn.Close()
 		mockSvr.Close()
+		mockpubsubClient.Close()
 	}
 }
 

--- a/clients/pkg/promtail/targets/gcplog/push_target.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target.go
@@ -159,6 +159,7 @@ func (h *pushTarget) Details() interface{} {
 
 func (h *pushTarget) Stop() error {
 	level.Info(h.logger).Log("msg", "stopping gcp push target", "job", h.jobName)
+	h.server.Stop()
 	h.server.Shutdown()
 	h.handler.Stop()
 	return nil

--- a/clients/pkg/promtail/targets/gcplog/push_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target_test.go
@@ -363,6 +363,7 @@ func TestPushTarget_ErroneousPayloadsAreRejected(t *testing.T) {
 			req, err := makeGCPPushRequest(fmt.Sprintf("http://%s:%d", localhost, port), testPayload)
 			require.NoError(t, err, "expected request to be created successfully")
 			res, err := http.DefaultClient.Do(req)
+			res.Request.Body.Close()
 			require.NoError(t, err)
 			require.Equal(t, http.StatusBadRequest, res.StatusCode, "expected bad request status code")
 		})

--- a/clients/pkg/promtail/targets/gcplog/push_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target_test.go
@@ -153,6 +153,7 @@ func TestPushTarget(t *testing.T) {
 		},
 	}
 	for name, tc := range cases {
+		outerName := t.Name()
 		t.Run(name, func(t *testing.T) {
 			// Create fake promtail client
 			eh := fake.New(func() {})
@@ -169,7 +170,7 @@ func TestPushTarget(t *testing.T) {
 
 			prometheus.DefaultRegisterer = prometheus.NewRegistry()
 			metrics := gcplog.NewMetrics(prometheus.DefaultRegisterer)
-			pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, tc.args.RelabelConfigs, "test_job", config)
+			pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, tc.args.RelabelConfigs, outerName+"_test_job", config)
 			require.NoError(t, err)
 			defer func() {
 				_ = pt.Stop()
@@ -231,7 +232,7 @@ func TestPushTarget_UseIncomingTimestamp(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := gcplog.NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, nil, "test_job", config)
+	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, nil, t.Name()+"_test_job", config)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()
@@ -284,7 +285,7 @@ func TestPushTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 			Action:       relabel.Replace,
 		},
 	}
-	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, tenantIDRelabelConfig, "test_job", config)
+	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, tenantIDRelabelConfig, t.Name()+"_test_job", config)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()
@@ -327,7 +328,7 @@ func TestPushTarget_ErroneousPayloadsAreRejected(t *testing.T) {
 
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	metrics := gcplog.NewMetrics(prometheus.DefaultRegisterer)
-	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, nil, "test_job", config)
+	pt, err := gcplog.NewGCPLogTarget(metrics, logger, eh, nil, t.Name()+"_test_job", config)
 	require.NoError(t, err)
 	defer func() {
 		_ = pt.Stop()

--- a/clients/pkg/promtail/targets/gcplog/target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/target_test.go
@@ -47,7 +47,7 @@ func TestNewGCPLogTarget(t *testing.T) {
 				logger:  logger,
 				handler: eh,
 				relabel: nil,
-				jobName: "test_job",
+				jobName: "test_job_defaults_to_pull_target",
 				config: &scrapeconfig.GcplogTargetConfig{
 					SubscriptionType: "",
 				},
@@ -62,7 +62,7 @@ func TestNewGCPLogTarget(t *testing.T) {
 				logger:  logger,
 				handler: eh,
 				relabel: nil,
-				jobName: "test_job",
+				jobName: "test_job_pull_subscriptiontype_creates_new",
 				config: &scrapeconfig.GcplogTargetConfig{
 					SubscriptionType: "pull",
 				},
@@ -77,7 +77,7 @@ func TestNewGCPLogTarget(t *testing.T) {
 				logger:  logger,
 				handler: eh,
 				relabel: nil,
-				jobName: "test_job",
+				jobName: "test_job_push_subscription_creates_new",
 				config: &scrapeconfig.GcplogTargetConfig{
 					SubscriptionType: "push",
 				},
@@ -92,7 +92,7 @@ func TestNewGCPLogTarget(t *testing.T) {
 				logger:  logger,
 				handler: eh,
 				relabel: nil,
-				jobName: "test_job",
+				jobName: "test_job_unknown_substype_fails_to_create_target",
 				config: &scrapeconfig.GcplogTargetConfig{
 					SubscriptionType: "magic",
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of https://github.com/grafana/loki/pull/7273
* Tune a filetarget test to remove created files to guarantee that all tailers are interrupted/fred
* Call pubsub close for our GCP `pull target`
* Append testName to the job names used in GCP tests. This will help us to identify which tests are struggling.