### PR TITLE
loki-canary: respect `useTLS` flag when `push` mode is enabled.

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -157,6 +157,7 @@ func main() {
 				config.DefaultHTTPClientConfig,
 				*lName, *lVal,
 				*sName, *sValue,
+				*useTLS,
 				tlsConfig,
 				*caFile,
 				*user, *pass,

--- a/pkg/canary/writer/push.go
+++ b/pkg/canary/writer/push.go
@@ -63,7 +63,7 @@ func NewPush(
 	cfg config.HTTPClientConfig,
 	labelName, labelValue string,
 	streamName, streamValue string,
-	useTls bool,
+	useTLS bool,
 	tlsCfg *tls.Config,
 	caFile string,
 	username, password string,
@@ -91,7 +91,7 @@ func NewPush(
 		scheme = "https"
 	}
 
-	if useTls {
+	if useTLS {
 		scheme = "https"
 	}
 

--- a/pkg/canary/writer/push.go
+++ b/pkg/canary/writer/push.go
@@ -63,6 +63,7 @@ func NewPush(
 	cfg config.HTTPClientConfig,
 	labelName, labelValue string,
 	streamName, streamValue string,
+	useTls bool,
 	tlsCfg *tls.Config,
 	caFile string,
 	username, password string,
@@ -87,6 +88,10 @@ func NewPush(
 			return nil, fmt.Errorf("failed to create TLS config for transport: %w", err)
 		}
 		client.Transport = rt
+		scheme = "https"
+	}
+
+	if useTls {
 		scheme = "https"
 	}
 

--- a/pkg/canary/writer/push_test.go
+++ b/pkg/canary/writer/push_test.go
@@ -42,7 +42,7 @@ func Test_Push(t *testing.T) {
 	defer mock.Close()
 
 	// without TLS
-	push, err := NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "stream", "stdout", nil, "", "", "", &backoff, log.NewNopLogger())
+	push, err := NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "stream", "stdout", false, nil, "", "", "", &backoff, log.NewNopLogger())
 	require.NoError(t, err)
 	ts, payload := testPayload()
 	n, err := push.Write([]byte(payload))
@@ -52,7 +52,7 @@ func Test_Push(t *testing.T) {
 	assertResponse(t, resp, false, labelSet("name", "loki-canary", "stream", "stdout"), ts, payload)
 
 	// with basic Auth
-	push, err = NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "stream", "stdout", nil, "", testUsername, testPassword, &backoff, log.NewNopLogger())
+	push, err = NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "stream", "stdout", false, nil, "", testUsername, testPassword, &backoff, log.NewNopLogger())
 	require.NoError(t, err)
 	ts, payload = testPayload()
 	n, err = push.Write([]byte(payload))
@@ -62,7 +62,7 @@ func Test_Push(t *testing.T) {
 	assertResponse(t, resp, true, labelSet("name", "loki-canary", "stream", "stdout"), ts, payload)
 
 	// with custom labels
-	push, err = NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "pod", "abc", nil, "", testUsername, testPassword, &backoff, log.NewNopLogger())
+	push, err = NewPush(mock.Listener.Addr().String(), "test1", 2*time.Second, config.DefaultHTTPClientConfig, "name", "loki-canary", "pod", "abc", false, nil, "", testUsername, testPassword, &backoff, log.NewNopLogger())
 	require.NoError(t, err)
 	ts, payload = testPayload()
 	n, err = push.Write([]byte(payload))
@@ -133,7 +133,6 @@ func createServerHandler(responses chan response) http.HandlerFunc {
 				rw.WriteHeader(500)
 				return
 			}
-			fmt.Println("decoded", decoded)
 			toks := strings.FieldsFunc(string(decoded), func(r rune) bool {
 				return r == ':'
 			})


### PR DESCRIPTION


**What this PR does / why we need it**:
Currently `useTLS` flag is ignored on the push writer. This PR consider that flag and adjust the schema (http -> https) when that flag is enabled.

**Which issue(s) this PR fixes**:
Fixes #7692 

**Special notes for your reviewer**:

**Checklist**

