### PR TITLE
Helm: Include PVC annotations for volumeClaimTemplates

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -2478,6 +2478,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>read.persistence.annotations</td>
+			<td>object</td>
+			<td>Annotations for the volumeClaimTemplates</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.persistence.selector</td>
 			<td>string</td>
 			<td>Selector for persistent disk</td>
@@ -2769,6 +2778,15 @@ null
 			<td>singleBinary.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for single binary pods</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.persistence.annotations</td>
+			<td>object</td>
+			<td>Annotations for the volumeClaimTemplates</td>
 			<td><pre lang="json">
 {}
 </pre>
@@ -3074,6 +3092,15 @@ null
 			<td>write.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for write pods</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.persistence.annotations</td>
+			<td>object</td>
+			<td>Annotations for the volumeClaimTemplates</td>
 			<td><pre lang="json">
 {}
 </pre>

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -141,6 +141,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        {{- with with .Values.read.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -132,6 +132,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: storage
+        {{- with with .Values.singleBinary.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -129,6 +129,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        {{- with with .Values.write.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -789,6 +789,8 @@ write:
     storageClass: null
     # -- Selector for persistent disk
     selector: null
+    # -- Annotations for the volumeClaimTemplates
+    annotations: {}
 
 # Configuration for the read node(s)
 read:
@@ -860,6 +862,8 @@ read:
     storageClass: null
     # -- Selector for persistent disk
     selector: null
+    # -- Annotations for the volumeClaimTemplates
+    annotations: {}
 
 # Configuration for the single binary node(s)
 singleBinary:
@@ -929,6 +933,8 @@ singleBinary:
     storageClass: null
     # -- Selector for persistent disk
     selector: null
+    # -- Annotations for the volumeClaimTemplates
+    annotations: {}
 
 # Use either this ingress or the gateway, but not both at once.
 # If you enable this, make sure to disable the gateway.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the possibility of including annotations to the PVC created with `volumeClaimTemplates` from the `StatefulSets`. The annotations can be convenient as configuration parameter of external tools (in my case we're using annotations for configuring the auto-expansion of pvcs).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
