### PR TITLE
operator: Replace fifocache usage by embedded_cache

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7808](https://github.com/grafana/loki/pull/7808) **xperimental**: Replace fifocache usage by embedded_cache
 - [7753](https://github.com/grafana/loki/pull/7753) **periklis**: Check for mandatory CA configmap name in ObjectStorageTLS spec
 - [7744](https://github.com/grafana/loki/pull/7744) **periklis**: Fix object storage TLS spec CAKey descriptor
 - [7716](https://github.com/grafana/loki/pull/7716) **aminesnow**: Migrate API docs generation tool

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -15,9 +15,9 @@ func TestBuild_ConfigAndRuntimeConfig_NoRuntimeConfigGenerated(t *testing.T) {
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -125,9 +125,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -252,9 +252,9 @@ func TestBuild_ConfigAndRuntimeConfig_BothGenerated(t *testing.T) {
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -362,9 +362,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -580,9 +580,9 @@ func TestBuild_ConfigAndRuntimeConfig_RulerConfigGenerated_WithHeaderAuthorizati
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -690,9 +690,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -918,9 +918,9 @@ func TestBuild_ConfigAndRuntimeConfig_RulerConfigGenerated_WithBasicAuthorizatio
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -1028,9 +1028,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -1257,9 +1257,9 @@ func TestBuild_ConfigAndRuntimeConfig_RulerConfigGenerated_WithRelabelConfigs(t 
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -1367,9 +1367,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -1626,9 +1626,9 @@ func TestBuild_ConfigAndRuntimeConfig_WithRetention(t *testing.T) {
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -1744,9 +1744,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -1916,9 +1916,9 @@ func TestBuild_ConfigAndRuntimeConfig_RulerConfigGenerated_WithAlertRelabelConfi
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -2026,9 +2026,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:
@@ -2315,9 +2315,9 @@ func TestBuild_ConfigAndRuntimeConfig_WithTLS(t *testing.T) {
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     s3:
@@ -2454,9 +2454,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -3,9 +3,9 @@
 auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
-    enable_fifocache: true
-    fifocache:
-      max_size_bytes: 500MB
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
 common:
   storage:
     {{- with .ObjectStorage.Azure }}
@@ -196,9 +196,9 @@ query_range:
   max_retries: 5
   results_cache:
     cache:
-      enable_fifocache: true
-      fifocache:
-        max_size_bytes: 500MB
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
   parallelise_shardable_queries: true
 schema_config:
   configs:


### PR DESCRIPTION
**What this PR does / why we need it**:

This replaces the deprecated usage of `fifocache` in the configuration generated by Loki Operator by the updated `embedded_cache` configuration block. The same configuration values are used.

**Which issue(s) this PR fixes**:

[LOG-3333](https://issues.redhat.com/browse/LOG-3333)

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Tests updated
- [x] `CHANGELOG.md` updated
