### PR TITLE
promtail: Fix broken diagram link for gcp logs target

### DIFF
--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -13,7 +13,7 @@ There's two flavours of how to configure this:
 
 Overall, the setup between GCP, Promtail and Loki will look like the following:
 
-<img src="../gcp-logs-diagram.png" width="1200px"/>
+<img src="gcp-logs-diagram.png" width="1200px"/>
 
 ## Roles and Permission
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We were recently informed that the image on this page, https://grafana.com/docs/loki/latest/clients/promtail/gcplog-cloud/, wasn't loading. This PR fixes the link so the image should render now.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
