### PR TITLE
Refactor CacheSplitter interface

### DIFF
--- a/clients/pkg/promtail/targets/cloudflare/fields.go
+++ b/clients/pkg/promtail/targets/cloudflare/fields.go
@@ -31,7 +31,7 @@ var (
 	allFields = append(extendedFields, []string{
 		"BotScore", "BotScoreSrc", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources",
 		"FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID",
-        "RequestHeaders", "ResponseHeaders",
+		"RequestHeaders", "ResponseHeaders",
 	}...)
 )
 

--- a/clients/pkg/promtail/targets/lokipush/pushtargetmanager_test.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtargetmanager_test.go
@@ -68,7 +68,7 @@ func Test_validateJobName(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:     false,
 			expectedJob: "job_1_2_3_4_job",
 		},
 	}

--- a/pkg/logqlmodel/logqlmodel.go
+++ b/pkg/logqlmodel/logqlmodel.go
@@ -1,8 +1,9 @@
 package logqlmodel
 
 import (
-	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase/definitions"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase/definitions"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"

--- a/pkg/logqlmodel/metadata/context_test.go
+++ b/pkg/logqlmodel/metadata/context_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase/definitions"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase/definitions"
 )
 
 func TestHeaders(t *testing.T) {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -35,7 +35,6 @@ var (
 type Limits interface {
 	queryrangebase.Limits
 	logql.Limits
-	QuerySplitDuration(string) time.Duration
 	MaxQuerySeries(string) int
 	MaxEntriesLimitPerQuery(string) int
 	MinShardingLookback(string) time.Duration
@@ -58,14 +57,10 @@ func WithSplitByLimits(l Limits, splitBy time.Duration) Limits {
 	}
 }
 
-// cacheKeyLimits intersects Limits and CacheSplitter
-type cacheKeyLimits struct {
-	Limits
-}
+// intervalAndSplitSplitter is a utility for using a split interval and split config when determining cache keys
+type intervalAndSplitSplitter struct{}
 
-func (l cacheKeyLimits) GenerateCacheKey(userID string, r queryrangebase.Request) string {
-	split := l.QuerySplitDuration(userID)
-
+func (l intervalAndSplitSplitter) GenerateCacheKey(_ context.Context, userID string, r queryrangebase.Request, split time.Duration) string {
 	var currentInterval int64
 	if denominator := int64(split / time.Millisecond); denominator > 0 {
 		currentInterval = r.GetStart() / denominator

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -40,10 +40,11 @@ func TestLimits(t *testing.T) {
 		Step:    int64(time.Minute / time.Millisecond),
 	}
 
+	splitter := intervalAndSplitSplitter{}
 	require.Equal(
 		t,
 		fmt.Sprintf("%s:%s:%d:%d:%d", "a", r.GetQuery(), r.GetStep(), r.GetStart()/int64(time.Hour/time.Millisecond), int64(time.Hour)),
-		cacheKeyLimits{wrapped}.GenerateCacheKey("a", r),
+		splitter.GenerateCacheKey(context.Background(), "a", r, wrapped.QuerySplitDuration("a")),
 	)
 }
 
@@ -268,7 +269,7 @@ func Test_MaxQueryLookBack(t *testing.T) {
 }
 
 func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {
-	l := cacheKeyLimits{WithSplitByLimits(nil, 0)}
+	splitter := intervalAndSplitSplitter{}
 	start := time.Now()
 	r := &LokiRequest{
 		Query:   "qry",
@@ -279,6 +280,6 @@ func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {
 	require.Equal(
 		t,
 		fmt.Sprintf("foo:qry:%d:0:0", r.GetStep()),
-		l.GenerateCacheKey("foo", r),
+		splitter.GenerateCacheKey(context.Background(), "foo", r, 0),
 	)
 }

--- a/pkg/querier/queryrange/queryrangebase/limits.go
+++ b/pkg/querier/queryrange/queryrangebase/limits.go
@@ -20,4 +20,8 @@ type Limits interface {
 	// MaxCacheFreshness returns the period after which results are cacheable,
 	// to prevent caching of very recent results.
 	MaxCacheFreshness(string) time.Duration
+
+	// QuerySplitDuration returns the per-tenant configurable split by interface.
+	// This is needed in determining cache keys.
+	QuerySplitDuration(string) time.Duration
 }

--- a/pkg/querier/queryrange/queryrangebase/limits_test.go
+++ b/pkg/querier/queryrange/queryrangebase/limits_test.go
@@ -8,6 +8,7 @@ type mockLimits struct {
 	maxQueryLookback  time.Duration
 	maxQueryLength    time.Duration
 	maxCacheFreshness time.Duration
+	splitBy           time.Duration
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -24,4 +25,8 @@ func (mockLimits) MaxQueryParallelism(string) int {
 
 func (m mockLimits) MaxCacheFreshness(string) time.Duration {
 	return m.maxCacheFreshness
+}
+
+func (m mockLimits) QuerySplitDuration(string) time.Duration {
+	return m.splitBy
 }

--- a/pkg/querier/queryrange/queryrangebase/roundtrip.go
+++ b/pkg/querier/queryrange/queryrangebase/roundtrip.go
@@ -48,6 +48,8 @@ type Config struct {
 	ShardedQueries       bool `yaml:"parallelise_shardable_queries"`
 	// List of headers which query_range middleware chain would forward to downstream querier.
 	ForwardHeaders flagext.StringSlice `yaml:"forward_headers_list"`
+
+	Splitter CacheSplitter `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -413,10 +413,14 @@ func NewMetricTripperware(
 	)
 
 	if cfg.CacheResults {
+		if cfg.Splitter == nil {
+			cfg.Splitter = intervalAndSplitSplitter{}
+		}
+
 		queryCacheMiddleware, err := queryrangebase.NewResultsCacheMiddleware(
 			log,
 			c,
-			cacheKeyLimits{limits},
+			cfg.Splitter,
 			limits,
 			codec,
 			extractor,


### PR DESCRIPTION
**What this PR does / why we need it**:

This is another approach to fixing the LBAC cache previously fixed by https://github.com/grafana/loki/pull/7542. Instead of injecting a "callback" function, this refactors the `CacheSplitter` interface a little, as well as pushing the `QuerySplitDuration` limit down into the `queryrangebase` package. 