### PR TITLE
Remove helm post-install hook for loki-canary ServiceAccount

### DIFF
--- a/production/helm/loki/templates/loki-canary/serviceaccount.yaml
+++ b/production/helm/loki/templates/loki-canary/serviceaccount.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "loki-canary.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
   {{- with .Values.monitoring.selfMonitoring.lokiCanary.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the loki-canary ServiceAccount spec.  I'm applying version 3.2.1 in ArgoCD, but the application syncing never completes because the loki-canary ServiceAccount is missing.  This creates an infinite loop where the loki-canary ServiceAccount is never created because the `helm install` never completes, but `helm install` never completes because the ServiceAccount will be created on completion.

Here is a screenshot of the completed sync on my local branch
![Screen Shot 2022-10-13 at 9 37 04 AM](https://user-images.githubusercontent.com/1929541/195612058-3cb00bb2-dfb7-4b71-95dc-0a754dc1d4cc.png)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
