### PR TITLE
Add config changes to upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Check the history of the branch FIXME.
 
 ### Dependencies
 
-* Go Version:     FIXME
+* Go Version: 1.19
 
 ## 2.7.0
 
@@ -126,9 +126,9 @@ Check the history of the branch FIXME.
 
 ### Notes
 
-This release was created from a branch starting at commit FIXME but it may also contain backported changes from main.
+This release was created from a branch starting at commit `706c22e9e40b0156031f214b63dc6ed4e210abc1` but it may also contain backported changes from main.
 
-Check the history of the branch FIXME.
+Check the history of the branch `release-2.7.x`.
 
 ### Dependencies
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -122,7 +122,7 @@ The configuration for anonymous usage statistics reporting to Grafana has change
 
 #### TLS `cipher_suites` and `tls_min_version` have moved
 
-These were previoulsy configurable under `server.http_tls_config` and `server.grpc_tls_config` separately. They are now only configurable under `server.tls_cipher_suites` and `server.tls_min_version`. These values are also now configurable for individual clients, for example `distributor.ring.etcd` or `querier.ingester_client.grpc_client_config`.
+These were previously configurable under `server.http_tls_config` and `server.grpc_tls_config` separately. They are now under `server.tls_cipher_suites` and `server.tls_min_version`. These values are also now configurable for individual clients, for example: `distributor.ring.etcd` or `querier.ingester_client.grpc_client_config`.
 
 #### Querier `query_timeout` default changed
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -116,6 +116,22 @@ The global `deletion_mode` option in the compactor configuration moved to runtim
 
 The name of this metric was changed to `loki_internal_log_messages_total` to reduce ambiguity. The previous name is still present but is deprecated.
 
+#### TLS `cipher_suites` and `tls_min_version` have moved
+
+These were previoulsy configurable under `server.http_tls_config` and `server.grpc_tls_config` separately. They are now only configurable under `server.tls_cipher_suites` and `server.tls_min_version`. These values are also now configurable for individual clients, for example `distributor.ring.etcd` or `querier.ingester_client.grpc_client_config`.
+
+#### Querier `query_timeout` default changed
+
+The previous default of `querier.query_timeout` of `1m` has changed to `0s`;
+
+#### `ruler.storage.configdb` has been removed
+
+ConfigDB was disallowed as a Ruler storage option back in 2.0. The config struct has finally been removed.
+
+#### `ruler.remote_write.client` has been removed
+
+Can no longer specify a remote write client for the ruler.
+
 ### Promtail
 
 #### `gcp_push_target_parsing_errors_total` has a new `reason` label

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -116,6 +116,10 @@ The global `deletion_mode` option in the compactor configuration moved to runtim
 
 The name of this metric was changed to `loki_internal_log_messages_total` to reduce ambiguity. The previous name is still present but is deprecated.
 
+#### Usage Report  / Telemetry config has changed named
+
+The `usage_report` config for configuring if and how annonymous usage statistics are reported back to Grafana has changes from `usage_report` to `analytics`.
+
 #### TLS `cipher_suites` and `tls_min_version` have moved
 
 These were previoulsy configurable under `server.http_tls_config` and `server.grpc_tls_config` separately. They are now only configurable under `server.tls_cipher_suites` and `server.tls_min_version`. These values are also now configurable for individual clients, for example `distributor.ring.etcd` or `querier.ingester_client.grpc_client_config`.

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -118,7 +118,7 @@ The name of this metric was changed to `loki_internal_log_messages_total` to red
 
 #### Usage Report  / Telemetry config has changed named
 
-The `usage_report` config for configuring if and how annonymous usage statistics are reported back to Grafana has changes from `usage_report` to `analytics`.
+The configuration for anonymous usage statistics reporting to Grafana has changed from `usage_report` to `analytics`.
 
 #### TLS `cipher_suites` and `tls_min_version` have moved
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -126,7 +126,7 @@ These were previoulsy configurable under `server.http_tls_config` and `server.gr
 
 #### Querier `query_timeout` default changed
 
-The previous default of `querier.query_timeout` of `1m` has changed to `0s`;
+The previous default value for `querier.query_timeout` of `1m` has changed to `0s`.
 
 #### `ruler.storage.configdb` has been removed
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This add config differences I noticed when running the config diff tool between 2.6 and 2.7
