### PR TITLE
Improve ratestore performance

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -137,6 +137,9 @@ func (s *rateStore) cleanupExpired() (int64, int64, int64) {
 		for stream, rate := range tenant {
 			if time.Since(rate.createdAt) > s.rateKeepAlive {
 				delete(s.rates[tID], stream)
+				if len(s.rates[tID]) == 0 {
+					delete(s.rates, tID)
+				}
 				continue
 			}
 

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -55,7 +55,7 @@ type rateStore struct {
 
 	ring            ring.ReadRing
 	clientPool      poolClientFactory
-	rates           map[string]map[uint64]expiringRate
+	rates           map[string]map[uint64]expiringRate // tenant id -> fingerprint -> rate
 	rateLock        sync.RWMutex
 	rateKeepAlive   time.Duration
 	ingesterTimeout time.Duration

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -23,8 +23,6 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 )
 
-const keySeparator = ":"
-
 type poolClientFactory interface {
 	GetClientFor(addr string) (client.PoolClient, error)
 }

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -177,7 +177,7 @@ func (s *rateStore) aggregateByShard(streamRates map[string]map[uint64]*logproto
 
 			rate := rates[tID][streamRate.StreamHashNoShard]
 			rate.rate += streamRate.Rate
-			rate.shards += 1
+			rate.shards++
 			rate.createdAt = time.Now()
 
 			rates[tID][streamRate.StreamHashNoShard] = rate

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -9,6 +9,7 @@ import (
 type ratestoreMetrics struct {
 	rateRefreshFailures *prometheus.CounterVec
 	streamCount         prometheus.Gauge
+	expiredCount        prometheus.Counter
 	maxStreamShardCount prometheus.Gauge
 	streamShardCount    prometheus.Histogram
 	maxStreamRate       prometheus.Gauge
@@ -28,6 +29,11 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Namespace: "loki",
 			Name:      "rate_store_streams",
 			Help:      "The number of unique streams reported by all ingesters. Sharded streams are combined",
+		}),
+		expiredCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "rate_store_expired_streams_total",
+			Help:      "The number of streams that have been expired by the ratestore",
 		}),
 		maxStreamShardCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -2,6 +2,8 @@ package distributor
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -185,6 +187,31 @@ func TestRateStore(t *testing.T) {
 	})
 }
 
+var benchErr error
+
+func BenchmarkRateStore(b *testing.B) {
+	tc := setup(true)
+	tc.ring.replicationSet = ring.ReplicationSet{
+		Instances: []ring.InstanceDesc{
+			{Addr: "ingester0"},
+		},
+	}
+
+	rates := make([]*logproto.StreamRate, 200000)
+	for i := 0; i < 200000; i++ {
+		rates[i] = &logproto.StreamRate{Tenant: fmt.Sprintf("tenant %d", i%2), StreamHash: uint64(i % 3), StreamHashNoShard: uint64(i % 4), Rate: rand.Int63()}
+	}
+
+	tc.clientPool.clients = map[string]client.PoolClient{
+		"ingester0": newRateClient(rates),
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		benchErr = tc.rateStore.updateAllRates(context.Background())
+	}
+}
+
 func newFakeRing() *fakeRing {
 	return &fakeRing{}
 }
@@ -268,7 +295,7 @@ type testContext struct {
 	rateStore  *rateStore
 }
 
-func setup(enabled bool) *testContext {
+func setup(shardingEnabled bool) *testContext {
 	ring := newFakeRing()
 	cp := newFakeClientPool()
 	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond}
@@ -276,6 +303,6 @@ func setup(enabled bool) *testContext {
 	return &testContext{
 		ring:       ring,
 		clientPool: cp,
-		rateStore:  NewRateStore(cfg, ring, cp, &fakeOverrides{enabled: enabled}, nil),
+		rateStore:  NewRateStore(cfg, ring, cp, &fakeOverrides{enabled: shardingEnabled}, nil),
 	}
 }


### PR DESCRIPTION
This PR changes the Rate Store to use multi-level maps rather than `tenant+stream-fingerprint` key. 

Benchmarks:

*old*
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/distributor
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkRateStore-8         117          10420080 ns/op         3201761 B/op     200025 allocs/op

PASS
ok      github.com/grafana/loki/pkg/distributor 14.646s
```

*new*
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/distributor
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkRateStore-8         320           3811906 ns/op            2660 B/op         26 allocs/op
```

*stats*
```
name         old time/op    new time/op    delta
RateStore-8    10.7ms ± 8%     4.1ms ± 8%  -61.42%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
RateStore-8    3.20MB ± 0%    0.00MB ± 0%  -99.92%  (p=0.000 n=8+9)

name         old allocs/op  new allocs/op  delta
RateStore-8      200k ± 0%        0k ± 0%  -99.99%  (p=0.000 n=9+10)
```