### PR TITLE
mmap tsdb index file while opening it for querying

### DIFF
--- a/pkg/storage/stores/tsdb/compact_test.go
+++ b/pkg/storage/stores/tsdb/compact_test.go
@@ -368,7 +368,7 @@ func TestCompactor(t *testing.T) {
 			}
 			require.Nil(t, err)
 
-			idx, err := NewShippableTSDBFile(out, false)
+			idx, err := NewShippableTSDBFile(out)
 			require.Nil(t, err)
 			defer idx.Close()
 

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -380,7 +380,7 @@ func (c *compactedIndex) ToIndexFile() (index_shipper.Index, error) {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id, false)
+	return NewShippableTSDBFile(id)
 }
 
 func getUnsafeBytes(s string) []byte {

--- a/pkg/storage/stores/tsdb/identifier.go
+++ b/pkg/storage/stores/tsdb/identifier.go
@@ -59,23 +59,6 @@ func (p prefixedIdentifier) Name() string {
 	return path.Join(p.parentName, p.Identifier.Name())
 }
 
-func newSuffixedIdentifier(id Identifier, pathSuffix string) suffixedIdentifier {
-	return suffixedIdentifier{
-		pathSuffix: pathSuffix,
-		Identifier: id,
-	}
-}
-
-// Generally useful for gzip extensions
-type suffixedIdentifier struct {
-	pathSuffix string
-	Identifier
-}
-
-func (s suffixedIdentifier) Path() string {
-	return s.Identifier.Path() + s.pathSuffix
-}
-
 // Identifier has all the information needed to resolve a TSDB index
 // Notably this abstracts away OS path separators, etc.
 type SingleTenantTSDBIdentifier struct {

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -1338,6 +1338,10 @@ func (r *Reader) Version() int {
 	return r.version
 }
 
+func (r *Reader) RawFileReader() (io.ReadSeeker, error) {
+	return bytes.NewReader(r.b.Range(0, r.b.Len())), nil
+}
+
 // Range marks a byte range.
 type Range struct {
 	Start, End int64

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -134,10 +134,7 @@ func (m *tsdbManager) Start() (err error) {
 			indices++
 
 			prefixed := newPrefixedIdentifier(id, filepath.Join(mulitenantDir, bucket), "")
-			loaded, err := NewShippableTSDBFile(
-				prefixed,
-				false,
-			)
+			loaded, err := NewShippableTSDBFile(prefixed)
 
 			if err != nil {
 				level.Warn(m.log).Log(
@@ -229,7 +226,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads) (err error) {
 
 		level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
 
-		loaded, err := NewShippableTSDBFile(dst, false)
+		loaded, err := NewShippableTSDBFile(dst)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -2,17 +2,17 @@ package tsdb
 
 import (
 	"context"
-	"github.com/go-kit/log/level"
-	util_log "github.com/grafana/loki/pkg/util/log"
 	"io"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/storage/chunk"
 	index_shipper "github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 func OpenShippableTSDB(p string) (index_shipper.Index, error) {

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -13,7 +13,8 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
-type getRawFileReaderFunc func() (io.ReadSeeker, error)
+// GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
+type GetRawFileReaderFunc func() (io.ReadSeeker, error)
 
 func OpenShippableTSDB(p string) (index_shipper.Index, error) {
 	id, err := identifierFromPath(p)
@@ -34,7 +35,7 @@ type TSDBFile struct {
 	Index
 
 	// to sastisfy Reader() and Close() methods
-	getRawFileReader getRawFileReaderFunc
+	getRawFileReader GetRawFileReaderFunc
 }
 
 func NewShippableTSDBFile(id Identifier) (*TSDBFile, error) {
@@ -69,7 +70,7 @@ type TSDBIndex struct {
 
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
-func NewTSDBIndexFromFile(location string) (*TSDBIndex, getRawFileReaderFunc, error) {
+func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, error) {
 	reader, err := index.NewFileReader(location)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/storage/stores/tsdb/util_test.go
+++ b/pkg/storage/stores/tsdb/util_test.go
@@ -35,7 +35,7 @@ func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
 	})
 	require.Nil(t, err)
 
-	idx, err := NewShippableTSDBFile(dst, false)
+	idx, err := NewShippableTSDBFile(dst)
 	require.Nil(t, err)
 	return idx
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR #7321, we re-introduced mmap for reading tsdb index, but it does not cover all the paths where we open the index. This PR takes care of it.

I have also removed the code for decompressing the index file since we always get a decompressed file from the `indexshipper`.