### PR TITLE
Improve the JSON parser performance.

### DIFF
--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -25,11 +25,16 @@ type ParserHint interface {
 	//		 sum(rate({app="foo"} | json [5m]))
 	// We don't need to extract any labels from the log line.
 	NoLabels() bool
+	Keys() []string
 }
 
 type parserHint struct {
 	noLabels       bool
 	requiredLabels []string
+}
+
+func (p *parserHint) Keys() []string {
+	return p.requiredLabels
 }
 
 func (p *parserHint) ShouldExtract(key string) bool {

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -25,16 +25,11 @@ type ParserHint interface {
 	//		 sum(rate({app="foo"} | json [5m]))
 	// We don't need to extract any labels from the log line.
 	NoLabels() bool
-	Keys() []string
 }
 
 type parserHint struct {
 	noLabels       bool
 	requiredLabels []string
-}
-
-func (p *parserHint) Keys() []string {
-	return p.requiredLabels
 }
 
 func (p *parserHint) ShouldExtract(key string) bool {

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -80,7 +80,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 			labels.Labels{},
 			labels.Labels{
 				{Name: "__error__", Value: "JSONParserErr"},
-				{Name: "__error_details__", Value: "ReadMapCB: expect \" after {, but found n, error found in #2 byte of ...|{n}|..., bigger context ...|{n}|..."},
+				{Name: "__error_details__", Value: "Value looks like object, but can't find closing '}' symbol"},
 			},
 		},
 		{

--- a/pkg/logql/log/util.go
+++ b/pkg/logql/log/util.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"strings"
 )
 
@@ -35,4 +36,27 @@ func sanitizeLabelKey(key string, isPrefix bool) string {
 		}
 		return '_'
 	}, key)
+}
+
+// appendSanitize appends the sanitized key to the slice.
+func appendSanitized(to, key []byte) []byte {
+	if len(key) == 0 {
+		return to
+	}
+	key = bytes.TrimSpace(key)
+
+	if len(to) == 0 && key[0] >= '0' && key[0] <= '9' {
+		to = append(to, '_')
+	}
+	// range over rune
+
+	for _, r := range string(key) {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (r >= '0' && r <= '9')) {
+			to = append(to, '_')
+			continue
+		}
+		to = append(to, byte(r))
+
+	}
+	return to
 }


### PR DESCRIPTION
Sorry I couldn't help myself and worked a bit on the JSON parser by using another library that allows way less allocations.

On top of this, the parser code is also much simpler to understand.

I realize that we could possibly also intern/cache (limited obviously) extracted JSON value per key. I would do it per key because otherwise, a high cardinality key can take over the intern/cache which will make it worthless. Happy to walk someone through the idea, I think this would be a big jump too.

Would be great to run and test this in our dev environment using some JSON queries before releasing it.

```
❯ benchstat before.txt after.txt                                                                                                              
name                             old time/op    new time/op    delta
_Parser/json/no_labels_hints-10    2.53µs ± 0%    2.16µs ± 2%  -14.59%  (p=0.008 n=5+5)
_Parser/json/labels_hints-10       1.93µs ± 0%    1.47µs ± 0%  -23.96%  (p=0.008 n=5+5)

name                             old alloc/op   new alloc/op   delta
_Parser/json/no_labels_hints-10      656B ± 0%      280B ± 0%  -57.32%  (p=0.008 n=5+5)
_Parser/json/labels_hints-10         512B ± 0%      176B ± 0%  -65.62%  (p=0.008 n=5+5)

name                             old allocs/op  new allocs/op  delta
_Parser/json/no_labels_hints-10      46.0 ± 0%      18.0 ± 0%  -60.87%  (p=0.008 n=5+5)
_Parser/json/labels_hints-10         39.0 ± 0%      12.0 ± 0%  -69.23%  (p=0.008 n=5+5)
```
