### PR TITLE
Loki: Change ingesters rate store to decay rates exponentially

### DIFF
--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -39,3 +39,29 @@ func TestStreamRateCalculator(t *testing.T) {
 		return len(rates) == 0
 	}, 2*time.Second, 250*time.Millisecond)
 }
+
+func TestStreamRateCalculatorDecaying(t *testing.T) {
+	calc := NewStreamRateCalculator()
+	defer calc.Stop()
+
+	expectedRates := []int64{128 * kilobyte, 64 * kilobyte, 32 * kilobyte, 16 * kilobyte, 8 * kilobyte, 4 * kilobyte, 2 * kilobyte, 1 * kilobyte}
+
+	initialRate := expectedRates[0]
+	calc.Record("tenant 1", 1, 1, int(initialRate))
+
+	for _, r := range expectedRates {
+		require.Eventually(t, func() bool {
+			rates := calc.Rates()
+			if len(rates) == 1 {
+				return rates[0].Tenant == "tenant 1" && rates[0].Rate == r
+			}
+
+			return false
+		}, 2*time.Second, 250*time.Millisecond)
+	}
+
+	require.Eventually(t, func() bool {
+		rates := calc.Rates()
+		return len(rates) == 0
+	}, 2*time.Second, 250*time.Millisecond)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes ingesters rateStore to decay stored rates exponentially every second instead of throwing their whole value away.
As of now if an ingester doesn't receive any data for a stream for a second, its ingestion rate is considered zero. With this, they're going to reduce rates by half until they're below the threshold of 1 KB.