### PR TITLE
fifocache config is deprecated. use embedded-cache instead

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -518,9 +518,9 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 		case t.Cfg.isModuleEnabled(Ingester), t.Cfg.isModuleEnabled(Write):
 			// Use fifo cache for caching index in memory, this also significantly helps performance.
 			t.Cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{
-				EnableFifoCache: true,
-				Fifocache: cache.FifoCacheConfig{
-					MaxSizeBytes: "200 MB",
+				EmbeddedCache: cache.EmbeddedCacheConfig{
+					Enabled:   true,
+					MaxSizeMB: 200,
 					// This is a small hack to save some CPU cycles.
 					// We check if the object is still valid after pulling it from cache using the IndexCacheValidity value
 					// however it has to be deserialized to do so, setting the cache validity to some arbitrary amount less than the


### PR DESCRIPTION
**What this PR does / why we need it**:
fifocache config is deprecated. use embedded-cache instead

**Which issue(s) this PR fixes**:
Fixes #7798

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
