### PR TITLE
Updating loki-build-image to Go 1.19

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.23.0',
+    local build_image_tag = '0.24.0',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.23.0
+    - 0.24.0
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.23.0
+    - 0.24.0
     username:
       from_secret: docker_username
   when:
@@ -1528,6 +1528,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: a9b8921396d009dc5ff6a4bb9057525fca82a4ec04e545de7056a3318bd04ce6
+hmac: 41046711568f49c5e0ad33648d594f500b512eb702010ebbb8048cdfff34fa7a
 
 ...

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -15,7 +15,7 @@ As a **first step** to build the new image, you need to create a pull
 request with the desired changes to the Dockerfile. To increase the version of
 the image, you also need to update the version tag of the `loki-build-image`
 pipeline defined in `.drone/drone.jsonnet` (search for
-`pipeline('loki-build-image')`) and run `BUILD_IN_CONTAINER=false make drone`
+`pipeline('loki-build-image')`) and run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone`
 and commit the changes to the same pull request.
 Once approved and merged to `main`, the image with the new version is built.
 

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.18.5 as drone
+FROM golang:1.19.2 as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,28 +47,28 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 #	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.18.5 as faillint
+FROM golang:1.19.2 as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.10.0
 
-FROM golang:1.18.5 as delve
+FROM golang:1.19.2 as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@v1.7.3
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.18.5 as ghr
+FROM golang:1.19.2 as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.18.5 as nfpm
+FROM golang:1.19.2 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install tools used to compile jsonnet.
-FROM golang:1.18.5 as jsonnet
+FROM golang:1.19.2 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.18.5-buster
+FROM golang:1.19.2-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the `loki-build-image` to Go 1.19.2 as a precursor for https://github.com/grafana/loki/pull/7243.