### PR TITLE
Do not log 'unable to read rules directory' at startup if directory hasn't been created yet

### DIFF
--- a/pkg/ruler/base/mapper.go
+++ b/pkg/ruler/base/mapper.go
@@ -3,6 +3,7 @@ package base
 import (
 	"crypto/md5"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -60,6 +61,11 @@ func (m *mapper) users() ([]string, error) {
 	var result []string
 
 	dirs, err := afero.ReadDir(m.FS, m.Path)
+	if os.IsNotExist(err) {
+		// The directory may have not been created yet. With regards to this function
+		// it's like the ruler has no tenants and it shouldn't be considered an error.
+		return nil, nil
+	}
 	for _, u := range dirs {
 		if u.IsDir() {
 			result = append(result, u.Name())

--- a/pkg/ruler/base/mapper_test.go
+++ b/pkg/ruler/base/mapper_test.go
@@ -429,3 +429,15 @@ func TestYamlFormatting(t *testing.T) {
 
 	require.Equal(t, expected, string(data))
 }
+
+func Test_mapper_CleanupShouldNotFailIfPathDoesNotExist(t *testing.T) {
+	m := &mapper{
+		Path:   "/path-does-not-exist",
+		FS:     afero.NewMemMapFs(),
+		logger: log.NewNopLogger(),
+	}
+
+	actual, err := m.users()
+	require.NoError(t, err)
+	require.Empty(t, actual)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Do not log 'unable to read rules directory' at startup if directory hasn't been created yet

mimir pr here:
https://github.com/grafana/mimir/pull/1058/files#diff-1b3ab3225a853e6d596155b5e713954df925e60df6b0826f7f851db243bca71e

**Which issue(s) this PR fixes**:
Fixes #6069

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
