### PR TITLE
Loki: Add one additional bucket to `rate_store_stream_shards`

### DIFF
--- a/pkg/distributor/ratestore_metrics.go
+++ b/pkg/distributor/ratestore_metrics.go
@@ -38,7 +38,7 @@ func newRateStoreMetrics(reg prometheus.Registerer) *ratestoreMetrics {
 			Namespace: "loki",
 			Name:      "rate_store_stream_shards",
 			Help:      "The distribution of number of shards for a single stream reported by ingesters during a sync operation.",
-			Buckets:   []float64{0, 2, 4, 8, 16, 32, 64, 128},
+			Buckets:   []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
 		}),
 		maxStreamRate: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",


### PR DESCRIPTION
**What this PR does / why we need it**:
Add one additional bucket (value=1) to the `rate_store_stream_shards`.
By jumping from 0 to 2 we can't distinguish between streams that were minimally sharded (shards=2) to non-sharded ones (shards=1).