### PR TITLE
Provision alerts for Loki Canary in Helm Chart.

### DIFF
--- a/production/helm/loki/src/alerts.yaml
+++ b/production/helm/loki/src/alerts.yaml
@@ -39,3 +39,14 @@ groups:
     for: 5m
     labels:
       severity: warning
+  name: 'loki_canaries_alerts',
+  rules:
+  - alert: 'LokiCanaryLatency',
+    annotations:
+      message: |
+        {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+    expr: |
+      histogram_quantile(0.99, sum(rate(loki_canary_response_latency_seconds_bucket[5m])) by (le, namespace, cluster)) > 5
+    for: '15m'
+    labels:
+      severity: 'warning'


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm Charts install the Loki canary. It should also install the alerts for the canary so the users get the full value.

**Which issue(s) this PR fixes**:
Fixes #7284

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
