### PR TITLE
lock boltdb and tsdb index while queries are in process

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -178,7 +178,11 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	if err := t.indexMtx.rLock(ctx); err != nil {
 		return err
 	}
-	defer t.indexMtx.rUnlock()
+
+	go func() {
+		<-ctx.Done()
+		t.indexMtx.rUnlock()
+	}()
 
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,7 +40,10 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			return indexSet.ForEach(context.Background(), callbackFunc)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 		stopFunc()
 	}
@@ -85,7 +88,10 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				return indexSet.ForEach(context.Background(), callbackFunc)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				return indexSet.ForEach(ctx, callbackFunc)
 			})
 		})
 	}
@@ -104,7 +110,10 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			return indexSet.ForEach(context.Background(), callbackFunc)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,7 +87,10 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 			})
 		}
 	}
@@ -376,7 +379,10 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+
+					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 				})
 			}
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -313,10 +313,13 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table has expected indexes setup
 	var indexesFound []string
-	err := table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -334,10 +337,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -376,10 +381,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -410,7 +417,10 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		return table.ForEach(context.Background(), userID, callbackFunc)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -431,7 +441,10 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		return table.ForEach(context.Background(), userID, callbackFunc)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -48,6 +48,8 @@ type IndexShipper interface {
 	// ForEach lets us iterates through each index file in a table for a specific user.
 	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
 	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
+	// Note: The index files would be locked until the passed ctx is cancelled to avoid making any changes to the index
+	// while it is being queried.
 	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 	Stop()
 }
@@ -175,7 +177,7 @@ func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, ca
 	}
 
 	if s.uploadsManager != nil {
-		if err := s.uploadsManager.ForEach(tableName, userID, callback); err != nil {
+		if err := s.uploadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,7 +36,10 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			err = indexSet.ForEach(func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
@@ -107,10 +110,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			err = idxSet.ForEach(func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
+			cancel()
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -131,10 +136,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			err = idxSet.ForEach(func(_ bool, index index.Index) error {
+			ctx, cancel = context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
+			cancel()
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -20,7 +20,7 @@ const (
 type Table interface {
 	Name() string
 	AddIndex(userID string, idx index.Index) error
-	ForEach(userID string, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
 	Stop()
@@ -78,9 +78,13 @@ func (lt *table) AddIndex(userID string, idx index.Index) error {
 }
 
 // ForEach iterates over all the indexes belonging to the user.
-func (lt *table) ForEach(userID string, callback index.ForEachIndexCallback) error {
+func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	lt.indexSetMtx.RLock()
-	defer lt.indexSetMtx.RUnlock()
+
+	go func() {
+		<-ctx.Done()
+		lt.indexSetMtx.RUnlock()
+	}()
 
 	// TODO(owen-d): refactor? Uploads mgr never has user indices,
 	// only common (multitenant) ones.
@@ -91,7 +95,7 @@ func (lt *table) ForEach(userID string, callback index.ForEachIndexCallback) err
 			continue
 		}
 
-		if err := idxSet.ForEach(callback); err != nil {
+		if err := idxSet.ForEach(ctx, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(tableName, userID string, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(tableName, userID string, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(userID, callback)
+	return table.ForEach(ctx, userID, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -1,6 +1,7 @@
 package uploads
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -64,10 +65,12 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					err := testTableManager.ForEach(tableName, userID, func(_ bool, index index.Index) error {
+					ctx, cancel := context.WithCancel(context.Background())
+					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
+					cancel()
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -1,6 +1,7 @@
 package uploads
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -35,10 +36,13 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			err := testTable.ForEach(userID, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
+			cancel()
+
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,6 +40,9 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
 	for table, queries := range queriesByTable {

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -84,6 +84,9 @@ func (i *indexShipperQuerier) Close() error {
 }
 
 func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -92,6 +95,9 @@ func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, f
 }
 
 func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -100,6 +106,9 @@ func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, t
 }
 
 func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -108,6 +117,9 @@ func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, fro
 }
 
 func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -116,6 +128,9 @@ func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, fr
 }
 
 func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
We noticed ingesters and index-gateways panicking when using `tsdb` as an index store with the latest build. This is caused by closing `mmap` while the index queries are still being processed. This PR takes care of it by locking the index until we are done querying the index.

**Checklist**
- [x] Tests updated