### PR TITLE
Loki: Use default limits when cant get the tenantId

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -487,14 +487,7 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			log, ctx := spanlogger.New(req.Context(), call)
-			userID, err := tenant.TenantID(ctx)
-			if err != nil {
-				level.Error(log).Log("msg", "couldn't fetch tenantID", "err", err)
-				serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, err.Error()), w)
-				return
-			}
-
-			// Enforce the query timeout while querying backends
+			userID, _ := tenant.TenantID(ctx)
 			queryTimeout := q.limits.QueryTimeout(userID)
 			// TODO: remove this clause once we remove the deprecated query-timeout flag.
 			if q.cfg.QueryTimeout != 0 { // querier YAML configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a quick fix to not fail and use default limits if can not get the single tenantId, which makes multi-tenant queries work again.
**Which issue(s) this PR fixes**:
Fixes #7696 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
