### PR TITLE
changed the URL to LogQL Analyzer backend v2.7.0

### DIFF
--- a/docs/sources/logql/analyzer/script.js
+++ b/docs/sources/logql/analyzer/script.js
@@ -1,4 +1,4 @@
-let host = "https://logql-analyzer.grafana.net/next";
+let host = "https://logql-analyzer.grafana.net/2-7-x";
 Handlebars.registerHelper("inc", (val) => parseInt(val) + 1);
 let streamSelector = `{job="analyze"}`;
 const logsSourceInputElement = document.getElementById("logs-source-input");


### PR DESCRIPTION
**What this PR does / why we need it**:

It's needed to point LogQL Analyzer page to the backend with v2.7.0