### PR TITLE
Indexshipper revert locking issues

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -178,11 +178,7 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	if err := t.indexMtx.rLock(ctx); err != nil {
 		return err
 	}
-
-	go func() {
-		<-ctx.Done()
-		t.indexMtx.rUnlock()
-	}()
+	defer t.indexMtx.rUnlock()
 
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -32,7 +32,7 @@ var errIndexListCacheTooStale = fmt.Errorf("index list cache too stale")
 type IndexSet interface {
 	Init(forQuerying bool) error
 	Close()
-	ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
 	DropAllDBs() error
 	Err() error
 	LastUsedAt() time.Time
@@ -174,13 +174,13 @@ func (t *indexSet) Close() {
 	t.index = map[string]index.Index{}
 }
 
-func (t *indexSet) ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	if err := t.indexMtx.rLock(ctx); err != nil {
 		return err
 	}
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		t.indexMtx.rUnlock()
 	}()
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,10 +40,7 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), callbackFunc)
 		})
 		stopFunc()
 	}
@@ -88,10 +85,7 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				return indexSet.ForEach(ctx, callbackFunc)
+				return indexSet.ForEach(context.Background(), callbackFunc)
 			})
 		})
 	}
@@ -110,10 +104,7 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,10 +40,10 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			doneChan := make(chan struct{})
-			defer close(doneChan)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 		stopFunc()
 	}
@@ -88,10 +88,10 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				doneChan := make(chan struct{})
-				defer close(doneChan)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-				return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+				return indexSet.ForEach(ctx, callbackFunc)
 			})
 		})
 	}
@@ -110,10 +110,10 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			doneChan := make(chan struct{})
-			defer close(doneChan)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -28,7 +28,7 @@ const (
 
 type Table interface {
 	Close()
-	ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
 	Sync(ctx context.Context) error
 	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
@@ -144,7 +144,7 @@ func (t *table) Close() {
 	t.indexSets = map[string]IndexSet{}
 }
 
-func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	// iterate through both user and common index
 	for _, uid := range []string{userID, ""} {
 		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
@@ -157,7 +157,7 @@ func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan stru
 			return indexSet.Err()
 		}
 
-		err = indexSet.ForEach(ctx, doneChan, callback)
+		err = indexSet.ForEach(ctx, callback)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -42,7 +42,7 @@ type IndexGatewayOwnsTenant func(tenant string) bool
 
 type TableManager interface {
 	Stop()
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type Config struct {
@@ -155,12 +155,12 @@ func (tm *tableManager) Stop() {
 	}
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, err := tm.getOrCreateTable(tableName)
 	if err != nil {
 		return err
 	}
-	return table.ForEach(ctx, userID, doneChan, callback)
+	return table.ForEach(ctx, userID, callback)
 }
 
 func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,10 +87,7 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+				return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
 			})
 		}
 	}
@@ -379,10 +376,7 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-
-					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+					return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
 				})
 			}
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,10 +87,10 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				doneChan := make(chan struct{})
-				defer close(doneChan)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-				return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
+				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 			})
 		}
 	}
@@ -379,10 +379,10 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					doneChan := make(chan struct{})
-					defer close(doneChan)
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
 
-					return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
+					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 				})
 			}
 		}
@@ -455,7 +455,7 @@ type mockTable struct {
 	queryReadinessDoneForUsers []string
 }
 
-func (m *mockTable) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (m *mockTable) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	return nil
 }
 

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -81,7 +81,7 @@ type mockIndexSet struct {
 	lastUsedAt  time.Time
 }
 
-func (m *mockIndexSet) ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (m *mockIndexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	for _, idx := range m.indexes {
 		if err := callback(false, idx); err != nil {
 			return err
@@ -147,13 +147,11 @@ func TestTable_ForEach(t *testing.T) {
 			}
 
 			var indexesFound []index.Index
-			doneChan := make(chan struct{})
-			err := table.ForEach(context.Background(), tc.withUserID, doneChan, func(_ bool, idx index.Index) error {
+
+			err := table.ForEach(context.Background(), tc.withUserID, func(_ bool, idx index.Index) error {
 				indexesFound = append(indexesFound, idx)
 				return nil
 			})
-			close(doneChan)
-
 			if tc.withError {
 				require.Error(t, err)
 				require.Len(t, table.indexSets, len(usersToSetup))
@@ -316,12 +314,12 @@ func TestTable_Sync(t *testing.T) {
 	// check that table has expected indexes setup
 	var indexesFound []string
 
-	doneChan := make(chan struct{})
-	err := table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -339,12 +337,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	doneChan = make(chan struct{})
-	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -383,12 +381,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	doneChan = make(chan struct{})
-	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -419,10 +417,10 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		doneChan := make(chan struct{})
-		defer close(doneChan)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -443,10 +441,10 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		doneChan := make(chan struct{})
-		defer close(doneChan)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -313,13 +313,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table has expected indexes setup
 	var indexesFound []string
-
-	ctx, cancel := context.WithCancel(context.Background())
-	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err := table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -337,12 +334,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -381,12 +376,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -417,10 +410,7 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -441,10 +431,7 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -48,8 +48,6 @@ type IndexShipper interface {
 	// ForEach lets us iterates through each index file in a table for a specific user.
 	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
 	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
-	// Note: The index files would be locked until the passed ctx is cancelled to avoid making any changes to the index
-	// while it is being queried.
 	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 	Stop()
 }
@@ -177,7 +175,7 @@ func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, ca
 	}
 
 	if s.uploadsManager != nil {
-		if err := s.uploadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
+		if err := s.uploadsManager.ForEach(tableName, userID, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -48,9 +48,9 @@ type IndexShipper interface {
 	// ForEach lets us iterates through each index file in a table for a specific user.
 	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
 	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
-	// Note: The index files would be locked until the passed done chan is closed to avoid making any changes to the index
+	// Note: The index files would be locked until the passed ctx is cancelled to avoid making any changes to the index
 	// while it is being queried.
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 	Stop()
 }
 
@@ -169,15 +169,15 @@ func (s *indexShipper) AddIndex(tableName, userID string, index index.Index) err
 	return s.uploadsManager.AddIndex(tableName, userID, index)
 }
 
-func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	if s.downloadsManager != nil {
-		if err := s.downloadsManager.ForEach(ctx, tableName, userID, doneChan, callback); err != nil {
+		if err := s.downloadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
 			return err
 		}
 	}
 
 	if s.uploadsManager != nil {
-		if err := s.uploadsManager.ForEach(ctx, tableName, userID, doneChan, callback); err != nil {
+		if err := s.uploadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -21,7 +21,7 @@ type IndexSet interface {
 	Add(idx index.Index)
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
-	ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
 	Close()
 }
 
@@ -65,11 +65,11 @@ func (t *indexSet) Add(idx index.Index) {
 	t.index[idx.Name()] = idx
 }
 
-func (t *indexSet) ForEach(_ context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	t.indexMtx.RLock()
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		t.indexMtx.RUnlock()
 	}()
 

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -21,7 +21,7 @@ type IndexSet interface {
 	Add(idx index.Index)
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
-	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
+	ForEach(callback index.ForEachIndexCallback) error
 	Close()
 }
 
@@ -65,13 +65,9 @@ func (t *indexSet) Add(idx index.Index) {
 	t.index[idx.Name()] = idx
 }
 
-func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(callback index.ForEachIndexCallback) error {
 	t.indexMtx.RLock()
-
-	go func() {
-		<-ctx.Done()
-		t.indexMtx.RUnlock()
-	}()
+	defer t.indexMtx.RUnlock()
 
 	for _, idx := range t.index {
 		if err := callback(t.userID == "", idx); err != nil {

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,12 +36,13 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err = indexSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -109,12 +110,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -135,12 +136,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			doneChan = make(chan struct{})
-			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel = context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,10 +36,7 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = indexSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
@@ -110,12 +107,10 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = idxSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -136,12 +131,10 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			ctx, cancel = context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = idxSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -20,7 +20,7 @@ const (
 type Table interface {
 	Name() string
 	AddIndex(userID string, idx index.Index) error
-	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
+	ForEach(userID string, callback index.ForEachIndexCallback) error
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
 	Stop()
@@ -78,13 +78,9 @@ func (lt *table) AddIndex(userID string, idx index.Index) error {
 }
 
 // ForEach iterates over all the indexes belonging to the user.
-func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+func (lt *table) ForEach(userID string, callback index.ForEachIndexCallback) error {
 	lt.indexSetMtx.RLock()
-
-	go func() {
-		<-ctx.Done()
-		lt.indexSetMtx.RUnlock()
-	}()
+	defer lt.indexSetMtx.RUnlock()
 
 	// TODO(owen-d): refactor? Uploads mgr never has user indices,
 	// only common (multitenant) ones.
@@ -95,7 +91,7 @@ func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForE
 			continue
 		}
 
-		if err := idxSet.ForEach(ctx, callback); err != nil {
+		if err := idxSet.ForEach(callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -20,7 +20,7 @@ const (
 type Table interface {
 	Name() string
 	AddIndex(userID string, idx index.Index) error
-	ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
 	Stop()
@@ -78,11 +78,11 @@ func (lt *table) AddIndex(userID string, idx index.Index) error {
 }
 
 // ForEach iterates over all the indexes belonging to the user.
-func (lt *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	lt.indexSetMtx.RLock()
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		lt.indexSetMtx.RUnlock()
 	}()
 
@@ -95,7 +95,7 @@ func (lt *table) ForEach(ctx context.Context, userID string, doneChan <-chan str
 			continue
 		}
 
-		if err := idxSet.ForEach(ctx, doneChan, callback); err != nil {
+		if err := idxSet.ForEach(ctx, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
+	ForEach(tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(ctx, userID, callback)
+	return table.ForEach(userID, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(ctx, userID, doneChan, callback)
+	return table.ForEach(ctx, userID, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -1,7 +1,6 @@
 package uploads
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -65,12 +64,10 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					ctx, cancel := context.WithCancel(context.Background())
-					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
+					err := testTableManager.ForEach(tableName, userID, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
-					cancel()
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -65,12 +65,12 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					doneChan := make(chan struct{})
-					err := testTableManager.ForEach(context.Background(), tableName, userID, doneChan, func(_ bool, index index.Index) error {
+					ctx, cancel := context.WithCancel(context.Background())
+					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
-					close(doneChan)
+					cancel()
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -36,12 +36,12 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err := testTable.ForEach(context.Background(), userID, doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 
 			require.NoError(t, err)
 

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -1,7 +1,6 @@
 package uploads
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,13 +35,10 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
+			err := testTable.ForEach(userID, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
-
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,9 +40,6 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
 	for table, queries := range queriesByTable {

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,8 +40,8 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
-	doneChan := make(chan struct{})
-	defer close(doneChan)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
@@ -57,7 +57,7 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 				}
 			}
 
-			return q.indexShipper.ForEach(ctx, table, userID, doneChan, func(_ bool, idx shipper_index.Index) error {
+			return q.indexShipper.ForEach(ctx, table, userID, func(_ bool, idx shipper_index.Index) error {
 				boltdbIndexFile, ok := idx.(*indexfile.IndexFile)
 				if !ok {
 					return fmt.Errorf("unexpected index type %T", idx)

--- a/pkg/storage/stores/shipper/index/table_manager.go
+++ b/pkg/storage/stores/shipper/index/table_manager.go
@@ -44,7 +44,7 @@ type TableManager struct {
 
 type Shipper interface {
 	AddIndex(tableName, userID string, index shipper_index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback shipper_index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
 }
 
 func NewTableManager(cfg Config, indexShipper Shipper, registerer prometheus.Registerer) (*TableManager, error) {

--- a/pkg/storage/stores/shipper/index/table_manager_test.go
+++ b/pkg/storage/stores/shipper/index/table_manager_test.go
@@ -111,7 +111,7 @@ func TestLoadTables(t *testing.T) {
 		// see if index shipper has the index files
 		testutil.VerifyIndexes(t, userID, []index.Query{{TableName: tableName}},
 			func(ctx context.Context, table string, callback func(boltdb *bbolt.DB) error) error {
-				return tm.indexShipper.ForEach(ctx, table, userID, nil, func(_ bool, index index_shipper.Index) error {
+				return tm.indexShipper.ForEach(ctx, table, userID, func(_ bool, index index_shipper.Index) error {
 					return callback(index.(*indexfile.IndexFile).GetBoltDB())
 				})
 			},

--- a/pkg/storage/stores/shipper/index/table_test.go
+++ b/pkg/storage/stores/shipper/index/table_test.go
@@ -41,7 +41,7 @@ func (m *mockIndexShipper) AddIndex(tableName, _ string, index shipper_index.Ind
 	return nil
 }
 
-func (m *mockIndexShipper) ForEach(ctx context.Context, tableName, _ string, _ <-chan struct{}, callback shipper_index.ForEachIndexCallback) error {
+func (m *mockIndexShipper) ForEach(ctx context.Context, tableName, _ string, callback shipper_index.ForEachIndexCallback) error {
 	for _, idx := range m.addedIndexes[tableName] {
 		if err := callback(false, idx); err != nil {
 			return err
@@ -228,7 +228,7 @@ func TestTable_HandoverIndexesToShipper(t *testing.T) {
 
 			testutil.VerifyIndexes(t, userID, []index.Query{{TableName: table.name}},
 				func(ctx context.Context, _ string, callback func(boltdb *bbolt.DB) error) error {
-					return indexShipper.ForEach(ctx, table.name, "", nil, func(_ bool, index shipper_index.Index) error {
+					return indexShipper.ForEach(ctx, table.name, "", func(_ bool, index shipper_index.Index) error {
 						return callback(index.(*indexfile.IndexFile).GetBoltDB())
 					})
 				},
@@ -248,7 +248,7 @@ func TestTable_HandoverIndexesToShipper(t *testing.T) {
 			require.Len(t, indexShipper.addedIndexes[table.name], 2)
 			testutil.VerifyIndexes(t, userID, []index.Query{{TableName: table.name}},
 				func(ctx context.Context, _ string, callback func(boltdb *bbolt.DB) error) error {
-					return indexShipper.ForEach(ctx, table.name, "", nil, func(_ bool, index shipper_index.Index) error {
+					return indexShipper.ForEach(ctx, table.name, "", func(_ bool, index shipper_index.Index) error {
 						return callback(index.(*indexfile.IndexFile).GetBoltDB())
 					})
 				},

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -18,7 +18,7 @@ type mockIndexShipperIndexIterator struct {
 	tables map[string][]*TSDBFile
 }
 
-func (m mockIndexShipperIndexIterator) ForEach(ctx context.Context, tableName, userID string, _ <-chan struct{}, callback index_shipper.ForEachIndexCallback) error {
+func (m mockIndexShipperIndexIterator) ForEach(ctx context.Context, tableName, userID string, callback index_shipper.ForEachIndexCallback) error {
 	indexes := m.tables[tableName]
 	for _, idx := range indexes {
 		if err := callback(false, idx); err != nil {

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -84,9 +84,6 @@ func (i *indexShipperQuerier) Close() error {
 }
 
 func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -95,9 +92,6 @@ func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, f
 }
 
 func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -106,9 +100,6 @@ func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, t
 }
 
 func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -117,9 +108,6 @@ func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, fro
 }
 
 func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -128,9 +116,6 @@ func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, fr
 }
 
 func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return err


### PR DESCRIPTION
*Note: Reverting these will reintroduce an older bug (race condition around mmap access), but with less complexity than the current bug. I will followup with a second PR that fixes our underlying issue as an accompanying PR*

This reverts two locking related PRs in the indexshipper. They both attempted to introduce safe locking practices, but the problem is structural and neither fixed the underlying problem. The issue occurs when

```
1) ForEach
  * `RLock`s table1, acquires indexset: tenant="1", the post-compacted user.
    * `Lock`s indexset for tenant="1", the post compacted user
    * Does not yet call `RUnlock`, which will be called at end of query
  * `RUnlock`s table1
2) Sync
  * `RLock`s table1
    * _Blocks_ calling `Lock` on the tenant="1" indexset (still held from (1)
3) ForEach
  * _Blocks_ `RLock`ing table1, intending to acquire the tenant="" indexset for the pre-compacted users
4) Deadlock!

This is because the locking pattern looks like:


* Sync
  * RLock table
    * Lock indexset
    * Unlock indexset
  * RUnlock Table

* ForEach
  * RLock table
  * RUnlock table
    * RLock indexset
    * RUnlock indexset at end of query
```

Note: This can also happen in any order of lock acquisitions on the indexSets because `RWMutex` prioritized write locks:
```
// If a goroutine holds a RWMutex for reading and another goroutine might
// call Lock, no goroutine should expect to be able to acquire a read lock
// until the initial read lock is released. In particular, this prohibits
// recursive read locking. This is to ensure that the lock eventually becomes
// available; a blocked Lock call excludes new readers from acquiring the
// lock.
```

A recent goroutine capture during this deadlock shows:
* Goroutines waiting for read lock on the indexset
```
goroutine profile: total 34599
32434 @ 0x43ccf6 0x44dc7e 0x44dc55 0x46a285 0x1c2af6d 0x1c2af48 0x1c29eff 0x1c2d62e 0x1c4062b 0x1c42723 0x1a430af 0x1c42175 0x1c49bb0 0xbbd99a 0x1c49b05 0x1c30ac7 0xf10570 0x1fbffe2 0xb2a71a 0x1d2bc50 0xb2a71a 0xbe7022 0x1e9f166 0xb2a71a 0xbe762a 0xb2a71a 0xb2e27b 0xb2a71a 0xbe8ac2 0xb2a71a 0xb2a5be 0xae4fdb
#	0x46a284	sync.runtime_SemacquireMutex+0x24									/usr/local/go/src/runtime/sema.go:77
#	0x1c2af6c	sync.(*RWMutex).RLock+0xac										/usr/local/go/src/sync/rwmutex.go:71
#	0x1c2af47	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*table).getOrCreateIndexSet+0x87	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table.go:251
#	0x1c29efe	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*table).ForEach+0xbe			/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table.go:150
#	0x1c2d62d	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*tableManager).ForEach+0x8d		/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table_manager.go:163
#	0x1c4062a	github.com/grafana/loki/pkg/storage/stores/indexshipper.(*indexShipper).ForEach+0x8a			/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/shipper.go:174
#	0x1c42722	github.com/grafana/loki/pkg/storage/stores/shipper/index.(*querier).QueryPages.func1+0x2e2		/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/shipper/index/querier.go:60
#	0x1a430ae	github.com/grafana/loki/pkg/storage/stores/shipper/util.DoParallelQueries+0x16e				/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/shipper/util/queries.go:39
```

* Goroutine waiting for lock on the underlying indexset
```
1 @ 0x43ccf6 0x44dc7e 0x44dc55 0x46a285 0x488411 0x1c2fe65 0x1c2787d 0x1c26fb5 0x1c26eca 0x1c2acdf 0x1c2df27 0x1c2cfb8 0x46e481
#	0x46a284	sync.runtime_SemacquireMutex+0x24									/usr/local/go/src/runtime/sema.go:77
#	0x488410	sync.(*RWMutex).Lock+0x70										/usr/local/go/src/sync/rwmutex.go:152
#	0x1c2fe64	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*mtxWithReadiness).lock+0x44		/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/util.go:39
#	0x1c2787c	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*indexSet).sync+0x63c		/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/index_set.go:297
#	0x1c26fb4	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*indexSet).syncWithRetry+0xb4	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/index_set.go:256
#	0x1c26ec9	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*indexSet).Sync+0x29			/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/index_set.go:249
#	0x1c2acde	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*table).Sync+0x2be			/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table.go:237
#	0x1c2df26	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*tableManager).syncTables+0x266	/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table_manager.go:216
#	0x1c2cfb7	github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads.(*tableManager).loop+0x377		/src/enterprise-logs/vendor/github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads/table_manager.go:125
