### PR TITLE
operator: Remove default value from replicationFactor field

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7711](https://github.com/grafana/loki/pull/7711) **Red-GV**: Remove default value from replicationFactor field
 - [7617](https://github.com/grafana/loki/pull/7617) **Red-GV**: Modify ingestionRate for respective shirt size
 - [7592](https://github.com/grafana/loki/pull/7592) **aminesnow**: Update API docs generation using gen-crd-api-reference-docs
 - [7448](https://github.com/grafana/loki/pull/7448) **periklis**: Add TLS support for compactor delete client

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -707,7 +707,6 @@ type LokiStackSpec struct {
 	// +optional
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum:=1
-	// +kubebuilder:default:=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Replication Factor"
 	ReplicationFactor int32 `json:"replicationFactor"`
 

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -708,7 +708,7 @@ type LokiStackSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum:=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Replication Factor"
-	ReplicationFactor int32 `json:"replicationFactor"`
+	ReplicationFactor int32 `json:"replicationFactor,omitempty"`
 
 	// Rules defines the spec for the ruler component
 	//

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -52,7 +52,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LokiStackSpec defines the desired state of LokiStack
+            description: LokiStack CR spec field.
             properties:
               limits:
                 description: Limits defines the limits to be applied to log stream
@@ -314,7 +314,6 @@ spec:
                     type: boolean
                 type: object
               replicationFactor:
-                default: 1
                 description: ReplicationFactor defines the policy for log stream replication.
                 format: int32
                 minimum: 1
@@ -1135,7 +1134,7 @@ spec:
             - storageClassName
             type: object
           status:
-            description: LokiStackStatus defines the observed state of LokiStack
+            description: LokiStack CR spec Status.
             properties:
               components:
                 description: Components provides summary of all Loki pod status grouped

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -35,7 +35,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LokiStackSpec defines the desired state of LokiStack
+            description: LokiStack CR spec field.
             properties:
               limits:
                 description: Limits defines the limits to be applied to log stream
@@ -297,7 +297,6 @@ spec:
                     type: boolean
                 type: object
               replicationFactor:
-                default: 1
                 description: ReplicationFactor defines the policy for log stream replication.
                 format: int32
                 minimum: 1
@@ -1118,7 +1117,7 @@ spec:
             - storageClassName
             type: object
           status:
-            description: LokiStackStatus defines the observed state of LokiStack
+            description: LokiStack CR spec Status.
             properties:
               components:
                 description: Components provides summary of all Loki pod status grouped


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the OpenShift console to create instances, the `replicationFactor` is set to a default of 1. This prevents the defaults listed in the `sizes.go` file from taking effect. This removes this from the PR, which allows an instance to be created with an empty field and thus lets the default values take effect.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
