### PR TITLE
promtail: add RFC3164 syslog support

### DIFF
--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -194,6 +194,9 @@ type SyslogTargetConfig struct {
 	// message should be pushed to Loki
 	UseRFC5424Message bool `yaml:"use_rfc5424_message"`
 
+	// IsRFC3164Message defines wether the log is formated as RFC3164
+	IsRFC3164Message bool `yaml:"is_rfc3164_message"`
+
 	// MaxMessageLength sets the maximum limit to the length of syslog messages
 	MaxMessageLength int `yaml:"max_message_length"`
 

--- a/clients/pkg/promtail/targets/heroku/target_test.go
+++ b/clients/pkg/promtail/targets/heroku/target_test.go
@@ -100,7 +100,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testPayload},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "some_job_name",
@@ -145,7 +145,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testLogLine1, testLogLine2},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "multiple_line_job",
@@ -215,7 +215,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testLogLine1},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "relabeling_job",

--- a/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser.go
+++ b/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser.go
@@ -14,7 +14,7 @@ import (
 // the callback function with the parsed messages. The parser automatically
 // detects octet counting.
 // The function returns on EOF or unrecoverable errors.
-func ParseStream(r io.Reader, callback func(res *syslog.Result), maxMessageLength int) error {
+func ParseStream(isRFC3164Message bool, r io.Reader, callback func(res *syslog.Result), maxMessageLength int) error {
 	buf := bufio.NewReaderSize(r, 1<<10)
 
 	b, err := buf.ReadByte()
@@ -24,9 +24,17 @@ func ParseStream(r io.Reader, callback func(res *syslog.Result), maxMessageLengt
 	_ = buf.UnreadByte()
 
 	if b == '<' {
-		nontransparent.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		if isRFC3164Message {
+			nontransparent.NewParserRFC3164(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		} else {
+			nontransparent.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		}
 	} else if b >= '0' && b <= '9' {
-		octetcounting.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		if isRFC3164Message {
+			octetcounting.NewParserRFC3164(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		} else {
+			octetcounting.NewParser(syslog.WithListener(callback), syslog.WithMaxMessageLength(maxMessageLength), syslog.WithBestEffort()).Parse(buf)
+		}
 	} else {
 		return fmt.Errorf("invalid or unsupported framing. first byte: '%s'", string(b))
 	}

--- a/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser_test.go
@@ -24,7 +24,7 @@ func TestParseStream_OctetCounting(t *testing.T) {
 		results = append(results, res)
 	}
 
-	err := syslogparser.ParseStream(r, cb, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, cb, defaultMaxMessageLength)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(results))
@@ -43,7 +43,7 @@ func TestParseStream_ValidParseError(t *testing.T) {
 		results = append(results, res)
 	}
 
-	err := syslogparser.ParseStream(r, cb, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, cb, defaultMaxMessageLength)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results))
@@ -59,7 +59,7 @@ func TestParseStream_OctetCounting_LongMessage(t *testing.T) {
 		results = append(results, res)
 	}
 
-	err := syslogparser.ParseStream(r, cb, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, cb, defaultMaxMessageLength)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results))
@@ -74,7 +74,7 @@ func TestParseStream_NewlineSeparated(t *testing.T) {
 		results = append(results, res)
 	}
 
-	err := syslogparser.ParseStream(r, cb, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, cb, defaultMaxMessageLength)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(results))
@@ -87,13 +87,13 @@ func TestParseStream_NewlineSeparated(t *testing.T) {
 func TestParseStream_InvalidStream(t *testing.T) {
 	r := strings.NewReader("invalid")
 
-	err := syslogparser.ParseStream(r, func(res *syslog.Result) {}, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, func(res *syslog.Result) {}, defaultMaxMessageLength)
 	require.EqualError(t, err, "invalid or unsupported framing. first byte: 'i'")
 }
 
 func TestParseStream_EmptyStream(t *testing.T) {
 	r := strings.NewReader("")
 
-	err := syslogparser.ParseStream(r, func(res *syslog.Result) {}, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, r, func(res *syslog.Result) {}, defaultMaxMessageLength)
 	require.Equal(t, err, io.EOF)
 }

--- a/clients/pkg/promtail/targets/syslog/syslogtarget.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -106,7 +107,7 @@ func (t *SyslogTarget) handleMessageError(err error) {
 	t.metrics.syslogParsingErrors.Inc()
 }
 
-func (t *SyslogTarget) handleMessage(connLabels labels.Labels, msg syslog.Message) {
+func (t *SyslogTarget) handleMessageRFC5424(connLabels labels.Labels, msg syslog.Message) {
 	rfc5424Msg := msg.(*rfc5424.SyslogMessage)
 
 	if rfc5424Msg.Message == nil {
@@ -171,6 +172,64 @@ func (t *SyslogTarget) handleMessage(connLabels labels.Labels, msg syslog.Messag
 		}
 	}
 	t.messages <- message{filtered, m, timestamp}
+}
+
+func (t *SyslogTarget) handleMessageRFC3164(connLabels labels.Labels, msg syslog.Message) {
+	rfc3164Msg := msg.(*rfc3164.SyslogMessage)
+
+	if rfc3164Msg.Message == nil {
+		t.metrics.syslogEmptyMessages.Inc()
+		return
+	}
+
+	lb := labels.NewBuilder(connLabels)
+	if v := rfc3164Msg.SeverityLevel(); v != nil {
+		lb.Set("__syslog_message_severity", *v)
+	}
+	if v := rfc3164Msg.FacilityLevel(); v != nil {
+		lb.Set("__syslog_message_facility", *v)
+	}
+	if v := rfc3164Msg.Hostname; v != nil {
+		lb.Set("__syslog_message_hostname", *v)
+	}
+	if v := rfc3164Msg.Appname; v != nil {
+		lb.Set("__syslog_message_app_name", *v)
+	}
+	if v := rfc3164Msg.ProcID; v != nil {
+		lb.Set("__syslog_message_proc_id", *v)
+	}
+	if v := rfc3164Msg.MsgID; v != nil {
+		lb.Set("__syslog_message_msg_id", *v)
+	}
+
+	processed := relabel.Process(lb.Labels(nil), t.relabelConfig...)
+
+	filtered := make(model.LabelSet)
+	for _, lbl := range processed {
+		if strings.HasPrefix(lbl.Name, "__") {
+			continue
+		}
+		filtered[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
+	var timestamp time.Time
+	if t.config.UseIncomingTimestamp && rfc3164Msg.Timestamp != nil {
+		timestamp = *rfc3164Msg.Timestamp
+	} else {
+		timestamp = time.Now()
+	}
+
+	m := *rfc3164Msg.Message
+
+	t.messages <- message{filtered, m, timestamp}
+}
+
+func (t *SyslogTarget) handleMessage(connLabels labels.Labels, msg syslog.Message) {
+	if t.config.IsRFC3164Message {
+		t.handleMessageRFC3164(connLabels, msg)
+	} else {
+		t.handleMessageRFC5424(connLabels, msg)
+	}
 }
 
 func (t *SyslogTarget) messageSender(entries chan<- api.Entry) {

--- a/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
@@ -916,7 +916,7 @@ func TestParseStream_WithAsyncPipe(t *testing.T) {
 		results = append(results, res)
 	}
 
-	err := syslogparser.ParseStream(pipe, cb, defaultMaxMessageLength)
+	err := syslogparser.ParseStream(false, pipe, cb, defaultMaxMessageLength)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(results))
 }

--- a/clients/pkg/promtail/targets/syslog/transport.go
+++ b/clients/pkg/promtail/targets/syslog/transport.go
@@ -274,7 +274,7 @@ func (t *TCPTransport) handleConnection(cn net.Conn) {
 
 	lbs := t.connectionLabels(ipFromConn(c).String())
 
-	err := syslogparser.ParseStream(c, func(result *syslog.Result) {
+	err := syslogparser.ParseStream(t.config.IsRFC3164Message, c, func(result *syslog.Result) {
 		if err := result.Error; err != nil {
 			t.handleMessageError(err)
 			return
@@ -383,7 +383,7 @@ func (t *UDPTransport) handleRcv(c *ConnPipe) {
 	defer t.openConnections.Done()
 
 	lbs := t.connectionLabels(c.addr.String())
-	err := syslogparser.ParseStream(c, func(result *syslog.Result) {
+	err := syslogparser.ParseStream(t.config.IsRFC3164Message, c, func(result *syslog.Result) {
 		if err := result.Error; err != nil {
 			t.handleMessageError(err)
 		} else {

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -167,7 +167,7 @@ func validateSampleExpr(expr SampleExpr) error {
 		}
 
 		return validateSampleExpr(e.RHS)
-	case *LiteralExpr , *VectorExpr:
+	case *LiteralExpr, *VectorExpr:
 		return nil
 	default:
 		return validateMatchers(expr.Selector().Matchers())

--- a/vendor/github.com/influxdata/go-syslog/v3/nontransparent/parser.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/nontransparent/parser.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	syslog "github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 	parser "github.com/leodido/ragel-machinery/parser"
 )
@@ -213,6 +214,29 @@ func NewParser(options ...syslog.ParserOption) syslog.Parser {
 		m.internal = rfc5424.NewMachine(rfc5424.WithBestEffort())
 	} else {
 		m.internal = rfc5424.NewMachine()
+	}
+
+	return m
+}
+
+func NewParserRFC3164(options ...syslog.ParserOption) syslog.Parser {
+	m := &machine{
+		emit: func(*syslog.Result) { /* noop */ },
+	}
+
+	for _, opt := range options {
+		m = opt(m).(*machine)
+	}
+
+	// No error can happens since during its setting we check the trailer type passed in
+	trailer, _ := m.trailertyp.Value()
+	m.trailer = byte(trailer)
+
+	// Create internal parser depending on options
+	if m.bestEffort {
+		m.internal = rfc3164.NewMachine(rfc3164.WithBestEffort())
+	} else {
+		m.internal = rfc3164.NewMachine()
 	}
 
 	return m

--- a/vendor/github.com/influxdata/go-syslog/v3/octetcounting/parser.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/octetcounting/parser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	syslog "github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 )
 
@@ -38,6 +39,26 @@ func NewParser(opts ...syslog.ParserOption) syslog.Parser {
 		p.internal = rfc5424.NewMachine(rfc5424.WithBestEffort())
 	} else {
 		p.internal = rfc5424.NewMachine()
+	}
+
+	return p
+}
+
+func NewParserRFC3164(opts ...syslog.ParserOption) syslog.Parser {
+	p := &parser{
+		emit:             func(*syslog.Result) { /* noop */ },
+		maxMessageLength: 1024,
+	}
+
+	for _, opt := range opts {
+		p = opt(p).(*parser)
+	}
+
+	// Create internal parser depending on options
+	if p.bestEffort {
+		p.internal = rfc3164.NewMachine(rfc3164.WithBestEffort())
+	} else {
+		p.internal = rfc3164.NewMachine()
 	}
 
 	return p

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/example_test.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/example_test.go
@@ -1,0 +1,186 @@
+package rfc3164
+
+import (
+	// "time"
+
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func output(out interface{}) {
+	spew.Config.DisableCapacities = true
+	spew.Config.DisablePointerAddresses = true
+	spew.Dump(out)
+}
+
+func Example() {
+	i := []byte(`<13>Dec  2 16:31:03 host app: Test`)
+	p := NewParser()
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(0000-12-02 16:31:03 +0000 UTC),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}
+
+func Example_currentyear() {
+	i := []byte(`<13>Dec  2 16:31:03 host app: Test`)
+	p := NewParser(WithYear(CurrentYear{}))
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(2021-12-02 16:31:03 +0000 UTC),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}
+
+func Example_withtimezone() {
+	cet, _ := time.LoadLocation("CET")
+	i := []byte(`<13>Jan 30 02:08:03 host app: Test`)
+	p := NewParser(WithTimezone(cet))
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(0000-01-30 03:08:03 +0100 CET),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}
+
+func Example_withlocaletimezone() {
+	pst, _ := time.LoadLocation("America/New_York")
+	i := []byte(`<13>Nov 22 17:09:42 xxx kernel: [118479565.921459] EXT4-fs warning (device sda8): ext4_dx_add_entry:2006: Directory index full!`)
+	p := NewParser(WithLocaleTimezone(pst))
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(0000-11-22 17:09:42 -0456 LMT),
+	//   Hostname: (*string)((len=3) "xxx"),
+	//   Appname: (*string)((len=6) "kernel"),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=95) "[118479565.921459] EXT4-fs warning (device sda8): ext4_dx_add_entry:2006: Directory index full!")
+	//  }
+	// })
+}
+
+func Example_withtimezone_and_year() {
+	est, _ := time.LoadLocation("EST")
+	i := []byte(`<13>Jan 30 02:08:03 host app: Test`)
+	p := NewParser(WithTimezone(est), WithYear(Year{YYYY: 1987}))
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(1987-01-29 21:08:03 -0500 EST),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}
+
+func Example_besteffort() {
+	i := []byte(`<13>Dec  2 16:31:03 -`)
+	p := NewParser(WithBestEffort())
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(1),
+	//   Severity: (*uint8)(5),
+	//   Priority: (*uint8)(13),
+	//   Timestamp: (*time.Time)(0000-12-02 16:31:03 +0000 UTC),
+	//   Hostname: (*string)(<nil>),
+	//   Appname: (*string)(<nil>),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)(<nil>)
+	//  }
+	// })
+}
+
+func Example_rfc3339timestamp() {
+	i := []byte(`<28>2019-12-02T16:49:23+02:00 host app[23410]: Test`)
+	p := NewParser(WithRFC3339())
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(3),
+	//   Severity: (*uint8)(4),
+	//   Priority: (*uint8)(28),
+	//   Timestamp: (*time.Time)(2019-12-02 16:49:23 +0200 +0200),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)((len=5) "23410"),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}
+
+func Example_stamp_also_when_rfc3339() {
+	i := []byte(`<28>Dec  2 16:49:23 host app[23410]: Test`)
+	p := NewParser(WithYear(Year{YYYY: 2019}), WithRFC3339())
+	m, _ := p.Parse(i)
+	output(m)
+	// Output:
+	// (*rfc3164.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(3),
+	//   Severity: (*uint8)(4),
+	//   Priority: (*uint8)(28),
+	//   Timestamp: (*time.Time)(2019-12-02 16:49:23 +0000 UTC),
+	//   Hostname: (*string)((len=4) "host"),
+	//   Appname: (*string)((len=3) "app"),
+	//   ProcID: (*string)((len=5) "23410"),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)((len=4) "Test")
+	//  }
+	// })
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine.go
@@ -1,0 +1,7263 @@
+package rfc3164
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/common"
+)
+
+var (
+	errPrival       = "expecting a priority value in the range 1-191 or equal to 0 [col %d]"
+	errPri          = "expecting a priority value within angle brackets [col %d]"
+	errTimestamp    = "expecting a Stamp timestamp [col %d]"
+	errRFC3339      = "expecting a Stamp or a RFC3339 timestamp [col %d]"
+	errHostname     = "expecting an hostname (from 1 to max 255 US-ASCII characters) [col %d]"
+	errTag          = "expecting an alphanumeric tag (max 32 characters) [col %d]"
+	errContentStart = "expecting a content part starting with a non-alphanumeric character [col %d]"
+	errContent      = "expecting a content part composed by visible characters only [col %d]"
+	errParse        = "parsing error [col %d]"
+)
+
+const start int = 1
+const firstFinal int = 333
+
+const enFail int = 373
+const enMain int = 1
+
+type machine struct {
+	data       []byte
+	cs         int
+	p, pe, eof int
+	pb         int
+	err        error
+	bestEffort bool
+	yyyy       int
+	rfc3339    bool
+	loc        *time.Location
+	timezone   *time.Location
+}
+
+// NewMachine creates a new FSM able to parse RFC3164 syslog messages.
+func NewMachine(options ...syslog.MachineOption) syslog.Machine {
+	m := &machine{}
+
+	for _, opt := range options {
+		opt(m)
+	}
+
+	return m
+}
+
+// WithBestEffort enables best effort mode.
+func (m *machine) WithBestEffort() {
+	m.bestEffort = true
+}
+
+// HasBestEffort tells whether the receiving machine has best effort mode on or off.
+func (m *machine) HasBestEffort() bool {
+	return m.bestEffort
+}
+
+// WithYear sets the year for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithYear(o YearOperator) {
+	m.yyyy = YearOperation{o}.Operate()
+}
+
+// WithTimezone sets the time zone for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithTimezone(loc *time.Location) {
+	m.loc = loc
+}
+
+// WithLocaleTimezone sets the locale time zone for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithLocaleTimezone(loc *time.Location) {
+	m.timezone = loc
+}
+
+// WithRFC3339 enables ability to ALSO match RFC3339 timestamps.
+//
+// Notice this does not disable the default and correct timestamps - ie., Stamp timestamps.
+func (m *machine) WithRFC3339() {
+	m.rfc3339 = true
+}
+
+// Err returns the error that occurred on the last call to Parse.
+//
+// If the result is nil, then the line was parsed successfully.
+func (m *machine) Err() error {
+	return m.err
+}
+
+func (m *machine) text() []byte {
+	return m.data[m.pb:m.p]
+}
+
+// Parse parses the input byte array as a RFC3164 syslog message.
+func (m *machine) Parse(input []byte) (syslog.Message, error) {
+	m.data = input
+	m.p = 0
+	m.pb = 0
+	m.pe = len(input)
+	m.eof = len(input)
+	m.err = nil
+	output := &syslogMessage{}
+
+	{
+		m.cs = start
+	}
+
+	{
+		var _widec int16
+		if (m.p) == (m.pe) {
+			goto _testEof
+		}
+		switch m.cs {
+		case 1:
+			goto stCase1
+		case 0:
+			goto stCase0
+		case 2:
+			goto stCase2
+		case 3:
+			goto stCase3
+		case 4:
+			goto stCase4
+		case 5:
+			goto stCase5
+		case 6:
+			goto stCase6
+		case 7:
+			goto stCase7
+		case 8:
+			goto stCase8
+		case 9:
+			goto stCase9
+		case 10:
+			goto stCase10
+		case 11:
+			goto stCase11
+		case 12:
+			goto stCase12
+		case 13:
+			goto stCase13
+		case 14:
+			goto stCase14
+		case 15:
+			goto stCase15
+		case 16:
+			goto stCase16
+		case 17:
+			goto stCase17
+		case 18:
+			goto stCase18
+		case 19:
+			goto stCase19
+		case 20:
+			goto stCase20
+		case 21:
+			goto stCase21
+		case 22:
+			goto stCase22
+		case 333:
+			goto stCase333
+		case 334:
+			goto stCase334
+		case 335:
+			goto stCase335
+		case 336:
+			goto stCase336
+		case 337:
+			goto stCase337
+		case 338:
+			goto stCase338
+		case 339:
+			goto stCase339
+		case 340:
+			goto stCase340
+		case 341:
+			goto stCase341
+		case 342:
+			goto stCase342
+		case 343:
+			goto stCase343
+		case 344:
+			goto stCase344
+		case 345:
+			goto stCase345
+		case 346:
+			goto stCase346
+		case 347:
+			goto stCase347
+		case 348:
+			goto stCase348
+		case 349:
+			goto stCase349
+		case 350:
+			goto stCase350
+		case 351:
+			goto stCase351
+		case 352:
+			goto stCase352
+		case 353:
+			goto stCase353
+		case 354:
+			goto stCase354
+		case 355:
+			goto stCase355
+		case 356:
+			goto stCase356
+		case 357:
+			goto stCase357
+		case 358:
+			goto stCase358
+		case 359:
+			goto stCase359
+		case 360:
+			goto stCase360
+		case 361:
+			goto stCase361
+		case 362:
+			goto stCase362
+		case 363:
+			goto stCase363
+		case 364:
+			goto stCase364
+		case 365:
+			goto stCase365
+		case 366:
+			goto stCase366
+		case 367:
+			goto stCase367
+		case 368:
+			goto stCase368
+		case 23:
+			goto stCase23
+		case 24:
+			goto stCase24
+		case 25:
+			goto stCase25
+		case 26:
+			goto stCase26
+		case 369:
+			goto stCase369
+		case 370:
+			goto stCase370
+		case 371:
+			goto stCase371
+		case 372:
+			goto stCase372
+		case 27:
+			goto stCase27
+		case 28:
+			goto stCase28
+		case 29:
+			goto stCase29
+		case 30:
+			goto stCase30
+		case 31:
+			goto stCase31
+		case 32:
+			goto stCase32
+		case 33:
+			goto stCase33
+		case 34:
+			goto stCase34
+		case 35:
+			goto stCase35
+		case 36:
+			goto stCase36
+		case 37:
+			goto stCase37
+		case 38:
+			goto stCase38
+		case 39:
+			goto stCase39
+		case 40:
+			goto stCase40
+		case 41:
+			goto stCase41
+		case 42:
+			goto stCase42
+		case 43:
+			goto stCase43
+		case 44:
+			goto stCase44
+		case 45:
+			goto stCase45
+		case 46:
+			goto stCase46
+		case 47:
+			goto stCase47
+		case 48:
+			goto stCase48
+		case 49:
+			goto stCase49
+		case 50:
+			goto stCase50
+		case 51:
+			goto stCase51
+		case 52:
+			goto stCase52
+		case 53:
+			goto stCase53
+		case 54:
+			goto stCase54
+		case 55:
+			goto stCase55
+		case 56:
+			goto stCase56
+		case 57:
+			goto stCase57
+		case 58:
+			goto stCase58
+		case 59:
+			goto stCase59
+		case 60:
+			goto stCase60
+		case 61:
+			goto stCase61
+		case 62:
+			goto stCase62
+		case 63:
+			goto stCase63
+		case 64:
+			goto stCase64
+		case 65:
+			goto stCase65
+		case 66:
+			goto stCase66
+		case 67:
+			goto stCase67
+		case 68:
+			goto stCase68
+		case 69:
+			goto stCase69
+		case 70:
+			goto stCase70
+		case 71:
+			goto stCase71
+		case 72:
+			goto stCase72
+		case 73:
+			goto stCase73
+		case 74:
+			goto stCase74
+		case 75:
+			goto stCase75
+		case 76:
+			goto stCase76
+		case 77:
+			goto stCase77
+		case 78:
+			goto stCase78
+		case 79:
+			goto stCase79
+		case 80:
+			goto stCase80
+		case 81:
+			goto stCase81
+		case 82:
+			goto stCase82
+		case 83:
+			goto stCase83
+		case 84:
+			goto stCase84
+		case 85:
+			goto stCase85
+		case 86:
+			goto stCase86
+		case 87:
+			goto stCase87
+		case 88:
+			goto stCase88
+		case 89:
+			goto stCase89
+		case 90:
+			goto stCase90
+		case 91:
+			goto stCase91
+		case 92:
+			goto stCase92
+		case 93:
+			goto stCase93
+		case 94:
+			goto stCase94
+		case 95:
+			goto stCase95
+		case 96:
+			goto stCase96
+		case 97:
+			goto stCase97
+		case 98:
+			goto stCase98
+		case 99:
+			goto stCase99
+		case 100:
+			goto stCase100
+		case 101:
+			goto stCase101
+		case 102:
+			goto stCase102
+		case 103:
+			goto stCase103
+		case 104:
+			goto stCase104
+		case 105:
+			goto stCase105
+		case 106:
+			goto stCase106
+		case 107:
+			goto stCase107
+		case 108:
+			goto stCase108
+		case 109:
+			goto stCase109
+		case 110:
+			goto stCase110
+		case 111:
+			goto stCase111
+		case 112:
+			goto stCase112
+		case 113:
+			goto stCase113
+		case 114:
+			goto stCase114
+		case 115:
+			goto stCase115
+		case 116:
+			goto stCase116
+		case 117:
+			goto stCase117
+		case 118:
+			goto stCase118
+		case 119:
+			goto stCase119
+		case 120:
+			goto stCase120
+		case 121:
+			goto stCase121
+		case 122:
+			goto stCase122
+		case 123:
+			goto stCase123
+		case 124:
+			goto stCase124
+		case 125:
+			goto stCase125
+		case 126:
+			goto stCase126
+		case 127:
+			goto stCase127
+		case 128:
+			goto stCase128
+		case 129:
+			goto stCase129
+		case 130:
+			goto stCase130
+		case 131:
+			goto stCase131
+		case 132:
+			goto stCase132
+		case 133:
+			goto stCase133
+		case 134:
+			goto stCase134
+		case 135:
+			goto stCase135
+		case 136:
+			goto stCase136
+		case 137:
+			goto stCase137
+		case 138:
+			goto stCase138
+		case 139:
+			goto stCase139
+		case 140:
+			goto stCase140
+		case 141:
+			goto stCase141
+		case 142:
+			goto stCase142
+		case 143:
+			goto stCase143
+		case 144:
+			goto stCase144
+		case 145:
+			goto stCase145
+		case 146:
+			goto stCase146
+		case 147:
+			goto stCase147
+		case 148:
+			goto stCase148
+		case 149:
+			goto stCase149
+		case 150:
+			goto stCase150
+		case 151:
+			goto stCase151
+		case 152:
+			goto stCase152
+		case 153:
+			goto stCase153
+		case 154:
+			goto stCase154
+		case 155:
+			goto stCase155
+		case 156:
+			goto stCase156
+		case 157:
+			goto stCase157
+		case 158:
+			goto stCase158
+		case 159:
+			goto stCase159
+		case 160:
+			goto stCase160
+		case 161:
+			goto stCase161
+		case 162:
+			goto stCase162
+		case 163:
+			goto stCase163
+		case 164:
+			goto stCase164
+		case 165:
+			goto stCase165
+		case 166:
+			goto stCase166
+		case 167:
+			goto stCase167
+		case 168:
+			goto stCase168
+		case 169:
+			goto stCase169
+		case 170:
+			goto stCase170
+		case 171:
+			goto stCase171
+		case 172:
+			goto stCase172
+		case 173:
+			goto stCase173
+		case 174:
+			goto stCase174
+		case 175:
+			goto stCase175
+		case 176:
+			goto stCase176
+		case 177:
+			goto stCase177
+		case 178:
+			goto stCase178
+		case 179:
+			goto stCase179
+		case 180:
+			goto stCase180
+		case 181:
+			goto stCase181
+		case 182:
+			goto stCase182
+		case 183:
+			goto stCase183
+		case 184:
+			goto stCase184
+		case 185:
+			goto stCase185
+		case 186:
+			goto stCase186
+		case 187:
+			goto stCase187
+		case 188:
+			goto stCase188
+		case 189:
+			goto stCase189
+		case 190:
+			goto stCase190
+		case 191:
+			goto stCase191
+		case 192:
+			goto stCase192
+		case 193:
+			goto stCase193
+		case 194:
+			goto stCase194
+		case 195:
+			goto stCase195
+		case 196:
+			goto stCase196
+		case 197:
+			goto stCase197
+		case 198:
+			goto stCase198
+		case 199:
+			goto stCase199
+		case 200:
+			goto stCase200
+		case 201:
+			goto stCase201
+		case 202:
+			goto stCase202
+		case 203:
+			goto stCase203
+		case 204:
+			goto stCase204
+		case 205:
+			goto stCase205
+		case 206:
+			goto stCase206
+		case 207:
+			goto stCase207
+		case 208:
+			goto stCase208
+		case 209:
+			goto stCase209
+		case 210:
+			goto stCase210
+		case 211:
+			goto stCase211
+		case 212:
+			goto stCase212
+		case 213:
+			goto stCase213
+		case 214:
+			goto stCase214
+		case 215:
+			goto stCase215
+		case 216:
+			goto stCase216
+		case 217:
+			goto stCase217
+		case 218:
+			goto stCase218
+		case 219:
+			goto stCase219
+		case 220:
+			goto stCase220
+		case 221:
+			goto stCase221
+		case 222:
+			goto stCase222
+		case 223:
+			goto stCase223
+		case 224:
+			goto stCase224
+		case 225:
+			goto stCase225
+		case 226:
+			goto stCase226
+		case 227:
+			goto stCase227
+		case 228:
+			goto stCase228
+		case 229:
+			goto stCase229
+		case 230:
+			goto stCase230
+		case 231:
+			goto stCase231
+		case 232:
+			goto stCase232
+		case 233:
+			goto stCase233
+		case 234:
+			goto stCase234
+		case 235:
+			goto stCase235
+		case 236:
+			goto stCase236
+		case 237:
+			goto stCase237
+		case 238:
+			goto stCase238
+		case 239:
+			goto stCase239
+		case 240:
+			goto stCase240
+		case 241:
+			goto stCase241
+		case 242:
+			goto stCase242
+		case 243:
+			goto stCase243
+		case 244:
+			goto stCase244
+		case 245:
+			goto stCase245
+		case 246:
+			goto stCase246
+		case 247:
+			goto stCase247
+		case 248:
+			goto stCase248
+		case 249:
+			goto stCase249
+		case 250:
+			goto stCase250
+		case 251:
+			goto stCase251
+		case 252:
+			goto stCase252
+		case 253:
+			goto stCase253
+		case 254:
+			goto stCase254
+		case 255:
+			goto stCase255
+		case 256:
+			goto stCase256
+		case 257:
+			goto stCase257
+		case 258:
+			goto stCase258
+		case 259:
+			goto stCase259
+		case 260:
+			goto stCase260
+		case 261:
+			goto stCase261
+		case 262:
+			goto stCase262
+		case 263:
+			goto stCase263
+		case 264:
+			goto stCase264
+		case 265:
+			goto stCase265
+		case 266:
+			goto stCase266
+		case 267:
+			goto stCase267
+		case 268:
+			goto stCase268
+		case 269:
+			goto stCase269
+		case 270:
+			goto stCase270
+		case 271:
+			goto stCase271
+		case 272:
+			goto stCase272
+		case 273:
+			goto stCase273
+		case 274:
+			goto stCase274
+		case 275:
+			goto stCase275
+		case 276:
+			goto stCase276
+		case 277:
+			goto stCase277
+		case 278:
+			goto stCase278
+		case 279:
+			goto stCase279
+		case 280:
+			goto stCase280
+		case 281:
+			goto stCase281
+		case 282:
+			goto stCase282
+		case 283:
+			goto stCase283
+		case 284:
+			goto stCase284
+		case 285:
+			goto stCase285
+		case 286:
+			goto stCase286
+		case 287:
+			goto stCase287
+		case 288:
+			goto stCase288
+		case 289:
+			goto stCase289
+		case 290:
+			goto stCase290
+		case 291:
+			goto stCase291
+		case 292:
+			goto stCase292
+		case 293:
+			goto stCase293
+		case 294:
+			goto stCase294
+		case 295:
+			goto stCase295
+		case 296:
+			goto stCase296
+		case 297:
+			goto stCase297
+		case 298:
+			goto stCase298
+		case 299:
+			goto stCase299
+		case 300:
+			goto stCase300
+		case 301:
+			goto stCase301
+		case 302:
+			goto stCase302
+		case 303:
+			goto stCase303
+		case 304:
+			goto stCase304
+		case 305:
+			goto stCase305
+		case 306:
+			goto stCase306
+		case 307:
+			goto stCase307
+		case 308:
+			goto stCase308
+		case 309:
+			goto stCase309
+		case 310:
+			goto stCase310
+		case 311:
+			goto stCase311
+		case 312:
+			goto stCase312
+		case 313:
+			goto stCase313
+		case 314:
+			goto stCase314
+		case 315:
+			goto stCase315
+		case 316:
+			goto stCase316
+		case 317:
+			goto stCase317
+		case 318:
+			goto stCase318
+		case 319:
+			goto stCase319
+		case 320:
+			goto stCase320
+		case 321:
+			goto stCase321
+		case 322:
+			goto stCase322
+		case 323:
+			goto stCase323
+		case 324:
+			goto stCase324
+		case 325:
+			goto stCase325
+		case 326:
+			goto stCase326
+		case 327:
+			goto stCase327
+		case 328:
+			goto stCase328
+		case 329:
+			goto stCase329
+		case 330:
+			goto stCase330
+		case 331:
+			goto stCase331
+		case 332:
+			goto stCase332
+		case 373:
+			goto stCase373
+		}
+		goto stOut
+	stCase1:
+		if (m.data)[(m.p)] == 60 {
+			goto st2
+		}
+		goto tr0
+	tr0:
+
+		m.err = fmt.Errorf(errPri, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	tr2:
+
+		m.err = fmt.Errorf(errPrival, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		m.err = fmt.Errorf(errPri, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	tr7:
+
+		m.err = fmt.Errorf(errTimestamp, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	tr37:
+
+		m.err = fmt.Errorf(errHostname, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	tr41:
+
+		m.err = fmt.Errorf(errTag, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	tr333:
+
+		m.err = fmt.Errorf(errRFC3339, m.p)
+		(m.p)--
+
+		{
+			goto st373
+		}
+
+		goto st0
+	stCase0:
+	st0:
+		m.cs = 0
+		goto _out
+	st2:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof2
+		}
+	stCase2:
+		switch (m.data)[(m.p)] {
+		case 48:
+			goto tr3
+		case 49:
+			goto tr4
+		}
+		if 50 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto tr5
+		}
+		goto tr2
+	tr3:
+
+		m.pb = m.p
+
+		goto st3
+	st3:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof3
+		}
+	stCase3:
+
+		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+		output.prioritySet = true
+
+		if (m.data)[(m.p)] == 62 {
+			goto st4
+		}
+		goto tr2
+	st4:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof4
+		}
+	stCase4:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 65:
+			goto tr8
+		case 68:
+			goto tr9
+		case 70:
+			goto tr10
+		case 74:
+			goto tr11
+		case 77:
+			goto tr12
+		case 78:
+			goto tr13
+		case 79:
+			goto tr14
+		case 83:
+			goto tr15
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto tr16
+		}
+		goto tr7
+	tr8:
+
+		m.pb = m.p
+
+		goto st5
+	st5:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof5
+		}
+	stCase5:
+		switch (m.data)[(m.p)] {
+		case 112:
+			goto st6
+		case 117:
+			goto st284
+		}
+		goto tr7
+	st6:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof6
+		}
+	stCase6:
+		if (m.data)[(m.p)] == 114 {
+			goto st7
+		}
+		goto tr7
+	st7:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof7
+		}
+	stCase7:
+		if (m.data)[(m.p)] == 32 {
+			goto st8
+		}
+		goto tr7
+	st8:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof8
+		}
+	stCase8:
+		switch (m.data)[(m.p)] {
+		case 32:
+			goto st9
+		case 51:
+			goto st283
+		}
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
+			goto st282
+		}
+		goto tr7
+	st9:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof9
+		}
+	stCase9:
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st10
+		}
+		goto tr7
+	st10:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof10
+		}
+	stCase10:
+		if (m.data)[(m.p)] == 32 {
+			goto st11
+		}
+		goto tr7
+	st11:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof11
+		}
+	stCase11:
+		if (m.data)[(m.p)] == 50 {
+			goto st281
+		}
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
+			goto st12
+		}
+		goto tr7
+	st12:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof12
+		}
+	stCase12:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st13
+		}
+		goto tr7
+	st13:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof13
+		}
+	stCase13:
+		if (m.data)[(m.p)] == 58 {
+			goto st14
+		}
+		goto tr7
+	st14:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof14
+		}
+	stCase14:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
+			goto st15
+		}
+		goto tr7
+	st15:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof15
+		}
+	stCase15:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st16
+		}
+		goto tr7
+	st16:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof16
+		}
+	stCase16:
+		if (m.data)[(m.p)] == 58 {
+			goto st17
+		}
+		goto tr7
+	st17:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof17
+		}
+	stCase17:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
+			goto st18
+		}
+		goto tr7
+	st18:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof18
+		}
+	stCase18:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st19
+		}
+		goto tr7
+	st19:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof19
+		}
+	stCase19:
+		if (m.data)[(m.p)] == 32 {
+			goto tr35
+		}
+		goto st0
+	tr35:
+
+		if t, e := time.Parse(time.Stamp, string(m.text())); e != nil {
+			m.err = fmt.Errorf("%s [col %d]", e, m.p)
+			(m.p)--
+
+			{
+				goto st373
+			}
+		} else {
+			if m.timezone != nil {
+				t, _ = time.ParseInLocation(time.Stamp, string(m.text()), m.timezone)
+			}
+			output.timestamp = t.AddDate(m.yyyy, 0, 0)
+			if m.loc != nil {
+				output.timestamp = output.timestamp.In(m.loc)
+			}
+			output.timestampSet = true
+		}
+
+		goto st20
+	tr341:
+
+		if t, e := time.Parse(time.RFC3339, string(m.text())); e != nil {
+			m.err = fmt.Errorf("%s [col %d]", e, m.p)
+			(m.p)--
+
+			{
+				goto st373
+			}
+		} else {
+			output.timestamp = t
+			output.timestampSet = true
+		}
+
+		goto st20
+	st20:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof20
+		}
+	stCase20:
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto tr38
+		}
+		goto tr37
+	tr38:
+
+		m.pb = m.p
+
+		goto st21
+	st21:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof21
+		}
+	stCase21:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st27
+		}
+		goto tr37
+	tr39:
+
+		output.hostname = string(m.text())
+
+		goto st22
+	st22:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof22
+		}
+	stCase22:
+		if (m.data)[(m.p)] == 127 {
+			goto tr41
+		}
+		switch {
+		case (m.data)[(m.p)] < 33:
+			if (m.data)[(m.p)] <= 31 {
+				goto tr41
+			}
+		case (m.data)[(m.p)] > 57:
+			switch {
+			case (m.data)[(m.p)] > 90:
+				if 92 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+					goto tr43
+				}
+			case (m.data)[(m.p)] >= 59:
+				goto tr43
+			}
+		default:
+			goto tr43
+		}
+		goto tr42
+	tr42:
+
+		m.pb = m.p
+
+		goto st333
+	st333:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof333
+		}
+	stCase333:
+		if (m.data)[(m.p)] == 127 {
+			goto st0
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st0
+		}
+		goto st333
+	tr43:
+
+		m.pb = m.p
+
+		goto st334
+	st334:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof334
+		}
+	stCase334:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st335
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st335:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof335
+		}
+	stCase335:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st336
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st336:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof336
+		}
+	stCase336:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st337
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st337:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof337
+		}
+	stCase337:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st338
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st338:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof338
+		}
+	stCase338:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st339
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st339:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof339
+		}
+	stCase339:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st340
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st340:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof340
+		}
+	stCase340:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st341
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st341:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof341
+		}
+	stCase341:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st342
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st342:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof342
+		}
+	stCase342:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st343
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st343:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof343
+		}
+	stCase343:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st344
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st344:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof344
+		}
+	stCase344:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st345
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st345:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof345
+		}
+	stCase345:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st346
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st346:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof346
+		}
+	stCase346:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st347
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st347:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof347
+		}
+	stCase347:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st348
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st348:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof348
+		}
+	stCase348:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st349
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st349:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof349
+		}
+	stCase349:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st350
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st350:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof350
+		}
+	stCase350:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st351
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st351:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof351
+		}
+	stCase351:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st352
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st352:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof352
+		}
+	stCase352:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st353
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st353:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof353
+		}
+	stCase353:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st354
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st354:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof354
+		}
+	stCase354:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st355
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st355:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof355
+		}
+	stCase355:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st356
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st356:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof356
+		}
+	stCase356:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st357
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st357:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof357
+		}
+	stCase357:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st358
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st358:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof358
+		}
+	stCase358:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st359
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st359:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof359
+		}
+	stCase359:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st360
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st360:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof360
+		}
+	stCase360:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st361
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st361:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof361
+		}
+	stCase361:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st362
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st362:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof362
+		}
+	stCase362:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st363
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st363:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof363
+		}
+	stCase363:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st364
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st364:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof364
+		}
+	stCase364:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		switch {
+		case (m.data)[(m.p)] > 31:
+			if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+				goto st365
+			}
+		default:
+			goto st0
+		}
+		goto st333
+	st365:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof365
+		}
+	stCase365:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto tr347
+		case 91:
+			goto tr348
+		case 127:
+			goto st0
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st0
+		}
+		goto st333
+	tr347:
+
+		output.tag = string(m.text())
+
+		goto st366
+	st366:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof366
+		}
+	stCase366:
+		switch (m.data)[(m.p)] {
+		case 32:
+			goto st367
+		case 127:
+			goto st0
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st0
+		}
+		goto st333
+	st367:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof367
+		}
+	stCase367:
+		if (m.data)[(m.p)] == 127 {
+			goto st0
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st0
+		}
+		goto tr42
+	tr348:
+
+		output.tag = string(m.text())
+
+		goto st368
+	st368:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof368
+		}
+	stCase368:
+		switch (m.data)[(m.p)] {
+		case 93:
+			goto tr381
+		case 127:
+			goto tr380
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto tr380
+		}
+		goto tr48
+	tr380:
+
+		m.pb = m.p
+
+		goto st23
+	st23:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof23
+		}
+	stCase23:
+		if (m.data)[(m.p)] == 93 {
+			goto tr45
+		}
+		goto st23
+	tr45:
+
+		output.content = string(m.text())
+
+		goto st24
+	st24:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof24
+		}
+	stCase24:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto st25
+		case 93:
+			goto tr45
+		}
+		goto st23
+	st25:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof25
+		}
+	stCase25:
+		switch (m.data)[(m.p)] {
+		case 32:
+			goto st26
+		case 93:
+			goto tr45
+		}
+		goto st23
+	st26:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof26
+		}
+	stCase26:
+		switch (m.data)[(m.p)] {
+		case 93:
+			goto tr49
+		case 127:
+			goto st23
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st23
+		}
+		goto tr48
+	tr48:
+
+		m.pb = m.p
+
+		goto st369
+	st369:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof369
+		}
+	stCase369:
+		switch (m.data)[(m.p)] {
+		case 93:
+			goto tr383
+		case 127:
+			goto st23
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st23
+		}
+		goto st369
+	tr383:
+
+		output.content = string(m.text())
+
+		goto st370
+	tr49:
+
+		output.content = string(m.text())
+
+		m.pb = m.p
+
+		goto st370
+	tr381:
+
+		m.pb = m.p
+
+		output.content = string(m.text())
+
+		goto st370
+	st370:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof370
+		}
+	stCase370:
+		switch (m.data)[(m.p)] {
+		case 58:
+			goto st371
+		case 93:
+			goto tr383
+		case 127:
+			goto st23
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st23
+		}
+		goto st369
+	st371:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof371
+		}
+	stCase371:
+		switch (m.data)[(m.p)] {
+		case 32:
+			goto st372
+		case 93:
+			goto tr383
+		case 127:
+			goto st23
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st23
+		}
+		goto st369
+	st372:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof372
+		}
+	stCase372:
+		switch (m.data)[(m.p)] {
+		case 93:
+			goto tr49
+		case 127:
+			goto st23
+		}
+		if (m.data)[(m.p)] <= 31 {
+			goto st23
+		}
+		goto tr48
+	st27:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof27
+		}
+	stCase27:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st28
+		}
+		goto tr37
+	st28:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof28
+		}
+	stCase28:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st29
+		}
+		goto tr37
+	st29:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof29
+		}
+	stCase29:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st30
+		}
+		goto tr37
+	st30:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof30
+		}
+	stCase30:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st31
+		}
+		goto tr37
+	st31:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof31
+		}
+	stCase31:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st32
+		}
+		goto tr37
+	st32:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof32
+		}
+	stCase32:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st33
+		}
+		goto tr37
+	st33:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof33
+		}
+	stCase33:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st34
+		}
+		goto tr37
+	st34:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof34
+		}
+	stCase34:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st35
+		}
+		goto tr37
+	st35:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof35
+		}
+	stCase35:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st36
+		}
+		goto tr37
+	st36:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof36
+		}
+	stCase36:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st37
+		}
+		goto tr37
+	st37:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof37
+		}
+	stCase37:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st38
+		}
+		goto tr37
+	st38:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof38
+		}
+	stCase38:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st39
+		}
+		goto tr37
+	st39:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof39
+		}
+	stCase39:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st40
+		}
+		goto tr37
+	st40:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof40
+		}
+	stCase40:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st41
+		}
+		goto tr37
+	st41:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof41
+		}
+	stCase41:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st42
+		}
+		goto tr37
+	st42:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof42
+		}
+	stCase42:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st43
+		}
+		goto tr37
+	st43:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof43
+		}
+	stCase43:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st44
+		}
+		goto tr37
+	st44:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof44
+		}
+	stCase44:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st45
+		}
+		goto tr37
+	st45:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof45
+		}
+	stCase45:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st46
+		}
+		goto tr37
+	st46:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof46
+		}
+	stCase46:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st47
+		}
+		goto tr37
+	st47:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof47
+		}
+	stCase47:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st48
+		}
+		goto tr37
+	st48:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof48
+		}
+	stCase48:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st49
+		}
+		goto tr37
+	st49:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof49
+		}
+	stCase49:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st50
+		}
+		goto tr37
+	st50:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof50
+		}
+	stCase50:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st51
+		}
+		goto tr37
+	st51:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof51
+		}
+	stCase51:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st52
+		}
+		goto tr37
+	st52:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof52
+		}
+	stCase52:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st53
+		}
+		goto tr37
+	st53:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof53
+		}
+	stCase53:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st54
+		}
+		goto tr37
+	st54:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof54
+		}
+	stCase54:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st55
+		}
+		goto tr37
+	st55:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof55
+		}
+	stCase55:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st56
+		}
+		goto tr37
+	st56:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof56
+		}
+	stCase56:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st57
+		}
+		goto tr37
+	st57:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof57
+		}
+	stCase57:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st58
+		}
+		goto tr37
+	st58:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof58
+		}
+	stCase58:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st59
+		}
+		goto tr37
+	st59:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof59
+		}
+	stCase59:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st60
+		}
+		goto tr37
+	st60:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof60
+		}
+	stCase60:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st61
+		}
+		goto tr37
+	st61:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof61
+		}
+	stCase61:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st62
+		}
+		goto tr37
+	st62:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof62
+		}
+	stCase62:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st63
+		}
+		goto tr37
+	st63:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof63
+		}
+	stCase63:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st64
+		}
+		goto tr37
+	st64:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof64
+		}
+	stCase64:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st65
+		}
+		goto tr37
+	st65:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof65
+		}
+	stCase65:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st66
+		}
+		goto tr37
+	st66:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof66
+		}
+	stCase66:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st67
+		}
+		goto tr37
+	st67:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof67
+		}
+	stCase67:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st68
+		}
+		goto tr37
+	st68:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof68
+		}
+	stCase68:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st69
+		}
+		goto tr37
+	st69:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof69
+		}
+	stCase69:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st70
+		}
+		goto tr37
+	st70:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof70
+		}
+	stCase70:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st71
+		}
+		goto tr37
+	st71:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof71
+		}
+	stCase71:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st72
+		}
+		goto tr37
+	st72:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof72
+		}
+	stCase72:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st73
+		}
+		goto tr37
+	st73:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof73
+		}
+	stCase73:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st74
+		}
+		goto tr37
+	st74:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof74
+		}
+	stCase74:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st75
+		}
+		goto tr37
+	st75:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof75
+		}
+	stCase75:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st76
+		}
+		goto tr37
+	st76:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof76
+		}
+	stCase76:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st77
+		}
+		goto tr37
+	st77:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof77
+		}
+	stCase77:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st78
+		}
+		goto tr37
+	st78:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof78
+		}
+	stCase78:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st79
+		}
+		goto tr37
+	st79:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof79
+		}
+	stCase79:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st80
+		}
+		goto tr37
+	st80:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof80
+		}
+	stCase80:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st81
+		}
+		goto tr37
+	st81:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof81
+		}
+	stCase81:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st82
+		}
+		goto tr37
+	st82:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof82
+		}
+	stCase82:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st83
+		}
+		goto tr37
+	st83:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof83
+		}
+	stCase83:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st84
+		}
+		goto tr37
+	st84:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof84
+		}
+	stCase84:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st85
+		}
+		goto tr37
+	st85:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof85
+		}
+	stCase85:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st86
+		}
+		goto tr37
+	st86:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof86
+		}
+	stCase86:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st87
+		}
+		goto tr37
+	st87:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof87
+		}
+	stCase87:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st88
+		}
+		goto tr37
+	st88:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof88
+		}
+	stCase88:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st89
+		}
+		goto tr37
+	st89:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof89
+		}
+	stCase89:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st90
+		}
+		goto tr37
+	st90:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof90
+		}
+	stCase90:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st91
+		}
+		goto tr37
+	st91:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof91
+		}
+	stCase91:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st92
+		}
+		goto tr37
+	st92:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof92
+		}
+	stCase92:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st93
+		}
+		goto tr37
+	st93:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof93
+		}
+	stCase93:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st94
+		}
+		goto tr37
+	st94:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof94
+		}
+	stCase94:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st95
+		}
+		goto tr37
+	st95:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof95
+		}
+	stCase95:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st96
+		}
+		goto tr37
+	st96:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof96
+		}
+	stCase96:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st97
+		}
+		goto tr37
+	st97:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof97
+		}
+	stCase97:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st98
+		}
+		goto tr37
+	st98:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof98
+		}
+	stCase98:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st99
+		}
+		goto tr37
+	st99:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof99
+		}
+	stCase99:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st100
+		}
+		goto tr37
+	st100:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof100
+		}
+	stCase100:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st101
+		}
+		goto tr37
+	st101:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof101
+		}
+	stCase101:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st102
+		}
+		goto tr37
+	st102:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof102
+		}
+	stCase102:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st103
+		}
+		goto tr37
+	st103:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof103
+		}
+	stCase103:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st104
+		}
+		goto tr37
+	st104:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof104
+		}
+	stCase104:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st105
+		}
+		goto tr37
+	st105:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof105
+		}
+	stCase105:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st106
+		}
+		goto tr37
+	st106:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof106
+		}
+	stCase106:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st107
+		}
+		goto tr37
+	st107:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof107
+		}
+	stCase107:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st108
+		}
+		goto tr37
+	st108:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof108
+		}
+	stCase108:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st109
+		}
+		goto tr37
+	st109:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof109
+		}
+	stCase109:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st110
+		}
+		goto tr37
+	st110:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof110
+		}
+	stCase110:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st111
+		}
+		goto tr37
+	st111:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof111
+		}
+	stCase111:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st112
+		}
+		goto tr37
+	st112:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof112
+		}
+	stCase112:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st113
+		}
+		goto tr37
+	st113:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof113
+		}
+	stCase113:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st114
+		}
+		goto tr37
+	st114:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof114
+		}
+	stCase114:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st115
+		}
+		goto tr37
+	st115:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof115
+		}
+	stCase115:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st116
+		}
+		goto tr37
+	st116:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof116
+		}
+	stCase116:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st117
+		}
+		goto tr37
+	st117:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof117
+		}
+	stCase117:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st118
+		}
+		goto tr37
+	st118:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof118
+		}
+	stCase118:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st119
+		}
+		goto tr37
+	st119:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof119
+		}
+	stCase119:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st120
+		}
+		goto tr37
+	st120:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof120
+		}
+	stCase120:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st121
+		}
+		goto tr37
+	st121:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof121
+		}
+	stCase121:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st122
+		}
+		goto tr37
+	st122:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof122
+		}
+	stCase122:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st123
+		}
+		goto tr37
+	st123:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof123
+		}
+	stCase123:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st124
+		}
+		goto tr37
+	st124:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof124
+		}
+	stCase124:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st125
+		}
+		goto tr37
+	st125:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof125
+		}
+	stCase125:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st126
+		}
+		goto tr37
+	st126:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof126
+		}
+	stCase126:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st127
+		}
+		goto tr37
+	st127:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof127
+		}
+	stCase127:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st128
+		}
+		goto tr37
+	st128:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof128
+		}
+	stCase128:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st129
+		}
+		goto tr37
+	st129:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof129
+		}
+	stCase129:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st130
+		}
+		goto tr37
+	st130:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof130
+		}
+	stCase130:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st131
+		}
+		goto tr37
+	st131:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof131
+		}
+	stCase131:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st132
+		}
+		goto tr37
+	st132:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof132
+		}
+	stCase132:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st133
+		}
+		goto tr37
+	st133:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof133
+		}
+	stCase133:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st134
+		}
+		goto tr37
+	st134:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof134
+		}
+	stCase134:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st135
+		}
+		goto tr37
+	st135:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof135
+		}
+	stCase135:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st136
+		}
+		goto tr37
+	st136:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof136
+		}
+	stCase136:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st137
+		}
+		goto tr37
+	st137:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof137
+		}
+	stCase137:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st138
+		}
+		goto tr37
+	st138:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof138
+		}
+	stCase138:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st139
+		}
+		goto tr37
+	st139:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof139
+		}
+	stCase139:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st140
+		}
+		goto tr37
+	st140:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof140
+		}
+	stCase140:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st141
+		}
+		goto tr37
+	st141:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof141
+		}
+	stCase141:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st142
+		}
+		goto tr37
+	st142:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof142
+		}
+	stCase142:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st143
+		}
+		goto tr37
+	st143:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof143
+		}
+	stCase143:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st144
+		}
+		goto tr37
+	st144:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof144
+		}
+	stCase144:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st145
+		}
+		goto tr37
+	st145:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof145
+		}
+	stCase145:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st146
+		}
+		goto tr37
+	st146:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof146
+		}
+	stCase146:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st147
+		}
+		goto tr37
+	st147:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof147
+		}
+	stCase147:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st148
+		}
+		goto tr37
+	st148:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof148
+		}
+	stCase148:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st149
+		}
+		goto tr37
+	st149:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof149
+		}
+	stCase149:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st150
+		}
+		goto tr37
+	st150:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof150
+		}
+	stCase150:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st151
+		}
+		goto tr37
+	st151:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof151
+		}
+	stCase151:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st152
+		}
+		goto tr37
+	st152:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof152
+		}
+	stCase152:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st153
+		}
+		goto tr37
+	st153:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof153
+		}
+	stCase153:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st154
+		}
+		goto tr37
+	st154:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof154
+		}
+	stCase154:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st155
+		}
+		goto tr37
+	st155:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof155
+		}
+	stCase155:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st156
+		}
+		goto tr37
+	st156:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof156
+		}
+	stCase156:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st157
+		}
+		goto tr37
+	st157:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof157
+		}
+	stCase157:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st158
+		}
+		goto tr37
+	st158:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof158
+		}
+	stCase158:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st159
+		}
+		goto tr37
+	st159:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof159
+		}
+	stCase159:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st160
+		}
+		goto tr37
+	st160:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof160
+		}
+	stCase160:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st161
+		}
+		goto tr37
+	st161:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof161
+		}
+	stCase161:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st162
+		}
+		goto tr37
+	st162:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof162
+		}
+	stCase162:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st163
+		}
+		goto tr37
+	st163:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof163
+		}
+	stCase163:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st164
+		}
+		goto tr37
+	st164:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof164
+		}
+	stCase164:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st165
+		}
+		goto tr37
+	st165:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof165
+		}
+	stCase165:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st166
+		}
+		goto tr37
+	st166:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof166
+		}
+	stCase166:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st167
+		}
+		goto tr37
+	st167:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof167
+		}
+	stCase167:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st168
+		}
+		goto tr37
+	st168:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof168
+		}
+	stCase168:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st169
+		}
+		goto tr37
+	st169:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof169
+		}
+	stCase169:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st170
+		}
+		goto tr37
+	st170:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof170
+		}
+	stCase170:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st171
+		}
+		goto tr37
+	st171:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof171
+		}
+	stCase171:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st172
+		}
+		goto tr37
+	st172:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof172
+		}
+	stCase172:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st173
+		}
+		goto tr37
+	st173:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof173
+		}
+	stCase173:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st174
+		}
+		goto tr37
+	st174:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof174
+		}
+	stCase174:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st175
+		}
+		goto tr37
+	st175:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof175
+		}
+	stCase175:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st176
+		}
+		goto tr37
+	st176:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof176
+		}
+	stCase176:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st177
+		}
+		goto tr37
+	st177:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof177
+		}
+	stCase177:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st178
+		}
+		goto tr37
+	st178:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof178
+		}
+	stCase178:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st179
+		}
+		goto tr37
+	st179:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof179
+		}
+	stCase179:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st180
+		}
+		goto tr37
+	st180:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof180
+		}
+	stCase180:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st181
+		}
+		goto tr37
+	st181:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof181
+		}
+	stCase181:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st182
+		}
+		goto tr37
+	st182:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof182
+		}
+	stCase182:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st183
+		}
+		goto tr37
+	st183:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof183
+		}
+	stCase183:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st184
+		}
+		goto tr37
+	st184:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof184
+		}
+	stCase184:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st185
+		}
+		goto tr37
+	st185:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof185
+		}
+	stCase185:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st186
+		}
+		goto tr37
+	st186:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof186
+		}
+	stCase186:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st187
+		}
+		goto tr37
+	st187:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof187
+		}
+	stCase187:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st188
+		}
+		goto tr37
+	st188:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof188
+		}
+	stCase188:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st189
+		}
+		goto tr37
+	st189:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof189
+		}
+	stCase189:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st190
+		}
+		goto tr37
+	st190:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof190
+		}
+	stCase190:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st191
+		}
+		goto tr37
+	st191:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof191
+		}
+	stCase191:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st192
+		}
+		goto tr37
+	st192:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof192
+		}
+	stCase192:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st193
+		}
+		goto tr37
+	st193:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof193
+		}
+	stCase193:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st194
+		}
+		goto tr37
+	st194:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof194
+		}
+	stCase194:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st195
+		}
+		goto tr37
+	st195:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof195
+		}
+	stCase195:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st196
+		}
+		goto tr37
+	st196:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof196
+		}
+	stCase196:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st197
+		}
+		goto tr37
+	st197:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof197
+		}
+	stCase197:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st198
+		}
+		goto tr37
+	st198:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof198
+		}
+	stCase198:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st199
+		}
+		goto tr37
+	st199:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof199
+		}
+	stCase199:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st200
+		}
+		goto tr37
+	st200:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof200
+		}
+	stCase200:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st201
+		}
+		goto tr37
+	st201:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof201
+		}
+	stCase201:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st202
+		}
+		goto tr37
+	st202:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof202
+		}
+	stCase202:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st203
+		}
+		goto tr37
+	st203:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof203
+		}
+	stCase203:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st204
+		}
+		goto tr37
+	st204:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof204
+		}
+	stCase204:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st205
+		}
+		goto tr37
+	st205:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof205
+		}
+	stCase205:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st206
+		}
+		goto tr37
+	st206:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof206
+		}
+	stCase206:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st207
+		}
+		goto tr37
+	st207:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof207
+		}
+	stCase207:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st208
+		}
+		goto tr37
+	st208:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof208
+		}
+	stCase208:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st209
+		}
+		goto tr37
+	st209:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof209
+		}
+	stCase209:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st210
+		}
+		goto tr37
+	st210:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof210
+		}
+	stCase210:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st211
+		}
+		goto tr37
+	st211:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof211
+		}
+	stCase211:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st212
+		}
+		goto tr37
+	st212:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof212
+		}
+	stCase212:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st213
+		}
+		goto tr37
+	st213:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof213
+		}
+	stCase213:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st214
+		}
+		goto tr37
+	st214:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof214
+		}
+	stCase214:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st215
+		}
+		goto tr37
+	st215:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof215
+		}
+	stCase215:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st216
+		}
+		goto tr37
+	st216:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof216
+		}
+	stCase216:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st217
+		}
+		goto tr37
+	st217:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof217
+		}
+	stCase217:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st218
+		}
+		goto tr37
+	st218:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof218
+		}
+	stCase218:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st219
+		}
+		goto tr37
+	st219:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof219
+		}
+	stCase219:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st220
+		}
+		goto tr37
+	st220:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof220
+		}
+	stCase220:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st221
+		}
+		goto tr37
+	st221:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof221
+		}
+	stCase221:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st222
+		}
+		goto tr37
+	st222:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof222
+		}
+	stCase222:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st223
+		}
+		goto tr37
+	st223:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof223
+		}
+	stCase223:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st224
+		}
+		goto tr37
+	st224:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof224
+		}
+	stCase224:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st225
+		}
+		goto tr37
+	st225:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof225
+		}
+	stCase225:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st226
+		}
+		goto tr37
+	st226:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof226
+		}
+	stCase226:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st227
+		}
+		goto tr37
+	st227:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof227
+		}
+	stCase227:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st228
+		}
+		goto tr37
+	st228:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof228
+		}
+	stCase228:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st229
+		}
+		goto tr37
+	st229:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof229
+		}
+	stCase229:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st230
+		}
+		goto tr37
+	st230:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof230
+		}
+	stCase230:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st231
+		}
+		goto tr37
+	st231:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof231
+		}
+	stCase231:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st232
+		}
+		goto tr37
+	st232:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof232
+		}
+	stCase232:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st233
+		}
+		goto tr37
+	st233:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof233
+		}
+	stCase233:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st234
+		}
+		goto tr37
+	st234:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof234
+		}
+	stCase234:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st235
+		}
+		goto tr37
+	st235:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof235
+		}
+	stCase235:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st236
+		}
+		goto tr37
+	st236:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof236
+		}
+	stCase236:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st237
+		}
+		goto tr37
+	st237:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof237
+		}
+	stCase237:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st238
+		}
+		goto tr37
+	st238:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof238
+		}
+	stCase238:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st239
+		}
+		goto tr37
+	st239:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof239
+		}
+	stCase239:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st240
+		}
+		goto tr37
+	st240:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof240
+		}
+	stCase240:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st241
+		}
+		goto tr37
+	st241:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof241
+		}
+	stCase241:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st242
+		}
+		goto tr37
+	st242:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof242
+		}
+	stCase242:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st243
+		}
+		goto tr37
+	st243:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof243
+		}
+	stCase243:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st244
+		}
+		goto tr37
+	st244:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof244
+		}
+	stCase244:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st245
+		}
+		goto tr37
+	st245:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof245
+		}
+	stCase245:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st246
+		}
+		goto tr37
+	st246:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof246
+		}
+	stCase246:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st247
+		}
+		goto tr37
+	st247:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof247
+		}
+	stCase247:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st248
+		}
+		goto tr37
+	st248:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof248
+		}
+	stCase248:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st249
+		}
+		goto tr37
+	st249:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof249
+		}
+	stCase249:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st250
+		}
+		goto tr37
+	st250:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof250
+		}
+	stCase250:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st251
+		}
+		goto tr37
+	st251:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof251
+		}
+	stCase251:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st252
+		}
+		goto tr37
+	st252:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof252
+		}
+	stCase252:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st253
+		}
+		goto tr37
+	st253:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof253
+		}
+	stCase253:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st254
+		}
+		goto tr37
+	st254:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof254
+		}
+	stCase254:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st255
+		}
+		goto tr37
+	st255:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof255
+		}
+	stCase255:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st256
+		}
+		goto tr37
+	st256:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof256
+		}
+	stCase256:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st257
+		}
+		goto tr37
+	st257:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof257
+		}
+	stCase257:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st258
+		}
+		goto tr37
+	st258:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof258
+		}
+	stCase258:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st259
+		}
+		goto tr37
+	st259:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof259
+		}
+	stCase259:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st260
+		}
+		goto tr37
+	st260:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof260
+		}
+	stCase260:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st261
+		}
+		goto tr37
+	st261:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof261
+		}
+	stCase261:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st262
+		}
+		goto tr37
+	st262:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof262
+		}
+	stCase262:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st263
+		}
+		goto tr37
+	st263:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof263
+		}
+	stCase263:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st264
+		}
+		goto tr37
+	st264:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof264
+		}
+	stCase264:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st265
+		}
+		goto tr37
+	st265:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof265
+		}
+	stCase265:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st266
+		}
+		goto tr37
+	st266:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof266
+		}
+	stCase266:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st267
+		}
+		goto tr37
+	st267:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof267
+		}
+	stCase267:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st268
+		}
+		goto tr37
+	st268:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof268
+		}
+	stCase268:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st269
+		}
+		goto tr37
+	st269:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof269
+		}
+	stCase269:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st270
+		}
+		goto tr37
+	st270:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof270
+		}
+	stCase270:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st271
+		}
+		goto tr37
+	st271:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof271
+		}
+	stCase271:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st272
+		}
+		goto tr37
+	st272:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof272
+		}
+	stCase272:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st273
+		}
+		goto tr37
+	st273:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof273
+		}
+	stCase273:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st274
+		}
+		goto tr37
+	st274:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof274
+		}
+	stCase274:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st275
+		}
+		goto tr37
+	st275:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof275
+		}
+	stCase275:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st276
+		}
+		goto tr37
+	st276:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof276
+		}
+	stCase276:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st277
+		}
+		goto tr37
+	st277:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof277
+		}
+	stCase277:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st278
+		}
+		goto tr37
+	st278:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof278
+		}
+	stCase278:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st279
+		}
+		goto tr37
+	st279:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof279
+		}
+	stCase279:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+			goto st280
+		}
+		goto tr37
+	st280:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof280
+		}
+	stCase280:
+		if (m.data)[(m.p)] == 32 {
+			goto tr39
+		}
+		goto tr37
+	st281:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof281
+		}
+	stCase281:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
+			goto st13
+		}
+		goto tr7
+	st282:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof282
+		}
+	stCase282:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st10
+		}
+		goto tr7
+	st283:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof283
+		}
+	stCase283:
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
+			goto st10
+		}
+		goto tr7
+	st284:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof284
+		}
+	stCase284:
+		if (m.data)[(m.p)] == 103 {
+			goto st7
+		}
+		goto tr7
+	tr9:
+
+		m.pb = m.p
+
+		goto st285
+	st285:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof285
+		}
+	stCase285:
+		if (m.data)[(m.p)] == 101 {
+			goto st286
+		}
+		goto tr7
+	st286:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof286
+		}
+	stCase286:
+		if (m.data)[(m.p)] == 99 {
+			goto st7
+		}
+		goto tr7
+	tr10:
+
+		m.pb = m.p
+
+		goto st287
+	st287:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof287
+		}
+	stCase287:
+		if (m.data)[(m.p)] == 101 {
+			goto st288
+		}
+		goto tr7
+	st288:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof288
+		}
+	stCase288:
+		if (m.data)[(m.p)] == 98 {
+			goto st7
+		}
+		goto tr7
+	tr11:
+
+		m.pb = m.p
+
+		goto st289
+	st289:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof289
+		}
+	stCase289:
+		switch (m.data)[(m.p)] {
+		case 97:
+			goto st290
+		case 117:
+			goto st291
+		}
+		goto tr7
+	st290:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof290
+		}
+	stCase290:
+		if (m.data)[(m.p)] == 110 {
+			goto st7
+		}
+		goto tr7
+	st291:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof291
+		}
+	stCase291:
+		switch (m.data)[(m.p)] {
+		case 108:
+			goto st7
+		case 110:
+			goto st7
+		}
+		goto tr7
+	tr12:
+
+		m.pb = m.p
+
+		goto st292
+	st292:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof292
+		}
+	stCase292:
+		if (m.data)[(m.p)] == 97 {
+			goto st293
+		}
+		goto tr7
+	st293:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof293
+		}
+	stCase293:
+		switch (m.data)[(m.p)] {
+		case 114:
+			goto st7
+		case 121:
+			goto st7
+		}
+		goto tr7
+	tr13:
+
+		m.pb = m.p
+
+		goto st294
+	st294:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof294
+		}
+	stCase294:
+		if (m.data)[(m.p)] == 111 {
+			goto st295
+		}
+		goto tr7
+	st295:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof295
+		}
+	stCase295:
+		if (m.data)[(m.p)] == 118 {
+			goto st7
+		}
+		goto tr7
+	tr14:
+
+		m.pb = m.p
+
+		goto st296
+	st296:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof296
+		}
+	stCase296:
+		if (m.data)[(m.p)] == 99 {
+			goto st297
+		}
+		goto tr7
+	st297:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof297
+		}
+	stCase297:
+		if (m.data)[(m.p)] == 116 {
+			goto st7
+		}
+		goto tr7
+	tr15:
+
+		m.pb = m.p
+
+		goto st298
+	st298:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof298
+		}
+	stCase298:
+		if (m.data)[(m.p)] == 101 {
+			goto st299
+		}
+		goto tr7
+	st299:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof299
+		}
+	stCase299:
+		if (m.data)[(m.p)] == 112 {
+			goto st7
+		}
+		goto tr7
+	tr16:
+
+		m.pb = m.p
+
+		goto st300
+	st300:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof300
+		}
+	stCase300:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st301
+		}
+		goto st0
+	st301:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof301
+		}
+	stCase301:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st302
+		}
+		goto st0
+	st302:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof302
+		}
+	stCase302:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st303
+		}
+		goto st0
+	st303:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof303
+		}
+	stCase303:
+		_widec = int16((m.data)[(m.p)])
+		if 45 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 45 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 557 {
+			goto st304
+		}
+		goto st0
+	st304:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof304
+		}
+	stCase304:
+		_widec = int16((m.data)[(m.p)])
+		switch {
+		case (m.data)[(m.p)] > 48:
+			if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		case (m.data)[(m.p)] >= 48:
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 560:
+			goto st305
+		case 561:
+			goto st329
+		}
+		goto st0
+	st305:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof305
+		}
+	stCase305:
+		_widec = int16((m.data)[(m.p)])
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 561 <= _widec && _widec <= 569 {
+			goto st306
+		}
+		goto st0
+	st306:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof306
+		}
+	stCase306:
+		_widec = int16((m.data)[(m.p)])
+		if 45 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 45 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 557 {
+			goto st307
+		}
+		goto st0
+	st307:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof307
+		}
+	stCase307:
+		_widec = int16((m.data)[(m.p)])
+		switch {
+		case (m.data)[(m.p)] < 49:
+			if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 48 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		case (m.data)[(m.p)] > 50:
+			if 51 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 560:
+			goto st308
+		case 563:
+			goto st328
+		}
+		if 561 <= _widec && _widec <= 562 {
+			goto st327
+		}
+		goto st0
+	st308:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof308
+		}
+	stCase308:
+		_widec = int16((m.data)[(m.p)])
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 561 <= _widec && _widec <= 569 {
+			goto st309
+		}
+		goto st0
+	st309:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof309
+		}
+	stCase309:
+		_widec = int16((m.data)[(m.p)])
+		if 84 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 84 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 596 {
+			goto st310
+		}
+		goto st0
+	st310:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof310
+		}
+	stCase310:
+		_widec = int16((m.data)[(m.p)])
+		switch {
+		case (m.data)[(m.p)] > 49:
+			if 50 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		case (m.data)[(m.p)] >= 48:
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 562 {
+			goto st326
+		}
+		if 560 <= _widec && _widec <= 561 {
+			goto st311
+		}
+		goto st0
+	st311:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof311
+		}
+	stCase311:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st312
+		}
+		goto st0
+	st312:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof312
+		}
+	stCase312:
+		_widec = int16((m.data)[(m.p)])
+		if 58 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 58 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 570 {
+			goto st313
+		}
+		goto st0
+	st313:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof313
+		}
+	stCase313:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 565 {
+			goto st314
+		}
+		goto st0
+	st314:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof314
+		}
+	stCase314:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st315
+		}
+		goto st0
+	st315:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof315
+		}
+	stCase315:
+		_widec = int16((m.data)[(m.p)])
+		if 58 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 58 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 570 {
+			goto st316
+		}
+		goto st0
+	st316:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof316
+		}
+	stCase316:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 565 {
+			goto st317
+		}
+		goto st0
+	st317:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof317
+		}
+	stCase317:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st318
+		}
+		goto st0
+	st318:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof318
+		}
+	stCase318:
+		_widec = int16((m.data)[(m.p)])
+		switch {
+		case (m.data)[(m.p)] < 45:
+			if 43 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 43 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		case (m.data)[(m.p)] > 45:
+			if 90 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 90 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 555:
+			goto st319
+		case 557:
+			goto st319
+		case 602:
+			goto st324
+		}
+		goto tr333
+	st319:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof319
+		}
+	stCase319:
+		_widec = int16((m.data)[(m.p)])
+		switch {
+		case (m.data)[(m.p)] > 49:
+			if 50 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
+				_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+				if m.rfc3339 {
+					_widec += 256
+				}
+			}
+		case (m.data)[(m.p)] >= 48:
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 562 {
+			goto st325
+		}
+		if 560 <= _widec && _widec <= 561 {
+			goto st320
+		}
+		goto tr333
+	st320:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof320
+		}
+	stCase320:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st321
+		}
+		goto tr333
+	st321:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof321
+		}
+	stCase321:
+		_widec = int16((m.data)[(m.p)])
+		if 58 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 58 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if _widec == 570 {
+			goto st322
+		}
+		goto tr333
+	st322:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof322
+		}
+	stCase322:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 565 {
+			goto st323
+		}
+		goto tr333
+	st323:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof323
+		}
+	stCase323:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st324
+		}
+		goto tr333
+	st324:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof324
+		}
+	stCase324:
+		if (m.data)[(m.p)] == 32 {
+			goto tr341
+		}
+		goto st0
+	st325:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof325
+		}
+	stCase325:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 563 {
+			goto st321
+		}
+		goto tr333
+	st326:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof326
+		}
+	stCase326:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 563 {
+			goto st312
+		}
+		goto st0
+	st327:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof327
+		}
+	stCase327:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 569 {
+			goto st309
+		}
+		goto st0
+	st328:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof328
+		}
+	stCase328:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 561 {
+			goto st309
+		}
+		goto st0
+	st329:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof329
+		}
+	stCase329:
+		_widec = int16((m.data)[(m.p)])
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.rfc3339 {
+				_widec += 256
+			}
+		}
+		if 560 <= _widec && _widec <= 562 {
+			goto st306
+		}
+		goto st0
+	tr4:
+
+		m.pb = m.p
+
+		goto st330
+	st330:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof330
+		}
+	stCase330:
+
+		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+		output.prioritySet = true
+
+		switch (m.data)[(m.p)] {
+		case 57:
+			goto st332
+		case 62:
+			goto st4
+		}
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 56 {
+			goto st331
+		}
+		goto tr2
+	tr5:
+
+		m.pb = m.p
+
+		goto st331
+	st331:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof331
+		}
+	stCase331:
+
+		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+		output.prioritySet = true
+
+		if (m.data)[(m.p)] == 62 {
+			goto st4
+		}
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
+			goto st3
+		}
+		goto tr2
+	st332:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof332
+		}
+	stCase332:
+
+		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+		output.prioritySet = true
+
+		if (m.data)[(m.p)] == 62 {
+			goto st4
+		}
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
+			goto st3
+		}
+		goto tr2
+	st373:
+		if (m.p)++; (m.p) == (m.pe) {
+			goto _testEof373
+		}
+	stCase373:
+		switch (m.data)[(m.p)] {
+		case 10:
+			goto st0
+		case 13:
+			goto st0
+		}
+		goto st373
+	stOut:
+	_testEof2:
+		m.cs = 2
+		goto _testEof
+	_testEof3:
+		m.cs = 3
+		goto _testEof
+	_testEof4:
+		m.cs = 4
+		goto _testEof
+	_testEof5:
+		m.cs = 5
+		goto _testEof
+	_testEof6:
+		m.cs = 6
+		goto _testEof
+	_testEof7:
+		m.cs = 7
+		goto _testEof
+	_testEof8:
+		m.cs = 8
+		goto _testEof
+	_testEof9:
+		m.cs = 9
+		goto _testEof
+	_testEof10:
+		m.cs = 10
+		goto _testEof
+	_testEof11:
+		m.cs = 11
+		goto _testEof
+	_testEof12:
+		m.cs = 12
+		goto _testEof
+	_testEof13:
+		m.cs = 13
+		goto _testEof
+	_testEof14:
+		m.cs = 14
+		goto _testEof
+	_testEof15:
+		m.cs = 15
+		goto _testEof
+	_testEof16:
+		m.cs = 16
+		goto _testEof
+	_testEof17:
+		m.cs = 17
+		goto _testEof
+	_testEof18:
+		m.cs = 18
+		goto _testEof
+	_testEof19:
+		m.cs = 19
+		goto _testEof
+	_testEof20:
+		m.cs = 20
+		goto _testEof
+	_testEof21:
+		m.cs = 21
+		goto _testEof
+	_testEof22:
+		m.cs = 22
+		goto _testEof
+	_testEof333:
+		m.cs = 333
+		goto _testEof
+	_testEof334:
+		m.cs = 334
+		goto _testEof
+	_testEof335:
+		m.cs = 335
+		goto _testEof
+	_testEof336:
+		m.cs = 336
+		goto _testEof
+	_testEof337:
+		m.cs = 337
+		goto _testEof
+	_testEof338:
+		m.cs = 338
+		goto _testEof
+	_testEof339:
+		m.cs = 339
+		goto _testEof
+	_testEof340:
+		m.cs = 340
+		goto _testEof
+	_testEof341:
+		m.cs = 341
+		goto _testEof
+	_testEof342:
+		m.cs = 342
+		goto _testEof
+	_testEof343:
+		m.cs = 343
+		goto _testEof
+	_testEof344:
+		m.cs = 344
+		goto _testEof
+	_testEof345:
+		m.cs = 345
+		goto _testEof
+	_testEof346:
+		m.cs = 346
+		goto _testEof
+	_testEof347:
+		m.cs = 347
+		goto _testEof
+	_testEof348:
+		m.cs = 348
+		goto _testEof
+	_testEof349:
+		m.cs = 349
+		goto _testEof
+	_testEof350:
+		m.cs = 350
+		goto _testEof
+	_testEof351:
+		m.cs = 351
+		goto _testEof
+	_testEof352:
+		m.cs = 352
+		goto _testEof
+	_testEof353:
+		m.cs = 353
+		goto _testEof
+	_testEof354:
+		m.cs = 354
+		goto _testEof
+	_testEof355:
+		m.cs = 355
+		goto _testEof
+	_testEof356:
+		m.cs = 356
+		goto _testEof
+	_testEof357:
+		m.cs = 357
+		goto _testEof
+	_testEof358:
+		m.cs = 358
+		goto _testEof
+	_testEof359:
+		m.cs = 359
+		goto _testEof
+	_testEof360:
+		m.cs = 360
+		goto _testEof
+	_testEof361:
+		m.cs = 361
+		goto _testEof
+	_testEof362:
+		m.cs = 362
+		goto _testEof
+	_testEof363:
+		m.cs = 363
+		goto _testEof
+	_testEof364:
+		m.cs = 364
+		goto _testEof
+	_testEof365:
+		m.cs = 365
+		goto _testEof
+	_testEof366:
+		m.cs = 366
+		goto _testEof
+	_testEof367:
+		m.cs = 367
+		goto _testEof
+	_testEof368:
+		m.cs = 368
+		goto _testEof
+	_testEof23:
+		m.cs = 23
+		goto _testEof
+	_testEof24:
+		m.cs = 24
+		goto _testEof
+	_testEof25:
+		m.cs = 25
+		goto _testEof
+	_testEof26:
+		m.cs = 26
+		goto _testEof
+	_testEof369:
+		m.cs = 369
+		goto _testEof
+	_testEof370:
+		m.cs = 370
+		goto _testEof
+	_testEof371:
+		m.cs = 371
+		goto _testEof
+	_testEof372:
+		m.cs = 372
+		goto _testEof
+	_testEof27:
+		m.cs = 27
+		goto _testEof
+	_testEof28:
+		m.cs = 28
+		goto _testEof
+	_testEof29:
+		m.cs = 29
+		goto _testEof
+	_testEof30:
+		m.cs = 30
+		goto _testEof
+	_testEof31:
+		m.cs = 31
+		goto _testEof
+	_testEof32:
+		m.cs = 32
+		goto _testEof
+	_testEof33:
+		m.cs = 33
+		goto _testEof
+	_testEof34:
+		m.cs = 34
+		goto _testEof
+	_testEof35:
+		m.cs = 35
+		goto _testEof
+	_testEof36:
+		m.cs = 36
+		goto _testEof
+	_testEof37:
+		m.cs = 37
+		goto _testEof
+	_testEof38:
+		m.cs = 38
+		goto _testEof
+	_testEof39:
+		m.cs = 39
+		goto _testEof
+	_testEof40:
+		m.cs = 40
+		goto _testEof
+	_testEof41:
+		m.cs = 41
+		goto _testEof
+	_testEof42:
+		m.cs = 42
+		goto _testEof
+	_testEof43:
+		m.cs = 43
+		goto _testEof
+	_testEof44:
+		m.cs = 44
+		goto _testEof
+	_testEof45:
+		m.cs = 45
+		goto _testEof
+	_testEof46:
+		m.cs = 46
+		goto _testEof
+	_testEof47:
+		m.cs = 47
+		goto _testEof
+	_testEof48:
+		m.cs = 48
+		goto _testEof
+	_testEof49:
+		m.cs = 49
+		goto _testEof
+	_testEof50:
+		m.cs = 50
+		goto _testEof
+	_testEof51:
+		m.cs = 51
+		goto _testEof
+	_testEof52:
+		m.cs = 52
+		goto _testEof
+	_testEof53:
+		m.cs = 53
+		goto _testEof
+	_testEof54:
+		m.cs = 54
+		goto _testEof
+	_testEof55:
+		m.cs = 55
+		goto _testEof
+	_testEof56:
+		m.cs = 56
+		goto _testEof
+	_testEof57:
+		m.cs = 57
+		goto _testEof
+	_testEof58:
+		m.cs = 58
+		goto _testEof
+	_testEof59:
+		m.cs = 59
+		goto _testEof
+	_testEof60:
+		m.cs = 60
+		goto _testEof
+	_testEof61:
+		m.cs = 61
+		goto _testEof
+	_testEof62:
+		m.cs = 62
+		goto _testEof
+	_testEof63:
+		m.cs = 63
+		goto _testEof
+	_testEof64:
+		m.cs = 64
+		goto _testEof
+	_testEof65:
+		m.cs = 65
+		goto _testEof
+	_testEof66:
+		m.cs = 66
+		goto _testEof
+	_testEof67:
+		m.cs = 67
+		goto _testEof
+	_testEof68:
+		m.cs = 68
+		goto _testEof
+	_testEof69:
+		m.cs = 69
+		goto _testEof
+	_testEof70:
+		m.cs = 70
+		goto _testEof
+	_testEof71:
+		m.cs = 71
+		goto _testEof
+	_testEof72:
+		m.cs = 72
+		goto _testEof
+	_testEof73:
+		m.cs = 73
+		goto _testEof
+	_testEof74:
+		m.cs = 74
+		goto _testEof
+	_testEof75:
+		m.cs = 75
+		goto _testEof
+	_testEof76:
+		m.cs = 76
+		goto _testEof
+	_testEof77:
+		m.cs = 77
+		goto _testEof
+	_testEof78:
+		m.cs = 78
+		goto _testEof
+	_testEof79:
+		m.cs = 79
+		goto _testEof
+	_testEof80:
+		m.cs = 80
+		goto _testEof
+	_testEof81:
+		m.cs = 81
+		goto _testEof
+	_testEof82:
+		m.cs = 82
+		goto _testEof
+	_testEof83:
+		m.cs = 83
+		goto _testEof
+	_testEof84:
+		m.cs = 84
+		goto _testEof
+	_testEof85:
+		m.cs = 85
+		goto _testEof
+	_testEof86:
+		m.cs = 86
+		goto _testEof
+	_testEof87:
+		m.cs = 87
+		goto _testEof
+	_testEof88:
+		m.cs = 88
+		goto _testEof
+	_testEof89:
+		m.cs = 89
+		goto _testEof
+	_testEof90:
+		m.cs = 90
+		goto _testEof
+	_testEof91:
+		m.cs = 91
+		goto _testEof
+	_testEof92:
+		m.cs = 92
+		goto _testEof
+	_testEof93:
+		m.cs = 93
+		goto _testEof
+	_testEof94:
+		m.cs = 94
+		goto _testEof
+	_testEof95:
+		m.cs = 95
+		goto _testEof
+	_testEof96:
+		m.cs = 96
+		goto _testEof
+	_testEof97:
+		m.cs = 97
+		goto _testEof
+	_testEof98:
+		m.cs = 98
+		goto _testEof
+	_testEof99:
+		m.cs = 99
+		goto _testEof
+	_testEof100:
+		m.cs = 100
+		goto _testEof
+	_testEof101:
+		m.cs = 101
+		goto _testEof
+	_testEof102:
+		m.cs = 102
+		goto _testEof
+	_testEof103:
+		m.cs = 103
+		goto _testEof
+	_testEof104:
+		m.cs = 104
+		goto _testEof
+	_testEof105:
+		m.cs = 105
+		goto _testEof
+	_testEof106:
+		m.cs = 106
+		goto _testEof
+	_testEof107:
+		m.cs = 107
+		goto _testEof
+	_testEof108:
+		m.cs = 108
+		goto _testEof
+	_testEof109:
+		m.cs = 109
+		goto _testEof
+	_testEof110:
+		m.cs = 110
+		goto _testEof
+	_testEof111:
+		m.cs = 111
+		goto _testEof
+	_testEof112:
+		m.cs = 112
+		goto _testEof
+	_testEof113:
+		m.cs = 113
+		goto _testEof
+	_testEof114:
+		m.cs = 114
+		goto _testEof
+	_testEof115:
+		m.cs = 115
+		goto _testEof
+	_testEof116:
+		m.cs = 116
+		goto _testEof
+	_testEof117:
+		m.cs = 117
+		goto _testEof
+	_testEof118:
+		m.cs = 118
+		goto _testEof
+	_testEof119:
+		m.cs = 119
+		goto _testEof
+	_testEof120:
+		m.cs = 120
+		goto _testEof
+	_testEof121:
+		m.cs = 121
+		goto _testEof
+	_testEof122:
+		m.cs = 122
+		goto _testEof
+	_testEof123:
+		m.cs = 123
+		goto _testEof
+	_testEof124:
+		m.cs = 124
+		goto _testEof
+	_testEof125:
+		m.cs = 125
+		goto _testEof
+	_testEof126:
+		m.cs = 126
+		goto _testEof
+	_testEof127:
+		m.cs = 127
+		goto _testEof
+	_testEof128:
+		m.cs = 128
+		goto _testEof
+	_testEof129:
+		m.cs = 129
+		goto _testEof
+	_testEof130:
+		m.cs = 130
+		goto _testEof
+	_testEof131:
+		m.cs = 131
+		goto _testEof
+	_testEof132:
+		m.cs = 132
+		goto _testEof
+	_testEof133:
+		m.cs = 133
+		goto _testEof
+	_testEof134:
+		m.cs = 134
+		goto _testEof
+	_testEof135:
+		m.cs = 135
+		goto _testEof
+	_testEof136:
+		m.cs = 136
+		goto _testEof
+	_testEof137:
+		m.cs = 137
+		goto _testEof
+	_testEof138:
+		m.cs = 138
+		goto _testEof
+	_testEof139:
+		m.cs = 139
+		goto _testEof
+	_testEof140:
+		m.cs = 140
+		goto _testEof
+	_testEof141:
+		m.cs = 141
+		goto _testEof
+	_testEof142:
+		m.cs = 142
+		goto _testEof
+	_testEof143:
+		m.cs = 143
+		goto _testEof
+	_testEof144:
+		m.cs = 144
+		goto _testEof
+	_testEof145:
+		m.cs = 145
+		goto _testEof
+	_testEof146:
+		m.cs = 146
+		goto _testEof
+	_testEof147:
+		m.cs = 147
+		goto _testEof
+	_testEof148:
+		m.cs = 148
+		goto _testEof
+	_testEof149:
+		m.cs = 149
+		goto _testEof
+	_testEof150:
+		m.cs = 150
+		goto _testEof
+	_testEof151:
+		m.cs = 151
+		goto _testEof
+	_testEof152:
+		m.cs = 152
+		goto _testEof
+	_testEof153:
+		m.cs = 153
+		goto _testEof
+	_testEof154:
+		m.cs = 154
+		goto _testEof
+	_testEof155:
+		m.cs = 155
+		goto _testEof
+	_testEof156:
+		m.cs = 156
+		goto _testEof
+	_testEof157:
+		m.cs = 157
+		goto _testEof
+	_testEof158:
+		m.cs = 158
+		goto _testEof
+	_testEof159:
+		m.cs = 159
+		goto _testEof
+	_testEof160:
+		m.cs = 160
+		goto _testEof
+	_testEof161:
+		m.cs = 161
+		goto _testEof
+	_testEof162:
+		m.cs = 162
+		goto _testEof
+	_testEof163:
+		m.cs = 163
+		goto _testEof
+	_testEof164:
+		m.cs = 164
+		goto _testEof
+	_testEof165:
+		m.cs = 165
+		goto _testEof
+	_testEof166:
+		m.cs = 166
+		goto _testEof
+	_testEof167:
+		m.cs = 167
+		goto _testEof
+	_testEof168:
+		m.cs = 168
+		goto _testEof
+	_testEof169:
+		m.cs = 169
+		goto _testEof
+	_testEof170:
+		m.cs = 170
+		goto _testEof
+	_testEof171:
+		m.cs = 171
+		goto _testEof
+	_testEof172:
+		m.cs = 172
+		goto _testEof
+	_testEof173:
+		m.cs = 173
+		goto _testEof
+	_testEof174:
+		m.cs = 174
+		goto _testEof
+	_testEof175:
+		m.cs = 175
+		goto _testEof
+	_testEof176:
+		m.cs = 176
+		goto _testEof
+	_testEof177:
+		m.cs = 177
+		goto _testEof
+	_testEof178:
+		m.cs = 178
+		goto _testEof
+	_testEof179:
+		m.cs = 179
+		goto _testEof
+	_testEof180:
+		m.cs = 180
+		goto _testEof
+	_testEof181:
+		m.cs = 181
+		goto _testEof
+	_testEof182:
+		m.cs = 182
+		goto _testEof
+	_testEof183:
+		m.cs = 183
+		goto _testEof
+	_testEof184:
+		m.cs = 184
+		goto _testEof
+	_testEof185:
+		m.cs = 185
+		goto _testEof
+	_testEof186:
+		m.cs = 186
+		goto _testEof
+	_testEof187:
+		m.cs = 187
+		goto _testEof
+	_testEof188:
+		m.cs = 188
+		goto _testEof
+	_testEof189:
+		m.cs = 189
+		goto _testEof
+	_testEof190:
+		m.cs = 190
+		goto _testEof
+	_testEof191:
+		m.cs = 191
+		goto _testEof
+	_testEof192:
+		m.cs = 192
+		goto _testEof
+	_testEof193:
+		m.cs = 193
+		goto _testEof
+	_testEof194:
+		m.cs = 194
+		goto _testEof
+	_testEof195:
+		m.cs = 195
+		goto _testEof
+	_testEof196:
+		m.cs = 196
+		goto _testEof
+	_testEof197:
+		m.cs = 197
+		goto _testEof
+	_testEof198:
+		m.cs = 198
+		goto _testEof
+	_testEof199:
+		m.cs = 199
+		goto _testEof
+	_testEof200:
+		m.cs = 200
+		goto _testEof
+	_testEof201:
+		m.cs = 201
+		goto _testEof
+	_testEof202:
+		m.cs = 202
+		goto _testEof
+	_testEof203:
+		m.cs = 203
+		goto _testEof
+	_testEof204:
+		m.cs = 204
+		goto _testEof
+	_testEof205:
+		m.cs = 205
+		goto _testEof
+	_testEof206:
+		m.cs = 206
+		goto _testEof
+	_testEof207:
+		m.cs = 207
+		goto _testEof
+	_testEof208:
+		m.cs = 208
+		goto _testEof
+	_testEof209:
+		m.cs = 209
+		goto _testEof
+	_testEof210:
+		m.cs = 210
+		goto _testEof
+	_testEof211:
+		m.cs = 211
+		goto _testEof
+	_testEof212:
+		m.cs = 212
+		goto _testEof
+	_testEof213:
+		m.cs = 213
+		goto _testEof
+	_testEof214:
+		m.cs = 214
+		goto _testEof
+	_testEof215:
+		m.cs = 215
+		goto _testEof
+	_testEof216:
+		m.cs = 216
+		goto _testEof
+	_testEof217:
+		m.cs = 217
+		goto _testEof
+	_testEof218:
+		m.cs = 218
+		goto _testEof
+	_testEof219:
+		m.cs = 219
+		goto _testEof
+	_testEof220:
+		m.cs = 220
+		goto _testEof
+	_testEof221:
+		m.cs = 221
+		goto _testEof
+	_testEof222:
+		m.cs = 222
+		goto _testEof
+	_testEof223:
+		m.cs = 223
+		goto _testEof
+	_testEof224:
+		m.cs = 224
+		goto _testEof
+	_testEof225:
+		m.cs = 225
+		goto _testEof
+	_testEof226:
+		m.cs = 226
+		goto _testEof
+	_testEof227:
+		m.cs = 227
+		goto _testEof
+	_testEof228:
+		m.cs = 228
+		goto _testEof
+	_testEof229:
+		m.cs = 229
+		goto _testEof
+	_testEof230:
+		m.cs = 230
+		goto _testEof
+	_testEof231:
+		m.cs = 231
+		goto _testEof
+	_testEof232:
+		m.cs = 232
+		goto _testEof
+	_testEof233:
+		m.cs = 233
+		goto _testEof
+	_testEof234:
+		m.cs = 234
+		goto _testEof
+	_testEof235:
+		m.cs = 235
+		goto _testEof
+	_testEof236:
+		m.cs = 236
+		goto _testEof
+	_testEof237:
+		m.cs = 237
+		goto _testEof
+	_testEof238:
+		m.cs = 238
+		goto _testEof
+	_testEof239:
+		m.cs = 239
+		goto _testEof
+	_testEof240:
+		m.cs = 240
+		goto _testEof
+	_testEof241:
+		m.cs = 241
+		goto _testEof
+	_testEof242:
+		m.cs = 242
+		goto _testEof
+	_testEof243:
+		m.cs = 243
+		goto _testEof
+	_testEof244:
+		m.cs = 244
+		goto _testEof
+	_testEof245:
+		m.cs = 245
+		goto _testEof
+	_testEof246:
+		m.cs = 246
+		goto _testEof
+	_testEof247:
+		m.cs = 247
+		goto _testEof
+	_testEof248:
+		m.cs = 248
+		goto _testEof
+	_testEof249:
+		m.cs = 249
+		goto _testEof
+	_testEof250:
+		m.cs = 250
+		goto _testEof
+	_testEof251:
+		m.cs = 251
+		goto _testEof
+	_testEof252:
+		m.cs = 252
+		goto _testEof
+	_testEof253:
+		m.cs = 253
+		goto _testEof
+	_testEof254:
+		m.cs = 254
+		goto _testEof
+	_testEof255:
+		m.cs = 255
+		goto _testEof
+	_testEof256:
+		m.cs = 256
+		goto _testEof
+	_testEof257:
+		m.cs = 257
+		goto _testEof
+	_testEof258:
+		m.cs = 258
+		goto _testEof
+	_testEof259:
+		m.cs = 259
+		goto _testEof
+	_testEof260:
+		m.cs = 260
+		goto _testEof
+	_testEof261:
+		m.cs = 261
+		goto _testEof
+	_testEof262:
+		m.cs = 262
+		goto _testEof
+	_testEof263:
+		m.cs = 263
+		goto _testEof
+	_testEof264:
+		m.cs = 264
+		goto _testEof
+	_testEof265:
+		m.cs = 265
+		goto _testEof
+	_testEof266:
+		m.cs = 266
+		goto _testEof
+	_testEof267:
+		m.cs = 267
+		goto _testEof
+	_testEof268:
+		m.cs = 268
+		goto _testEof
+	_testEof269:
+		m.cs = 269
+		goto _testEof
+	_testEof270:
+		m.cs = 270
+		goto _testEof
+	_testEof271:
+		m.cs = 271
+		goto _testEof
+	_testEof272:
+		m.cs = 272
+		goto _testEof
+	_testEof273:
+		m.cs = 273
+		goto _testEof
+	_testEof274:
+		m.cs = 274
+		goto _testEof
+	_testEof275:
+		m.cs = 275
+		goto _testEof
+	_testEof276:
+		m.cs = 276
+		goto _testEof
+	_testEof277:
+		m.cs = 277
+		goto _testEof
+	_testEof278:
+		m.cs = 278
+		goto _testEof
+	_testEof279:
+		m.cs = 279
+		goto _testEof
+	_testEof280:
+		m.cs = 280
+		goto _testEof
+	_testEof281:
+		m.cs = 281
+		goto _testEof
+	_testEof282:
+		m.cs = 282
+		goto _testEof
+	_testEof283:
+		m.cs = 283
+		goto _testEof
+	_testEof284:
+		m.cs = 284
+		goto _testEof
+	_testEof285:
+		m.cs = 285
+		goto _testEof
+	_testEof286:
+		m.cs = 286
+		goto _testEof
+	_testEof287:
+		m.cs = 287
+		goto _testEof
+	_testEof288:
+		m.cs = 288
+		goto _testEof
+	_testEof289:
+		m.cs = 289
+		goto _testEof
+	_testEof290:
+		m.cs = 290
+		goto _testEof
+	_testEof291:
+		m.cs = 291
+		goto _testEof
+	_testEof292:
+		m.cs = 292
+		goto _testEof
+	_testEof293:
+		m.cs = 293
+		goto _testEof
+	_testEof294:
+		m.cs = 294
+		goto _testEof
+	_testEof295:
+		m.cs = 295
+		goto _testEof
+	_testEof296:
+		m.cs = 296
+		goto _testEof
+	_testEof297:
+		m.cs = 297
+		goto _testEof
+	_testEof298:
+		m.cs = 298
+		goto _testEof
+	_testEof299:
+		m.cs = 299
+		goto _testEof
+	_testEof300:
+		m.cs = 300
+		goto _testEof
+	_testEof301:
+		m.cs = 301
+		goto _testEof
+	_testEof302:
+		m.cs = 302
+		goto _testEof
+	_testEof303:
+		m.cs = 303
+		goto _testEof
+	_testEof304:
+		m.cs = 304
+		goto _testEof
+	_testEof305:
+		m.cs = 305
+		goto _testEof
+	_testEof306:
+		m.cs = 306
+		goto _testEof
+	_testEof307:
+		m.cs = 307
+		goto _testEof
+	_testEof308:
+		m.cs = 308
+		goto _testEof
+	_testEof309:
+		m.cs = 309
+		goto _testEof
+	_testEof310:
+		m.cs = 310
+		goto _testEof
+	_testEof311:
+		m.cs = 311
+		goto _testEof
+	_testEof312:
+		m.cs = 312
+		goto _testEof
+	_testEof313:
+		m.cs = 313
+		goto _testEof
+	_testEof314:
+		m.cs = 314
+		goto _testEof
+	_testEof315:
+		m.cs = 315
+		goto _testEof
+	_testEof316:
+		m.cs = 316
+		goto _testEof
+	_testEof317:
+		m.cs = 317
+		goto _testEof
+	_testEof318:
+		m.cs = 318
+		goto _testEof
+	_testEof319:
+		m.cs = 319
+		goto _testEof
+	_testEof320:
+		m.cs = 320
+		goto _testEof
+	_testEof321:
+		m.cs = 321
+		goto _testEof
+	_testEof322:
+		m.cs = 322
+		goto _testEof
+	_testEof323:
+		m.cs = 323
+		goto _testEof
+	_testEof324:
+		m.cs = 324
+		goto _testEof
+	_testEof325:
+		m.cs = 325
+		goto _testEof
+	_testEof326:
+		m.cs = 326
+		goto _testEof
+	_testEof327:
+		m.cs = 327
+		goto _testEof
+	_testEof328:
+		m.cs = 328
+		goto _testEof
+	_testEof329:
+		m.cs = 329
+		goto _testEof
+	_testEof330:
+		m.cs = 330
+		goto _testEof
+	_testEof331:
+		m.cs = 331
+		goto _testEof
+	_testEof332:
+		m.cs = 332
+		goto _testEof
+	_testEof373:
+		m.cs = 373
+		goto _testEof
+
+	_testEof:
+		{
+		}
+		if (m.p) == (m.eof) {
+			switch m.cs {
+			case 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372:
+
+				output.message = string(m.text())
+
+			case 1:
+
+				m.err = fmt.Errorf(errPri, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			case 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299:
+
+				m.err = fmt.Errorf(errTimestamp, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			case 318, 319, 320, 321, 322, 323, 325:
+
+				m.err = fmt.Errorf(errRFC3339, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			case 20, 21, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280:
+
+				m.err = fmt.Errorf(errHostname, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			case 22:
+
+				m.err = fmt.Errorf(errTag, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			case 2, 3, 330, 331, 332:
+
+				m.err = fmt.Errorf(errPrival, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+				m.err = fmt.Errorf(errPri, m.p)
+				(m.p)--
+
+				{
+					goto st373
+				}
+
+			}
+		}
+
+	_out:
+		{
+		}
+	}
+
+	if m.cs < firstFinal || m.cs == enFail {
+		if m.bestEffort && output.minimal() {
+			// An error occurred but partial parsing is on and partial message is minimally valid
+			return output.export(), m.err
+		}
+		return nil, m.err
+	}
+
+	return output.export(), nil
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine.go.rl
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine.go.rl
@@ -1,0 +1,263 @@
+package rfc3164
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/common"
+)
+
+var (
+	errPrival         = "expecting a priority value in the range 1-191 or equal to 0 [col %d]"
+	errPri            = "expecting a priority value within angle brackets [col %d]"
+	errTimestamp      = "expecting a Stamp timestamp [col %d]"
+	errRFC3339        = "expecting a Stamp or a RFC3339 timestamp [col %d]"
+	errHostname       = "expecting an hostname (from 1 to max 255 US-ASCII characters) [col %d]"
+	errTag            = "expecting an alphanumeric tag (max 32 characters) [col %d]"
+	errContentStart   = "expecting a content part starting with a non-alphanumeric character [col %d]"
+	errContent        = "expecting a content part composed by visible characters only [col %d]"
+	errParse          = "parsing error [col %d]"
+)
+
+%%{
+machine rfc3164;
+
+include common "common.rl";
+
+# unsigned alphabet
+alphtype uint8;
+
+action mark {
+	m.pb = m.p
+}
+
+action set_prival {
+	output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+	output.prioritySet = true
+}
+
+action set_timestamp {
+	if t, e := time.Parse(time.Stamp, string(m.text())); e != nil {
+		m.err = fmt.Errorf("%s [col %d]", e, m.p)
+		fhold;
+		fgoto fail;
+	} else {
+		if m.timezone != nil {
+			t, _ = time.ParseInLocation(time.Stamp, string(m.text()), m.timezone)
+		}
+		output.timestamp = t.AddDate(m.yyyy, 0, 0)
+		if m.loc != nil {
+			output.timestamp = output.timestamp.In(m.loc)
+		}
+		output.timestampSet = true
+	}
+}
+
+action set_rfc3339 {
+	if t, e := time.Parse(time.RFC3339, string(m.text())); e != nil {
+		m.err = fmt.Errorf("%s [col %d]", e, m.p)
+		fhold;
+		fgoto fail;
+	} else {
+		output.timestamp = t
+		output.timestampSet = true
+	}
+}
+
+action set_hostname {
+	output.hostname = string(m.text())
+}
+
+action set_tag {
+	output.tag = string(m.text())
+}
+
+action set_content {
+	output.content = string(m.text())
+}
+
+action set_message {
+	output.message = string(m.text())
+}
+
+action err_prival {
+	m.err = fmt.Errorf(errPrival, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_pri {
+	m.err = fmt.Errorf(errPri, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_timestamp {
+	m.err = fmt.Errorf(errTimestamp, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_rfc3339 {
+	m.err = fmt.Errorf(errRFC3339, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_hostname {
+	m.err = fmt.Errorf(errHostname, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_tag {
+	m.err = fmt.Errorf(errTag, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_contentstart {
+	m.err = fmt.Errorf(errContentStart, m.p)
+	fhold;
+	fgoto fail;
+}
+
+action err_content {
+	m.err = fmt.Errorf(errContent, m.p)
+	fhold;
+	fgoto fail;
+}
+
+pri = ('<' prival >mark %from(set_prival) $err(err_prival) '>') @err(err_pri);
+
+timestamp = (datemmm sp datemday sp hhmmss) >mark %set_timestamp @err(err_timestamp);
+
+rfc3339 = fulldate >mark 'T' hhmmss timeoffset %set_rfc3339 @err(err_rfc3339);
+
+# note > RFC 3164 says "The Domain Name MUST NOT be included in the HOSTNAME field"
+# note > this could mean that the we may need to create and to use a labelrange = graph{1,63} here if we want the parser to be stricter.
+hostname = hostnamerange >mark %set_hostname $err(err_hostname);
+
+# Section 4.1.3
+# note > alnum{1,32} is too restrictive (eg., no dashes)
+# note > see https://tools.ietf.org/html/rfc2234#section-2.1 for an interpretation of "ABNF alphanumeric" as stated by RFC 3164 regarding the tag
+# note > while RFC3164 assumes only ABNF alphanumeric process names, many BSD-syslog contains processe names with additional characters (-, _, .)
+tag = (print -- [ :\[]){1,32} >mark %set_tag @err(err_tag);
+
+visible = print | 0x80..0xFF;
+
+# The first not alphanumeric character starts the content (usually containing a PID) part of the message part
+contentval = !alnum @err(err_contentstart) >mark print* %set_content @err(err_content);
+
+content = '[' contentval ']'; # todo(leodido) > support ':' and ' ' too. Also they have to match?
+
+mex = visible+ >mark %set_message;
+
+msg = (tag content? ':' sp)? mex;
+
+fail := (any - [\n\r])* @err{ fgoto main; };
+
+main := pri (timestamp | (rfc3339 when { m.rfc3339 })) sp hostname sp msg;
+
+}%%
+
+%% write data noerror noprefix;
+
+type machine struct {
+	data         []byte
+	cs           int
+	p, pe, eof   int
+	pb           int
+	err          error
+	bestEffort   bool
+	yyyy         int
+	rfc3339      bool
+	loc          *time.Location
+	timezone     *time.Location
+}
+
+// NewMachine creates a new FSM able to parse RFC3164 syslog messages.
+func NewMachine(options ...syslog.MachineOption) syslog.Machine {
+	m := &machine{}
+
+	for _, opt := range options {
+		opt(m)
+	}
+
+	%% access m.;
+	%% variable p m.p;
+	%% variable pe m.pe;
+	%% variable eof m.eof;
+	%% variable data m.data;
+
+	return m
+}
+
+// WithBestEffort enables best effort mode.
+func (m *machine) WithBestEffort() {
+	m.bestEffort = true
+}
+
+// HasBestEffort tells whether the receiving machine has best effort mode on or off.
+func (m *machine) HasBestEffort() bool {
+	return m.bestEffort
+}
+
+// WithYear sets the year for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithYear(o YearOperator) {
+	m.yyyy = YearOperation{o}.Operate()
+}
+
+// WithTimezone sets the time zone for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithTimezone(loc *time.Location) {
+	m.loc = loc
+}
+
+// WithLocaleTimezone sets the locale time zone for the Stamp timestamp of the RFC 3164 syslog message.
+func (m *machine) WithLocaleTimezone(loc *time.Location) {
+	m.timezone = loc
+}
+
+// WithRFC3339 enables ability to ALSO match RFC3339 timestamps.
+//
+// Notice this does not disable the default and correct timestamps - ie., Stamp timestamps.
+func (m *machine) WithRFC3339() {
+	m.rfc3339 = true
+}
+
+// Err returns the error that occurred on the last call to Parse.
+//
+// If the result is nil, then the line was parsed successfully.
+func (m *machine) Err() error {
+	return m.err
+}
+
+func (m *machine) text() []byte {
+	return m.data[m.pb:m.p]
+}
+
+// Parse parses the input byte array as a RFC3164 syslog message.
+func (m *machine) Parse(input []byte) (syslog.Message, error) {
+	m.data = input
+	m.p = 0
+	m.pb = 0
+	m.pe = len(input)
+	m.eof = len(input)
+	m.err = nil
+	output := &syslogMessage{}
+
+	%% write init;
+	%% write exec;
+
+	if m.cs < first_final || m.cs == en_fail {
+		if m.bestEffort && output.minimal() {
+			// An error occurred but partial parsing is on and partial message is minimally valid
+			return output.export(), m.err
+		}
+		return nil, m.err
+	}
+
+	return output.export(), nil
+}
+

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine_test.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/machine_test.go
@@ -1,0 +1,178 @@
+package rfc3164
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/go-syslog/v3"
+	syslogtesting "github.com/influxdata/go-syslog/v3/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+// todo > add support for testing `best effort` mode
+
+type testCase struct {
+	input        []byte
+	valid        bool
+	value        syslog.Message
+	errorString  string
+	partialValue syslog.Message
+}
+
+var testCases = []testCase{
+	{
+		[]byte(`<34>Jan 12 06:30:00 xxx apache: 1.2.3.4 - - [12/Jan/2011:06:29:59 +0100] "GET /foo/bar.html HTTP/1.1" 301 96 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12 ( .NET CLR 3.5.30729)" PID 18904 Time Taken 0`),
+		true,
+		&SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(34),
+				Severity:  syslogtesting.Uint8Address(2),
+				Facility:  syslogtesting.Uint8Address(4),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Jan 12 06:30:00"),
+				Hostname:  syslogtesting.StringAddress("xxx"),
+				Appname:   syslogtesting.StringAddress("apache"),
+				Message:   syslogtesting.StringAddress(`1.2.3.4 - - [12/Jan/2011:06:29:59 +0100] "GET /foo/bar.html HTTP/1.1" 301 96 "-" "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12 ( .NET CLR 3.5.30729)" PID 18904 Time Taken 0`),
+			},
+		},
+		"",
+		nil,
+	},
+	{
+		[]byte(`<34>Aug  7 06:30:00 xxx aaa: message from 1.2.3.4`),
+		true,
+		&SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(34),
+				Severity:  syslogtesting.Uint8Address(2),
+				Facility:  syslogtesting.Uint8Address(4),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Aug 7 06:30:00"),
+				Hostname:  syslogtesting.StringAddress("xxx"),
+				Appname:   syslogtesting.StringAddress("aaa"),
+				Message:   syslogtesting.StringAddress(`message from 1.2.3.4`),
+			},
+		},
+		"",
+		nil,
+	},
+	{
+		input: []byte(`<85>Jan 24 15:50:41 ip-172-31-30-110 sudo[6040]: ec2-user : TTY=pts/0 ; PWD=/var/log ; USER=root ; COMMAND=/bin/tail secure`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(85),
+				Facility:  syslogtesting.Uint8Address(10),
+				Severity:  syslogtesting.Uint8Address(5),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Jan 24 15:50:41"),
+				Hostname:  syslogtesting.StringAddress("ip-172-31-30-110"),
+				Appname:   syslogtesting.StringAddress("sudo"),
+				ProcID:    syslogtesting.StringAddress("6040"),
+				Message:   syslogtesting.StringAddress(`ec2-user : TTY=pts/0 ; PWD=/var/log ; USER=root ; COMMAND=/bin/tail secure`),
+			},
+		},
+	},
+	{
+		input: []byte(`<166>Jul  6 20:33:28 ABC-1-234567 Some message here`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(166),
+				Facility:  syslogtesting.Uint8Address(20),
+				Severity:  syslogtesting.Uint8Address(6),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Jul  6 20:33:28"),
+				Hostname:  syslogtesting.StringAddress("ABC-1-234567"),
+				Message:   syslogtesting.StringAddress("Some message here"),
+			},
+		},
+	},
+	{
+		input: []byte(`<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(34),
+				Facility:  syslogtesting.Uint8Address(4),
+				Severity:  syslogtesting.Uint8Address(2),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Oct 11 22:14:15"),
+				Hostname:  syslogtesting.StringAddress("mymachine"),
+				Appname:   syslogtesting.StringAddress("su"),
+				Message:   syslogtesting.StringAddress("'su root' failed for lonvick on /dev/pts/8"),
+			},
+		},
+	},
+	{
+		input: []byte(`<13>Feb  5 17:32:18 10.0.0.99 Use the BFG!`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(13),
+				Facility:  syslogtesting.Uint8Address(1),
+				Severity:  syslogtesting.Uint8Address(5),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Feb  5 17:32:18"),
+				Hostname:  syslogtesting.StringAddress("10.0.0.99"),
+				Message:   syslogtesting.StringAddress("Use the BFG!"),
+			},
+		},
+	},
+	{
+		input: []byte(`<165>Aug 24 05:34:00 mymachine myproc[10]: %% It's time to make the do-nuts.  %%  Ingredients: Mix=OK, Jelly=OK # Devices: Mixer=OK, Jelly_Injector=OK, Frier=OK # Transport: Conveyer1=OK, Conveyer2=OK # %%`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(165),
+				Facility:  syslogtesting.Uint8Address(20),
+				Severity:  syslogtesting.Uint8Address(5),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Aug 24 05:34:00"),
+				Hostname:  syslogtesting.StringAddress("mymachine"),
+				Appname:   syslogtesting.StringAddress("myproc"),
+				ProcID:    syslogtesting.StringAddress("10"),
+				Message:   syslogtesting.StringAddress(`%% It's time to make the do-nuts.  %%  Ingredients: Mix=OK, Jelly=OK # Devices: Mixer=OK, Jelly_Injector=OK, Frier=OK # Transport: Conveyer1=OK, Conveyer2=OK # %%`),
+			},
+		},
+	},
+	{
+		input: []byte(`<0>Oct 22 10:52:01 10.1.2.3 sched[0]: That's All Folks!`),
+		valid: true,
+		value: &SyslogMessage{
+			Base: syslog.Base{
+				Priority:  syslogtesting.Uint8Address(0),
+				Facility:  syslogtesting.Uint8Address(0),
+				Severity:  syslogtesting.Uint8Address(0),
+				Timestamp: syslogtesting.TimeParse(time.Stamp, "Oct 22 10:52:01"),
+				Hostname:  syslogtesting.StringAddress("10.1.2.3"),
+				Appname:   syslogtesting.StringAddress("sched"),
+				ProcID:    syslogtesting.StringAddress("0"),
+				Message:   syslogtesting.StringAddress(`That's All Folks!`),
+			},
+		},
+	},
+	// todo > other test cases pleaaaase
+}
+
+func TestMachineParse(t *testing.T) {
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(syslogtesting.RightPad(string(tc.input), 50), func(t *testing.T) {
+			t.Parallel()
+
+			message, merr := NewMachine().Parse(tc.input)
+			partial, perr := NewMachine(WithBestEffort()).Parse(tc.input)
+
+			if !tc.valid {
+				assert.Nil(t, message)
+				assert.Error(t, merr)
+				assert.EqualError(t, merr, tc.errorString)
+
+				assert.Equal(t, tc.partialValue, partial)
+				assert.EqualError(t, perr, tc.errorString)
+			}
+			if tc.valid {
+				assert.Nil(t, merr)
+				assert.NotEmpty(t, message)
+				assert.Equal(t, message, partial)
+				assert.Equal(t, merr, perr)
+			}
+
+			assert.Equal(t, tc.value, message)
+		})
+	}
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/options.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/options.go
@@ -1,0 +1,68 @@
+package rfc3164
+
+import (
+	"time"
+
+	syslog "github.com/influxdata/go-syslog/v3"
+)
+
+// WithBestEffort enables the best effort mode.
+func WithBestEffort() syslog.MachineOption {
+	return func(m syslog.Machine) syslog.Machine {
+		m.WithBestEffort()
+		return m
+	}
+}
+
+// WithYear sets the strategy to decide the year for the Stamp timestamp of RFC 3164.
+func WithYear(o YearOperator) syslog.MachineOption {
+	return func(m syslog.Machine) syslog.Machine {
+		m.(*machine).WithYear(o)
+		return m
+	}
+}
+
+// WithTimezone sets the strategy to decide the timezone to apply to the Stamp timestamp of RFC 3164.
+func WithTimezone(loc *time.Location) syslog.MachineOption {
+	return func(m syslog.Machine) syslog.Machine {
+		m.(*machine).WithTimezone(loc)
+		return m
+	}
+}
+
+// WithLocaleTimezone sets the strategy to decide the timezone to apply to the Stamp timestamp of RFC 3164.
+func WithLocaleTimezone(loc *time.Location) syslog.MachineOption {
+	return func(m syslog.Machine) syslog.Machine {
+		m.(*machine).WithLocaleTimezone(loc)
+		return m
+	}
+}
+
+// todo > WithStrictHostname() option - see RFC3164 page 10
+// WithStrictHostname tells the parser to match the hostnames strictly as per RFC 3164 recommentations.
+//
+// The HOSTNAME field will contain only the hostname, the IPv4 address, or the IPv6 address of the originator of the message.
+// The preferred value is the hostname.
+// If the hostname is used, the HOSTNAME field MUST contain the hostname of the device as specified in STD 13 [4].
+// It should be noted that this MUST NOT contain any embedded spaces.
+// The Domain Name MUST NOT be included in the HOSTNAME field.
+// If the IPv4 address is used, it MUST be shown as the dotted decimal notation as used in STD 13 [5].
+// If an IPv6 address is used, any valid representation used in RFC 2373 [6] MAY be used.
+// A single space character MUST also follow the HOSTNAME field.
+// func WithStrictHostname() syslog.MachineOption {
+// 	return func(m syslog.Machine) syslog.Machine {
+// 		m.(*machine).WithStrictHostname()
+// 		return m
+// 	}
+// }
+
+// WithRFC3339 tells the parser to look for RFC3339 timestamps, too.
+//
+// It tells the parser to accept also RFC3339 timestamps even if they are not in the RFC3164 timestamp part.
+// Note that WithYear option will be ignored when an RFC3339 timestamp will match.
+func WithRFC3339() syslog.MachineOption {
+	return func(m syslog.Machine) syslog.Machine {
+		m.(*machine).WithRFC3339()
+		return m
+	}
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/parser.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/parser.go
@@ -1,0 +1,45 @@
+package rfc3164
+
+import (
+	"sync"
+
+	syslog "github.com/influxdata/go-syslog/v3"
+)
+
+// parser represent a RFC3164 parser with mutex capabilities.
+type parser struct {
+	sync.Mutex
+	*machine
+}
+
+// NewParser creates a syslog.Machine that parses RFC3164 syslog messages.
+func NewParser(options ...syslog.MachineOption) syslog.Machine {
+	p := &parser{
+		machine: NewMachine(options...).(*machine),
+	}
+
+	return p
+}
+
+// HasBestEffort tells whether the receiving parser has best effort mode on or off.
+func (p *parser) HasBestEffort() bool {
+	return p.bestEffort
+}
+
+// Parse parses the input RFC3164 syslog message using its FSM.
+//
+// Best effort mode enables the partial parsing.
+func (p *parser) Parse(input []byte) (syslog.Message, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	msg, err := p.machine.Parse(input)
+	if err != nil {
+		if p.bestEffort {
+			return msg, err
+		}
+		return nil, err
+	}
+
+	return msg, nil
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/syslog_message.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/syslog_message.go
@@ -1,0 +1,55 @@
+package rfc3164
+
+import (
+	"time"
+
+	"github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/common"
+)
+
+type syslogMessage struct {
+	prioritySet  bool // We explictly flag the setting of priority since its zero value is a valid priority by RFC 3164
+	timestampSet bool // We explictly flag the setting of timestamp since its zero value is a valid timestamp by RFC 3164
+	priority     uint8
+	timestamp    time.Time
+	hostname     string
+	tag          string
+	content      string
+	message      string
+}
+
+func (sm *syslogMessage) minimal() bool {
+	return sm.prioritySet && common.ValidPriority(sm.priority)
+}
+
+// export is meant to be called on minimally-valid messages
+// thus it presumes priority and version values exists and are correct
+func (sm *syslogMessage) export() *SyslogMessage {
+	out := &SyslogMessage{}
+	out.ComputeFromPriority(sm.priority)
+
+	if sm.timestampSet {
+		out.Timestamp = &sm.timestamp
+	}
+	if sm.hostname != "-" && sm.hostname != "" {
+		out.Hostname = &sm.hostname
+	}
+	if sm.tag != "-" && sm.tag != "" {
+		out.Appname = &sm.tag
+	}
+	if sm.content != "-" && sm.content != "" {
+		// Content is usually process ID
+		// See https://tools.ietf.org/html/rfc3164#section-5.3
+		out.ProcID = &sm.content
+	}
+	if sm.message != "" {
+		out.Message = &sm.message
+	}
+
+	return out
+}
+
+// SyslogMessage represents a RFC3164 syslog message.
+type SyslogMessage struct {
+	syslog.Base
+}

--- a/vendor/github.com/influxdata/go-syslog/v3/rfc3164/year.go
+++ b/vendor/github.com/influxdata/go-syslog/v3/rfc3164/year.go
@@ -1,0 +1,38 @@
+package rfc3164
+
+import (
+	"time"
+)
+
+// YearOperator is an interface that the operation inferring the year have to implement.
+type YearOperator interface {
+	Apply() int
+}
+
+// YearOperation represents the operation to perform to obtain the year depending on the inner operator/strategy.
+type YearOperation struct {
+	Operator YearOperator
+}
+
+// Operate gets the year depending on the current strategy.
+func (y YearOperation) Operate() int {
+	return y.Operator.Apply()
+}
+
+// CurrentYear is a strategy to obtain the current year in RFC 3164 syslog messages.
+type CurrentYear struct{}
+
+// Apply gets the current year
+func (CurrentYear) Apply() int {
+	return time.Now().Year()
+}
+
+// Year is a strategy to obtain the specified year in the RFC 3164 syslog messages.
+type Year struct {
+	YYYY int
+}
+
+// Apply gets the specified year
+func (y Year) Apply() int {
+	return y.YYYY
+}


### PR DESCRIPTION
I'm no Go programmer so somewhat glued ends together, please be patient. If this is of general interest I'm happy to fill the gaps like testing, documentation and change log. Since this requires changes of a vendor package, I created [a PR](https://github.com/influxdata/go-syslog/pull/46) there as well.

**What this PR does / why we need it**:

It adds RFC3164 support to promtail. Commonly used for OpenWrt and Ubiquiti syslogs.

**Which issue(s) this PR fixes**:

I opened a PR directly instead of an issue first.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
