### PR TITLE
operator: Fix docs AWS storage uses bucketnames

### DIFF
--- a/operator/docs/lokistack/object_storage.md
+++ b/operator/docs/lokistack/object_storage.md
@@ -29,7 +29,7 @@ Loki Operator supports [AWS S3](https://aws.amazon.com/), [Azure](https://azure.
 
     ```console
     kubectl create secret generic lokistack-dev-s3 \
-      --from-literal=bucketname="<BUCKET_NAME>" \
+      --from-literal=bucketnames="<BUCKET_NAME>" \
       --from-literal=endpoint="<AWS_BUCKET_ENDPOINT>" \
       --from-literal=access_key_id="<AWS_ACCESS_KEY_ID>" \
       --from-literal=access_key_secret="<AWS_ACCESS_KEY_SECRET>" \


### PR DESCRIPTION
Signed-off-by: Joel Takvorian <jtakvori@redhat.com>

**What this PR does / why we need it**:

Fixes probably a typo in documentation for the operator, with S3 storage: secret needs to contains key `bucketnames`, not `bucketname`.
See also the hack script that doesn't contain this mistake: https://github.com/grafana/loki/blob/main/operator/hack/deploy-aws-storage-secret.sh#L16

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

PS: I haven't updated the changelog, guessing it's not necessary for a doc typo?