### PR TITLE
Loki: Implement random entries assignment when sharding

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -444,7 +444,7 @@ func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID
 		return d.divideEntriesBetweenShards(logger, userID, len(stream.Entries), shardStreamsCfg, stream, shardsOrder)
 	}
 
-	return d.divideEntriesBetweenShards(logger, userID, len(stream.Entries), shardStreamsCfg, stream, nil)
+	return d.divideEntriesBetweenShards(logger, userID, shardCount, shardStreamsCfg, stream, nil)
 }
 
 func (d *Distributor) randomizeShardsOrder(shardCount int) []int {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"math"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -418,6 +419,12 @@ func min(x1, x2 int) int {
 // shardStream shards (divides) the given stream into N smaller streams, where
 // N is the sharding size for the given stream. shardSteam returns the smaller
 // streams and their associated keys for hashing to ingesters.
+//
+// The number of shards is limited by the number of entries.
+// If the right number of shards for the current load is bigger than the number of entries, entries are randomized between shards
+// to avoid hotspots.
+// Ex: If the right amount of shards for a stream is 8 but it only has 3 entries, the 3 entries are randomized between the 8 shards.
+// This way we avoid the first 3 shards receiving all the load while the last 5 would receive no load.
 func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID string) ([]uint32, []streamTracker) {
 	shardStreamsCfg := d.validator.Limits.ShardStreams(userID)
 	logger := log.With(util_log.WithUserID(userID, util_log.Logger), "stream", stream.Labels)
@@ -432,13 +439,36 @@ func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID
 		level.Info(logger).Log("msg", "sharding request", "shard_count", shardCount)
 	}
 
+	if shardCount > len(stream.Entries) {
+		shardsOrder := d.randomizeShardsOrder(shardCount)
+		return d.divideEntriesBetweenShards(logger, userID, len(stream.Entries), shardStreamsCfg, stream, shardsOrder)
+	}
+
+	return d.divideEntriesBetweenShards(logger, userID, len(stream.Entries), shardStreamsCfg, stream, nil)
+}
+
+func (d *Distributor) randomizeShardsOrder(shardCount int) []int {
+	shardsOrder := make([]int, shardCount)
+	for i := 0; i < shardCount; i++ {
+		shardsOrder = append(shardsOrder, i)
+	}
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(shardsOrder), func(i, j int) { shardsOrder[i], shardsOrder[j] = shardsOrder[j], shardsOrder[i] })
+	return shardsOrder
+}
+
+func (d *Distributor) divideEntriesBetweenShards(logger log.Logger, userID string, shardCount int, shardStreamsCfg *shardstreams.Config, stream logproto.Stream, alternateShardsOrder []int) ([]uint32, []streamTracker) {
+	derivedKeys := make([]uint32, 0, shardCount)
+	derivedStreams := make([]streamTracker, 0, shardCount)
 	streamLabels := labelTemplate(stream.Labels)
 	streamPattern := streamLabels.String()
 
-	derivedKeys := make([]uint32, 0, shardCount)
-	derivedStreams := make([]streamTracker, 0, shardCount)
 	for i := 0; i < shardCount; i++ {
-		shard, ok := d.createShard(shardStreamsCfg, stream, streamLabels, streamPattern, shardCount, i)
+		j := i
+		if alternateShardsOrder != nil {
+			j = alternateShardsOrder[i]
+		}
+		shard, ok := d.createShard(shardStreamsCfg, stream, streamLabels, streamPattern, shardCount, i, j)
 		if !ok {
 			level.Error(logger).Log("msg", "couldn't create shard", "idx", i)
 			continue
@@ -471,8 +501,8 @@ func labelTemplate(lbls string) labels.Labels {
 	return streamLabels
 }
 
-func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream logproto.Stream, lbls labels.Labels, streamPattern string, totalShards, shardNumber int) (logproto.Stream, bool) {
-	lowerBound, upperBound, ok := d.boundsFor(stream, totalShards, shardNumber, streamshardCfg.LoggingEnabled)
+func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream logproto.Stream, lbls labels.Labels, streamPattern string, totalShards, spot, shardNumber int) (logproto.Stream, bool) {
+	lowerBound, upperBound, ok := d.boundsFor(stream, totalShards, spot, streamshardCfg.LoggingEnabled)
 	if !ok {
 		return logproto.Stream{}, false
 	}
@@ -486,12 +516,12 @@ func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream lo
 	}, true
 }
 
-func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, shardNumber int, loggingEnabled bool) (int, int, bool) {
+func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, spot int, loggingEnabled bool) (int, int, bool) {
 	entriesPerWindow := float64(len(stream.Entries)) / float64(totalShards)
 
-	fIdx := float64(shardNumber)
-	lowerBound := int(fIdx * entriesPerWindow)
-	upperBound := min(int(entriesPerWindow*(1+fIdx)), len(stream.Entries))
+	idx := float64(spot)
+	lowerBound := int(idx * entriesPerWindow)
+	upperBound := min(int(entriesPerWindow*(1+idx)), len(stream.Entries))
 
 	if lowerBound > upperBound {
 		if loggingEnabled {
@@ -634,7 +664,7 @@ func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, 
 		if streamShardcfg.LoggingEnabled {
 			level.Error(logger).Log("msg", "number of shards bigger than number of entries", "shards", shards, "entries", len(stream.Entries))
 		}
-		return len(stream.Entries)
+		return shards
 	}
 
 	if shards == 0 {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -465,7 +465,7 @@ func (d *Distributor) divideEntriesBetweenShards(logger log.Logger, userID strin
 
 	for i := 0; i < shardCount; i++ {
 		j := i
-		if alternateShardsOrder != nil {
+		if len(alternateShardsOrder) > 0 {
 			j = alternateShardsOrder[i]
 		}
 		shard, ok := d.createShard(shardStreamsCfg, stream, streamLabels, streamPattern, shardCount, i, j)
@@ -516,12 +516,12 @@ func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream lo
 	}, true
 }
 
-func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, spot int, loggingEnabled bool) (int, int, bool) {
+func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, idx int, loggingEnabled bool) (int, int, bool) {
 	entriesPerWindow := float64(len(stream.Entries)) / float64(totalShards)
 
-	idx := float64(spot)
-	lowerBound := int(idx * entriesPerWindow)
-	upperBound := min(int(entriesPerWindow*(1+idx)), len(stream.Entries))
+	fidx := float64(idx)
+	lowerBound := int(fidx * entriesPerWindow)
+	upperBound := min(int(entriesPerWindow*(1+fidx)), len(stream.Entries))
 
 	if lowerBound > upperBound {
 		if loggingEnabled {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -786,15 +786,6 @@ func TestShardCountFor(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "0 entries, return 0 shards always",
-			stream:         &logproto.Stream{Hash: 1},
-			rate:           0,
-			desiredRate:    3, // in bytes
-			wantStreamSize: 2, // in bytes
-			wantShards:     0,
-			wantErr:        true,
-		},
-		{
 			// although in this scenario we have enough size to be sharded, we can't divide the number of entries between the ingesters
 			// because the number of entries is lower than the number of shards.
 			name:           "not enough entries to be sharded, stream size (2b) + ingested rate (0b) < 3b = 1 shard but 0 entries",

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
@@ -488,13 +487,6 @@ func TestStreamShard(t *testing.T) {
 		}
 		return entries
 	}
-	generateShardLabels := func(baseLabels string, idx int) labels.Labels {
-		// append a shard label to the given labels. The shard value will be 'idx'.
-		lbs, err := syntax.ParseLabels(baseLabels)
-		require.NoError(t, err)
-		lbs = append(lbs, labels.Label{Name: ingester.ShardLbName, Value: fmt.Sprintf("%d", idx)})
-		return lbs
-	}
 
 	totalEntries := generateEntries(100)
 
@@ -515,173 +507,60 @@ func TestStreamShard(t *testing.T) {
 		entries    []logproto.Entry
 		streamSize int
 
-		wantDerivedStream []streamTracker
+		wantDerivedStreamSize int
 	}{
 		{
-			name:              "zero shard because no entries",
-			entries:           nil,
-			streamSize:        50,
-			wantDerivedStream: []streamTracker{{stream: baseStream}},
+			name:                  "zero shard because no entries",
+			entries:               nil,
+			streamSize:            50,
+			wantDerivedStreamSize: 1,
 		},
 		{
-			name:       "one shard with one entry",
-			streamSize: 1,
-			entries:    totalEntries[0:1],
-			wantDerivedStream: []streamTracker{
-				{
-					stream: logproto.Stream{
-						Entries: []logproto.Entry{totalEntries[0]},
-						Labels:  baseStream.Labels,
-						Hash:    baseStream.Hash,
-					},
-				},
-			},
+			name:                  "one shard with one entry",
+			streamSize:            1,
+			entries:               totalEntries[0:1],
+			wantDerivedStreamSize: 1,
 		},
 		{
-			name:       "two shards with 3 entries",
-			streamSize: desiredRate.Val() + 1, // pass the desired rate for 1 byte to force two shards.
-			entries:    totalEntries[0:3],
-			wantDerivedStream: []streamTracker{
-				{ // shard 1.
-					stream: logproto.Stream{
-						Entries: totalEntries[0:1],
-						Labels:  generateShardLabels(baseLabels, 0).String(),
-						Hash:    generateShardLabels(baseLabels, 0).Hash(),
-					},
-				}, // shard 2.
-				{
-					stream: logproto.Stream{
-						Entries: totalEntries[1:3],
-						Labels:  generateShardLabels(baseLabels, 1).String(),
-						Hash:    generateShardLabels(baseLabels, 1).Hash(),
-					},
-				},
-			},
+			name:                  "two shards with 3 entries",
+			streamSize:            desiredRate.Val() + 1, // pass the desired rate by 1 byte to force two shards.
+			entries:               totalEntries[0:3],
+			wantDerivedStreamSize: 2,
 		},
 		{
-			name:       "two shards with 5 entries",
-			entries:    totalEntries[0:5],
-			streamSize: desiredRate.Val() + 1, // pass the desired rate for 1 byte to force two shards.
-			wantDerivedStream: []streamTracker{
-				{ // shard 1.
-					stream: logproto.Stream{
-						Entries: totalEntries[0:2],
-						Labels:  generateShardLabels(baseLabels, 0).String(),
-						Hash:    generateShardLabels(baseLabels, 0).Hash(),
-					},
-				}, // shard 2.
-				{
-					stream: logproto.Stream{
-						Entries: totalEntries[2:5],
-						Labels:  generateShardLabels(baseLabels, 1).String(),
-						Hash:    generateShardLabels(baseLabels, 1).Hash(),
-					},
-				},
-			},
+			name:                  "two shards with 5 entries",
+			entries:               totalEntries[0:5],
+			streamSize:            desiredRate.Val() + 1, // pass the desired rate for 1 byte to force two shards.
+			wantDerivedStreamSize: 2,
 		},
 		{
-			name:       "one shard with 20 entries",
-			entries:    totalEntries[0:20],
-			streamSize: 1,
-			wantDerivedStream: []streamTracker{
-				{ // shard 1.
-					stream: logproto.Stream{
-						Entries: totalEntries[0:20],
-						Labels:  baseStream.Labels,
-						Hash:    baseStream.Hash,
-					},
-				},
-			},
+			name:                  "one shard with 20 entries",
+			entries:               totalEntries[0:20],
+			streamSize:            1,
+			wantDerivedStreamSize: 1,
 		},
 		{
-			name:       "two shards with 20 entries",
-			entries:    totalEntries[0:20],
-			streamSize: desiredRate.Val() + 1, // pass desired rate by 1 to force two shards.
-			wantDerivedStream: []streamTracker{
-				{ // shard 1.
-					stream: logproto.Stream{
-						Entries: totalEntries[0:10],
-						Labels:  generateShardLabels(baseLabels, 0).String(),
-						Hash:    generateShardLabels(baseLabels, 0).Hash(),
-					},
-				}, // shard 2.
-				{
-					stream: logproto.Stream{
-						Entries: totalEntries[10:20],
-						Labels:  generateShardLabels(baseLabels, 1).String(),
-						Hash:    generateShardLabels(baseLabels, 1).Hash(),
-					},
-				},
-			},
+			name:                  "two shards with 20 entries",
+			entries:               totalEntries[0:20],
+			streamSize:            desiredRate.Val() + 1, // pass desired rate by 1 to force two shards.
+			wantDerivedStreamSize: 2,
 		},
 		{
-			name:       "four shards with 20 entries",
-			entries:    totalEntries[0:20],
-			streamSize: 1 + (desiredRate.Val() * 3), // force 4 shards.
-			wantDerivedStream: []streamTracker{
-				{ // shard 1.
-					stream: logproto.Stream{
-						Entries: totalEntries[0:5],
-						Labels:  generateShardLabels(baseLabels, 0).String(),
-						Hash:    generateShardLabels(baseLabels, 0).Hash(),
-					},
-				},
-				{ // shard 2.
-					stream: logproto.Stream{
-						Entries: totalEntries[5:10],
-						Labels:  generateShardLabels(baseLabels, 1).String(),
-						Hash:    generateShardLabels(baseLabels, 1).Hash(),
-					},
-				},
-				{ // shard 3.
-					stream: logproto.Stream{
-						Entries: totalEntries[10:15],
-						Labels:  generateShardLabels(baseLabels, 2).String(),
-						Hash:    generateShardLabels(baseLabels, 2).Hash(),
-					},
-				},
-				{ // shard 4.
-					stream: logproto.Stream{
-						Entries: totalEntries[15:20],
-						Labels:  generateShardLabels(baseLabels, 3).String(),
-						Hash:    generateShardLabels(baseLabels, 3).Hash(),
-					},
-				},
-			},
+			name:                  "four shards with 20 entries",
+			entries:               totalEntries[0:20],
+			streamSize:            1 + (desiredRate.Val() * 3), // force 4 shards.
+			wantDerivedStreamSize: 4,
 		},
 		{
-			name:       "size for four shards with 2 entries, ends up with 4 shards ",
-			streamSize: 1 + (desiredRate.Val() * 3), // force 4 shards.
-			entries:    totalEntries[0:2],
-			wantDerivedStream: []streamTracker{
-				{
-					stream: logproto.Stream{
-						Entries: totalEntries[0:1],
-						Labels:  generateShardLabels(baseLabels, 0).String(),
-						Hash:    generateShardLabels(baseLabels, 0).Hash(),
-					},
-				},
-				{
-					stream: logproto.Stream{
-						Entries: totalEntries[1:2],
-						Labels:  generateShardLabels(baseLabels, 1).String(),
-						Hash:    generateShardLabels(baseLabels, 1).Hash(),
-					},
-				},
-			},
+			name:                  "size for four shards with 2 entries, ends up with 4 shards ",
+			streamSize:            1 + (desiredRate.Val() * 3), // force 4 shards.
+			entries:               totalEntries[0:2],
+			wantDerivedStreamSize: 2,
 		},
 		{
-			name:    "four shards with 1 entry, ends up with 1 shard only",
-			entries: totalEntries[0:1],
-			wantDerivedStream: []streamTracker{
-				{
-					stream: logproto.Stream{ // when only one shard we don't even add the stream_shard label.
-						Labels:  baseStream.Labels,
-						Hash:    baseStream.Hash,
-						Entries: totalEntries[0:1],
-					},
-				},
-			},
+			name:                  "four shards with 1 entry, ends up with 1 shard only",
+			entries:               totalEntries[0:1],
+			wantDerivedStreamSize: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -705,7 +584,7 @@ func TestStreamShard(t *testing.T) {
 			}
 
 			_, derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake")
-			require.Equal(t, tc.wantDerivedStream, derivedStreams)
+			require.Len(t, derivedStreams, tc.wantDerivedStreamSize)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify sharding to assign random shards when the number of shards is bigger than the number of entries.
This helps us to avoid hot-spotting the first shards. Ex:
- Let's say we calculate the number of shards for a given stream to be 8, but we receive a push request for that same stream with only 3 entries. Previously, we would assign the 3 entries for the first 3 shards. That means that, if we regularly receive push requests for that stream with only 3 entries, the last 5 shards wouldn't receive any load. By randomizing the entries assignment we help spreading the load between all shards.
