### PR TITLE
Mention default port in docs

### DIFF
--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -5,8 +5,8 @@ weight: 20
 # Observing Grafana Loki
 
 Both Grafana Loki and Promtail expose a `/metrics` endpoint that expose Prometheus
-metrics. You will need a local Prometheus and add Loki and Promtail as targets.
-See [configuring
+metrics (the default port is 3100 for Loki and 80 for Promtail). You will need
+a local Prometheus and add Loki and Promtail as targets. See [configuring
 Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration)
 for more information.
 


### PR DESCRIPTION
I ran across a user setting up Loki and following this documentation, and they couldn't figure out the port where the HTTP server is listening for metrics requests. Be nice and mention the default here.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
