### PR TITLE
Fix promtail scrape config job name validation

### DIFF
--- a/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
@@ -69,7 +69,7 @@ func validateJobName(scrapeConfigs []scrapeconfig.Config) error {
 		}
 		jobNames[cfg.JobName] = struct{}{}
 
-		scrapeConfigs[i].JobName = strutil.SanitizeLabelName(cfg.JobName);
+		scrapeConfigs[i].JobName = strutil.SanitizeLabelName(cfg.JobName)
 	}
 	return nil
 }

--- a/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtargetmanager.go
@@ -3,11 +3,11 @@ package lokipush
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/util/strutil"
 
 	"github.com/grafana/loki/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/clients/pkg/promtail/api"
@@ -69,7 +69,7 @@ func validateJobName(scrapeConfigs []scrapeconfig.Config) error {
 		}
 		jobNames[cfg.JobName] = struct{}{}
 
-		scrapeConfigs[i].JobName = strings.Replace(cfg.JobName, " ", "_", -1)
+		scrapeConfigs[i].JobName = strutil.SanitizeLabelName(cfg.JobName);
 	}
 	return nil
 }

--- a/clients/pkg/promtail/targets/lokipush/pushtargetmanager_test.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtargetmanager_test.go
@@ -58,6 +58,19 @@ func Test_validateJobName(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "validate with special characters",
+			configs: []scrapeconfig.Config{
+				{
+					JobName: "job$1-2!3@4*job",
+					PushConfig: &scrapeconfig.PushTargetConfig{
+						Server: server.Config{},
+					},
+				},
+			},
+			wantErr: false,
+			expectedJob: "job_1_2_3_4_job",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The current promtail scrapeConfig jobName validation only sanitizes empty spaces. If special characters are introduced it causes a panic. The implemented fix uses the label sanitzer in the strutil package.
 

**Which issue(s) this PR fixes**:
Fixes #7275


**Special notes for your reviewer**:
Not sure if I described things correctly in the PR title, I'm very new to Loki in general.
 
**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
