### PR TITLE
[helm] Ignore single binary headless service from service-monitor

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.3.3
+
+- [BUGFIX] Add missing label `prometheus.io/service-monitor: "false"` to single-binary headless service
+
 ## 3.3.2
 
 - [BUGFIX] Fixed indentation in single-binary pdb template

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.3.2
+version: 3.3.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.3.3](https://img.shields.io/badge/Version-3.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/single-binary/service-headless.yaml
+++ b/production/helm/loki/templates/single-binary/service-headless.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "loki.labels" . | nindent 4 }}
     variant: headless
+    prometheus.io/service-monitor: "false"
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore the headless service from the Prometheus service-monitor as it was resulting in duplicate metrics. Replaces https://github.com/grafana/loki/pull/7049
