### PR TITLE
Revert "[release-2.7.x] docs/upgrading: Add a note about windows event log fix"

### DIFF
--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -130,10 +130,6 @@ Can no longer specify a remote write client for the ruler.
 
 The `gcp_push_target_parsing_errors_total` GCP Push Target metrics has been added a new label named `reason`. This includes detail on what might have caused the parsing to fail.
 
-#### Windows event logs: now correctly includes `user_data`
-
-The contents of the `user_data` field was erroneously set to the same value as `event_data` in previous versions. This was fixed in [#7461](https://github.com/grafana/loki/pull/7461) and log queries relying on this broken behaviour may be impacted.
-
 ## 2.6.0
 
 ### Loki


### PR DESCRIPTION
Reverts grafana/loki#7675
as long as https://github.com/grafana/loki/pull/7461 was not merged to release-2.7.x branch, we do not need the upgrade guide