### PR TITLE
Prepare changelog and release notes for 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ Check the history of the branch FIXME.
 
 * Go Version: 1.19
 
+## 2.7.1
+
+#### Loki
+
+##### Fixes
+* [7453](https://github.com/grafana/loki/pull/7453) **periklis**: Add single compactor http client for delete and gennumber clients
+
+##### Changes
+* [7877](https://github.com/grafana/loki/pull/7877)A **trevorwhitney**: Due to a known bug with experimental new delete mode feature, the default delete mode has been changed to `filter-only`.
+
 ## 2.7.0
 
 #### Loki
@@ -82,7 +92,6 @@ Check the history of the branch FIXME.
 * [6952](https://github.com/grafana/loki/pull/6952) **DylanGuedes**: Experimental: Introduce a new feature named stream sharding.
 
 ##### Fixes
-* [7453](https://github.com/grafana/loki/pull/7453) **periklis**: Add single compactor http client for delete and gennumber clients
 * [7426](https://github.com/grafana/loki/pull/7426) **periklis**: Add missing compactor delete client tls client config
 * [7238](https://github.com/grafana/loki/pull/7328) **periklis**: Fix internal server bootstrap for query frontend
 * [7288](https://github.com/grafana/loki/pull/7288) **ssncferreira**: Fix query mapping in AST mapper `rangemapper` to support the new `VectorExpr` expression.

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -32,3 +32,18 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 As always, please read the [upgrade guide](../../upgrading/#270) before upgrading Loki.
 
 ## Bug fixes
+
+### 2.6.1 
+
+* Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were  enabeld:
+
+    ```console
+    level=error ts=2022-10-18T14:13:41.598649348Z caller=delete_requests_client.go:211 msg="error getting delete requests from the store" err="unexpected status code: 404"
+    ts=2022-10-18T14:13:41.598697295Z caller=spanlogger.go:80 user=application level=error msg="failed loading deletes for user" err="unexpected status code: 404"
+    ```
+
+* Change default deltion mode to `filter-only` on account of the bug (see below).
+
+#### Known Issues
+
+* There is a bug with the experimental deletion mode in 2.6.x and 2.7.x that in some cases can cause the wrong chunks to be deleted. As a result we have changed the default deletion mode to `filter-only` until this bug has been addressed.

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -35,7 +35,7 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 
 ### 2.7.1 
 
-* Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were  enabeld:
+* Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were enabled:
 
     ```console
     level=error ts=2022-10-18T14:13:41.598649348Z caller=delete_requests_client.go:211 msg="error getting delete requests from the store" err="unexpected status code: 404"

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -33,7 +33,7 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 
 ## Bug fixes
 
-### 2.6.1 
+### 2.7.1 
 
 * Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were  enabeld:
 

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -42,7 +42,7 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
     ts=2022-10-18T14:13:41.598697295Z caller=spanlogger.go:80 user=application level=error msg="failed loading deletes for user" err="unexpected status code: 404"
     ```
 
-* Change default deltion mode to `filter-only` on account of the bug (see below).
+* Change default deletion mode to `filter-only` on account of the bug (see below).
 
 #### Known Issues
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares changelog and release notes for 2.7.1 release.