### PR TITLE
[Helm] Add flags needed for migration from distributed

### DIFF
--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -285,7 +285,7 @@ monitoring:
 | migrate | object | `{"fromDistributed":{"enabled":false,"memberlistService":""}}` | Options that may be necessary when performing a migration from another helm chart |
 | migrate.fromDistributed | object | `{"enabled":false,"memberlistService":""}` | When migrating from a distributed chart like loki-distributed or enterprise-logs |
 | migrate.fromDistributed.enabled | bool | `false` | Set to true if migrating from a distributed helm chart |
-| migrate.fromDistributed.memberlistService | string | `""` | If migrating from a distributed service, provide the distributed deployment's memberlis service DNS so the new deployment can join it's ring. |
+| migrate.fromDistributed.memberlistService | string | `""` | If migrating from a distributed service, provide the distributed deployment's memberlist service DNS so the new deployment can join it's ring. |
 | minio | object | `{"buckets":[{"name":"chunks","policy":"none","purge":false},{"name":"ruler","policy":"none","purge":false},{"name":"admin","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"enterprise-logs"}` | ----------------------------------- |
 | monitoring.alerts.annotations | object | `{}` | Additional annotations for the alerts PrometheusRule resource |
 | monitoring.alerts.enabled | bool | `true` | If enabled, create PrometheusRule resource with Loki alerting rules |

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -282,6 +282,10 @@ monitoring:
 | loki.storage | object | `{"bucketNames":{"admin":"admin","chunks":"chunks","ruler":"ruler"},"filesystem":{"chunks_directory":"/var/loki/chunks","rules_directory":"/var/loki/rules"},"gcs":{"chunkBufferSize":0,"enableHttp2":true,"requestTimeout":"0s"},"s3":{"accessKeyId":null,"endpoint":null,"http_config":{},"insecure":false,"region":null,"s3":null,"s3ForcePathStyle":false,"secretAccessKey":null},"type":"s3"}` | Storage config. Providing this will automatically populate all necessary storage configs in the templated config. |
 | loki.storage_config | object | `{"hedging":{"at":"250ms","max_per_second":20,"up_to":3}}` | Additional storage config |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
+| migrate | object | `{"fromDistributed":{"enabled":false,"memberlistService":""}}` | Options that may be necessary when performing a migration from another helm chart |
+| migrate.fromDistributed | object | `{"enabled":false,"memberlistService":""}` | When migrating from a distributed chart like loki-distributed or enterprise-logs |
+| migrate.fromDistributed.enabled | bool | `false` | Set to true if migrating from a distributed helm chart |
+| migrate.fromDistributed.memberlistService | string | `""` | If migrating from a distributed service, provide the distributed deployment's memberlis service DNS so the new deployment can join it's ring. |
 | minio | object | `{"buckets":[{"name":"chunks","policy":"none","purge":false},{"name":"ruler","policy":"none","purge":false},{"name":"admin","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"enterprise-logs"}` | ----------------------------------- |
 | monitoring.alerts.annotations | object | `{}` | Additional annotations for the alerts PrometheusRule resource |
 | monitoring.alerts.enabled | bool | `true` | If enabled, create PrometheusRule resource with Loki alerting rules |

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -38,9 +38,11 @@ spec:
             - -labelvalue=$(POD_NAME)
             {{- if $.Values.enterprise.enabled }}
             - -user=$(USER)
+            - -tenant-id=$(USER)
             - -pass=$(PASS)
             {{- else if $.Values.loki.auth_enabled }}
             - -user={{ $.Values.monitoring.selfMonitoring.tenant }}
+            - -tenant-id={{ $.Values.monitoring.selfMonitoring.tenant }}
             {{- end }}
             {{- with .extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -523,7 +523,7 @@ migrate:
     # -- Set to true if migrating from a distributed helm chart
     enabled: false
     # -- If migrating from a distributed service, provide the distributed deployment's
-    # memberlis service DNS so the new deployment can join it's ring.
+    # memberlist service DNS so the new deployment can join it's ring.
     memberlistService: ""
 
 serviceAccount:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -84,6 +84,11 @@ loki:
     memberlist:
       join_members:
         - {{ include "loki.memberlist" . }}
+        {{- with .Values.migrate.fromDistributed }}
+        {{- if .enabled }}
+        - {{ .memberlistService }}
+        {{- end }}
+        {{- end }}
 
     {{- if .Values.loki.commonConfig}}
     common:
@@ -510,6 +515,16 @@ enterprise:
           {{- end }}
         }
       }
+
+# -- Options that may be necessary when performing a migration from another helm chart
+migrate:
+  # -- When migrating from a distributed chart like loki-distributed or enterprise-logs
+  fromDistributed:
+    # -- Set to true if migrating from a distributed helm chart
+    enabled: false
+    # -- If migrating from a distributed service, provide the distributed deployment's
+    # memberlis service DNS so the new deployment can join it's ring.
+    memberlistService: ""
 
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds flags to the helm charts that are needed when doing a zero-downtime migration from a `loki-distributed` helm chart deployment. The flags allow for an additional memberlist join member to be specified. This allows the new `grafana/loki` cluster to join the old `grafana/loki-distributed` cluster, forming one big cluster. The ingesters in the `grafana/loki-distributed` cluster can then be taken down 1-by-1, allowing the whole `grafana/loki-distributed` cluster to be deleted once all the ingesters have scaled down.

Documentation coming in a follow-up PR.

**Which issue(s) this PR fixes**:
Fixes #7330

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
