### PR TITLE
Update Ingester Rate Calculations

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -319,6 +319,7 @@ func (i *instance) getOrCreateStream(pushReqStream logproto.Stream, record *WALR
 // removeStream removes a stream from the instance.
 func (i *instance) removeStream(s *stream) {
 	if i.streams.Delete(s) {
+		i.streamRateCalculator.Remove(i.instanceID, s.labelHash)
 		i.index.Delete(s.labels, s.fp)
 		i.streamsRemovedTotal.Inc()
 		memoryStreams.WithLabelValues(i.instanceID).Dec()

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -204,17 +204,6 @@ func TestGetStreamRates(t *testing.T) {
 
 		return valid
 	}, 3*time.Second, 100*time.Millisecond)
-
-	// Decay back to 0
-	require.Eventually(t, func() bool {
-		rates = inst.streamRateCalculator.Rates()
-		for _, r := range rates {
-			if r.Rate != 0 {
-				return false
-			}
-		}
-		return true
-	}, 3*time.Second, 100*time.Millisecond)
 }
 
 func labelHashNoShard(l labels.Labels) uint64 {

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -204,6 +204,17 @@ func TestGetStreamRates(t *testing.T) {
 
 		return valid
 	}, 3*time.Second, 100*time.Millisecond)
+
+	// Decay
+	require.Eventually(t, func() bool {
+		rates = inst.streamRateCalculator.Rates()
+		for _, r := range rates {
+			if r.Rate > 65000 {
+				return false
+			}
+		}
+		return true
+	}, 3*time.Second, 100*time.Millisecond)
 }
 
 func labelHashNoShard(l labels.Labels) uint64 {

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -18,7 +18,7 @@ const (
 	// The factor used to weight the moving average. Must be in the range [0, 1.0].
 	// A larger factor weights recent samples more heavily while a smaller
 	// factor weights historic samples more heavily.
-	smoothingFactor = .7
+	smoothingFactor = .66
 )
 
 // stripeLock is taken from ruler/storage/wal/series.go

--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -52,13 +52,13 @@ func TestStreamRateCalculator(t *testing.T) {
 		calc.updateRates()
 		rates = calc.Rates()
 		require.Len(t, rates, 1)
-		require.Equal(t, int64(3000), rates[0].Rate)
+		require.Equal(t, int64(3400), rates[0].Rate)
 
 		calc.Record("tenant 1", 1, 1, 10000)
 		calc.updateRates()
 		rates = calc.Rates()
 		require.Len(t, rates, 1)
-		require.Equal(t, int64(7900), rates[0].Rate)
+		require.Equal(t, int64(7756), rates[0].Rate)
 	})
 }
 

--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -3,39 +3,78 @@ package ingester
 import (
 	"sort"
 	"testing"
-	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestStreamRateCalculator(t *testing.T) {
-	calc := NewStreamRateCalculator()
-	defer calc.Stop()
+	t.Run("it records rates for tenants and streams", func(t *testing.T) {
+		calc := setupCalculator()
 
-	for i := 0; i < 100; i++ {
-		calc.Record("tenant 1", 1, 1, 100)
-	}
+		for i := 0; i < 100; i++ {
+			calc.Record("tenant 1", 1, 1, 100)
+		}
 
-	for i := 0; i < 100; i++ {
-		calc.Record("tenant 2", 1, 1, 100)
-	}
+		for i := 0; i < 100; i++ {
+			calc.Record("tenant 2", 1, 1, 100)
+		}
 
-	require.Eventually(t, func() bool {
+		calc.updateRates()
 		rates := calc.Rates()
+		require.Len(t, rates, 2)
 		sort.Slice(rates, func(i, j int) bool {
 			return rates[i].Tenant < rates[j].Tenant
 		})
 
-		if len(rates) > 1 {
-			return rates[0].Tenant == "tenant 1" && rates[0].Rate == 10000 &&
-				rates[1].Tenant == "tenant 2" && rates[1].Rate == 10000
-		}
+		require.Equal(t, []logproto.StreamRate{
+			{StreamHash: 1, StreamHashNoShard: 1, Rate: 10000, Tenant: "tenant 1"},
+			{StreamHash: 1, StreamHashNoShard: 1, Rate: 10000, Tenant: "tenant 2"},
+		}, rates)
 
-		return false
-	}, 2*time.Second, 250*time.Millisecond)
+		calc.Remove("tenant 1", 1)
+		calc.Remove("tenant 2", 1)
+		calc.updateRates()
 
-	require.Eventually(t, func() bool {
+		require.Len(t, calc.Rates(), 0)
+	})
+
+	t.Run("it records rates using an exponential weighted average", func(t *testing.T) {
+		calc := setupCalculator()
+
+		calc.Record("tenant 1", 1, 1, 10000)
+		calc.updateRates()
 		rates := calc.Rates()
-		return len(rates) == 0
-	}, 2*time.Second, 250*time.Millisecond)
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(10000), rates[0].Rate)
+
+		calc.updateRates()
+		rates = calc.Rates()
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(3000), rates[0].Rate)
+
+		calc.Record("tenant 1", 1, 1, 10000)
+		calc.updateRates()
+		rates = calc.Rates()
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(7900), rates[0].Rate)
+	})
+}
+
+// This is just the constructor without the async start so we can control it for tests
+func setupCalculator() *StreamRateCalculator {
+	calc := &StreamRateCalculator{
+		size: defaultStripeSize,
+		// Lookup pattern: tenant -> fingerprint -> rate
+		samples:  make([]map[string]map[uint64]logproto.StreamRate, defaultStripeSize),
+		locks:    make([]stripeLock, defaultStripeSize),
+		stopchan: make(chan struct{}),
+	}
+
+	for i := 0; i < defaultStripeSize; i++ {
+		calc.samples[i] = make(map[string]map[uint64]logproto.StreamRate)
+	}
+
+	return calc
 }

--- a/pkg/ingester/stream_rate_calculator_test.go
+++ b/pkg/ingester/stream_rate_calculator_test.go
@@ -52,13 +52,34 @@ func TestStreamRateCalculator(t *testing.T) {
 		calc.updateRates()
 		rates = calc.Rates()
 		require.Len(t, rates, 1)
-		require.Equal(t, int64(3400), rates[0].Rate)
+		require.Equal(t, int64(8000), rates[0].Rate)
 
 		calc.Record("tenant 1", 1, 1, 10000)
 		calc.updateRates()
 		rates = calc.Rates()
 		require.Len(t, rates, 1)
-		require.Equal(t, int64(7756), rates[0].Rate)
+		require.Equal(t, int64(8400), rates[0].Rate)
+	})
+
+	t.Run("it uses the larger sample without taking the average when there's a spike in load", func(t *testing.T) {
+		calc := setupCalculator()
+
+		calc.Record("tenant 1", 1, 1, 10000)
+		calc.updateRates()
+		rates := calc.Rates()
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(10000), rates[0].Rate)
+
+		calc.updateRates()
+		rates = calc.Rates()
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(8000), rates[0].Rate)
+
+		calc.Record("tenant 1", 1, 1, 13000)
+		calc.updateRates()
+		rates = calc.Rates()
+		require.Len(t, rates, 1)
+		require.Equal(t, int64(13000), rates[0].Rate)
 	})
 }
 


### PR DESCRIPTION
- Use weighted moving average for rates
- Keep Streams around until they are removed

Previously, the rate calculator only kept the most recent second. This led to issues where bursty streams that didn't get pushes every second resulted in undersharding those streams