### PR TITLE
Promtail: Add configuration to drop batches when rate limited by Loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 #### Promtail
 
 * [7619](https://github.com/grafana/loki/pull/7619) **cadrake**: Add ability to pass query params to heroku drain targets for relabelling.
+* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize stage to Promtail to easily parse colored logs.
+* [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client
 
 ##### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 #### Promtail
 
 * [7619](https://github.com/grafana/loki/pull/7619) **cadrake**: Add ability to pass query params to heroku drain targets for relabelling.
+* [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client.
+
 * [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize stage to Promtail to easily parse colored logs.
 * [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,7 @@
 #### Promtail
 
 * [7619](https://github.com/grafana/loki/pull/7619) **cadrake**: Add ability to pass query params to heroku drain targets for relabelling.
-* [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client.
-
-* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize stage to Promtail to easily parse colored logs.
-* [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client
+* [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client and new metric label for drop reason.
 
 ##### Enhancements
 

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -348,8 +348,8 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		// Immediately drop rate limited batches to avoid HOL blocking for other tenants not experiencing throttling
 		if c.cfg.DropRateLimitedBatches && status == 429 {
 			level.Warn(c.logger).Log("msg", "dropping batch due to rate limiting applied at ingester")
-			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host).Add(bufBytes)
-			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host).Add(float64(entriesCount))
+			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
+			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(entriesCount))
 			return
 		}
 

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -35,25 +35,33 @@ const (
 	// pipeline stages
 	ReservedLabelTenantID = "__tenant_id__"
 
-	LatencyLabel = "filename"
-	HostLabel    = "host"
-	ClientLabel  = "client"
-	TenantLabel  = "tenant"
+	LatencyLabel    = "filename"
+	HostLabel       = "host"
+	ClientLabel     = "client"
+	TenantLabel     = "tenant"
+	DropReasonLabel = "reason"
+
+	DropReasonGeneric       = "ingester_error"
+	DropReasonRateLimited   = "rate_limited"
+	DropReasonStreamLimited = "stream_limited"
 )
+
+var DropReasons = []string{DropReasonGeneric, DropReasonRateLimited, DropReasonStreamLimited}
 
 var UserAgent = fmt.Sprintf("promtail/%s", build.Version)
 
 type Metrics struct {
-	encodedBytes       *prometheus.CounterVec
-	sentBytes          *prometheus.CounterVec
-	droppedBytes       *prometheus.CounterVec
-	sentEntries        *prometheus.CounterVec
-	droppedEntries     *prometheus.CounterVec
-	requestDuration    *prometheus.HistogramVec
-	batchRetries       *prometheus.CounterVec
-	countersWithHost   []*prometheus.CounterVec
-	countersWithTenant []*prometheus.CounterVec
-	streamLag          *prometheus.GaugeVec
+	encodedBytes                 *prometheus.CounterVec
+	sentBytes                    *prometheus.CounterVec
+	droppedBytes                 *prometheus.CounterVec
+	sentEntries                  *prometheus.CounterVec
+	droppedEntries               *prometheus.CounterVec
+	requestDuration              *prometheus.HistogramVec
+	batchRetries                 *prometheus.CounterVec
+	countersWithHost             []*prometheus.CounterVec
+	countersWithHostTenant       []*prometheus.CounterVec
+	countersWithHostTenantReason []*prometheus.CounterVec
+	streamLag                    *prometheus.GaugeVec
 }
 
 func NewMetrics(reg prometheus.Registerer, streamLagLabels []string) *Metrics {
@@ -73,7 +81,7 @@ func NewMetrics(reg prometheus.Registerer, streamLagLabels []string) *Metrics {
 		Namespace: "promtail",
 		Name:      "dropped_bytes_total",
 		Help:      "Number of bytes dropped because failed to be sent to the ingester after all retries.",
-	}, []string{HostLabel, TenantLabel})
+	}, []string{HostLabel, TenantLabel, DropReasonLabel})
 	m.sentEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "promtail",
 		Name:      "sent_entries_total",
@@ -83,7 +91,7 @@ func NewMetrics(reg prometheus.Registerer, streamLagLabels []string) *Metrics {
 		Namespace: "promtail",
 		Name:      "dropped_entries_total",
 		Help:      "Number of log entries dropped because failed to be sent to the ingester after all retries.",
-	}, []string{HostLabel, TenantLabel})
+	}, []string{HostLabel, TenantLabel, DropReasonLabel})
 	m.requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "promtail",
 		Name:      "request_duration_seconds",
@@ -99,8 +107,12 @@ func NewMetrics(reg prometheus.Registerer, streamLagLabels []string) *Metrics {
 		m.encodedBytes, m.sentBytes, m.sentEntries,
 	}
 
-	m.countersWithTenant = []*prometheus.CounterVec{
-		m.droppedBytes, m.droppedEntries, m.batchRetries,
+	m.countersWithHostTenant = []*prometheus.CounterVec{
+		m.batchRetries,
+	}
+
+	m.countersWithHostTenantReason = []*prometheus.CounterVec{
+		m.droppedBytes, m.droppedEntries,
 	}
 
 	streamLagLabelsMerged := []string{HostLabel, ClientLabel}
@@ -237,6 +249,20 @@ func NewWithTripperware(metrics *Metrics, cfg Config, streamLagLabels []string, 
 	return c, nil
 }
 
+func (c *client) initBatchMetrics(tenantID string) {
+	// Initialize counters to 0 so the metrics are exported before the first
+	// occurrence of incrementing to avoid missing metrics.
+	for _, counter := range c.metrics.countersWithHostTenantReason {
+		for _, reason := range DropReasons {
+			counter.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(0)
+		}
+	}
+
+	for _, counter := range c.metrics.countersWithHostTenant {
+		counter.WithLabelValues(c.cfg.URL.Host, tenantID).Add(0)
+	}
+}
+
 func (c *client) run() {
 	batches := map[string]*batch{}
 
@@ -276,11 +302,7 @@ func (c *client) run() {
 			// If the batch doesn't exist yet, we create a new one with the entry
 			if !ok {
 				batches[tenantID] = newBatch(c.maxStreams, e)
-				// Initialize counters to 0 so the metrics are exported before the first
-				// occurrence of incrementing to avoid missing metrics.
-				for _, counter := range c.metrics.countersWithTenant {
-					counter.WithLabelValues(c.cfg.URL.Host, tenantID).Add(0)
-				}
+				c.initBatchMetrics(tenantID)
 				break
 			}
 
@@ -297,8 +319,12 @@ func (c *client) run() {
 			err := batch.add(e)
 			if err != nil {
 				level.Error(c.logger).Log("msg", "batch add err", "tenant", tenantID, "error", err)
-				c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(len(e.Line)))
-				c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Inc()
+				reason := DropReasonGeneric
+				if err.Error() == errMaxStreamsLimitExceeded {
+					reason = DropReasonStreamLimited
+				}
+				c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Add(float64(len(e.Line)))
+				c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, reason).Inc()
 				return
 			}
 		case <-maxWaitCheck.C:
@@ -327,6 +353,10 @@ func asSha256(o interface{}) string {
 	return temp[:6]
 }
 
+func batchIsRateLimited(status int) bool {
+	return status == 429
+}
+
 func (c *client) sendBatch(tenantID string, batch *batch) {
 	buf, entriesCount, err := batch.encode()
 	if err != nil {
@@ -346,10 +376,10 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		c.metrics.requestDuration.WithLabelValues(strconv.Itoa(status), c.cfg.URL.Host).Observe(time.Since(start).Seconds())
 
 		// Immediately drop rate limited batches to avoid HOL blocking for other tenants not experiencing throttling
-		if c.cfg.DropRateLimitedBatches && status == 429 {
+		if c.cfg.DropRateLimitedBatches && batchIsRateLimited(status) {
 			level.Warn(c.logger).Log("msg", "dropping batch due to rate limiting applied at ingester")
-			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
-			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(entriesCount))
+			c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, DropReasonRateLimited).Add(bufBytes)
+			c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, DropReasonRateLimited).Add(float64(entriesCount))
 			return
 		}
 
@@ -392,7 +422,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 		}
 
 		// Only retry 429s, 500s and connection-level errors.
-		if status > 0 && status != 429 && status/100 != 5 {
+		if status > 0 && !batchIsRateLimited(status) && status/100 != 5 {
 			break
 		}
 
@@ -408,8 +438,14 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 
 	if err != nil {
 		level.Error(c.logger).Log("msg", "final error sending batch", "status", status, "tenant", tenantID, "error", err)
-		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID).Add(bufBytes)
-		c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID).Add(float64(entriesCount))
+		// If the reason for the last retry error was rate limiting, count the drops as such, even if the previous errors
+		// were for a different reason
+		dropReason := DropReasonGeneric
+		if batchIsRateLimited(status) {
+			dropReason = DropReasonRateLimited
+		}
+		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(bufBytes)
+		c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, dropReason).Add(float64(entriesCount))
 	}
 }
 

--- a/clients/pkg/promtail/client/client_test.go
+++ b/clients/pkg/promtail/client/client_test.go
@@ -71,13 +71,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 3.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 0
-			`,
+                               # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                               # TYPE promtail_sent_entries_total counter
+                               promtail_sent_entries_total{host="__HOST__"} 3.0
+                               # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                               # TYPE promtail_dropped_entries_total counter
+                               promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                               promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 0
+                               promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                       `,
 		},
 		"batch log entries together until the batch wait time is reached": {
 			clientBatchSize:      10,
@@ -97,13 +99,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 2.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 0
-			`,
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 2.0
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                       `,
 		},
 		"retry send a batch up to backoff's max retries in case the server responds with a 5xx": {
 			clientBatchSize:      10,
@@ -126,13 +130,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
-			`,
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 1
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 0
+                       `,
 		},
 		"do not retry send a batch in case the server responds with a 4xx": {
 			clientBatchSize:      10,
@@ -147,13 +153,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
-			`,
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 1
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 0
+                       `,
 		},
 		"do retry sending a batch in case the server responds with a 429": {
 			clientBatchSize:      10,
@@ -176,13 +184,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
-			`,
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 1
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 0
+                       `,
 		},
 		"do not retry in case of 429 when client is configured to drop rate limited batches": {
 			clientBatchSize:       10,
@@ -198,13 +208,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
-			`,
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 1
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 0
+                       `,
 		},
 		"batch log entries together honoring the client tenant ID": {
 			clientBatchSize:      100,
@@ -220,13 +232,15 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 2.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant="tenant-default"} 0
-			`,
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 2.0
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__", reason="ingester_error", tenant="tenant-default"} 0
+                              promtail_dropped_entries_total{host="__HOST__", reason="rate_limited", tenant="tenant-default"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant="tenant-default"} 0
+                       `,
 		},
 		"batch log entries together honoring the tenant ID overridden while processing the pipeline stages": {
 			clientBatchSize:      100,
@@ -250,15 +264,21 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 4.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant="tenant-1"} 0
-				promtail_dropped_entries_total{host="__HOST__", tenant="tenant-2"} 0
-				promtail_dropped_entries_total{host="__HOST__", tenant="tenant-default"} 0
-			`,
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 4.0
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant="tenant-1"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant="tenant-2"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant="tenant-default"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant="tenant-1"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant="tenant-2"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant="tenant-default"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant="tenant-1"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant="tenant-2"} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant="tenant-default"} 0
+                       `,
 		},
 	}
 
@@ -364,13 +384,15 @@ func TestClient_StopNow(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 3.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 0
-			`,
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 3.0
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                       `,
 		},
 		{
 			name:                 "shouldn't retry after StopNow()",
@@ -386,13 +408,15 @@ func TestClient_StopNow(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__", tenant=""} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
-			`,
+                              # HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+                              # TYPE promtail_dropped_entries_total counter
+                              promtail_dropped_entries_total{host="__HOST__",reason="ingester_error",tenant=""} 0
+                              promtail_dropped_entries_total{host="__HOST__",reason="rate_limited",tenant=""} 1
+                              promtail_dropped_entries_total{host="__HOST__",reason="stream_limited",tenant=""} 0
+                              # HELP promtail_sent_entries_total Number of log entries sent to the ingester.
+                              # TYPE promtail_sent_entries_total counter
+                              promtail_sent_entries_total{host="__HOST__"} 0
+                       `,
 		},
 	}
 

--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -62,6 +62,7 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&c.ExternalLabels, prefix+"client.external-labels", "list of external labels to add to each log (e.g: --client.external-labels=lb1=v1,lb2=v2) (deprecated).")
 
 	f.StringVar(&c.TenantID, prefix+"client.tenant-id", "", "Tenant ID to use when pushing logs to Loki (deprecated).")
+	f.BoolVar(&c.DropRateLimitedBatches, prefix+"client.drop-rate-limited-batches", false, "Do not retry batches that have been rate limited by Loki (deprecated).")
 }
 
 // RegisterFlags registers flags.

--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// single tenant mode)
 	TenantID string `yaml:"tenant_id"`
 
+	// When enabled, Promtail will not retry batches that get a
+	// 429 'Too Many Requests' response from the distributor. Helps
+	// prevent HOL blocking in multitenant deployments.
+	DropRateLimitedBatches bool `yaml:"drop_rate_limited_batches"`
+
 	// deprecated use StreamLagLabels from config.Config instead
 	StreamLagLabels flagext.StringSliceCSV `yaml:"stream_lag_labels"`
 }

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -277,6 +277,10 @@ backoff_config:
   # Maximum number of retries to do
   [max_retries: <int> | default = 10]
 
+# Disable retries of batches that Loki responds to with a 429 status code (TooManyRequests). This reduces
+# impacts on batches from other tenants, which could end up being delayed or dropped due to exponential backoff.
+[drop_rate_limited_batches: <boolean> | default = false]
+
 # Static labels to add to all logs being sent to Loki.
 # Use map like {"foo": "bar"} to add a label foo with
 # value bar.


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will allow for more deterministic behavior by multitenant Promtail instances where one or more tenants are being heavily throttled due to limits exceeded within Loki. Specifically, it will reduce the performance impact of having exponential backoff cause HOL blocking for rate limit response codes while other tenants are ready to send batches.

**Which issue(s) this PR fixes**:
Fixes #7972 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
