### PR TITLE
logging: Change Docker target discovery log level from Error to Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 * [7016](https://github.com/grafana/loki/pull/7016) **chodges15**: Fix issue with dropping logs when a file based SD target's labels are updated
 
 ##### Changes
+* **quodlibetor**: Change Docker target discovery log level from `Error` to `Info`
+
 
 #### Fluent Bit
 

--- a/clients/pkg/promtail/targets/docker/target_group.go
+++ b/clients/pkg/promtail/targets/docker/target_group.go
@@ -92,7 +92,7 @@ func (tg *targetGroup) addTarget(id string, discoveredLabels model.LabelSet) err
 		return err
 	}
 	tg.targets[id] = t
-	level.Error(tg.logger).Log("msg", "added Docker target", "containerID", id)
+	level.Info(tg.logger).Log("msg", "added Docker target", "containerID", id)
 	return nil
 }
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -203,6 +203,11 @@ This creates a lot of series and we don't think this metric has enough value to 
 
 While this isn't a direct replacement, two metrics we find more useful are size and line counters configured via pipeline stages, an example of how to configure these metrics can be found in the [metrics pipeline stage docs](https://grafana.com/docs/loki/latest/clients/promtail/stages/metrics/#counter)
 
+#### `added Docker target` log message has been demoted from level=error to level=info
+
+If you have dashboards that depended on the log level, change them to search for the `msg="added
+Docker target"` property.
+
 ### Jsonnet
 
 #### Compactor config defined as command line args moved to yaml config


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovering a new node is not an error, so having it send errors to dashboards is confusing.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
