### PR TITLE
[Helm] Create metricsInstance only if available

### DIFF
--- a/production/helm/loki/templates/monitoring/metrics-instance.yaml
+++ b/production/helm/loki/templates/monitoring/metrics-instance.yaml
@@ -1,5 +1,6 @@
-{{- if and .Values.monitoring.serviceMonitor.enabled .Values.monitoring.serviceMonitor.metricsInstance.enabled  }}
+{{- if .Values.monitoring.serviceMonitor.enabled }}
 {{- with .Values.monitoring.serviceMonitor.metricsInstance }}
+{{- if and ($.Capabilities.APIVersions.Has "monitoring.grafana.com/v1alpha1/MetricsInstance") .enabled }}
 apiVersion: monitoring.grafana.com/v1alpha1
 kind: MetricsInstance
 metadata:
@@ -25,5 +26,6 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       {{- include "loki.selectorLabels" $ | nindent 6 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
If you're using prometheus operator and not Grafana Agent a metricsInstance shouldn't be auto-created.

**Which issue(s) this PR fixes**:
#7529

**Special notes for your reviewer**:
I would also propose moving the definition at the same level with serviceMonitor and adding .enabled i.e.:
```
  serviceMonitor:
    enabled: true
    ...
  metricsInstance:
    enabled: true
    annotations: {}
    labels: {}
    remoteWrite: null
```
This of course would be a breaking change.
**L.E.** Just noticed this other PR: #7525

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
