### PR TITLE
Loki: Fix multitenant querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
 
+* [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
+
 ##### Changes
 
 #### Promtail

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -30,6 +30,9 @@ auth_enabled: true
 server:
   http_listen_port: 0
   grpc_listen_port: 0
+  grpc_server_max_recv_msg_size: 110485813
+  grpc_server_max_send_msg_size: 110485813
+
 
 common:
   path_prefix: {{.dataPath}}
@@ -42,6 +45,12 @@ common:
     instance_addr: 127.0.0.1
     kvstore:
       store: inmemory
+
+limits_config:
+  per_stream_rate_limit: 50MB
+  per_stream_rate_limit_burst: 50MB
+  ingestion_rate_mb: 50
+  ingestion_burst_size_mb: 50
 
 storage_config:
   boltdb_shipper:
@@ -70,6 +79,9 @@ analytics:
 ingester:
   lifecycler:
     min_ready_duration: 0s
+
+querier:
+  multi_tenant_queries_enabled: true
 
 {{if .remoteWriteUrls}}
 ruler:

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -1,0 +1,66 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/integration/client"
+	"github.com/grafana/loki/integration/cluster"
+)
+
+func TestMultiTenantQuery(t *testing.T) {
+	clu := cluster.New()
+	defer func() {
+		assert.NoError(t, clu.Cleanup())
+	}()
+
+	var (
+		tAll = clu.AddComponent(
+			"all",
+			"-target=all",
+		)
+	)
+
+	require.NoError(t, clu.Run())
+
+	cliTenant1 := client.New("org1", "", tAll.HTTPURL())
+	cliTenant2 := client.New("org2", "", tAll.HTTPURL())
+	cliMultitenant := client.New("org1|org2", "", tAll.HTTPURL())
+
+	// ingest log lines for tenant 1 and tenant 2.
+	require.NoError(t, cliTenant1.PushLogLineWithTimestamp("lineA", cliTenant1.Now.Add(-45*time.Minute), map[string]string{"job": "fake1"}))
+	require.NoError(t, cliTenant2.PushLogLineWithTimestamp("lineB", cliTenant2.Now.Add(-45*time.Minute), map[string]string{"job": "fake2"}))
+
+	// check that tenant1 only have access to log line A.
+	matchLines(t, cliTenant1, `{job="fake2"}`, []string{})
+	matchLines(t, cliTenant1, `{job=~"fake.*"}`, []string{"lineA"})
+	matchLines(t, cliTenant1, `{job="fake1"}`, []string{"lineA"})
+
+	// check that tenant2 only have access to log line B.
+	matchLines(t, cliTenant2, `{job="fake1"}`, []string{})
+	matchLines(t, cliTenant2, `{job=~"fake.*"}`, []string{"lineB"})
+	matchLines(t, cliTenant2, `{job="fake2"}`, []string{"lineB"})
+
+	// check that multitenant has access to all log lines on same query.
+	matchLines(t, cliMultitenant, `{job=~"fake.*"}`, []string{"lineA", "lineB"})
+	matchLines(t, cliMultitenant, `{job="fake1"}`, []string{"lineA"})
+	matchLines(t, cliMultitenant, `{job="fake2"}`, []string{"lineB"})
+	matchLines(t, cliMultitenant, `{job="fake3"}`, []string{})
+}
+
+func matchLines(t *testing.T, client *client.Client, labels string, expectedLines []string) {
+	resp, err := client.RunRangeQuery(context.Background(), labels)
+	require.NoError(t, err)
+
+	var lines []string
+	for _, stream := range resp.Data.Stream {
+		for _, val := range stream.Values {
+			lines = append(lines, val[1])
+		}
+	}
+	require.ElementsMatch(t, expectedLines, lines)
+}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -240,12 +240,12 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 }
 
 func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
-	// set as timeout the longest timeout across all tenants.
+	// set as timeout the smallest timeout across all tenants.
 	queryTimeout := q.limits.QueryTimeout("")
 	tenants, _ := tenant.TenantIDs(ctx)
 	for _, tenant := range tenants {
 		t := q.limits.QueryTimeout(tenant)
-		if t > queryTimeout {
+		if t < queryTimeout {
 			queryTimeout = t
 		}
 	}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -240,15 +240,8 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 }
 
 func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
-	// set as timeout the smallest timeout across all tenants.
-	queryTimeout := q.limits.QueryTimeout("")
 	tenants, _ := tenant.TenantIDs(ctx)
-	for _, tenant := range tenants {
-		t := q.limits.QueryTimeout(tenant)
-		if t < queryTimeout {
-			queryTimeout = t
-		}
-	}
+	queryTimeout := validation.SmallestPositiveNonZeroDurationPerTenant(tenants, q.limits.QueryTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -506,7 +507,7 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 
 			// TODO: remove this clause once we remove the deprecated query-timeout flag.
 			if q.cfg.QueryTimeout != 0 { // querier YAML configuration is still configured.
-				level.Warn(log).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "WrapQuerySpanAndTimeout", "org_id", tenantID)
+				level.Warn(log).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "WrapQuerySpanAndTimeout", "org_id", strings.Join(tenants, ","))
 				longestTimeout = q.cfg.QueryTimeout
 			}
 

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -487,7 +487,7 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			log, ctx := spanlogger.New(req.Context(), call)
-			tenantIDS, err := tenant.TenantIDs(ctx)
+			tenants, err := tenant.TenantIDs(ctx)
 			if err != nil {
 				level.Error(log).Log("msg", "couldn't fetch tenantID", "err", err)
 				serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, err.Error()), w)
@@ -496,8 +496,8 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 
 			// use the longest timeout across all tenants
 			longestTimeout := q.limits.QueryTimeout("")
-			for _, tenantID := range tenantIDS {
-				queryTimeout := q.limits.QueryTimeout(tenantID)
+			for _, tenant := range tenants {
+				queryTimeout := q.limits.QueryTimeout(tenant)
 				if longestTimeout < queryTimeout {
 					longestTimeout = queryTimeout
 

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -495,16 +495,7 @@ func WrapQuerySpanAndTimeout(call string, q *QuerierAPI) middleware.Interface {
 				return
 			}
 
-			// use the smallest timeout across all tenants.
-			timeout := q.limits.QueryTimeout("")
-			for _, tenant := range tenants {
-				t := q.limits.QueryTimeout(tenant)
-				if timeout > t {
-					timeout = t
-
-				}
-			}
-
+			timeout := util_validation.SmallestPositiveNonZeroDurationPerTenant(tenants, q.limits.QueryTimeout)
 			// TODO: remove this clause once we remove the deprecated query-timeout flag.
 			if q.cfg.QueryTimeout != 0 { // querier YAML configuration is still configured.
 				level.Warn(log).Log("msg", "deprecated querier:query_timeout YAML configuration identified. Please migrate to limits:query_timeout instead.", "call", "WrapQuerySpanAndTimeout", "org_id", strings.Join(tenants, ","))

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -99,7 +99,7 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return ast.next.Do(ctx, r)
 	}
 
-	// use biggest max query parallelism across all given tenants
+	// use smallest max query parallelism across all given tenants
 	maxQueryParallelism := ast.limits.MaxQueryParallelism("")
 	tenants, err := tenant.TenantIDs(ctx)
 	if err != nil {
@@ -107,7 +107,7 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 	}
 	for _, tenant := range tenants {
 		m := ast.limits.MaxQueryParallelism(tenant)
-		if m > maxQueryParallelism {
+		if m < maxQueryParallelism {
 			maxQueryParallelism = m
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently broke multitenant querying because of recent changes to how timeouts working across Loki. This PR fixes this by:
- Adapt the timeout wrapper to work with multitenant queries. It will take the shortest timeout across all given tenants
- Adapt the query engine timeout assigning to work with multitenant queries. It will take the shortest timeout between all the tenants
- Adapt query sharding to use smallest max query parallelism across given tenants
- Add a functional test to ensure multitenant is behaving as expected

Signed-off-by: DylanGuedes <djmgguedes@gmail.com>
Signed-off-by: Mehmet Burak Devecí <mhmtbrkdvc@gmail.com>

**Which issue(s) this PR fixes**:
https://github.com/grafana/loki/issues/7696

**Special notes for your reviewer**:
The regression was probably introduced by https://github.com/grafana/loki/pull/7555