### PR TITLE
docs: Fix refs on helm docs that breaks rendering new docs

### DIFF
--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -6,13 +6,11 @@ aliases:
   - /docs/writers-toolkit/latest/templates/concept-template
 weight: 100
 keywords:
-  - helm 
+  - helm
   - scalable
   - simple-scalable
   - installation
 ---
-
-<!-- Refer to [Front matter]({{< relref "../../front-matter/" >}}) for more information about how to populate front matter. -->
 
 The [Helm](https://helm.sh/) chart allows you to configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 

--- a/docs/sources/installation/helm/concepts.md
+++ b/docs/sources/installation/helm/concepts.md
@@ -11,8 +11,6 @@ keywords:
   - caching
 ---
 
--<!-- Refer to [Front matter]({{< relref "../../front-matter/" >}}) for more information about how to populate front matter. -->
-
 # Components
 
 This section describes the components installed by the Helm Chart.


### PR DESCRIPTION

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

**What this PR does / why we need it**:
Remove the non-exist references on couple of helm docs.

this fixes the docs building errors for v2.7 on grafana website.
https://github.com/grafana/loki/actions/runs/3443596525/jobs/5745297762

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

## NOTE: this merges to `release-2.7.x` branch not `main` branch

**Checklist**

- [x] Documentation added
