### PR TITLE
Promtail: Improve LabelsMap CPU performance

### DIFF
--- a/clients/pkg/promtail/client/batch.go
+++ b/clients/pkg/promtail/client/batch.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strconv"
 
 	"strings"
 	"time"
@@ -96,7 +97,7 @@ func labelsMapToString(ls model.LabelSet, without model.LabelName) string {
 
 		b.WriteString(string(l))
 		b.WriteString(`="`)
-		b.WriteString(strings.ReplaceAll(string(ls[l]), `"`, `\"`))
+		b.WriteString(strconv.Quote(string(ls[l])))
 		b.WriteString(`"`)
 	}
 	b.WriteByte('}')

--- a/clients/pkg/promtail/client/batch.go
+++ b/clients/pkg/promtail/client/batch.go
@@ -96,9 +96,8 @@ func labelsMapToString(ls model.LabelSet, without model.LabelName) string {
 		}
 
 		b.WriteString(string(l))
-		b.WriteString(`="`)
+		b.WriteString(`=`)
 		b.WriteString(strconv.Quote(string(ls[l])))
-		b.WriteString(`"`)
 	}
 	b.WriteByte('}')
 

--- a/clients/pkg/promtail/client/batch.go
+++ b/clients/pkg/promtail/client/batch.go
@@ -84,6 +84,7 @@ func labelsMapToString(ls model.LabelSet, without model.LabelName) string {
 		}
 
 		lstrs = append(lstrs, l)
+		// guess size increase: 2 for `, ` between labels and 3 for the `=` and quotes around label value
 		totalSize += len(l) + 2 + len(v) + 3
 	}
 

--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -164,3 +164,17 @@ func TestHashCollisions(t *testing.T) {
 		assert.Equal(t, ls1.String(), req.Streams[1].Labels)
 	}
 }
+
+func BenchmarkLabelsMapToString(b *testing.B) {
+	labelSet := make(model.LabelSet)
+	labelSet["label"] = "value"
+	labelSet["label1"] = "value"
+	labelSet["label2"] = "value"
+	labelSet["__tenant_id__"] = "value"
+
+	ReservedLabelTenantID := "__tenant_id__"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = labelsMapToString(labelSet, model.LabelName(ReservedLabelTenantID))
+	}
+}

--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -173,7 +173,7 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 	labelSet := make(model.LabelSet)
 	labelSet["label"] = "value"
 	labelSet["label1"] = "value"
-	labelSet["label2"] = "value"
+	labelSet["label2"] = "value3"
 	labelSet["__tenant_id__"] = "another_value"
 
 	b.ResetTimer()

--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -165,6 +165,10 @@ func TestHashCollisions(t *testing.T) {
 	}
 }
 
+// store the result to a package level variable
+// so the compiler cannot eliminate the Benchmark itself.
+var result string
+
 func BenchmarkLabelsMapToString(b *testing.B) {
 	labelSet := make(model.LabelSet)
 	labelSet["label"] = "value"
@@ -172,9 +176,11 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 	labelSet["label2"] = "value"
 	labelSet["__tenant_id__"] = "value"
 
-	ReservedLabelTenantID := "__tenant_id__"
 	b.ResetTimer()
+	var r string
 	for i := 0; i < b.N; i++ {
-		_ = labelsMapToString(labelSet, model.LabelName(ReservedLabelTenantID))
+		// store in r prevent the compiler eliminating the function call.
+		r = labelsMapToString(labelSet, ReservedLabelTenantID)
 	}
+	result = r
 }

--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -174,7 +174,7 @@ func BenchmarkLabelsMapToString(b *testing.B) {
 	labelSet["label"] = "value"
 	labelSet["label1"] = "value"
 	labelSet["label2"] = "value"
-	labelSet["__tenant_id__"] = "value"
+	labelSet["__tenant_id__"] = "another_value"
 
 	b.ResetTimer()
 	var r string

--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -172,7 +172,7 @@ var result string
 func BenchmarkLabelsMapToString(b *testing.B) {
 	labelSet := make(model.LabelSet)
 	labelSet["label"] = "value"
-	labelSet["label1"] = "value"
+	labelSet["label1"] = "value2"
 	labelSet["label2"] = "value3"
 	labelSet["__tenant_id__"] = "another_value"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The labelsMapToString function takes a relative high amount of CPU in a simple promtail pipeline. By replacing the fmt.Sprintf with a string. Builder we achieve a 50+% improvement in the function.  In my local promtail installation I get about a 10% global cpu reduction. 

```
name                 old time/op    new time/op    delta
LabelsMapToString-8    1.10µs ± 3%    0.30µs ± 4%  -72.40%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
LabelsMapToString-8      344B ± 0%      184B ± 0%  -46.51%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
LabelsMapToString-8      14.0 ± 0%       6.0 ± 0%  -57.14%  (p=0.008 n=5+5)
```

**Special notes for your reviewer**:
The code does get more complex, and this might be a trade-off. Considering promtail is running on many machines (ie. kubernetes nodes) I think the gain is worth it.

Two alternatives:
- Only replace the `lstrs = append(lstrs, fmt.Sprintf("%s=%q", l, v))` call, as it takes most of the time
- Get rid of the explicit `b.Grow` calls and the tracking of size. This only adds a slight improvement

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
