### PR TITLE
fix/docs: Fixed a typo in the ingestor section

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1154,7 +1154,7 @@ lifecycler:
     [heartbeat_timeout: <duration> | default = 1m]
 
     # The number of ingesters to write to and read from.
-    # CLI flag: -distributor.replication-factor
+    # CLI flag: -ingester.replication-factor
     [replication_factor: <int> | default = 3]
 
   # The number of tokens the lifecycler will generate and put into the ring if


### PR DESCRIPTION
Hello, 🖖 

I spotted a typo in the loki documentation in the ingester section regarding the `replication_factor` option.

https://grafana.com/docs/loki/latest/configuration/#ingester

For the typo :

```
    # The number of ingesters to write to and read from.
    # CLI flag: -distributor.replication-factor
    [replication_factor: <int> | default = 3]
```

should be :

```
    # The number of ingesters to write to and read from.
    # CLI flag: -ingester.replication-factor
    [replication_factor: <int> | default = 3]
```

**Special notes for your reviewer**:

You're awesome <3

**Checklist**
- [] Reviewed the `CONTRIBUTING.md` guide
- [] Documentation added
- [] Tests updated
- [] `CHANGELOG.md` updated
- [] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
