### PR TITLE
[docs] Fix docs for `rate_counter()`

### DIFF
--- a/docs/sources/logql/metric_queries.md
+++ b/docs/sources/logql/metric_queries.md
@@ -81,7 +81,7 @@ Supported function for operating over unwrapped ranges are:
 - `quantile_over_time(scalar,unwrapped-range)`: the φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.
 - `absent_over_time(unwrapped-range)`: returns an empty vector if the range vector passed to it has any elements and a 1-element vector with the value 1 if the range vector passed to it has no elements. (`absent_over_time` is useful for alerting on when no time series and logs stream exist for label combination for a certain amount of time.)
 
-Except for `sum_over_time`,`absent_over_time` and `rate`, unwrapped range aggregations support grouping.
+Except for `sum_over_time`,`absent_over_time`, `rate` and `rate_counter`, unwrapped range aggregations support grouping.
 
 ```logql
 <aggr-op>([parameter,] <unwrapped-range>) [without|by (<label list>)]


### PR DESCRIPTION
`rate_counter` behaves like `rate` and therefore does not support grouping.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
