### PR TITLE
Create automated SBOM reports on Release

### DIFF
--- a/.github/workflows/syft-sbom-ci
+++ b/.github/workflows/syft-sbom-ci
@@ -1,0 +1,20 @@
+name: syft-sbom-ci
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  syft-sbom:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+        
+    - name: Anchore SBOM Action
+      uses: anchore/sbom-action@v0.12.0
+      with:
+         artifact-name: ${{ github.event.repository.name }}-spdx.json
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a GitHub action to automatically build an SPDX SBOM report when a release is created. This action will automatically attach an SPDX JSON report to the release assets. 

We've implemented this in OSS Grafana, see here for an example. 

https://github.com/grafana/grafana/actions/workflows/sbom-report.yml

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
@dannykopping This might be of interest to you 👍 


**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
