### PR TITLE
Fix enable of internal server for modules

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -571,23 +571,24 @@ func (t *Loki) setupModuleManager() error {
 	}
 
 	if t.Cfg.InternalServer.Enable {
-		depsToUpdate := []string{Distributor, Ingester, Querier, QueryFrontendTripperware, QueryScheduler, Ruler, TableManager, Compactor, IndexGateway}
-
-		for _, dep := range depsToUpdate {
-			var idx int
-			for i, v := range deps[dep] {
+		for key, ds := range deps {
+			idx := -1
+			for i, v := range ds {
 				if v == Server {
 					idx = i
 					break
 				}
 			}
 
-			lhs := deps[dep][0 : idx+1]
-			rhs := deps[dep][idx+2:]
+			if idx == -1 {
+				continue
+			}
 
-			deps[dep] = append(lhs, InternalServer)
-			deps[dep] = append(deps[dep], rhs...)
+			a := append(ds[:idx+1], ds[idx:]...)
+			a[idx] = InternalServer
+			deps[key] = a
 		}
+
 	}
 
 	for mod, targets := range deps {

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -112,12 +112,6 @@ func TestLoki_AppendOptionalInternalServer(t *testing.T) {
 
 	var tests []string
 	for target, deps := range fake.deps {
-		switch target {
-		// Blacklist these targets for using the internal server
-		case IndexGatewayRing, MemberlistKV, OverridesExporter, Ring, Embededcache, Server:
-			continue
-		}
-
 		for _, dep := range deps {
 			if dep == Server {
 				tests = append(tests, target)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes adding the internal server modules to the module map more robust. The previous implementation accidentally dropped other modules.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
