### PR TITLE
Completing step 2 of updating loki-build-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 .defaults: &defaults
   docker:
-    - image: grafana/loki-build-image:0.24.1
+    - image: grafana/loki-build-image:0.24.3
   working_directory: /src/loki
 
 jobs:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: compare-coverage
   when:
     event:
@@ -158,7 +158,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: report-coverage
   when:
     event:
@@ -168,7 +168,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -176,7 +176,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -187,21 +187,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: check-example-config-doc
 trigger:
   ref:
@@ -228,7 +228,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: loki-mixin-check
   when:
     event:
@@ -253,7 +253,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1340,7 +1340,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1348,7 +1348,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1374,7 +1374,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.24.3
   name: publish
   when:
     event:
@@ -1613,6 +1613,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 209b41a9cee719fa211a9e97f38a4964233e9ecb46664bc12dab23f819dbcca8
+hmac: 1abf633c26259d324da5804cd9fada3eacaf9b3184497f8b48ee29bad674b617
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.24.2
+BUILD_IMAGE_VERSION := 0.24.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,7 +1,7 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
-FROM grafana/loki-build-image:0.24.2 as build
+FROM grafana/loki-build-image:0.24.3 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -18,10 +18,12 @@ if there were made any changes in the folder `./loki-build-image/`.
 3. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` and commit the changes to the same branch
 4. create a PR
 5. once approved and merged to `main`, the image with the new version is built and published
+   - **hint:** keep an eye on https://drone.grafana.net/grafana/loki for the build after merging ([example](https://drone.grafana.net/grafana/loki/17760/1/2))
 
 ## Step 2
 
 1. create a branch
 2. update the `BUILD_IMAGE_VERSION` variable in the `Makefile`
+3. Repeat step 1.3, which will use the new image
 3. run `loki-build-image/version-updater.sh <new-version>` to update all the references
 4. create a PR

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.24.3
 
 FROM golang:1.19.1-alpine as goenv
 RUN go env GOARCH > /goarch && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `loki-build-image`  and corrects mistake in https://github.com/grafana/loki/pull/7793 where I overwrote the `0.24.2` image.

[Step 1](https://github.com/grafana/loki/pull/7795)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Followed my docs and found one step missing.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
