### PR TITLE
operator: Move Loki operand from v2.6.1 to main-ec0bf70

### DIFF
--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1193,7 +1193,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.6.1
+                  value: docker.io/grafana/loki:main-ec0bf70
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1321,7 +1321,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.6.1
+  - image: docker.io/grafana/loki:main-ec0bf70
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.6.1
+            value: docker.io/grafana/loki:main-ec0bf70
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.6.1
+            value: docker.io/grafana/loki:main-ec0bf70
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/production/manager_related_image_patch.yaml
+++ b/operator/config/overlays/production/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.6.1
+            value: docker.io/grafana/loki:main-ec0bf70
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -79,6 +79,11 @@ func ConfigOptions(opt Options) config.Options {
 		Stack:     opt.Stack,
 		Namespace: opt.Namespace,
 		Name:      opt.Name,
+		Compactor: config.Address{
+			FQDN:     fqdn(NewCompactorHTTPService(opt).GetName(), opt.Namespace),
+			Port:     httpPort,
+			Protocol: protocol,
+		},
 		FrontendWorker: config.Address{
 			FQDN: fqdn(NewQueryFrontendGRPCService(opt).GetName(), opt.Namespace),
 			Port: grpcPort,

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -26,6 +26,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -189,6 +190,11 @@ overrides:
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -256,6 +262,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -436,6 +443,11 @@ overrides:
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -506,6 +518,11 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -572,6 +589,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -789,6 +807,11 @@ overrides:
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -903,6 +926,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1120,6 +1144,11 @@ overrides:
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -1235,6 +1264,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1465,6 +1495,11 @@ overrides:
 		},
 		Namespace: "test-ns",
 		Name:      "test",
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
+		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
@@ -1597,6 +1632,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
+  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1826,6 +1862,11 @@ overrides:
 		IndexGateway: Address{
 			FQDN: "loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local",
 			Port: 9095,
+		},
+		Compactor: Address{
+			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+			Protocol: "http",
 		},
 		StorageDirectory: "/tmp/loki",
 		MaxConcurrent: MaxConcurrent{

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -44,6 +44,7 @@ common:
       region_name: {{ .Region }}
       container_name: {{ .Container }}
     {{- end }}
+  compactor_address: {{ .Compactor.Protocol }}://{{ .Compactor.FQDN }}:{{ .Compactor.Port }}
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -15,6 +15,7 @@ type Options struct {
 
 	Namespace             string
 	Name                  string
+	Compactor             Address
 	FrontendWorker        Address
 	GossipRing            Address
 	Querier               Address


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the operand Loki from v2.6.1 temporarily to `main-ec0bf70` to include 2.7.0 targeted features for the operator development:
- https://github.com/grafana/loki/pull/7069
- https://github.com/grafana/loki/pull/7085
- https://github.com/grafana/loki/pull/7227

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
