### PR TITLE
Helm: Replace incorrect key loki.authEnabled in example override values

### DIFF
--- a/production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml
+++ b/production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml
@@ -15,7 +15,7 @@ enterprise:
     cluster_name: loki-logs
 
 loki:
-  authEnabled: false
+  auth_enabled: false
 
   commonConfig:
     path_prefix: /var/loki


### PR DESCRIPTION
**What this PR does**:

Replace `loki.authEnabled` in one of the example override YAMLs with `loki.authEnabled` to match the actual key name. Also adds missing newline at end of file.

**Why we need it**:

As of today the example [production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml (permalink)](https://github.com/grafana/loki/blob/85e524788e9892c4413157ce07b516f88109c935/production/helm/loki/docs/examples/oss/overrides-oss-gcs.yaml) contains the following block:

```yaml
loki:
  authEnabled: false
```

This is incorrect. There is no `authEnabled` in the `values.yaml`. It has to be `auth_enabled`.

**Which issue(s) this PR fixes**:

Fixes #7409

**Checklist**

- [x] Reviewed the `CONTRIBUTING.md` guide

