### PR TITLE
Add dependabot.yml to ignore ieproxy dependency version

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    ignore:
+     - dependency-name: "github.com/mattn/go-ieproxy"
+       versions: ["0.0.9"] 


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot tries to update https://github.com/mattn/go-ieproxy to v0.0.9. This doesn't work as it seems to redeclare a function, probably due to missing build tags. This dependabot config file excludes this version. 

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>