### PR TITLE
[helm] Bump helm Loki and GEL version

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -129,15 +129,6 @@ null
 </td>
 		</tr>
 		<tr>
-			<td>enterprise.image.tag</td>
-			<td>string</td>
-			<td>Overrides the image tag whose default is the chart's appVersion</td>
-			<td><pre lang="json">
-"v1.4.0"
-</pre>
-</td>
-		</tr>
-		<tr>
 			<td>enterprise.license</td>
 			<td>object</td>
 			<td>Grafana Enterprise Logs license In order to use Grafana Enterprise Logs features, you will need to provide the contents of your Grafana Enterprise Logs license, either by providing the contents of the license.jwt, or the name Kubernetes Secret that contains your license.jwt. To set the license contents, use the flag `--set-file 'license.contents=./license.jwt'`</td>
@@ -477,7 +468,7 @@ false
 			<td>string</td>
 			<td></td>
 			<td><pre lang="json">
-"v1.5.2"
+"v1.6.0"
 </pre>
 </td>
 		</tr>

--- a/flake.nix
+++ b/flake.nix
@@ -46,16 +46,16 @@
           {
             buildGoModule = args:
               prev.buildGoModule (args // rec {
-                version = "1.8.1";
+                version = "1.11.0";
 
                 src = prev.fetchFromGitHub {
                   owner = "norwoodj";
                   repo = "helm-docs";
                   rev = "v${version}";
-                  sha256 = "sha256-OpS/CYBb2Ll6ktvEhqkw/bWMSrFa4duidK3Glu8EnPw=";
+                  sha256 = "sha256-476ZhjRwHlNJFkHzY8qQ7WbAUUpFNSoxXLGX9esDA/E=";
                 };
 
-                vendorSha256 = "sha256-FpmeOQ8nV+sEVu2+nY9o9aFbCpwSShQUFOmyzwEQ9Pw=";
+                vendorSha256 = "sha256-xXwunk9rmzZEtqmSo8biuXnAjPp7fqWdQ+Kt9+Di9N8=";
 
                 ldflags = [
                   "-w"

--- a/nix/loki.nix
+++ b/nix/loki.nix
@@ -30,6 +30,9 @@ pkgs.stdenv.mkDerivation {
       --replace "IMAGE_TAG := \$(shell ./tools/image-tag)" "IMAGE_TAG := ${imageTag}" \
       --replace "GIT_REVISION := \$(shell git rev-parse --short HEAD)" "GIT_REVISION := ${version}" \
       --replace "GIT_BRANCH := \$(shell git rev-parse --abbrev-ref HEAD)" "GIT_BRANCH := nix" \
+
+    substituteInPlace clients/cmd/fluentd/Makefile \
+      --replace "SHELL    = /usr/bin/env bash -o pipefail" "SHELL = ${bash}/bin/bash -o pipefail"
   '';
 
   buildPhase = ''

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -19,6 +19,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [ENHANCEMENT] Allow to change Loki `-target` argument
 
+## 3.5.0
+
+- [CHANGE] Bump Loki version to 2.7.0 and GEL version to 1.6.0
+
 ## 3.4.2
 
 - [BUGFIX] Fix read-only /tmp in single-binary mode

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.6.0
+
+- [CHANGE] Bump Loki version to 2.7.0 and GEL version to 1.6.0
+
 ## 3.5.0
 
 - [FEATURE] Add support for azure blob storage
@@ -18,10 +22,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 3.4.3
 
 - [ENHANCEMENT] Allow to change Loki `-target` argument
-
-## 3.5.0
-
-- [CHANGE] Bump Loki version to 2.7.0 and GEL version to 1.6.0
 
 ## 3.4.2
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 3.5.0
+version: 3.5.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.6.1
+appVersion: 2.7.0
 version: 3.5.0
 home: https://grafana.github.io/helm-charts
 sources:

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 3.5.1
+version: 3.6.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -272,7 +272,7 @@ enterprise:
   enabled: false
 
   # Default verion of GEL to deploy
-  version: v1.5.2
+  version: v1.6.0
 
   # -- Optional name of the GEL cluster, otherwise will use .Release.Name
   # The cluster name must match what is in your GEL license
@@ -323,8 +323,6 @@ enterprise:
     registry: docker.io
     # -- Docker image repository
     repository: grafana/enterprise-logs
-    # -- Overrides the image tag whose default is the chart's appVersion
-    tag: v1.4.0
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps Loki to 2.7.0 and GEL to 1.6.0 in the helm chart.