### PR TITLE
loki-build-image: update faillint

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.24.3',
+    local build_image_tag = '0.25.0',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.3
+    - 0.25.0
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.3
+    - 0.25.0
     username:
       from_secret: docker_username
   when:
@@ -1613,6 +1613,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 1abf633c26259d324da5804cd9fada3eacaf9b3184497f8b48ee29bad674b617
+hmac: 053973b5cf1dd520bd742aab4e6e9e03367ecdcb871eebedac688dbd1a5fd9db
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -45,10 +45,10 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Install faillint used to lint go imports in CI.
 # This collisions with the version of go tools used in the base image, thus we install it in its own image and copy it over.
 # Error:
-#	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
+# github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
 FROM golang:1.19.2 as faillint
-RUN GO111MODULE=on go install github.com/fatih/faillint@v1.10.0
+RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
 FROM golang:1.19.2 as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest


### PR DESCRIPTION
faillint needs an update for Go 1.19 where it fails unexpectedly. First observed in #7826.

See fatih/faillint#36