### PR TITLE
operator: Fix api doc generation

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -276,7 +276,7 @@ oci-push-calculator: ## Push the calculator image
 
 ##@ Website
 TYPES_TARGET := $(shell find apis/loki -type f -iname "*_types.go")
-docs/operator/api.md: $(TYPES_TARGET)
+docs/operator/api.md: $(TYPES_TARGET) $(GEN_CRD_API_REFERENCE_DOCS)
 	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir "github.com/grafana/loki/operator/apis/loki/" -config "$(PWD)/config/docs/config.json" -template-dir "$(PWD)/config/docs/templates" -out-file "$(PWD)/$@"
 	sed -i 's/+docs:/  docs:/' $@
 	sed -i 's/+parent:/    parent:/' $@
@@ -284,7 +284,7 @@ docs/operator/api.md: $(TYPES_TARGET)
 	sed -i 's/+newline/\n/' $@
 
 FEATURE_GATES_TARGET := $(shell find apis/config -type f -iname "*_types.go")
-docs/operator/feature-gates.md: $(FEATURE_GATES_TARGET)
+docs/operator/feature-gates.md: $(FEATURE_GATES_TARGET) $(GEN_CRD_API_REFERENCE_DOCS)
 	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir "github.com/grafana/loki/operator/apis/config/v1/" -config "$(PWD)/config/docs/config.json" -template-dir "$(PWD)/config/docs/templates" -out-file "$(PWD)/$@"
 	sed -i 's/title: "API"/title: "Feature Gates"/' $@
 	sed -i 's/+docs:/  docs:/' $@

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -183,18 +183,6 @@ string
 <p>NoProxy configures the NO_PROXY/no_proxy env variable.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>readVarsFromEnv</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReadVarsFromEnv defines a flag to use Operator-lib provides a helper function</p>
-</td>
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
****What** this PR does / why we need it**:
Adds the `$(GEN_CRD_API_REFERENCE_DOCS)` deps to Make targets `docs/operator/api.md` and `docs/operator/feature-gates.md`. Re-generate api docs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
