### PR TITLE
operator: Fix lookup CA Bundle options on fresh install

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Main
 
+- [7596](https://github.com/grafana/loki/pull/7596) **periklis**: Fix fresh-installs with built-in cert management enabled
+- [7064](https://github.com/grafana/loki/pull/7064) **periklis**: Add support for built-in cert management
 - [7471](https://github.com/grafana/loki/pull/7471) **aminesnow**: Expose and migrate query_timeout in limits config
 - [7437](https://github.com/grafana/loki/pull/7437) **aminesnow**: Fix Custom TLS profile setting for LokiStack on OpenShift
 - [7415](https://github.com/grafana/loki/pull/7415) **aminesnow**: Add alert relabel config

--- a/operator/internal/handlers/internal/certificates/options.go
+++ b/operator/internal/handlers/internal/certificates/options.go
@@ -113,6 +113,10 @@ func configureCertificatesForTenantMode(certs certrotation.ComponentCertificates
 }
 
 func configureCABundleForTenantMode(cm *corev1.ConfigMap, mode lokiv1.ModeType) {
+	if cm == nil {
+		return
+	}
+
 	switch mode {
 	case "", lokiv1.Dynamic, lokiv1.Static:
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
Small fix on fresh LokIStack installs when feature gate `BuiltInCertManagement: true`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
 Follow up on #7064

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
