### PR TITLE
promtail/scraping.md: Fix 404

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -422,7 +422,7 @@ scrape_configs:
 ```
 
 Only `api_token` and `zone_id` are required.
-Refer to the [Cloudfare](../configuration/#cloudflare) configuration section for details.
+Refer to the [Cloudfare](configuration/#cloudflare) configuration section for details.
 
 ## Heroku Drain
 Promtail supports receiving logs from a Heroku application by using a [Heroku HTTPS Drain](https://devcenter.heroku.com/articles/log-drains#https-drains).


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the `Cloudflare` link refers to: https://grafana.com/docs/loki/latest/clients/configuration/#cloudflare
But it should be: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#cloudflare

**Checklist**
- [X] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
