### PR TITLE
[helm] Fix incorrect ingress paths when using single binary deployment

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ docs-test: pull
 
 sources/installation/helm/reference.md: ../production/helm/loki/reference.md.gotmpl
 ifeq ($(BUILD_IN_CONTAINER),true)
-	docker run --rm --volume "$(realpath ..):/helm-docs:z" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.8.1" \
+	docker run --rm --volume "$(realpath ..):/helm-docs:z" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
 		-c /helm-docs/production/helm/ \
 		-t reference.md.gotmpl \
 		-o reference.md

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1086,6 +1086,87 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>ingress.paths.singleBinary[0]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/api/prom/push"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[1]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/loki/api/v1/push"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[2]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/api/prom/tail"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[3]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/loki/api/v1/tail"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[4]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/loki/api"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[5]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/api/prom/rules"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[6]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/loki/api/v1/rules"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[7]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/prometheus/api/v1/rules"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.paths.singleBinary[8]</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+"/prometheus/api/v1/alerts"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>ingress.paths.write[0]</td>
 			<td>string</td>
 			<td></td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -34,6 +34,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 3.3.1
 
 - [BUGFIX] Fix invalid ruler config when filesystem storage is being used
+- [BUGFIX] Fix ingress template to work with both deployment types (scalable and single binary)
 
 ## 3.3.0
 

--- a/production/helm/loki/templates/ingress.yaml
+++ b/production/helm/loki/templates/ingress.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.ingress.enabled }}
-{{- $ingressApiIsStable := eq (include "loki.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "loki.ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "loki.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "loki.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -33,23 +31,6 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          {{- range $svcName, $paths := $.Values.ingress.paths }}
-            {{- range $paths }}
-          - path: {{ . }}
-            {{- if $ingressSupportsPathType }}
-            pathType: Prefix
-            {{- end }}
-            backend:
-              {{- if $ingressApiIsStable }}
-              service:
-                name: {{ include "loki.fullname" $ }}-{{ $svcName }}
-                port:
-                  number: 3100
-              {{- else }}
-              serviceName: {{ include "loki.fullname" $ }}-{{ $svcName }}
-              servicePort: 3100
-              {{- end }}
-              {{- end }}
-           {{- end }}
+          {{- include "loki.ingress.servicePaths" $ | indent 10}}
     {{- end }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -948,6 +948,17 @@ ingress:
       - /loki/api/v1/rules
       - /prometheus/api/v1/rules
       - /prometheus/api/v1/alerts
+    singleBinary:
+      - /api/prom/push
+      - /loki/api/v1/push
+      - /api/prom/tail
+      - /loki/api/v1/tail
+      - /loki/api
+      - /api/prom/rules
+      - /loki/api/v1/rules
+      - /prometheus/api/v1/rules
+      - /prometheus/api/v1/alerts
+
   hosts:
     - loki.example.com
 #  tls:


### PR DESCRIPTION
**What this PR does / why we need it**:
The helm ingress template was copied over from the simple scalable chart and does not work when deploying the chart in single binary configuration. This fixes that by adding a set of single binary routes, and conditionally configuring the ingress resource based on deployment type.

**Which issue(s) this PR fixes**:
Fixes #7080

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
