### PR TITLE
tsdb post compaction cleanup

### DIFF
--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -89,8 +88,9 @@ func newTableCompactor(
 func (t *tableCompactor) CompactTable() error {
 	multiTenantIndexes := t.commonIndexSet.ListSourceFiles()
 
-	var multiTenantIndices []Index
-	indicesMtx := sync.Mutex{}
+	// index reference and download paths would be stored at the same slice index
+	multiTenantIndices := make([]Index, len(multiTenantIndexes))
+	downloadPaths := make([]string, len(multiTenantIndexes))
 
 	// concurrently download and open all the multi-tenant indexes
 	err := concurrency.ForEachJob(t.ctx, len(multiTenantIndexes), readDBsConcurrency, func(ctx context.Context, job int) error {
@@ -99,26 +99,31 @@ func (t *tableCompactor) CompactTable() error {
 			return err
 		}
 
-		defer func() {
-			if err := os.Remove(downloadedAt); err != nil {
-				level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to remove downloaded index file", "path", downloadedAt, "err", err)
-			}
-		}()
-
+		downloadPaths[job] = downloadedAt
 		idx, err := OpenShippableTSDB(downloadedAt)
 		if err != nil {
 			return err
 		}
 
-		indicesMtx.Lock()
-		defer indicesMtx.Unlock()
-		multiTenantIndices = append(multiTenantIndices, idx.(Index))
+		multiTenantIndices[job] = idx.(Index)
 
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		for i, idx := range multiTenantIndices {
+			if err := idx.Close(); err != nil {
+				level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to close multi-tenant source index file", "path", downloadPaths[i], "err", err)
+			}
+
+			if err := os.Remove(downloadPaths[i]); err != nil {
+				level.Error(t.commonIndexSet.GetLogger()).Log("msg", "failed to remove downloaded index file", "path", downloadPaths[i], "err", err)
+			}
+		}
+	}()
 
 	var multiTenantIndex Index = NoopIndex{}
 	if len(multiTenantIndices) > 0 {

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -1587,8 +1587,6 @@ func (r *Reader) SymbolTableSize() uint64 {
 }
 
 // SortedLabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
 func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	values, err := r.LabelValues(name, matchers...)
 	if err == nil && r.version == FormatV1 {
@@ -1598,8 +1596,6 @@ func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]
 }
 
 // LabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
 // TODO(replay): Support filtering by matchers
 func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
@@ -1643,7 +1639,7 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 		} else {
 			d.Skip(skip)
 		}
-		s := yoloString(d.UvarintBytes()) // Label value.
+		s := string(d.UvarintBytes()) // Label value.
 		values = append(values, s)
 		if s == lastVal {
 			break


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously when we were reading the whole tsdb index in memory, there was not much cleanup required after we were done with the index. Now that we are mmaping the tsdb index, we need to close the mmap.
I had missed calling `index.Close()` on the compacted-away multi-tenant index. This causes the compactor to retain the files on disk, leading to the compactor running away from disk space. This PR takes care of it.

While doing the changes, I noticed that some of the tests failed due to `LabelValues` tsdb implementation returning strings valid only until the underlying byte slice stays valid. Since the underlying byte slice could become invalid when we close the tsdb, we should return a copy instead of yolostring. This can also happen on the query path when a sync closes the index before we get to return the response. This PR also fixes that.
