### PR TITLE
operator: Fix Custom TLS profile setting for LokiStack on OpenShift

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7437](https://github.com/grafana/loki/pull/7437) **aminesnow**: Fix Custom TLS profile setting for LokiStack on OpenShift
 - [7415](https://github.com/grafana/loki/pull/7415) **aminesnow**: Add alert relabel config
 - [7418](https://github.com/grafana/loki/pull/7418) **Red-GV**: Update golang to v1.19 and k8s dependencies to v0.25.2
 - [7322](https://github.com/grafana/loki/pull/7322) **Red-GV**: Configuring server and client HTTP and GRPC TLS options

--- a/operator/internal/manifests/build.go
+++ b/operator/internal/manifests/build.go
@@ -151,14 +151,16 @@ func ApplyTLSSettings(opts *Options, profile *openshiftconfigv1.TLSSecurityProfi
 		tlsSecurityProfile = profile
 	}
 
-	profileSpec, ok := openshiftconfigv1.TLSProfiles[tlsSecurityProfile.Type]
-
-	if !ok {
-		return kverrors.New("unable to determine tls profile settings")
-	}
-
+	var profileSpec *openshiftconfigv1.TLSProfileSpec
 	if tlsSecurityProfile.Type == openshiftconfigv1.TLSProfileCustomType && tlsSecurityProfile.Custom != nil {
 		profileSpec = &tlsSecurityProfile.Custom.TLSProfileSpec
+	} else {
+		var ok bool
+		profileSpec, ok = openshiftconfigv1.TLSProfiles[tlsSecurityProfile.Type]
+
+		if !ok {
+			return kverrors.New("unable to determine tls profile settings")
+		}
 	}
 
 	// need to remap all ciphers to their respective IANA names used by Go

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -185,7 +185,7 @@ func TestApplyTLSSettings_OverrideDefaults(t *testing.T) {
 			profile: openshiftconfigv1.TLSSecurityProfile{
 				Type: openshiftconfigv1.TLSProfileCustomType,
 			},
-			err: kverrors.New("unable to determine tls profile settings"),
+			err: kverrors.New("missing TLS custom profile spec"),
 		},
 	}
 

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ViaQ/logerr/v2/kverrors"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -91,6 +92,7 @@ func TestApplyTLSSettings_OverrideDefaults(t *testing.T) {
 		desc     string
 		profile  openshiftconfigv1.TLSSecurityProfile
 		expected TLSProfileSpec
+		err      error
 	}
 
 	tc := []tt{
@@ -152,6 +154,39 @@ func TestApplyTLSSettings_OverrideDefaults(t *testing.T) {
 				Ciphers: []string{},
 			},
 		},
+		{
+			desc: "custom profile",
+			profile: openshiftconfigv1.TLSSecurityProfile{
+				Type: openshiftconfigv1.TLSProfileCustomType,
+				Custom: &openshiftconfigv1.CustomTLSProfile{
+					TLSProfileSpec: openshiftconfigv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS11",
+						Ciphers: []string{
+							"ECDHE-ECDSA-CHACHA20-POLY1305",
+							"ECDHE-RSA-CHACHA20-POLY1305",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			},
+			expected: TLSProfileSpec{
+				MinTLSVersion: "VersionTLS11",
+				Ciphers: []string{
+					"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				},
+			},
+		},
+		{
+			desc: "broken custom profile",
+			profile: openshiftconfigv1.TLSSecurityProfile{
+				Type: openshiftconfigv1.TLSProfileCustomType,
+			},
+			err: kverrors.New("unable to determine tls profile settings"),
+		},
 	}
 
 	for _, tc := range tc {
@@ -162,7 +197,7 @@ func TestApplyTLSSettings_OverrideDefaults(t *testing.T) {
 			opts := Options{}
 			err := ApplyTLSSettings(&opts, &tc.profile)
 
-			require.Nil(t, err)
+			require.EqualValues(t, tc.err, err)
 			require.EqualValues(t, tc.expected, opts.TLSProfile)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the error when using Custom profile on Openshift

**Which issue(s) this PR fixes**:
Fixes [LOG-3186](https://issues.redhat.com/browse/LOG-3186)

**Special notes for your reviewer**:
@Red-GV Please review this 

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
