### PR TITLE
Add diff-config command to flake.nix

### DIFF
--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -27,7 +27,7 @@ diff --color=always --side-by-side <(docker run --rm -t -v "${PWD}":/config graf
 
 the `tr -d '\r'` is likely not necessary for most people, seems like WSL2 was sneaking in some windows newline characters...
 
-Alternatively, if using `nix`, you can run `nix run .#diff-config` from the root of the repository to compare config changes between your locally check out repo and the lastest released version.
+Alternatively, if using `nix`, you can run `nix run .#diff-config` from the root of the Loki repository to compare config changes between your locally checked out version and the lastest released version.
 
 The output is incredibly verbose as it shows the entire internal config struct used to run Loki, you can play around with the diff command if you prefer to only show changes or a different style output.
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -27,6 +27,8 @@ diff --color=always --side-by-side <(docker run --rm -t -v "${PWD}":/config graf
 
 the `tr -d '\r'` is likely not necessary for most people, seems like WSL2 was sneaking in some windows newline characters...
 
+Alternatively, if using `nix`, you can run `nix run .#diff-config` from the root of the repository to compare config changes between your locally check out repo and the lastest released version.
+
 The output is incredibly verbose as it shows the entire internal config struct used to run Loki, you can play around with the diff command if you prefer to only show changes or a different style output.
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,50 @@
             type = "app";
             program = with pkgs; "${loki-helm-test}/bin/helm-test";
           };
+
+          diff-config =
+            let
+              previousVersion = "2.6.1";
+              previousVersionBranch = "v${previousVersion}";
+              previousSource = pkgs.fetchFromGitHub {
+                owner = "grafana";
+                repo = "loki";
+                rev = previousVersionBranch;
+                sha256 = "sha256-6g0tzI6ZW+wwbPrNTdj0t2H0/M8+M9ioJl6iPL0mAtY=";
+              };
+
+              loki-old =
+                pkgs.loki.overrideAttrs (old: rec {
+                  version = previousVersion;
+                  src = previousSource;
+                  doCheck = false;
+
+                  configurePhase = with pkgs; ''
+                    patchShebangs tools
+
+                    substituteInPlace Makefile \
+                      --replace "SHELL = /usr/bin/env bash -o pipefail" "SHELL = ${bash}/bin/bash -o pipefail" \
+                      --replace "IMAGE_TAG := \$(shell ./tools/image-tag)" "IMAGE_TAG := ${previousVersion}" \
+                      --replace "GIT_REVISION := \$(shell git rev-parse --short HEAD)" "GIT_REVISION := ${previousVersionBranch}" \
+                      --replace "GIT_BRANCH := \$(shell git rev-parse --abbrev-ref HEAD)" "GIT_BRANCH := ${previousVersionBranch}" \
+                  '';
+                });
+
+              loki = pkgs.loki.overrideAttrs (old: rec {
+                doCheck = false;
+              });
+            in
+            {
+              type = "app";
+              program = with pkgs; "${(writeShellScriptBin "diff-config" ''
+              ${diffutils}/bin/diff --color=always --side-by-side \
+                <(${loki-old}/bin/loki -config.file ${previousSource}/cmd/loki/loki-local-config.yaml -print-config-stderr 2>&1 \
+                | sed '/Starting Loki/q') \
+                <(${loki}/bin/loki -config.file ${self}/cmd/loki/loki-local-config.yaml -print-config-stderr 2>&1 \
+                | sed '/Starting Loki/q') \
+                | ${less}/bin/less -R
+            '')}/bin/diff-config";
+            };
         };
 
         devShell = pkgs.mkShell {

--- a/nix/loki.nix
+++ b/nix/loki.nix
@@ -30,6 +30,9 @@ pkgs.stdenv.mkDerivation {
       --replace "IMAGE_TAG := \$(shell ./tools/image-tag)" "IMAGE_TAG := ${imageTag}" \
       --replace "GIT_REVISION := \$(shell git rev-parse --short HEAD)" "GIT_REVISION := ${version}" \
       --replace "GIT_BRANCH := \$(shell git rev-parse --abbrev-ref HEAD)" "GIT_BRANCH := nix" \
+
+    substituteInPlace clients/cmd/fluentd/Makefile \
+      --replace "SHELL    = /usr/bin/env bash -o pipefail" "SHELL = ${bash}/bin/bash -o pipefail"
   '';
 
   buildPhase = ''


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds @slim-bean's config diffing command to `flake.nix` so it can diff the current checked out version against the last released version without having to create docker images.
