### PR TITLE
Helm: Add ingester config in helm values

### DIFF
--- a/production/docker/config/promtail.yaml
+++ b/production/docker/config/promtail.yaml
@@ -2,14 +2,14 @@ server:
     http_listen_port: 9080
     grpc_listen_port: 0
     log_level: "info"
-  
+
 positions:
     filename: /tmp/positions.yaml
-  
+
 clients:
     - url: http://loki-gateway:80/loki/api/v1/push
       tenant_id: docker
-  
+
 scrape_configs:
   - job_name: generated-logs
     static_configs:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -90,6 +90,11 @@ loki:
         {{- end }}
         {{- end }}
 
+    {{- with .Values.loki.ingester }}
+    ingester:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
+
     {{- if .Values.loki.commonConfig}}
     common:
     {{- toYaml .Values.loki.commonConfig | nindent 2}}
@@ -266,6 +271,9 @@ loki:
 
   # --  Optional querier configuration
   querier: {}
+
+  # --  Optional querier configuration
+  ingester: {}
 
 enterprise:
   # Enable enterprise features, license must be provided


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuring ingester config from helm values: https://grafana.com/docs/loki/latest/configuration/#ingester
We wanted to change the default `chunk_encoding`, which right now not possible in the current values template.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
