### PR TITLE
Add config for optional pod labels

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -814,6 +814,15 @@ See values.yaml
 </td>
 		</tr>
 		<tr>
+			<td>gateway.podLabels</td>
+			<td>object</td>
+			<td>Additional labels for gateway pods</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>gateway.podSecurityContext</td>
 			<td>object</td>
 			<td>The SecurityContext for gateway containers</td>
@@ -1430,6 +1439,15 @@ null
 			<td>loki.podAnnotations</td>
 			<td>object</td>
 			<td>Common annotations for all pods</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>loki.podLabels</td>
+			<td>object</td>
+			<td>Common labels for all pods</td>
 			<td><pre lang="json">
 {}
 </pre>
@@ -2505,6 +2523,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>read.podLabels</td>
+			<td>object</td>
+			<td>Additional labels for each `read` pod</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.priorityClassName</td>
 			<td>string</td>
 			<td>The name of the PriorityClass for read pods</td>
@@ -2534,7 +2561,7 @@ null
 		<tr>
 			<td>read.selectorLabels</td>
 			<td>object</td>
-			<td>Additional selecto labels for each `read` pod</td>
+			<td>Additional selector labels for each `read` pod</td>
 			<td><pre lang="json">
 {}
 </pre>
@@ -2802,6 +2829,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>singleBinary.podLabels</td>
+			<td>object</td>
+			<td>Additional labels for each `single binary` pod</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>singleBinary.priorityClassName</td>
 			<td>string</td>
 			<td>The name of the PriorityClass for single binary pods</td>
@@ -2831,7 +2867,7 @@ null
 		<tr>
 			<td>singleBinary.selectorLabels</td>
 			<td>object</td>
-			<td>Additional selecto labels for each `single binary` pod</td>
+			<td>Additional selector labels for each `single binary` pod</td>
 			<td><pre lang="json">
 {}
 </pre>
@@ -3101,6 +3137,15 @@ null
 			<td>write.podAnnotations</td>
 			<td>object</td>
 			<td>Annotations for write pods</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.podLabels</td>
+			<td>object</td>
+			<td>Additional labels for each `write` pod</td>
 			<td><pre lang="json">
 {}
 </pre>

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -29,6 +29,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.gateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "loki.gatewaySelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "loki.serviceAccountName" . -}}

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -41,6 +41,12 @@ spec:
       labels:
         app.kubernetes.io/part-of: memberlist
         {{- include "loki.readSelectorLabels" . | nindent 8 }}
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.read.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.read.selectorLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -31,6 +31,12 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.singleBinarySelectorLabels" . | nindent 8 }}
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.singleBinary.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.singleBinary.selectorLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -32,6 +32,12 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.writeSelectorLabels" . | nindent 8 }}
+        {{- with .Values.loki.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.write.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.write.selectorLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -50,6 +50,8 @@ loki:
     pullPolicy: IfNotPresent
   # -- Common annotations for all pods
   podAnnotations: {}
+  # -- Common labels for all pods
+  podLabels: {}
   # -- The number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10
   # -- The SecurityContext for Loki pods
@@ -741,6 +743,8 @@ write:
   priorityClassName: null
   # -- Annotations for write pods
   podAnnotations: {}
+  # -- Additional labels for each `write` pod
+  podLabels: {}
   # -- Additional selector labels for each `write` pod
   selectorLabels: {}
   # -- Labels for ingestor service
@@ -814,7 +818,9 @@ read:
   priorityClassName: null
   # -- Annotations for read pods
   podAnnotations: {}
-  # -- Additional selecto labels for each `read` pod
+  # -- Additional labels for each `read` pod
+  podLabels: {}
+  # -- Additional selector labels for each `read` pod
   selectorLabels: {}
   # -- Labels for read service
   serviceLabels: {}
@@ -885,7 +891,9 @@ singleBinary:
   priorityClassName: null
   # -- Annotations for single binary pods
   podAnnotations: {}
-  # -- Additional selecto labels for each `single binary` pod
+  # -- Additional labels for each `single binary` pod
+  podLabels: {}
+  # -- Additional selector labels for each `single binary` pod
   selectorLabels: {}
   # -- Comma-separated list of Loki modules to load for the single binary
   targetModule: "all"
@@ -1006,6 +1014,8 @@ gateway:
   priorityClassName: null
   # -- Annotations for gateway pods
   podAnnotations: {}
+  # -- Additional labels for gateway pods
+  podLabels: {}
   # -- Additional CLI args for the gateway
   extraArgs: []
   # -- Environment variables to add to the gateway pods


### PR DESCRIPTION
Currently, pod labels for Loki services can only
be added via the `selectorLabels` key. However, it's a
confusing name as it actually doesn't change the
selectors but only adds additional pod labels.

Additionally, it's currently not possible to add labels 
for the gateway and single binary deployments.

This change adds a new `podLabels` key for all Loki services
analog to `podAnnotations` in order to prevent adding the
confusing `selectorLabels` key to more sections and keep
everything consistent.

The `selectorLabels` keys could then be removed with
the next major version bump of this chart.