### PR TITLE
promtail: register reload metrics after running options

### DIFF
--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -82,6 +82,13 @@ func New(cfg config.Config, newConfig func() (*config.Config, error), metrics *c
 		metrics: metrics,
 		dryRun:  dryRun,
 	}
+	for _, o := range opts {
+		// todo (callum) I don't understand why I needed to add this check
+		if o == nil {
+			continue
+		}
+		o(promtail)
+	}
 	err := promtail.reg.Register(reloadSuccessTotal)
 	if err != nil {
 		return nil, fmt.Errorf("error register prometheus collector reloadSuccessTotal :%w", err)
@@ -89,13 +96,6 @@ func New(cfg config.Config, newConfig func() (*config.Config, error), metrics *c
 	err = promtail.reg.Register(reloadFailTotal)
 	if err != nil {
 		return nil, fmt.Errorf("error register prometheus collector reloadFailTotal :%w", err)
-	}
-	for _, o := range opts {
-		// todo (callum) I don't understand why I needed to add this check
-		if o == nil {
-			continue
-		}
-		o(promtail)
 	}
 	err = promtail.reloadConfig(&cfg)
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
This allows the reload metrics to be sent to a custom registerer, which is required for Grafana Agent to be able to use the Promtail code.

**Which issue(s) this PR fixes**:
N/A 

**Special notes for your reviewer**:
Is it possible for us to cherry-pick this into k121? That's the version we're trying to update Grafana Agent to.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
