### PR TITLE
operator: Update Loki operand to v2.7.0

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7673](https://github.com/grafana/loki/pull/7673) **periklis**: Update Loki operand to v2.7.0
 - [7617](https://github.com/grafana/loki/pull/7617) **Red-GV**: Modify ingestionRate for respective shirt size
 - [7592](https://github.com/grafana/loki/pull/7592) **aminesnow**: Update API docs generation using gen-crd-api-reference-docs
 - [7448](https://github.com/grafana/loki/pull/7448) **periklis**: Add TLS support for compactor delete client

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1247,7 +1247,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.7.0-pre
+                  value: quay.io/openshift-logging/loki:v2.7.0
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1375,7 +1375,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.7.0-pre
+  - image: quay.io/openshift-logging/loki:v2.7.0
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -52,7 +52,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LokiStackSpec defines the desired state of LokiStack
+            description: LokiStack CR spec field.
             properties:
               limits:
                 description: Limits defines the limits to be applied to log stream
@@ -1114,7 +1114,7 @@ spec:
             - storageClassName
             type: object
           status:
-            description: LokiStackStatus defines the observed state of LokiStack
+            description: LokiStack CR spec Status.
             properties:
               components:
                 description: Components provides summary of all Loki pod status grouped

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -35,7 +35,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LokiStackSpec defines the desired state of LokiStack
+            description: LokiStack CR spec field.
             properties:
               limits:
                 description: Limits defines the limits to be applied to log stream
@@ -1097,7 +1097,7 @@ spec:
             - storageClassName
             type: object
           status:
-            description: LokiStackStatus defines the observed state of LokiStack
+            description: LokiStack CR spec Status.
             properties:
               components:
                 description: Components provides summary of all Loki pod status grouped

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.7.0-pre
+            value: quay.io/openshift-logging/loki:v2.7.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -27,5 +27,4 @@ Due to the use of apiextensions.k8s.io/v1 CustomResourceDefinitions, requires Ku
 
 The versions of Loki compatible to be run with the Loki Operator are:
 
-* v2.6.0
-* v2.6.1
+* v2.7.0

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1-amd64
+          image: docker.io/grafana/logcli:2.7.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.6.1
+          image: docker.io/grafana/promtail:2.7.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1-amd64
+          image: docker.io/grafana/logcli:2.7.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.6.1
+          image: docker.io/grafana/promtail:2.7.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -52,7 +52,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.6.1"
+	DefaultContainerImage = "docker.io/grafana/loki:2.7.0"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the Loki operator references of Loki as an operand from v2.6.1/v2.7.0-pre to v2.7.0

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
