### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,5 +2,5 @@
 
 Some parts of the codebase have other maintainers:
 - `docs`:
-  - @osg-grafana - [@osg-grafana](https://github.com/@osg-grafana) ([Grafana Labs](https://grafana.com/))
-  - @knylander-grafana - [@knylander-grafana](https://github.com/@knylander-grafana) ([Grafana Labs](https://grafana.com/))
+  - @osg-grafana - [@osg-grafana](https://github.com/osg-grafana) ([Grafana Labs](https://grafana.com/))
+  - @knylander-grafana - [@knylander-grafana](https://github.com/knylander-grafana) ([Grafana Labs](https://grafana.com/))


### PR DESCRIPTION
This change removes removes Karen Miller, and includes at least one alternative, interim technical writer.