### PR TITLE
operator: Watch APIServer changes and reconcile accordingly

### DIFF
--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -908,9 +908,9 @@ type LokiStackStatus struct {
 //
 // +operator-sdk:csv:customresourcedefinitions:displayName="LokiStack",resources={{Deployment,v1},{StatefulSet,v1},{ConfigMap,v1},{Ingress,v1},{Service,v1},{ServiceAccount,v1},{PersistentVolumeClaims,v1},{Route,v1},{ServiceMonitor,v1}}
 type LokiStack struct {
-	// LokiStack CR spec field.
+	// LokiStackSpec defines the desired state of LokiStack
 	Spec LokiStackSpec `json:"spec,omitempty"`
-	// LokiStack CR spec Status.
+	// LokiStackStatus defines the observed state of LokiStack
 	Status            LokiStackStatus `json:"status,omitempty"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	metav1.TypeMeta   `json:",inline"`

--- a/operator/controllers/loki/certrotation_controller.go
+++ b/operator/controllers/loki/certrotation_controller.go
@@ -39,7 +39,7 @@ type CertRotationReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
 func (r *CertRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	managed, err := state.IsManaged(ctx, req, r.Client)
+	managed, err := state.IsManaged(ctx, req, r.Client, r.Log)
 	if err != nil {
 		return ctrl.Result{
 			Requeue: true,

--- a/operator/controllers/loki/internal/management/state/state.go
+++ b/operator/controllers/loki/internal/management/state/state.go
@@ -2,23 +2,94 @@ package state
 
 import (
 	"context"
+	"sync"
 
+	"github.com/go-logr/logr"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/external/k8s"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // IsManaged checks if the custom resource is configured with ManagementState Managed.
-func IsManaged(ctx context.Context, req ctrl.Request, k k8s.Client) (bool, error) {
+func IsManaged(ctx context.Context, req ctrl.Request, k k8s.Client, log logr.Logger) (bool, error) {
 	var stack lokiv1.LokiStack
 	if err := k.Get(ctx, req.NamespacedName, &stack); err != nil {
 		if apierrors.IsNotFound(err) {
+			unregisterLokiStackNamespacedName(log, req)
 			return false, nil
 		}
 		return false, kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
 	}
+
 	return stack.Spec.ManagementState == lokiv1.ManagementStateManaged, nil
+}
+
+type RegisteredNamespacedNames struct {
+	registered []types.NamespacedName
+	mux        sync.Mutex
+}
+
+var registeredLokiStacks RegisteredNamespacedNames
+
+// this is used for when we get an apiserver change
+// it will return requests for all known loki CRs
+func GetLokiStackEvents(a client.Object) []reconcile.Request {
+	requests := []reconcile.Request{}
+
+	registeredLokiStacks.mux.Lock()
+	defer registeredLokiStacks.mux.Unlock()
+
+	for _, loki := range registeredLokiStacks.registered {
+		requests = append(requests, reconcile.Request{NamespacedName: loki})
+	}
+
+	return requests
+}
+
+func RegisterLokiStackNamespacedName(log logr.Logger, request reconcile.Request) {
+	// check to see if the namespaced name is already registered first
+	found := false
+
+	registeredLokiStacks.mux.Lock()
+	defer registeredLokiStacks.mux.Unlock()
+
+	for _, loki := range registeredLokiStacks.registered {
+		if loki == request.NamespacedName {
+			found = true
+		}
+	}
+
+	// if not, add it to registeredLokiStacks
+	if !found {
+		log.Info("Registering future events", "name", request.NamespacedName)
+		registeredLokiStacks.registered = append(registeredLokiStacks.registered, request.NamespacedName)
+	}
+}
+
+func unregisterLokiStackNamespacedName(log logr.Logger, request reconcile.Request) {
+	// look for a namespacedname registered already
+	found := false
+	index := -1
+
+	registeredLokiStacks.mux.Lock()
+	defer registeredLokiStacks.mux.Unlock()
+
+	for i, loki := range registeredLokiStacks.registered {
+		if loki == request.NamespacedName {
+			found = true
+			index = i
+		}
+	}
+
+	// if we find it, remove it from registeredLokiStacks
+	if found {
+		log.Info("Unregistering future events", "name", request.NamespacedName)
+		registeredLokiStacks.registered = append(registeredLokiStacks.registered[:index], registeredLokiStacks.registered[index+1:]...)
+	}
 }

--- a/operator/controllers/loki/internal/management/state/state_test.go
+++ b/operator/controllers/loki/internal/management/state/state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/loki/operator/internal/external/k8s/k8sfakes"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
+	"github.com/ViaQ/logerr/v2/log"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,8 @@ func TestIsManaged(t *testing.T) {
 			Namespace: "some-ns",
 		},
 	}
+	logr := log.NewLogger("state-test")
+
 	table := []test{
 		{
 			name: "managed",
@@ -73,7 +76,7 @@ func TestIsManaged(t *testing.T) {
 				k.SetClientObject(object, &tst.stack)
 				return nil
 			}
-			ok, err := state.IsManaged(context.TODO(), r, k)
+			ok, err := state.IsManaged(context.TODO(), r, k, logr)
 			require.NoError(t, err)
 			require.Equal(t, ok, tst.wantOk)
 		})
@@ -95,6 +98,8 @@ func TestIsManaged_WhenError_ReturnNotManagedWithError(t *testing.T) {
 			Namespace: "some-ns",
 		},
 	}
+	logr := log.NewLogger("state-test")
+
 	table := []test{
 		{
 			name:     "stack not found error",
@@ -109,7 +114,7 @@ func TestIsManaged_WhenError_ReturnNotManagedWithError(t *testing.T) {
 	for _, tst := range table {
 		t.Run(tst.name, func(t *testing.T) {
 			k.GetReturns(tst.apierror)
-			ok, err := state.IsManaged(context.TODO(), r, k)
+			ok, err := state.IsManaged(context.TODO(), r, k, logr)
 			require.Equal(t, tst.wantErr, err)
 			require.False(t, ok)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
When the operator is used in an OpenShift cluster, the APIServer resource is used to determine the TLS Policy to be used for the operator components. 
This PR makes the operator watch for changes in the APIServer in order to reconcile.

**Which issue(s) this PR fixes**:
Fixes [LOG-3286](https://issues.redhat.com/browse/LOG-3286)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
