### PR TITLE
Flush buffered logger on exit.

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -21,6 +21,11 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 )
 
+func exit(code int) {
+	util_log.Flush()
+	os.Exit(code)
+}
+
 func main() {
 	var config loki.ConfigWrapper
 
@@ -41,7 +46,7 @@ func main() {
 	// Init the logger which will honor the log level set in config.Server
 	if reflect.DeepEqual(&config.Server.LogLevel, &logging.Level{}) {
 		level.Error(util_log.Logger).Log("msg", "invalid log level")
-		os.Exit(1)
+		exit(1)
 	}
 	util_log.InitLogger(&config.Server, prometheus.DefaultRegisterer, config.UseBufferedLogger, config.UseSyncLogger)
 
@@ -49,7 +54,7 @@ func main() {
 	// and CLI flags parsed.
 	if err := config.Validate(); err != nil {
 		level.Error(util_log.Logger).Log("msg", "validating config", "err", err.Error())
-		os.Exit(1)
+		exit(1)
 	}
 
 	if config.PrintConfig {
@@ -66,7 +71,7 @@ func main() {
 
 	if config.VerifyConfig {
 		level.Info(util_log.Logger).Log("msg", "config is valid")
-		os.Exit(0)
+		exit(0)
 	}
 
 	if config.Tracing.Enabled {
@@ -97,7 +102,7 @@ func main() {
 
 	if config.ListTargets {
 		t.ListTargets()
-		os.Exit(0)
+		exit(0)
 	}
 
 	level.Info(util_log.Logger).Log("msg", "Starting Loki", "version", version.Info())

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -92,9 +92,6 @@ func newPrometheusLogger(l logging.Level, format logging.Format, reg prometheus.
 
 	var writer io.Writer
 	if buffered {
-		// TODO: it's technically possible here to lose logs between the 100ms flush and the process being killed
-		// 	=> call buf.Flush() in a signal handler if this is a concern, but this is unlikely to be a problem
-
 		// retain a reference to this logger because it doesn't conform to the standard Logger interface,
 		// and we can't unwrap it to get the underlying logger when we flush on shutdown
 		bufferedLogger = log.NewLineBufferedLogger(os.Stderr, logEntries,
@@ -172,6 +169,8 @@ func CheckFatal(location string, err error, logger log.Logger) {
 	fmt.Fprintln(os.Stderr, errStr)
 
 	logger.Log("err", errStr)
+	err = Flush()
+	fmt.Fprintln(os.Stderr, "Could not flush logger", err)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I ran into this issue several times. No error logs were printed or no generated token for GEL. This is because crashing runs can be much faster than the flush period.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
