### PR TITLE
AST rangemapper support binary operation with a splittable operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Loki
 
 ##### Enhancements
+* [7294](https://github.com/grafana/loki/pull/7294) **ssncferreira**: Add support for AST `rangemapper` to split binary expressions if at least one operand is splittable.
 * [7227](https://github.com/grafana/loki/pull/7227) **Red-GV**: Add ability to configure tls minimum version and cipher suites
 * [7179](https://github.com/grafana/loki/pull/7179) **vlad-diachenko**: Add ability to use Azure Service Principals credentials to authenticate to Azure Blob Storage.
 * [7101](https://github.com/grafana/loki/pull/7101) **liguozhong**: Promtail: Add support for max stream limit.

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -290,6 +290,8 @@ func TestRangeMappingEquivalence(t *testing.T) {
 		{`bytes_over_time({a=~".+"}[3s]) + count_over_time({a=~".+"}[5s])`, time.Second},
 		{`sum(count_over_time({a=~".+"}[3s]) * count(sum_over_time({a=~".+"} | unwrap b [5s])))`, time.Second},
 		{`sum by (a) (count_over_time({a=~".+"} | logfmt | line > 5 [3s])) / sum by (a) (count_over_time({a=~".+"} [3s]))`, time.Second},
+		// should split a binary expression if at least one operand is splittable
+		{`sum by (a) (sum_over_time({a=~".+"} | logfmt | unwrap b [3s])) / sum_over_time({a=~".+"} | logfmt | unwrap b [6s])`, time.Second},
 		{`count_over_time({a=~".+"}[3s]) or vector(0)`, time.Second},
 		{`vector(0) or count_over_time({a=~".+"}[3s])`, time.Second},
 

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -290,6 +290,8 @@ func TestRangeMappingEquivalence(t *testing.T) {
 		{`bytes_over_time({a=~".+"}[3s]) + count_over_time({a=~".+"}[5s])`, time.Second},
 		{`sum(count_over_time({a=~".+"}[3s]) * count(sum_over_time({a=~".+"} | unwrap b [5s])))`, time.Second},
 		{`sum by (a) (count_over_time({a=~".+"} | logfmt | line > 5 [3s])) / sum by (a) (count_over_time({a=~".+"} [3s]))`, time.Second},
+		{`count_over_time({a=~".+"}[3s]) or vector(0)`, time.Second},
+		{`vector(0) or count_over_time({a=~".+"}[3s])`, time.Second},
 
 		// Multi vector aggregator layer queries
 		{`sum(max(bytes_over_time({a=~".+"}[3s])))`, time.Second},


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous implementation of AST rangemapper only supported mapping a instant query with a binary expression if both operands were splittable, or if 1 operand was splittable and the other was a literal expression (e.g., `5`). 
This PR updates the rangemapper to always map a binary expression if at least 1 operand is splittable.

In case sharding is enabled, the mapped query will be input to the shardmapper, and since this AST mapper supports all expression types, the non-splittable operand can be passed as input to be sharded.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
