### PR TITLE
Helm: Add ingester config in helm values

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1640,6 +1640,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>loki.ingester</td>
+			<td>object</td>
+			<td>Optional ingester configuration</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>loki.limits_config</td>
 			<td>object</td>
 			<td>Limits config</td>

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 4.2.0
+version: 4.3.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -96,6 +96,11 @@ loki:
         {{- end }}
         {{- end }}
 
+    {{- with .Values.loki.ingester }}
+    ingester:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
+
     {{- if .Values.loki.commonConfig}}
     common:
     {{- toYaml .Values.loki.commonConfig | nindent 2}}
@@ -287,6 +292,9 @@ loki:
 
   # --  Optional querier configuration
   querier: {}
+
+  # --  Optional querier configuration
+  ingester: {}
 
 enterprise:
   # Enable enterprise features, license must be provided

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -293,7 +293,7 @@ loki:
   # --  Optional querier configuration
   querier: {}
 
-  # --  Optional querier configuration
+  # --  Optional ingester configuration
   ingester: {}
 
 enterprise:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuring ingester config from helm values: https://grafana.com/docs/loki/latest/configuration/#ingester
We wanted to change the default chunk_encoding, which right now not possible in the current values template.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
