### PR TITLE
Use UserIDTransformer only when getting limits

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -67,7 +67,12 @@ type cacheKeyLimits struct {
 }
 
 func (l cacheKeyLimits) GenerateCacheKey(ctx context.Context, userID string, r queryrangebase.Request) string {
-	split := l.QuerySplitDuration(userID)
+	overridesUserID := userID
+	if l.transformer != nil {
+		overridesUserID = l.transformer(ctx, userID)
+	}
+
+	split := l.QuerySplitDuration(overridesUserID)
 
 	var currentInterval int64
 	if denominator := int64(split / time.Millisecond); denominator > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

The UserIDTransformer should only be used to get the limits.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>