### PR TITLE
adds Dropbox to the adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,3 +6,4 @@
 * [X4B](https://www.x4b.net)
 * [Heureka Group](https://heureka.group)
 * [Norwegian Refugee Council](https://www.nrc.no/)
+* [Dropbox](https://www.dropbox.com/)


### PR DESCRIPTION
**What this PR does / why we need it**:
Dropbox recently deployed Loki. This PR adds us to the adopters list


