### PR TITLE
docs(embedded-cache): config uses embedded_cache

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1846,7 +1846,7 @@ the index to a backing cache store.
 <span style="background-color:#f3f973;">The memcached configuration variable addresses is experimental.</span>
 
 ```yaml
-# NOTE: `fifocache` is deprecated. Use `embedded-cache` instead.
+# NOTE: `fifocache` is deprecated. Use `embedded_cache` instead.
 # Enable in-memory cache (auto-enabled for the chunks & query results cache if no other cache is configured).
 # CLI flag: -<prefix>.cache.enable-fifocache
 [enable_fifocache: <boolean>]
@@ -1857,9 +1857,9 @@ the index to a backing cache store.
 [default_validity: <duration>]
 
 # Configures embedded cache settings.
-embedded-cache:
+embedded_cache:
   # Whether embedded cache is enabled.
-  # CLI flag: -<prefix>.embeddec-cache.enabled
+  # CLI flag: -<prefix>.embedded-cache.enabled
   [enabled: <bool> | default = false]
 
   # Maximum memory size of the cache in MB.


### PR DESCRIPTION
**What this PR does / why we need it**:
In the documentation for Loki configuration use the correct field name `embedded_cache` to match the expectations in the YAML parser

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
