### PR TITLE
update local docker-compose file to provision the Loki data source

### DIFF
--- a/production/README.md
+++ b/production/README.md
@@ -35,7 +35,7 @@ To test locally, we recommend using the `docker-compose.yaml` file in this direc
    docker-compose up
    ```
 
-1. Grafana should now be available at http://localhost:3000/. Log in with `admin` / `admin` and follow the [steps for configuring the datasource in Grafana](../docs/sources/getting-started/grafana.md), using `http://loki:3100` for the URL field.
+1. Grafana should now be available at http://localhost:3000/.
 
 **Note:** When running locally, Promtail starts before Loki is ready. This can lead to the error message "Data source connected, but no labels received." After a couple seconds, Promtail will forward all newly created log messages correctly.
 Until this is fixed we recommend [building and running from source](#build-and-run-from-source).

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -21,6 +21,29 @@ services:
       - loki
 
   grafana:
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy 
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
     image: grafana/grafana:latest
     ports:
       - "3000:3000"


### PR DESCRIPTION
**What this PR does / why we need it**:
* auto-provisions the dockerized Loki as a datasource
* [existing docs](https://github.com/grafana/loki/tree/main/production#run-locally-using-docker) tell user to "follow the [steps for configuring the datasource in Grafana](https://github.com/grafana/loki/blob/main/docs/sources/getting-started/grafana.md)", but that link is broken
* and this docker-compose should be focused on getting the user up and running ASAP anyway, without requiring jumping to a different reference doc

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
