### PR TITLE
Add remote schema option

### DIFF
--- a/docs/sources/tools/logcli.md
+++ b/docs/sources/tools/logcli.md
@@ -341,6 +341,9 @@ Flags:
       --labels-length=0    Set a fixed padding to labels
       --store-config=""    Execute the current query using a configured storage
                            from a given Loki configuration file.
+      --remote-schema      Execute the current query using a remote schema
+                           retrieved using the configured storage in the given
+                           Loki configuration file.
       --colored-output     Show output with colored labels
   -t, --tail               Tail the logs
   -f, --follow             Alias for --tail


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a missing option for logcli.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>