### PR TITLE
Only check mixin on file changes.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -565,6 +565,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       },
       make('loki-mixin-check', container=false) {
         depends_on: ['clone'],
+        when: onPRs + onPath('production/loki-mixin/**'),
       },
     ],
   },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -230,6 +230,11 @@ steps:
   environment: {}
   image: grafana/loki-build-image:0.24.2
   name: loki-mixin-check
+  when:
+    event:
+    - pull_request
+    paths:
+    - production/loki-mixin/**
 trigger:
   ref:
   - refs/heads/main
@@ -1607,6 +1612,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 3e912c7f00b4d1e8c96a37a6da65a696ec455d81fb4a1ab66f2e87041dd023de
+hmac: c0eb47ec65c18d431d2d326925e9f9b6cf4dded08dce0b3f28c969a0a24ac791
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:
The mixin check sometimes (e.g. [this build](https://drone.grafana.net/grafana/loki/17667/4/2)) which blocks pull requests with unrelated changes. This is a quick fix. Ideally we would investigate why Jsonnet Bundler is failing sometimes.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
