### PR TITLE
Fix Promtail GCP Logs diagram route

### DIFF
--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -13,7 +13,7 @@ There's two flavours of how to configure this:
 
 Overall, the setup between GCP, Promtail and Loki will look like the following:
 
-<img src="gcp-logs-diagram.png" width="1200px"/>
+<img src="../gcp-logs-diagram.png" width="1200px"/>
 
 ## Roles and Permission
 

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -13,7 +13,7 @@ There's two flavours of how to configure this:
 
 Overall, the setup between GCP, Promtail and Loki will look like the following:
 
-<img src="./gcp-logs-diagram.png" width="1200px"/>
+<img src="gcp-logs-diagram.png" width="1200px"/>
 
 ## Roles and Permission
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of the latest changes to the GCP Logs Promtial docs include an architecture diagram. It seems the link to this diagram is broken. This PR attempts to fix that by removing a relative routing the image tag path, since the image is deployed in [here](https://grafana.com/docs/loki/next/clients/promtail/gcp-logs-diagram.png), but was being fetched in this path: `https://grafana.com/docs/loki/next/clients/promtail/gcplog-cloud/gcp-logs-diagram.png`.

The img is deployed in the same directory as the site, so should use a `../` parent directory relative routing, as in [here](https://github.com/grafana/loki/blob/3d6210e424574ae3b5a9c111a7527f1159645436/docs/sources/clients/promtail/troubleshooting.md#L48).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
