### PR TITLE
Promtail: Add go build tag promtail_journal_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Check the history of the branch FIXME.
 * [7263](https://github.com/grafana/loki/pull/7263) **bboreham**: Dependencies: klauspost/compress package to v1.15.11; improves performance.
 * [7270](https://github.com/grafana/loki/pull/7270) **wilfriedroset**: Add support for `username` to redis cache configuration.
 * [6952](https://github.com/grafana/loki/pull/6952) **DylanGuedes**: Experimental: Introduce a new feature named stream sharding.
+* [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude promtail journald code from binary.
 
 ##### Fixes
 * [7453](https://github.com/grafana/loki/pull/7453) **periklis**: Add single compactor http client for delete and gennumber clients

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ##### Fixes
 
 ##### Changes
+* [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude Promtail journald code from binary.
 
 #### Fluent Bit
 
@@ -61,7 +62,6 @@ Check the history of the branch FIXME.
 * [7263](https://github.com/grafana/loki/pull/7263) **bboreham**: Dependencies: klauspost/compress package to v1.15.11; improves performance.
 * [7270](https://github.com/grafana/loki/pull/7270) **wilfriedroset**: Add support for `username` to redis cache configuration.
 * [6952](https://github.com/grafana/loki/pull/6952) **DylanGuedes**: Experimental: Introduce a new feature named stream sharding.
-* [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude promtail journald code from binary.
 
 ##### Fixes
 * [7453](https://github.com/grafana/loki/pull/7453) **periklis**: Add single compactor http client for delete and gennumber clients

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,9 @@ PROMTAIL_GO_FLAGS = $(DYN_GO_FLAGS)
 PROMTAIL_DEBUG_GO_FLAGS = $(DYN_DEBUG_GO_FLAGS)
 endif
 endif
+ifeq ($(PROMTAIL_JOURNAL_ENABLED), true)
+PROMTAIL_GO_TAGS = promtail_journal_enabled
+endif
 .PHONY: clients/cmd/promtail/promtail clients/cmd/promtail/promtail-debug
 promtail: clients/cmd/promtail/promtail
 promtail-debug: clients/cmd/promtail/promtail-debug
@@ -199,10 +202,10 @@ $(PROMTAIL_GENERATED_FILE): $(PROMTAIL_UI_FILES)
 	GOOS=$(shell go env GOHOSTOS) go generate -x -v ./clients/pkg/promtail/server/ui
 
 clients/cmd/promtail/promtail:
-	CGO_ENABLED=$(PROMTAIL_CGO) go build $(PROMTAIL_GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=$(PROMTAIL_CGO) go build $(PROMTAIL_GO_FLAGS) --tags=$(PROMTAIL_GO_TAGS) -o $@ ./$(@D)
 
 clients/cmd/promtail/promtail-debug:
-	CGO_ENABLED=$(PROMTAIL_CGO) go build $(PROMTAIL_DEBUG_GO_FLAGS) -o $@ ./$(@D)
+	CGO_ENABLED=$(PROMTAIL_CGO) go build $(PROMTAIL_DEBUG_GO_FLAGS) --tags=$(PROMTAIL_GO_TAGS) -o $@ ./$(@D)
 
 #########
 # Mixin #

--- a/README.md
+++ b/README.md
@@ -113,21 +113,22 @@ To build Promtail on non-Linux platforms, use the following command:
 $ go build ./clients/cmd/promtail
 ```
 
-On Linux, Promtail requires the systemd headers to be installed for
-Journal support.
+On Linux, Promtail requires the systemd headers to be installed if
+Journal support is enabled.
+To enable Journal support the go build tag flag `promtail_journal_enabled` should be passed
 
 With Journal support on Ubuntu, run with the following commands:
 
 ```bash
 $ sudo apt install -y libsystemd-dev
-$ go build ./clients/cmd/promtail
+$ go build ./clients/cmd/promtail --tags=promtail_journal_enabled
 ```
 
 With Journal support on CentOS, run with the following commands:
 
 ```bash
 $ sudo yum install -y systemd-devel
-$ go build ./clients/cmd/promtail
+$ go build ./clients/cmd/promtail --tags=promtail_journal_enabled
 ```
 
 Otherwise, to build Promtail without Journal support, run `go build`

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/loki
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
-RUN make clean && make BUILD_IN_CONTAINER=false promtail
+RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:bullseye-slim

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -5,7 +5,7 @@ WORKDIR /src/loki
 # Backports repo required to get a libsystemd version 246 or newer which is required to handle journal +ZSTD compression
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -t bullseye-backports -qy libsystemd-dev
-RUN make clean && make BUILD_IN_CONTAINER=false promtail
+RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:bullseye-slim

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -10,7 +10,7 @@ FROM --platform=linux/amd64 $BUILD_IMAGE as build
 COPY --from=goenv /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false promtail
+RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail
 
 # Promtail requires debian as the base image to support systemd journal reading
 FROM debian:stretch-slim

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -6,7 +6,7 @@ FROM grafana/loki-build-image as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false promtail-debug
+RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail-debug
 
 
 FROM       alpine:3.16.2

--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -1,5 +1,5 @@
-//go:build linux && cgo
-// +build linux,cgo
+//go:build linux && cgo && promtail_journal_enabled
+// +build linux,cgo,promtail_journal_enabled
 
 package journal
 

--- a/clients/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget_test.go
@@ -1,5 +1,5 @@
-//go:build linux && cgo
-// +build linux,cgo
+//go:build linux && cgo && promtail_journal_enabled
+// +build linux,cgo,promtail_journal_enabled
 
 package journal
 

--- a/clients/pkg/promtail/targets/journal/journaltargetmanager.go
+++ b/clients/pkg/promtail/targets/journal/journaltargetmanager.go
@@ -1,5 +1,5 @@
-//go:build !linux || !cgo
-// +build !linux !cgo
+//go:build !linux || !cgo || !promtail_journal_enabled
+// +build !linux !cgo !promtail_journal_enabled
 
 package journal
 

--- a/clients/pkg/promtail/targets/journal/journaltargetmanager_linux.go
+++ b/clients/pkg/promtail/targets/journal/journaltargetmanager_linux.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && promtail_journal_enabled
+// +build cgo,promtail_journal_enabled
 
 package journal
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -32,6 +32,18 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Promtail
+
+#### The go build tag `promtail_journal_enabled` was introduced
+
+The go build tag `promtail_journal_enabled` should be passed to include Journal support to the promtail binary.
+If you need Journal support you will need to run go build with tag `promtail_journal_enabled`:
+
+```shell
+go build ./clients/cmd/promtail --tags=promtail_journal_enabled
+```
+Introducing this tag aims to relieve Linux/CentOS users with CGO enabled from installing libsystemd-dev/systemd-devel libraries if they don't need Journal support.
+
 ## 2.7.0
 
 ### Loki


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the new go build tag `promtail_journal_enabled`. This tag is passed to go build if the environment variable `PROMTAIL_JOURNAL_ENABLED=true` is present.
It is useful for users with Linux OS and CGO enabled. Currently, if the user has Linux and CGO enabled he has to install `libsystemd-dev` library (`sudo apt install -y libsystemd-dev`) even when he doesn't need journald support.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
