### PR TITLE
feat(lambda-promtail): add bearer token support

### DIFF
--- a/tools/lambda-promtail/README.md
+++ b/tools/lambda-promtail/README.md
@@ -47,6 +47,8 @@ The `lambda-promtail` code picks this value up via an environment variable.
 
 Also, if your deployment requires a [VPC configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config), make sure to edit the `vpc_config` field in `main.tf` manually. Additonal documentation for the Lambda specific Terraform configuration is [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config).
 
+`lambda-promtail` supports authentication either using HTTP Basic Auth or using Bearer Token.  
+
 Then use Terraform to deploy:
 
 ```bash

--- a/tools/lambda-promtail/README.md
+++ b/tools/lambda-promtail/README.md
@@ -50,13 +50,13 @@ Also, if your deployment requires a [VPC configuration](https://registry.terrafo
 Then use Terraform to deploy:
 
 ```bash
-terraform apply -var "<ecr-repo>:<tag>" -var "write_address=https://your-loki-url/loki/api/v1/push" -var "password=<basic-auth-pw>" -var "username=<basic-auth-username>" -var 'log_group_names=["log-group-01", "log-group-02"]' -var 'extra_labels="name1,value1,name2,value2"' -var "tenant_id=<value>"
+terraform apply -var "<ecr-repo>:<tag>" -var "write_address=https://your-loki-url/loki/api/v1/push" -var "password=<basic-auth-pw>" -var "username=<basic-auth-username>" -var 'bearer_token=<bearer-token>' -var 'log_group_names=["log-group-01", "log-group-02"]' -var 'extra_labels="name1,value1,name2,value2"' -var "tenant_id=<value>"
 ```
 
 or CloudFormation:
 
 ```bash
-aws cloudformation create-stack --stack-name lambda-promtail-stack --template-body file://template.yaml --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --region us-east-2 --parameters ParameterKey=WriteAddress,ParameterValue=https://your-loki-url/loki/api/v1/push ParameterKey=Username,ParameterValue=<basic-auth-username> ParameterKey=Password,ParameterValue=<basic-auth-pw> ParameterKey=LambdaPromtailImage,ParameterValue=<ecr-repo>:<tag> ParameterKey=ExtraLabels,ParameterValue="name1,value1,name2,value2" ParameterKey=TenantID,ParameterValue=<value>
+aws cloudformation create-stack --stack-name lambda-promtail-stack --template-body file://template.yaml --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --region us-east-2 --parameters ParameterKey=WriteAddress,ParameterValue=https://your-loki-url/loki/api/v1/push ParameterKey=Username,ParameterValue=<basic-auth-username> ParameterKey=Password,ParameterValue=<basic-auth-pw> ParameterKey=BearerToken,ParameterValue=<bearer-token> ParameterKey=LambdaPromtailImage,ParameterValue=<ecr-repo>:<tag> ParameterKey=ExtraLabels,ParameterValue="name1,value1,name2,value2" ParameterKey=TenantID,ParameterValue=<value>
 ```
 
 # Appendix

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -27,12 +27,12 @@ const (
 )
 
 var (
-	writeAddress                                 *url.URL
-	username, password, extraLabelsRaw, tenantID string
-	keepStream                                   bool
-	batchSize                                    int
-	s3Clients                                    map[string]*s3.Client
-	extraLabels                                  model.LabelSet
+	writeAddress                                              *url.URL
+	username, password, extraLabelsRaw, tenantID, bearerToken string
+	keepStream                                                bool
+	batchSize                                                 int
+	s3Clients                                                 map[string]*s3.Client
+	extraLabels                                               model.LabelSet
 )
 
 func setupArguments() {
@@ -60,6 +60,12 @@ func setupArguments() {
 	// If either username or password is set then both must be.
 	if (username != "" && password == "") || (username == "" && password != "") {
 		panic("both username and password must be set if either one is set")
+	}
+
+	bearerToken = os.Getenv("BEARER_TOKEN")
+	// If username and password are set, bearer token is not allowed
+	if username != "" && bearerToken != "" {
+		panic("both username and bearerToken are not allowed")
 	}
 
 	tenantID = os.Getenv("TENANT_ID")

--- a/tools/lambda-promtail/lambda-promtail/promtail.go
+++ b/tools/lambda-promtail/lambda-promtail/promtail.go
@@ -185,6 +185,10 @@ func send(ctx context.Context, buf []byte) (int, error) {
 		req.SetBasicAuth(username, password)
 	}
 
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
 	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return -1, err

--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -102,6 +102,7 @@ resource "aws_lambda_function" "lambda_promtail" {
       WRITE_ADDRESS = var.write_address
       USERNAME      = var.username
       PASSWORD      = var.password
+      BEARER_TOKEN  = var.bearer_token
       KEEP_STREAM   = var.keep_stream
       BATCH_SIZE    = var.batch_size
       EXTRA_LABELS  = var.extra_labels

--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -22,6 +22,11 @@ Parameters:
     Type: String
     Default: ""
     NoEcho: true
+  BearerToken:
+    Description: The bearer token, necessary if target endpoint requires it.
+    Type: String
+    Default: ""
+    NoEcho: true
   LambdaPromtailImage:
     Description: The ECR image URI to pull and use for lambda-promtail.
     Type: String
@@ -82,6 +87,7 @@ Resources:
           WRITE_ADDRESS: !Ref WriteAddress
           USERNAME: !Ref Username
           PASSWORD: !Ref Password
+          BEARER_TOKEN: !Ref BearerToken
           KEEP_STREAM: !Ref KeepStream
           EXTRA_LABELS: !Ref ExtraLabels
           TENANT_ID: !Ref TenantID

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -35,6 +35,13 @@ variable "password" {
   default     = ""
 }
 
+variable "bearer_token" {
+  type        = string
+  description = "The bearer token, necessary if target endpoint requires it."
+  sensitive   = true
+  default     = ""
+}
+
 variable "tenant_id" {
   type        = string
   description = "Tenant ID to be added when writing logs from lambda-promtail."


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds bearer token support for lambda-promtail, as it supports only http basic auth.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
