### PR TITLE
Add helm-docs to build image.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.24.1',
+    local build_image_tag = '0.24.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.1
+    - 0.24.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.1
+    - 0.24.2
     username:
       from_secret: docker_username
   when:
@@ -1537,6 +1537,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: ea642602380887b8bf4dde09c3e6fd6d8ef522eacaef5a63dc2abfb9026fbfdc
+hmac: 8738700b68f651859a25c2c9bd9f70efb8092aa1eca2ad35238a85ec19f9fe31
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,10 +5,9 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM alpine:3.16.2 as helm
+FROM golang:1.19.2 as helm
 ARG HELM_VER="v3.2.3"
-RUN apk add --no-cache curl && \
-    curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
+RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
     mv /tmp/linux-amd64/helm /usr/bin/helm && \
     rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -4,14 +4,15 @@
 # tag of the Docker image in `../.drone/drone.jsonnet` and run `make drone`.
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
+# Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
 FROM alpine:3.16.2 as helm
 ARG HELM_VER="v3.2.3"
-
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
     mv /tmp/linux-amd64/helm /usr/bin/helm && \
     rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
+RUN GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 
 FROM alpine:3.16.2 as lychee
 ARG LYCHEE_VER="0.7.0"
@@ -79,6 +80,7 @@ RUN apt-get update && \
 
 COPY --from=docker /usr/bin/docker /usr/bin/docker
 COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY --from=helm /go/bin/helm-docs /usr/bin/helm-docs
 COPY --from=lychee /usr/bin/lychee /usr/bin/lychee
 COPY --from=golangci /bin/golangci-lint /usr/local/bin
 COPY --from=buf /usr/bin/buf /usr/bin/buf


### PR DESCRIPTION
**What this PR does / why we need it**:
The tool `helm-docs`is required by the Helm Chart documentation overhaul. See #7034

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
