### PR TITLE
Promtail: Fix broken promtail-debug docker image

### DIFF
--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image as build
+FROM grafana/loki-build-image:0.25.0 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki
@@ -12,7 +12,7 @@ RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true pr
 FROM       alpine:3.16.2
 RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/clients/cmd/promtail/promtail-debug /usr/bin/promtail-debug
-COPY       --from=build /go/bin/dlv /usr/bin/dlv
+COPY       --from=build /usr/bin/dlv /usr/bin/dlv
 COPY       clients/cmd/promtail/promtail-local-config.yaml /etc/promtail/local-config.yaml
 COPY       clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 
@@ -25,5 +25,5 @@ RUN apk add --no-cache libc6-compat
 # Run delve, ending with -- because we pass params via kubernetes, per the docs:
 #   Pass flags to the program you are debugging using --, for example:`
 #   dlv exec ./hello -- server --config conf/config.toml`
-ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/usr/bin/promtail-debug", "--"]
+ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true", "--continue", "--accept-multiclient", "--api-version=2", "exec", "/usr/bin/promtail-debug", "--"]
 CMD ["-config.file=/etc/promtail/config.yml"]


### PR DESCRIPTION
**What this PR does / why we need it**:
The 'grafana/loki-build-image' version was not specified for the promtail-debug docker image, resulting in a ~6 month old 'latest' image as a build image. Updating this resulted in one more change: the newer version has a different location for the 'dlv' binary.

The promtail-debug image would also hang waiting for a connection when ran, this adds the same flag, `--continue`, as added to the loki debug file in #1372.

**Special notes for your reviewer**:
I was interested in using the `-server.profiling_enabled=true` flag, to enable pprof endpoints, and scrape with phlare. This flag is not available in the non-debug version. Therefore I do not really care for attaching a debugger right away. Open to removing that change though.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
