### PR TITLE
consider range and offset in queries while looking for schema config for query sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ##### Enhancements
 * [7380](https://github.com/grafana/loki/pull/7380) **liguozhong**: metrics query: range vector support streaming agg when no overlap
-
 * [7684](https://github.com/grafana/loki/pull/7684) **kavirajk**: Add missing `embedded-cache` config under `cache_config` doc.
 * [6360](https://github.com/grafana/loki/pull/6099) **liguozhong**: Hide error message when ctx timeout occurs in s3.getObject
 * [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize filter to easily parse colored logs.
@@ -19,10 +18,9 @@
 ##### Fixes
 
 * [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
-
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
-
 * [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.
+* [7880](https://github.com/grafana/loki/pull/7880) **sandeepsukhani**: consider range and offset in queries while looking for schema config for query sharding.
 
 ##### Changes
 

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -92,8 +92,14 @@ type astMapperware struct {
 }
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	conf, err := ast.confs.GetConf(r)
 	logger := util_log.WithContext(ctx, ast.logger)
+	maxRVDuration, maxOffset, err := maxRangeVectorAndOffsetDuration(r.GetQuery())
+	if err != nil {
+		level.Warn(logger).Log("err", err.Error(), "msg", "failed to get range-vector and offset duration so skipped AST mapper for request")
+		return ast.next.Do(ctx, r)
+	}
+
+	conf, err := ast.confs.GetConf(int64(model.Time(r.GetStart()).Add(-maxRVDuration).Add(-maxOffset)), int64(model.Time(r.GetEnd()).Add(-maxOffset)))
 	// cannot shard with this timerange
 	if err != nil {
 		level.Warn(logger).Log("err", err.Error(), "msg", "skipped AST mapper for request")
@@ -271,8 +277,8 @@ func (confs ShardingConfigs) ValidRange(start, end int64) (config.PeriodConfig, 
 }
 
 // GetConf will extract a shardable config corresponding to a request and the shardingconfigs
-func (confs ShardingConfigs) GetConf(r queryrangebase.Request) (config.PeriodConfig, error) {
-	conf, err := confs.ValidRange(r.GetStart(), r.GetEnd())
+func (confs ShardingConfigs) GetConf(start, end int64) (config.PeriodConfig, error) {
+	conf, err := confs.ValidRange(start, end)
 	// query exists across multiple sharding configs
 	if err != nil {
 		return conf, err
@@ -329,7 +335,7 @@ type seriesShardingHandler struct {
 }
 
 func (ss *seriesShardingHandler) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	conf, err := ss.confs.GetConf(r)
+	conf, err := ss.confs.GetConf(r.GetStart(), r.GetEnd())
 	// cannot shard with this timerange
 	if err != nil {
 		level.Warn(ss.logger).Log("err", err.Error(), "msg", "skipped sharding for request")

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/prometheus/common/model"
 	"math"
 	"sort"
 	"sync"
@@ -28,6 +29,7 @@ var (
 	nilShardingMetrics = logql.NewShardMapperMetrics(nil)
 	defaultReq         = func() *LokiRequest {
 		return &LokiRequest{
+			Step: 1000,
 			Limit:     100,
 			StartTs:   start,
 			EndTs:     end,
@@ -395,4 +397,258 @@ func Test_SeriesShardingHandler(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
+	now := model.Now()
+	confs := ShardingConfigs{
+		{
+			From:        config.DayTime{Time: now.Add(-30*24*time.Hour)},
+			RowShards:   2,
+		},
+		{
+			From: config.DayTime{Time: now.Add(-24*time.Hour)},
+			RowShards: 3,
+		},
+	}
+
+	for _, tc := range []struct{
+		name string
+		req queryrangebase.Request
+		resp queryrangebase.Response
+		numExpectedShards int
+	}{
+		{
+			name: "logs query touching just the active schema config",
+			req: defaultReq().WithStartEndTime(now.Add(-time.Hour).Time(), now.Time()).WithQuery(`{foo="bar"}`),
+			resp: &LokiResponse{
+				Status: loghttp.QueryStatusSuccess,
+				Headers: []definitions.PrometheusResponseHeader{
+					{Name: "Header", Values: []string{"value"}},
+				},
+			},
+			numExpectedShards: 3,
+		},
+		{
+			name: "logs query touching just the prev schema config",
+			req: defaultReq().WithStartEndTime(confs[0].From.Time.Time(), confs[0].From.Time.Add(time.Hour).Time()).WithQuery(`{foo="bar"}`),
+			resp: &LokiResponse{
+				Status: loghttp.QueryStatusSuccess,
+				Headers: []definitions.PrometheusResponseHeader{
+					{Name: "Header", Values: []string{"value"}},
+				},
+			},
+			numExpectedShards: 2,
+		},
+		{
+			name: "metric query touching just the active schema config",
+			req: defaultReq().WithStartEndTime(confs[1].From.Time.Add(5*time.Minute).Time(), confs[1].From.Time.Add(time.Hour).Time()).WithQuery(`rate({foo="bar"}[1m])`),
+			resp: &LokiPromResponse{
+				Response: &queryrangebase.PrometheusResponse{
+					Status: loghttp.QueryStatusSuccess,
+					Data: queryrangebase.PrometheusData{
+						ResultType: "",
+						Result:     []queryrangebase.SampleStream{},
+					},
+					Headers: []*definitions.PrometheusResponseHeader{
+						{Name: "Header", Values: []string{"value"}},
+					},
+				},
+			},
+			numExpectedShards: 3,
+		},
+		{
+			name: "metric query touching just the prev schema config",
+			req: defaultReq().WithStartEndTime(confs[0].From.Time.Add(time.Hour).Time(), confs[0].From.Time.Add(2*time.Hour).Time()).WithQuery(`rate({foo="bar"}[1m])`),
+			resp: &LokiPromResponse{
+				Response: &queryrangebase.PrometheusResponse{
+					Status: loghttp.QueryStatusSuccess,
+					Data: queryrangebase.PrometheusData{
+						ResultType: "",
+						Result:     []queryrangebase.SampleStream{},
+					},
+					Headers: []*definitions.PrometheusResponseHeader{
+						{Name: "Header", Values: []string{"value"}},
+					},
+				},
+			},
+			numExpectedShards: 2,
+		},
+		{
+			name: "logs query covering both schemas",
+			req: defaultReq().WithStartEndTime(confs[0].From.Time.Time(), now.Time()).WithQuery(`{foo="bar"}`),
+			resp: &LokiResponse{
+				Status: loghttp.QueryStatusSuccess,
+				Headers: []definitions.PrometheusResponseHeader{
+					{Name: "Header", Values: []string{"value"}},
+				},
+			},
+			numExpectedShards: 1,
+		},
+		{
+			name: "metric query covering both schemas",
+			req: defaultReq().WithStartEndTime(confs[0].From.Time.Time(), now.Time()).WithQuery(`rate({foo="bar"}[1m])`),
+			resp: &LokiPromResponse{
+				Response: &queryrangebase.PrometheusResponse{
+					Status: loghttp.QueryStatusSuccess,
+					Data: queryrangebase.PrometheusData{
+						ResultType: "",
+						Result:     []queryrangebase.SampleStream{},
+					},
+					Headers: []*definitions.PrometheusResponseHeader{
+						{Name: "Header", Values: []string{"value"}},
+					},
+				},
+			},
+			numExpectedShards: 1,
+		},
+		{
+			name: "metric query with start/end within first schema but with large enough range to cover previous schema too",
+			req: defaultReq().WithStartEndTime(confs[1].From.Time.Add(5*time.Minute).Time(), confs[1].From.Time.Add(time.Hour).Time()).WithQuery(`rate({foo="bar"}[24h])`),
+			resp: &LokiPromResponse{
+				Response: &queryrangebase.PrometheusResponse{
+					Status: loghttp.QueryStatusSuccess,
+					Data: queryrangebase.PrometheusData{
+						ResultType: "",
+						Result:     []queryrangebase.SampleStream{},
+					},
+					Headers: []*definitions.PrometheusResponseHeader{
+						{Name: "Header", Values: []string{"value"}},
+					},
+				},
+			},
+			numExpectedShards: 1,
+		},
+		{
+			name: "metric query with start/end within first schema but with large enough offset to shift it to previous schema",
+			req: defaultReq().WithStartEndTime(confs[1].From.Time.Add(5*time.Minute).Time(), now.Time()).WithQuery(`rate({foo="bar"}[1m] offset 12h)`),
+			resp: &LokiPromResponse{
+				Response: &queryrangebase.PrometheusResponse{
+					Status: loghttp.QueryStatusSuccess,
+					Data: queryrangebase.PrometheusData{
+						ResultType: "",
+						Result:     []queryrangebase.SampleStream{},
+					},
+					Headers: []*definitions.PrometheusResponseHeader{
+						{Name: "Header", Values: []string{"value"}},
+					},
+				},
+			},
+			numExpectedShards: 1,
+		},
+	}{
+		t.Run(tc.name, func(t *testing.T) {
+			var lock sync.Mutex
+			called := 0
+
+			handler := queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+				lock.Lock()
+				defer lock.Unlock()
+				called++
+				return tc.resp, nil
+			})
+
+			mware := newASTMapperware(
+				confs,
+				handler,
+				log.NewNopLogger(),
+				nilShardingMetrics,
+				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
+			)
+
+			resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), tc.req)
+			require.Nil(t, err)
+
+			require.Equal(t, []*definitions.PrometheusResponseHeader{
+				{Name: "Header", Values: []string{"value"}},
+			}, resp.GetHeaders())
+
+			require.Equal(t, tc.numExpectedShards, called)
+		})
+	}
+}
+
+func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
+	now := model.Now()
+	confs := ShardingConfigs{
+		{
+			From:        config.DayTime{Time: now.Add(-30*24*time.Hour)},
+			RowShards:   2,
+		},
+		{
+			From: config.DayTime{Time: now.Add(-24*time.Hour)},
+			RowShards: 3,
+		},
+	}
+
+	for _, tc := range []struct{
+		name string
+		req *LokiSeriesRequest
+		numExpectedShards int
+	}{
+		{
+			name: "series query touching just the active schema config",
+			req: &LokiSeriesRequest{
+				Match:   []string{"foo", "bar"},
+				StartTs: confs[1].From.Time.Add(5*time.Minute).Time(),
+				EndTs:   now.Time(),
+				Path:    "foo",
+			},
+			numExpectedShards: 3,
+		},
+		{
+			name: "series query touching just the prev schema config",
+			req: &LokiSeriesRequest{
+				Match:   []string{"foo", "bar"},
+				StartTs: confs[0].From.Time.Time(),
+				EndTs:   confs[0].From.Time.Add(time.Hour).Time(),
+				Path:    "foo",
+			},
+			numExpectedShards: 2,
+		},
+		{
+			name: "series query covering both schemas",
+			req: &LokiSeriesRequest{
+				Match:   []string{"foo", "bar"},
+				StartTs: confs[0].From.Time.Time(),
+				EndTs:   now.Time(),
+				Path:    "foo",
+			},			numExpectedShards: 1,
+		},
+	}{
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := user.InjectOrgID(context.Background(), "1")
+			var lock sync.Mutex
+			called := 0
+
+			mware := NewSeriesQueryShardMiddleware(
+				log.NewNopLogger(),
+				confs,
+				queryrangebase.NewInstrumentMiddlewareMetrics(nil),
+				nilShardingMetrics,
+				fakeLimits{
+					maxQueryParallelism: 10,
+				},
+				LokiCodec,
+			)
+
+			_, err := mware.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+				_, ok := r.(*LokiSeriesRequest)
+				if !ok {
+					return nil, errors.New("not a series call")
+				}
+				lock.Lock()
+				defer lock.Unlock()
+				called++
+				return &LokiSeriesResponse{
+					Status:  "success",
+					Version: 1,
+					Data: []logproto.SeriesIdentifier{},
+				}, nil
+			})).Do(ctx, tc.req)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.numExpectedShards, called)
+		})
+	}
 }

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -276,25 +276,35 @@ func splitByTime(req queryrangebase.Request, interval time.Duration) ([]queryran
 	return reqs, nil
 }
 
-// maxRangeVectorDuration returns the maximum range vector duration within a LogQL query.
-func maxRangeVectorDuration(q string) (time.Duration, error) {
-	expr, err := syntax.ParseSampleExpr(q)
+// maxRangeVectorAndOffsetDuration returns the maximum range vector and offset duration within a LogQL query.
+func maxRangeVectorAndOffsetDuration(q string) (time.Duration, time.Duration, error) {
+	expr, err := syntax.ParseExpr(q)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	var max time.Duration
+
+	if _, ok := expr.(syntax.SampleExpr); !ok {
+		return 0, 0, nil
+	}
+	
+	var maxRVDuration, maxOffset time.Duration
 	expr.Walk(func(e interface{}) {
-		if r, ok := e.(*syntax.LogRange); ok && r.Interval > max {
-			max = r.Interval
+		if r, ok := e.(*syntax.LogRange); ok {
+			if r.Interval > maxRVDuration {
+				maxRVDuration = r.Interval
+			}
+			if r.Offset > maxOffset {
+				maxOffset = r.Offset
+			}
 		}
 	})
-	return max, nil
+	return maxRVDuration, maxOffset, nil
 }
 
 // reduceSplitIntervalForRangeVector reduces the split interval for a range query based on the duration of the range vector.
 // Large range vector durations will not be split into smaller intervals because it can cause the queries to be slow by over-processing data.
 func reduceSplitIntervalForRangeVector(r queryrangebase.Request, interval time.Duration) (time.Duration, error) {
-	maxRange, err := maxRangeVectorDuration(r.GetQuery())
+	maxRange, _, err := maxRangeVectorAndOffsetDuration(r.GetQuery())
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We disable query sharding when a query touches multiple schema configs since they might have different sharding factors and might handle sharding differently. This check was done purely on the start and end time of the query without considering `range` and `offset`, which would change the length of the actual data being queried.

Besides being incorrect, it also causes us to fail queries when migrating between tsdb and non-tsdb stores since both handle query sharding differently. For e.g., if the prev schema is `boltdb-shipper` and starting today, `tsdb` index is being used, so if we do a query `sum(rate({foo="bar"}[24h])` even with start and end within `tsdb` range, we will fail the query with error `incompatible index shard` if dynamic sharding goes with shard factor other than `32`(default shard factor in ingester for inverted index). The reason being the `range` here is `24h` which causes us to process data from previous schema as well.

This PR takes care of the issue by factoring in `range` and `offset` in the queries while looking for schema config for query sharding.

**Checklist**
- [x] `CHANGELOG.md` updated
