### PR TITLE
Fix stream sharding

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -134,6 +134,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
@@ -159,6 +160,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 0), Line: "heyiiiiiii"},
@@ -184,6 +186,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
@@ -209,6 +212,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123457, 0), Line: "heyiiiiiii"},
@@ -234,6 +238,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 1), Line: "heyiiiiiii"},
@@ -259,6 +264,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
@@ -285,6 +291,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 1), Line: "hi"},
@@ -312,6 +319,7 @@ func Test_IncrementTimestamp(t *testing.T) {
 				Streams: []logproto.Stream{
 					{
 						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
 						Entries: []logproto.Entry{
 							{Timestamp: time.Unix(123456, 0), Line: "heyooooooo"},
 							{Timestamp: time.Unix(123456, 1), Line: "hi"},
@@ -693,6 +701,7 @@ func TestStreamShard(t *testing.T) {
 				rateStore:              &fakeRateStore{},
 				streamShardingFailures: shardingFailureMetric,
 				validator:              validator,
+				streamShardCount:       prometheus.NewCounter(prometheus.CounterOpts{}),
 			}
 
 			_, derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake")
@@ -792,7 +801,7 @@ func Benchmark_SortLabelsOnPush(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		stream := request.Streams[0]
 		stream.Labels = `{buzz="f", a="b"}`
-		_, err := d.parseStreamLabels(vCtx, stream.Labels, &stream)
+		_, _, err := d.parseStreamLabels(vCtx, stream.Labels, &stream)
 		if err != nil {
 			panic("parseStreamLabels fail,err:" + err.Error())
 		}

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -124,19 +124,17 @@ func (s *rateStore) aggregateByShard(streamRates map[uint64]*logproto.StreamRate
 	shardCount := make(map[uint64]int)
 	rates := make(map[uint64]int64)
 	for _, sr := range streamRates {
+		shardCount[sr.StreamHashNoShard]++
+
 		if _, ok := rates[sr.StreamHashNoShard]; ok {
 			rates[sr.StreamHashNoShard] += sr.Rate
-
 			maxRate = max(rates[sr.StreamHashNoShard], maxRate)
-			shardCount[sr.StreamHashNoShard]++
 
 			continue
 		}
 
 		rates[sr.StreamHashNoShard] = sr.Rate
-
 		maxRate = max(rates[sr.StreamHashNoShard], maxRate)
-		shardCount[sr.StreamHashNoShard]++
 	}
 
 	var maxShards int64
@@ -169,7 +167,7 @@ func (s *rateStore) getRates(ctx context.Context, clients []ingesterClient) map[
 	}
 	close(parallelClients)
 
-	return ratesPerStream(responses, len(clients))
+	return s.ratesPerStream(responses, len(clients))
 }
 
 func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan ingesterClient, responses chan *logproto.StreamRatesResponse) {
@@ -187,7 +185,8 @@ func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan inge
 	}
 }
 
-func ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) map[uint64]*logproto.StreamRate {
+func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) map[uint64]*logproto.StreamRate {
+	var maxRate int64
 	streamRates := make(map[uint64]*logproto.StreamRate)
 	for i := 0; i < totalResponses; i++ {
 		resp := <-responses
@@ -197,6 +196,7 @@ func ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses
 
 		for j := 0; j < len(resp.StreamRates); j++ {
 			rate := resp.StreamRates[j]
+			maxRate = max(maxRate, rate.Rate)
 
 			if r, ok := streamRates[rate.StreamHash]; ok {
 				if r.Rate < rate.Rate {
@@ -209,6 +209,7 @@ func ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses
 		}
 	}
 
+	s.metrics.maxUniqueStreamRate.Add(float64(maxRate))
 	return streamRates
 }
 

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -209,7 +209,7 @@ func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse,
 		}
 	}
 
-	s.metrics.maxUniqueStreamRate.Add(float64(maxRate))
+	s.metrics.maxUniqueStreamRate.Set(float64(maxRate))
 	return streamRates
 }
 

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -11,6 +11,7 @@ type ratestoreMetrics struct {
 	streamCount         prometheus.Gauge
 	maxStreamShardCount prometheus.Gauge
 	maxStreamRate       prometheus.Gauge
+	maxUniqueStreamRate prometheus.Gauge
 	refreshDuration     *instrument.HistogramCollector
 }
 
@@ -35,6 +36,11 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Namespace: "loki",
 			Name:      "rate_store_max_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
+		}),
+		maxUniqueStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Name:      "rate_store_max_unique_stream_rate_bytes",
+			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered seperate.",
 		}),
 		refreshDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -40,7 +40,7 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 		maxUniqueStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_unique_stream_rate_bytes",
-			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered seperate.",
+			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered separate.",
 		}),
 		refreshDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(


### PR DESCRIPTION
Promtail doesn't add a stream hash to push requests. As a result, we weren't accounting for the current rate in our sharding calculation and only sharding on individual large pushes. 

This PR ensures that streams have a hash as they're ingested. It also add a couple of metrics that were useful in debugging this issue.
