### PR TITLE
Helm: allow override for read/write service type

### DIFF
--- a/production/helm/loki/templates/read/service-read.yaml
+++ b/production/helm/loki/templates/read/service-read.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.read.service.type }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/templates/write/service-write.yaml
+++ b/production/helm/loki/templates/write/service-write.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.write.service.type }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -786,6 +786,12 @@ write:
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
 
+  # Write service configuration
+  service:
+    # -- Type of the write service
+    type: ClusterIP
+
+
 # Configuration for the read node(s)
 read:
   # -- Number of replicas for the read
@@ -852,6 +858,10 @@ read:
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+
+  service:
+    # -- Type of the read service
+    type: ClusterIP
 
 # Configuration for the single binary node(s)
 singleBinary:


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow users to override the default Kubernetes service type for the read and write services.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
