### PR TITLE
Deprecate CLI flag -ruler.wal-cleaer.period in favor of CLI flag -ruler.wal-cleaner.period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
 * [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.
 * [7880](https://github.com/grafana/loki/pull/7880) **sandeepsukhani**: consider range and offset in queries while looking for schema config for query sharding.
+* [7937](https://github.com/grafana/loki/pull/7937) **ssncferreira**: Deprecate CLI flag `-ruler.wal-cleaer.period` and replace it with `-ruler.wal-cleaner.period`.
 
 ##### Changes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1038,8 +1038,11 @@ wal_cleaner:
   # CLI flag: -ruler.wal-cleaner.min-age
   [min_age: <duration> | default = 12h]
 
+  # Deprecated: CLI flag -ruler.wal-cleaer.period.
+  # Use -ruler.wal-cleaner.period instead.
+  # 
   # How often to run the WAL cleaner. 0 = disabled.
-  # CLI flag: -ruler.wal-cleaer.period
+  # CLI flag: -ruler.wal-cleaner.period
   [period: <duration> | default = 0s]
 
 # Remote-write configuration to send rule samples to a Prometheus remote-write

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -44,6 +44,19 @@ go build ./clients/cmd/promtail --tags=promtail_journal_enabled
 ```
 Introducing this tag aims to relieve Linux/CentOS users with CGO enabled from installing libsystemd-dev/systemd-devel libraries if they don't need Journal support.
 
+### Ruler
+
+#### CLI flag `ruler.wal-cleaer.period` deprecated
+
+CLI flag `ruler.wal-cleaer.period` is now deprecated and replaced with a typo fix `ruler.wal-cleaner.period`.
+The yaml configuration remains unchanged:
+
+```yaml
+ruler:
+  wal_cleaner:
+    period: 5s
+```
+
 ## 2.7.0
 
 ### Loki

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -44,6 +44,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid ruler remote-write config: %w", err)
 	}
 
+	if err := c.WALCleaner.Validate(); err != nil {
+		return fmt.Errorf("invalid ruler wal cleaner config: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/ruler/storage/cleaner/config.go
+++ b/pkg/ruler/storage/cleaner/config.go
@@ -13,9 +13,23 @@ import (
 type Config struct {
 	MinAge time.Duration `yaml:"min_age,omitempty"`
 	Period time.Duration `yaml:"period,omitempty"`
+	// Deprecated
+	// TODO(ssncferreira): remove on next major version
+	DeprecatedPeriod time.Duration `doc:"hidden"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&c.MinAge, "ruler.wal-cleaner.min-age", DefaultCleanupAge, "The minimum age of a WAL to consider for cleaning.")
-	f.DurationVar(&c.Period, "ruler.wal-cleaer.period", DefaultCleanupPeriod, "How often to run the WAL cleaner. 0 = disabled.")
+	f.DurationVar(&c.Period, "ruler.wal-cleaner.period", DefaultCleanupPeriod, "Deprecated: CLI flag -ruler.wal-cleaer.period.\nUse -ruler.wal-cleaner.period instead.\n\nHow often to run the WAL cleaner. 0 = disabled.")
+
+	// Deprecated: typo replaced by c.Period
+	// TODO(ssncferreira): remove on next major version
+	f.DurationVar(&c.DeprecatedPeriod, "ruler.wal-cleaer.period", DefaultCleanupPeriod, "Deprecated: CLI flag -ruler.wal-cleaer.period.\nUse -ruler.wal-cleaner.period instead.")
+}
+
+func (c *Config) Validate() error {
+	if c.DeprecatedPeriod != DefaultCleanupPeriod && c.Period == DefaultCleanupPeriod {
+		c.Period = c.DeprecatedPeriod
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Deprecate CLI flag `-ruler.wal-cleaer.period` in favor of CLI flag `-ruler.wal-cleaner.period`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/pull/7916#issuecomment-1348276269 and https://github.com/grafana/loki/pull/7916#discussion_r1047043534

**NOTE:** correctly registring the `ruler.wal-cleaner` configuration flags is not a breaking change and doesn't require an upgrade guide, because the ruler WAL cleaner initialization code already guarantees that the default values are used: https://github.com/grafana/loki/blob/c71620ae9437aa23142cdc410115f28ae8f29997/pkg/ruler/storage/cleaner/cleaner.go#L76-L101

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
