### PR TITLE
[helm] Release 3.6.1 to reintroduce PrometheusRule alerts

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.6.1
+
+- [BUGFIX] Fix regression that produced empty PrometheusRule alerts resource
+
 ## 3.6.0
 
 - [CHANGE] Bump Loki version to 2.7.0 and GEL version to 1.6.0

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 3.6.0
+version: 3.6.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 


### PR DESCRIPTION
Commit 30caf142b2e9d2e0b63339b66c92a4f528ec884e introduced a regression ending up in generating no PrometheusRule alerts.

That was fixed in commit 433d883fcd7b837b927637e09893008cd2eec356 but no releases were done.

Bump version to have a release about it.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Should hopefully fix a request done by @xinbinhuang - who spotted and fixed this problem, thanks! - in #7860.

I think it is important to tag a release ASAP because stopping having alerts can be a regression in possible production environments.

**Special notes for your reviewer**:
I have no idea if that will force to release a 3.6.1 Helm release without doing any tag or similar, sorry! I have tried to skim documentation about that and I have skimmed `.github/workflows/helm-release.yaml` and `grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main` and I think that this will create a tag... but I'm not super-sure about that!

If I've missed anything please let me know!

Thanks!

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
