### PR TITLE
[new feature] promtail: supports deduplication of log file content.

### DIFF
--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -49,6 +49,7 @@ type Config struct {
 	DockerSDConfigs        []*moby.DockerSDConfig `mapstructure:"docker_sd_configs,omitempty" yaml:"docker_sd_configs,omitempty"`
 	ServiceDiscoveryConfig ServiceDiscoveryConfig `mapstructure:",squash" yaml:",inline"`
 	Encoding               string                 `mapstructure:"encoding,omitempty" yaml:"encoding,omitempty"`
+	Dedup                  bool                   `mapstructure:"dedup,omitempty" yaml:"dedup,omitempty"`
 }
 
 type ServiceDiscoveryConfig struct {

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -127,6 +127,7 @@ func NewFileTargetManager(
 			targetConfig:      targetConfig,
 			fileEventWatchers: map[string]chan fsnotify.Event{},
 			encoding:          cfg.Encoding,
+			dedup:             cfg.Dedup,
 		}
 		tm.syncers[cfg.JobName] = s
 		configs[cfg.JobName] = cfg.ServiceDiscoveryConfig.Configs()
@@ -277,6 +278,7 @@ type targetSyncer struct {
 	targetConfig  *Config
 
 	encoding string
+	dedup    bool
 }
 
 // sync synchronize target based on received target groups received by service discovery
@@ -434,7 +436,7 @@ func (s *targetSyncer) sendFileCreateEvent(event fsnotify.Event) {
 }
 
 func (s *targetSyncer) newTarget(path, pathExclude string, labels model.LabelSet, discoveredLabels model.LabelSet, fileEventWatcher chan fsnotify.Event, targetEventHandler chan fileTargetEvent) (*FileTarget, error) {
-	return NewFileTarget(s.metrics, s.log, s.entryHandler, s.positions, path, pathExclude, labels, discoveredLabels, s.targetConfig, fileEventWatcher, targetEventHandler, s.encoding)
+	return NewFileTarget(s.metrics, s.log, s.entryHandler, s.positions, path, pathExclude, labels, discoveredLabels, s.targetConfig, fileEventWatcher, targetEventHandler, s.encoding, s.dedup)
 }
 
 func (s *targetSyncer) DroppedTargets() []target.Target {

--- a/clients/pkg/promtail/targets/file/reader.go
+++ b/clients/pkg/promtail/targets/file/reader.go
@@ -2,6 +2,7 @@ package file
 
 // Reader contains the set of expected calls the file target manager relies on.
 type Reader interface {
+	Start() error
 	Stop()
 	IsRunning() bool
 	Path() string

--- a/clients/pkg/promtail/targets/file/summary.go
+++ b/clients/pkg/promtail/targets/file/summary.go
@@ -1,0 +1,70 @@
+package file
+
+import (
+	"bufio"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+)
+
+var summaryThread = 10
+
+type Summary struct {
+	lines   []string
+	summary string
+
+	t *FileTarget
+}
+
+func NewSummary(t *FileTarget) *Summary {
+	return &Summary{
+		t:     t,
+		lines: make([]string, 0),
+	}
+}
+
+func (s *Summary) readLine(line string) bool {
+	if s.summary != "" {
+		return true
+	}
+	s.lines = append(s.lines, line)
+	if len(s.lines) <= summaryThread {
+		return false
+	}
+
+	summaryLines := ""
+	for _, line := range s.lines {
+		summaryLines += line
+	}
+	summary := fmt.Sprintf("%x", md5.Sum([]byte(summaryLines)))
+	if s.t != nil {
+		s.t.summarys.Add(summary, 1)
+	}
+	s.summary = summary
+	return true
+}
+
+func (s *Summary) Summary() string {
+	return s.summary
+}
+
+func summaryFile(path string) (string, error) {
+	file, err := os.Open(path)
+	defer file.Close()
+	summary := NewSummary(nil)
+	if nil == err {
+		buff := bufio.NewReader(file)
+		for {
+			line, err := buff.ReadString('\n')
+			if err == io.EOF {
+				break
+			}
+			isEnd := summary.readLine(line)
+			if isEnd {
+				break
+			}
+		}
+	}
+	return summary.Summary(), nil
+}

--- a/clients/pkg/promtail/targets/file/tailer.go
+++ b/clients/pkg/promtail/targets/file/tailer.go
@@ -205,6 +205,9 @@ func (t *tailer) readLines() {
 
 func (t *tailer) SummaryFile(path string) (string, error) {
 	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
 	defer file.Close()
 	summary := NewSummary(nil)
 	if nil == err {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is mainly to solve the issue that has existed for a long time. Don't make users wait too long .
this PR may not be perfect, look forward to review
![image](https://user-images.githubusercontent.com/9583245/198300134-e3966817-9124-4d02-94f2-a5d16a981b18.png)
When dealing with this peak log volume, roll files to buffer logs that are too late to process. And introduce deduplication files to avoid log duplication. So as to solve the problem of log loss.

Promtail supports deduplication of log file content to deal with rolling logs with a very large amount of logs. When promtail cannot handle it, we can guide users to configure the way of rolling logs. Then promtail config scrape /*.log, obtain a.2022 by comparing the contents of a.log and a.2022-10-27-1.log and a.2022-10-27-2.log and other logs. -10-27-1.log and other rolling logs to extract the lost log content.


```yaml
scrape_configs:
- job_name: system
  static_configs:
  - targets:
      - localhost
    labels:
      job: varlogs
      dedup: true
      __path__: /var/log/*log
```

add       dedup: true config to fix this case.

```
Here is what actually happens:

I start promtail
I start logrotate with 100 megabytes threshold
I start generating log with rate 50 000 lines per second.
After 150 seconds log file has 7 500 000 lines in it, and 100mb threshold is reached. At this moment, I have only 3 000 000 lines in loki. Then logrotate moves this file to another path, and then new file is created.
Promtail reads original (first) file to the end. When it reaches the end, it starts reading newly created file. At this moment, we already have about 6 000 000 log lines in new file.
Logrotate reads the new (second) file to the end. After the end reached, logrotate already rotated next (third) file and the fourth file is in place.
Promtail starts reading the fourth file.
So, I have 1, 2, and 4 files on loki, but 3rd file is missed.
```

**Which issue(s) this PR fixes**:
Fixes #2134

**Special notes for your reviewer**:
vector also solves this problem in a similar way.
https://vector.dev/docs/reference/configuration/sources/file/#fingerprint

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
