### PR TITLE
Bump version `1.2.19` of `fluentd-plugin-grafana-loki`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,7 @@ clean:
 	rm -rf clients/cmd/fluent-bit/out_grafana_loki.so
 	rm -rf cmd/migrate/migrate
 	rm -rf cmd/logql-analyzer/logql-analyzer
+	$(MAKE) -BC clients/cmd/fluentd $@
 	go clean ./...
 
 #########
@@ -443,15 +444,16 @@ fluent-bit-test:
 # fluentd plugin #
 ##################
 fluentd-plugin:
-	gem install bundler --version 2.3.4
-	bundle config silence_root_warning true
-	bundle config set --local path clients/cmd/fluentd/vendor/bundle
-	bundle install --gemfile=clients/cmd/fluentd/Gemfile
+	$(MAKE) -BC clients/cmd/fluentd $@
+
+fluentd-plugin-push:
+	$(MAKE) -BC clients/cmd/fluentd $@
 
 fluentd-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/fluent-plugin-loki:$(IMAGE_TAG) -f clients/cmd/fluentd/Dockerfile .
 
 fluentd-push:
+fluentd-image-push:
 	$(SUDO) $(PUSH_OCI) $(IMAGE_PREFIX)/fluent-plugin-loki:$(IMAGE_TAG)
 
 fluentd-test: LOKI_URL ?= http://loki:3100

--- a/clients/cmd/fluentd/Makefile
+++ b/clients/cmd/fluentd/Makefile
@@ -1,0 +1,27 @@
+.PHONY: clean
+
+SHELL    = /usr/bin/env bash -o pipefail
+# needs to match the name in fluent-plugin-grafana-loki.gemspec
+NAME    := fluent-plugin-grafana-loki
+# needs to match the version in fluent-plugin-grafana-loki.gemspec
+VERSION := 1.2.18
+
+clean:
+	rm -f $(NAME)-*.gem
+	rm -rf .bundle
+
+.bundle:
+	ruby --version
+	@echo ""
+	ruby -S gem install bundler --version 2.3.4
+	ruby -S bundle config silence_root_warning true
+	ruby -S bundle config set --local path ./vendor/bundle
+
+fluentd-plugin: .bundle
+	ruby -S bundle install --gemfile=Gemfile
+
+$(NAME)-$(VERSION).gem: .bundle
+	ruby -S gem build $(NAME).gemspec
+
+fluentd-plugin-push: $(NAME)-$(VERSION).gem
+	ruby -S gem push $(NAME)-$(VERSION).gem

--- a/clients/cmd/fluentd/Makefile
+++ b/clients/cmd/fluentd/Makefile
@@ -4,7 +4,7 @@ SHELL    = /usr/bin/env bash -o pipefail
 # needs to match the name in fluent-plugin-grafana-loki.gemspec
 NAME    := fluent-plugin-grafana-loki
 # needs to match the version in fluent-plugin-grafana-loki.gemspec
-VERSION := 1.2.18
+VERSION := 1.2.19
 
 clean:
 	rm -f $(NAME)-*.gem

--- a/clients/cmd/fluentd/README.md
+++ b/clients/cmd/fluentd/README.md
@@ -82,6 +82,15 @@ The expected output is:
 ]
 ```
 
+## Build and publish gem
+
+To build and publish a gem to
+[rubygems](https://rubygems.org/gems/fluent-plugin-grafana-loki) you first need
+to update the version in the `fluent-plugin-grafana-loki.gemspec` file.
+Then update the `VERSION` variable in the `Makefile` to match the new version number.
+Create a PR with the changes against the `main` branch und run `make
+fluentd-plugin-push` from the root of the project once the PR has been merged.
+
 ## Copyright
 
 * Copyright(c) 2018- Grafana Labs

--- a/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.18'
+  spec.version = '1.2.19'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Version 1.2.19 contains the bugfix [#6240](https://github.com/grafana/loki/pull/6240)

**Special notes for your reviewer**:

At the moment releases of Loki and FluentD plugin are decoupled. In the future we probably want to maintain a separate changelog for the plugin, because it's now not easy to figure out what has been released and what not.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
