### PR TITLE
Upgrade operator gh workflows to go1.19

### DIFF
--- a/.github/workflows/operator-bundle.yaml
+++ b/.github/workflows/operator-bundle.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3

--- a/.github/workflows/operator-scorecard.yaml
+++ b/.github/workflows/operator-scorecard.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Install make
       run: sudo apt-get install make
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Install make
       run: sudo apt-get install make
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Install make
       run: sudo apt-get install make
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18']
+        go: ['1.19']
     steps:
     - name: Install make
       run: sudo apt-get install make


### PR DESCRIPTION
**What this PR does / why we need it**:
Update GH workflows for the operator submodule to use go 1.19. Follow up on #7243 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
