### PR TITLE
operator: Upgrade operator-sdk to v1.24.1

### DIFF
--- a/operator/.bingo/Variables.mk
+++ b/operator/.bingo/Variables.mk
@@ -59,11 +59,11 @@ $(KUSTOMIZE): $(BINGO_DIR)/kustomize.mod
 	@echo "(re)installing $(GOBIN)/kustomize-v4.5.7"
 	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=kustomize.mod -o=$(GOBIN)/kustomize-v4.5.7 "sigs.k8s.io/kustomize/kustomize/v4"
 
-OPERATOR_SDK := $(GOBIN)/operator-sdk-v1.24.0
+OPERATOR_SDK := $(GOBIN)/operator-sdk-v1.24.1
 $(OPERATOR_SDK): $(BINGO_DIR)/operator-sdk.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/operator-sdk-v1.24.0"
-	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=operator-sdk.mod -o=$(GOBIN)/operator-sdk-v1.24.0 "github.com/operator-framework/operator-sdk/cmd/operator-sdk"
+	@echo "(re)installing $(GOBIN)/operator-sdk-v1.24.1"
+	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=operator-sdk.mod -o=$(GOBIN)/operator-sdk-v1.24.1 "github.com/operator-framework/operator-sdk/cmd/operator-sdk"
 
 PROMTOOL := $(GOBIN)/promtool-v0.39.1
 $(PROMTOOL): $(BINGO_DIR)/promtool.mod

--- a/operator/.bingo/operator-sdk.mod
+++ b/operator/.bingo/operator-sdk.mod
@@ -8,4 +8,4 @@ replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-
 
 replace github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 
-require github.com/operator-framework/operator-sdk v1.24.0 // cmd/operator-sdk
+require github.com/operator-framework/operator-sdk v1.24.1 // cmd/operator-sdk

--- a/operator/.bingo/operator-sdk.sum
+++ b/operator/.bingo/operator-sdk.sum
@@ -1192,6 +1192,8 @@ github.com/operator-framework/operator-sdk v1.22.0 h1:kM8KxaDW+aGfWXdFucJQUmW315
 github.com/operator-framework/operator-sdk v1.22.0/go.mod h1:YJwc2MvoBgUaRo2AeLSPfhBnJSZ7HhLw22sTv/89P1g=
 github.com/operator-framework/operator-sdk v1.24.0 h1:TolUfgiamUrznCfP5m+88Wj8Bq/TgVq1qtQyN47q+7Y=
 github.com/operator-framework/operator-sdk v1.24.0/go.mod h1:ABeI+hU/bPfO1u09f7Vranx5GHcwdFnAa21IZjTTKxo=
+github.com/operator-framework/operator-sdk v1.24.1 h1:exm5snGUOPSysHF0z1p/APrTn/Fl0kfzIl4/NPfP12s=
+github.com/operator-framework/operator-sdk v1.24.1/go.mod h1:ABeI+hU/bPfO1u09f7Vranx5GHcwdFnAa21IZjTTKxo=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/operator/.bingo/variables.env
+++ b/operator/.bingo/variables.env
@@ -22,7 +22,7 @@ KIND="${GOBIN}/kind-v0.16.0"
 
 KUSTOMIZE="${GOBIN}/kustomize-v4.5.7"
 
-OPERATOR_SDK="${GOBIN}/operator-sdk-v1.24.0"
+OPERATOR_SDK="${GOBIN}/operator-sdk-v1.24.1"
 
 PROMTOOL="${GOBIN}/promtool-v0.39.1"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades local tool operator-sdk to v1.24.1 (See changelog: https://github.com/operator-framework/operator-sdk/releases/tag/v1.24.1)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
