### PR TITLE
adds result cache key version comparison metrics

### DIFF
--- a/pkg/querier/queryrange/metrics.go
+++ b/pkg/querier/queryrange/metrics.go
@@ -13,6 +13,7 @@ type Metrics struct {
 	*MiddlewareMapperMetrics
 	*SplitByMetrics
 	*LogResultCacheMetrics
+	*queryrangebase.ResultsCacheMetrics
 }
 
 type MiddlewareMapperMetrics struct {
@@ -34,5 +35,6 @@ func NewMetrics(registerer prometheus.Registerer) *Metrics {
 		MiddlewareMapperMetrics:     NewMiddlewareMapperMetrics(registerer),
 		SplitByMetrics:              NewSplitByMetrics(registerer),
 		LogResultCacheMetrics:       NewLogResultCacheMetrics(registerer),
+		ResultsCacheMetrics:         queryrangebase.NewResultsCacheMetrics(registerer),
 	}
 }

--- a/pkg/querier/queryrange/queryrangebase/results_cache.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache.go
@@ -18,6 +18,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
@@ -42,6 +43,31 @@ var (
 	// ResultsCacheGenNumberHeaderName holds name of the header we want to set in http response
 	ResultsCacheGenNumberHeaderName = "Results-Cache-Gen-Number"
 )
+
+const (
+	reasonMissing  = "missing"
+	reasonMismatch = "mismatch"
+)
+
+type ResultsCacheMetrics struct {
+	versionComparisons        prometheus.Counter
+	versionComparisonFailures *prometheus.CounterVec
+}
+
+func NewResultsCacheMetrics(registerer prometheus.Registerer) *ResultsCacheMetrics {
+	return &ResultsCacheMetrics{
+		versionComparisons: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "results_cache_version_comparisons_total",
+			Help:      "Comparisons of cache key versions in the results cache between query-frontends & queriers",
+		}),
+		versionComparisonFailures: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "results_cache_version_comparisons_failed",
+			Help:      "Comparison failures of cache key versions in the results cache between query-frontends & queriers",
+		}, []string{"reason"}),
+	}
+}
 
 type CacheGenNumberLoader interface {
 	GetResultsCacheGenNumber(tenantIDs []string) string
@@ -140,6 +166,7 @@ type resultsCache struct {
 	merger               Merger
 	cacheGenNumberLoader CacheGenNumberLoader
 	shouldCache          ShouldCacheFn
+	metrics              *ResultsCacheMetrics
 }
 
 // NewResultsCacheMiddleware creates results cache middleware from config.
@@ -157,7 +184,7 @@ func NewResultsCacheMiddleware(
 	extractor Extractor,
 	cacheGenNumberLoader CacheGenNumberLoader,
 	shouldCache ShouldCacheFn,
-	reg prometheus.Registerer,
+	metrics *ResultsCacheMetrics,
 ) (Middleware, error) {
 	if cacheGenNumberLoader != nil {
 		c = cache.NewCacheGenNumMiddleware(c)
@@ -175,6 +202,7 @@ func NewResultsCacheMiddleware(
 			splitter:             splitter,
 			cacheGenNumberLoader: cacheGenNumberLoader,
 			shouldCache:          shouldCache,
+			metrics:              metrics,
 		}
 	}), nil
 }
@@ -248,14 +276,22 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req Request, r Re
 	genNumbersFromResp := getHeaderValuesWithName(r, ResultsCacheGenNumberHeaderName)
 	genNumberFromCtx := cache.ExtractCacheGenNumber(ctx)
 
+	s.metrics.versionComparisons.Inc()
+
 	if len(genNumbersFromResp) == 0 && genNumberFromCtx != "" {
 		level.Debug(logger).Log("msg", fmt.Sprintf("we found results cache gen number %s set in store but none in headers", genNumberFromCtx))
+
+		// NB(owen-d):
+		// If the queriers aren't returning cache numbers, something is likely broken
+		// (i.e. the queriers aren't reporting the cache numbers they see or aren't seeing cache numbers at all).
+		s.metrics.versionComparisonFailures.WithLabelValues(reasonMissing).Inc()
 		return false
 	}
 
 	for _, gen := range genNumbersFromResp {
 		if gen != genNumberFromCtx {
 			level.Debug(logger).Log("msg", fmt.Sprintf("inconsistency in results cache gen numbers %s (GEN-FROM-RESPONSE) != %s (GEN-FROM-STORE), not caching the response", gen, genNumberFromCtx))
+			s.metrics.versionComparisonFailures.WithLabelValues(reasonMismatch).Inc()
 			return false
 		}
 	}

--- a/pkg/querier/queryrange/queryrangebase/results_cache_test.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache_test.go
@@ -116,7 +116,8 @@ func mkExtentWithStep(start, end, step int64) Extent {
 
 func TestShouldCache(t *testing.T) {
 	maxCacheTime := int64(150 * 1000)
-	c := &resultsCache{logger: log.NewNopLogger(), cacheGenNumberLoader: newMockCacheGenNumberLoader()}
+	c := &resultsCache{logger: log.NewNopLogger(), cacheGenNumberLoader: newMockCacheGenNumberLoader(),
+		metrics: NewResultsCacheMetrics(nil)}
 	for _, tc := range []struct {
 		name                   string
 		request                Request

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -427,7 +427,7 @@ func NewMetricTripperware(
 			func(r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
-			registerer,
+			metrics.ResultsCacheMetrics,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Followup to https://github.com/grafana/loki/pull/7300 which gives more metric visibility into the underlying errors when comparing cache key versions on the queriers vs query frontends.