### PR TITLE
fluent-bit: Update the Fluent Bit plugin README with correct golang minimum version

### DIFF
--- a/clients/cmd/fluent-bit/README.md
+++ b/clients/cmd/fluent-bit/README.md
@@ -10,7 +10,7 @@ This plugin is implemented with [Fluent Bit's Go plugin](https://github.com/flue
 
 Prerequisites:
 
-* Go 1.16+
+* Go 1.17+
 * gcc (for cgo)
 
 To build the output plugin library file (`out_grafana_loki.so`), you can use:


### PR DESCRIPTION
**What this PR does / why we need it**:

The Loki plugin for Fluent Bit will not build with golang < 1.17 because of the use of net.IP.IsPrivate in the referenced version of github.com/grafana/dskit/netutil/netutil.go

**Which issue(s) this PR fixes**:
No issue exists (this is a minor documentation issue).

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the `CONTRIBUTING.md` guide
- [N/A] Documentation added
- [N/A] Tests updated
- [N/A] `CHANGELOG.md` updated
- [N/A] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
