### PR TITLE
operator: Apply delete client changes for compat with release-2.7.x

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7815](https://github.com/grafana/loki/pull/7815) **periklis**: Apply delete client changes for compat with release-2.7.x
 - [7809](https://github.com/grafana/loki/pull/7809) **xperimental**: Fix histogram-based alerting rules
 - [7808](https://github.com/grafana/loki/pull/7808) **xperimental**: Replace fifocache usage by embedded_cache
 - [7753](https://github.com/grafana/loki/pull/7753) **periklis**: Check for mandatory CA configmap name in ObjectStorageTLS spec

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -2440,7 +2440,7 @@ querier:
   max_concurrent: 2
   query_ingesters_within: 3h
   tail_max_duration: 1h
-compactor_client:
+delete_client:
   tls_enabled: true
   tls_cert_path: /var/run/tls/http/tls.crt
   tls_key_path: /var/run/tls/http/tls.key
@@ -2631,7 +2631,6 @@ overrides:
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
-	t.Log(string(cfg))
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
 }

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -181,7 +181,7 @@ querier:
   tail_max_duration: 1h
   max_concurrent: {{ .MaxConcurrent.AvailableQuerierCPUCores }}
 {{- if .Gates.HTTPEncryption }}
-compactor_client:
+delete_client:
   tls_enabled: true
   tls_cert_path: {{ .TLS.Paths.HTTP.Certificate }}
   tls_key_path: {{ .TLS.Paths.HTTP.Key }}


### PR DESCRIPTION
**What this PR does / why we need it**:
After merging into #7607 we need to retrofit the `compactor_client` as `delete_client` again to re-establish compatibility with upcoming v2.7.x Loki releases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
