### PR TITLE
operator: Ensuring amd64 binaries are built; Correcting distroless image name

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,11 +16,11 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -mod=readonly -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=readonly -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that an amd64 binary is built. On M1 Macs, the operator image cannot be utilized because the image crashes with a `exec format error` error. This also adjusts the name of the distroless image used to what is depicted in the table here: https://github.com/GoogleContainerTools/distroless#what-images-are-available.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
