### PR TITLE
Update delve version to be compatible with Go 1.19

### DIFF
--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,9 +1,7 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
-ARG BUILD_IMAGE
-
-FROM $BUILD_IMAGE as build
+FROM grafana/loki-build-image:0.24.2 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,8 +1,9 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
+ARG BUILD_IMAGE
 
-FROM grafana/loki-build-image as build
+FROM $BUILD_IMAGE as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -51,7 +51,7 @@ FROM golang:1.19.2 as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.10.0
 
 FROM golang:1.19.2 as delve
-RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@v1.7.3
+RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to use the `production/docker` with an interactive debugger, we need to upgrade the Delve tool to a version that works with the version of Go which Loki uses: 1.19

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This is step 1 of 2 in the [release process](https://github.com/grafana/loki/blob/main/docs/sources/maintaining/release-loki-build-image.md) of the build image.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
