### PR TITLE
[promtail] log:   simplify log, only print hash

### DIFF
--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -119,7 +120,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 		return errConfigNotChange
 	}
 	newConf := cfg.String()
-	level.Info(p.logger).Log("msg", "Reloading configuration file", "newConf", newConf)
+	level.Info(p.logger).Log("msg", "Reloading configuration file", "newConf hash", xxhash.Sum64String(newConf))
 	if p.targetManagers != nil {
 		p.targetManagers.Stop()
 	}

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -1,6 +1,7 @@
 package promtail
 
 import (
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -120,7 +120,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 		return errConfigNotChange
 	}
 	newConf := cfg.String()
-	level.Info(p.logger).Log("msg", "Reloading configuration file", "newConf hash", xxhash.Sum64String(newConf))
+	level.Info(p.logger).Log("msg", "Reloading configuration file", "newConf.hash", md5.New().Sum([]byte(newConf)))
 	if p.targetManagers != nil {
 		p.targetManagers.Stop()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When promtail reload config.yaml, simplify log print, only print hash.

Hash function Use the same hash function as prometheus.
/github.com/prometheus/prometheus/model/labels/labels.go
```go
import  "github.com/cespare/xxhash/v2"

func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
	...
	return xxhash.Sum64(b), b
}

```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
`level=info ts=2022-10-12T14:40:05.323235834Z caller=promtail.go:122 msg="Reloading configuration file" newConf="server:\n  http_listen_network: tcp\n  http_listen_address: \"\"\n  http_listen_port: 9082\n  http_listen_conn_limit: 0\n  grpc_listen_network: tcp\n  grpc_listen_address: \"\"\n  grpc_listen_port: 0\n  grpc_listen_conn_limit: 0\n  tls_cipher_suites: \"\"\n  tls_min_version: \"\"\n  http_tls_config:\n    cert_file: \"\"\n    key_file: \"\"\n    client_auth_type: \"\"\n    client_ca_file: \"\"\n  grpc_tls_config:\n    cert_file: \"\"\n    key_file: \"\"\n    client_auth_type: \"\"\n    client_ca_file: \"\"\n  register_instrumentation: true\n  graceful_shutdown_timeout: 30s\n  http_server_read_timeout: 30s\n  http_server_write_timeout: 30s\n  http_server_idle_timeout: 2m0s\n  grpc_server_max_recv_msg_size: 4194304\n  grpc_server_max_send_msg_size: 4194304\n  grpc_server_max_concurrent_streams: 100\n  grpc_server_max_connection_idle: 2562047h47m16.854775807s\n  grpc_server_max_connection_age: 2562047h47m16.854775807s\n  grpc_server_max_connection_age_grace: 2562047h47m16.854775807s\n  grpc_server_keepalive_time: 2h0m0s\n  grpc_server_keepalive_timeout: 20s\n  grpc_server_min_time_between_pings: 5m0s\n  grpc_server_ping_without_stream_allowed: false\n  log_format: logfmt\n  log_level: info\n  log_source_ips_enabled: false\n  log_source_ips_header: \"\"\n  log_source_ips_regex: \"\"\n  log_request_at_info_level_enabled: false\n  http_path_prefix: \"\"\n  external_url: \"\"\n  health_check_target: null\n  disable: false\n  enable_runtime_reload: false\nclient:\n  url: \"\"\n  batchwait: 1s\n  batchsize: 1048576\n  follow_redirects: false\n  enable_http2: false\n  backoff_config:\n    min_period: 500ms\n    max_period: 5m0s\n    max_retries: 10\n  timeout: 10s\n  tenant_id: \"\"\n  stream_lag_labels: \"\"\nclients:\n- url: http://localhost:3100/loki/api/v1/push\n  batchwait: 1s\n  batchsize: 1048576\n  follow_redirects: false\n  enable_http2: false\n  backoff_config:\n    min_period: 100ms\n    max_period: 10s\n    max_retries: 1000\n  timeout: 10s\n  tenant_id: docker\n  stream_lag_labels: \"\"\npositions:\n  sync_period: 10s\n  filename: /tmp/positions.yaml\n  ignore_invalid_yaml: false\nscrape_configs:\n- job_name: generated-logs\n  pipeline_stages:\n  - json:\n      expressions:\n        datetime: datetime\n        http_method: method\n        http_status: status\n  - labels:\n      ʊmlaʊt: hi\n  static_configs:\n  - targets:\n    - localhost\n    labels:\n      __path__: /tmp/random\n      job: generated-logs\ntarget_config:\n  sync_period: 10s\n  stdin: false\nlimits_config:\n  readline_rate: 10000\n  readline_burst: 10000\n  readline_rate_drop: true\n  max_streams: 0\n"`

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
