### PR TITLE
[Helm] Allow single binary with Object Storage

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -235,6 +235,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>deployment.singleBinary</td>
+			<td>string</td>
+			<td></td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>enterprise.adminApi</td>
 			<td>object</td>
 			<td>If enabled, the correct admin_client storage will be configured. If disabled while running enterprise, make sure auth is set to `type: trust`, or that `auth_enabled` is set to `false`.</td>

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -26,14 +26,24 @@ singleBinary fullname
 Return if deployment mode is simple scalable
 */}}
 {{- define "loki.deployment.isScalable" -}}
+{{- $singleBinary := (.Values.deployment.singleBinary | toString) }}
+{{- if ne $singleBinary "" }}
+  {{- ne $singleBinary "true" }}
+{{- else }}
   {{- eq (include "loki.isUsingObjectStorage" . ) "true" }}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Return if deployment mode is single binary
 */}}
 {{- define "loki.deployment.isSingleBinary" -}}
+{{- $singleBinary := (.Values.deployment.singleBinary | toString) }}
+{{- if ne $singleBinary "" }}
+  {{- eq $singleBinary "true" }}
+{{- else }}
   {{- eq (include "loki.isUsingObjectStorage" . ) "false" }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -2,6 +2,10 @@
 {{- fail "Top level 'config' is not allowed. Most common configuration sections are exposed under the `loki` section. If you need to override the whole config, provide the configuration as a string that can contain template expressions under `loki.config`. Alternatively, you can provide the configuration as an external secret." }}
 {{- end }}
 
+{{- if and (eq (include "loki.deployment.isSingleBinary" .) "false") (eq (include "loki.isUsingObjectStorage" . ) "false") }}
+{{- fail "loki.storage.type=filesystem and deployment.singleBinary=false are not compatible."}}
+{{- end }}
+
 {{- if and (not .Values.monitoring.selfMonitoring.enabled) .Values.test.enabled }}
 {{- fail "Helm test requires self monitoring to be enabled"}}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1142,6 +1142,10 @@ networkPolicy:
 tracing:
   jaegerAgentHost: ""
 
+# Override auto-detection of scalable deployment
+deployment:
+  singleBinary: ""
+
 # -------------------------------------
 # Configuration for `minio` child chart
 # -------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow run loki in single binary mode with object storage. See also https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
