### PR TITLE
Fix min and max aggregations when using instant queries.

### DIFF
--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -616,7 +616,7 @@ func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, err
 	case syntax.OpRangeTypeMax:
 		return &MaxOverTime{}, nil
 	case syntax.OpRangeTypeMin:
-		return &MinOverTime{}, nil
+		return &MinOverTime{min: math.NaN()}, nil
 	case syntax.OpRangeTypeStddev:
 		return &StddevOverTime{}, nil
 	case syntax.OpRangeTypeStdvar:

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -614,7 +614,7 @@ func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, err
 	case syntax.OpRangeTypeAvg:
 		return &AvgOverTime{}, nil
 	case syntax.OpRangeTypeMax:
-		return &MaxOverTime{}, nil
+		return &MaxOverTime{max: math.NaN()}, nil
 	case syntax.OpRangeTypeMin:
 		return &MinOverTime{min: math.NaN()}, nil
 	case syntax.OpRangeTypeStddev:


### PR DESCRIPTION
Instant queries use the new `streamRangeVectorIterator` which has a new set of `aggregators`. Before, aggregations were based on the first point in the range to be aggregated. With  `streamRangeVectorIterator`, points are instead treated one at a time. 

The aggregations were simply checking whether the value was less than the min or greater than the max without any initialization. This PR fixes these aggregations by initializing `min` or `max` to `math.Nan` so the first point is always considered.