### PR TITLE
Only release Helm Chart when version changed.

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'production/helm/**'
+      - 'production/helm/loki/Chart.yaml'
 
 jobs:
   call-update-helm-repo:


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm Chart release often breaks when changes missed to update the Helm Chart version. There is also often a conflict in the version.

This solution proposes to check the `Chart.yaml` for changes.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
