### PR TITLE
Serialize query JSON response in a stream.

### DIFF
--- a/pkg/loghttp/entry.go
+++ b/pkg/loghttp/entry.go
@@ -111,14 +111,14 @@ func readTimestamp(iter *jsoniter.Iterator) (time.Time, bool) {
 	return time.Unix(0, t), true
 }
 
-type entryEncoder struct{}
+type EntryEncoder struct{}
 
-func (entryEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+func (EntryEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 	// we don't omit-empty with log entries.
 	return false
 }
 
-func (entryEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (EntryEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	e := *((*Entry)(ptr))
 	stream.WriteArrayStart()
 	stream.WriteRaw(`"`)
@@ -138,7 +138,7 @@ func (e *jsonExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
 
 func (e *jsonExtension) CreateEncoder(typ reflect2.Type) jsoniter.ValEncoder {
 	if typ == reflect2.TypeOf(Entry{}) {
-		return entryEncoder{}
+		return EntryEncoder{}
 	}
 	return nil
 }

--- a/pkg/util/marshal/marshal.go
+++ b/pkg/util/marshal/marshal.go
@@ -18,23 +18,12 @@ import (
 // WriteQueryResponseJSON marshals the promql.Value to v1 loghttp JSON and then
 // writes it to the provided io.Writer.
 func WriteQueryResponseJSON(v logqlmodel.Result, w io.Writer) error {
-	value, err := NewResultValue(v.Data)
+	s := jsoniter.ConfigFastest.BorrowStream(w)
+	defer jsoniter.ConfigFastest.ReturnStream(s)
+	err := EncodeResult(v, s)
 	if err != nil {
 		return err
 	}
-
-	q := loghttp.QueryResponse{
-		Status: "success",
-		Data: loghttp.QueryResponseData{
-			ResultType: value.Type(),
-			Result:     value,
-			Statistics: v.Statistics,
-		},
-	}
-
-	s := jsoniter.ConfigFastest.BorrowStream(w)
-	defer jsoniter.ConfigFastest.ReturnStream(s)
-	s.WriteVal(q)
 	s.WriteRaw("\n")
 	return s.Flush()
 }

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -3,10 +3,14 @@ package marshal
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"reflect"
 	"testing"
+	"testing/quick"
 	"time"
 
 	json "github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -487,7 +491,7 @@ func Test_WriteQueryResponseJSON(t *testing.T) {
 		err := WriteQueryResponseJSON(logqlmodel.Result{Data: queryTest.actual}, &b)
 		require.NoError(t, err)
 
-		testJSONBytesEqual(t, []byte(queryTest.expected), b.Bytes(), "Query Test %d failed", i)
+		require.JSONEqf(t, queryTest.expected, b.String(), "Query Test %d failed", i)
 	}
 }
 
@@ -497,7 +501,7 @@ func Test_WriteLabelResponseJSON(t *testing.T) {
 		err := WriteLabelResponseJSON(labelTest.actual, &b)
 		require.NoError(t, err)
 
-		testJSONBytesEqual(t, []byte(labelTest.expected), b.Bytes(), "Label Test %d failed", i)
+		require.JSONEqf(t, labelTest.expected, b.String(), "Label Test %d failed", i)
 	}
 }
 
@@ -511,7 +515,7 @@ func Test_MarshalTailResponse(t *testing.T) {
 		bytes, err := json.Marshal(model)
 		require.NoError(t, err)
 
-		testJSONBytesEqual(t, []byte(tailTest.expected), bytes, "Tail Test %d failed", i)
+		require.JSONEqf(t, tailTest.expected, string(bytes), "Tail Test %d failed", i)
 	}
 }
 
@@ -567,7 +571,7 @@ func Test_LabelResponseMarshalLoop(t *testing.T) {
 		jsonOut, err := json.Marshal(r)
 		require.NoError(t, err)
 
-		testJSONBytesEqual(t, []byte(labelTest.expected), jsonOut, "Label Marshal Loop %d failed", i)
+		require.JSONEqf(t, labelTest.expected, string(jsonOut), "Label Marshal Loop %d failed", i)
 	}
 }
 
@@ -581,7 +585,7 @@ func Test_TailResponseMarshalLoop(t *testing.T) {
 		jsonOut, err := json.Marshal(r)
 		require.NoError(t, err)
 
-		testJSONBytesEqual(t, []byte(tailTest.expected), jsonOut, "Tail Marshal Loop %d failed", i)
+		require.JSONEqf(t, tailTest.expected, string(jsonOut), "Tail Marshal Loop %d failed", i)
 	}
 }
 
@@ -615,21 +619,122 @@ func Test_WriteSeriesResponseJSON(t *testing.T) {
 			err := WriteSeriesResponseJSON(tc.input, &b)
 			require.NoError(t, err)
 
-			testJSONBytesEqual(t, []byte(tc.expected), b.Bytes(), "Label Test %d failed", i)
+			require.JSONEqf(t, tc.expected, b.String(), "Label Test %d failed", i)
 		})
 	}
 }
 
-func testJSONBytesEqual(t *testing.T, expected []byte, actual []byte, msg string, args ...interface{}) {
-	var expectedValue map[string]interface{}
-	err := json.Unmarshal(expected, &expectedValue)
-	require.NoError(t, err)
+// wrappedValue and its Generate method is used by quick to generate a random
+// parser.Value.
+type wrappedValue struct {
+	parser.Value
+}
 
-	var actualValue map[string]interface{}
-	err = json.Unmarshal(actual, &actualValue)
-	require.NoError(t, err)
+func (w wrappedValue) Generate(rand *rand.Rand, size int) reflect.Value {
+	types := []string{
+		loghttp.ResultTypeMatrix,
+		loghttp.ResultTypeScalar,
+		loghttp.ResultTypeStream,
+		loghttp.ResultTypeVector,
+	}
+	t := types[rand.Intn(len(types))]
 
-	require.Equalf(t, expectedValue, actualValue, msg, args)
+	switch t {
+	case loghttp.ResultTypeMatrix:
+		s, _ := quick.Value(reflect.TypeOf(promql.Series{}), rand)
+		series, _ := s.Interface().(promql.Series)
+
+		l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
+		series.Metric = l.Interface().(labels.Labels)
+
+		matrix := promql.Matrix{series}
+		return reflect.ValueOf(wrappedValue{matrix})
+	case loghttp.ResultTypeScalar:
+		q, _ := quick.Value(reflect.TypeOf(promql.Scalar{}), rand)
+		return reflect.ValueOf(wrappedValue{q.Interface().(parser.Value)})
+	case loghttp.ResultTypeStream:
+		stream := logproto.Stream{
+			Labels:  randLabels(rand).String(),
+			Entries: randEntries(rand),
+			Hash:    0,
+		}
+
+		streams := logqlmodel.Streams([]logproto.Stream{stream})
+		return reflect.ValueOf(wrappedValue{streams})
+	case loghttp.ResultTypeVector:
+		v, _ := quick.Value(reflect.TypeOf(promql.Sample{}), rand)
+		sample, _ := v.Interface().(promql.Sample)
+
+		l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
+		sample.Metric = l.Interface().(labels.Labels)
+		vector := promql.Vector([]promql.Sample{sample})
+		return reflect.ValueOf(wrappedValue{vector})
+
+	}
+	return reflect.ValueOf(nil)
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+
+func randLabel(rand *rand.Rand) labels.Label {
+	var label labels.Label
+	b := make([]rune, 10)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	b[0] = 'n'
+	label.Name = string(b)
+
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	b[0] = 'v'
+	label.Value = string(b)
+
+	return label
+}
+
+func randLabels(rand *rand.Rand) labels.Labels {
+	var labels labels.Labels
+	for i := 0; i < rand.Intn(100); i++ {
+		labels = append(labels, randLabel(rand))
+	}
+
+	return labels
+}
+
+func randEntries(rand *rand.Rand) []logproto.Entry {
+	var entries []logproto.Entry
+	for i := 0; i < rand.Intn(100); i++ {
+		l, _ := quick.Value(reflect.TypeOf(""), rand)
+		entries = append(entries, logproto.Entry{Timestamp: time.Now(), Line: l.Interface().(string)})
+	}
+
+	return entries
+}
+
+func Test_EncodeResult_And_ResultValue_Parity(t *testing.T) {
+	f := func(w wrappedValue) bool {
+		var buf bytes.Buffer
+		js := jsoniter.NewStream(jsoniter.ConfigFastest, &buf, 0)
+		encodeResult(w.Value, js)
+		js.Flush()
+		actual := buf.String()
+
+		buf.Reset()
+		v, err := NewResultValue(w.Value)
+		require.NoError(t, err)
+		js.WriteVal(v)
+		js.Flush()
+		expected := buf.String()
+
+		require.JSONEq(t, expected, actual)
+		return true
+	}
+
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
 }
 
 func Benchmark_Encode(b *testing.B) {
@@ -638,6 +743,7 @@ func Benchmark_Encode(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		for _, queryTest := range queryTests {
 			require.NoError(b, WriteQueryResponseJSON(logqlmodel.Result{Data: queryTest.actual}, buf))
+			buf.Reset()
 		}
 	}
 }

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -653,21 +653,27 @@ func (w wrappedValue) Generate(rand *rand.Rand, size int) reflect.Value {
 		q, _ := quick.Value(reflect.TypeOf(promql.Scalar{}), rand)
 		return reflect.ValueOf(wrappedValue{q.Interface().(parser.Value)})
 	case loghttp.ResultTypeStream:
-		stream := logproto.Stream{
-			Labels:  randLabels(rand).String(),
-			Entries: randEntries(rand),
-			Hash:    0,
-		}
+		var streams logqlmodel.Streams
+		for i := 0; i < rand.Intn(100); i++ {
+			stream := logproto.Stream{
+				Labels:  randLabels(rand).String(),
+				Entries: randEntries(rand),
+				Hash:    0,
+			}
 
-		streams := logqlmodel.Streams([]logproto.Stream{stream})
+			streams = append(streams, stream)
+		}
 		return reflect.ValueOf(wrappedValue{streams})
 	case loghttp.ResultTypeVector:
-		v, _ := quick.Value(reflect.TypeOf(promql.Sample{}), rand)
-		sample, _ := v.Interface().(promql.Sample)
+		var vector promql.Vector
+		for i := 0; i < rand.Intn(100); i++ {
+			v, _ := quick.Value(reflect.TypeOf(promql.Sample{}), rand)
+			sample, _ := v.Interface().(promql.Sample)
 
-		l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
-		sample.Metric = l.Interface().(labels.Labels)
-		vector := promql.Vector([]promql.Sample{sample})
+			l, _ := quick.Value(reflect.TypeOf(labels.Labels{}), rand)
+			sample.Metric = l.Interface().(labels.Labels)
+			vector = append(vector, sample)
+		}
 		return reflect.ValueOf(wrappedValue{vector})
 
 	}

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -717,7 +717,8 @@ func Test_EncodeResult_And_ResultValue_Parity(t *testing.T) {
 	f := func(w wrappedValue) bool {
 		var buf bytes.Buffer
 		js := jsoniter.NewStream(jsoniter.ConfigFastest, &buf, 0)
-		encodeResult(w.Value, js)
+		err := encodeResult(w.Value, js)
+		require.NoError(t, err)
 		js.Flush()
 		actual := buf.String()
 

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -2,7 +2,9 @@ package marshal
 
 import (
 	"fmt"
+	"strconv"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -174,4 +176,227 @@ func NewMetric(l labels.Labels) model.Metric {
 	}
 
 	return ret
+}
+
+func EncodeResult(v logqlmodel.Result, s *jsoniter.Stream) error {
+	s.WriteObjectStart()
+	s.WriteObjectField("status")
+	s.WriteString("success")
+
+	s.WriteMore()
+	s.WriteObjectField("data")
+	encodeData(v, s)
+
+	s.WriteObjectEnd()
+	return nil
+}
+
+func encodeData(v logqlmodel.Result, s *jsoniter.Stream) {
+	s.WriteObjectStart()
+
+	s.WriteObjectField("resultType")
+	s.WriteString(string(v.Data.Type()))
+
+	s.WriteMore()
+	s.WriteObjectField("result")
+	encodeResult(v.Data, s)
+
+	s.WriteMore()
+	s.WriteObjectField("stats")
+	s.WriteVal(v.Statistics)
+
+	s.WriteObjectEnd()
+	s.Flush()
+}
+
+func encodeResult(v parser.Value, s *jsoniter.Stream) error {
+	switch v.Type() {
+	case loghttp.ResultTypeStream:
+		result, ok := v.(logqlmodel.Streams)
+
+		if !ok {
+			return fmt.Errorf("unexpected type %T for streams", s)
+		}
+
+		encodeStreams(result, s)
+	case loghttp.ResultTypeScalar:
+		scalar, ok := v.(promql.Scalar)
+
+		if !ok {
+			return fmt.Errorf("unexpected type %T for scalar", scalar)
+		}
+
+		encodeScalar(scalar, s)
+
+	case loghttp.ResultTypeVector:
+		vector, ok := v.(promql.Vector)
+
+		if !ok {
+			return fmt.Errorf("unexpected type %T for vector", vector)
+		}
+
+		encodeVector(vector, s)
+
+	case loghttp.ResultTypeMatrix:
+		m, ok := v.(promql.Matrix)
+
+		if !ok {
+			return fmt.Errorf("unexpected type %T for matrix", m)
+		}
+
+		encodeMatrix(m, s)
+
+	default:
+		s.WriteNil()
+		return fmt.Errorf("v1 endpoints do not support type %s", v.Type())
+	}
+	return nil
+}
+
+func encodeStreams(streams logqlmodel.Streams, s *jsoniter.Stream) error {
+	s.WriteArrayStart()
+	defer s.WriteArrayEnd()
+
+	for _, stream := range streams {
+		err := encodeStream(stream, s)
+		if err != nil {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func encodeStream(stream logproto.Stream, s *jsoniter.Stream) error {
+	s.WriteObjectStart()
+	defer s.WriteObjectEnd()
+
+	s.WriteObjectField("stream")
+	s.WriteObjectStart()
+	labels, err := parser.ParseMetric(stream.Labels)
+	if err != nil {
+		return err
+	}
+
+	for i, l := range labels {
+		if i > 0 {
+			s.WriteMore()
+		}
+
+		s.WriteObjectField(l.Name)
+		s.WriteString(l.Value)
+	}
+	s.WriteObjectEnd()
+	s.Flush()
+
+	s.WriteMore()
+	s.WriteObjectField("values")
+	s.WriteArrayStart()
+
+	for i, e := range stream.Entries {
+		if i > 0 {
+			s.WriteMore()
+		}
+
+		s.WriteArrayStart()
+		s.WriteRaw(`"`)
+		s.WriteRaw(strconv.FormatInt(e.Timestamp.UnixNano(), 10))
+		s.WriteRaw(`"`)
+		s.WriteMore()
+		s.WriteStringWithHTMLEscaped(e.Line)
+		s.WriteArrayEnd()
+
+		s.Flush()
+	}
+
+	s.WriteArrayEnd()
+
+	return nil
+}
+
+func encodeScalar(v promql.Scalar, s *jsoniter.Stream) {
+	s.WriteArrayStart()
+	defer s.WriteArrayEnd()
+
+	s.WriteRaw(model.Time(v.T).String())
+	s.WriteMore()
+	s.WriteString(model.SampleValue(v.V).String())
+}
+
+func encodeVector(v promql.Vector, s *jsoniter.Stream) {
+	s.WriteArrayStart()
+	defer s.WriteArrayEnd()
+
+	for i, sample := range v {
+		if i > 0 {
+			s.WriteMore()
+		}
+		encodeSample(sample, s)
+		s.Flush()
+	}
+}
+
+func encodeSample(sample promql.Sample, s *jsoniter.Stream) {
+	s.WriteObjectStart()
+	defer s.WriteObjectEnd()
+
+	s.WriteObjectField("metric")
+	encodeMetric(sample.Metric, s)
+
+	s.WriteMore()
+	s.WriteObjectField("value")
+	encodeValue(sample.T, sample.V, s)
+}
+
+func encodeValue(T int64, V float64, s *jsoniter.Stream) {
+	s.WriteArrayStart()
+	s.WriteRaw(model.Time(T).String())
+	s.WriteMore()
+	s.WriteString(model.SampleValue(V).String())
+	s.WriteArrayEnd()
+}
+
+func encodeMetric(l labels.Labels, s *jsoniter.Stream) {
+	s.WriteObjectStart()
+	for i, label := range l {
+		if i > 0 {
+			s.WriteMore()
+		}
+
+		s.WriteObjectField(label.Name)
+		s.WriteString(label.Value)
+	}
+	s.WriteObjectEnd()
+}
+
+func encodeMatrix(m promql.Matrix, s *jsoniter.Stream) {
+	s.WriteArrayStart()
+	defer s.WriteArrayEnd()
+
+	for i, sampleStream := range m {
+		if i > 0 {
+			s.WriteMore()
+		}
+		encodeSampleStream(sampleStream, s)
+		s.Flush()
+	}
+}
+
+func encodeSampleStream(stream promql.Series, s *jsoniter.Stream) {
+	s.WriteObjectStart()
+	defer s.WriteObjectEnd()
+
+	s.WriteObjectField("metric")
+	encodeMetric(stream.Metric, s)
+
+	s.WriteMore()
+	s.WriteObjectField("values")
+	s.WriteArrayStart()
+	for i, p := range stream.Points {
+		if i > 0 {
+			s.WriteMore()
+		}
+		encodeValue(p.T, p.V, s)
+	}
+	s.WriteArrayEnd()
 }

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -257,7 +257,11 @@ func encodeStreams(streams logqlmodel.Streams, s *jsoniter.Stream) error {
 	s.WriteArrayStart()
 	defer s.WriteArrayEnd()
 
-	for _, stream := range streams {
+	for i, stream := range streams {
+		if i > 0 {
+			s.WriteMore()
+		}
+
 		err := encodeStream(stream, s)
 		if err != nil {
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the query response was converted to `loghttp.ResultValue`. This requires a lot of allocations. Furthermore, the JSON response string was allocated before it was written to the response writer. This changes replaces the conversion from `parser.Value` to `loghttp.ResultValue` with a hand written JSON stream. This redueces the allocation overhead quite a bit:

```
› benchstat before.txt after.txt
name        old time/op    new time/op    delta
_Encode-16    51.5µs ± 1%    24.1µs ± 5%  -53.25%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
_Encode-16    7.68kB ± 0%    1.66kB ± 0%  -78.34%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
_Encode-16       129 ± 0%        28 ± 0%  -78.29%  (p=0.008 n=5+5)
```

The correctness is validate with quick check.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
