### PR TITLE
[server] grpc: Make gRPC connection timeout configurable

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -43,7 +43,7 @@ func main() {
 		level.Error(util_log.Logger).Log("msg", "invalid log level")
 		os.Exit(1)
 	}
-	util_log.InitLogger(&config.Server, prometheus.DefaultRegisterer, config.UseBufferedLogger, config.UseSyncLogger)
+	util_log.InitLogger(&config.Server.Config, prometheus.DefaultRegisterer, config.UseBufferedLogger, config.UseSyncLogger)
 
 	// Validate the config once both the config file has been loaded
 	// and CLI flags parsed.

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -41,7 +41,7 @@ import (
 	"github.com/grafana/loki/pkg/ruler/rulestore"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/scheduler"
-	internalserver "github.com/grafana/loki/pkg/server"
+	lokiserver "github.com/grafana/loki/pkg/server"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
@@ -71,8 +71,8 @@ type Config struct {
 	UseSyncLogger     bool `yaml:"use_sync_logger"`
 
 	Common           common.Config            `yaml:"common,omitempty"`
-	Server           server.Config            `yaml:"server,omitempty"`
-	InternalServer   internalserver.Config    `yaml:"internal_server,omitempty"`
+	Server           lokiserver.CommonConfig  `yaml:"server,omitempty"`
+	InternalServer   lokiserver.Config        `yaml:"internal_server,omitempty"`
 	Distributor      distributor.Config       `yaml:"distributor,omitempty"`
 	Querier          querier.Config           `yaml:"querier,omitempty"`
 	DeleteClient     deletion.Config          `yaml:"delete_client,omitempty"`
@@ -298,7 +298,7 @@ func New(cfg Config) (*Loki, error) {
 func (t *Loki) setupAuthMiddleware() {
 	// Don't check auth header on TransferChunks, as we weren't originally
 	// sending it and this could cause transfers to fail on update.
-	t.HTTPAuthMiddleware = fakeauth.SetupAuthMiddleware(&t.Cfg.Server, t.Cfg.AuthEnabled,
+	t.HTTPAuthMiddleware = fakeauth.SetupAuthMiddleware(&t.Cfg.Server.Config, t.Cfg.AuthEnabled,
 		// Also don't check auth for these gRPC methods, since single call is used for multiple users (or no user like health check).
 		[]string{
 			"/grpc.health.v1.Health/Check",

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -32,9 +32,6 @@ func TestFlagGRPCServerConnectionTimeout(t *testing.T) {
 	f.PrintDefaults()
 
 	const delim = '\n'
-
-	// Populate map with parsed default flags.
-	// Key is the flag and value is the default text.
 	gotFlags := make(map[string]string)
 	for {
 		line, err := buf.ReadString(delim)

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -32,6 +32,9 @@ func TestFlagGRPCServerConnectionTimeout(t *testing.T) {
 	f.PrintDefaults()
 
 	const delim = '\n'
+
+	// Populate map with parsed default flags.
+	// Key is the flag and value is the default text.
 	gotFlags := make(map[string]string)
 	for {
 		line, err := buf.ReadString(delim)

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/loki/pkg/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	serverww "github.com/weaveworks/common/server"
+	wwserver "github.com/weaveworks/common/server"
 
 	internalserver "github.com/grafana/loki/pkg/server"
 )
@@ -138,7 +138,7 @@ func TestLoki_AppendOptionalInternalServer(t *testing.T) {
 		Cfg: Config{
 			Target: flagext.StringSliceCSV{All},
 			Server: server.CommonConfig{
-				Config: serverww.Config{
+				Config: wwserver.Config{
 					HTTPListenAddress: "3100",
 				},
 			},
@@ -165,12 +165,12 @@ func TestLoki_AppendOptionalInternalServer(t *testing.T) {
 				Cfg: Config{
 					Target: flagext.StringSliceCSV{tt},
 					Server: server.CommonConfig{
-						Config: serverww.Config{
+						Config: wwserver.Config{
 							HTTPListenAddress: "3100",
 						},
 					},
 					InternalServer: internalserver.Config{
-						Config: serverww.Config{
+						Config: wwserver.Config{
 							HTTPListenAddress: "3101",
 						},
 						Enable: true,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,12 +4,12 @@ import (
 	"flag"
 	"time"
 
-	serverww "github.com/weaveworks/common/server"
+	"github.com/weaveworks/common/server"
 )
 
 // CommonConfig extends weaveworks server config
 type CommonConfig struct {
-	serverww.Config             `yaml:",inline"`
+	server.Config               `yaml:",inline"`
 	GRPCServerConnectionTimeout time.Duration `yaml:"grpc_server_connection_timeout"`
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"flag"
+	"time"
+
+	serverww "github.com/weaveworks/common/server"
+)
+
+// CommonConfig extends weaveworks server config
+type CommonConfig struct {
+	serverww.Config             `yaml:",inline"`
+	GRPCServerConnectionTimeout time.Duration `yaml:"grpc_server_connection_timeout"`
+}
+
+// RegisterFlags add internal server flags to flagset
+func (cfg *CommonConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.Config.RegisterFlags(f)
+	f.DurationVar(&cfg.GRPCServerConnectionTimeout, "server.grpc.connection.timeout", time.Minute*2, "sets the timeout for connection establishment (up to and including HTTP/2 handshaking) for all new connections.  If this is not set, the default is 120 seconds.  A zero or negative value will result in an immediate timeout.")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR attempts to add a grpc connection timeout so that loki's operator can have the opportunity to raise this timeout.

```
 server:
      grpc_server_connection_timeout: 600s
```
querier -> index-gateway 
log
```
level=info ts=2022-10-17T06:28:23.653973829Z caller=handler.go:174 org_id=fake msg="slow query detected" method=GET host=loki-loki-distributed-query-frontend.loki-research-x4.svc.cluster.local:3100 path=/loki/api/v1/query_range time_taken=2m1.965813572s param_direction=backward param_end=1665987976954000000 param_limit=1000 param_query="{evtType=\"evt_ttsd\"} | json" param_start=1665966376954000000 param_step=10000ms
level=warn ts=2022-10-17T06:28:23.654024222Z caller=logging.go:86 traceID=55bbc9c1308e9842 orgID=fake msg="GET /loki/api/v1/query_range?direction=backward&end=1665987976954000000&limit=1000&query=%7BevtType%3D%22evt_ttsd%22%7D+%7C+json&start=1665966376954000000&step=10000ms (500) 2m1.9659356s Response: \"query index: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing dial tcp 10.100.190.157:9095: i/o timeout\\\"\\n\" ws: false; Accept-Encoding: gzip; Connection: close; User-Agent: Grafana/9.1.5; "

level=error ts=2022-10-17T06:28:23.654071531Z caller=retry.go:73 org_id=fake msg="error processing request" try=0 err="rpc error: code = Code(500) desc = query index: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.100.190.157:9095: i/o timeout\"\n"
```

 (500) 2m1.9659356s and connection error ... : i/o timeout .
I infer that grpc has connection timeout through 2m and connection timeout in the log.

https://github.com/weaveworks/common/pull/261
this PR having received some detailed review tips from @bboreham  in the weave/common project, this PR will provide an adjustable connection timeout in an attempt to solve a slack(https://grafana.slack.com/archives/CEPJRLQNL/p1665738667866879) user's problem. If this PR is valid, it will be fed back to the weave/common project.

This PR does not sure solve the timeout problem, so it is very likely that the PR will be rejected. 

The PR is only to invite more maintainers to notice the timeout problem, participate in the discussion, and give some suggestions to help users in slack.

**Which issue(s) this PR fixes**:
Fixes https://github.com/weaveworks/common/pull/261
https://grafana.slack.com/archives/CEPJRLQNL/p1665738667866879

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
