### PR TITLE
use fifocache.duration instead of fifocache.interval in warn deprecated

### DIFF
--- a/pkg/storage/chunk/cache/fifo_cache.go
+++ b/pkg/storage/chunk/cache/fifo_cache.go
@@ -125,7 +125,7 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 
 	if cfg.DeprecatedValidity > 0 {
 		flagext.DeprecatedFlagsUsed.Inc()
-		level.Warn(logger).Log("msg", "running with DEPRECATED flag fifocache.interval, use fifocache.ttl instead", "cache", name)
+		level.Warn(logger).Log("msg", "running with DEPRECATED flag fifocache.duration, use fifocache.ttl instead", "cache", name)
 		cfg.TTL = cfg.DeprecatedValidity
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I configured fifo cache with `validity` option (which is [deprecated](https://github.com/grafana/loki/blob/b92f113cb0961b628b643f4f3f9fddc1c18ed921/docs/sources/configuration/_index.md?plain=1#L2004) in v2.6.0, `fifocache.duration` as an flag) and loki print that:

```
level=warn ts=2022-07-08T17:01:30.134251284Z caller=fifo_cache.go:125 msg="running with DEPRECATED flag fifocache.interval, use fifocache.ttl instead" cache=frontend.fifocache
```

However, there is no flag `fifocache.interval`.
As #5148 changed, the deprecated flag should be `fifocache.duration`, not `fifocache.interval`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
