### PR TITLE
default data location changed to /var/lib/loki

### DIFF
--- a/cmd/loki/loki-local-config.yaml
+++ b/cmd/loki/loki-local-config.yaml
@@ -5,7 +5,7 @@ server:
   grpc_listen_port: 9096
 
 common:
-  path_prefix: /tmp/loki
+  path_prefix: /var/lib/loki
   storage:
     filesystem:
       chunks_directory: /tmp/loki/chunks


### PR DESCRIPTION
**What this PR does / why we need it**: For ideal default location for config file

**Which issue(s) this PR fixes**:
Fixes #7748

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
