### PR TITLE
Index gw lock bugfix

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -145,15 +145,19 @@ func (t *table) Close() {
 }
 
 func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+	ids := []string{userID, ""}
+	sets, err := t.getOrCreateIndexSets(ctx, ids, true)
+	if err != nil {
+		return err
+	}
+
 	// iterate through both user and common index
-	for _, uid := range []string{userID, ""} {
-		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
-		if err != nil {
-			return err
-		}
+	for i, indexSet := range sets {
 
 		if indexSet.Err() != nil {
-			t.cleanupBrokenIndexSet(ctx, uid)
+			// since getOrCreateIndexSets preserves input->output positional mapping,
+			// we know this indexSet corresponds to the i'th ID.
+			t.cleanupBrokenIndexSet(ctx, ids[i])
 			return indexSet.Err()
 		}
 
@@ -242,61 +246,89 @@ func (t *table) Sync(ctx context.Context) error {
 	return nil
 }
 
-// getOrCreateIndexSet gets or creates the index set for the userID.
+// getOrCreateIndexSets gets or creates the index sets for the userIDs.
 // If it does not exist, it creates a new one and initializes it in a goroutine.
 // Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
 // forQuerying must be set to true only getting the index for querying since
 // it captures the amount of time it takes to download the index at query time.
-func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying bool) (IndexSet, error) {
+// NOTE: order of inputs and outputs are preserved: if user "A" is the 0th position in the `ids`
+// argument, it will be the 0th position in the returned []IndexSet as well.
+func (t *table) getOrCreateIndexSets(ctx context.Context, ids []string, forQuerying bool) ([]IndexSet, error) {
+
+	// withLock keeps track of index sets which didn't exist and therefore need
+	// to be tried again under a Lock instead of RLock
+	var withLock []int
+	results := make([]IndexSet, len(ids))
+	var found int
+	var err error
+
 	t.indexSetsMtx.RLock()
-	indexSet, ok := t.indexSets[id]
+	for i, id := range ids {
+		set, ok := t.indexSets[id]
+		if ok {
+			results[i] = set
+			found++
+		} else {
+			withLock = append(withLock, i)
+		}
+	}
 	t.indexSetsMtx.RUnlock()
-	if ok {
-		return indexSet, nil
+
+	// happy path: all required index sets were found
+	if found == len(ids) {
+		return results, nil
 	}
 
 	t.indexSetsMtx.Lock()
 	defer t.indexSetsMtx.Unlock()
 
-	indexSet, ok = t.indexSets[id]
-	if ok {
-		return indexSet, nil
-	}
+	for i := range withLock {
 
-	var err error
-	baseIndexSet := t.baseUserIndexSet
-	if id == "" {
-		baseIndexSet = t.baseCommonIndexSet
-	}
+		// since we're starting goroutines with references to this item
+		// during iteration over the slice,
+		// we must bind it within the iteration
+		pos := withLock[i]
+		id := ids[pos]
 
-	// instantiate the index set, add it to the map
-	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc,
-		loggerWithUserID(t.logger, id))
-	if err != nil {
-		return nil, err
-	}
-	t.indexSets[id] = indexSet
+		set, ok := t.indexSets[id]
+		if !ok {
+			baseIndexSet := t.baseUserIndexSet
+			if id == "" {
+				baseIndexSet = t.baseCommonIndexSet
+			}
 
-	// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
-	go func() {
-		if forQuerying {
-			start := time.Now()
-			defer func() {
-				duration := time.Since(start)
-				t.metrics.queryTimeTableDownloadDurationSeconds.WithLabelValues(t.name).Add(duration.Seconds())
-				logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
-				level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
+			// instantiate the index set, add it to the map
+			set, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc,
+				loggerWithUserID(t.logger, id))
+			if err != nil {
+				return nil, err
+			}
+			t.indexSets[id] = set
+
+			// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
+			go func() {
+				if forQuerying {
+					start := time.Now()
+					defer func() {
+						duration := time.Since(start)
+						t.metrics.queryTimeTableDownloadDurationSeconds.WithLabelValues(t.name).Add(duration.Seconds())
+						logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
+						level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
+					}()
+				}
+
+				err := set.Init(forQuerying)
+				if err != nil {
+					level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
+					t.cleanupBrokenIndexSet(ctx, id)
+				}
 			}()
 		}
 
-		err := indexSet.Init(forQuerying)
-		if err != nil {
-			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
-			t.cleanupBrokenIndexSet(ctx, id)
-		}
-	}()
+		results[pos] = set
+	}
 
-	return indexSet, nil
+	return results, err
 }
 
 // cleanupBrokenIndexSet if an indexSet with given id exists and is really broken i.e Err() returns a non-nil error
@@ -320,10 +352,12 @@ func (t *table) cleanupBrokenIndexSet(ctx context.Context, id string) {
 // EnsureQueryReadiness ensures that we have downloaded the common index as well as user index for the provided userIDs.
 // When ensuring query readiness for a table, we will always download common index set because it can include index for one of the provided user ids.
 func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
-	commonIndexSet, err := t.getOrCreateIndexSet(ctx, "", false)
+	res, err := t.getOrCreateIndexSets(ctx, []string{""}, false)
 	if err != nil {
 		return err
 	}
+
+	commonIndexSet := res[0]
 	err = commonIndexSet.AwaitReady(ctx)
 	if err != nil {
 		return err
@@ -347,12 +381,13 @@ func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) erro
 
 // downloadUserIndexes downloads user specific index files concurrently.
 func (t *table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
-	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
-		indexSet, err := t.getOrCreateIndexSet(ctx, userIDs[idx], false)
-		if err != nil {
-			return err
-		}
+	sets, err := t.getOrCreateIndexSets(ctx, userIDs, false)
+	if err != nil {
+		return err
+	}
 
+	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
+		indexSet := sets[idx]
 		return indexSet.AwaitReady(ctx)
 	})
 }


### PR DESCRIPTION
While I'm still in favor of a longer refactor to address the complexity described in https://github.com/grafana/loki/pull/7490, I'm opening this PR as a shorter, more immediate alternative that should fix the deadlocks. This also reduces the number of total lock calls in many cases as we lock to act over entire groups rather than individual items.