### PR TITLE
Loki: log when a query starts in the logql engine

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	log2 "github.com/grafana/loki/pkg/util/log"
 	"math"
 	"sort"
 	"strings"
@@ -191,6 +192,12 @@ func (q *query) resultLength(res promql_parser.Value) int {
 func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	log, ctx := spanlogger.New(ctx, "query.Exec")
 	defer log.Finish()
+
+	if GetRangeType(q.params) == InstantType {
+		level.Info(log2.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query())
+	} else {
+		level.Info(log2.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step())
+	}
 
 	rangeType := GetRangeType(q.params)
 	timer := prometheus.NewTimer(QueryTime.WithLabelValues(string(rangeType)))

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	log2 "github.com/grafana/loki/pkg/util/log"
 	"math"
 	"sort"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/httpreq"
+	logutil "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 	"github.com/grafana/loki/pkg/util/validation"
 )
@@ -194,9 +194,9 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	defer log.Finish()
 
 	if GetRangeType(q.params) == InstantType {
-		level.Info(log2.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query())
+		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query())
 	} else {
-		level.Info(log2.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step())
+		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step())
 	}
 
 	rangeType := GetRangeType(q.params)


### PR DESCRIPTION
Signed-off-by: Edward Welch <edward.welch@grafana.com>

**What this PR does / why we need it**:

There are cases where a query cannot finish (OOM of a querier/ruler) and most of our logs are emitted upon completion of a query. This can help us find queries which are OOM crashing a component.

Note: It only covers queries executed by the engine, so only instant and range queries. Another PR will be necessary to cover labels/series endpoints. However this approach seemed the best to be able to get this information from ruler executed queries.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
