### PR TITLE
docs: Document setting up command completion for logcli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 
 ##### Changes
 
+#### Logcli
+* [7325](https://github.com/grafana/loki/pull/7325) **dbirks**: Document setting up command completion
+
 #### Fluent Bit
 
 #### Loki Canary

--- a/docs/sources/tools/logcli.md
+++ b/docs/sources/tools/logcli.md
@@ -33,6 +33,20 @@ Optionally, move the binary into a directory that is part of your `$PATH`.
 cp cmd/logcli/logcli /usr/local/bin/logcli
 ```
 
+## Set up command completion
+
+You can set up tab-completion for `logcli` with one of the two options, depending on your shell:
+
+- For bash, add this to your `~/.bashrc` file:
+  ```
+  eval "$(logcli --completion-script-bash)"
+  ```
+
+- For zsh, add this to your `~/.zshrc` file:
+  ```
+  eval "$(logcli --completion-script-zsh)"
+  ```
+
 ## LogCLI usage
 
 ### Grafana Cloud example


### PR DESCRIPTION
**What this PR does / why we need it**:

This documents the existing command completion that kingpin provides (docs [here](https://github.com/alecthomas/kingpin#bashzsh-shell-completion) on that).

**Which issue(s) this PR fixes**:
Fixes #2949

**Special notes for your reviewer**:

Please feel free to adjust/reword any of this! I thought I would give it a shot. I ran `make docs` too, and confirmed the formatting looked good. Hugo even indented the code blocks under the bullet points. :open_mouth: 

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
