### PR TITLE
[bugfix]  Remove hardwired '127.0.0.1' values in default addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
 
+* [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.
+
 ##### Changes
 
 #### Promtail

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -703,7 +703,11 @@ func (t *Loki) supportIndexDeleteRequest() bool {
 func (t *Loki) compactorAddress() (string, error) {
 	if t.Cfg.isModuleEnabled(All) || t.Cfg.isModuleEnabled(Read) {
 		// In single binary or read modes, this module depends on Server
-		return fmt.Sprintf("http://127.0.0.1:%d", t.Cfg.Server.HTTPListenPort), nil
+		proto := "http"
+		if len(t.Cfg.Server.HTTPTLSConfig.TLSCertPath) > 0 && len(t.Cfg.Server.HTTPTLSConfig.TLSKeyPath) > 0 {
+			proto = "https"
+		}
+		return fmt.Sprintf("%s://%s:%d", proto, t.Cfg.Server.HTTPListenAddress, t.Cfg.Server.HTTPListenPort), nil
 	}
 
 	if t.Cfg.Common.CompactorAddress == "" {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -339,6 +339,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	querierWorkerServiceConfig := querier.WorkerServiceConfig{
 		AllEnabled:            t.Cfg.isModuleEnabled(All),
 		ReadEnabled:           t.Cfg.isModuleEnabled(Read),
+		GrpcListenAddress:     t.Cfg.Server.GRPCListenAddress,
 		GrpcListenPort:        t.Cfg.Server.GRPCListenPort,
 		QuerierMaxConcurrent:  t.Cfg.Querier.MaxConcurrent,
 		QuerierWorkerConfig:   &t.Cfg.Worker,

--- a/pkg/querier/worker_service.go
+++ b/pkg/querier/worker_service.go
@@ -23,6 +23,7 @@ import (
 type WorkerServiceConfig struct {
 	AllEnabled            bool
 	ReadEnabled           bool
+	GrpcListenAddress     string
 	GrpcListenPort        int
 	QuerierMaxConcurrent  int
 	QuerierWorkerConfig   *querier_worker.Config
@@ -112,7 +113,11 @@ func InitWorkerService(
 	// Since we must be running a querier with either a frontend and/or scheduler at this point, if no scheduler ring, frontend, or scheduler address
 	// is configured, Loki will default to using the frontend on localhost on it's own GRPC listening port.
 	if cfg.SchedulerRing == nil && (*cfg.QuerierWorkerConfig).FrontendAddress == "" && (*cfg.QuerierWorkerConfig).SchedulerAddress == "" {
-		address := fmt.Sprintf("127.0.0.1:%d", cfg.GrpcListenPort)
+		listenAddress := "127.0.0.1"
+		if cfg.GrpcListenAddress != "" {
+			listenAddress = cfg.GrpcListenAddress
+		}
+		address := fmt.Sprintf("%s:%d", listenAddress, cfg.GrpcListenPort)
 		level.Warn(util_log.Logger).Log(
 			"msg", "Worker address is empty, attempting automatic worker configuration. If queries are unresponsive consider configuring the worker explicitly.",
 			"address", address)


### PR DESCRIPTION
While running all-in-one Loki instance, it's not possible to listen on anything other than IPv4 since compactor_address is then set to http://127.0.0.1. This enables listening on only IPv6.

Also if frontent_address, scheduler_ring and scheduler_address is not set, the default value is to connect to '127.0.0.1:<grpc_listen_port'. Which means that grpc_listen_address is ignored.

**What this PR does / why we need it**:
It's not possible to use compactor while using an all-in-one instance and listening to IPv6.

Let's not ignore grpc_listen_address to not confuse users.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

As noted in the first commit, the default behavior is changed from defaulting to `127.0.0.1` to `localhost`. Not sure how major that change is though.
My /etc/hosts says
```
$ grep localhost /etc/hosts
127.0.0.1 localhost
```

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] ~~Documentation added~~
- [ ] ~~Tests updated~~
- [ ] ~~`CHANGELOG.md` updated~~
- [ ] ~~Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`~~