### PR TITLE
Patching loki-build-image with latest golangci-lint version

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.24.0',
+    local build_image_tag = '0.24.1',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.0
+    - 0.24.1
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.0
+    - 0.24.1
     username:
       from_secret: docker_username
   when:
@@ -1528,6 +1528,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 41046711568f49c5e0ad33648d594f500b512eb702010ebbb8048cdfff34fa7a
+hmac: 82c2ce679681c7b24901ec66097dd822a33d405663d540cda3572f202d86f6ab
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.16.2 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.45.2
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
 
 FROM alpine:3.16.2 as buf
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the `loki-build-image` has a version of golangci-lint which is based on Go 1.18.
[This issue](https://drone.grafana.net/grafana/loki/16278/2/9) has arisen in our CI: https://github.com/golangci/golangci-lint/issues/3107