### PR TITLE
Revert "Make some stream shard metrics per-tenant (#7838)"

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -555,7 +555,7 @@ func TestStreamShard(t *testing.T) {
 			d := Distributor{
 				rateStore:        &fakeRateStore{},
 				validator:        validator,
-				streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
+				streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
 				shardTracker:     NewShardTracker(),
 			}
 
@@ -600,7 +600,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 		d := Distributor{
 			rateStore:        &fakeRateStore{},
 			validator:        validator,
-			streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
+			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
 			shardTracker:     NewShardTracker(),
 		}
 
@@ -664,7 +664,7 @@ func BenchmarkShardStream(b *testing.B) {
 	distributorBuilder := func(shards int) *Distributor {
 		d := &Distributor{
 			validator:        validator,
-			streamShardCount: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"}),
+			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
 			shardTracker:     NewShardTracker(),
 			// streamSize is always zero, so number of shards will be dictated just by the rate returned from store.
 			rateStore: &fakeRateStore{rate: int64(desiredRate*shards - 1)},

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -105,8 +105,8 @@ func (s *rateStore) updateAllRates(ctx context.Context) error {
 	updated := s.aggregateByShard(streamRates)
 	updateStats := s.updateRates(updated)
 
-	s.metrics.maxStreamRate.WithLabelValues(updateStats.maxRateTenant).Set(float64(updateStats.maxRate))
-	s.metrics.maxStreamShardCount.WithLabelValues(updateStats.maxShardsTenant).Set(float64(updateStats.maxShards))
+	s.metrics.maxStreamRate.Set(float64(updateStats.maxRate))
+	s.metrics.maxStreamShardCount.Set(float64(updateStats.maxShards))
 	s.metrics.streamCount.Set(float64(updateStats.totalStreams))
 	s.metrics.expiredCount.Add(float64(updateStats.expiredCount))
 
@@ -114,12 +114,10 @@ func (s *rateStore) updateAllRates(ctx context.Context) error {
 }
 
 type rateStats struct {
-	maxShards       int64
-	maxShardsTenant string
-	maxRate         int64
-	maxRateTenant   string
-	totalStreams    int64
-	expiredCount    int64
+	maxShards    int64
+	maxRate      int64
+	totalStreams int64
+	expiredCount int64
 }
 
 func (s *rateStore) updateRates(updated map[string]map[uint64]expiringRate) rateStats {
@@ -154,8 +152,8 @@ func (s *rateStore) cleanupExpired() rateStats {
 				continue
 			}
 
-			rs.maxRate, rs.maxRateTenant = max(rs.maxRate, rs.maxRateTenant, rate.rate, tID)
-			rs.maxShards, rs.maxShardsTenant = max(rs.maxShards, rs.maxShardsTenant, rate.shards, tID)
+			rs.maxRate = max(rs.maxRate, rate.rate)
+			rs.maxShards = max(rs.maxShards, rate.shards)
 
 			s.metrics.streamShardCount.Observe(float64(rate.shards))
 			s.metrics.streamRate.Observe(float64(rate.rate))
@@ -202,11 +200,11 @@ func (s *rateStore) aggregateByShard(streamRates map[string]map[uint64]*logproto
 	return rates
 }
 
-func max(a int64, aTenant string, b int64, bTenant string) (int64, string) {
+func max(a, b int64) int64 {
 	if a > b {
-		return a, aTenant
+		return a
 	}
-	return b, bTenant
+	return b
 }
 
 func (s *rateStore) getRates(ctx context.Context, clients []ingesterClient) map[string]map[uint64]*logproto.StreamRate {
@@ -242,7 +240,6 @@ func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan inge
 
 func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse, totalResponses int) map[string]map[uint64]*logproto.StreamRate {
 	var maxRate int64
-	var maxRateTenant string
 	streamRates := map[string]map[uint64]*logproto.StreamRate{}
 	for i := 0; i < totalResponses; i++ {
 		resp := <-responses
@@ -251,7 +248,7 @@ func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse,
 		}
 
 		for _, rate := range resp.StreamRates {
-			maxRate, maxRateTenant = max(maxRate, maxRateTenant, rate.Rate, rate.Tenant)
+			maxRate = max(maxRate, rate.Rate)
 
 			if _, ok := streamRates[rate.Tenant]; !ok {
 				streamRates[rate.Tenant] = map[uint64]*logproto.StreamRate{}
@@ -268,7 +265,7 @@ func (s *rateStore) ratesPerStream(responses chan *logproto.StreamRatesResponse,
 		}
 	}
 
-	s.metrics.maxUniqueStreamRate.WithLabelValues(maxRateTenant).Set(float64(maxRate))
+	s.metrics.maxUniqueStreamRate.Set(float64(maxRate))
 	return streamRates
 }
 

--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -8,13 +8,13 @@ import (
 
 type ratestoreMetrics struct {
 	rateRefreshFailures *prometheus.CounterVec
-	expiredCount        prometheus.Counter
 	streamCount         prometheus.Gauge
-	maxStreamShardCount *prometheus.GaugeVec
-	maxStreamRate       *prometheus.GaugeVec
-	maxUniqueStreamRate *prometheus.GaugeVec
+	expiredCount        prometheus.Counter
+	maxStreamShardCount prometheus.Gauge
 	streamShardCount    prometheus.Histogram
+	maxStreamRate       prometheus.Gauge
 	streamRate          prometheus.Histogram
+	maxUniqueStreamRate prometheus.Gauge
 	refreshDuration     *instrument.HistogramCollector
 }
 
@@ -35,33 +35,33 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Name:      "rate_store_expired_streams_total",
 			Help:      "The number of streams that have been expired by the ratestore",
 		}),
-		maxStreamShardCount: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		maxStreamShardCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_stream_shards",
 			Help:      "The number of shards for a single stream reported by ingesters during a sync operation.",
-		}, []string{"tenant"}),
+		}),
 		streamShardCount: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Name:      "rate_store_stream_shards",
 			Help:      "The distribution of number of shards for a single stream reported by ingesters during a sync operation.",
 			Buckets:   []float64{0, 2, 4, 8, 16, 32, 64, 128},
 		}),
-		maxStreamRate: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		maxStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
-		}, []string{"tenant"}),
+		}),
 		streamRate: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loki",
 			Name:      "rate_store_stream_rate_bytes",
 			Help:      "The distribution of stream rates for any stream reported by ingesters during a sync operation. Sharded Streams are combined.",
 			Buckets:   prometheus.ExponentialBuckets(20000, 2, 14), // biggest bucket is 20000*2^(14-1) = 163,840,000 (~163.84MB)
 		}),
-		maxUniqueStreamRate: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		maxUniqueStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",
 			Name:      "rate_store_max_unique_stream_rate_bytes",
 			Help:      "The maximum stream rate for any stream reported by ingesters during a sync operation. Sharded Streams are considered separate.",
-		}, []string{"tenant"}),
+		}),
 		refreshDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(
 				prometheus.HistogramOpts{


### PR DESCRIPTION
Because these metrics will be coming from each distributor, this is going to have an adverse impact on cardinality. Consider doing this with logging