### PR TITLE
Fix json stage fields in example

### DIFF
--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig_test.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig_test.go
@@ -30,14 +30,15 @@ pipeline_stages:
   - regex:
       expr: "./*"
   - json:
-      timestamp:
-        source: time
-        format: RFC3339
-      labels:
-        stream:
-          source: json_key_name.json_sub_key_name
-      output:
-        source: log
+      expressions:
+        timestamp:
+          source: time
+          format: RFC3339
+        labels:
+          stream:
+            source: json_key_name.json_sub_key_name
+        output:
+          source: log
 job_name: kubernetes-pods-name
 kubernetes_sd_configs:
 - role: pod

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig_test.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig_test.go
@@ -139,4 +139,6 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
+	require.NotZero(t, len(config.PipelineStages))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the json section of a scrape config used in a unit test. The unit test doesn't fail as the unmarshaling is very generic. The json stage is unit tested in a different place.
This was mentioned as a comment on another PR: https://github.com/grafana/loki/pull/7653.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>