### PR TITLE
Improve rate store refresh latency

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -627,15 +627,8 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 
 // GetStreamRates returns a response containing all streams and their current rate
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
-func (i *Ingester) GetStreamRates(ctx context.Context, req *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
-	instances := i.getInstances()
-
-	var rates []*logproto.StreamRate
-	for _, inst := range instances {
-		rates = append(rates, inst.GetStreamRates(ctx, req)...)
-	}
-
-	return &logproto.StreamRatesResponse{StreamRates: rates}, nil
+func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
+	return &logproto.StreamRatesResponse{StreamRates: i.streamRateCalculator.Rates()}, nil
 }
 
 func (i *Ingester) GetOrCreateInstance(instanceID string) (*instance, error) { //nolint:revive

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -186,7 +186,7 @@ func TestGetStreamRates(t *testing.T) {
 
 	var rates []*logproto.StreamRate
 	require.Eventually(t, func() bool {
-		rates = inst.GetStreamRates(context.Background(), &logproto.StreamRatesRequest{})
+		rates = inst.streamRateCalculator.Rates()
 
 		if len(rates) != concurrent {
 			return false
@@ -207,7 +207,7 @@ func TestGetStreamRates(t *testing.T) {
 
 	// Decay back to 0
 	require.Eventually(t, func() bool {
-		rates = inst.GetStreamRates(context.Background(), &logproto.StreamRatesRequest{})
+		rates = inst.streamRateCalculator.Rates()
 		for _, r := range rates {
 			if r.Rate != 0 {
 				return false

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -43,8 +43,10 @@ type stream struct {
 	fp       model.Fingerprint // possibly remapped fingerprint, used in the streams map
 	chunkMtx sync.RWMutex
 
-	labels       labels.Labels
-	labelsString string
+	labels           labels.Labels
+	labelsString     string
+	labelHash        uint64
+	labelHashNoShard uint64
 
 	// most recently pushed line. This is used to prevent duplicate pushes.
 	// It also determines chunk synchronization when unordered writes are disabled.
@@ -87,12 +89,15 @@ type entryWithError struct {
 }
 
 func newStream(cfg *Config, limits RateLimiterStrategy, tenant string, fp model.Fingerprint, labels labels.Labels, unorderedWrites bool, streamRateCalculator *StreamRateCalculator, metrics *ingesterMetrics) *stream {
+	hashNoShard, _ := labels.HashWithoutLabels(make([]byte, 0, 1024), ShardLbName)
 	return &stream{
 		limiter:              NewStreamRateLimiter(limits, tenant, 10*time.Second),
 		cfg:                  cfg,
 		fp:                   fp,
 		labels:               labels,
 		labelsString:         labels.String(),
+		labelHash:            labels.Hash(),
+		labelHashNoShard:     hashNoShard,
 		tailers:              map[uint32]*tailer{},
 		metrics:              metrics,
 		tenant:               tenant,
@@ -395,7 +400,7 @@ func (s *stream) validateEntries(entries []logproto.Entry, isReplay, rateLimitWh
 		}
 	}
 
-	s.streamRateCalculator.Record(s.labels.Hash(), int64(totalBytes))
+	s.streamRateCalculator.Record(s.labelHash, s.labelHashNoShard, int64(totalBytes))
 	s.reportMetrics(outOfOrderSamples, outOfOrderBytes, rateLimitedSamples, rateLimitedBytes)
 	return toStore, failedEntriesWithError
 }

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -3,6 +3,8 @@ package ingester
 import (
 	"sync"
 	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 const (
@@ -23,17 +25,20 @@ type stripeLock struct {
 
 type StreamRateCalculator struct {
 	size     int
-	samples  []int64
-	rates    []int64
+	samples  []logproto.StreamRate
+	rates    []logproto.StreamRate
 	locks    []stripeLock
 	stopchan chan struct{}
+
+	rateLock sync.RWMutex
+	allRates []logproto.StreamRate
 }
 
 func NewStreamRateCalculator() *StreamRateCalculator {
 	calc := &StreamRateCalculator{
 		size:     defaultStripeSize,
-		samples:  make([]int64, defaultStripeSize),
-		rates:    make([]int64, defaultStripeSize),
+		samples:  make([]logproto.StreamRate, defaultStripeSize),
+		rates:    make([]logproto.StreamRate, defaultStripeSize),
 		locks:    make([]stripeLock, defaultStripeSize),
 		stopchan: make(chan struct{}),
 	}
@@ -58,30 +63,57 @@ func (c *StreamRateCalculator) updateLoop() {
 }
 
 func (c *StreamRateCalculator) updateRates() {
+	rates := make([]logproto.StreamRate, 0, defaultStripeSize)
+
 	for i := 0; i < c.size; i++ {
 		c.locks[i].Lock()
 		c.rates[i] = c.samples[i]
-		c.samples[i] = 0
+		c.samples[i] = logproto.StreamRate{}
+
+		sr := c.rates[i]
+		if sr.StreamHash != 0 {
+			rates = append(rates, logproto.StreamRate{
+				StreamHash:        sr.StreamHash,
+				StreamHashNoShard: sr.StreamHashNoShard,
+				Rate:              sr.Rate,
+			})
+		}
 		c.locks[i].Unlock()
 	}
+
+	c.rateLock.Lock()
+	defer c.rateLock.Unlock()
+
+	c.allRates = rates
 }
 
-func (c *StreamRateCalculator) RateFor(streamHash uint64) int64 {
-	i := streamHash & uint64(c.size-1)
+func (c *StreamRateCalculator) Rates() []*logproto.StreamRate {
+	c.rateLock.RLock()
+	defer c.rateLock.RUnlock()
 
-	c.locks[i].RLock()
-	defer c.locks[i].RUnlock()
+	rates := make([]*logproto.StreamRate, 0, len(c.allRates))
+	for _, r := range c.allRates {
+		rates = append(rates, &logproto.StreamRate{
+			StreamHash:        r.StreamHash,
+			StreamHashNoShard: r.StreamHashNoShard,
+			Rate:              r.Rate,
+		})
+	}
 
-	return c.rates[i]
+	return rates
 }
 
-func (c *StreamRateCalculator) Record(streamHash uint64, bytes int64) {
+func (c *StreamRateCalculator) Record(streamHash, streamHashNoShard uint64, bytes int64) {
 	i := streamHash & uint64(c.size-1)
 
 	c.locks[i].Lock()
 	defer c.locks[i].Unlock()
 
-	c.samples[i] += bytes
+	streamRate := c.samples[i]
+	streamRate.StreamHash = streamHash
+	streamRate.StreamHashNoShard = streamHashNoShard
+	streamRate.Rate += bytes
+	c.samples[i] = streamRate
 }
 
 func (c *StreamRateCalculator) Stop() {

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -63,7 +63,7 @@ func (c *StreamRateCalculator) updateLoop() {
 }
 
 func (c *StreamRateCalculator) updateRates() {
-	rates := make([]logproto.StreamRate, 0, defaultStripeSize)
+	rates := make([]logproto.StreamRate, 0, c.size)
 
 	for i := 0; i < c.size; i++ {
 		c.locks[i].Lock()

--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -12,14 +12,16 @@ func TestStreamRateCalculator(t *testing.T) {
 	defer calc.Stop()
 
 	for i := 0; i < 100; i++ {
-		calc.Record(0, 100)
+		calc.Record(1, 1, 100)
 	}
 
 	require.Eventually(t, func() bool {
-		return calc.RateFor(0) == 10000
+		rates := calc.Rates()
+		return len(rates) > 0 && rates[0].Rate == 10000
 	}, 2*time.Second, 250*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		return calc.RateFor(0) == 0
+		rates := calc.Rates()
+		return len(rates) == 0
 	}, 2*time.Second, 250*time.Millisecond)
 }


### PR DESCRIPTION
Rather than iterating streams and getting rates per stream, keep all necessary information in the rate calculator and just hand back the current rates when asked.

This change took p99 latencies from ~1.8s to ~400ms and p50 latences from ~1s to 6ms.


