### PR TITLE
Prevent IndexShipper from leaking mutex accesses.

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -178,11 +178,7 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	if err := t.indexMtx.rLock(ctx); err != nil {
 		return err
 	}
-
-	go func() {
-		<-ctx.Done()
-		t.indexMtx.rUnlock()
-	}()
+	defer t.indexMtx.rUnlock()
 
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -32,7 +32,7 @@ var errIndexListCacheTooStale = fmt.Errorf("index list cache too stale")
 type IndexSet interface {
 	Init(forQuerying bool) error
 	Close()
-	ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
 	DropAllDBs() error
 	Err() error
 	LastUsedAt() time.Time
@@ -174,13 +174,13 @@ func (t *indexSet) Close() {
 	t.index = map[string]index.Index{}
 }
 
-func (t *indexSet) ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	if err := t.indexMtx.rLock(ctx); err != nil {
 		return err
 	}
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		t.indexMtx.rUnlock()
 	}()
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
@@ -33,6 +34,7 @@ type IndexSet interface {
 	Init(forQuerying bool) error
 	Close()
 	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
+	ForEachConcurrent(ctx context.Context, callback index.ForEachIndexCallback) error
 	DropAllDBs() error
 	Err() error
 	LastUsedAt() time.Time
@@ -190,6 +192,27 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	}
 
 	return nil
+}
+
+func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEachIndexCallback) error {
+
+	if err := t.indexMtx.rLock(ctx); err != nil {
+		return err
+	}
+	defer t.indexMtx.rUnlock()
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	logger := util_log.WithContext(ctx, t.logger)
+	level.Debug(logger).Log("index-files-count", len(t.index))
+
+	for i := range t.index {
+		idx := t.index[i]
+		g.Go(func() error {
+			return callback(t.userID == "", idx)
+		})
+	}
+	return g.Wait()
 }
 
 // DropAllDBs closes reference to all the open index and removes the local files.

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,10 +40,7 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), callbackFunc)
 		})
 		stopFunc()
 	}
@@ -88,10 +85,7 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				return indexSet.ForEach(ctx, callbackFunc)
+				return indexSet.ForEach(context.Background(), callbackFunc)
 			})
 		})
 	}
@@ -110,10 +104,7 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			return indexSet.ForEach(ctx, callbackFunc)
+			return indexSet.ForEach(context.Background(), callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set_test.go
@@ -40,10 +40,10 @@ func TestIndexSet_Init(t *testing.T) {
 		indexSet, stopFunc := buildTestIndexSet(t, userID, tempDir)
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			doneChan := make(chan struct{})
-			defer close(doneChan)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 		stopFunc()
 	}
@@ -88,10 +88,10 @@ func TestIndexSet_doConcurrentDownload(t *testing.T) {
 				require.Len(t, indexSet.index, tc)
 			}
 			verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-				doneChan := make(chan struct{})
-				defer close(doneChan)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-				return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+				return indexSet.ForEach(ctx, callbackFunc)
 			})
 		})
 	}
@@ -110,10 +110,10 @@ func TestIndexSet_Sync(t *testing.T) {
 	checkIndexSet := func() {
 		require.Len(t, indexSet.index, len(indexesSetup))
 		verifyIndexForEach(t, indexesSetup, func(callbackFunc index.ForEachIndexCallback) error {
-			doneChan := make(chan struct{})
-			defer close(doneChan)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-			return indexSet.ForEach(context.Background(), doneChan, callbackFunc)
+			return indexSet.ForEach(ctx, callbackFunc)
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -28,7 +28,7 @@ const (
 
 type Table interface {
 	Close()
-	ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
 	Sync(ctx context.Context) error
 	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
@@ -144,7 +144,7 @@ func (t *table) Close() {
 	t.indexSets = map[string]IndexSet{}
 }
 
-func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	// iterate through both user and common index
 	for _, uid := range []string{userID, ""} {
 		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
@@ -157,7 +157,7 @@ func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan stru
 			return indexSet.Err()
 		}
 
-		err = indexSet.ForEach(ctx, doneChan, callback)
+		err = indexSet.ForEach(ctx, callback)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -152,7 +152,7 @@ func (t *table) ForEachConcurrent(ctx context.Context, userID string, callback i
 	// iterate through both user and common index
 	users := []string{userID, ""}
 
-	for i := range []string{userID, ""} {
+	for i := range users {
 		// bind locally within iteration before
 		// sending to goroutine
 		uid := users[i]

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -24,7 +24,6 @@ import (
 const (
 	downloadTimeout        = 5 * time.Minute
 	maxDownloadConcurrency = 50
-	CommonTenantIdentifier = ""
 )
 
 type Table interface {
@@ -117,7 +116,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		table.indexSets[userID] = userIndexSet
 	}
 
-	commonIndexSet, err := NewIndexSet(name, CommonTenantIdentifier, cacheLocation, table.baseCommonIndexSet,
+	commonIndexSet, err := NewIndexSet(name, "", cacheLocation, table.baseCommonIndexSet,
 		openIndexFileFunc, table.logger)
 	if err != nil {
 		return nil, err
@@ -128,7 +127,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		return nil, err
 	}
 
-	table.indexSets[CommonTenantIdentifier] = commonIndexSet
+	table.indexSets[""] = commonIndexSet
 
 	return &table, nil
 }
@@ -146,19 +145,15 @@ func (t *table) Close() {
 }
 
 func (t *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
-	ids := []string{userID, CommonTenantIdentifier}
-	sets, err := t.getOrCreateIndexSets(ctx, ids, true)
-	if err != nil {
-		return err
-	}
-
 	// iterate through both user and common index
-	for i, indexSet := range sets {
+	for _, uid := range []string{userID, ""} {
+		indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
+		if err != nil {
+			return err
+		}
 
 		if indexSet.Err() != nil {
-			// since getOrCreateIndexSets preserves input->output positional mapping,
-			// we know this indexSet corresponds to the i'th ID.
-			t.cleanupBrokenIndexSet(ctx, ids[i])
+			t.cleanupBrokenIndexSet(ctx, uid)
 			return indexSet.Err()
 		}
 
@@ -181,7 +176,7 @@ func (t *table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string 
 	for userID, userIndexSet := range t.indexSets {
 		lastUsedAt := userIndexSet.LastUsedAt()
 		if lastUsedAt.Add(ttl).Before(now) {
-			if userID == CommonTenantIdentifier {
+			if userID == "" {
 				// add the userID for common index set at the end of the list to make sure it is the last one cleaned up
 				// because we remove directories containing the index sets which in case of common index is
 				// the parent directory of all the user index sets.
@@ -194,7 +189,7 @@ func (t *table) findExpiredIndexSets(ttl time.Duration, now time.Time) []string 
 
 	// common index set should expire only after all the user index sets have expired.
 	if commonIndexSetExpired && len(expiredIndexSets) == len(t.indexSets)-1 {
-		expiredIndexSets = append(expiredIndexSets, CommonTenantIdentifier)
+		expiredIndexSets = append(expiredIndexSets, "")
 	}
 
 	return expiredIndexSets
@@ -211,7 +206,7 @@ func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) 
 		for _, userID := range indexSetsToCleanup {
 			// additional check for cleaning up the common index set when it is the only one left.
 			// This is just for safety because the index sets could change between findExpiredIndexSets and the actual cleanup.
-			if userID == CommonTenantIdentifier && len(t.indexSets) != 1 {
+			if userID == "" && len(t.indexSets) != 1 {
 				level.Info(t.logger).Log("msg", "skipping cleanup of common index set because we possibly have unexpired user index sets left")
 				continue
 			}
@@ -247,89 +242,61 @@ func (t *table) Sync(ctx context.Context) error {
 	return nil
 }
 
-// getOrCreateIndexSets gets or creates the index sets for the userIDs.
+// getOrCreateIndexSet gets or creates the index set for the userID.
 // If it does not exist, it creates a new one and initializes it in a goroutine.
 // Caller can use IndexSet.AwaitReady() to wait until the IndexSet gets ready, if required.
 // forQuerying must be set to true only getting the index for querying since
 // it captures the amount of time it takes to download the index at query time.
-// NOTE: order of inputs and outputs are preserved: if user "A" is the 0th position in the `ids`
-// argument, it will be the 0th position in the returned []IndexSet as well.
-func (t *table) getOrCreateIndexSets(ctx context.Context, ids []string, forQuerying bool) ([]IndexSet, error) {
-
-	// withLock keeps track of index sets which didn't exist and therefore need
-	// to be tried again under a Lock instead of RLock
-	var withLock []int
-	results := make([]IndexSet, len(ids))
-	var found int
-	var err error
-
+func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying bool) (IndexSet, error) {
 	t.indexSetsMtx.RLock()
-	for i, id := range ids {
-		set, ok := t.indexSets[id]
-		if ok {
-			results[i] = set
-			found++
-		} else {
-			withLock = append(withLock, i)
-		}
-	}
+	indexSet, ok := t.indexSets[id]
 	t.indexSetsMtx.RUnlock()
-
-	// happy path: all required index sets were found
-	if found == len(ids) {
-		return results, nil
+	if ok {
+		return indexSet, nil
 	}
 
 	t.indexSetsMtx.Lock()
 	defer t.indexSetsMtx.Unlock()
 
-	for i := range withLock {
+	indexSet, ok = t.indexSets[id]
+	if ok {
+		return indexSet, nil
+	}
 
-		// since we're starting goroutines with references to this item
-		// during iteration over the slice,
-		// we must bind it within the iteration
-		pos := withLock[i]
-		id := ids[pos]
+	var err error
+	baseIndexSet := t.baseUserIndexSet
+	if id == "" {
+		baseIndexSet = t.baseCommonIndexSet
+	}
 
-		set, ok := t.indexSets[id]
-		if !ok {
-			baseIndexSet := t.baseUserIndexSet
-			if id == CommonTenantIdentifier {
-				baseIndexSet = t.baseCommonIndexSet
-			}
+	// instantiate the index set, add it to the map
+	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc,
+		loggerWithUserID(t.logger, id))
+	if err != nil {
+		return nil, err
+	}
+	t.indexSets[id] = indexSet
 
-			// instantiate the index set, add it to the map
-			set, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc,
-				loggerWithUserID(t.logger, id))
-			if err != nil {
-				return nil, err
-			}
-			t.indexSets[id] = set
-
-			// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
-			go func() {
-				if forQuerying {
-					start := time.Now()
-					defer func() {
-						duration := time.Since(start)
-						t.metrics.queryTimeTableDownloadDurationSeconds.WithLabelValues(t.name).Add(duration.Seconds())
-						logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
-						level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
-					}()
-				}
-
-				err := set.Init(forQuerying)
-				if err != nil {
-					level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
-					t.cleanupBrokenIndexSet(ctx, id)
-				}
+	// initialize the index set in async mode, it would be upto the caller to wait for its readiness using IndexSet.AwaitReady()
+	go func() {
+		if forQuerying {
+			start := time.Now()
+			defer func() {
+				duration := time.Since(start)
+				t.metrics.queryTimeTableDownloadDurationSeconds.WithLabelValues(t.name).Add(duration.Seconds())
+				logger := spanlogger.FromContextWithFallback(ctx, loggerWithUserID(t.logger, id))
+				level.Info(logger).Log("msg", "downloaded index set at query time", "duration", duration)
 			}()
 		}
 
-		results[pos] = set
-	}
+		err := indexSet.Init(forQuerying)
+		if err != nil {
+			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to init user index set %s", id), "err", err)
+			t.cleanupBrokenIndexSet(ctx, id)
+		}
+	}()
 
-	return results, err
+	return indexSet, nil
 }
 
 // cleanupBrokenIndexSet if an indexSet with given id exists and is really broken i.e Err() returns a non-nil error
@@ -353,12 +320,10 @@ func (t *table) cleanupBrokenIndexSet(ctx context.Context, id string) {
 // EnsureQueryReadiness ensures that we have downloaded the common index as well as user index for the provided userIDs.
 // When ensuring query readiness for a table, we will always download common index set because it can include index for one of the provided user ids.
 func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) error {
-	res, err := t.getOrCreateIndexSets(ctx, []string{CommonTenantIdentifier}, false)
+	commonIndexSet, err := t.getOrCreateIndexSet(ctx, "", false)
 	if err != nil {
 		return err
 	}
-
-	commonIndexSet := res[0]
 	err = commonIndexSet.AwaitReady(ctx)
 	if err != nil {
 		return err
@@ -383,19 +348,17 @@ func (t *table) EnsureQueryReadiness(ctx context.Context, userIDs []string) erro
 // downloadUserIndexes downloads user specific index files concurrently.
 func (t *table) downloadUserIndexes(ctx context.Context, userIDs []string) error {
 	return concurrency.ForEachJob(ctx, len(userIDs), maxDownloadConcurrency, func(ctx context.Context, idx int) error {
-		// TODO: concurrency should be controlled globally
-		// Here, we call getOrCreateIndexSets one at a time in order to run with proper concurrency since
-		// we call `AwaitReady` afterwards.
-		indexSet, err := t.getOrCreateIndexSets(ctx, []string{userIDs[idx]}, false)
+		indexSet, err := t.getOrCreateIndexSet(ctx, userIDs[idx], false)
 		if err != nil {
 			return err
 		}
-		return indexSet[0].AwaitReady(ctx)
+
+		return indexSet.AwaitReady(ctx)
 	})
 }
 
 func loggerWithUserID(logger log.Logger, userID string) log.Logger {
-	if userID == CommonTenantIdentifier {
+	if userID == "" {
 		return logger
 	}
 

--- a/pkg/storage/stores/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/indexshipper/downloads/table.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
@@ -29,6 +30,7 @@ const (
 type Table interface {
 	Close()
 	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
+	ForEachConcurrent(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error)
 	Sync(ctx context.Context) error
 	EnsureQueryReadiness(ctx context.Context, userIDs []string) error
@@ -142,6 +144,34 @@ func (t *table) Close() {
 	}
 
 	t.indexSets = map[string]IndexSet{}
+}
+
+func (t *table) ForEachConcurrent(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	// iterate through both user and common index
+	users := []string{userID, ""}
+
+	for i := range []string{userID, ""} {
+		// bind locally within iteration before
+		// sending to goroutine
+		uid := users[i]
+
+		g.Go(func() error {
+			indexSet, err := t.getOrCreateIndexSet(ctx, uid, true)
+			if err != nil {
+				return err
+			}
+
+			if indexSet.Err() != nil {
+				t.cleanupBrokenIndexSet(ctx, uid)
+				return indexSet.Err()
+			}
+
+			return indexSet.ForEachConcurrent(ctx, callback)
+		})
+	}
+	return g.Wait()
 }
 
 func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {

--- a/pkg/storage/stores/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager.go
@@ -42,7 +42,7 @@ type IndexGatewayOwnsTenant func(tenant string) bool
 
 type TableManager interface {
 	Stop()
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type Config struct {
@@ -155,12 +155,12 @@ func (tm *tableManager) Stop() {
 	}
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, err := tm.getOrCreateTable(tableName)
 	if err != nil {
 		return err
 	}
-	return table.ForEach(ctx, userID, doneChan, callback)
+	return table.ForEach(ctx, userID, callback)
 }
 
 func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -452,6 +452,9 @@ type mockTable struct {
 func (m *mockTable) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	return nil
 }
+func (m *mockTable) ForEachConcurrent(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+	return nil
+}
 
 func (m *mockTable) Close() {}
 

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,10 +87,7 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+				return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
 			})
 		}
 	}
@@ -379,10 +376,7 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-
-					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
+					return tableManager.ForEach(context.Background(), tableName, userID, callbackFunc)
 				})
 			}
 		}

--- a/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_manager_test.go
@@ -87,10 +87,10 @@ func TestTableManager_ForEach(t *testing.T) {
 				expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 			}
 			verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-				doneChan := make(chan struct{})
-				defer close(doneChan)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-				return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
+				return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 			})
 		}
 	}
@@ -379,10 +379,10 @@ func TestTableManager_loadTables(t *testing.T) {
 					expectedIndexes = append(expectedIndexes, buildListOfExpectedIndexes(userID, 1, 5)...)
 				}
 				verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-					doneChan := make(chan struct{})
-					defer close(doneChan)
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
 
-					return tableManager.ForEach(context.Background(), tableName, userID, doneChan, callbackFunc)
+					return tableManager.ForEach(ctx, tableName, userID, callbackFunc)
 				})
 			}
 		}
@@ -455,7 +455,7 @@ type mockTable struct {
 	queryReadinessDoneForUsers []string
 }
 
-func (m *mockTable) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (m *mockTable) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	return nil
 }
 

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -81,7 +81,7 @@ type mockIndexSet struct {
 	lastUsedAt  time.Time
 }
 
-func (m *mockIndexSet) ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (m *mockIndexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	for _, idx := range m.indexes {
 		if err := callback(false, idx); err != nil {
 			return err
@@ -147,13 +147,11 @@ func TestTable_ForEach(t *testing.T) {
 			}
 
 			var indexesFound []index.Index
-			doneChan := make(chan struct{})
-			err := table.ForEach(context.Background(), tc.withUserID, doneChan, func(_ bool, idx index.Index) error {
+
+			err := table.ForEach(context.Background(), tc.withUserID, func(_ bool, idx index.Index) error {
 				indexesFound = append(indexesFound, idx)
 				return nil
 			})
-			close(doneChan)
-
 			if tc.withError {
 				require.Error(t, err)
 				require.Len(t, table.indexSets, len(usersToSetup))
@@ -316,12 +314,12 @@ func TestTable_Sync(t *testing.T) {
 	// check that table has expected indexes setup
 	var indexesFound []string
 
-	doneChan := make(chan struct{})
-	err := table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -339,12 +337,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	doneChan = make(chan struct{})
-	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -383,12 +381,12 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	doneChan = make(chan struct{})
-	err = table.ForEach(context.Background(), userID, doneChan, func(_ bool, idx index.Index) error {
+	ctx, cancel = context.WithCancel(context.Background())
+	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	close(doneChan)
+	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -419,10 +417,10 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		doneChan := make(chan struct{})
-		defer close(doneChan)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -443,10 +441,10 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		doneChan := make(chan struct{})
-		defer close(doneChan)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		return table.ForEach(context.Background(), userID, doneChan, callbackFunc)
+		return table.ForEach(ctx, userID, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/indexshipper/downloads/table_test.go
@@ -313,13 +313,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table has expected indexes setup
 	var indexesFound []string
-
-	ctx, cancel := context.WithCancel(context.Background())
-	err := table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err := table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{deleteDB, noUpdatesDB}, indexesFound)
@@ -337,12 +334,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// check that table got the new index and dropped the deleted index
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{newDB, noUpdatesDB}, indexesFound)
@@ -381,12 +376,10 @@ func TestTable_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	indexesFound = []string{}
-	ctx, cancel = context.WithCancel(context.Background())
-	err = table.ForEach(ctx, userID, func(_ bool, idx index.Index) error {
+	err = table.ForEach(context.Background(), userID, func(_ bool, idx index.Index) error {
 		indexesFound = append(indexesFound, idx.Name())
 		return nil
 	})
-	cancel()
 	require.NoError(t, err)
 	sort.Strings(indexesFound)
 	require.Equal(t, []string{compactedDBName}, indexesFound)
@@ -417,10 +410,7 @@ func TestLoadTable(t *testing.T) {
 	// check the loaded table to see it has right index files.
 	expectedIndexes := append(buildListOfExpectedIndexes(userID, 0, 5), buildListOfExpectedIndexes("", 0, 5)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, callbackFunc)
 	})
 
 	// close the table to test reloading of table with already having files in the cache dir.
@@ -441,10 +431,7 @@ func TestLoadTable(t *testing.T) {
 
 	expectedIndexes = append(buildListOfExpectedIndexes(userID, 0, 10), buildListOfExpectedIndexes("", 0, 10)...)
 	verifyIndexForEach(t, expectedIndexes, func(callbackFunc index.ForEachIndexCallback) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		return table.ForEach(ctx, userID, callbackFunc)
+		return table.ForEach(context.Background(), userID, callbackFunc)
 	})
 }
 

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -48,8 +48,6 @@ type IndexShipper interface {
 	// ForEach lets us iterates through each index file in a table for a specific user.
 	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
 	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
-	// Note: The index files would be locked until the passed ctx is cancelled to avoid making any changes to the index
-	// while it is being queried.
 	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 	Stop()
 }
@@ -177,7 +175,7 @@ func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, ca
 	}
 
 	if s.uploadsManager != nil {
-		if err := s.uploadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
+		if err := s.uploadsManager.ForEach(tableName, userID, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -48,9 +48,9 @@ type IndexShipper interface {
 	// ForEach lets us iterates through each index file in a table for a specific user.
 	// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
 	// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
-	// Note: The index files would be locked until the passed done chan is closed to avoid making any changes to the index
+	// Note: The index files would be locked until the passed ctx is cancelled to avoid making any changes to the index
 	// while it is being queried.
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 	Stop()
 }
 
@@ -169,15 +169,15 @@ func (s *indexShipper) AddIndex(tableName, userID string, index index.Index) err
 	return s.uploadsManager.AddIndex(tableName, userID, index)
 }
 
-func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	if s.downloadsManager != nil {
-		if err := s.downloadsManager.ForEach(ctx, tableName, userID, doneChan, callback); err != nil {
+		if err := s.downloadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
 			return err
 		}
 	}
 
 	if s.uploadsManager != nil {
-		if err := s.uploadsManager.ForEach(ctx, tableName, userID, doneChan, callback); err != nil {
+		if err := s.uploadsManager.ForEach(ctx, tableName, userID, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -21,7 +21,7 @@ type IndexSet interface {
 	Add(idx index.Index)
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
-	ForEach(ctx context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
 	Close()
 }
 
@@ -65,11 +65,11 @@ func (t *indexSet) Add(idx index.Index) {
 	t.index[idx.Name()] = idx
 }
 
-func (t *indexSet) ForEach(_ context.Context, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
 	t.indexMtx.RLock()
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		t.indexMtx.RUnlock()
 	}()
 

--- a/pkg/storage/stores/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set.go
@@ -21,7 +21,7 @@ type IndexSet interface {
 	Add(idx index.Index)
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
-	ForEach(ctx context.Context, callback index.ForEachIndexCallback) error
+	ForEach(callback index.ForEachIndexCallback) error
 	Close()
 }
 
@@ -65,13 +65,9 @@ func (t *indexSet) Add(idx index.Index) {
 	t.index[idx.Name()] = idx
 }
 
-func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallback) error {
+func (t *indexSet) ForEach(callback index.ForEachIndexCallback) error {
 	t.indexMtx.RLock()
-
-	go func() {
-		<-ctx.Done()
-		t.indexMtx.RUnlock()
-	}()
+	defer t.indexMtx.RUnlock()
 
 	for _, idx := range t.index {
 		if err := callback(t.userID == "", idx); err != nil {

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,12 +36,13 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err = indexSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -109,12 +110,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -135,12 +136,12 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			doneChan = make(chan struct{})
-			err = idxSet.ForEach(context.Background(), doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel = context.WithCancel(context.Background())
+			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/index_set_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/index_set_test.go
@@ -36,10 +36,7 @@ func TestIndexSet_Add(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			err = indexSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = indexSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
@@ -110,12 +107,10 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// all the indexes should be retained since they were just uploaded
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = idxSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)
@@ -136,12 +131,10 @@ func TestIndexSet_Cleanup(t *testing.T) {
 
 			// get all the indexes that are retained
 			indexesFound = map[string]*mockIndex{}
-			ctx, cancel = context.WithCancel(context.Background())
-			err = idxSet.ForEach(ctx, func(_ bool, index index.Index) error {
+			err = idxSet.ForEach(func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
 			require.NoError(t, err)
 
 			// we should have only the indexes whose upload time was not changed above

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -20,7 +20,7 @@ const (
 type Table interface {
 	Name() string
 	AddIndex(userID string, idx index.Index) error
-	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
+	ForEach(userID string, callback index.ForEachIndexCallback) error
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
 	Stop()
@@ -78,13 +78,9 @@ func (lt *table) AddIndex(userID string, idx index.Index) error {
 }
 
 // ForEach iterates over all the indexes belonging to the user.
-func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
+func (lt *table) ForEach(userID string, callback index.ForEachIndexCallback) error {
 	lt.indexSetMtx.RLock()
-
-	go func() {
-		<-ctx.Done()
-		lt.indexSetMtx.RUnlock()
-	}()
+	defer lt.indexSetMtx.RUnlock()
 
 	// TODO(owen-d): refactor? Uploads mgr never has user indices,
 	// only common (multitenant) ones.
@@ -95,7 +91,7 @@ func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForE
 			continue
 		}
 
-		if err := idxSet.ForEach(ctx, callback); err != nil {
+		if err := idxSet.ForEach(callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/table.go
+++ b/pkg/storage/stores/indexshipper/uploads/table.go
@@ -20,7 +20,7 @@ const (
 type Table interface {
 	Name() string
 	AddIndex(userID string, idx index.Index) error
-	ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error
 	Upload(ctx context.Context) error
 	Cleanup(indexRetainPeriod time.Duration) error
 	Stop()
@@ -78,11 +78,11 @@ func (lt *table) AddIndex(userID string, idx index.Index) error {
 }
 
 // ForEach iterates over all the indexes belonging to the user.
-func (lt *table) ForEach(ctx context.Context, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (lt *table) ForEach(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	lt.indexSetMtx.RLock()
 
 	go func() {
-		<-doneChan
+		<-ctx.Done()
 		lt.indexSetMtx.RUnlock()
 	}()
 
@@ -95,7 +95,7 @@ func (lt *table) ForEach(ctx context.Context, userID string, doneChan <-chan str
 			continue
 		}
 
-		if err := idxSet.ForEach(ctx, doneChan, callback); err != nil {
+		if err := idxSet.ForEach(ctx, callback); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
+	ForEach(tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(ctx, userID, callback)
+	return table.ForEach(userID, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager.go
@@ -21,7 +21,7 @@ type Config struct {
 type TableManager interface {
 	Stop()
 	AddIndex(tableName, userID string, index index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error
 }
 
 type tableManager struct {
@@ -118,13 +118,13 @@ func (tm *tableManager) getOrCreateTable(tableName string) Table {
 	return table
 }
 
-func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback index.ForEachIndexCallback) error {
+func (tm *tableManager) ForEach(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 	table, ok := tm.getTable(tableName)
 	if !ok {
 		return nil
 	}
 
-	return table.ForEach(ctx, userID, doneChan, callback)
+	return table.ForEach(ctx, userID, callback)
 }
 
 func (tm *tableManager) uploadTables(ctx context.Context) {

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -1,7 +1,6 @@
 package uploads
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -65,12 +64,10 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					ctx, cancel := context.WithCancel(context.Background())
-					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
+					err := testTableManager.ForEach(tableName, userID, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
-					cancel()
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_manager_test.go
@@ -65,12 +65,12 @@ func TestTableManager(t *testing.T) {
 
 					// see if we can find all the added indexes in the table.
 					indexesFound := map[string]*mockIndex{}
-					doneChan := make(chan struct{})
-					err := testTableManager.ForEach(context.Background(), tableName, userID, doneChan, func(_ bool, index index.Index) error {
+					ctx, cancel := context.WithCancel(context.Background())
+					err := testTableManager.ForEach(ctx, tableName, userID, func(_ bool, index index.Index) error {
 						indexesFound[index.Path()] = index.(*mockIndex)
 						return nil
 					})
-					close(doneChan)
+					cancel()
 					require.NoError(t, err)
 
 					require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -36,12 +36,12 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			doneChan := make(chan struct{})
-			err := testTable.ForEach(context.Background(), userID, doneChan, func(_ bool, index index.Index) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			close(doneChan)
+			cancel()
 
 			require.NoError(t, err)
 

--- a/pkg/storage/stores/indexshipper/uploads/table_test.go
+++ b/pkg/storage/stores/indexshipper/uploads/table_test.go
@@ -1,7 +1,6 @@
 package uploads
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,13 +35,10 @@ func TestTable(t *testing.T) {
 
 			// see if we can find all the added indexes in the table.
 			indexesFound := map[string]*mockIndex{}
-			ctx, cancel := context.WithCancel(context.Background())
-			err := testTable.ForEach(ctx, userID, func(_ bool, index index.Index) error {
+			err := testTable.ForEach(userID, func(_ bool, index index.Index) error {
 				indexesFound[index.Path()] = index.(*mockIndex)
 				return nil
 			})
-			cancel()
-
 			require.NoError(t, err)
 
 			require.Equal(t, testIndexes, indexesFound)

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,9 +40,6 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
 	for table, queries := range queriesByTable {

--- a/pkg/storage/stores/shipper/index/querier.go
+++ b/pkg/storage/stores/shipper/index/querier.go
@@ -40,8 +40,8 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 		return err
 	}
 
-	doneChan := make(chan struct{})
-	defer close(doneChan)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	userIDBytes := util.GetUnsafeBytes(userID)
 	queriesByTable := util.QueriesByTable(queries)
@@ -57,7 +57,7 @@ func (q *querier) QueryPages(ctx context.Context, queries []index.Query, callbac
 				}
 			}
 
-			return q.indexShipper.ForEach(ctx, table, userID, doneChan, func(_ bool, idx shipper_index.Index) error {
+			return q.indexShipper.ForEach(ctx, table, userID, func(_ bool, idx shipper_index.Index) error {
 				boltdbIndexFile, ok := idx.(*indexfile.IndexFile)
 				if !ok {
 					return fmt.Errorf("unexpected index type %T", idx)

--- a/pkg/storage/stores/shipper/index/table_manager.go
+++ b/pkg/storage/stores/shipper/index/table_manager.go
@@ -44,7 +44,7 @@ type TableManager struct {
 
 type Shipper interface {
 	AddIndex(tableName, userID string, index shipper_index.Index) error
-	ForEach(ctx context.Context, tableName, userID string, doneChan <-chan struct{}, callback shipper_index.ForEachIndexCallback) error
+	ForEach(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
 }
 
 func NewTableManager(cfg Config, indexShipper Shipper, registerer prometheus.Registerer) (*TableManager, error) {

--- a/pkg/storage/stores/shipper/index/table_manager_test.go
+++ b/pkg/storage/stores/shipper/index/table_manager_test.go
@@ -111,7 +111,7 @@ func TestLoadTables(t *testing.T) {
 		// see if index shipper has the index files
 		testutil.VerifyIndexes(t, userID, []index.Query{{TableName: tableName}},
 			func(ctx context.Context, table string, callback func(boltdb *bbolt.DB) error) error {
-				return tm.indexShipper.ForEach(ctx, table, userID, nil, func(_ bool, index index_shipper.Index) error {
+				return tm.indexShipper.ForEach(ctx, table, userID, func(_ bool, index index_shipper.Index) error {
 					return callback(index.(*indexfile.IndexFile).GetBoltDB())
 				})
 			},

--- a/pkg/storage/stores/shipper/index/table_test.go
+++ b/pkg/storage/stores/shipper/index/table_test.go
@@ -41,7 +41,7 @@ func (m *mockIndexShipper) AddIndex(tableName, _ string, index shipper_index.Ind
 	return nil
 }
 
-func (m *mockIndexShipper) ForEach(ctx context.Context, tableName, _ string, _ <-chan struct{}, callback shipper_index.ForEachIndexCallback) error {
+func (m *mockIndexShipper) ForEach(ctx context.Context, tableName, _ string, callback shipper_index.ForEachIndexCallback) error {
 	for _, idx := range m.addedIndexes[tableName] {
 		if err := callback(false, idx); err != nil {
 			return err
@@ -228,7 +228,7 @@ func TestTable_HandoverIndexesToShipper(t *testing.T) {
 
 			testutil.VerifyIndexes(t, userID, []index.Query{{TableName: table.name}},
 				func(ctx context.Context, _ string, callback func(boltdb *bbolt.DB) error) error {
-					return indexShipper.ForEach(ctx, table.name, "", nil, func(_ bool, index shipper_index.Index) error {
+					return indexShipper.ForEach(ctx, table.name, "", func(_ bool, index shipper_index.Index) error {
 						return callback(index.(*indexfile.IndexFile).GetBoltDB())
 					})
 				},
@@ -248,7 +248,7 @@ func TestTable_HandoverIndexesToShipper(t *testing.T) {
 			require.Len(t, indexShipper.addedIndexes[table.name], 2)
 			testutil.VerifyIndexes(t, userID, []index.Query{{TableName: table.name}},
 				func(ctx context.Context, _ string, callback func(boltdb *bbolt.DB) error) error {
-					return indexShipper.ForEach(ctx, table.name, "", nil, func(_ bool, index shipper_index.Index) error {
+					return indexShipper.ForEach(ctx, table.name, "", func(_ bool, index shipper_index.Index) error {
 						return callback(index.(*indexfile.IndexFile).GetBoltDB())
 					})
 				},

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -127,11 +127,7 @@ func (t *tableCompactor) CompactTable() error {
 
 	var multiTenantIndex Index = NoopIndex{}
 	if len(multiTenantIndices) > 0 {
-		var err error
-		multiTenantIndex, err = NewMultiIndex(multiTenantIndices...)
-		if err != nil {
-			return err
-		}
+		multiTenantIndex = NewMultiIndex(IndexSlice(multiTenantIndices))
 	}
 
 	// find all the user ids from the multi-tenant indexes using TenantLabel.

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -135,8 +135,7 @@ func NewHeadManager(logger log.Logger, dir string, metrics *Metrics, tsdbManager
 			indices = append(indices, m.activeHeads)
 		}
 
-		return NewMultiIndex(indices...)
-
+		return NewMultiIndex(IndexSlice(indices)), nil
 	})
 
 	return m

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -283,8 +283,7 @@ func Test_HeadManager_Lifecycle(t *testing.T) {
 	require.Nil(t, mgr.Start())
 
 	// Ensure old WAL data is queryable
-	multiIndex, err := NewMultiIndex(mgr, mgr.tsdbManager.(noopTSDBManager).tenantHeads)
-	require.Nil(t, err)
+	multiIndex := NewMultiIndex(IndexSlice{mgr, mgr.tsdbManager.(noopTSDBManager).tenantHeads})
 
 	for _, c := range cases {
 		refs, err := multiIndex.GetChunkRefs(

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -18,6 +18,10 @@ type mockIndexShipperIndexIterator struct {
 	tables map[string][]*TSDBFile
 }
 
+func (m mockIndexShipperIndexIterator) ForEachConcurrent(ctx context.Context, tableName, userID string, callback index_shipper.ForEachIndexCallback) error {
+	return m.ForEach(ctx, tableName, userID, callback)
+}
+
 func (m mockIndexShipperIndexIterator) ForEach(ctx context.Context, tableName, userID string, callback index_shipper.ForEachIndexCallback) error {
 	indexes := m.tables[tableName]
 	for _, idx := range indexes {

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -18,7 +18,7 @@ type mockIndexShipperIndexIterator struct {
 	tables map[string][]*TSDBFile
 }
 
-func (m mockIndexShipperIndexIterator) ForEach(ctx context.Context, tableName, userID string, _ <-chan struct{}, callback index_shipper.ForEachIndexCallback) error {
+func (m mockIndexShipperIndexIterator) ForEach(ctx context.Context, tableName, userID string, callback index_shipper.ForEachIndexCallback) error {
 	indexes := m.tables[tableName]
 	for _, idx := range indexes {
 		if err := callback(false, idx); err != nil {

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -15,7 +17,7 @@ import (
 )
 
 type indexShipperIterator interface {
-	ForEach(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
+	ForEachConcurrent(ctx context.Context, tableName, userID string, callback shipper_index.ForEachIndexCallback) error
 }
 
 // indexShipperQuerier is used for querying index from the shipper.
@@ -29,36 +31,35 @@ func newIndexShipperQuerier(shipper indexShipperIterator, tableRanges config.Tab
 	return &indexShipperQuerier{shipper: shipper, tableRanges: tableRanges}
 }
 
+type indexIterFunc func(func(context.Context, Index) error) error
+
+func (i indexIterFunc) For(ctx context.Context, f func(context.Context, Index) error) error {
+	return i(f)
+}
+
 func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.Time, user string) (Index, error) {
-	var indices []Index
+	itr := indexIterFunc(func(f func(context.Context, Index) error) error {
+		// Ensure we query both per tenant and multitenant TSDBs
+		idxBuckets := indexBuckets(from, through, i.tableRanges)
+		for _, bkt := range idxBuckets {
+			if err := i.shipper.ForEachConcurrent(ctx, bkt, user, func(multitenant bool, idx shipper_index.Index) error {
+				impl, ok := idx.(Index)
+				if !ok {
+					return fmt.Errorf("unexpected shipper index type: %T", idx)
+				}
+				if multitenant {
+					impl = NewMultiTenantIndex(impl)
+				}
 
-	// Ensure we query both per tenant and multitenant TSDBs
-	idxBuckets := indexBuckets(from, through, i.tableRanges)
-	for _, bkt := range idxBuckets {
-		if err := i.shipper.ForEach(ctx, bkt, user, func(multitenant bool, idx shipper_index.Index) error {
-			impl, ok := idx.(Index)
-			if !ok {
-				return fmt.Errorf("unexpected shipper index type: %T", idx)
+				return f(ctx, impl)
+			}); err != nil {
+				return err
 			}
-			if multitenant {
-				indices = append(indices, NewMultiTenantIndex(impl))
-			} else {
-				indices = append(indices, impl)
-			}
-			return nil
-		}); err != nil {
-			return nil, err
 		}
+		return nil
+	})
 
-	}
-
-	if len(indices) == 0 {
-		return NoopIndex{}, nil
-	}
-	idx, err := NewMultiIndex(indices...)
-	if err != nil {
-		return nil, err
-	}
+	idx := NewMultiIndex(itr)
 
 	if i.chunkFilter != nil {
 		idx.SetChunkFilterer(i.chunkFilter)
@@ -123,3 +124,35 @@ func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, th
 
 	return idx.Stats(ctx, userID, from, through, acc, shard, shouldIncludeChunk, matchers...)
 }
+
+type resultAccumulator struct {
+	mtx   sync.Mutex
+	items []interface{}
+	merge func(xs []interface{}) (interface{}, error)
+}
+
+func newResultAccumulator(merge func(xs []interface{}) (interface{}, error)) *resultAccumulator {
+	return &resultAccumulator{
+		merge: merge,
+	}
+}
+
+func (acc *resultAccumulator) Add(item interface{}) {
+	acc.mtx.Lock()
+	defer acc.mtx.Unlock()
+	acc.items = append(acc.items, item)
+
+}
+
+func (acc *resultAccumulator) Merge() (interface{}, error) {
+	acc.mtx.Lock()
+	defer acc.mtx.Unlock()
+
+	if len(acc.items) == 0 {
+		return nil, ErrEmptyAccumulator
+	}
+
+	return acc.merge(acc.items)
+}
+
+var ErrEmptyAccumulator = errors.New("no items in result accumulator")

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -84,9 +84,6 @@ func (i *indexShipperQuerier) Close() error {
 }
 
 func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -95,9 +92,6 @@ func (i *indexShipperQuerier) GetChunkRefs(ctx context.Context, userID string, f
 }
 
 func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -106,9 +100,6 @@ func (i *indexShipperQuerier) Series(ctx context.Context, userID string, from, t
 }
 
 func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -117,9 +108,6 @@ func (i *indexShipperQuerier) LabelNames(ctx context.Context, userID string, fro
 }
 
 func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return nil, err
@@ -128,9 +116,6 @@ func (i *indexShipperQuerier) LabelValues(ctx context.Context, userID string, fr
 }
 
 func (i *indexShipperQuerier) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	idx, err := i.indices(ctx, from, through, userID)
 	if err != nil {
 		return err

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -21,7 +21,11 @@ type MultiIndex struct {
 type IndexIter interface {
 	// For may be executed concurrently,
 	// but all work must complete before
-	// it returns
+	// it returns.
+	// TODO(owen-d|sandeepsukhani):
+	// Lazy iteration may touch different index files within the same index query.
+	// `For` e.g, Bounds and GetChunkRefs might go through different index files
+	// if a sync happened between the calls.
 	For(context.Context, func(context.Context, Index) error) error
 }
 

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -2,9 +2,9 @@ package tsdb
 
 import (
 	"context"
-	"errors"
+	"math"
+	"sync"
 
-	"github.com/grafana/dskit/multierror"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
@@ -14,231 +14,321 @@ import (
 )
 
 type MultiIndex struct {
-	indices []Index
+	iter     IndexIter
+	filterer chunk.RequestChunkFilterer
 }
 
-func NewMultiIndex(indices ...Index) (*MultiIndex, error) {
-	if len(indices) == 0 {
-		return nil, errors.New("must supply at least one index")
-	}
+type IndexIter interface {
+	// For may be executed concurrently,
+	// but all work must complete before
+	// it returns
+	For(context.Context, func(context.Context, Index) error) error
+}
 
-	return &MultiIndex{indices: indices}, nil
+type IndexSlice []Index
+
+func (xs IndexSlice) For(ctx context.Context, fn func(context.Context, Index) error) error {
+	g, ctx := errgroup.WithContext(ctx)
+	for i := range xs {
+		x := xs[i]
+		g.Go(func() error {
+			return fn(ctx, x)
+		})
+	}
+	return g.Wait()
+}
+
+func NewMultiIndex(i IndexIter) *MultiIndex {
+	return &MultiIndex{iter: i}
 }
 
 func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 	var lowest, highest model.Time
-	for _, idx := range i.indices {
-		from, through := idx.Bounds()
-		if lowest == 0 || from < lowest {
-			lowest = from
-		}
+	var mtx sync.Mutex
 
-		if highest == 0 || through > highest {
-			highest = through
-		}
-	}
+	_ = i.forMatchingIndices(
+		context.Background(),
+		0, math.MaxInt64,
+		func(_ context.Context, idx Index) error {
+			from, through := idx.Bounds()
+
+			mtx.Lock()
+			defer mtx.Unlock()
+
+			if lowest == 0 || from < lowest {
+				lowest = from
+			}
+
+			if highest == 0 || through > highest {
+				highest = through
+			}
+			return nil
+		},
+	)
 
 	return lowest, highest
 }
 
 func (i *MultiIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	for _, x := range i.indices {
-		x.SetChunkFilterer(chunkFilter)
-	}
+	i.filterer = chunkFilter
 }
 
 func (i *MultiIndex) Close() error {
-	var errs multierror.MultiError
-	for _, idx := range i.indices {
-		if err := idx.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errs.Err()
-
+	return i.forMatchingIndices(
+		context.Background(),
+		0, math.MaxInt64,
+		func(_ context.Context, idx Index) error {
+			return idx.Close()
+		},
+	)
 }
 
-func (i *MultiIndex) forIndices(ctx context.Context, from, through model.Time, fn func(context.Context, Index) (interface{}, error)) ([]interface{}, error) {
+func (i *MultiIndex) forMatchingIndices(ctx context.Context, from, through model.Time, f func(context.Context, Index) error) error {
 	queryBounds := newBounds(from, through)
-	g, ctx := errgroup.WithContext(ctx)
 
-	// ensure we prebuffer the channel by the maximum possible
-	// return length so our goroutines don't block
-	ch := make(chan interface{}, len(i.indices))
-
-	for _, idx := range i.indices {
-		// ignore indices which can't match this query
+	return i.iter.For(ctx, func(ctx context.Context, idx Index) error {
 		if Overlap(queryBounds, idx) {
-			// run all queries in linked goroutines (cancel after first err),
-			// bounded by parallelism controls if applicable.
 
-			// must wrap g.Go in anonymous function to capture
-			// idx variable during iteration
-			func(idx Index) {
-				g.Go(func() error {
-					got, err := fn(ctx, idx)
-					if err != nil {
-						return err
-					}
-					ch <- got
-					return nil
-				})
-			}(idx)
+			if i.filterer != nil {
+				// TODO(owen-d): Find a nicer way
+				// to handle filterer passing. Doing it
+				// in the read path rather than during instantiation
+				// feels bad :(
+				idx.SetChunkFilterer(i.filterer)
+			}
 
+			return f(ctx, idx)
 		}
-	}
+		return nil
+	})
 
-	// wait for work to finish or error|ctx expiration
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-	close(ch)
-
-	results := make([]interface{}, 0, len(i.indices))
-	for x := range ch {
-		results = append(results, x)
-	}
-	return results, nil
 }
 
 func (i *MultiIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
-	if res == nil {
-		res = ChunkRefsPool.Get()
-	}
-	res = res[:0]
+	acc := newResultAccumulator(func(xs []interface{}) (interface{}, error) {
+		if res == nil {
+			res = ChunkRefsPool.Get()
+		}
+		res = res[:0]
 
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.GetChunkRefs(ctx, userID, from, through, nil, shard, matchers...)
+		// keep track of duplicates
+		seen := make(map[ChunkRef]struct{})
+
+		// TODO(owen-d): Do this more efficiently,
+		// not all indices overlap each other
+		for _, group := range xs {
+			g := group.([]ChunkRef)
+			for _, ref := range g {
+				_, ok := seen[ref]
+				if ok {
+					continue
+				}
+				seen[ref] = struct{}{}
+				res = append(res, ref)
+			}
+			ChunkRefsPool.Put(g)
+
+		}
+
+		return res, nil
 	})
-	if err != nil {
+
+	if err := i.forMatchingIndices(
+		ctx,
+		from,
+		through,
+		func(ctx context.Context, idx Index) error {
+			got, err := idx.GetChunkRefs(ctx, userID, from, through, nil, shard, matchers...)
+			if err != nil {
+				return err
+			}
+			acc.Add(got)
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
 
-	// keep track of duplicates
-	seen := make(map[ChunkRef]struct{})
-
-	// TODO(owen-d): Do this more efficiently,
-	// not all indices overlap each other
-	for _, group := range groups {
-		g := group.([]ChunkRef)
-		for _, ref := range g {
-			_, ok := seen[ref]
-			if ok {
-				continue
-			}
-			seen[ref] = struct{}{}
-			res = append(res, ref)
+	merged, err := acc.Merge()
+	if err != nil {
+		if err == ErrEmptyAccumulator {
+			return nil, nil
 		}
-		ChunkRefsPool.Put(g)
+		return nil, err
 	}
+	return merged.([]ChunkRef), nil
 
-	return res, nil
 }
 
 func (i *MultiIndex) Series(ctx context.Context, userID string, from, through model.Time, res []Series, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]Series, error) {
-	if res == nil {
-		res = SeriesPool.Get()
-	}
-	res = res[:0]
+	acc := newResultAccumulator(func(xs []interface{}) (interface{}, error) {
+		if res == nil {
+			res = SeriesPool.Get()
+		}
+		res = res[:0]
 
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.Series(ctx, userID, from, through, nil, shard, matchers...)
+		seen := make(map[model.Fingerprint]struct{})
+
+		for _, x := range xs {
+			seriesSet := x.([]Series)
+			for _, s := range seriesSet {
+				_, ok := seen[s.Fingerprint]
+				if ok {
+					continue
+				}
+				seen[s.Fingerprint] = struct{}{}
+				res = append(res, s)
+			}
+			SeriesPool.Put(seriesSet)
+		}
+
+		return res, nil
 	})
-	if err != nil {
+
+	if err := i.forMatchingIndices(
+		ctx,
+		from,
+		through,
+		func(ctx context.Context, idx Index) error {
+			got, err := idx.Series(ctx, userID, from, through, nil, shard, matchers...)
+			if err != nil {
+				return err
+			}
+			acc.Add(got)
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
 
-	seen := make(map[model.Fingerprint]struct{})
-
-	for _, x := range groups {
-		seriesSet := x.([]Series)
-		for _, s := range seriesSet {
-			_, ok := seen[s.Fingerprint]
-			if ok {
-				continue
-			}
-			seen[s.Fingerprint] = struct{}{}
-			res = append(res, s)
+	merged, err := acc.Merge()
+	if err != nil {
+		if err == ErrEmptyAccumulator {
+			return nil, nil
 		}
-		SeriesPool.Put(seriesSet)
+		return nil, err
 	}
-
-	return res, nil
+	return merged.([]Series), nil
 }
 
 func (i *MultiIndex) LabelNames(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]string, error) {
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.LabelNames(ctx, userID, from, through, matchers...)
+	acc := newResultAccumulator(func(xs []interface{}) (interface{}, error) {
+		var (
+			maxLn int // maximum number of lNames, assuming no duplicates
+			lists [][]string
+		)
+		for _, group := range xs {
+			x := group.([]string)
+			maxLn += len(x)
+			lists = append(lists, x)
+		}
+
+		// optimistically allocate the maximum length slice
+		// to avoid growing incrementally
+		// TODO(owen-d): use pool
+		results := make([]string, 0, maxLn)
+		seen := make(map[string]struct{})
+
+		for _, ls := range lists {
+			for _, l := range ls {
+				_, ok := seen[l]
+				if ok {
+					continue
+				}
+				seen[l] = struct{}{}
+				results = append(results, l)
+			}
+		}
+
+		return results, nil
 	})
-	if err != nil {
+
+	if err := i.forMatchingIndices(
+		ctx,
+		from,
+		through,
+		func(ctx context.Context, idx Index) error {
+			got, err := idx.LabelNames(ctx, userID, from, through, matchers...)
+			if err != nil {
+				return err
+			}
+			acc.Add(got)
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
 
-	var maxLn int // maximum number of chunk refs, assuming no duplicates
-	xs := make([][]string, 0, len(i.indices))
-	for _, group := range groups {
-		x := group.([]string)
-		maxLn += len(x)
-		xs = append(xs, x)
-	}
-
-	// optimistically allocate the maximum length slice
-	// to avoid growing incrementally
-	results := make([]string, 0, maxLn)
-	seen := make(map[string]struct{})
-
-	for _, ls := range xs {
-		for _, l := range ls {
-			_, ok := seen[l]
-			if ok {
-				continue
-			}
-			seen[l] = struct{}{}
-			results = append(results, l)
+	merged, err := acc.Merge()
+	if err != nil {
+		if err == ErrEmptyAccumulator {
+			return nil, nil
 		}
+		return nil, err
 	}
-
-	return results, nil
+	return merged.([]string), nil
 }
 
 func (i *MultiIndex) LabelValues(ctx context.Context, userID string, from, through model.Time, name string, matchers ...*labels.Matcher) ([]string, error) {
-	groups, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return idx.LabelValues(ctx, userID, from, through, name, matchers...)
+	acc := newResultAccumulator(func(xs []interface{}) (interface{}, error) {
+		var (
+			maxLn int // maximum number of lValues, assuming no duplicates
+			lists [][]string
+		)
+		for _, group := range xs {
+			x := group.([]string)
+			maxLn += len(x)
+			lists = append(lists, x)
+		}
+
+		// optimistically allocate the maximum length slice
+		// to avoid growing incrementally
+		// TODO(owen-d): use pool
+		results := make([]string, 0, maxLn)
+		seen := make(map[string]struct{})
+
+		for _, ls := range lists {
+			for _, l := range ls {
+				_, ok := seen[l]
+				if ok {
+					continue
+				}
+				seen[l] = struct{}{}
+				results = append(results, l)
+			}
+		}
+
+		return results, nil
 	})
-	if err != nil {
+
+	if err := i.forMatchingIndices(
+		ctx,
+		from,
+		through,
+		func(ctx context.Context, idx Index) error {
+			got, err := idx.LabelValues(ctx, userID, from, through, name, matchers...)
+			if err != nil {
+				return err
+			}
+			acc.Add(got)
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
 
-	var maxLn int // maximum number of chunk refs, assuming no duplicates
-	xs := make([][]string, 0, len(i.indices))
-	for _, group := range groups {
-		x := group.([]string)
-		maxLn += len(x)
-		xs = append(xs, x)
-	}
-
-	// optimistically allocate the maximum length slice
-	// to avoid growing incrementally
-	results := make([]string, 0, maxLn)
-	seen := make(map[string]struct{})
-
-	for _, ls := range xs {
-		for _, l := range ls {
-			_, ok := seen[l]
-			if ok {
-				continue
-			}
-			seen[l] = struct{}{}
-			results = append(results, l)
+	merged, err := acc.Merge()
+	if err != nil {
+		if err == ErrEmptyAccumulator {
+			return nil, nil
 		}
+		return nil, err
 	}
-
-	return results, nil
+	return merged.([]string), nil
 }
 
 func (i *MultiIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
-	_, err := i.forIndices(ctx, from, through, func(ctx context.Context, idx Index) (interface{}, error) {
-		return nil, idx.Stats(ctx, userID, from, through, acc, shard, shouldIncludeChunk, matchers...)
+	return i.forMatchingIndices(ctx, from, through, func(ctx context.Context, idx Index) error {
+		return idx.Stats(ctx, userID, from, through, acc, shard, shouldIncludeChunk, matchers...)
 	})
-	return err
 }

--- a/pkg/storage/stores/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/tsdb/multi_file_index_test.go
@@ -64,8 +64,7 @@ func TestMultiIndex(t *testing.T) {
 		indices = append(indices, BuildIndex(t, dir, cases))
 	}
 
-	idx, err := NewMultiIndex(indices...)
-	require.Nil(t, err)
+	idx := NewMultiIndex(IndexSlice(indices))
 
 	t.Run("GetChunkRefs", func(t *testing.T) {
 		refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -165,10 +165,7 @@ func (s *store) init(indexShipperCfg indexshipper.Config, objectClient client.Ob
 	}
 
 	indices = append(indices, newIndexShipperQuerier(s.indexShipper, tableRanges))
-	multiIndex, err := NewMultiIndex(indices...)
-	if err != nil {
-		return err
-	}
+	multiIndex := NewMultiIndex(IndexSlice(indices))
 
 	s.Reader = NewIndexClient(multiIndex, opts)
 


### PR DESCRIPTION
# What

Inverts control in the `index-shipper` so consumers don't manage accesses to mutexes. This prevents deadlocks and no longer requires consumers have internal knowledge of the `index-shipper` itself.

This PR reverts a few previous attempts. Look at the last commit to see the net-additions.

# Background:

TSDB previously didn't use mmap, which meant we could freely pass around TSDBs as `[]byte`. Since they were immutable, we didn't need to know when an underlying index was cleaned up/closed; this coordination was unnecessary and the garbage collector would clean up dangling memory for us. After introducing TSDB, we needed to control access to avoid use-after-free bugs. A few attempts at controlling this became increasingly complex & error prone. Instead of requiring _consumers_ to prevent deadlocks on index-shipper internals, it makes more sense that references to the index-shipper's resources should not leak outside the `ForEach` functions that give temporary access to them. This _inverts control_ from the consumer (code which queries the indices) to the producer (the index-shipper).
