### PR TITLE
fluentd: Add un-escaping of control characters in JSON

### DIFF
--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -278,6 +278,7 @@ module Fluent
           case @line_format
           when :json
             line = Yajl.dump(record)
+            line = line.gsub("\\n", "\n").gsub("\\r", "\r").gsub("\\s", "\s").gsub("\\t", "\t")
           when :key_value
             formatted_labels = []
             record.each do |k, v|


### PR DESCRIPTION
**What this PR does / why we need it**:

Like mentioned in https://github.com/grafana/loki/issues/5010 we also want to use line_format json but noticed that newlines in the message text would be escaped. This change will un-escape double-escaped control characters (applies for \n, \r, \s, \t) e.g. newline characters "\\\n" by "\n" in the record.

This will fix e.g. newline errors when parsing the JSON message later (for example Grafana Dashboard, which shows newline errors otherwise).

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/5010

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`