### PR TITLE
[Helm] Add toggle for MetricsInstance

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1968,6 +1968,7 @@ null
 			<td><pre lang="json">
 {
   "annotations": {},
+  "enabled": true,
   "labels": {},
   "remoteWrite": null
 }
@@ -1980,6 +1981,15 @@ null
 			<td>MerticsInstance annotations</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>monitoring.serviceMonitor.metricsInstance.enabled</td>
+			<td>bool</td>
+			<td>If enabled, MetricsInstance resources for Grafana Agent Operator are created</td>
+			<td><pre lang="json">
+true
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/monitoring/metrics-instance.yaml
+++ b/production/helm/loki/templates/monitoring/metrics-instance.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.serviceMonitor.enabled }}
+{{- if and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.metricsInstance.enabled  }}
 {{- with .Values.monitoring.serviceMonitor.metricsInstance }}
 apiVersion: monitoring.grafana.com/v1alpha1
 kind: MetricsInstance

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -633,6 +633,8 @@ monitoring:
     tlsConfig: null
     # -- If defined, will create a MetricsInstance for the Grafana Agent Operator.
     metricsInstance:
+      # -- If enabled, MetricsInstance resources for Grafana Agent Operator are created
+      enabled: true
       # -- MerticsInstance annotations
       annotations: {}
       # -- Additional MatricsInstance labels


### PR DESCRIPTION
Signed-off-by: Jan-Otto Kröpke <jok@cloudeteer.de>

**What this PR does / why we need it**:

Chart version 3.3.0 introduced a new MetricsInstance CR. The only way to disable the MetricsInstance is `--set loki.monitoring.serviceMonitor.metricsInstance=null`, but this raises helm warning... 

```
coalesce.go:220: warning: cannot overwrite table with non table for loki.monitoring.serviceMonitor.metricsInstance (map[annotations:map[] labels:map[] remoteWrite:<nil>])
coalesce.go:220: warning: cannot overwrite table with non table for loki.monitoring.serviceMonitor.metricsInstance (map[annotations:map[] labels:map[] remoteWrite:<nil>])
coalesce.go:220: warning: cannot overwrite table with non table for loki.monitoring.serviceMonitor.metricsInstance (map[annotations:map[] labels:map[] remoteWrite:<nil>])
```



**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
