### PR TITLE
Fix sizing tool.

### DIFF
--- a/docs/sources/installation/sizing/index.md
+++ b/docs/sources/installation/sizing/index.md
@@ -71,7 +71,7 @@ This tool helps to generate a Helm Charts `values.yaml` file based on specified
 </style>
 
 <script>
-const API_URL = `http://logql-analyzer.grafana.net/next/api/sizing`
+const API_URL = `https://logql-analyzer.grafana.net/next/api/sizing`
 const { createApp } = Vue
 
 createApp({
@@ -99,7 +99,7 @@ createApp({
   methods: {
     async fetchNodeTypes() {
       const url = `${API_URL}/nodes`
-      this.nodes = await (await fetch(url)).json()
+      this.nodes = await (await fetch(url),{mode: 'cors'}).json()
     }
   }
 }).mount('#app')


### PR DESCRIPTION
**What this PR does / why we need it**
The current sizing tool is broken because it would not allow cross origin requests. See LogQL Analyzer (https://github.com/grafana/loki/blob/main/docs/sources/logql/analyzer/script.js#L115) for the proper way to call its API.
