### PR TITLE
fix bugs in processing delete requests with line filters and add proper tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ##### Fixes
 
+* [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
+
 ##### Changes
 
 #### Promtail

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
@@ -139,6 +139,7 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, []retention
 
 	intervals := make([]retention.IntervalFilter, 0, 2)
 
+	// chunk partially deleted from the end
 	if d.StartTime > entry.From {
 		// Add the deleted part with Filter func
 		if ff != nil {
@@ -160,6 +161,7 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, []retention
 		})
 	}
 
+	// chunk partially deleted from the beginning
 	if d.EndTime < entry.Through {
 		// Add the deleted part with Filter func
 		if ff != nil {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
@@ -2,13 +2,12 @@ package deletion
 
 import (
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 	"github.com/grafana/loki/pkg/util/filter"
 	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 type DeleteRequest struct {
@@ -40,6 +39,7 @@ func (d *DeleteRequest) SetQuery(logQL string) error {
 }
 
 // FilterFunction returns a filter function that returns true if the given line matches
+// Note: FilterFunction can be nil when the delete request does not have a line filter.
 func (d *DeleteRequest) FilterFunction(labels labels.Labels) (filter.Func, error) {
 	if d.logSelectorExpr == nil {
 		err := d.SetQuery(d.Query)
@@ -47,6 +47,12 @@ func (d *DeleteRequest) FilterFunction(labels labels.Labels) (filter.Func, error
 			return nil, err
 		}
 	}
+
+	// return a filter func if the delete request has a line filter
+	if !d.logSelectorExpr.HasFilter() {
+		return nil, nil
+	}
+
 	p, err := d.logSelectorExpr.Pipeline()
 	if err != nil {
 		return nil, err
@@ -134,22 +140,44 @@ func (d *DeleteRequest) IsDeleted(entry retention.ChunkEntry) (bool, []retention
 	intervals := make([]retention.IntervalFilter, 0, 2)
 
 	if d.StartTime > entry.From {
+		// Add the deleted part with Filter func
+		if ff != nil {
+			intervals = append(intervals, retention.IntervalFilter{
+				Interval: model.Interval{
+					Start: d.StartTime,
+					End:   entry.Through,
+				},
+				Filter: ff,
+			})
+		}
+
+		// Add non-deleted part without Filter func
 		intervals = append(intervals, retention.IntervalFilter{
 			Interval: model.Interval{
 				Start: entry.From,
 				End:   d.StartTime - 1,
 			},
-			Filter: ff,
 		})
 	}
 
 	if d.EndTime < entry.Through {
+		// Add the deleted part with Filter func
+		if ff != nil {
+			intervals = append(intervals, retention.IntervalFilter{
+				Interval: model.Interval{
+					Start: entry.From,
+					End:   d.EndTime,
+				},
+				Filter: ff,
+			})
+		}
+
+		// Add non-deleted part without Filter func
 		intervals = append(intervals, retention.IntervalFilter{
 			Interval: model.Interval{
 				Start: d.EndTime + 1,
 				End:   entry.Through,
 			},
-			Filter: ff,
 		})
 	}
 

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_manager_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
-
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletionmode"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
+	"github.com/grafana/loki/pkg/util/filter"
 )
 
 const testUserID = "test-user"
@@ -21,10 +21,14 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 		isExpired           bool
 		nonDeletedIntervals []retention.IntervalFilter
 	}
+	var dummyFilterFunc filter.Func = func(s string) bool {
+		return false
+	}
 
 	now := model.Now()
 	lblFoo, err := syntax.ParseLabels(`{foo="bar"}`)
 	require.NoError(t, err)
+	streamSelectorWithLineFilters := lblFoo.String() + `|="fizz"`
 
 	chunkEntry := retention.ChunkEntry{
 		ChunkRef: retention.ChunkRef{
@@ -90,6 +94,37 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			expectedResp: resp{
 				isExpired:           true,
 				nonDeletedIntervals: nil,
+			},
+			expectedDeletionRangeByUser: map[string]model.Interval{
+				testUserID: {
+					Start: now.Add(-24 * time.Hour),
+					End:   now,
+				},
+			},
+		},
+		{
+			name:         "whole chunk deleted by single request with line filters",
+			deletionMode: deletionmode.FilterAndDelete,
+			batchSize:    70,
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-24 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired: true,
+				nonDeletedIntervals: []retention.IntervalFilter{
+					{
+						Interval: model.Interval{
+							Start: chunkEntry.ChunkRef.From,
+							End:   chunkEntry.ChunkRef.Through,
+						},
+						Filter: dummyFilterFunc,
+					},
+				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
 				testUserID: {
@@ -175,6 +210,43 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			expectedResp: resp{
 				isExpired:           true,
 				nonDeletedIntervals: nil,
+			},
+			expectedDeletionRangeByUser: map[string]model.Interval{
+				testUserID: {
+					Start: now.Add(-48 * time.Hour),
+					End:   now,
+				},
+			},
+		},
+		{
+			name:         "multiple delete requests with line filters and one deleting the whole chunk",
+			deletionMode: deletionmode.FilterAndDelete,
+			batchSize:    70,
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-48 * time.Hour),
+					EndTime:   now.Add(-24 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-12 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired: true,
+				nonDeletedIntervals: []retention.IntervalFilter{
+					{
+						Interval: model.Interval{
+							Start: chunkEntry.ChunkRef.From,
+							End:   chunkEntry.ChunkRef.Through,
+						},
+						Filter: dummyFilterFunc,
+					},
+				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
 				testUserID: {
@@ -273,6 +345,50 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			},
 		},
 		{
+			name:         "multiple overlapping requests with line filters deleting the whole chunk",
+			deletionMode: deletionmode.FilterAndDelete,
+			batchSize:    70,
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-13 * time.Hour),
+					EndTime:   now.Add(-6 * time.Hour),
+				},
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-8 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired: true,
+				nonDeletedIntervals: []retention.IntervalFilter{
+					{
+						Interval: model.Interval{
+							Start: chunkEntry.ChunkRef.From,
+							End:   now.Add(-6 * time.Hour),
+						},
+						Filter: dummyFilterFunc,
+					},
+					{
+						Interval: model.Interval{
+							Start: now.Add(-6*time.Hour) + 1,
+							End:   chunkEntry.ChunkRef.Through,
+						},
+						Filter: dummyFilterFunc,
+					},
+				},
+			},
+			expectedDeletionRangeByUser: map[string]model.Interval{
+				testUserID: {
+					Start: now.Add(-13 * time.Hour),
+					End:   now,
+				},
+			},
+		},
+		{
 			name:         "multiple non-overlapping requests deleting the whole chunk",
 			deletionMode: deletionmode.FilterAndDelete,
 			batchSize:    70,
@@ -299,6 +415,63 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 			expectedResp: resp{
 				isExpired:           true,
 				nonDeletedIntervals: nil,
+			},
+			expectedDeletionRangeByUser: map[string]model.Interval{
+				testUserID: {
+					Start: now.Add(-12 * time.Hour),
+					End:   now,
+				},
+			},
+		},
+		{
+			name:         "multiple non-overlapping requests with line filter deleting the whole chunk",
+			deletionMode: deletionmode.FilterAndDelete,
+			batchSize:    70,
+			deleteRequestsFromStore: []DeleteRequest{
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-12 * time.Hour),
+					EndTime:   now.Add(-6*time.Hour) - 1,
+				},
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-6 * time.Hour),
+					EndTime:   now.Add(-4*time.Hour) - 1,
+				},
+				{
+					UserID:    testUserID,
+					Query:     streamSelectorWithLineFilters,
+					StartTime: now.Add(-4 * time.Hour),
+					EndTime:   now,
+				},
+			},
+			expectedResp: resp{
+				isExpired: true,
+				nonDeletedIntervals: []retention.IntervalFilter{
+					{
+						Interval: model.Interval{
+							Start: chunkEntry.ChunkRef.From,
+							End:   now.Add(-6*time.Hour) - 1,
+						},
+						Filter: dummyFilterFunc,
+					},
+					{
+						Interval: model.Interval{
+							Start: now.Add(-6 * time.Hour),
+							End:   now.Add(-4*time.Hour) - 1,
+						},
+						Filter: dummyFilterFunc,
+					},
+					{
+						Interval: model.Interval{
+							Start: now.Add(-4 * time.Hour),
+							End:   chunkEntry.ChunkRef.Through,
+						},
+						Filter: dummyFilterFunc,
+					},
+				},
 			},
 			expectedDeletionRangeByUser: map[string]model.Interval{
 				testUserID: {
@@ -444,10 +617,15 @@ func TestDeleteRequestsManager_Expired(t *testing.T) {
 
 			isExpired, nonDeletedIntervals := mgr.Expired(chunkEntry, model.Now())
 			require.Equal(t, tc.expectedResp.isExpired, isExpired)
+			require.Len(t, nonDeletedIntervals, len(tc.expectedResp.nonDeletedIntervals))
 			for idx, interval := range nonDeletedIntervals {
 				require.Equal(t, tc.expectedResp.nonDeletedIntervals[idx].Interval.Start, interval.Interval.Start)
 				require.Equal(t, tc.expectedResp.nonDeletedIntervals[idx].Interval.End, interval.Interval.End)
-				require.NotNil(t, interval.Filter)
+				if tc.expectedResp.nonDeletedIntervals[idx].Filter != nil {
+					require.NotNil(t, interval.Filter)
+				} else {
+					require.Nil(t, interval.Filter)
+				}
 			}
 
 			require.Equal(t, len(tc.expectedDeletionRangeByUser), len(mgr.deleteRequestsToProcess))


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the following issues:
* Whole chunks being deleted with a line filter were skipped.
* Chunks partially covered by delete requests with a line filter were not properly processed. The part that **was not covered** by the delete request was rewritten with a line filter, while the part that **was covered** by the delete request was completely deleted.

The issue went unnoticed because it seems we continue to do query time filtering of data even after the delete requests are processed.

**Which issue(s) this PR fixes**:
Fixes #7590 

**Special notes for your reviewer**:
If multiple delete requests with a line filter touch the same chunk, then I am considering just the first request that marks it for deletion to keep this PR simple. I have left a to-do to see if we can make it work efficiently.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated
