### PR TITLE
[helm] Add a flag to enable/disable persistentVolumeClaimRetentionPolicy feature

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -2360,6 +2360,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>read.persistence.enableStatefulSetAutoDeletePVC</td>
+			<td>bool</td>
+			<td>Enable StatefulSetAutoDeletePVC feature</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.persistence.selector</td>
 			<td>string</td>
 			<td>Selector for persistent disk</td>

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -16,7 +16,7 @@ spec:
       partition: 0
   serviceName: {{ printf "%s-headless" (include "loki.readFullname" .) }}
   revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.read.persistence.enableStatefulSetAutoDeletePVC)  }}
   {{/*
     Data on the read nodes is easy to replace, so we want to always delete PVCs to make
     operation easier, and will rely on re-fetching data when needed.

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -846,6 +846,8 @@ read:
   # -- Tolerations for read pods
   tolerations: []
   persistence:
+    # -- Enable StatefulSetAutoDeletePVC feature
+    enableStatefulSetAutoDeletePVC: true
     # -- Size of persistent disk
     size: 10Gi
     # -- Storage class to be used.


### PR DESCRIPTION
**What this PR does / why we need it**:

add a flag to enable/disable persistentVolumeClaimRetentionPolicy feature which is available since kubernetes 1.23 but in alpha (StatefulSetAutoDeletePVC) and disabled by default on most cloud provider

I've set the flag to true by default, to not change the actual behavior
 
**Which issue(s) this PR fixes**:
Fixes #7249

**Special notes for your reviewer**:
@trevorwhitney 

**Checklist**
- [ X] Reviewed the `CONTRIBUTING.md` guide
- [ X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
