### PR TITLE
operator: Use quayio v2.7.0-pre image for openshift overlay

### DIFF
--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1193,7 +1193,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: docker.io/grafana/loki:main-ec0bf70
+                  value: quay.io/openshift-logging/loki:v2.7.0-pre
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1321,7 +1321,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: docker.io/grafana/loki:main-ec0bf70
+  - image: quay.io/openshift-logging/loki:v2.7.0-pre
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:main-ec0bf70
+            value: quay.io/openshift-logging/loki:v2.7.0-pre
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up on #7298 to use the CI-published image for OpenShift bundle.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
