### PR TITLE
Shard streams round-robin rather in batches. 

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"math"
-	"math/rand"
 	"net/http"
 	"sort"
 	"strconv"
@@ -87,7 +86,8 @@ type Distributor struct {
 	validator        *Validator
 	pool             *ring_client.Pool
 
-	rateStore RateStore
+	rateStore    RateStore
+	shardTracker *ShardTracker
 
 	// The global rate limiter requires a distributors ring to count
 	// the number of healthy instances.
@@ -104,7 +104,6 @@ type Distributor struct {
 	ingesterAppends        *prometheus.CounterVec
 	ingesterAppendFailures *prometheus.CounterVec
 	replicationFactor      prometheus.Gauge
-	streamShardingFailures *prometheus.CounterVec
 	streamShardCount       prometheus.Counter
 }
 
@@ -174,6 +173,7 @@ func New(
 		pool:                   clientpool.NewPool(clientCfg.PoolConfig, ingestersRing, factory, util_log.Logger),
 		ingestionRateLimiter:   limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
 		labelCache:             labelCache,
+		shardTracker:           NewShardTracker(),
 		rateLimitStrat:         rateLimitStrat,
 		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",
@@ -189,13 +189,6 @@ func New(
 			Namespace: "loki",
 			Name:      "distributor_replication_factor",
 			Help:      "The configured replication factor.",
-		}),
-		streamShardingFailures: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki",
-			Name:      "stream_sharding_failures",
-			Help:      "Total number of failures when sharding a stream",
-		}, []string{
-			"reason",
 		}),
 		streamShardCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Namespace: "loki",
@@ -410,22 +403,11 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	}
 }
 
-func min(x1, x2 int) int {
-	if x1 < x2 {
-		return x1
-	}
-	return x2
-}
-
 // shardStream shards (divides) the given stream into N smaller streams, where
 // N is the sharding size for the given stream. shardSteam returns the smaller
 // streams and their associated keys for hashing to ingesters.
 //
 // The number of shards is limited by the number of entries.
-// If the right number of shards for the current load is bigger than the number of entries, entries are randomized between shards
-// to avoid hotspots.
-// Ex: If the right amount of shards for a stream is 8 but it only has 3 entries, the 3 entries are randomized between the 8 shards.
-// This way we avoid the first 3 shards receiving all the load while the last 5 would receive no load.
 func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID string) ([]uint32, []streamTracker) {
 	shardStreamsCfg := d.validator.Limits.ShardStreams(userID)
 	logger := log.With(util_log.WithUserID(userID, util_log.Logger), "stream", stream.Labels)
@@ -440,40 +422,35 @@ func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, userID
 		level.Info(logger).Log("msg", "sharding request", "shard_count", shardCount)
 	}
 
-	if shardCount > len(stream.Entries) {
-		shardsOrder := d.randomizeShardsOrder(shardCount)
-		return d.divideEntriesBetweenShards(logger, userID, len(stream.Entries), shardStreamsCfg, stream, shardsOrder)
-	}
-
-	return d.divideEntriesBetweenShards(logger, userID, shardCount, shardStreamsCfg, stream, nil)
+	return d.divideEntriesBetweenShards(userID, shardCount, shardStreamsCfg, stream)
 }
 
-func (d *Distributor) randomizeShardsOrder(shardCount int) []int {
-	shardsOrder := make([]int, shardCount)
-	for i := 0; i < shardCount; i++ {
-		shardsOrder = append(shardsOrder, i)
+func (d *Distributor) divideEntriesBetweenShards(userID string, totalShards int, shardStreamsCfg *shardstreams.Config, stream logproto.Stream) ([]uint32, []streamTracker) {
+	derivedKeys, derivedStreams := d.createShards(stream, totalShards, userID, shardStreamsCfg)
+
+	for i := 0; i < len(stream.Entries); i++ {
+		streamIndex := i % len(derivedStreams)
+		entries := append(derivedStreams[streamIndex].stream.Entries, stream.Entries[i])
+		derivedStreams[streamIndex].stream.Entries = entries
 	}
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(shardsOrder), func(i, j int) { shardsOrder[i], shardsOrder[j] = shardsOrder[j], shardsOrder[i] })
-	return shardsOrder
+
+	return derivedKeys, derivedStreams
 }
 
-func (d *Distributor) divideEntriesBetweenShards(logger log.Logger, userID string, shardCount int, shardStreamsCfg *shardstreams.Config, stream logproto.Stream, alternateShardsOrder []int) ([]uint32, []streamTracker) {
-	derivedKeys := make([]uint32, 0, shardCount)
-	derivedStreams := make([]streamTracker, 0, shardCount)
-	streamLabels := labelTemplate(stream.Labels)
-	streamPattern := streamLabels.String()
+func (d *Distributor) createShards(stream logproto.Stream, totalShards int, userID string, shardStreamsCfg *shardstreams.Config) ([]uint32, []streamTracker) {
+	var (
+		streamLabels   = labelTemplate(stream.Labels)
+		streamPattern  = streamLabels.String()
+		derivedKeys    = make([]uint32, 0, totalShards)
+		derivedStreams = make([]streamTracker, 0, totalShards)
 
-	for i := 0; i < shardCount; i++ {
-		j := i
-		if len(alternateShardsOrder) > 0 {
-			j = alternateShardsOrder[i]
-		}
-		shard, ok := d.createShard(shardStreamsCfg, stream, streamLabels, streamPattern, shardCount, i, j)
-		if !ok {
-			level.Error(logger).Log("msg", "couldn't create shard", "idx", i)
-			continue
-		}
+		streamCount = streamCount(totalShards, stream)
+	)
+
+	startShard := d.shardTracker.LastShardNum(stream.Hash)
+	for i := 0; i < streamCount; i++ {
+		shardNum := (startShard + i) % totalShards
+		shard := d.createShard(streamLabels, streamPattern, shardNum)
 
 		derivedKeys = append(derivedKeys, util.TokenFor(userID, shard.Labels))
 		derivedStreams = append(derivedStreams, streamTracker{stream: shard})
@@ -482,8 +459,16 @@ func (d *Distributor) divideEntriesBetweenShards(logger log.Logger, userID strin
 			level.Info(util_log.Logger).Log("msg", "stream derived from sharding", "src-stream", stream.Labels, "derived-stream", shard.Labels)
 		}
 	}
+	d.shardTracker.SetLastShardNum(stream.Hash, startShard+streamCount)
 
 	return derivedKeys, derivedStreams
+}
+
+func streamCount(totalShards int, stream logproto.Stream) int {
+	if len(stream.Entries) < totalShards {
+		return len(stream.Entries)
+	}
+	return totalShards
 }
 
 // labelTemplate returns a label set that includes the dummy label to be replaced
@@ -504,12 +489,7 @@ func labelTemplate(lbls string) labels.Labels {
 	return streamLabels
 }
 
-func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream logproto.Stream, lbls labels.Labels, streamPattern string, totalShards, spot, shardNumber int) (logproto.Stream, bool) {
-	lowerBound, upperBound, ok := d.boundsFor(stream, totalShards, spot, streamshardCfg.LoggingEnabled)
-	if !ok {
-		return logproto.Stream{}, false
-	}
-
+func (d *Distributor) createShard(lbls labels.Labels, streamPattern string, shardNumber int) logproto.Stream {
 	shardLabel := strconv.Itoa(shardNumber)
 	for i := 0; i < len(lbls); i++ {
 		if lbls[i].Name == ingester.ShardLbName {
@@ -521,25 +501,8 @@ func (d *Distributor) createShard(streamshardCfg *shardstreams.Config, stream lo
 	return logproto.Stream{
 		Labels:  strings.Replace(streamPattern, ingester.ShardLbPlaceholder, shardLabel, 1),
 		Hash:    lbls.Hash(),
-		Entries: stream.Entries[lowerBound:upperBound],
-	}, true
-}
-
-func (d *Distributor) boundsFor(stream logproto.Stream, totalShards, idx int, loggingEnabled bool) (int, int, bool) {
-	entriesPerWindow := float64(len(stream.Entries)) / float64(totalShards)
-
-	fidx := float64(idx)
-	lowerBound := int(fidx * entriesPerWindow)
-	upperBound := min(int(entriesPerWindow*(1+fidx)), len(stream.Entries))
-
-	if lowerBound > upperBound {
-		if loggingEnabled {
-			level.Warn(util_log.Logger).Log("msg", "sharding with lowerbound > upperbound", "lowerbound", lowerBound, "upperbound", upperBound, "shards", totalShards, "labels", stream.Labels)
-		}
-		return 0, 0, false
+		Entries: make([]logproto.Entry, 0, 1024),
 	}
-
-	return lowerBound, upperBound, true
 }
 
 // maxT returns the highest between two given timestamps.
@@ -667,14 +630,6 @@ func (d *Distributor) shardCountFor(logger log.Logger, stream *logproto.Stream, 
 
 	rate := d.rateStore.RateFor(stream.Hash)
 	shards := calculateShards(rate, streamSize, streamShardcfg.DesiredRate.Val())
-	if shards > len(stream.Entries) {
-		d.streamShardingFailures.WithLabelValues("too_many_shards").Inc()
-		if streamShardcfg.LoggingEnabled {
-			level.Error(logger).Log("msg", "number of shards bigger than number of entries", "shards", shards, "entries", len(stream.Entries))
-		}
-		return shards
-	}
-
 	if shards == 0 {
 		// 1 shard is enough for the given stream.
 		return 1

--- a/pkg/distributor/shard_tracker.go
+++ b/pkg/distributor/shard_tracker.go
@@ -1,0 +1,56 @@
+package distributor
+
+import (
+	"sync"
+)
+
+const (
+	// defaultStripeSize is the default number of entries to allocate in the
+	// stripeSeries list.
+	defaultStripeSize = 1 << 15
+)
+
+// stripeLock is taken from ruler/storage/wal/series.go
+type stripeLock struct {
+	sync.RWMutex
+	// Padding to avoid multiple locks being on the same cache line.
+	_ [40]byte
+}
+
+// ShardTracker is a data structure to keep track of the last pushed shard
+// number for a given stream hash. This allows the distributor to evenly shard
+// streams across pushes even when any given push has fewer entries than the
+// calculated number of shards
+type ShardTracker struct {
+	size         int
+	currentShard []int
+	locks        []stripeLock
+}
+
+func NewShardTracker() *ShardTracker {
+	tracker := &ShardTracker{
+		size:         defaultStripeSize,
+		currentShard: make([]int, defaultStripeSize),
+		locks:        make([]stripeLock, defaultStripeSize),
+	}
+
+	return tracker
+}
+
+func (t *ShardTracker) LastShardNum(streamHash uint64) int {
+	i := streamHash & uint64(t.size-1)
+
+	t.locks[i].Lock()
+	defer t.locks[i].Unlock()
+
+	return t.currentShard[i]
+}
+
+func (t *ShardTracker) SetLastShardNum(streamHash uint64, shardNum int) {
+	i := streamHash & uint64(t.size-1)
+
+	t.locks[i].Lock()
+	defer t.locks[i].Unlock()
+
+	t.currentShard[i] = shardNum
+}

--- a/pkg/distributor/shard_tracker.go
+++ b/pkg/distributor/shard_tracker.go
@@ -7,7 +7,7 @@ import (
 const (
 	// defaultStripeSize is the default number of entries to allocate in the
 	// stripeSeries list.
-	defaultStripeSize = 1 << 15
+	defaultStripeSize = 1 << 10
 )
 
 // stripeLock is taken from ruler/storage/wal/series.go

--- a/pkg/distributor/shard_tracker_test.go
+++ b/pkg/distributor/shard_tracker_test.go
@@ -1,0 +1,16 @@
+package distributor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardTracker(t *testing.T) {
+	st := NewShardTracker()
+	st.SetLastShardNum(0, 5)
+	st.SetLastShardNum(1, 6)
+
+	require.Equal(t, 5, st.LastShardNum(0))
+	require.Equal(t, 6, st.LastShardNum(1))
+}


### PR DESCRIPTION
To avoid hot spots, keep track of shard numbers across pushes. When tracking shard numbers across pushes, it's no longer necessary to randomize shards, in the case where the desired number of shards is greater than the number of entries. Instead, we just partition the entries among the shards in round robin fashion. Over time, this should give us a more even distribution of logs in shards, particularly for large streams that are made of small individual pushes.