### PR TITLE
Adding Promtail and Heroku blogpost files to `examples/`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Loki examples
 
-This directory contains examples and example configuration for Loki.
+This directory contains examples and example configuration for Loki and Promtail.
 
 ## Hosted logs in Grafana Cloud
 
@@ -9,3 +9,7 @@ You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-l
 ## Getting started with Loki
 
 Configuration files in the `getting-started` directory are used by the [Loki getting started guide](https://grafana.com/docs/loki/latest/getting-started/).
+
+## Sending logs from Heroku to Loki
+
+Configuration files in the `promtail-heroku` directory are used by the [Promtail and Heroku blogpost](https://grafana.com/blog/2022/09/19/how-to-easily-configure-grafana-loki-and-promtail-to-receive-logs-from-heroku/).

--- a/examples/promtail-heroku/Dockerfile
+++ b/examples/promtail-heroku/Dockerfile
@@ -1,0 +1,10 @@
+from grafana/promtail:main-c9ef062
+
+# Copy the config.yml file we created in the step above, inside the container itself. This simplifies the 
+# configuration of the Promtail instance.
+COPY config.yml /etc/promtail/config.yml
+
+# This three flags indicates promtail where the configurations is located, to interpolate the configuration
+# file with environment variables (this is to avoid hardcoding values such as API Keys), and lastly, to print
+# the whole configuration file to STDERR when starting the container (this is helpful for debugging).
+CMD ["-config.file=/etc/promtail/config.yml", "-config.expand-env=true", "-print-config-stderr"]

--- a/examples/promtail-heroku/README.md
+++ b/examples/promtail-heroku/README.md
@@ -1,0 +1,4 @@
+# Promtail configuration for sending Heroku logs to Loki
+
+This directory contains configuration to use with the [Promtail and Heroku blogpost](https://grafana.com/blog/2022/09/19/how-to-easily-configure-grafana-loki-and-promtail-to-receive-logs-from-heroku/).
+

--- a/examples/promtail-heroku/config.yml
+++ b/examples/promtail-heroku/config.yml
@@ -1,0 +1,38 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: "info"
+
+positions:
+  filename: /tmp/positions.yaml
+
+# This bit indicates what Loki instance to write the logs to. We’ll inject the
+# details and credentials through environment variables
+clients:
+  - url: https://${LOKI_TENANT_ID}:${LOKI_TOKEN}@${LOKI_HOST}/loki/api/v1/push
+
+scrape_configs:
+  # Job name, that will be injected in each log line
+  - job_name: ${JOB_NAME}
+
+# Apply relabel to keep Heroku internal labels
+relabel_configs:
+  - source_labels: ["__heroku_drain_host"]
+    target_label: "host"
+  - source_labels: ["__heroku_drain_app"]
+    target_label: "app"
+  - source_labels: ["__heroku_drain_proc"]
+    target_label: "proc"
+
+    # Main heroku target configuration
+    heroku_drain:
+      server:
+        http_listen_address: 0.0.0.0
+        # $PORT is a special environment variable that Heroku fills with
+        # port that’s accessible from outside the container. We indicate promtail
+        # to listen for Heroku logs in it.
+        http_listen_port: ${PORT}
+        log_level: info
+      # Tag each log entry with our job name
+      labels:
+        job: ${JOB_NAME}

--- a/examples/promtail-heroku/heroku.yml
+++ b/examples/promtail-heroku/heroku.yml
@@ -1,0 +1,4 @@
+# Heroku application configuration. It indicates heroku what to deploy
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:
Some weeks ago a blogpost was written on how to configure Promtail to receive logs from Heroku, and write them to Loki. This blogpost contains some configuration snippets like a Promtail config, a Dockerfile, etc. It's been mentioned is annoying to copy and paste the snippets from there, so this PR adds this snippets under the `examples/` folder, so that they are easily readable and iterated if necessary.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
