### PR TITLE
operator: Check for mandatory CA configmap name in ObjectStorageTLS spec

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7753](https://github.com/grafana/loki/pull/7753) **periklis**: Check for mandatory CA configmap name in ObjectStorageTLS spec
 - [7744](https://github.com/grafana/loki/pull/7744) **periklis**: Fix object storage TLS spec CAKey descriptor
 - [7716](https://github.com/grafana/loki/pull/7716) **aminesnow**: Migrate API docs generation tool
 - [7710](https://github.com/grafana/loki/pull/7710) **periklis**: Fix LokiStackController watches for cluster-scoped resources

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -349,6 +349,7 @@ type ClusterProxy struct {
 type ObjectStorageTLSSpec struct {
 	// Key is the data key of a ConfigMap containing a CA certificate.
 	// It needs to be in the same namespace as the LokiStack custom resource.
+	// If empty, it defaults to "service-ca.crt".
 	//
 	// +optional
 	// +kubebuilder:validation:optional
@@ -357,10 +358,10 @@ type ObjectStorageTLSSpec struct {
 	// CA is the name of a ConfigMap containing a CA certificate.
 	// It needs to be in the same namespace as the LokiStack custom resource.
 	//
-	// +optional
-	// +kubebuilder:validation:optional
+	// +required
+	// +kubebuilder:validation:required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMap",displayName="CA ConfigMap Name"
-	CA string `json:"caName,omitempty"`
+	CA string `json:"caName"`
 }
 
 // ObjectStorageSecretType defines the type of storage which can be used with the Loki cluster.

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -352,7 +352,6 @@ type ObjectStorageTLSSpec struct {
 	//
 	// +optional
 	// +kubebuilder:validation:optional
-	// +kubebuilder:default:=service-ca.crt
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CA ConfigMap Key"
 	CAKey string `json:"caKey,omitempty"`
 	// CA is the name of a ConfigMap containing a CA certificate.

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -486,7 +486,8 @@ spec:
         displayName: TLS Config
         path: storage.tls
       - description: Key is the data key of a ConfigMap containing a CA certificate.
-          It needs to be in the same namespace as the LokiStack custom resource.
+          It needs to be in the same namespace as the LokiStack custom resource. If
+          empty, it defaults to "service-ca.crt".
         displayName: CA ConfigMap Key
         path: storage.tls.caKey
       - description: CA is the name of a ConfigMap containing a CA certificate. It

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -482,13 +482,16 @@ spec:
                       caKey:
                         description: Key is the data key of a ConfigMap containing
                           a CA certificate. It needs to be in the same namespace as
-                          the LokiStack custom resource.
+                          the LokiStack custom resource. If empty, it defaults to
+                          "service-ca.crt".
                         type: string
                       caName:
                         description: CA is the name of a ConfigMap containing a CA
                           certificate. It needs to be in the same namespace as the
                           LokiStack custom resource.
                         type: string
+                    required:
+                    - caName
                     type: object
                 required:
                 - secret

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -480,7 +480,6 @@ spec:
                       endpoint.
                     properties:
                       caKey:
-                        default: service-ca.crt
                         description: Key is the data key of a ConfigMap containing
                           a CA certificate. It needs to be in the same namespace as
                           the LokiStack custom resource.

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -463,7 +463,6 @@ spec:
                       endpoint.
                     properties:
                       caKey:
-                        default: service-ca.crt
                         description: Key is the data key of a ConfigMap containing
                           a CA certificate. It needs to be in the same namespace as
                           the LokiStack custom resource.

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -465,13 +465,16 @@ spec:
                       caKey:
                         description: Key is the data key of a ConfigMap containing
                           a CA certificate. It needs to be in the same namespace as
-                          the LokiStack custom resource.
+                          the LokiStack custom resource. If empty, it defaults to
+                          "service-ca.crt".
                         type: string
                       caName:
                         description: CA is the name of a ConfigMap containing a CA
                           certificate. It needs to be in the same namespace as the
                           LokiStack custom resource.
                         type: string
+                    required:
+                    - caName
                     type: object
                 required:
                 - secret

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -341,7 +341,8 @@ spec:
         displayName: TLS Config
         path: storage.tls
       - description: Key is the data key of a ConfigMap containing a CA certificate.
-          It needs to be in the same namespace as the LokiStack custom resource.
+          It needs to be in the same namespace as the LokiStack custom resource. If
+          empty, it defaults to "service-ca.crt".
         displayName: CA ConfigMap Key
         path: storage.tls.caKey
       - description: CA is the name of a ConfigMap containing a CA certificate. It

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -142,14 +142,12 @@ func (r *LokiStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func handleDegradedError(ctx context.Context, c client.Client, req ctrl.Request, err error) (ctrl.Result, error) {
 	var degraded *status.DegradedError
 	if errors.As(err, &degraded) {
-		err = status.SetDegradedCondition(ctx, c, req, degraded.Message, degraded.Reason)
-		if err != nil {
-			return ctrl.Result{}, err
+		derr := status.SetDegradedCondition(ctx, c, req, degraded.Message, degraded.Reason)
+		if derr != nil {
+			return ctrl.Result{}, derr
 		}
 
-		return ctrl.Result{
-			Requeue: degraded.Requeue,
-		}, nil
+		return ctrl.Result{Requeue: degraded.Requeue}, err
 	}
 
 	if err != nil {

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -142,12 +142,14 @@ func (r *LokiStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func handleDegradedError(ctx context.Context, c client.Client, req ctrl.Request, err error) (ctrl.Result, error) {
 	var degraded *status.DegradedError
 	if errors.As(err, &degraded) {
-		derr := status.SetDegradedCondition(ctx, c, req, degraded.Message, degraded.Reason)
-		if derr != nil {
-			return ctrl.Result{}, derr
+		err = status.SetDegradedCondition(ctx, c, req, degraded.Message, degraded.Reason)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{Requeue: degraded.Requeue}, err
+		return ctrl.Result{
+			Requeue: degraded.Requeue,
+		}, nil
 	}
 
 	if err != nil {

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -101,7 +101,7 @@ func CreateOrUpdateLokiStack(
 
 	objStore.Schemas = storageSchemas
 
-	if stack.Spec.Storage.TLS != nil {
+	if stack.Spec.Storage.TLS != nil && stack.Spec.Storage.TLS.CA != "" {
 		var cm corev1.ConfigMap
 		key := client.ObjectKey{Name: stack.Spec.Storage.TLS.CA, Namespace: stack.Namespace}
 		if err = k.Get(ctx, key, &cm); err != nil {

--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -5,11 +5,11 @@ import (
 	"path"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
-	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/imdario/mergo"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 )
 
 const (
@@ -18,8 +18,9 @@ const (
 	// GCSFileName is the file containing the Google credentials for authentication
 	GCSFileName = "key.json"
 
-	secretDirectory = "/etc/storage/secrets"
-	caDirectory     = "/etc/storage/ca"
+	secretDirectory  = "/etc/storage/secrets"
+	storageTLSVolume = "storage-tls"
+	caDirectory      = "/etc/storage/ca"
 )
 
 // ConfigureDeployment appends additional pod volumes and container env vars, args, volume mounts
@@ -141,7 +142,7 @@ func ensureCAForS3(p *corev1.PodSpec, tls *TLSConfig) corev1.PodSpec {
 	volumes := p.Volumes
 
 	volumes = append(volumes, corev1.Volume{
-		Name: tls.CA,
+		Name: storageTLSVolume,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -152,7 +153,7 @@ func ensureCAForS3(p *corev1.PodSpec, tls *TLSConfig) corev1.PodSpec {
 	})
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      tls.CA,
+		Name:      storageTLSVolume,
 		ReadOnly:  false,
 		MountPath: caDirectory,
 	})

--- a/operator/internal/manifests/storage/configure_test.go
+++ b/operator/internal/manifests/storage/configure_test.go
@@ -3,11 +3,12 @@ package storage_test
 import (
 	"testing"
 
-	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests/storage"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
+	"github.com/grafana/loki/operator/internal/manifests/storage"
 )
 
 func TestConfigureDeploymentForStorageType(t *testing.T) {
@@ -306,7 +307,7 @@ func TestConfigureDeploymentForStorageCA(t *testing.T) {
 									Name: "loki-querier",
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "test",
+											Name:      "storage-tls",
 											ReadOnly:  false,
 											MountPath: "/etc/storage/ca",
 										},
@@ -318,7 +319,7 @@ func TestConfigureDeploymentForStorageCA(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
-									Name: "test",
+									Name: "storage-tls",
 									VolumeSource: corev1.VolumeSource{
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
@@ -423,7 +424,7 @@ func TestConfigureStatefulSetForStorageCA(t *testing.T) {
 									Name: "loki-ingester",
 									VolumeMounts: []corev1.VolumeMount{
 										{
-											Name:      "test",
+											Name:      "storage-tls",
 											ReadOnly:  false,
 											MountPath: "/etc/storage/ca",
 										},
@@ -435,7 +436,7 @@ func TestConfigureStatefulSetForStorageCA(t *testing.T) {
 							},
 							Volumes: []corev1.Volume{
 								{
-									Name: "test",
+									Name: "storage-tls",
 									VolumeSource: corev1.VolumeSource{
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup on #7744 to check for the `ObjectStorageTLSSpec.CA` field as mandatory before looking up for ConfigMap. This is a corner case where some one opens the dialog for `ObjectStorageTLSSpec` (e.g. in the OpenShift Console UI) and introduces doing so the default value for `CAKey` but does not select any CA ConfigMap. The same can happen when a user introduced in a YAML manifest the `caKey` field but not the `ca`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
