### PR TITLE
helm/loki: Allow to override default loki `target`

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -324,6 +324,7 @@ null
     "runAsNonRoot": true,
     "runAsUser": 10001
   },
+  "targetModule": "tokengen",
   "tolerations": []
 }
 </pre>
@@ -412,6 +413,15 @@ true
   "runAsNonRoot": true,
   "runAsUser": 10001
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>enterprise.tokengen.targetModule</td>
+			<td>string</td>
+			<td>Comma-separated list of Loki modules to load for tokengen</td>
+			<td><pre lang="json">
+"tokengen"
 </pre>
 </td>
 		</tr>
@@ -2522,6 +2532,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>read.targetModule</td>
+			<td>string</td>
+			<td>Comma-separated list of Loki modules to load for the read</td>
+			<td><pre lang="json">
+"read"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.terminationGracePeriodSeconds</td>
 			<td>int</td>
 			<td>Grace period to allow the read to shutdown before it is killed</td>
@@ -2788,6 +2807,15 @@ null
 			<td>Additional selecto labels for each `single binary` pod</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.targetModule</td>
+			<td>string</td>
+			<td>Comma-separated list of Loki modules to load for the single binary</td>
+			<td><pre lang="json">
+"all"
 </pre>
 </td>
 		</tr>
@@ -3093,6 +3121,15 @@ null
 			<td>Labels for ingestor service</td>
 			<td><pre lang="json">
 {}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.targetModule</td>
+			<td>string</td>
+			<td>Comma-separated list of Loki modules to load for the write</td>
+			<td><pre lang="json">
+"write"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.4.3
+
+- [ENHANCEMENT] Allow to change Loki `-target` argument
+
 ## 3.4.2
 
 - [BUGFIX] Fix read-only /tmp in single-binary mode

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.6.1
-version: 3.4.2
+version: 3.4.3
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.4.2](https://img.shields.io/badge/Version-3.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 3.4.3](https://img.shields.io/badge/Version-3.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -61,7 +61,7 @@ spec:
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -target=read
+            - -target={{ .Values.read.targetModule }}
             {{- with .Values.read.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -target=all
+            - -target={{ .Values.singleBinary.targetModule }}
             {{- with .Values.singleBinary.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -target=tokengen
+            - -target={{ .Values.enterprise.tokengen.targetModule }}
             - -tokengen.token-file=/shared/admin-token
             {{- with .Values.enterprise.tokengen.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -target=write
+            - -target={{ .Values.write.targetModule }}
             {{- with .Values.write.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -335,6 +335,8 @@ enterprise:
   tokengen:
     # -- Whether the job should be part of the deployment
     enabled: true
+    # -- Comma-separated list of Loki modules to load for tokengen
+    targetModule: "tokengen"
     # -- Additional CLI arguments for the `tokengen` target
     extraArgs: []
     # -- Additional Kubernetes environment
@@ -747,6 +749,8 @@ write:
   selectorLabels: {}
   # -- Labels for ingestor service
   serviceLabels: {}
+  # -- Comma-separated list of Loki modules to load for the write
+  targetModule: "write"
   # -- Additional CLI args for the write
   extraArgs: []
   # -- Environment variables to add to the write pods
@@ -818,6 +822,8 @@ read:
   selectorLabels: {}
   # -- Labels for read service
   serviceLabels: {}
+  # -- Comma-separated list of Loki modules to load for the read
+  targetModule: "read"
   # -- Additional CLI args for the read
   extraArgs: []
   # -- Environment variables to add to the read pods
@@ -885,6 +891,8 @@ singleBinary:
   podAnnotations: {}
   # -- Additional selecto labels for each `single binary` pod
   selectorLabels: {}
+  # -- Comma-separated list of Loki modules to load for the single binary
+  targetModule: "all"
   # -- Labels for single binary service
   extraArgs: []
   # -- Environment variables to add to the single binary pods


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the ability to change the Loki `target` argument. E.g. one might want to use the single-binary which has target `all` but also the `table-manager` which is not part of it. So one can override the target with `all,table-manager`.

**Which issue(s) this PR fixes**:
Fixes #7788 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] `CHANGELOG.md` updated