### PR TITLE
Implement Distributor Rate Store

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -58,16 +58,19 @@ type Config struct {
 
 	// For testing.
 	factory ring_client.PoolFactory `yaml:"-"`
+
+	RateStore RateStoreConfig `yaml:"rate_store"`
 }
 
 // RegisterFlags registers distributor-related flags.
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.DistributorRing.RegisterFlags(fs)
+	cfg.RateStore.RegisterFlagsWithPrefix("distributor", fs)
 }
 
 // RateStore manages the ingestion rate of streams, populated by data fetched from ingesters.
 type RateStore interface {
-	RateFor(stream *logproto.Stream) (int, error)
+	RateFor(streamHash uint64) int64
 }
 
 // Distributor coordinates replicates and distribution of log streams.
@@ -150,6 +153,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
+
 	d := Distributor{
 		cfg:                    cfg,
 		clientCfg:              clientCfg,
@@ -188,7 +192,10 @@ func New(
 	d.replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
 	rfStats.Set(int64(ingestersRing.ReplicationFactor()))
 
-	servs = append(servs, d.pool)
+	rs := NewRateStore(d.cfg.RateStore, ingestersRing, d.pool, registerer)
+	d.rateStore = rs
+
+	servs = append(servs, d.pool, rs)
 	d.subservices, err = services.NewManager(servs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "services manager")
@@ -196,8 +203,6 @@ func New(
 	d.subservicesWatcher = services.NewFailureWatcher()
 	d.subservicesWatcher.WatchManager(d.subservices)
 	d.Service = services.NewBasicService(d.starting, d.running, d.stopping)
-
-	d.rateStore = &noopRateStore{}
 
 	return &d, nil
 }
@@ -393,7 +398,7 @@ func min(x1, x2 int) int {
 func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID string) ([]uint32, []streamTracker) {
 	shardStreamsCfg := d.validator.Limits.ShardStreams(userID)
 	logger := log.With(util_log.WithUserID(userID, util_log.Logger), "stream", stream.Labels)
-	shardCount := d.shardCountFor(logger, &stream, streamSize, d.rateStore, shardStreamsCfg)
+	shardCount := d.shardCountFor(logger, &stream, streamSize, shardStreamsCfg)
 
 	if shardCount <= 1 {
 		return []uint32{util.TokenFor(userID, stream.Labels)}, []streamTracker{{stream: stream}}
@@ -442,8 +447,8 @@ func labelTemplate(lbls string) labels.Labels {
 	return streamLabels
 }
 
-func (d *Distributor) createShard(shardStreamsCfg *shardstreams.Config, stream logproto.Stream, lbls labels.Labels, streamPattern string, totalShards, shardNumber int) (logproto.Stream, bool) {
-	lowerBound, upperBound, ok := d.boundsFor(stream, totalShards, shardNumber, shardStreamsCfg.LoggingEnabled)
+func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream logproto.Stream, lbls labels.Labels, streamPattern string, totalShards, shardNumber int) (logproto.Stream, bool) {
+	lowerBound, upperBound, ok := d.boundsFor(stream, totalShards, shardNumber, streamshardCfg.LoggingEnabled)
 	if !ok {
 		return logproto.Stream{}, false
 	}
@@ -580,7 +585,7 @@ func (d *Distributor) parseStreamLabels(vContext validationContext, key string, 
 // based on the rate stored in the rate store and will store the new evaluated number of shards.
 //
 // desiredRate is expected to be given in bytes.
-func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, streamSize int, rateStore RateStore, streamShardcfg *shardstreams.Config) int {
+func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, streamSize int, streamShardcfg *shardstreams.Config) int {
 	if streamShardcfg.DesiredRate.Val() <= 0 {
 		if streamShardcfg.LoggingEnabled {
 			level.Error(logger).Log("msg", "invalid desired rate", "desired_rate", streamShardcfg.DesiredRate.String())
@@ -588,15 +593,7 @@ func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, 
 		return 1
 	}
 
-	rate, err := rateStore.RateFor(stream)
-	if err != nil {
-		d.streamShardingFailures.WithLabelValues("rate_not_found").Inc()
-		if streamShardcfg.LoggingEnabled {
-			level.Error(logger).Log("msg", "couldn't shard stream because rate store returned error", "err", err)
-		}
-		return 1
-	}
-
+	rate := d.rateStore.RateFor(stream.Hash)
 	shards := calculateShards(rate, streamSize, streamShardcfg.DesiredRate.Val())
 	if shards > len(stream.Entries) {
 		d.streamShardingFailures.WithLabelValues("too_many_shards").Inc()
@@ -613,8 +610,8 @@ func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, 
 	return shards
 }
 
-func calculateShards(rate, streamSize, desiredRate int) int {
-	shards := float64((rate + streamSize)) / float64(desiredRate)
+func calculateShards(rate int64, streamSize, desiredRate int) int {
+	shards := float64(rate+int64(streamSize)) / float64(desiredRate)
 	if shards <= 1 {
 		return 1
 	}

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -1,25 +1,183 @@
 package distributor
 
 import (
-	"fmt"
+	"context"
+	"flag"
+	"sync"
+	"time"
 
+	"github.com/grafana/dskit/services"
+
+	"github.com/go-kit/log/level"
+	util_log "github.com/grafana/loki/pkg/util/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-type unshardableStreamErr struct {
-	labels     string
-	entriesNum int
-	shardNum   int
+type poolClientFactory interface {
+	GetClientFor(addr string) (client.PoolClient, error)
 }
 
-func (u *unshardableStreamErr) Error() string {
-	return fmt.Sprintf("couldn't shard stream %s. number of shards (%d) is higher than number of entries (%d)", u.labels, u.shardNum, u.entriesNum)
+type RateStoreConfig struct {
+	MaxParallelism           int           `yaml:"max_request_parallelism"`
+	StreamRateUpdateInterval time.Duration `yaml:"stream_rate_update_interval"`
+	IngesterReqTimeout       time.Duration `yaml:"ingester_request_timeout"`
 }
 
-type noopRateStore struct {
-	rate int
+func (cfg *RateStoreConfig) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
+	fs.IntVar(&cfg.MaxParallelism, prefix+".rate-store.max-request-parallelism", 200, "The max number of concurrent requests to make to ingester stream apis")
+	fs.DurationVar(&cfg.StreamRateUpdateInterval, prefix+".rate-store.stream-rate-update-interval", 3*time.Second, "The interval on which distributors will update current stream rates from ingesters")
+	fs.DurationVar(&cfg.IngesterReqTimeout, prefix+".rate-store.ingester-request-timeout", time.Second, "Timeout for communication between distributors and ingesters when updating rates")
 }
 
-func (n *noopRateStore) RateFor(stream *logproto.Stream) (int, error) {
-	return n.rate, nil
+type rateStore struct {
+	services.Service
+
+	ring                   ring.ReadRing
+	clientPool             poolClientFactory
+	rates                  map[uint64]int64
+	rateLock               sync.RWMutex
+	rateCollectionInterval time.Duration
+	ingesterTimeout        time.Duration
+	rateRefreshFailures    *prometheus.CounterVec
+	maxParallelism         int
+}
+
+func NewRateStore(cfg RateStoreConfig, r ring.ReadRing, cf poolClientFactory, registerer prometheus.Registerer) *rateStore {
+	s := &rateStore{
+		ring:                   r,
+		clientPool:             cf,
+		rateCollectionInterval: cfg.StreamRateUpdateInterval,
+		maxParallelism:         cfg.MaxParallelism,
+		ingesterTimeout:        cfg.IngesterReqTimeout,
+		rateRefreshFailures: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "rate_store_refresh_failures_total",
+			Help:      "The total number of failed attempts to refresh the distributor's view of stream rates",
+		}, []string{"reason"}),
+	}
+
+	s.Service = services.
+		NewTimerService(s.rateCollectionInterval, s.updateAllRates, s.updateAllRates, nil).
+		WithName("rate store")
+
+	return s
+}
+
+func (s *rateStore) updateAllRates(ctx context.Context) error {
+	clients, err := s.getClients()
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "error getting ingester clients", "err", err)
+		s.rateRefreshFailures.WithLabelValues("ring_error").Inc()
+		return nil // Don't fail the service because we have an error getting the clients once
+	}
+
+	streamRates := s.getRates(ctx, clients)
+	rates := s.aggregateByShard(streamRates)
+
+	s.rateLock.Lock()
+	defer s.rateLock.Unlock()
+	s.rates = rates
+
+	return nil
+}
+
+func (s *rateStore) aggregateByShard(streamRates map[uint64]*logproto.StreamRate) map[uint64]int64 {
+	rates := make(map[uint64]int64)
+	for _, sr := range streamRates {
+		if _, ok := rates[sr.StreamHashNoShard]; ok {
+			rates[sr.StreamHashNoShard] += sr.Rate
+			continue
+		}
+
+		rates[sr.StreamHashNoShard] = sr.Rate
+	}
+	return rates
+}
+
+func (s *rateStore) getRates(ctx context.Context, clients []logproto.StreamDataClient) map[uint64]*logproto.StreamRate {
+	parallelClients := make(chan logproto.StreamDataClient, len(clients))
+	responses := make(chan *logproto.StreamRatesResponse, len(clients))
+
+	for i := 0; i < s.maxParallelism; i++ {
+		go s.getRatesFromIngesters(ctx, parallelClients, responses)
+	}
+
+	for _, c := range clients {
+		parallelClients <- c
+	}
+	close(parallelClients)
+
+	return ratesPerStream(responses, len(clients))
+}
+
+func ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) map[uint64]*logproto.StreamRate {
+	streamRates := make(map[uint64]*logproto.StreamRate)
+	for i := 0; i < totalResponses; i++ {
+		resp := <-responses
+		if resp == nil {
+			continue
+		}
+
+		for i := 0; i < len(resp.StreamRates); i++ {
+			rate := resp.StreamRates[i]
+
+			if r, ok := streamRates[rate.StreamHash]; ok {
+				if r.Rate < rate.Rate {
+					streamRates[rate.StreamHash] = rate
+				}
+				continue
+			}
+
+			streamRates[rate.StreamHash] = rate
+		}
+	}
+
+	return streamRates
+}
+
+func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan logproto.StreamDataClient, responses chan *logproto.StreamRatesResponse) {
+	for c := range clients {
+		ctx, cancel := context.WithTimeout(ctx, s.ingesterTimeout)
+
+		resp, err := c.GetStreamRates(ctx, &logproto.StreamRatesRequest{})
+		if err != nil {
+			level.Error(util_log.Logger).Log("msg", "unable to get stream rates", "err", err)
+			s.rateRefreshFailures.WithLabelValues("ingester_error").Inc()
+		}
+
+		responses <- resp
+		cancel()
+	}
+}
+
+func (s *rateStore) getClients() ([]logproto.StreamDataClient, error) {
+	ingesters, err := s.ring.GetAllHealthy(ring.Read)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := make([]logproto.StreamDataClient, 0, len(ingesters.Instances))
+	for _, i := range ingesters.Instances {
+		client, err := s.clientPool.GetClientFor(i.Addr)
+		if err != nil {
+			return nil, err
+		}
+
+		clients = append(clients, client.(logproto.StreamDataClient))
+	}
+
+	return clients, nil
+}
+
+func (s *rateStore) RateFor(streamHash uint64) int64 {
+	s.rateLock.RLock()
+	s.rateLock.RUnlock()
+
+	return s.rates[streamHash]
 }

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -1,0 +1,171 @@
+package distributor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	client2 "github.com/grafana/loki/pkg/ingester/client"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
+)
+
+func TestRateStore(t *testing.T) {
+	t.Run("it reports rates from all of the ingesters", func(t *testing.T) {
+		tc := setup()
+		tc.ring.replicationSet = ring.ReplicationSet{
+			Instances: []ring.InstanceDesc{
+				{Addr: "ingester0"},
+				{Addr: "ingester1"},
+				{Addr: "ingester2"},
+				{Addr: "ingester3"},
+			},
+		}
+
+		tc.clientPool.clients = map[string]client.PoolClient{
+			"ingester0": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 0, StreamHashNoShard: 0, Rate: 15}}),
+			"ingester1": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 1, StreamHashNoShard: 1, Rate: 25}}),
+			"ingester2": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 2, StreamHashNoShard: 2, Rate: 35}}),
+			"ingester3": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 3, StreamHashNoShard: 3, Rate: 45}}),
+		}
+
+		_ = tc.rateStore.StartAsync(context.Background())
+		defer tc.rateStore.StopAsync()
+
+		require.Eventually(t, func() bool { // There will be data
+			return tc.rateStore.RateFor(0) != 0
+		}, time.Second, time.Millisecond)
+
+		require.Equal(t, int64(15), tc.rateStore.RateFor(0))
+		require.Equal(t, int64(25), tc.rateStore.RateFor(1))
+		require.Equal(t, int64(35), tc.rateStore.RateFor(2))
+		require.Equal(t, int64(45), tc.rateStore.RateFor(3))
+	})
+
+	t.Run("it reports the highest rate from replicas", func(t *testing.T) {
+		tc := setup()
+		tc.ring.replicationSet = ring.ReplicationSet{
+			Instances: []ring.InstanceDesc{
+				{Addr: "ingester0"},
+				{Addr: "ingester1"},
+				{Addr: "ingester2"},
+			},
+		}
+
+		tc.clientPool.clients = map[string]client.PoolClient{
+			"ingester0": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 0, StreamHashNoShard: 0, Rate: 25}}),
+			"ingester1": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 0, StreamHashNoShard: 0, Rate: 35}}),
+			"ingester2": newRateClient([]*logproto.StreamRate{{
+				StreamHash: 0, StreamHashNoShard: 0, Rate: 15}}),
+		}
+
+		_ = tc.rateStore.StartAsync(context.Background())
+		defer tc.rateStore.StopAsync()
+
+		require.Eventually(t, func() bool { // There will be data
+			return tc.rateStore.RateFor(0) != 0
+		}, time.Second, time.Millisecond)
+
+		require.Equal(t, int64(35), tc.rateStore.RateFor(0))
+	})
+
+	t.Run("it aggregates rates over shards", func(t *testing.T) {
+		tc := setup()
+		tc.ring.replicationSet = ring.ReplicationSet{
+			Instances: []ring.InstanceDesc{
+				{Addr: "ingester0"},
+			},
+		}
+
+		tc.clientPool.clients = map[string]client.PoolClient{
+			"ingester0": newRateClient([]*logproto.StreamRate{
+				{StreamHash: 1, StreamHashNoShard: 0, Rate: 25},
+				{StreamHash: 2, StreamHashNoShard: 0, Rate: 35},
+				{StreamHash: 3, StreamHashNoShard: 0, Rate: 15},
+			}),
+		}
+		_ = tc.rateStore.StartAsync(context.Background())
+		defer tc.rateStore.StopAsync()
+
+		require.Eventually(t, func() bool { // There will be data
+			return tc.rateStore.RateFor(0) != 0
+		}, time.Second, time.Millisecond)
+
+		require.Equal(t, int64(75), tc.rateStore.RateFor(0))
+	})
+}
+
+func newFakeRing() *fakeRing {
+	return &fakeRing{}
+}
+
+type fakeRing struct {
+	ring.ReadRing
+
+	replicationSet ring.ReplicationSet
+	err            error
+}
+
+func (r *fakeRing) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error) {
+	return r.replicationSet, r.err
+}
+
+func newFakeClientPool() *fakeClientPool {
+	return &fakeClientPool{
+		clients: make(map[string]client.PoolClient),
+	}
+}
+
+type fakeClientPool struct {
+	clients map[string]client.PoolClient
+	err     error
+}
+
+func (p *fakeClientPool) GetClientFor(addr string) (client.PoolClient, error) {
+	return p.clients[addr], p.err
+}
+
+func newRateClient(rates []*logproto.StreamRate) client.PoolClient {
+	return client2.ClosableHealthAndIngesterClient{
+		StreamDataClient: &fakeStreamDataClient{resp: &logproto.StreamRatesResponse{StreamRates: rates}},
+	}
+}
+
+type fakeStreamDataClient struct {
+	resp *logproto.StreamRatesResponse
+	err  error
+}
+
+func (c *fakeStreamDataClient) GetStreamRates(ctx context.Context, in *logproto.StreamRatesRequest, opts ...grpc.CallOption) (*logproto.StreamRatesResponse, error) {
+	return c.resp, c.err
+}
+
+type testContext struct {
+	ring       *fakeRing
+	clientPool *fakeClientPool
+	rateStore  *rateStore
+}
+
+func setup() *testContext {
+	ring := newFakeRing()
+	cp := newFakeClientPool()
+	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond}
+
+	return &testContext{
+		ring:       ring,
+		clientPool: cp,
+		rateStore:  NewRateStore(cfg, ring, cp, nil),
+	}
+}

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -34,6 +34,7 @@ type ClosableHealthAndIngesterClient struct {
 	logproto.PusherClient
 	logproto.QuerierClient
 	logproto.IngesterClient
+	logproto.StreamDataClient
 	grpc_health_v1.HealthClient
 	io.Closer
 }
@@ -73,11 +74,12 @@ func New(cfg Config, addr string) (HealthAndIngesterClient, error) {
 		return nil, err
 	}
 	return ClosableHealthAndIngesterClient{
-		PusherClient:   logproto.NewPusherClient(conn),
-		QuerierClient:  logproto.NewQuerierClient(conn),
-		IngesterClient: logproto.NewIngesterClient(conn),
-		HealthClient:   grpc_health_v1.NewHealthClient(conn),
-		Closer:         conn,
+		PusherClient:     logproto.NewPusherClient(conn),
+		QuerierClient:    logproto.NewQuerierClient(conn),
+		IngesterClient:   logproto.NewIngesterClient(conn),
+		StreamDataClient: logproto.NewStreamDataClient(conn),
+		HealthClient:     grpc_health_v1.NewHealthClient(conn),
+		Closer:           conn,
 	}, nil
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -47,7 +47,8 @@ import (
 
 const (
 	// RingKey is the key under which we store the ingesters ring in the KVStore.
-	RingKey = "ring"
+	RingKey            = "ring"
+	internalInstanceId = "internal"
 )
 
 // ErrReadOnly is returned when the ingester is shutting down and a push was
@@ -192,10 +193,11 @@ type Ingester struct {
 	clientConfig  client.Config
 	tenantConfigs *runtime.TenantConfigs
 
-	shutdownMtx  sync.Mutex // Allows processes to grab a lock and prevent a shutdown
-	instancesMtx sync.RWMutex
-	instances    map[string]*instance
-	readonly     bool
+	shutdownMtx      sync.Mutex // Allows processes to grab a lock and prevent a shutdown
+	instancesMtx     sync.RWMutex
+	instances        map[string]*instance
+	internalInstance *instance // used for non-user communication from the distributors
+	readonly         bool
 
 	lifecycler        *ring.Lifecycler
 	lifecyclerWatcher *services.FailureWatcher
@@ -623,14 +625,7 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 // GetStreamRates returns a response containing all streams and their current rate
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
 func (i *Ingester) GetStreamRates(ctx context.Context, req *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
-	instanceID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return nil, err
-	} else if i.readonly {
-		return nil, ErrReadOnly
-	}
-
-	instance, err := i.GetOrCreateInstance(instanceID)
+	instance, err := i.getOrCreateInternalInstance()
 	if err != nil {
 		return &logproto.StreamRatesResponse{}, err
 	}
@@ -657,6 +652,25 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 		activeTenantsStats.Set(int64(len(i.instances)))
 	}
 	return inst, nil
+}
+
+func (i *Ingester) getOrCreateInternalInstance() (*instance, error) { //nolint:revive
+	if inst, ok := i.getInternalInstance(); ok {
+		return inst, nil
+	}
+
+	i.instancesMtx.Lock()
+	defer i.instancesMtx.Unlock()
+
+	if i.internalInstance == nil {
+		inst, err := newInstance(&i.cfg, i.periodicConfigs, internalInstanceId, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
+		if err != nil {
+			return nil, err
+		}
+		i.internalInstance = inst
+	}
+
+	return i.internalInstance, nil
 }
 
 // Query the ingests for log streams matching a set of matchers.
@@ -953,6 +967,17 @@ func (i *Ingester) getInstanceByID(id string) (*instance, bool) {
 
 	inst, ok := i.instances[id]
 	return inst, ok
+}
+
+func (i *Ingester) getInternalInstance() (*instance, bool) {
+	i.instancesMtx.RLock()
+	defer i.instancesMtx.RUnlock()
+
+	if i.internalInstance != nil {
+		return i.internalInstance, true
+	}
+
+	return nil, false
 }
 
 func (i *Ingester) getInstances() []*instance {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -301,6 +301,7 @@ func (t *Loki) setupAuthMiddleware() {
 		[]string{
 			"/grpc.health.v1.Health/Check",
 			"/logproto.Ingester/TransferChunks",
+			"/logproto.StreamData/GetStreamRates",
 			"/frontend.Frontend/Process",
 			"/frontend.Frontend/NotifyClientShutdown",
 			"/schedulerpb.SchedulerForFrontend/FrontendLoop",


### PR DESCRIPTION
The `RateStore` concurrently queries all ingester `GetStreamRate` APIs and stores the results. `RateStore` deduplicates replicas and combines sharded streams so a caller of `RateFor` gets an unsharded view of a stream's rate.