### PR TITLE
Make some stream shard metrics per-tenant

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -104,7 +104,7 @@ type Distributor struct {
 	ingesterAppends        *prometheus.CounterVec
 	ingesterAppendFailures *prometheus.CounterVec
 	replicationFactor      prometheus.Gauge
-	streamShardCount       prometheus.Counter
+	streamShardCount       *prometheus.CounterVec
 }
 
 // New a distributor creates.
@@ -190,11 +190,11 @@ func New(
 			Name:      "distributor_replication_factor",
 			Help:      "The configured replication factor.",
 		}),
-		streamShardCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+		streamShardCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "loki",
 			Name:      "stream_sharding_count",
 			Help:      "Total number of times the distributor has sharded streams",
-		}),
+		}, []string{"tenant"}),
 	}
 	d.replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
 	rfStats.Set(int64(ingestersRing.ReplicationFactor()))
@@ -417,7 +417,7 @@ func (d *Distributor) shardStream(stream logproto.Stream, streamSize int, tenant
 		return []uint32{util.TokenFor(tenantID, stream.Labels)}, []streamTracker{{stream: stream}}
 	}
 
-	d.streamShardCount.Inc()
+	d.streamShardCount.WithLabelValues(tenantID).Inc()
 	if shardStreamsCfg.LoggingEnabled {
 		level.Info(logger).Log("msg", "sharding request", "shard_count", shardCount)
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -555,7 +555,7 @@ func TestStreamShard(t *testing.T) {
 			d := Distributor{
 				rateStore:        &fakeRateStore{},
 				validator:        validator,
-				streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
+				streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
 				shardTracker:     NewShardTracker(),
 			}
 
@@ -600,7 +600,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 		d := Distributor{
 			rateStore:        &fakeRateStore{},
 			validator:        validator,
-			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
+			streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
 			shardTracker:     NewShardTracker(),
 		}
 
@@ -664,7 +664,7 @@ func BenchmarkShardStream(b *testing.B) {
 	distributorBuilder := func(shards int) *Distributor {
 		d := &Distributor{
 			validator:        validator,
-			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
+			streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
 			shardTracker:     NewShardTracker(),
 			// streamSize is always zero, so number of shards will be dictated just by the rate returned from store.
 			rateStore: &fakeRateStore{rate: int64(desiredRate*shards - 1)},

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -8,13 +8,13 @@ import (
 
 type ratestoreMetrics struct {
 	rateRefreshFailures *prometheus.CounterVec
-	streamCount         prometheus.Gauge
 	expiredCount        prometheus.Counter
-	maxStreamShardCount prometheus.Gauge
+	streamCount         prometheus.Gauge
+	maxStreamShardCount *prometheus.GaugeVec
+	maxStreamRate       *prometheus.GaugeVec
+	maxUniqueStreamRate *prometheus.GaugeVec
 	streamShardCount    prometheus.Histogram
-	maxStreamRate       prometheus.Gauge
 	streamRate          prometheus.Histogram
-	maxUniqueStreamRate prometheus.Gauge
 	refreshDuration     *instrument.HistogramCollector
 }
 
@@ -35,33 +35,33 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Name:      "rate_store_expired_streams_total",
 			Help:      "The number of streams that have been expired by the ratestore",
 		}),
-		maxStreamShardCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		maxStreamShardCount: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_stream_shards",
 			Help:      "The number of shards for a single stream reported by ingesters during a sync operation.",
-		}),
+		}, []string{"tenant"}),
 		streamShardCount: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Name:      "rate_store_stream_shards",
 			Help:      "The distribution of number of shards for a single stream reported by ingesters during a sync operation.",
 			Buckets:   []float64{0, 2, 4, 8, 16, 32, 64, 128},
 		}),
-		maxStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		maxStreamRate: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
-		}),
+		}, []string{"tenant"}),
 		streamRate: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Name:      "rate_store_stream_rate_bytes",
 			Help:      "The distribution of stream rates for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
 			Buckets:   prometheus.ExponentialBuckets(20000, 2, 14), // biggest bucket is 20000*2^(14-1) = 163,840,000 (~163.84MB)
 		}),
-		maxUniqueStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		maxUniqueStreamRate: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_unique_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered separate.",
-		}),
+		}, []string{"tenant"}),
 		refreshDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(
 				prometheus.HistogramOpts{


### PR DESCRIPTION
This PR just adds tenant information so some of our per-stream-rate-limit metrics.