### PR TITLE
operator: Fix object storage TLS spec CAKey descriptor

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7744](https://github.com/grafana/loki/pull/7744) **periklis**: Fix object storage TLS spec CAKey descriptor
 - [7716](https://github.com/grafana/loki/pull/7716) **aminesnow**: Migrate API docs generation tool
 - [7710](https://github.com/grafana/loki/pull/7710) **periklis**: Fix LokiStackController watches for cluster-scoped resources
 - [7682](https://github.com/grafana/loki/pull/7682) **periklis**: Refactor cluster proxy to use configv1.Proxy on OpenShift

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -353,7 +353,7 @@ type ObjectStorageTLSSpec struct {
 	// +optional
 	// +kubebuilder:validation:optional
 	// +kubebuilder:default:=service-ca.crt
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMap",displayName="CA ConfigMap Key"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CA ConfigMap Key"
 	CAKey string `json:"caKey,omitempty"`
 	// CA is the name of a ConfigMap containing a CA certificate.
 	// It needs to be in the same namespace as the LokiStack custom resource.

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -489,8 +489,6 @@ spec:
           It needs to be in the same namespace as the LokiStack custom resource.
         displayName: CA ConfigMap Key
         path: storage.tls.caKey
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:ConfigMap
       - description: CA is the name of a ConfigMap containing a CA certificate. It
           needs to be in the same namespace as the LokiStack custom resource.
         displayName: CA ConfigMap Name

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -344,8 +344,6 @@ spec:
           It needs to be in the same namespace as the LokiStack custom resource.
         displayName: CA ConfigMap Key
         path: storage.tls.caKey
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:ConfigMap
       - description: CA is the name of a ConfigMap containing a CA certificate. It
           needs to be in the same namespace as the LokiStack custom resource.
         displayName: CA ConfigMap Name


### PR DESCRIPTION
**What this PR does / why we need it**:
According to this OpenShift user bug report [LOG-3309](https://issues.redhat.com/browse/LOG-3309), putting a CAKey in to the `ObjectStorageTLSSpec` via the OpenShift Console is currently broken, because the ClusterServiceVersion renders an ConfigMap selector. The fix provided remove the accidental wrong descriptor for this field and makes it a usual text field. It still keeps the default value as `service-ca.crt`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
