### PR TITLE
Improvements to loki-build-image build & release process

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.24.2',
+    local build_image_tag = '0.24.3',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.2
+    - 0.24.3
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.2
+    - 0.24.3
     username:
       from_secret: docker_username
   when:
@@ -1613,6 +1613,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: fa871eb3f76a5fcf0bdf610e6ba80ce402aceb0bfe1a41e3064bb9cf94940c42
+hmac: 209b41a9cee719fa211a9e97f38a4964233e9ecb46664bc12dab23f819dbcca8
 
 ...

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -9,22 +9,19 @@ is the Docker image used to run tests and build Grafana Loki binaries in CI.
 The build and publish process of the image is triggered upon a merge to `main`
 if there were made any changes in the folder `./loki-build-image/`.
 
-**Building and using the `loki-build-image` is a two-step process.**
+**Building and using the `loki-build-image` is a two-step process:**
 
-As a **first step** to build the new image, you need to create a pull
-request with the desired changes to the Dockerfile. To increase the version of
-the image, you also need to update the version tag of the `loki-build-image`
-pipeline defined in `.drone/drone.jsonnet` (search for
-`pipeline('loki-build-image')`) and run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone`
-and commit the changes to the same pull request.
-Once approved and merged to `main`, the image with the new version is built.
+## Step 1
 
-The new image can only be used after updating the `BUILD_IMAGE_VERSION` in the
-`Makefile` a **second step**. After changing the version in the Makefile and
-updating it in all other places where the image is used:
+1. create a branch with the desired changes to the Dockerfile
+2. update the version tag of the `loki-build-image` pipeline defined in `.drone/drone.jsonnet` (search for `pipeline('loki-build-image')`) to a new version number (try follow semver)
+3. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` and commit the changes to the same branch
+4. create a PR
+5. once approved and merged to `main`, the image with the new version is built
 
-* Dockerfiles in `cmd` directory
-* `.circleci/config.yml`
+## Step 2
 
-run `BUILD_IN_CONTAINER=false make drone` again and submit a PR with the
-generated changes.
+1. create a branch
+2. update the `BUILD_IMAGE_VERSION` variable in the `Makefile`
+3. run `loki-build-image/version-updater.sh <new-version>` to update all the references
+4. create a PR

--- a/loki-build-image/version-updater.sh
+++ b/loki-build-image/version-updater.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 VERSION="${1-}"
-if [ -z "${VERSION}" ]; then
+if [[ -z "${VERSION}" ]]; then
   >&2 echo "Usage: $0 <version>"
   exit 1
 fi
@@ -11,7 +11,7 @@ fi
 echo "Updating loki-build-image references to '${VERSION}'"
 
 find . -type f \( -name '*.yml' -o -name '*.yaml' -o -name '*Dockerfile*' \) -exec grep -lP "grafana/loki-build-image:[0-9]+" {} \; | grep -ve '.drone' |
-  while read x; do
-    echo "Updating $x"
-    sed -i -re "s,grafana/loki-build-image:[0-9]+\.[0-9]+\.[0-9]+,grafana/loki-build-image:${VERSION},g" $x
+  while read -r x; do
+    echo "Updating ${x}"
+    sed -i -re "s,grafana/loki-build-image:[0-9]+\.[0-9]+\.[0-9]+,grafana/loki-build-image:${VERSION},g" "${x}"
   done

--- a/loki-build-image/version-updater.sh
+++ b/loki-build-image/version-updater.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="${1-}"
+if [ -z "${VERSION}" ]; then
+  >&2 echo "Usage: $0 <version>"
+  exit 1
+fi
+
+echo "Updating loki-build-image references to '${VERSION}'"
+
+find . -type f \( -name '*.yml' -o -name '*.yaml' -o -name '*Dockerfile*' \) -exec grep -lP "grafana/loki-build-image:[0-9]+" {} \; | grep -ve '.drone' |
+  while read x; do
+    echo "Updating $x"
+    sed -i -re "s,grafana/loki-build-image:[0-9]+\.[0-9]+\.[0-9]+,grafana/loki-build-image:${VERSION},g" $x
+  done


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/loki/pull/7793, I accidentally overwrote `grafana/loki-build-image:0.24.2` because the build & release steps were ambiguous. I've fixed that now, and included a script for keeping all references to this build image updated.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
