### PR TITLE
pkg/ruler/rulestore/configdb: Preallocate memory

### DIFF
--- a/pkg/ruler/rulestore/configdb/store.go
+++ b/pkg/ruler/rulestore/configdb/store.go
@@ -36,8 +36,7 @@ func NewConfigRuleStore(c client.Client) *ConfigRuleStore {
 func (c *ConfigRuleStore) ListAllUsers(ctx context.Context) ([]string, error) {
 	m, err := c.ListAllRuleGroups(ctx)
 
-	// TODO: this should be optimized, if possible.
-	result := []string(nil)
+	result := make([]string, 0, len(m))
 	for u := range m {
 		result = append(result, u)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Preallocate memory instead of enforcing an incremental growth. This will result in less work for the garbage collector.


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
none

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] ~Documentation added~
trivial fix - no update of Documentation required
- [ ] ~Tests updated~
- [ ] ~`CHANGELOG.md` updated~
trivial fix - no update of `CHANGELOG.md` required
- [ ] ~Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`~

