### PR TITLE
Loki: Fix index_set log message

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -278,14 +278,7 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 		return err
 	}
 
-	toDownloadBuilder := strings.Builder{}
-	for i, f := range toDownload {
-		if i != 0 {
-			toDownloadBuilder.WriteString(",")
-		}
-		toDownloadBuilder.WriteString(f.Name)
-	}
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownloadBuilder.String(), toDelete))
+	level.Debug(t.logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownload, toDelete))
 
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {
@@ -296,7 +289,7 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 	// it means the cache is not valid anymore since compaction would have happened after last index list cache refresh.
 	// Let us return error to ask the caller to re-run the sync after the list cache refresh.
 	if !bypassListCache && len(downloadedFiles) == 0 && len(toDownload) > 0 {
-		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownloadBuilder.String())
+		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", fmt.Sprint(toDownload))
 		return errIndexListCacheTooStale
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -278,7 +278,14 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 		return err
 	}
 
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownload, toDelete))
+	toDownloadBuilder := strings.Builder{}
+	for i, f := range toDownload {
+		if i != 0 {
+			toDownloadBuilder.WriteString(",")
+		}
+		toDownloadBuilder.WriteString(f.Name)
+	}
+	level.Debug(t.logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownloadBuilder.String(), toDelete))
 
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {
@@ -288,15 +295,8 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 	// if we did not bypass list cache and skipped downloading all the new files due to them being removed by compaction,
 	// it means the cache is not valid anymore since compaction would have happened after last index list cache refresh.
 	// Let us return error to ask the caller to re-run the sync after the list cache refresh.
-	toDownloadStr := strings.Builder{}
-	for i, f := range toDownload {
-		if i != 0 {
-			toDownloadStr.WriteString(",")
-		}
-		toDownloadStr.WriteString(f.Name)
-	}
 	if !bypassListCache && len(downloadedFiles) == 0 && len(toDownload) > 0 {
-		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownloadStr.String())
+		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownloadBuilder.String())
 		return errIndexListCacheTooStale
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -288,8 +288,15 @@ func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err er
 	// if we did not bypass list cache and skipped downloading all the new files due to them being removed by compaction,
 	// it means the cache is not valid anymore since compaction would have happened after last index list cache refresh.
 	// Let us return error to ask the caller to re-run the sync after the list cache refresh.
+	toDownloadStr := strings.Builder{}
+	for i, f := range toDownload {
+		if i != 0 {
+			toDownloadStr.WriteString(",")
+		}
+		toDownloadStr.WriteString(f.Name)
+	}
 	if !bypassListCache && len(downloadedFiles) == 0 && len(toDownload) > 0 {
-		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownload)
+		level.Error(t.logger).Log("msg", "we skipped downloading all the new files, possibly removed by compaction", "files", toDownloadStr.String())
 		return errIndexListCacheTooStale
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, this log message isn't correctly showing the list of files (instead it logs the value as "unsupported value type").