### PR TITLE
Fix internal server bootstrap for query frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [7270](https://github.com/grafana/loki/pull/7270) **wilfriedroset**: Add support for `username` to redis cache configuration.
 
 ##### Fixes
+* [7238](https://github.com/grafana/loki/pull/7328) **periklis**: Fix internal server bootstrap for query frontend
 * [7288](https://github.com/grafana/loki/pull/7288) **ssncferreira**: Fix query mapping in AST mapper `rangemapper` to support the new `VectorExpr` expression.
 * [7040](https://github.com/grafana/loki/pull/7040) **bakunowski**: Remove duplicated `loki_boltdb_shipper` prefix from `tables_upload_operation_total` metric.
 * [6937](https://github.com/grafana/loki/pull/6937) **ssncferreira**: Fix topk and bottomk expressions with parameter <= 0.

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -66,7 +66,7 @@ type Config struct {
 	BallastBytes int                    `yaml:"ballast_bytes"`
 
 	// TODO(dannyk): Remove these config options before next release; they don't need to be configurable.
-	// 				 These are only here to allow us to test the new functionality.
+	//				 These are only here to allow us to test the new functionality.
 	UseBufferedLogger bool `yaml:"use_buffered_logger"`
 	UseSyncLogger     bool `yaml:"use_sync_logger"`
 
@@ -570,7 +570,7 @@ func (t *Loki) setupModuleManager() error {
 	}
 
 	if t.Cfg.InternalServer.Enable {
-		depsToUpdate := []string{Distributor, Ingester, Querier, QueryFrontend, QueryScheduler, Ruler, TableManager, Compactor, IndexGateway}
+		depsToUpdate := []string{Distributor, Ingester, Querier, QueryFrontendTripperware, QueryScheduler, Ruler, TableManager, Compactor, IndexGateway}
 
 		for _, dep := range depsToUpdate {
 			var idx int
@@ -581,8 +581,8 @@ func (t *Loki) setupModuleManager() error {
 				}
 			}
 
-			lhs := deps[dep][0:idx]
-			rhs := deps[dep][idx+1:]
+			lhs := deps[dep][0 : idx+1]
+			rhs := deps[dep][idx+2:]
 
 			deps[dep] = append(lhs, InternalServer)
 			deps[dep] = append(deps[dep], rhs...)

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -99,24 +99,55 @@ func TestLoki_isModuleEnabled(t1 *testing.T) {
 }
 
 func TestLoki_AppendOptionalInternalServer(t *testing.T) {
-	tests := []string{Distributor, Ingester, Querier, QueryFrontend, QueryScheduler, Ruler, TableManager, Compactor, IndexGateway}
+	fake := &Loki{
+		Cfg: Config{
+			Target: flagext.StringSliceCSV{All},
+			Server: server.Config{
+				HTTPListenAddress: "3100",
+			},
+		},
+	}
+	err := fake.setupModuleManager()
+	assert.NoError(t, err)
+
+	var tests []string
+	for target, deps := range fake.deps {
+		switch target {
+		// Blacklist these targets for using the internal server
+		case IndexGatewayRing, MemberlistKV, OverridesExporter, Ring, Embededcache, Server:
+			continue
+		}
+
+		for _, dep := range deps {
+			if dep == Server {
+				tests = append(tests, target)
+				break
+			}
+		}
+	}
+
+	assert.NotEmpty(t, tests, tests)
+
 	for _, tt := range tests {
 		t.Run(tt, func(t *testing.T) {
 			l := &Loki{
 				Cfg: Config{
 					Target: flagext.StringSliceCSV{tt},
+					Server: server.Config{
+						HTTPListenAddress: "3100",
+					},
 					InternalServer: internalserver.Config{
 						Config: server.Config{
-							HTTPListenAddress: "3002",
+							HTTPListenAddress: "3101",
 						},
 						Enable: true,
 					},
 				},
 			}
-
 			err := l.setupModuleManager()
 			assert.NoError(t, err)
 			assert.Contains(t, l.deps[tt], InternalServer)
+			assert.Contains(t, l.deps[tt], Server)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The following PR adds a fix for setting up the internal server module for the query-frontend-tripperware instead for the query-frontend. Solves issue as:
```
level=info ts=2022-10-04T12:14:37.375681075Z caller=main.go:103 msg="Starting Loki" version="(version=main-ec0bf70, branch=main, revision=ec0bf7004)"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2f8 pc=0x1d034d3]

goroutine 1 [running]:
github.com/grafana/loki/pkg/loki.(*Loki).initQueryFrontend(0xc000c10000)
        /src/loki/pkg/loki/modules.go:738 +0x5b3
github.com/grafana/dskit/modules.(*Manager).initModule(0xc00000c330, {0x7ffd008d08b3, 0xe}, 0x1?, 0xc000c0e600?)
        /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:120 +0x224
github.com/grafana/dskit/modules.(*Manager).InitModuleServices(0x82d4b4?, {0xc0001b2ce0, 0x1, 0xc0001b3870?})
        /src/loki/vendor/github.com/grafana/dskit/modules/modules.go:92 +0x10c
github.com/grafana/loki/pkg/loki.(*Loki).Run(0xc000c10000, {0xc000c03ac0?})
        /src/loki/pkg/loki/loki.go:350 +0x56
main.main()
        /src/loki/cmd/loki/main.go:105 +0xdb2

```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
