### PR TITLE
Fix min and max aggregations when using instant queries. (#7957)

### DIFF
--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -614,9 +614,9 @@ func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, err
 	case syntax.OpRangeTypeAvg:
 		return &AvgOverTime{}, nil
 	case syntax.OpRangeTypeMax:
-		return &MaxOverTime{}, nil
+		return &MaxOverTime{max: math.NaN()}, nil
 	case syntax.OpRangeTypeMin:
-		return &MinOverTime{}, nil
+		return &MinOverTime{min: math.NaN()}, nil
 	case syntax.OpRangeTypeStddev:
 		return &StddevOverTime{}, nil
 	case syntax.OpRangeTypeStdvar:

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -3,6 +3,7 @@ package logql
 import (
 	"context"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ var (
 	labelBar, _ = syntax.ParseLabels("{app=\"bar\"}")
 )
 
-func newSampleIterator() iter.SampleIterator {
+func newSampleIterator(samples []logproto.Sample) iter.SampleIterator {
 	return iter.NewSortSampleIterator([]iter.SampleIterator{
 		iter.NewSeriesIterator(logproto.Series{
 			Labels:     labelFoo.String(),
@@ -49,8 +50,8 @@ func newSampleIterator() iter.SampleIterator {
 	})
 }
 
-func newfakePeekingSampleIterator() iter.PeekingSampleIterator {
-	return iter.NewPeekingSampleIterator(newSampleIterator())
+func newfakePeekingSampleIterator(samples []logproto.Sample) iter.PeekingSampleIterator {
+	return iter.NewPeekingSampleIterator(newSampleIterator(samples))
 }
 
 func newPoint(t time.Time, v float64) promql.Point {
@@ -74,7 +75,7 @@ func Benchmark_RangeVectorIteratorCompare(b *testing.B) {
 			time.Unix(100, 0),
 		}
 
-		iter := newfakePeekingSampleIterator()
+		iter := newfakePeekingSampleIterator(samples)
 		expr := &syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}
 		selRange := tt.selRange
 		step := tt.step
@@ -116,7 +117,7 @@ func Benchmark_RangeVectorIteratorCompare(b *testing.B) {
 			time.Unix(100, 0),
 		}
 
-		iter := newfakePeekingSampleIterator()
+		iter := newfakePeekingSampleIterator(samples)
 		expr := &syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}
 		selRange := tt.selRange
 		step := tt.step
@@ -194,7 +195,7 @@ func Benchmark_RangeVectorIterator(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		i := 0
-		it, err := newRangeVectorIterator(newfakePeekingSampleIterator(),
+		it, err := newRangeVectorIterator(newfakePeekingSampleIterator(samples),
 			&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}, tt.selRange,
 			tt.step, tt.start.UnixNano(), tt.end.UnixNano(), tt.offset)
 		if err != nil {
@@ -331,7 +332,7 @@ func Test_RangeVectorIterator(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("logs[%s] - step: %s - offset: %s", time.Duration(tt.selRange), time.Duration(tt.step), time.Duration(tt.offset)),
 			func(t *testing.T) {
-				it, err := newRangeVectorIterator(newfakePeekingSampleIterator(),
+				it, err := newRangeVectorIterator(newfakePeekingSampleIterator(samples),
 					&syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}, tt.selRange,
 					tt.step, tt.start.UnixNano(), tt.end.UnixNano(), tt.offset)
 				require.NoError(t, err)
@@ -371,4 +372,67 @@ func Test_RangeVectorIteratorBadLabels(t *testing.T) {
 		require.Fail(t, "goroutine took too long")
 	case <-ctx.Done():
 	}
+}
+
+func Test_InstantQueryRangeVectorAggregations(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectedValue float64
+		op            string
+		negative      bool
+	}{
+		{"rate", 1.5e+09, syntax.OpRangeTypeRate, false},
+		{"rate counter", 9.999999999999999e+08, syntax.OpRangeTypeRateCounter, false},
+		{"count", 3., syntax.OpRangeTypeCount, false},
+		{"bytes rate", 3e+09, syntax.OpRangeTypeBytesRate, false},
+		{"bytes", 6., syntax.OpRangeTypeBytes, false},
+		{"sum", 6., syntax.OpRangeTypeSum, false},
+		{"avg", 2., syntax.OpRangeTypeAvg, false},
+		{"max", -1, syntax.OpRangeTypeMax, true},
+		{"min", 1., syntax.OpRangeTypeMin, false},
+		{"std dev", 0.816496580927726, syntax.OpRangeTypeStddev, false},
+		{"std vara", 0.6666666666666666, syntax.OpRangeTypeStdvar, false},
+		{"quantile", 2.98, syntax.OpRangeTypeQuantile, false},
+		{"first", 1., syntax.OpRangeTypeFirst, false},
+		{"last", 3., syntax.OpRangeTypeLast, false},
+		{"absent", 1., syntax.OpRangeTypeAbsent, false},
+	}
+
+	var start, end int64 = 4, 4 // Instant query
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("testing aggregation %s", tt.name), func(t *testing.T) {
+			it, err := newRangeVectorIterator(sampleIter(tt.negative),
+				&syntax.RangeAggregationExpr{Left: &syntax.LogRange{Interval: 2}, Params: proto.Float64(0.99), Operation: tt.op},
+				3, 1, start, end, 0)
+			require.NoError(t, err)
+
+			for it.Next() {
+			}
+			_, value := it.At()
+			require.Equal(t, tt.expectedValue, value[0].V)
+		})
+	}
+}
+
+func sampleIter(negative bool) iter.PeekingSampleIterator {
+	return iter.NewPeekingSampleIterator(
+		iter.NewSortSampleIterator([]iter.SampleIterator{
+			iter.NewSeriesIterator(logproto.Series{
+				Labels: labelFoo.String(),
+				Samples: []logproto.Sample{
+					{Timestamp: 2, Hash: 1, Value: value(1., negative)},
+					{Timestamp: 3, Hash: 2, Value: value(2., negative)},
+					{Timestamp: 4, Hash: 3, Value: value(3., negative)},
+				},
+				StreamHash: labelFoo.Hash(),
+			}),
+		}),
+	)
+}
+
+func value(value float64, negative bool) float64 {
+	if negative {
+		return -1. * value
+	}
+	return value
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks changes from https://github.com/grafana/loki/pull/7957 into `k127`.

PR description from https://github.com/grafana/loki/pull/7957:

> Instant queries use the new `streamRangeVectorIterator` which has a new set of `aggregators`. Before, aggregations were based on the first point in the range to be aggregated. With `streamRangeVectorIterator`, points are instead treated one at a time.  
> The aggregations were simply checking whether the value was less than the min or greater than the max without any initialization. This PR fixes these aggregations by initializing `min` or `max` to `math.Nan` so the first point is always considered.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
