### PR TITLE
promtail: Handle nil error on target Details() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ##### Enhancements
 
 ##### Fixes
+* [7771](https://github.com/grafana/loki/pull/7771) **GeorgeTsilias**: Handle nil error on target Details() call.
 
 ##### Changes
 * [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude Promtail journald code from binary.

--- a/clients/pkg/promtail/targets/cloudflare/target.go
+++ b/clients/pkg/promtail/targets/cloudflare/target.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"context"
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -227,7 +226,7 @@ func (t *Target) Details() interface{} {
 	fields, _ := Fields(FieldsType(t.config.FieldsType))
 	var errMsg string
 	if t.err != nil {
-		errMsg = fmt.Sprintf("%v", t.err.Error())
+		errMsg = t.err.Error()
 	}
 	return map[string]string{
 		"zone_id":        t.config.ZoneID,

--- a/clients/pkg/promtail/targets/cloudflare/target.go
+++ b/clients/pkg/promtail/targets/cloudflare/target.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -224,9 +225,13 @@ func (t *Target) Ready() bool {
 
 func (t *Target) Details() interface{} {
 	fields, _ := Fields(FieldsType(t.config.FieldsType))
+	var errMsg string
+	if t.err != nil {
+		errMsg = fmt.Sprintf("%v", t.err.Error())
+	}
 	return map[string]string{
 		"zone_id":        t.config.ZoneID,
-		"error":          t.err.Error(),
+		"error":          errMsg,
 		"position":       t.positions.GetString(positions.CursorKey(t.config.ZoneID)),
 		"last_timestamp": t.to.String(),
 		"fields":         strings.Join(fields, ","),

--- a/clients/pkg/promtail/targets/docker/target.go
+++ b/clients/pkg/promtail/targets/docker/target.go
@@ -251,9 +251,13 @@ func (t *Target) Labels() model.LabelSet {
 
 // Details returns target-specific details.
 func (t *Target) Details() interface{} {
+	var errMsg string
+	if t.err != nil {
+		errMsg = fmt.Sprintf("%v", t.err.Error())
+	}
 	return map[string]string{
 		"id":       t.containerName,
-		"error":    t.err.Error(),
+		"error":    errMsg,
 		"position": t.positions.GetString(positions.CursorKey(t.containerName)),
 		"running":  strconv.FormatBool(t.running.Load()),
 	}

--- a/clients/pkg/promtail/targets/docker/target.go
+++ b/clients/pkg/promtail/targets/docker/target.go
@@ -253,7 +253,7 @@ func (t *Target) Labels() model.LabelSet {
 func (t *Target) Details() interface{} {
 	var errMsg string
 	if t.err != nil {
-		errMsg = fmt.Sprintf("%v", t.err.Error())
+		errMsg = t.err.Error()
 	}
 	return map[string]string{
 		"id":       t.containerName,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses issue [#6930](https://github.com/grafana/loki/issues/6930).
Promtail should not panic when the Details() method is called for a target that has no errors.

**Which issue(s) this PR fixes**:
Fixes #6930

**Special notes for your reviewer**:
This is my first contribution, please let me know if I need to add more details regarding the small fix.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
