### PR TITLE
Loki: Renames metric 'loki_log_messages_total' to 'loki_internal_log_messages_total'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [6349](https://github.com/grafana/loki/pull/6349) **simonswine**: Update the default HTTP listen port from 80 to 3100. Make sure to configure the port explicitly if you are using port 80.
 * [6835](https://github.com/grafana/loki/pull/6835) **DylanGuedes**: Add new per-tenant query timeout configuration and remove engine query timeout.
 * [7212](https://github.com/grafana/loki/pull/7212) **Juneezee**: Replaces deprecated `io/ioutil` with `io` and `os`.
+* [7361](https://github.com/grafana/loki/pull/7361) **szczepad**: Renames metric `loki_log_messages_total` to `loki_internal_log_messages_total`
 
 #### Promtail
 

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -12,10 +12,11 @@ for more information.
 
 All components of Loki expose the following metrics:
 
-| Metric Name                     | Metric Type | Description                              |
-| ------------------------------- | ----------- | ---------------------------------------- |
-| `loki_log_messages_total`       | Counter     | Total number of messages logged by Loki. |
-| `loki_request_duration_seconds` | Histogram   | Number of received HTTP requests.        |
+| Metric Name                        | Metric Type | Description                                                                                                                  |
+| ---------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `loki_log_messages_total`          | Counter     | DEPRECATED. Use internal_log_messages_total for the same functionality. Total number of log messages created by loki itself. |
+| `loki_internal_log_messages_total` | Counter     | Total number of log messages created by loki itself.                                                                         |
+| `loki_request_duration_seconds`    | Histogram   | Number of received HTTP requests.                                                                                            |
 
 The Loki Distributors expose the following metrics:
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -98,6 +98,10 @@ The global `deletion_mode` option in the compactor configuration moved to runtim
 - The `deletion_mode` global override needs to be set to the desired mode: `disabled`, `filter-only`, or `filter-and-delete`. By default, `filter-and-delete` is enabled.
 - Any `allow_delete` per-tenant overrides need to be removed or changed to `deletion_mode` overrides with the desired mode.
 
+#### Metric name for `loki_log_messages_total` changed 
+
+The name of this metric was changed to `loki_internal_log_messages_total` to reduce ambiguity. The previous name is still present but is deprecated.
+
 ### Promtail
 
 #### `gcp_push_target_parsing_errors_total` has a new `reason` label


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames the metric 'loki_log_messages_total' to a more descriptive name. 
Keeps and deprecates the previously existing metric to not break functionality.

**Which issue(s) this PR fixes**:
Fixes #7088 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
