### PR TITLE
area(promtail): add -check-syntax functionality

### DIFF
--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -78,7 +78,7 @@ func main() {
 			fmt.Println("Invalid config file")
 			os.Exit(1)
 		}
-		fmt.Println("Valid config file! no syntax issues found")
+		fmt.Println("Valid config file! No syntax issues found")
 		os.Exit(0)
 	}
 

--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -38,6 +38,7 @@ type Config struct {
 	printConfig     bool
 	logConfig       bool
 	dryRun          bool
+	checkSyntax     bool
 	configFile      string
 	configExpandEnv bool
 	inspect         bool
@@ -49,6 +50,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.logConfig, "log-config-reverse-order", false, "Dump the entire Loki config object at Info log "+
 		"level with the order reversed, reversing the order makes viewing the entries easier in Grafana.")
 	f.BoolVar(&c.dryRun, "dry-run", false, "Start Promtail but print entries instead of sending them to Loki.")
+	f.BoolVar(&c.checkSyntax, "check-syntax", false, "Validate the config file of its syntax")
 	f.BoolVar(&c.inspect, "inspect", false, "Allows for detailed inspection of pipeline stages")
 	f.StringVar(&c.configFile, "config.file", "", "yaml file to load")
 	f.BoolVar(&c.configExpandEnv, "config.expand-env", false, "Expands ${var} in config according to the values of the environment variables.")
@@ -69,6 +71,15 @@ func main() {
 	if err := cfg.DefaultUnmarshal(&config, os.Args[1:], flag.CommandLine); err != nil {
 		fmt.Println("Unable to parse config:", err)
 		os.Exit(1)
+	}
+
+	if config.checkSyntax {
+		if config.configFile == "" {
+			fmt.Println("Invalid config file")
+			os.Exit(1)
+		}
+		fmt.Println("Valid config file! no syntax issues found")
+		os.Exit(0)
 	}
 
 	// Handle -version CLI flag

--- a/docs/sources/clients/promtail/troubleshooting.md
+++ b/docs/sources/clients/promtail/troubleshooting.md
@@ -19,12 +19,12 @@ To start Promtail in dry run mode use the flag `--dry-run` as shown in the examp
 cat my.log | promtail --stdin --dry-run --client.url http://127.0.0.1:3100/loki/api/v1/push
 ```
 
-## Inspecting config file
+## Inspecting a config file
 
 Promtail can validate and syntatically check your `config` file for a valid configuration.
-This can be used to check for errors and inconsistency in your config file and help prevent deploy invalid configurations.
+This can be used to check for errors and inconsistency in your config file and help prevent deploying invalid configurations.
 
-In check syntax mode, promtail will just validate the config file and then exit
+In check syntax mode, promtail will just validate the config file and then exit:
 
 ```bash
 promtail -config.file=myConfigFile.yaml -check-syntax

--- a/docs/sources/clients/promtail/troubleshooting.md
+++ b/docs/sources/clients/promtail/troubleshooting.md
@@ -19,6 +19,17 @@ To start Promtail in dry run mode use the flag `--dry-run` as shown in the examp
 cat my.log | promtail --stdin --dry-run --client.url http://127.0.0.1:3100/loki/api/v1/push
 ```
 
+## Inspecting config file
+
+Promtail can validate and syntatically check your `config` file for a valid configuration.
+This can be used to check for errors and inconsistency in your config file and help prevent deploy invalid configurations.
+
+In check syntax mode, promtail will just validate the config file and then exit
+
+```bash
+promtail -config.file=myConfigFile.yaml -check-syntax
+```
+
 ## Inspecting pipeline stages
 
 Promtail can output all changes to log entries as each pipeline stage is executed.


### PR DESCRIPTION
Signed-off-by: Hemanth Krishna <hkpdev008@gmail.com>

**What this PR does / why we need it**:

Adds `-check-syntax` to promtail which will exit just by validating the
config file

**Which issue(s) this PR fixes**:
- Fixes #6862 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
