### PR TITLE
Clarify how and where to download the Loki config file from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Loki
 
 ##### Enhancements
+* [7346](https://github.com/grafana/loki/pull/7346) **mostafa**: Clarify how and where to download the Loki config file from
 * [7227](https://github.com/grafana/loki/pull/7227) **Red-GV**: Add ability to configure tls minimum version and cipher suites
 * [7179](https://github.com/grafana/loki/pull/7179) **vlad-diachenko**: Add ability to use Azure Service Principals credentials to authenticate to Azure Blob Storage.
 * [7101](https://github.com/grafana/loki/pull/7101) **liguozhong**: Promtail: Add support for max stream limit.

--- a/docs/sources/installation/local.md
+++ b/docs/sources/installation/local.md
@@ -17,10 +17,11 @@ The configuration specifies running Loki as a single binary.
 3. Download the Loki and Promtail .zip files that correspond to your system.
    **Note:** Do not download LogCLI or Loki Canary at this time. [LogCLI](../../getting-started/logcli/) allows you to run Loki queries in a command line interface. [Loki Canary](../../operations/loki-canary/) is a tool to audit Loki performance.
 4. Unzip the package contents into the same directory. This is where the two programs will run.
-5. In the command line, change directory (`cd` on most systems) to the directory with Loki and Promtail. Copy and paste the commands below into your command line to download generic configuration files:
+5. In the command line, change directory (`cd` on most systems) to the directory with Loki and Promtail. Copy and paste the commands below into your command line to download generic configuration files.
+   **Note:** Use the corresponding Git refs that match your downloaded Loki version to get the correct configuration file. For example, if you are using Loki version 2.6.1, you need to use the `https://raw.githubusercontent.com/grafana/loki/v2.6.1/cmd/loki/loki-local-config.yaml` URL to download the configuration file that corresponds to the Loki version you aim to run.
 
     ```
-    wget https://raw.githubusercontent.com/grafana/loki/master/cmd/loki/loki-local-config.yaml
+    wget https://raw.githubusercontent.com/grafana/loki/main/cmd/loki/loki-local-config.yaml
     wget https://raw.githubusercontent.com/grafana/loki/main/clients/cmd/promtail/promtail-local-config.yaml
     ```
 6. Enter the following command to start Loki:


### PR DESCRIPTION
**What this PR does / why we need it**:
The config file URL mentioned in the docs contain config options that doesn't match the latest version of Loki, which, as of now, is v2.6.1.

**Which issue(s) this PR fixes**:
Fixes #6915 

**Special notes for your reviewer**:
Disclaimer: I am a Grafanista from k6.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
