### PR TITLE
use a channel to signal completion of index read operation for tsdb and boltdb shipper

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,10 +40,10 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			doneChan := make(chan struct{})
+			defer close(doneChan)
 
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
 		})
 		stopFunc()
 	}
@@ -88,10 +88,10 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				doneChan := make(chan struct{})
+				defer close(doneChan)
 
-				return indexSet.ForEach(ctx, callbackFunc)
+				return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
 			})
 		})
 	}
@@ -110,10 +110,10 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			doneChan := make(chan struct{})
+			defer close(doneChan)
 
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -28,7 +28,7 @@ const (
 
 type Table interface {
 	Close()
-	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
 	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
 	Sync(ctx context.Context) error
 	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
@@ -144,7 +144,7 @@ func (t *table) Close() {
 	t.indexSets = map[string]IndexSet{}
 }
 
-func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	// iterate through both user and common index
 	for _, uid := range []string{userID, ""} {
 		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
@@ -157,7 +157,7 @@ func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEa
 			return indexSet.Err()
 		}
 
-		err = indexSet.ForEach(ctx, callback)
+		err = indexSet.ForEach(ctx, doneChan, callback)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -42,7 +42,7 @@ type IndexGatewayOwnsTenant func(tenant string) bool
 
 type TableManager interface {
 	Stop()
-	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
 }
 
 type Config struct {
@@ -155,12 +155,12 @@ func (tm *tableManager) Stop() {
 	}
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	table, err := tm.getOrCreateTable(tableName)
 	if err != nil {
 		return err
 	}
-	return table.ForEach(ctx, userID, callback)
+	return table.ForEach(ctx, userID, doneChan, callback)
 }
 
 func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,10 +87,10 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				doneChan := make(chan struct{})
+				defer close(doneChan)
 
-				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+				return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
 			})
 		}
 	}
@@ -379,10 +379,10 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
+					doneChan := make(chan struct{})
+					defer close(doneChan)
 
-					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+					return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
 				})
 			}
 		}
@@ -455,7 +455,7 @@ type mockTable struct {
 	queryReadinessDoneForUsers []string
 }
 
-func (m *mockTable) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+func (m *mockTable) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	return nil
 }
 

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -81,7 +81,7 @@ type mockIndexSet struct {
 	lastUsedAt  time.Time
 }
 
-func (m *mockIndexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+func (m *mockIndexSet) ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	for _, idx := range m.indexes {
 		if err := callback(false, idx); err != nil {
 			return err
@@ -147,11 +147,13 @@ func TestTable_ForEach(t *testing.T) {
 			}
 
 			var indexesFound []index.Index
-
-			err := table.ForEach(context.Background(), tc.withUserID, func(_ bool, idx index.Index) error {
+			doneChan := make(chan struct{})
+			err := table.ForEach(context.Background(), tc.withUserID, doneChan, func(_ bool, idx index.Index) error {
 				indexesFound = append(indexesFound, idx)
 				return nil
 			})
+			close(doneChan)
+
 			if tc.withError {
 				require.Error(t, err)
 				require.Len(t, table.indexSets, len(usersToSetup))
@@ -314,12 +316,12 @@ func TestTable_Sync(t *testing.T) {
 	// check that table has expected indexes setup
 	var indexesFound []string
 
-	ctx, cancel := context.WithCancel(context.Background())
-	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	doneChan := make(chan struct{})
+	err := table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
+	close(doneChan)
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -337,12 +339,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	doneChan = make(chan struct{})
+	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
+	close(doneChan)
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -381,12 +383,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	doneChan = make(chan struct{})
+	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
+	close(doneChan)
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -417,10 +419,10 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		doneChan := make(chan struct{})
+		defer close(doneChan)
 
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -441,10 +443,10 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		doneChan := make(chan struct{})
+		defer close(doneChan)
 
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -21,7 +21,7 @@ type IndexSet interface {
 	Add(idx index.Index)
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
-	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
 	Close()
 }
 
@@ -65,11 +65,11 @@ func (t *indexSet) Add(idx index.Index) {
 	t.index[idx.Name()] = idx
 }
 
-func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(_ context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	t.indexMtx.RLock()
 
 	go func() {
-		<-ctx.Done()
+		<-doneChan
 		t.indexMtx.RUnlock()
 	}()
 

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,13 +36,12 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			doneChan := make(chan struct{})
+			err = indexSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
+			close(doneChan)
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -110,12 +109,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			doneChan := make(chan struct{})
+			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
+			close(doneChan)
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -136,12 +135,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			ctx, cancel = context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			doneChan = make(chan struct{})
+			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
+			close(doneChan)
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(ctx, userID, callback)
+	return table.ForEach(ctx, userID, doneChan, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -65,12 +65,12 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					ctx, cancel := context.WithCancel(context.Background())
-					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
+					doneChan := make(chan struct{})
+					err := testTableManager.ForEach(context.Background(), tableName, userID, doneChan, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
-					cancel()
+					close(doneChan)
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -36,12 +36,12 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
+			doneChan := make(chan struct{})
+			err := testTable.ForEach(context.Background(), userID, doneChan, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
+			close(doneChan)
 
 			require.NoError(t, err)
 

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,8 +40,8 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
@@ -57,7 +57,7 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 				}
 			}
 
-			return q.indexShipper.ForEach(ctx, table, userID, func(_ bool, idx shipper_index.Index) error {
+			return q.indexShipper.ForEach(ctx, table, userID, doneChan, func(_ bool, idx shipper_index.Index) error {
 				boltdbIndexFile, ok := idx.(*indexfile.IndexFile)
 				if !ok {
 					return fmt.Errorf("unexpected index type %T", idx)

--- a/pkg/storage/stores/shipper/index/table_manager.go
+++ b/pkg/storage/stores/shipper/index/table_manager.go
@@ -44,7 +44,7 @@ type TableManager struct {
 
 type Shipper interface {
 	AddIndex(tableName, userID string, index shipper_index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback shipper_index.ForEachIndexCallback) error
 }
 
 func NewTableManager(cfg Config, indexShipper Shipper, registerer prometheus.Registerer) (*TableManager, error) {

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -15,7 +15,7 @@ import (
 )
 
 type indexShipperIterator interface {
-	ForEach(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback shipper_index.ForEachIndexCallback) error
 }
 
 // indexShipperQuerier is used for querying index from the shipper.
@@ -29,13 +29,13 @@ func newIndexShipperQuerier(shipper indexShipperIterator, tableRanges config.Tab
 	return &indexShipperQuerier{shipper: shipper, tableRanges: tableRanges}
 }
 
-func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.Time, user string) (Index, error) {
+func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.Time, user string, doneChan <-chan struct{}) (Index, error) {
 	var indices []Index
 
 	// Ensure we query both per tenant and multitenant TSDBs
 	idxBuckets := indexBuckets(from, through, i.tableRanges)
 	for _, bkt := range idxBuckets {
-		if err := i.shipper.ForEach(ctx, bkt, user, func(multitenant bool, idx shipper_index.Index) error {
+		if err := i.shipper.ForEach(ctx, bkt, user, doneChan, func(multitenant bool, idx shipper_index.Index) error {
 			impl, ok := idx.(Index)
 			if !ok {
 				return fmt.Errorf("unexpected shipper index type: %T", idx)
@@ -84,10 +84,10 @@ func (i *indexShipperQuerier) Close() error {
 }
 
 func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
-	idx, err := i.indices(ctx, from, through, userID)
+	idx, err := i.indices(ctx, from, through, userID, doneChan)
 	if err != nil {
 		return nil, err
 	}
@@ -95,10 +95,10 @@ func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, f
 }
 
 func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
-	idx, err := i.indices(ctx, from, through, userID)
+	idx, err := i.indices(ctx, from, through, userID, doneChan)
 	if err != nil {
 		return nil, err
 	}
@@ -106,10 +106,10 @@ func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, t
 }
 
 func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
-	idx, err := i.indices(ctx, from, through, userID)
+	idx, err := i.indices(ctx, from, through, userID, doneChan)
 	if err != nil {
 		return nil, err
 	}
@@ -117,10 +117,10 @@ func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, fro
 }
 
 func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
-	idx, err := i.indices(ctx, from, through, userID)
+	idx, err := i.indices(ctx, from, through, userID, doneChan)
 	if err != nil {
 		return nil, err
 	}
@@ -128,10 +128,10 @@ func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, fr
 }
 
 func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	doneChan := make(chan struct{})
+	defer close(doneChan)
 
-	idx, err := i.indices(ctx, from, through, userID)
+	idx, err := i.indices(ctx, from, through, userID, doneChan)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR #7367, I was relying on cancellation of context to detect if the index read operation has finished or not, but it is error prone since a cancelled or timed-out query could cancel the context while we are still reading the index. Since `tsdb` doesn't can't check the context for each read operation, we could still panic in this scenario. I am adding a channel where the consumer of the index would explicitly signal the completion of the read operation to the `indexshipper`

**Checklist**
- [x] Tests updated