### PR TITLE
Restoring lint checks that were previously disabled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,27 +59,22 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - goconst
     - revive
     - ineffassign
     - misspell
-    - structcheck
     - unconvert
-    - varcheck
     - govet
     - typecheck
     - depguard
     - exportloopref
-
-  # TODO(dannyk): restore these and fix linter errors in separate PR
-  disable:
-    - unused
     - gofmt
     - goimports
     - gosimple
     - staticcheck
+  disable:
+    - unused
     - unparam
 
 issues:
@@ -87,3 +82,5 @@ issues:
     - Error return value of .*log\.Logger\)\.Log\x60 is not checked
     - Error return value of .*.Log.* is not checked
     - Error return value of `` is not checked
+
+  fix: true

--- a/clients/cmd/fluent-bit/out_grafana_loki.go
+++ b/clients/cmd/fluent-bit/out_grafana_loki.go
@@ -46,9 +46,10 @@ func FLBPluginRegister(ctx unsafe.Pointer) int {
 	return output.FLBPluginRegister(ctx, "grafana-loki", "Ship fluent-bit logs to Grafana Loki")
 }
 
-//export FLBPluginInit
 // (fluentbit will call this)
 // ctx (context) pointer to fluentbit context (state/ c code)
+//
+//export FLBPluginInit
 func FLBPluginInit(ctx unsafe.Pointer) int {
 	conf, err := parseConfig(&pluginConfig{ctx: ctx})
 	if err != nil {

--- a/clients/pkg/logentry/stages/metrics.go
+++ b/clients/pkg/logentry/stages/metrics.go
@@ -324,8 +324,8 @@ func getFloat(unk interface{}) (float64, error) {
 
 // getFloatFromString converts string into float64
 // Two types of string formats are supported:
-//   * strings that represent floating point numbers, e.g., "0.804"
-//   * duration format strings, e.g., "0.5ms", "10h".
+//   - strings that represent floating point numbers, e.g., "0.804"
+//   - duration format strings, e.g., "0.5ms", "10h".
 //     Valid time units are "ns", "us", "ms", "s", "m", "h".
 //     Values in this format are converted as a floating point number of seconds.
 //     E.g., "0.5ms" is converted to 0.0005

--- a/clients/pkg/logentry/stages/pack.go
+++ b/clients/pkg/logentry/stages/pack.go
@@ -111,8 +111,9 @@ type PackConfig struct {
 	IngestTimestamp *bool    `mapstructure:"ingest_timestamp"`
 }
 
-//nolint:unparam // Always returns nil until someone adds more validation and can remove this.
 // validatePackConfig validates the PackConfig for the packStage
+//
+//nolint:unparam // Always returns nil until someone adds more validation and can remove this.
 func validatePackConfig(cfg *PackConfig) error {
 	// Default the IngestTimestamp value to be true
 	if cfg.IngestTimestamp == nil {

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -343,6 +343,8 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 					level.Warn(c.logger).Log("msg", "error converting stream label string to label.Labels, cannot update lagging metric", "error", err)
 					return
 				}
+
+				//nolint:staticcheck
 				lblSet := make(prometheus.Labels)
 				for _, lbl := range c.streamLagLabels {
 					// label from streamLagLabels may not be found but we still need an empty value
@@ -355,6 +357,8 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 					}
 					lblSet[lbl] = value
 				}
+
+				//nolint:staticcheck
 				if lblSet != nil {
 					// always set host
 					lblSet[HostLabel] = c.cfg.URL.Host

--- a/clients/pkg/promtail/targets/lokipush/pushtarget.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtarget.go
@@ -127,7 +127,7 @@ func (t *PushTarget) handleLoki(w http.ResponseWriter, r *http.Request) {
 
 		// Apply relabeling
 		processed := relabel.Process(lb.Labels(), t.relabelConfig...)
-		if processed == nil || len(processed) == 0 {
+		if len(processed) == 0 {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}

--- a/clients/pkg/promtail/targets/syslog/transport.go
+++ b/clients/pkg/promtail/targets/syslog/transport.go
@@ -17,10 +17,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
-	"github.com/grafana/loki/clients/pkg/promtail/targets/syslog/syslogparser"
 	"github.com/influxdata/go-syslog/v3"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/syslog/syslogparser"
 )
 
 var (
@@ -242,7 +243,7 @@ func (t *TCPTransport) acceptConnections() {
 				return
 			}
 
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+			if _, ok := err.(net.Error); ok {
 				level.Warn(l).Log("msg", "failed to accept syslog connection", "err", err, "num_retries", backoff.NumRetries())
 				backoff.Wait()
 				continue

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -456,7 +456,7 @@ func (r *Reader) closeAndReconnect() {
 			err := c.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(time.Second))
 			if err == websocket.ErrCloseSent {
 				return nil
-			} else if e, ok := err.(net.Error); ok && e.Temporary() {
+			} else if _, ok := err.(net.Error); ok {
 				return nil
 			}
 			return err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -454,9 +454,7 @@ func labelTemplate(lbls string) labels.Labels {
 	}
 
 	streamLabels := make([]labels.Label, len(baseLbls)+1)
-	for i := 0; i < len(baseLbls); i++ {
-		streamLabels[i] = baseLbls[i]
-	}
+	copy(streamLabels, baseLbls)
 	streamLabels[len(baseLbls)] = labels.Label{Name: ShardLbName, Value: ShardLbPlaceholder}
 
 	return streamLabels

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -547,8 +547,9 @@ func (i *Ingester) loop() {
 }
 
 // LegacyShutdownHandler triggers the following set of operations in order:
-//     * Change the state of ring to stop accepting writes.
-//     * Flush all the chunks.
+//   - Change the state of ring to stop accepting writes.
+//   - Flush all the chunks.
+//
 // Note: This handler does not trigger a termination of the Loki process,
 // despite its name. Instead, the ingester service is stopped, so an external
 // source can trigger a safe termination through a signal to the process.
@@ -590,11 +591,11 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleShutdown triggers the following operations:
-//     * Change the state of ring to stop accepting writes.
-//     * optional: Flush all the chunks.
-//     * optional: Delete ring tokens file
-//     * Unregister from KV store
-//     * optional: Terminate process (handled by service manager in loki.go)
+//   - Change the state of ring to stop accepting writes.
+//   - optional: Flush all the chunks.
+//   - optional: Delete ring tokens file
+//   - Unregister from KV store
+//   - optional: Terminate process (handled by service manager in loki.go)
 func (i *Ingester) handleShutdown(terminate, flush, del bool) error {
 	i.lifecycler.SetFlushOnShutdown(flush)
 	i.lifecycler.SetClearTokensOnShutdown(del)

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -441,9 +441,7 @@ func (i *instance) Label(ctx context.Context, req *logproto.LabelRequest, matche
 				return nil, err
 			}
 			labels = make([]string, len(values))
-			for i := 0; i < len(values); i++ {
-				labels[i] = values[i]
-			}
+			copy(labels, values)
 			return &logproto.LabelResponse{
 				Values: labels,
 			}, nil
@@ -453,9 +451,7 @@ func (i *instance) Label(ctx context.Context, req *logproto.LabelRequest, matche
 			return nil, err
 		}
 		labels = make([]string, len(names))
-		for i := 0; i < len(names); i++ {
-			labels[i] = names[i]
-		}
+		copy(labels, names)
 		return &logproto.LabelResponse{
 			Values: labels,
 		}, nil

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -11,7 +11,7 @@ var noParserHints = &parserHint{}
 // This is used only within metric queries since it's rare that you need all label keys.
 // For example in the following expression:
 //
-//		sum by (status_code) (rate({app="foo"} | json [5m]))
+//	sum by (status_code) (rate({app="foo"} | json [5m]))
 //
 // All we need to extract is the status_code in the json parser.
 type ParserHint interface {

--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -36,20 +36,20 @@ var splittableRangeVectorOp = map[string]struct{}{
 // using the downstream engine.
 //
 // A rewrite is performed using the following rules:
-// 1) Check if query is splittable based on the range.
-// 2) Check if the query is splittable based on the query AST
-// 3) Range aggregations are split into multiple downstream range aggregation expressions
-//    that are concatenated with an appropriate vector aggregator with a grouping operator.
-//    If the range aggregation has a grouping, the grouping is also applied to
-//    the resultant vector aggregator expression.
-//    If the range aggregation has no grouping, a grouping operator using "without" is applied
-//    to the resultant vector aggregator expression to preserve the stream labels.
-// 4) Vector aggregations are split into multiple downstream vector aggregations
-//    that are merged with vector aggregation using "without" and then aggregated
-//    using the vector aggregation with the same operator,
-//    either with or without grouping.
-// 5) Left and right-hand side of binary operations are split individually
-//    using the same rules as above.
+//  1. Check if query is splittable based on the range.
+//  2. Check if the query is splittable based on the query AST
+//  3. Range aggregations are split into multiple downstream range aggregation expressions
+//     that are concatenated with an appropriate vector aggregator with a grouping operator.
+//     If the range aggregation has a grouping, the grouping is also applied to
+//     the resultant vector aggregator expression.
+//     If the range aggregation has no grouping, a grouping operator using "without" is applied
+//     to the resultant vector aggregator expression to preserve the stream labels.
+//  4. Vector aggregations are split into multiple downstream vector aggregations
+//     that are merged with vector aggregation using "without" and then aggregated
+//     using the vector aggregation with the same operator,
+//     either with or without grouping.
+//  5. Left and right-hand side of binary operations are split individually
+//     using the same rules as above.
 type RangeMapper struct {
 	splitByInterval time.Duration
 	metrics         *MapperMetrics

--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -16,7 +16,6 @@ To get the  statistic from the current context you can use:
 Finally to get a snapshot of the current query statistic use
 
 	statsCtx.Result(time.Since(start), queueTime, totalEntriesReturned)
-
 */
 package stats
 

--- a/pkg/querier/astmapper/shard_summer.go
+++ b/pkg/querier/astmapper/shard_summer.go
@@ -210,7 +210,7 @@ func (summer *shardSummer) splitSum(
 
 // ShardSummer is explicitly passed a prometheus.Counter during construction
 // in order to prevent duplicate metric registerings (ShardSummers are created per request).
-//recordShards prevents calling nil interfaces (commonly used in tests).
+// recordShards prevents calling nil interfaces (commonly used in tests).
 func (summer *shardSummer) recordShards(_ float64) {
 	if summer.shardedQueries != nil {
 		summer.shardedQueries.Add(float64(summer.shards))

--- a/pkg/querier/astmapper/subtree_folder.go
+++ b/pkg/querier/astmapper/subtree_folder.go
@@ -8,7 +8,6 @@ import (
 subtreeFolder is a NodeMapper which embeds an entire parser.Node in an embedded query
 if it does not contain any previously embedded queries. This allows the frontend to "zip up" entire
 subtrees of an AST that have not already been parallelized.
-
 */
 type subtreeFolder struct{}
 

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -36,14 +36,13 @@ type WorkerServiceConfig struct {
 // the provided query routes/handlers. This router can either be registered with the external Loki HTTP server, or
 // be used internally by a querier worker so that it does not conflict with the routes registered by the Query Frontend module.
 //
-// 1. Query-Frontend Enabled: If Loki has an All or QueryFrontend target, the internal
-//    HTTP router is wrapped with Tenant ID parsing middleware and passed to the frontend
-//    worker.
+//  1. Query-Frontend Enabled: If Loki has an All or QueryFrontend target, the internal
+//     HTTP router is wrapped with Tenant ID parsing middleware and passed to the frontend
+//     worker.
 //
-// 2. Querier Standalone: The querier will register the internal HTTP router with the external
-//    HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
-//    as a http.Handler to the frontend worker.
-//
+//  2. Querier Standalone: The querier will register the internal HTTP router with the external
+//     HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
+//     as a http.Handler to the frontend worker.
 func InitWorkerService(
 	cfg WorkerServiceConfig,
 	reg prometheus.Registerer,

--- a/pkg/ruler/base/error_translate_queryable.go
+++ b/pkg/ruler/base/error_translate_queryable.go
@@ -18,10 +18,10 @@ import (
 //
 // Specifically, it supports:
 //
-//   promql.ErrQueryCanceled, mapped to 503
-//   promql.ErrQueryTimeout, mapped to 503
-//   promql.ErrStorage mapped to 500
-//   anything else is mapped to 422
+//	promql.ErrQueryCanceled, mapped to 503
+//	promql.ErrQueryTimeout, mapped to 503
+//	promql.ErrStorage mapped to 500
+//	anything else is mapped to 422
 //
 // Querier code produces different kinds of errors, and we want to map them to above-mentioned HTTP status codes correctly.
 //

--- a/pkg/ruler/base/ruler.go
+++ b/pkg/ruler/base/ruler.go
@@ -209,6 +209,7 @@ type MultiTenantManager interface {
 }
 
 // Ruler evaluates rules.
+//
 //	+---------------------------------------------------------------+
 //	|                                                               |
 //	|                   Query       +-------------+                 |

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -26,7 +26,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 }
 
 // Client expects to load already existing rules located at:
-//  cfg.Directory / userID / namespace
+//
+//	cfg.Directory / userID / namespace
 type Client struct {
 	cfg    Config
 	loader promRules.GroupLoader

--- a/pkg/storage/chunk/client/baidubce/bos_storage_client.go
+++ b/pkg/storage/chunk/client/baidubce/bos_storage_client.go
@@ -20,7 +20,8 @@ import (
 
 // NoSuchKeyErr The resource you requested does not exist.
 // refer to: https://cloud.baidu.com/doc/BOS/s/Ajwvysfpl
-//			 https://intl.cloud.baidu.com/doc/BOS/s/Ajwvysfpl-en
+//
+//	https://intl.cloud.baidu.com/doc/BOS/s/Ajwvysfpl-en
 const NoSuchKeyErr = "NoSuchKey"
 
 const DefaultEndpoint = bos.DEFAULT_SERVICE_DOMAIN

--- a/pkg/storage/stores/shipper/index/compactor/compacted_index.go
+++ b/pkg/storage/stores/shipper/index/compactor/compacted_index.go
@@ -55,12 +55,12 @@ func (c *CompactedIndex) isEmpty() (bool, error) {
 }
 
 // recreateCompactedDB just copies the old db to the new one using bbolt.Compact for following reasons:
-// 1. When index entries are deleted, boltdb leaves free pages in the file. The only way to drop those free pages is to re-create the file.
-//    See https://github.com/boltdb/bolt/issues/308 for more details.
-// 2. boltdb by default fills only about 50% of the page in the file. See https://github.com/etcd-io/bbolt/blob/master/bucket.go#L26.
-//    This setting is optimal for unordered writes.
-//    bbolt.Compact fills the whole page by setting FillPercent to 1 which works well here since while copying the data, it receives the index entries in order.
-//    The storage space goes down from anywhere between 25% to 50% as per my(Sandeep) tests.
+//  1. When index entries are deleted, boltdb leaves free pages in the file. The only way to drop those free pages is to re-create the file.
+//     See https://github.com/boltdb/bolt/issues/308 for more details.
+//  2. boltdb by default fills only about 50% of the page in the file. See https://github.com/etcd-io/bbolt/blob/master/bucket.go#L26.
+//     This setting is optimal for unordered writes.
+//     bbolt.Compact fills the whole page by setting FillPercent to 1 which works well here since while copying the data, it receives the index entries in order.
+//     The storage space goes down from anywhere between 25% to 50% as per my(Sandeep) tests.
 func (c *CompactedIndex) recreateCompactedDB() error {
 	destDB, err := openBoltdbFileWithNoSync(filepath.Join(c.workingDir, fmt.Sprint(time.Now().Unix())))
 	if err != nil {

--- a/pkg/storage/stores/shipper/index/compactor/table_compactor.go
+++ b/pkg/storage/stores/shipper/index/compactor/table_compactor.go
@@ -238,6 +238,7 @@ func (t *tableCompactor) fetchOrCreateUserCompactedIndexSet(userID string) error
 		return nil
 	}
 
+	//nolint:staticcheck
 	userIndexSet, ok := t.existingUserIndexSet[userID]
 	var result *compactedIndexSet
 	if !ok {

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -35,11 +35,11 @@ type TSDBManager interface {
 
 /*
 tsdbManager is used for managing active index and is responsible for:
- * Turning WALs into optimized multi-tenant TSDBs when requested
- * Serving reads from these TSDBs
- * Shipping them to remote storage
- * Keeping them available for querying
- * Removing old TSDBs which are no longer needed
+  - Turning WALs into optimized multi-tenant TSDBs when requested
+  - Serving reads from these TSDBs
+  - Shipping them to remote storage
+  - Keeping them available for querying
+  - Removing old TSDBs which are no longer needed
 */
 type tsdbManager struct {
 	nodeName    string // node name

--- a/pkg/util/flagext/bytesize.go
+++ b/pkg/util/flagext/bytesize.go
@@ -35,7 +35,7 @@ func (bs ByteSize) Val() int {
 	return int(bs)
 }
 
-// / UnmarshalYAML the Unmarshaler interface of the yaml pkg.
+// UnmarshalYAML the Unmarshaler interface of the yaml pkg.
 func (bs *ByteSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)

--- a/pkg/util/flagext/bytesize.go
+++ b/pkg/util/flagext/bytesize.go
@@ -35,7 +35,7 @@ func (bs ByteSize) Val() int {
 	return int(bs)
 }
 
-/// UnmarshalYAML the Unmarshaler interface of the yaml pkg.
+// / UnmarshalYAML the Unmarshaler interface of the yaml pkg.
 func (bs *ByteSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -74,7 +74,8 @@ func (l LogAdapter) Println(v ...interface{}) {
 }
 
 // TODO(dannyk): remove once weaveworks/common updates to go-kit/log
-// 					-> we can then revert to using Level.Gokit
+//
+//	-> we can then revert to using Level.Gokit
 func LogFilter(l string) level.Option {
 	switch l {
 	case "debug":

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -73,9 +73,9 @@ func (l LogAdapter) Println(v ...interface{}) {
 	level.Info(l).Log("msg", fmt.Sprint(v...))
 }
 
-// TODO(dannyk): remove once weaveworks/common updates to go-kit/log
+// LogFilter translates a log level into a go-kit/log level filter.
 //
-//	-> we can then revert to using Level.Gokit
+// TODO(dannyk): remove once weaveworks/common updates to go-kit/log, we can then revert to using Level.Gokit
 func LogFilter(l string) level.Option {
 	switch l {
 	case "debug":

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -148,7 +148,8 @@ func CheckFatal(location string, err error, logger log.Logger) {
 }
 
 // TODOe remove once weaveworks/common updates to go-kit/log
-//                                     -> we can then revert to using Level.Gokit
+//
+//	-> we can then revert to using Level.Gokit
 func levelFilter(l string) level.Option {
 	switch l {
 	case "debug":

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -147,9 +147,7 @@ func CheckFatal(location string, err error, logger log.Logger) {
 	os.Exit(1)
 }
 
-// TODOe remove once weaveworks/common updates to go-kit/log
-//
-//	-> we can then revert to using Level.Gokit
+// TODO: remove once weaveworks/common updates to go-kit/log, we can then revert to using Level.Gokit
 func levelFilter(l string) level.Option {
 	switch l {
 	case "debug":

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -20,8 +20,9 @@ func WithUserID(userID string, l log.Logger) log.Logger {
 // its details.
 //
 // e.g.
-//   log := util.WithContext(ctx)
-//   log.Errorf("Could not chunk chunks: %v", err)
+//
+//	log := util.WithContext(ctx)
+//	log.Errorf("Could not chunk chunks: %v", err)
 func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.

--- a/pkg/util/marshal/legacy/marshal.go
+++ b/pkg/util/marshal/legacy/marshal.go
@@ -1,5 +1,6 @@
 // Package marshal converts internal objects to loghttp model objects.  This package is designed to work with
-//  models in pkg/loghttp/legacy.
+//
+//	models in pkg/loghttp/legacy.
 package marshal
 
 import (

--- a/pkg/util/marshal/legacy/marshal.go
+++ b/pkg/util/marshal/legacy/marshal.go
@@ -1,6 +1,5 @@
 // Package marshal converts internal objects to loghttp model objects.  This package is designed to work with
-//
-//	models in pkg/loghttp/legacy.
+// models in pkg/loghttp/legacy.
 package marshal
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
I removed these checks in https://github.com/grafana/loki/pull/7337 to not make https://github.com/grafana/loki/pull/7243 overly complex to review.

Refactored code to fix valid lint issues, ignored the irrelevant/dangerous ones.
I also removed `unused` and `unparam` as these produce low-quality results that are largely useless.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I'd suggest reviewing with whitespace ignored, since a lot of these stupid lints were just whitespace fixes.