### PR TITLE
Promtail Docs: Clarifiy labels and timestamps set by cri stage

### DIFF
--- a/docs/sources/clients/promtail/stages/cri.md
+++ b/docs/sources/clients/promtail/stages/cri.md
@@ -46,4 +46,5 @@ The following key-value pairs would be created in the set of extracted data:
 
 - `content`: `message`
 - `stream`: `stdout`
-- `timestamp`: `2019-04-30T02:12:41.8443515`
+- `flags`: `xx`
+- `timestamp`: `2019-04-30T02:12:41.8443515` - The cri-stage both extracts the timestamp as a label and set it as the timestamp of the log entry.


### PR DESCRIPTION
Add description that `cri` stage not only adds labels for timestamp, but that it also sets the timestamp of the log-entry before sending it.

Honestly I don't know if this is the intention or not, but this is how things are implemented today and it makes the most sense. Even if not, changing the behavior now would not be possible without breaking old implicit assumptions, so better have more explicit documentation.

Existing Implementation: https://github.com/grafana/loki/blob/main/clients/pkg/logentry/stages/extensions.go#L31 
Existing tests for described behavior: https://github.com/grafana/loki/blob/main/clients/pkg/logentry/stages/extensions_test.go#L243 

Also clarify that the cri-`flags` get extracted as a label.