### PR TITLE
Update dskit to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/dskit v0.0.0-20220928083349-b1b307db4f30
+	github.com/grafana/dskit v0.0.0-20221212120341-3e308a49441b
 	github.com/grafana/go-gelf/v2 v2.0.1
 	github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -726,8 +726,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/dskit v0.0.0-20220928083349-b1b307db4f30 h1:Lbeu0ddFATI+cgXh6LzjAk9TdoU7WUZ2hry+5H4xXdM=
-github.com/grafana/dskit v0.0.0-20220928083349-b1b307db4f30/go.mod h1:NTfOwhBMmR7TyG4E3RB4F1qhvk+cawoXacyN30yipVY=
+github.com/grafana/dskit v0.0.0-20221212120341-3e308a49441b h1:3Di+jzpE0CHlzlYtjDq9xL5xinR4FUQ7GoQ44JkfQLc=
+github.com/grafana/dskit v0.0.0-20221212120341-3e308a49441b/go.mod h1:rJRGBDtyQNA3OFh7WecUILvxkgGrdIuA4f9wgZOn3V0=
 github.com/grafana/go-gelf/v2 v2.0.1 h1:BOChP0h/jLeD+7F9mL7tq10xVkDG15he3T1zHuQaWak=
 github.com/grafana/go-gelf/v2 v2.0.1/go.mod h1:lexHie0xzYGwCgiRGcvZ723bSNyNI8ZRD4s0CLobh90=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=

--- a/vendor/github.com/grafana/dskit/grpcutil/health_check.go
+++ b/vendor/github.com/grafana/dskit/grpcutil/health_check.go
@@ -4,29 +4,64 @@ import (
 	"context"
 
 	"github.com/gogo/status"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/dskit/services"
 )
 
+// Check is a function that determines if this gRPC application is healthy.
+type Check func(ctx context.Context) bool
+
+// WithManager returns a new Check that tests if the managed services are healthy.
+func WithManager(manager *services.Manager) Check {
+	return func(ctx context.Context) bool {
+		states := manager.ServicesByState()
+
+		// Given this is a health check endpoint for the whole instance, we should consider
+		// it healthy after all services have been started (running) and until all
+		// services are terminated. Some services, like ingesters, are still
+		// fully functioning while stopping.
+		if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
+			return false
+		}
+
+		return len(states[services.Running]) > 0 || len(states[services.Stopping]) > 0
+	}
+}
+
+// WithShutdownRequested returns a new Check that returns false when shutting down.
+func WithShutdownRequested(requested *atomic.Bool) Check {
+	return func(ctx context.Context) bool {
+		return !requested.Load()
+	}
+}
+
 // HealthCheck fulfills the grpc_health_v1.HealthServer interface by ensuring
-// the services being managed by the provided service manager are healthy.
+// each of the provided Checks indicates the application is healthy.
 type HealthCheck struct {
-	sm *services.Manager
+	checks []Check
 }
 
 // NewHealthCheck returns a new HealthCheck for the provided service manager.
 func NewHealthCheck(sm *services.Manager) *HealthCheck {
+	return NewHealthCheckFrom(WithManager(sm))
+}
+
+// NewHealthCheckFrom returns a new HealthCheck that uses each of the provided Checks.
+func NewHealthCheckFrom(checks ...Check) *HealthCheck {
 	return &HealthCheck{
-		sm: sm,
+		checks: checks,
 	}
 }
 
 // Check implements the grpc healthcheck.
-func (h *HealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	if !h.isHealthy() {
-		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+func (h *HealthCheck) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	for _, check := range h.checks {
+		if !check(ctx) {
+			return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+		}
 	}
 
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
@@ -35,19 +70,4 @@ func (h *HealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequ
 // Watch implements the grpc healthcheck.
 func (h *HealthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "Watching is not supported")
-}
-
-// isHealthy returns whether the instance should be considered healthy.
-func (h *HealthCheck) isHealthy() bool {
-	states := h.sm.ServicesByState()
-
-	// Given this is an health check endpoint for the whole instance, we should consider
-	// it healthy after all services have been started (running) and until all
-	// services are terminated. Some services, like ingesters, are still
-	// fully functioning while stopping.
-	if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
-		return false
-	}
-
-	return len(states[services.Running]) > 0 || len(states[services.Stopping]) > 0
 }

--- a/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
+++ b/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
@@ -141,8 +141,8 @@ type KVConfig struct {
 	AdvertiseAddr string `yaml:"advertise_addr"`
 	AdvertisePort int    `yaml:"advertise_port"`
 
-	ClusterLabel                     string `yaml:"cluster_label" category:"experimental"`
-	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled" category:"experimental"`
+	ClusterLabel                     string `yaml:"cluster_label" category:"advanced"`
+	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled" category:"advanced"`
 
 	// List of members to join
 	JoinMembers      flagext.StringSlice `yaml:"join_members"`

--- a/vendor/github.com/grafana/dskit/modules/modules.go
+++ b/vendor/github.com/grafana/dskit/modules/modules.go
@@ -18,7 +18,7 @@ type module struct {
 	// initFn for this module (can return nil)
 	initFn func() (services.Service, error)
 
-	// is this module user visible (i.e intended to be passed to `InitModuleServices`)
+	// is this module user visible (i.e. intended to be passed to `InitModuleServices`)
 	userVisible bool
 }
 

--- a/vendor/github.com/grafana/dskit/multierror/multierror.go
+++ b/vendor/github.com/grafana/dskit/multierror/multierror.go
@@ -1,3 +1,6 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/2027fb30/pkg/errutil/multierror.go
+// Provenance-includes-copyright: The Thanos Authors.
+
 package multierror
 
 import (

--- a/vendor/github.com/grafana/dskit/netutil/netutil.go
+++ b/vendor/github.com/grafana/dskit/netutil/netutil.go
@@ -2,7 +2,6 @@ package netutil
 
 import (
 	"net"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -53,6 +52,5 @@ func privateNetworkInterfaces(all []net.Interface, fallback []string, logger log
 	if len(privInts) == 0 {
 		return fallback
 	}
-	level.Debug(logger).Log("msg", "found network interfaces with private IP addresses assigned", "interfaces", strings.Join(privInts, " "))
 	return privInts
 }

--- a/vendor/github.com/grafana/dskit/ring/client/pool.go
+++ b/vendor/github.com/grafana/dskit/ring/client/pool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/ring/util"
 	"github.com/grafana/dskit/services"
 )
@@ -35,9 +36,10 @@ type PoolServiceDiscovery func() ([]string, error)
 
 // PoolConfig is config for creating a Pool.
 type PoolConfig struct {
-	CheckInterval      time.Duration
-	HealthCheckEnabled bool
-	HealthCheckTimeout time.Duration
+	CheckInterval             time.Duration
+	HealthCheckEnabled        bool
+	HealthCheckTimeout        time.Duration
+	MaxConcurrentHealthChecks int // defaults to 16
 }
 
 // Pool holds a cache of grpc_health_v1 clients.
@@ -58,6 +60,10 @@ type Pool struct {
 
 // NewPool creates a new Pool.
 func NewPool(clientName string, cfg PoolConfig, discovery PoolServiceDiscovery, factory PoolFactory, clientsMetric prometheus.Gauge, logger log.Logger) *Pool {
+	if cfg.MaxConcurrentHealthChecks == 0 {
+		cfg.MaxConcurrentHealthChecks = 16
+	}
+
 	p := &Pool{
 		cfg:           cfg,
 		discovery:     discovery,
@@ -173,24 +179,30 @@ func (p *Pool) removeStaleClients() {
 	}
 }
 
-// cleanUnhealthy loops through all servers and deletes any that fails a healthcheck.
+// cleanUnhealthy loops through all servers and deletes any that fail a healthcheck.
+// The health checks are executed concurrently with p.cfg.MaxConcurrentHealthChecks.
 func (p *Pool) cleanUnhealthy() {
-	for _, addr := range p.RegisteredAddresses() {
+	addresses := p.RegisteredAddresses()
+	_ = concurrency.ForEachJob(context.Background(), len(addresses), p.cfg.MaxConcurrentHealthChecks, func(ctx context.Context, idx int) error {
+		addr := addresses[idx]
 		client, ok := p.fromCache(addr)
 		// not ok means someone removed a client between the start of this loop and now
 		if ok {
-			err := healthCheck(client, p.cfg.HealthCheckTimeout)
+			err := healthCheck(ctx, client, p.cfg.HealthCheckTimeout)
 			if err != nil {
 				level.Warn(p.logger).Log("msg", fmt.Sprintf("removing %s failing healthcheck", p.clientName), "addr", addr, "reason", err)
 				p.RemoveClientFor(addr)
 			}
 		}
-	}
+		// Never return an error, because otherwise the processing would stop and
+		// remaining health checks would not been executed.
+		return nil
+	})
 }
 
 // healthCheck will check if the client is still healthy, returning an error if it is not
-func healthCheck(client PoolClient, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func healthCheck(ctx context.Context, client PoolClient, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	ctx = user.InjectOrgID(ctx, "0")
 

--- a/vendor/github.com/grafana/dskit/ring/http.go
+++ b/vendor/github.com/grafana/dskit/ring/http.go
@@ -18,7 +18,7 @@ var defaultPageContent string
 var defaultPageTemplate = template.Must(template.New("webpage").Funcs(template.FuncMap{
 	"mod": func(i, j int) bool { return i%j == 0 },
 	"humanFloat": func(f float64) string {
-		return fmt.Sprintf("%.2g", f)
+		return fmt.Sprintf("%.3g", f)
 	},
 	"timeOrEmptyString": func(t time.Time) string {
 		if t.IsZero() {

--- a/vendor/github.com/grafana/dskit/runtimeconfig/manager.go
+++ b/vendor/github.com/grafana/dskit/runtimeconfig/manager.go
@@ -62,7 +62,7 @@ type Manager struct {
 	fileHashes map[string]string
 }
 
-// New creates an instance of Manager and starts reload config loop based on config
+// New creates an instance of Manager. Manager is a services.Service, and must be explicitly started to perform any work.
 func New(cfg Config, registerer prometheus.Registerer, logger log.Logger) (*Manager, error) {
 	if len(cfg.LoadPath) == 0 {
 		return nil, errors.New("LoadPath is empty")

--- a/vendor/github.com/grafana/dskit/services/README.md
+++ b/vendor/github.com/grafana/dskit/services/README.md
@@ -131,10 +131,10 @@ func (s *exampleService) Send(msg string) bool {
 }
 ```
 
-Now `serv` is a service that can be started, observed for state changes, or stopped. As long as service is in Running state, clients can call its `Send` method:
+Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as service is in Running state, clients can call its `Send` method:
 
 ```go
-s := newServ()
+s := newExampleServ()
 s.StartAsync(context.Background())
 s.AwaitRunning(context.Background())
 // now collect() is running

--- a/vendor/github.com/grafana/dskit/services/manager.go
+++ b/vendor/github.com/grafana/dskit/services/manager.go
@@ -304,7 +304,7 @@ type funcBasedManagerListener struct {
 	failure func(service Service)
 }
 
-func (f *funcBasedManagerListener) Healthy() {
+func (f funcBasedManagerListener) Healthy() {
 	if f.healthy != nil {
 		f.healthy()
 	}

--- a/vendor/github.com/grafana/dskit/services/services.go
+++ b/vendor/github.com/grafana/dskit/services/services.go
@@ -64,7 +64,7 @@ type funcBasedListener struct {
 	failedFn     func(from State, failure error)
 }
 
-func (f *funcBasedListener) Starting() {
+func (f funcBasedListener) Starting() {
 	if f.startingFn != nil {
 		f.startingFn()
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -681,7 +681,7 @@ github.com/gorilla/mux
 # github.com/gorilla/websocket v1.5.0
 ## explicit; go 1.12
 github.com/gorilla/websocket
-# github.com/grafana/dskit v0.0.0-20220928083349-b1b307db4f30
+# github.com/grafana/dskit v0.0.0-20221212120341-3e308a49441b
 ## explicit; go 1.18
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/concurrency


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest dskit commit contains improvements for the gRPC health checks in the ingester client pool.

Full diff: https://github.com/grafana/dskit/compare/b1b307db4f30..3e308a49441b

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
