### PR TITLE
operator: Fix handling of Request requeues

### DIFF
--- a/operator/controllers/loki/alertingrule_controller.go
+++ b/operator/controllers/loki/alertingrule_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,10 +40,7 @@ type AlertingRuleReconciler struct {
 func (r *AlertingRuleReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	err := lokistack.AnnotateForDiscoveredRules(ctx, r.Client)
 	if err != nil {
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: time.Second,
-		}, err
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/operator/controllers/loki/recordingrule_controller.go
+++ b/operator/controllers/loki/recordingrule_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,10 +40,7 @@ type RecordingRuleReconciler struct {
 func (r *RecordingRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	err := lokistack.AnnotateForDiscoveredRules(ctx, r.Client)
 	if err != nil {
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: time.Second,
-		}, err
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/operator/controllers/loki/rulerconfig_controller.go
+++ b/operator/controllers/loki/rulerconfig_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,16 +35,14 @@ func (r *RulerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	err := lokistack.AnnotateForRulerConfig(ctx, r.Client, req.Name, req.Namespace)
 	if err != nil {
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: time.Second,
-		}, err
+		return ctrl.Result{}, err
 	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A small refactor to remove unnecessary parameters from `ctrl.Result{}` initializations to avoid confusion. It should also fix a bug where degraded conditions force a requeue, even when the `DegradedError` did not request it (for example, a missing storage secret).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the `CONTRIBUTING.md` guide
