### PR TITLE
Docs: Update helm installation docs for the simple scalable deployment

### DIFF
--- a/docs/sources/installation/simple-scalable-helm.md
+++ b/docs/sources/installation/simple-scalable-helm.md
@@ -16,7 +16,7 @@ within a Kubernetes cluster.
 
 ## Deploy Loki to the Kubernetes cluster
 
-1. Add [Loki's chart repository](https://github.com/grafana/helm-charts) to Helm:
+1. Add [Loki's chart repository](https://github.com/grafana/loki/tree/main/production/helm/loki) to Helm:
 
     ```bash
     helm repo add grafana https://grafana.github.io/helm-charts
@@ -33,28 +33,28 @@ within a Kubernetes cluster.
     - Deploy with the default configuration:
 
         ```bash
-        helm upgrade --install loki grafana/loki-simple-scalable
+        helm upgrade --install loki grafana/loki
         ```
 
     - Deploy with the default configuration in a custom Kubernetes cluster namespace:
 
         ```bash
-        helm upgrade --install loki --namespace=loki grafana/loki-simple-scalable
+        helm upgrade --install loki --namespace=loki grafana/loki
         ```
 
     - Deploy with added custom configuration using an overrides YAML file, useful for overriding a set of values:
 
         ```bash
-        helm upgrade --install loki grafana/loki-simple-scalable --values {PATH_TO_OVERRIDES_VALUES_FILE}
+        helm upgrade --install loki grafana/loki --values {PATH_TO_OVERRIDES_VALUES_FILE}
         ```
 
     - Deploy with added custom configuration, useful for overriding a small quantity of values:
 
         ```bash
-        helm upgrade --install loki grafana/loki-simple-scalable --set "key1=val1,key2=val2,..."
+        helm upgrade --install loki grafana/loki --set "key1=val1,key2=val2,..."
         ```
 
-Find deployment examples at [https://github.com/grafana/helm-charts/tree/main/charts/loki-simple-scalable/docs/examples](https://github.com/grafana/helm-charts/tree/main/charts/loki-simple-scalable/docs/examples).
+Find deployment examples at [https://github.com/grafana/loki/tree/main/production/helm/loki/docs/examples](https://github.com/grafana/loki/tree/main/production/helm/loki/docs/examples).
 
 ## Deploy Grafana to your Kubernetes cluster
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The docs still reference the old chart repository. It still works, but the chart got renamed and the instructions result in an outdated version version.

**Which issue(s) this PR fixes**:
Fixes #7374

**Special notes for your reviewer**:
I encountered this while setting up loki recently. Current docs are located here: https://grafana.com/docs/loki/latest/installation/simple-scalable-helm/. I saw the repo url was still the same, but I ended up with an outdated version. After some time (and reading the new github page more thoroughly) I realized the chart name is slightly different and the docs are outdated.

The docs for the [distributed chart](https://grafana.com/docs/loki/latest/installation/microservices-helm/) do not need an update, as they are still in the old location.

The referenced issue talks about improving the documentation further, but I don't have enough context for that. I think this small improvement will help people already.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
