### PR TITLE
Examples: Add healthckecks in docker example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [7684](https://github.com/grafana/loki/pull/7684) **kavirajk**: Add missing `embedded-cache` config under `cache_config` doc.
 * [6360](https://github.com/grafana/loki/pull/6099) **liguozhong**: Hide error message when ctx timeout occurs in s3.getObject
 * [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize filter to easily parse colored logs.
+* [7731](https://github.com/grafana/loki/pull/7731) **bitkill**: Add healthchecks to the docker-compose example.
 
 ##### Fixes
 

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -16,6 +16,11 @@ services:
       - ./loki-config.yaml:/etc/loki/config.yaml
     depends_on:
       - minio
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks: &loki-dns
       loki:
         aliases:
@@ -64,6 +69,11 @@ services:
       - 9000
     volumes:
       - ./.data/minio:/data
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 15s
+      timeout: 20s
+      retries: 5
     networks:
       - loki
 
@@ -95,6 +105,11 @@ services:
         /run.sh
     ports:
       - "3000:3000"
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - loki
 

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -35,6 +35,11 @@ services:
       - 9095
     volumes:
       - ./loki-config.yaml:/etc/loki/config.yaml
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       - minio
     networks:
@@ -174,6 +179,11 @@ services:
         /docker-entrypoint.sh nginx -g "daemon off;"
     ports:
       - "3100:3100"
+    healthcheck:
+      test: ["CMD", "service", "nginx", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - loki
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds healthchecks for the loki `docker compose` example, this makes the getting started example more complete,
and can be now used with the `--wait` command.

**Special notes for your reviewer**:
Use the following commands to test:
```sh
cd examples/getting-started
docker compose up -d --wait
docker compose ps
```

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] `CHANGELOG.md` updated
