### PR TITLE
Fix broken canary loki alerts

### DIFF
--- a/production/helm/loki/src/alerts.yaml
+++ b/production/helm/loki/src/alerts.yaml
@@ -39,9 +39,9 @@ groups:
     for: 5m
     labels:
       severity: warning
-  name: 'loki_canaries_alerts',
+- name: 'loki_canaries_alerts'
   rules:
-  - alert: 'LokiCanaryLatency',
+  - alert: 'LokiCanaryLatency'
     annotations:
       message: |
         {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.


### PR DESCRIPTION
**What this PR does / why we need it**:

The original added canary alert rules (https://github.com/grafana/loki/pull/7286) are malformatted and break the generated `loki-alerts` . i.e. 
```
// stripped away some labels
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  labels:
    helm.sh/chart: loki-3.6.0
  name: release-name-loki-alerts
spec:
  groups: << nothing here
```

PTAL @dannykopping @trevorwhitney

**Which issue(s) this PR fixes**:
Fixes a bug introduced in #7286

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
