### PR TITLE
config: Improve error message loading config with ENV variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [6360](https://github.com/grafana/loki/pull/6099) **liguozhong**: Hide error message when ctx timeout occurs in s3.getObject
 * [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize filter to easily parse colored logs.
 * [7731](https://github.com/grafana/loki/pull/7731) **bitkill**: Add healthchecks to the docker-compose example.
+* [7759](https://github.com/grafana/loki/pull/7759) **kavirajk**: Improve error message for loading config with ENV variables.
 
 ##### Fixes
 

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -58,6 +58,7 @@ func YAML(f string, expandEnvVars bool, strict bool) Source {
 		} else {
 			err = dYAML(y)(dst)
 		}
+
 		return errors.Wrap(err, f)
 	}
 }
@@ -77,7 +78,6 @@ func dYAML(y []byte) Source {
 }
 
 func ConfigFileLoader(args []string, name string, strict bool) Source {
-
 	return func(dst Cloneable) error {
 		freshFlags := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)
 
@@ -112,7 +112,11 @@ func ConfigFileLoader(args []string, name string, strict bool) Source {
 				expandEnv, _ = strconv.ParseBool(expandEnvFlag.Value.String()) // Can ignore error as false returned
 			}
 			if _, err := os.Stat(val); err == nil {
-				return YAML(val, expandEnv, strict)(dst)
+				err := YAML(val, expandEnv, strict)(dst)
+				if err != nil && !expandEnv {
+					err = fmt.Errorf("%w. You may have to try `-config.expand-env=true` flag if your config contains ENV variables", err)
+				}
+				return err
 			}
 		}
 		return fmt.Errorf("%s does not exist, set %s for custom config path", f.Value.String(), name)

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -114,7 +114,7 @@ func ConfigFileLoader(args []string, name string, strict bool) Source {
 			if _, err := os.Stat(val); err == nil {
 				err := YAML(val, expandEnv, strict)(dst)
 				if err != nil && !expandEnv {
-					err = fmt.Errorf("%w. You may have to try `-config.expand-env=true` flag if your config contains ENV variables", err)
+					err = fmt.Errorf("%w. Use `-config.expand-env=true` flag if you want to expand environment variables in your config file", err)
 				}
 				return err
 			}


### PR DESCRIPTION

**What this PR does / why we need it**:
Before:
```
Unable to parse config: ./clients/cmd/promtail/promtail-local-config.yaml: parse "http://${LOKI_URL}localhost:3100/loki/api/v1/push":
invalid character "{" in host name
```

After:
```
Unable to parse config: ./clients/cmd/promtail/promtail-local-config.yaml: parse "http://${LOKI_URL}localhost:3100/loki/api/v1/push":
invalid character "{" in host name. Use `-config.expand-env=true` flag if you want to expand environment variables in your config file
```
**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] `CHANGELOG.md` updated

