### PR TITLE
[Helm] Fix invalid ruler config when filesystem storage is used

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.3.1
+
+- [BUGFIX] Fix invalid ruler config when filesystem storage is being used
+
 ## 3.3.0
 
 - [CHANGE] Remove ServiceMonitor and PrometheusRule CRD

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.3.0
+version: 3.3.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -216,10 +216,12 @@ Storage config for ruler
 */}}
 {{- define "loki.rulerStorageConfig" -}}
 {{- if .Values.minio.enabled -}}
+type: "s3"
 s3:
   bucketnames: {{ $.Values.loki.storage.bucketNames.ruler }}
 {{- else if eq .Values.loki.storage.type "s3" -}}
 {{- with .Values.loki.storage.s3 }}
+type: "s3"
 s3:
   {{- with .s3 }}
   s3: {{ . }}
@@ -242,6 +244,7 @@ s3:
 {{- end -}}
 {{- else if eq .Values.loki.storage.type "gcs" -}}
 {{- with .Values.loki.storage.gcs }}
+type: "gcs"
 gcs:
   bucket_name: {{ $.Values.loki.storage.bucketNames.ruler }}
   chunk_buffer_size: {{ .chunkBufferSize }}
@@ -250,6 +253,24 @@ gcs:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Predicate function to determin if custom ruler config should be included */}}
+{{- define "loki.shouldIncludeRulerConfig" }}
+{{- or (not (empty .Values.loki.rulerConfig)) (.Values.minio.enabled) (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+{{- end }}
+
+{{/* Loki ruler config */}}
+{{- define "loki.rulerConfig" }}
+{{- if eq (include "loki.shouldIncludeRulerConfig" .) "true" }}
+ruler:
+{{- if (not (empty .Values.loki.rulerConfig)) }}
+{{- toYaml .Values.loki.rulerConfig | nindent 2}}
+{{- else }}
+  storage:
+  {{- include "loki.rulerStorageConfig" . | nindent 4}}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Memcached Docker image

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -136,14 +136,7 @@ loki:
             period: 24h
     {{- end }}
 
-    ruler:
-      storage:
-      {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
-      {{- include "loki.rulerStorageConfig" . | nindent 4}}
-      {{- end }}
-    {{- with .Values.loki.rulerConfig}}
-    {{- toYaml . | nindent 2}}
-    {{- end }}
+    {{ include "loki.rulerConfig" . }}
 
     {{- with .Values.loki.memcached.results_cache }}
     query_range:


### PR DESCRIPTION
**What this PR does / why we need it**:

When using filesystem storage, there's a bug in the configmap helm template that sets `ruler.storage` to `null`. This fixes that bug.

**Which issue(s) this PR fixes**:
Fixes #7267

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
