### PR TITLE
Promtail docs: Fix docker stage code example

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -431,9 +431,10 @@ The Docker stage is just a convenience wrapper for this definition:
 
 ```yaml
 - json:
-    output: log
-    stream: stream
-    timestamp: time
+    expressions:
+      output: log
+      stream: stream
+      timestamp: time
 - labels:
     stream:
 - timestamp:


### PR DESCRIPTION
The current, 2.6.x, documentation on [configuring promtail _pipeline_stages_](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#pipeline_stages) contains a [docker stage](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#docker) which wraps the json, labels, timestamp, and output stage. The unwrapped configuration is shown as example. However, this example is outdated as can be seen by the lack of `expressions`. I have stumbled across this as I tried the example in my own config as a starter to modify to my own needs. It took me some time to realize what `failed to make file target manager: invalid json stage config: JMES expression is required` meant. This PR updates the example to match the current code at <https://github.com/grafana/loki/blob/a6df09bc97f64584c2efbeb2550a2d59526f39c0/clients/pkg/logentry/stages/extensions.go#L16-L42>

Going back in history points to #576 as the origin of the divergence.

I found another usage of outdated configuration in a test file but was unsure whether it needed updating:
https://github.com/grafana/loki/blob/a6df09bc97f64584c2efbeb2550a2d59526f39c0/clients/pkg/promtail/scrapeconfig/scrapeconfig_test.go#L32-L40

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
