### PR TITLE
add user-id transformer for logs results cache

### DIFF
--- a/pkg/querier/queryrange/log_result_cache_test.go
+++ b/pkg/querier/queryrange/log_result_cache_test.go
@@ -29,6 +29,7 @@ func Test_LogResultCacheSameRange(t *testing.T) {
 			cache.NewMockCache(),
 			nil,
 			nil,
+			nil,
 		)
 	)
 
@@ -67,6 +68,7 @@ func Test_LogResultCacheSameRangeNonEmpty(t *testing.T) {
 				splits: map[string]time.Duration{"foo": time.Minute},
 			},
 			cache.NewMockCache(),
+			nil,
 			nil,
 			nil,
 		)
@@ -115,6 +117,7 @@ func Test_LogResultCacheSmallerRange(t *testing.T) {
 			cache.NewMockCache(),
 			nil,
 			nil,
+			nil,
 		)
 	)
 
@@ -159,6 +162,7 @@ func Test_LogResultCacheDifferentRange(t *testing.T) {
 				splits: map[string]time.Duration{"foo": time.Minute},
 			},
 			cache.NewMockCache(),
+			nil,
 			nil,
 			nil,
 		)
@@ -228,6 +232,7 @@ func Test_LogResultCacheDifferentRangeNonEmpty(t *testing.T) {
 				splits: map[string]time.Duration{"foo": time.Minute},
 			},
 			cache.NewMockCache(),
+			nil,
 			nil,
 			nil,
 		)
@@ -306,6 +311,7 @@ func Test_LogResultCacheDifferentRangeNonEmptyAndEmpty(t *testing.T) {
 				splits: map[string]time.Duration{"foo": time.Minute},
 			},
 			cache.NewMockCache(),
+			nil,
 			nil,
 			nil,
 		)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -269,6 +269,7 @@ func NewLogFilterTripperware(
 			func(r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
+			cfg.Transformer,
 			metrics.LogResultCacheMetrics,
 		)
 		queryRangeMiddleware = append(


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding transformer to results cache same as metrics cache done in PR #7542