### PR TITLE
Add terraform snippets to Promtail GCP Logs documentation

### DIFF
--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -169,7 +169,7 @@ resource "google_pubsub_topic_iam_binding" "log-writer" {
 }
 ```
 
-Then, another snippet needs to be added depending on wether the `pull` or `push` flavour is chosen.
+Then, another snippet needs to be added depending on whether the `pull` or `push` flavour is chosen.
 
 ### Pull
 

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -183,7 +183,7 @@ resource "google_pubsub_subscription" "main" {
 }
 ```
 
-Then, the new resources can be applied by running, filling the required variables.
+Then, to create the new resources run the snippet below after filling in the required variables.
 
 ```bash
 terraform apply \

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -173,7 +173,7 @@ Then, another snippet needs to be added depending on wether the `pull` or `push`
 
 ### Pull
 
-The following snippet configures the pull subscription, for Promtail to subscribe to.
+The following snippet configures a subscription to the pub/sub topic which Promtail will subscribe to.
 
 ```terraform
 // Subscription

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -150,7 +150,7 @@ resource "google_pubsub_topic" "main" {
 // Log sink
 variable "inclusion_filter" {
   type        = string
-  description = "GCP Logs query filtering down which logs should be sent to Promtail."
+  description = "Optional GCP Logs query which can filter logs being routed to the pub/sub topic and promtail"
 }
 
 resource "google_logging_project_sink" "main" {

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -136,6 +136,8 @@ gcloud pubsub subscriptions create cloud-logs \
 
 You also have the option of creating the required resources for GCP Log collection with terraform. First, the following snippet will add the resources needed for both `pull` and `push` flavours.
 
+How to use Terraform is outside the scope of this guide. You can find [this tutorial](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/google-cloud-platform-build) on how to work with Terraform and GCP useful.
+
 ```terraform
 // Provider module
 provider "google" {

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -134,7 +134,7 @@ gcloud pubsub subscriptions create cloud-logs \
 
 ## Setup using Terraform
 
-You can configure all resources created in the steps above with the `gcloud` CLI, but with terraform. First, the following snippet will add the resources needed for both `pull` and `push` flavours.
+You also have the option of creating the required resources for GCP Log collection with terraform. First, the following snippet will add the resources needed for both `pull` and `push` flavours.
 
 ```terraform
 // Provider module

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -192,7 +192,7 @@ terraform apply \
 
 ### Push
 
-The following snippet configures the push subscription, for GCP to send logs to Promtail.
+The following snippet configures a push subscription to the pub/sub topic which will forward logs to Promtail.
 
 ```terraform
 // Subscription

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -213,7 +213,7 @@ resource "google_pubsub_subscription" "main" {
 }
 ```
 
-Then, the new resources can be applied by running, filling the required variables.
+Then, to create the new resources run the snippet below after filling in the required variables.
 
 ```bash
 terraform apply \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up to the documentation added (https://github.com/grafana/loki/pull/7511) for configuring the infrastructure resources for shipping logs to the new-ish GCP Logs Push Promtail target. Terraform snippets are added for writing the same infrastructure in an as-code manner, which works better for infra folks.

**TODO**
- [ ] Add snippet on how to setup the pubsub push caveat with terraform (project wide policy)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
