### PR TITLE
Fix validation for pattern and rexexp parsers to they don't panic in query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ##### Fixes
 
+* [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and rexexp parsers to they don't panic in query-frontend.
 * [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
 * [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ##### Fixes
 
-* [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and rexexp parsers to they don't panic in query-frontend.
+* [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and regexp parsers.
 * [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
 * [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1750,4 +1750,6 @@ func Test_FailQuery(t *testing.T) {
 	require.Error(t, err)
 	_, _, err = rvm.Parse(`topk(0, sum(count_over_time({app="foo"} | json |  __error__="" [15m])))`)
 	require.Error(t, err)
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp[1d])))`)
+	require.Error(t, err)
 }

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1752,7 +1752,7 @@ func Test_FailQuery(t *testing.T) {
 	_, _, err = rvm.Parse(`topk(0, sum(count_over_time({app="foo"} | json |  __error__="" [15m])))`)
 	require.Error(t, err)
 
-	// Fix for bug where missing or empty parameters for regexp and pattern parsers threw a panic
+	// Check fixes for bug where missing or empty parameters for regexp and pattern parsers threw a panic
 	// Missing parameter to regexp parser
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1751,5 +1752,5 @@ func Test_FailQuery(t *testing.T) {
 	_, _, err = rvm.Parse(`topk(0, sum(count_over_time({app="foo"} | json |  __error__="" [15m])))`)
 	require.Error(t, err)
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp[1d])))`)
-	require.Error(t, err)
+	require.ErrorIs(t, err, logqlmodel.ErrParse)
 }

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1751,6 +1751,18 @@ func Test_FailQuery(t *testing.T) {
 	require.Error(t, err)
 	_, _, err = rvm.Parse(`topk(0, sum(count_over_time({app="foo"} | json |  __error__="" [15m])))`)
 	require.Error(t, err)
-	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp[1d])))`)
+
+	// Fix for bug where missing or empty parameters for regexp and pattern parsers threw a panic
+	// Missing parameter to regexp parser
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
+	// Empty parameter to regexp parser
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp \"\" [1d])))`)
+	require.ErrorIs(t, err, logqlmodel.ErrParse)
+	// Empty parameter to pattern parser
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | pattern \"\" [1d])))`)
+	require.ErrorIs(t, err, logqlmodel.ErrParse)
+	// Empty parameter to json parser
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | json [1d])))`)
+	require.NoError(t, err)
 }

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1751,16 +1751,15 @@ func Test_FailQuery(t *testing.T) {
 	require.Error(t, err)
 	_, _, err = rvm.Parse(`topk(0, sum(count_over_time({app="foo"} | json |  __error__="" [15m])))`)
 	require.Error(t, err)
-
 	// Check fixes for bug where missing or empty parameters for regexp and pattern parsers threw a panic
 	// Missing parameter to regexp parser
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
 	// Empty parameter to regexp parser
-	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp \"\" [1d])))`)
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp ` + "``" + ` [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
 	// Empty parameter to pattern parser
-	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | pattern \"\" [1d])))`)
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | pattern ` + "``" + ` [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
 	// Empty parameter to json parser
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | json [1d])))`)

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1759,7 +1759,7 @@ func Test_FailQuery(t *testing.T) {
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp ` + "``" + ` [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
 	// Empty parameter to pattern parser
-	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | pattern ` + "``" + ` [1d])))`)
+	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | pattern ` + `""` + ` [1d])))`)
 	require.ErrorIs(t, err, logqlmodel.ErrParse)
 	// Empty parameter to json parser
 	_, _, err = rvm.Parse(`topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | json [1d])))`)

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -332,6 +332,19 @@ type LabelParserExpr struct {
 }
 
 func newLabelParserExpr(op, param string) *LabelParserExpr {
+	if op == OpParserTypeRegexp {
+		_, err := log.NewRegexpParser(param)
+		if err != nil {
+			panic(logqlmodel.NewParseError(fmt.Sprintf("invalid regexp parser: %s", err.Error()), 0, 0))
+		}
+	}
+	if op == OpParserTypePattern {
+		_, err := log.NewPatternParser(param)
+		if err != nil {
+			panic(logqlmodel.NewParseError(fmt.Sprintf("invalid pattern parser: %s", err.Error()), 0, 0))
+		}
+	}
+
 	return &LabelParserExpr{
 		Op:    op,
 		Param: param,
@@ -367,6 +380,9 @@ func (e *LabelParserExpr) String() string {
 	if e.Param != "" {
 		sb.WriteString(" ")
 		sb.WriteString(strconv.Quote(e.Param))
+	}
+	if (e.Op == OpParserTypeRegexp || e.Op == OpParserTypePattern) && e.Param == "" {
+		sb.WriteString(" \"\"")
 	}
 	return sb.String()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Running the query `topk(10,sum by(namespace)(count_over_time({application="nginx", site!="eu-west-1-dev"} |= "/artifactory/" != "api" != "binarystore" | regexp `` [1d])))` causes a panic.

This PR adds validation for regexp and pattern parsers at parse time. If they don't have a (valid) parameter an error will be returned. 

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [X] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
