### PR TITLE
helm/loki: Remove extra `/` if `registry` or `repository` is empty

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.4.1
+
+- [BUGFIX] Remove extra `/` in image name if `registry` or `repository` is empty
+
 ## 3.4.0
 
 - [ENHANCEMENT] Allow to add some selector for Loki persistent volume

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.4.0
+version: 3.4.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -108,10 +108,14 @@ Create the name of the service account to use
 Base template for building docker image reference
 */}}
 {{- define "loki.baseImage" }}
-{{- $registry := .global.registry | default .service.registry -}}
-{{- $repository := .service.repository -}}
+{{- $registry := .global.registry | default .service.registry | default "" -}}
+{{- $repository := .service.repository | default "" -}}
 {{- $tag := .service.tag | default .defaultVersion | toString -}}
-{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- if and $registry $repository -}}
+  {{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+  {{- printf "%s%s:%s" $registry $repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
**What this PR does / why we need it**:

It removes the extra `/` when `registry` or `repository` is empty

**Which issue(s) this PR fixes**:
Fixes #7739 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] `CHANGELOG.md` updated
