### PR TITLE
Fix Hugo build for docs

### DIFF
--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -12,8 +12,6 @@ keywords:
   - installation
 ---
 
-<!-- Refer to [Front matter]({{< relref "../../front-matter/" >}}) for more information about how to populate front matter. -->
-
 The [Helm](https://helm.sh/) chart allows you to configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 
 This guide contains the following sections:

--- a/docs/sources/installation/helm/concepts.md
+++ b/docs/sources/installation/helm/concepts.md
@@ -11,8 +11,6 @@ keywords:
   - caching
 ---
 
--<!-- Refer to [Front matter]({{< relref "../../front-matter/" >}}) for more information about how to populate front matter. -->
-
 # Components
 
 This section describes the components installed by the Helm Chart.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the hugo build used for published docs, as it was broken due to a link check inside some comments.

https://github.com/grafana/loki/actions/runs/3379539854/jobs/5611233373

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
