### PR TITLE
Added mapstructure tag to promtail configs structs

### DIFF
--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -22,7 +22,7 @@ import (
 
 // Options contains cross-cutting promtail configurations
 type Options struct {
-	StreamLagLabels dskit_flagext.StringSliceCSV `yaml:"stream_lag_labels,omitempty"`
+	StreamLagLabels dskit_flagext.StringSliceCSV `mapstructure:"stream_lag_labels,omitempty" yaml:"stream_lag_labels,omitempty"`
 }
 
 // Config for promtail, describing what files to watch.

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Config struct {
-	ReadlineRate        float64 `yaml:"readline_rate" json:"readline_rate"`
-	ReadlineBurst       int     `yaml:"readline_burst" json:"readline_burst"`
-	ReadlineRateEnabled bool    `yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
-	ReadlineRateDrop    bool    `yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
-	MaxStreams          int     `yaml:"max_streams" json:"max_streams"`
+	ReadlineRate        float64 `mapstructure:"readline_rate" yaml:"readline_rate" json:"readline_rate"`
+	ReadlineBurst       int     `mapstructure:"readline_burst" yaml:"readline_burst" json:"readline_burst"`
+	ReadlineRateEnabled bool    `mapstructure:"readline_rate_enabled,omitempty" yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
+	ReadlineRateDrop    bool    `mapstructure:"readline_rate_drop,omitempty" yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
+	MaxStreams          int     `mapstructure:"max_streams" yaml:"max_streams" json:"max_streams"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {

--- a/clients/pkg/promtail/positions/positions.go
+++ b/clients/pkg/promtail/positions/positions.go
@@ -23,10 +23,10 @@ const (
 
 // Config describes where to get position information from.
 type Config struct {
-	SyncPeriod        time.Duration `yaml:"sync_period"`
-	PositionsFile     string        `yaml:"filename"`
-	IgnoreInvalidYaml bool          `yaml:"ignore_invalid_yaml"`
-	ReadOnly          bool          `yaml:"-"`
+	SyncPeriod        time.Duration `mapstructure:"sync_period" yaml:"sync_period"`
+	PositionsFile     string        `mapstructure:"filename" yaml:"filename"`
+	IgnoreInvalidYaml bool          `mapstructure:"ignore_invalid_yaml" yaml:"ignore_invalid_yaml"`
+	ReadOnly          bool          `mapstructure:"-" yaml:"-"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -33,57 +33,57 @@ import (
 
 // Config describes a job to scrape.
 type Config struct {
-	JobName           string                     `yaml:"job_name,omitempty"`
-	PipelineStages    stages.PipelineStages      `yaml:"pipeline_stages,omitempty"`
-	JournalConfig     *JournalTargetConfig       `yaml:"journal,omitempty"`
-	SyslogConfig      *SyslogTargetConfig        `yaml:"syslog,omitempty"`
-	GcplogConfig      *GcplogTargetConfig        `yaml:"gcplog,omitempty"`
-	PushConfig        *PushTargetConfig          `yaml:"loki_push_api,omitempty"`
-	WindowsConfig     *WindowsEventsTargetConfig `yaml:"windows_events,omitempty"`
-	KafkaConfig       *KafkaTargetConfig         `yaml:"kafka,omitempty"`
-	GelfConfig        *GelfTargetConfig          `yaml:"gelf,omitempty"`
-	CloudflareConfig  *CloudflareConfig          `yaml:"cloudflare,omitempty"`
-	HerokuDrainConfig *HerokuDrainTargetConfig   `yaml:"heroku_drain,omitempty"`
-	RelabelConfigs    []*relabel.Config          `yaml:"relabel_configs,omitempty"`
+	JobName           string                     `mapstructure:"job_name,omitempty" yaml:"job_name,omitempty"`
+	PipelineStages    stages.PipelineStages      `mapstructure:"pipeline_stages,omitempty" yaml:"pipeline_stages,omitempty"`
+	JournalConfig     *JournalTargetConfig       `mapstructure:"journal,omitempty" yaml:"journal,omitempty"`
+	SyslogConfig      *SyslogTargetConfig        `mapstructure:"syslog,omitempty" yaml:"syslog,omitempty"`
+	GcplogConfig      *GcplogTargetConfig        `mapstructure:"gcplog,omitempty" yaml:"gcplog,omitempty"`
+	PushConfig        *PushTargetConfig          `mapstructure:"loki_push_api,omitempty" yaml:"loki_push_api,omitempty"`
+	WindowsConfig     *WindowsEventsTargetConfig `mapstructure:"windows_events,omitempty" yaml:"windows_events,omitempty"`
+	KafkaConfig       *KafkaTargetConfig         `mapstructure:"kafka,omitempty" yaml:"kafka,omitempty"`
+	GelfConfig        *GelfTargetConfig          `mapstructure:"gelf,omitempty" yaml:"gelf,omitempty"`
+	CloudflareConfig  *CloudflareConfig          `mapstructure:"cloudflare,omitempty" yaml:"cloudflare,omitempty"`
+	HerokuDrainConfig *HerokuDrainTargetConfig   `mapstructure:"heroku_drain,omitempty" yaml:"heroku_drain,omitempty"`
+	RelabelConfigs    []*relabel.Config          `mapstructure:"relabel_configs,omitempty" yaml:"relabel_configs,omitempty"`
 	// List of Docker service discovery configurations.
-	DockerSDConfigs        []*moby.DockerSDConfig `yaml:"docker_sd_configs,omitempty"`
-	ServiceDiscoveryConfig ServiceDiscoveryConfig `yaml:",inline"`
-	Encoding               string                 `yaml:"encoding,omitempty"`
+	DockerSDConfigs        []*moby.DockerSDConfig `mapstructure:"docker_sd_configs,omitempty" yaml:"docker_sd_configs,omitempty"`
+	ServiceDiscoveryConfig ServiceDiscoveryConfig `mapstructure:",squash" yaml:",inline"`
+	Encoding               string                 `mapstructure:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
 
 type ServiceDiscoveryConfig struct {
 	// List of labeled target groups for this job.
-	StaticConfigs discovery.StaticConfig `yaml:"static_configs"`
+	StaticConfigs discovery.StaticConfig `mapstructure:"static_configs" yaml:"static_configs"`
 	// List of DNS service discovery configurations.
-	DNSSDConfigs []*dns.SDConfig `yaml:"dns_sd_configs,omitempty"`
+	DNSSDConfigs []*dns.SDConfig `mapstructure:"dns_sd_configs,omitempty" yaml:"dns_sd_configs,omitempty"`
 	// List of file service discovery configurations.
-	FileSDConfigs []*file.SDConfig `yaml:"file_sd_configs,omitempty"`
+	FileSDConfigs []*file.SDConfig `mapstructure:"file_sd_configs,omitempty" yaml:"file_sd_configs,omitempty"`
 	// List of Consul service discovery configurations.
-	ConsulSDConfigs []*consul.SDConfig `yaml:"consul_sd_configs,omitempty"`
+	ConsulSDConfigs []*consul.SDConfig `mapstructure:"consul_sd_configs,omitempty" yaml:"consul_sd_configs,omitempty"`
 	// List of Consul agent service discovery configurations.
-	ConsulAgentSDConfigs []*consulagent.SDConfig `yaml:"consulagent_sd_configs,omitempty"`
+	ConsulAgentSDConfigs []*consulagent.SDConfig `mapstructure:"consulagent_sd_configs,omitempty" yaml:"consulagent_sd_configs,omitempty"`
 	// List of DigitalOcean service discovery configurations.
-	DigitalOceanSDConfigs []*digitalocean.SDConfig `yaml:"digitalocean_sd_configs,omitempty"`
+	DigitalOceanSDConfigs []*digitalocean.SDConfig `mapstructure:"digitalocean_sd_configs,omitempty" yaml:"digitalocean_sd_configs,omitempty"`
 	// List of Docker Swarm service discovery configurations.
-	DockerSwarmSDConfigs []*moby.DockerSwarmSDConfig `yaml:"dockerswarm_sd_configs,omitempty"`
+	DockerSwarmSDConfigs []*moby.DockerSwarmSDConfig `mapstructure:"dockerswarm_sd_configs,omitempty" yaml:"dockerswarm_sd_configs,omitempty"`
 	// List of Serverset service discovery configurations.
-	ServersetSDConfigs []*zookeeper.ServersetSDConfig `yaml:"serverset_sd_configs,omitempty"`
+	ServersetSDConfigs []*zookeeper.ServersetSDConfig `mapstructure:"serverset_sd_configs,omitempty" yaml:"serverset_sd_configs,omitempty"`
 	// NerveSDConfigs is a list of Nerve service discovery configurations.
-	NerveSDConfigs []*zookeeper.NerveSDConfig `yaml:"nerve_sd_configs,omitempty"`
+	NerveSDConfigs []*zookeeper.NerveSDConfig `mapstructure:"nerve_sd_configs,omitempty" yaml:"nerve_sd_configs,omitempty"`
 	// MarathonSDConfigs is a list of Marathon service discovery configurations.
-	MarathonSDConfigs []*marathon.SDConfig `yaml:"marathon_sd_configs,omitempty"`
+	MarathonSDConfigs []*marathon.SDConfig `mapstructure:"marathon_sd_configs,omitempty" yaml:"marathon_sd_configs,omitempty"`
 	// List of Kubernetes service discovery configurations.
-	KubernetesSDConfigs []*kubernetes.SDConfig `yaml:"kubernetes_sd_configs,omitempty"`
+	KubernetesSDConfigs []*kubernetes.SDConfig `mapstructure:"kubernetes_sd_configs,omitempty" yaml:"kubernetes_sd_configs,omitempty"`
 	// List of GCE service discovery configurations.
-	GCESDConfigs []*gce.SDConfig `yaml:"gce_sd_configs,omitempty"`
+	GCESDConfigs []*gce.SDConfig `mapstructure:"gce_sd_configs,omitempty" yaml:"gce_sd_configs,omitempty"`
 	// List of EC2 service discovery configurations.
-	EC2SDConfigs []*aws.EC2SDConfig `yaml:"ec2_sd_configs,omitempty"`
+	EC2SDConfigs []*aws.EC2SDConfig `mapstructure:"ec2_sd_configs,omitempty" yaml:"ec2_sd_configs,omitempty"`
 	// List of OpenStack service discovery configurations.
-	OpenstackSDConfigs []*openstack.SDConfig `yaml:"openstack_sd_configs,omitempty"`
+	OpenstackSDConfigs []*openstack.SDConfig `mapstructure:"openstack_sd_configs,omitempty" yaml:"openstack_sd_configs,omitempty"`
 	// List of Azure service discovery configurations.
-	AzureSDConfigs []*azure.SDConfig `yaml:"azure_sd_configs,omitempty"`
+	AzureSDConfigs []*azure.SDConfig `mapstructure:"azure_sd_configs,omitempty" yaml:"azure_sd_configs,omitempty"`
 	// List of Triton service discovery configurations.
-	TritonSDConfigs []*triton.SDConfig `yaml:"triton_sd_configs,omitempty"`
+	TritonSDConfigs []*triton.SDConfig `mapstructure:"triton_sd_configs,omitempty" yaml:"triton_sd_configs,omitempty"`
 }
 
 func (cfg ServiceDiscoveryConfig) Configs() (res discovery.Configs) {

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -26,8 +26,8 @@ const (
 
 // Config describes behavior for Target
 type Config struct {
-	SyncPeriod time.Duration `yaml:"sync_period"`
-	Stdin      bool          `yaml:"stdin"`
+	SyncPeriod time.Duration `mapstructure:"sync_period" yaml:"sync_period"`
+	Stdin      bool          `mapstructure:"stdin" yaml:"stdin"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by


### PR DESCRIPTION
**What this PR does / why we need it**:
Added mapstructure tags to configs structs to promtail client. It is needed for [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib). I working on adding promtail receiver component there. Opentelemetry collector decodes configs with mapstructure

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9800

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
