### PR TITLE
operator: Fix histogram-based alerting rules

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7809](https://github.com/grafana/loki/pull/7809) **xperimental**: Fix histogram-based alerting rules
 - [7808](https://github.com/grafana/loki/pull/7808) **xperimental**: Replace fifocache usage by embedded_cache
 - [7753](https://github.com/grafana/loki/pull/7753) **periklis**: Check for mandatory CA configmap name in ObjectStorageTLS spec
 - [7744](https://github.com/grafana/loki/pull/7744) **periklis**: Fix object storage TLS spec CAKey descriptor

--- a/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
+++ b/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
@@ -88,7 +88,6 @@ groups:
           )
         ) by (job, le, namespace, route)
       )
-      * 100
       > 1
     for: 15m
     labels:
@@ -124,7 +123,6 @@ groups:
           job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="WRITE"}
         ) by (job, le, namespace)
       )
-      * 100
       > 1
     for: 15m
     labels:
@@ -141,7 +139,6 @@ groups:
           job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="Shipper.Query"}
         ) by (job, le, namespace)
       )
-      * 100
       > 5
     for: 15m
     labels:
@@ -174,7 +171,6 @@ groups:
           )
         ) by (job, le, namespace)
       )
-      * 100
       > 30
     for: 15m
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the histogram-based alerts created by Loki Operator are using a multiplication by 100, which does not seem correct in this context (the result of `histogram_quantile` should already be in `seconds`).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] `CHANGELOG.md` updated
