### PR TITLE
Measure Per-Stream rates

### DIFF
--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -3,6 +3,8 @@ package distributor
 import (
 	"time"
 
+	"github.com/grafana/loki/pkg/validation"
+
 	"github.com/grafana/loki/pkg/distributor/shardstreams"
 )
 
@@ -22,4 +24,5 @@ type Limits interface {
 	IncrementDuplicateTimestamps(userID string) bool
 
 	ShardStreams(userID string) *shardstreams.Config
+	AllByUserID() map[string]*validation.Limits
 }

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -177,6 +177,7 @@ func (c *fakeStreamDataClient) GetStreamRates(ctx context.Context, in *logproto.
 }
 
 type fakeOverrides struct {
+	Limits
 	enabled bool
 }
 
@@ -187,6 +188,12 @@ func (c *fakeOverrides) AllByUserID() map[string]*validation.Limits {
 				Enabled: c.enabled,
 			},
 		},
+	}
+}
+
+func (c *fakeOverrides) ShardStreams(_ string) *shardstreams.Config {
+	return &shardstreams.Config{
+		Enabled: c.enabled,
 	}
 }
 
@@ -204,6 +211,6 @@ func setup(enabled bool) *testContext {
 	return &testContext{
 		ring:       ring,
 		clientPool: cp,
-		rateStore:  NewRateStore(cfg, ring, cp, &fakeOverrides{enabled}, nil),
+		rateStore:  NewRateStore(cfg, ring, cp, &fakeOverrides{enabled: enabled}, nil),
 	}
 }

--- a/pkg/ingester/checkpoint_test.go
+++ b/pkg/ingester/checkpoint_test.go
@@ -449,7 +449,7 @@ func Test_SeriesIterator(t *testing.T) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := 0; i < 3; i++ {
-		inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+		inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, fmt.Sprintf("%d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil, NewStreamRateCalculator())
 		require.Nil(t, err)
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream1}}))
 		require.NoError(t, inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{stream2}}))
@@ -496,7 +496,7 @@ func Benchmark_SeriesIterator(b *testing.B) {
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
 	for i := range instances {
-		inst, _ := newInstance(defaultConfig(), defaultPeriodConfigs, fmt.Sprintf("instance %d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil)
+		inst, _ := newInstance(defaultConfig(), defaultPeriodConfigs, fmt.Sprintf("instance %d", i), limiter, runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, nil, nil, NewStreamRateCalculator())
 
 		require.NoError(b,
 			inst.Push(context.Background(), &logproto.PushRequest{

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -47,8 +47,7 @@ import (
 
 const (
 	// RingKey is the key under which we store the ingesters ring in the KVStore.
-	RingKey            = "ring"
-	internalInstanceID = "internal"
+	RingKey = "ring"
 )
 
 // ErrReadOnly is returned when the ingester is shutting down and a push was
@@ -193,11 +192,10 @@ type Ingester struct {
 	clientConfig  client.Config
 	tenantConfigs *runtime.TenantConfigs
 
-	shutdownMtx      sync.Mutex // Allows processes to grab a lock and prevent a shutdown
-	instancesMtx     sync.RWMutex
-	instances        map[string]*instance
-	internalInstance *instance // used for non-user communication from the distributors
-	readonly         bool
+	shutdownMtx  sync.Mutex // Allows processes to grab a lock and prevent a shutdown
+	instancesMtx sync.RWMutex
+	instances    map[string]*instance
+	readonly     bool
 
 	lifecycler        *ring.Lifecycler
 	lifecyclerWatcher *services.FailureWatcher
@@ -232,6 +230,8 @@ type Ingester struct {
 	wal WAL
 
 	chunkFilter chunk.RequestChunkFilterer
+
+	streamRateCalculator *StreamRateCalculator
 }
 
 // New makes a new Ingester.
@@ -260,6 +260,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits *valid
 		metrics:               metrics,
 		flushOnShutdownSwitch: &OnceSwitch{},
 		terminateOnShutdown:   false,
+		streamRateCalculator:  NewStreamRateCalculator(),
 	}
 	i.replayController = newReplayController(metrics, cfg.WAL, &replayFlusher{i})
 
@@ -521,6 +522,8 @@ func (i *Ingester) stopping(_ error) error {
 	}
 	i.flushQueuesDone.Wait()
 
+	i.streamRateCalculator.Stop()
+
 	// In case the flag to terminate on shutdown is set we need to mark the
 	// ingester service as "failed", so Loki will shut down entirely.
 	// The module manager logs the failure `modules.ErrStopProcess` in a special way.
@@ -625,12 +628,14 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 // GetStreamRates returns a response containing all streams and their current rate
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
 func (i *Ingester) GetStreamRates(ctx context.Context, req *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
-	instance, err := i.getOrCreateInternalInstance()
-	if err != nil {
-		return &logproto.StreamRatesResponse{}, err
+	instances := i.getInstances()
+
+	var rates []*logproto.StreamRate
+	for _, inst := range instances {
+		rates = append(rates, inst.GetStreamRates(ctx, req)...)
 	}
 
-	return instance.GetStreamRates(ctx, req)
+	return &logproto.StreamRatesResponse{StreamRates: rates}, nil
 }
 
 func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { //nolint:revive
@@ -644,7 +649,7 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 	inst, ok = i.instances[instanceID]
 	if !ok {
 		var err error
-		inst, err = newInstance(&i.cfg, i.periodicConfigs, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
+		inst, err = newInstance(&i.cfg, i.periodicConfigs, instanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter, i.streamRateCalculator)
 		if err != nil {
 			return nil, err
 		}
@@ -652,25 +657,6 @@ func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { /
 		activeTenantsStats.Set(int64(len(i.instances)))
 	}
 	return inst, nil
-}
-
-func (i *Ingester) getOrCreateInternalInstance() (*instance, error) { //nolint:revive
-	if inst, ok := i.getInternalInstance(); ok {
-		return inst, nil
-	}
-
-	i.instancesMtx.Lock()
-	defer i.instancesMtx.Unlock()
-
-	if i.internalInstance == nil {
-		inst, err := newInstance(&i.cfg, i.periodicConfigs, internalInstanceID, i.limiter, i.tenantConfigs, i.wal, i.metrics, i.flushOnShutdownSwitch, i.chunkFilter)
-		if err != nil {
-			return nil, err
-		}
-		i.internalInstance = inst
-	}
-
-	return i.internalInstance, nil
 }
 
 // Query the ingests for log streams matching a set of matchers.
@@ -967,17 +953,6 @@ func (i *Ingester) getInstanceByID(id string) (*instance, bool) {
 
 	inst, ok := i.instances[id]
 	return inst, ok
-}
-
-func (i *Ingester) getInternalInstance() (*instance, bool) {
-	i.instancesMtx.RLock()
-	defer i.instancesMtx.RUnlock()
-
-	if i.internalInstance != nil {
-		return i.internalInstance, true
-	}
-
-	return nil, false
 }
 
 func (i *Ingester) getInstances() []*instance {

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -1,0 +1,89 @@
+package ingester
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// defaultStripeSize is the default number of entries to allocate in the
+	// stripeSeries list.
+	defaultStripeSize = 1 << 15
+
+	// The intent is for a per-second rate so this is hard coded
+	updateInterval = time.Second
+)
+
+// stripeLock is taken from ruler/storage/wal/series.go
+type stripeLock struct {
+	sync.RWMutex
+	// Padding to avoid multiple locks being on the same cache line.
+	_ [40]byte
+}
+
+type StreamRateCalculator struct {
+	size     int
+	samples  []int64
+	rates    []int64
+	locks    []stripeLock
+	stopchan chan struct{}
+}
+
+func NewStreamRateCalculator() *StreamRateCalculator {
+	calc := &StreamRateCalculator{
+		size:     defaultStripeSize,
+		samples:  make([]int64, defaultStripeSize),
+		rates:    make([]int64, defaultStripeSize),
+		locks:    make([]stripeLock, defaultStripeSize),
+		stopchan: make(chan struct{}),
+	}
+
+	go calc.updateLoop()
+
+	return calc
+}
+
+func (c *StreamRateCalculator) updateLoop() {
+	t := time.NewTicker(updateInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			c.updateRates()
+		case <-c.stopchan:
+			return
+		}
+	}
+}
+
+func (c *StreamRateCalculator) updateRates() {
+	for i := 0; i < c.size; i++ {
+		c.locks[i].Lock()
+		c.rates[i] = c.samples[i]
+		c.samples[i] = 0
+		c.locks[i].Unlock()
+	}
+}
+
+func (c *StreamRateCalculator) RateFor(streamHash uint64) int64 {
+	i := streamHash & uint64(c.size-1)
+
+	c.locks[i].RLock()
+	defer c.locks[i].RUnlock()
+
+	return c.rates[i]
+}
+
+func (c *StreamRateCalculator) Record(streamHash uint64, bytes int64) {
+	i := streamHash & uint64(c.size-1)
+
+	c.locks[i].Lock()
+	defer c.locks[i].Unlock()
+
+	c.samples[i] += bytes
+}
+
+func (c *StreamRateCalculator) Stop() {
+	close(c.stopchan)
+}

--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -1,0 +1,25 @@
+package ingester
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamRateCalculator(t *testing.T) {
+	calc := NewStreamRateCalculator()
+	defer calc.Stop()
+
+	for i := 0; i < 100; i++ {
+		calc.Record(0, 100)
+	}
+
+	require.Eventually(t, func() bool {
+		return calc.RateFor(0) == 10000
+	}, 2*time.Second, 250*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return calc.RateFor(0) == 0
+	}, 2*time.Second, 250*time.Millisecond)
+}

--- a/pkg/ingester/stream_test.go
+++ b/pkg/ingester/stream_test.go
@@ -61,6 +61,7 @@ func TestMaxReturnedStreamsErrors(t *testing.T) {
 					{Name: "foo", Value: "bar"},
 				},
 				true,
+				NewStreamRateCalculator(),
 				NilMetrics,
 			)
 
@@ -107,6 +108,7 @@ func TestPushDeduplication(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -136,6 +138,7 @@ func TestPushRejectOldCounter(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -230,6 +233,7 @@ func TestUnorderedPush(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -326,6 +330,7 @@ func TestPushRateLimit(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -359,6 +364,7 @@ func TestPushRateLimitAllOrNothing(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -391,6 +397,7 @@ func TestReplayAppendIgnoresValidityWindow(t *testing.T) {
 			{Name: "foo", Value: "bar"},
 		},
 		true,
+		NewStreamRateCalculator(),
 		NilMetrics,
 	)
 
@@ -441,7 +448,7 @@ func Benchmark_PushStream(b *testing.B) {
 	require.NoError(b, err)
 	limiter := NewLimiter(limits, NilMetrics, &ringCountMock{count: 1}, 1)
 
-	s := newStream(&Config{MaxChunkAge: 24 * time.Hour}, limiter, "fake", model.Fingerprint(0), ls, true, NilMetrics)
+	s := newStream(&Config{MaxChunkAge: 24 * time.Hour}, limiter, "fake", model.Fingerprint(0), ls, true, NewStreamRateCalculator(), NilMetrics)
 	t, err := newTailer("foo", `{namespace="loki-dev"}`, &fakeTailServer{}, 10)
 	require.NoError(b, err)
 

--- a/pkg/ingester/streams_map_test.go
+++ b/pkg/ingester/streams_map_test.go
@@ -25,6 +25,7 @@ func TestStreamsMap(t *testing.T) {
 				{Name: "foo", Value: "bar"},
 			},
 			true,
+			NewStreamRateCalculator(),
 			NilMetrics,
 		),
 		newStream(
@@ -36,6 +37,7 @@ func TestStreamsMap(t *testing.T) {
 				{Name: "bar", Value: "foo"},
 			},
 			true,
+			NewStreamRateCalculator(),
 			NilMetrics,
 		),
 	}


### PR DESCRIPTION
This PR implements the ability for ingesters to measure per-stream rates at 1/s resolution.

It also fixes bugs in the kind of Limits used in the RateStore and the Ingester API
