### PR TITLE
[helm] Fix read-only /tmp in single-binary mode

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.4.2
+
+- [BUGFIX] Fix read-only /tmp in single-binary mode
+
 ## 3.4.1
 
 - [BUGFIX] Remove extra `/` in image name if `registry` or `repository` is empty

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.4.1
+version: 3.4.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.4.2](https://img.shields.io/badge/Version-3.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -79,6 +79,8 @@ spec:
           readinessProbe:
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: config
               mountPath: /etc/loki/config
             - name: storage
@@ -105,6 +107,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           {{- if .Values.loki.existingSecretForConfig }}
           secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
When running in single-binary mode, these warnings may appear:
`level=warn ts=2022-11-15T08:01:39.777179378Z caller=marker.go:214 msg="failed to process marks" path=/var/loki/compactor/retention/markers/1668476560013344947 err="open /tmp/marker-view-912253853: read-only file system"`

This was previously fixed in the old chart: grafana/helm-charts#967

**Which issue(s) this PR fixes**:
Fixes grafana/helm-charts#609, again.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
