### PR TITLE
Add empty k3d cluster for testing helm chart

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -24,3 +24,4 @@ dependencies:
     condition: monitoring.selfMonitoring.grafanaAgent.installOperator
 maintainers:
   - name: trevorwhitney
+  - name: jeschkies

--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -1,7 +1,8 @@
 .PHONY: loki-distributed down add-repos update-repos prepare build-latest-image
 
 IMAGE_TAG := $(shell ../../../tools/image-tag)
-REGISTRY_PORT ?= $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
+EXISTING_REGISTRY_PORT := $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
+REGISTRY_PORT ?= $(or $(EXISTING_REGISTRY_PORT),46453)
 
 loki-distributed: prepare build-latest-image
 	$(CURDIR)/scripts/create_cluster.sh loki-distributed $(REGISTRY_PORT)
@@ -14,18 +15,30 @@ enterprise-logs: prepare
 	# wait 5s for the cluster to be ready
 	sleep 5
 	$(MAKE) -C $(CURDIR) apply-enterprise-logs
+
+helm-cluster: prepare
+	ls -la $(CURDIR)
+	ls -la $(CURDIR)/scripts
+	$(CURDIR)/scripts/create_cluster.sh helm-cluster $(REGISTRY_PORT)
+	# wait 5s for the cluster to be ready
+	sleep 5
+	$(MAKE) -C $(CURDIR) apply-helm-cluster
 	
 apply-enterprise-logs:
 	tk apply --ext-str registry="k3d-grafana:$(REGISTRY_PORT)" environments/enterprise-logs
 
+apply-helm-cluster:
+	tk apply --ext-str registry="k3d-grafana:$(REGISTRY_PORT)" environments/helm-cluster
+
 down:
 	k3d cluster delete loki-distributed
 	k3d cluster delete enterprise-logs
+	k3d cluster delete helm-cluster
 
 add-repos:
 	helm repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add --force-update grafana https://grafana.github.io/helm-charts
-	helm repo add --force-update minio https://helm.min.io
+	helm repo add --force-update minio https://charts.min.io/
 
 update-repos: add-repos
 	helm repo update
@@ -65,3 +78,7 @@ build-latest-image:
 	make -C $(CURDIR)/../../.. loki-image
 	docker tag grafana/loki:$(IMAGE_TAG) grafana.k3d.localhost:$(REGISTRY_PORT)/loki:latest
 	docker push grafana.k3d.localhost:$(REGISTRY_PORT)/loki:latest
+
+HELM_DIR := $(shell cd $(CURDIR)/../../../production/helm/loki && pwd)
+helm-install-enterprise-logs:
+	helm install loki "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"

--- a/tools/dev/k3d/environments/helm-cluster/README.md
+++ b/tools/dev/k3d/environments/helm-cluster/README.md
@@ -1,0 +1,12 @@
+# Empty Helm Cluster
+
+This is a cluster designed for testing out helm charts. It is meant for running `helm install` against. It provides the required dependencies of the helm chart and nothing else (ie. minio is installed by the helm chart). This differs from the other envs that, while also using the helm chart, use `tanka` to deploy those charts.
+
+## Using
+
+From the `k3d` directory, run the following commands
+
+```bash
+make helm-cluster
+make helm-install-enterprise-logs
+```

--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -1,0 +1,130 @@
+local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
+local tanka = import 'github.com/grafana/jsonnet-libs/tanka-util/main.libsonnet';
+
+local grafana = import 'grafana/grafana.libsonnet';
+local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
+local helm = tanka.helm.new(std.thisFile);
+
+local spec = (import './spec.json').spec;
+
+{
+  local prometheusServerName = self.prometheus.service_prometheus_kube_prometheus_prometheus.metadata.name,
+  local prometheusUrl = 'http://%s:9090' % prometheusServerName,
+
+  local provisionedSecretPrefix = 'provisioned-secret',
+  local adminTokenSecret = 'gel-admin-token',
+
+  local tenant = 'loki',
+
+  _config+:: {
+    namespace: spec.namespace,
+    adminTokenSecret: adminTokenSecret,
+  },
+
+  lokiNamespace: k.core.v1.namespace.new('loki'),
+  gelLicenseSecret: k.core.v1.secret.new('gel-license', {}, type='Opaque')
+                    + k.core.v1.secret.withStringData({
+                      'license.jwt': importstr '../../secrets/gel.jwt',
+                    })
+                    + k.core.v1.secret.metadata.withNamespace('loki'),
+
+  prometheus: helm.template('prometheus', '../../charts/kube-prometheus-stack', {
+    namespace: $._config.namespace,
+    values+: {
+      grafana+: {
+        enabled: false,
+      },
+      prometheus: {
+        prometheusSpec: {
+          serviceMonitorSelector: {
+            matchLabels: {
+              release: 'prometheus',
+            },
+          },
+        },
+      },
+    },
+    kubeVersion: 'v1.18.0',
+    noHooks: false,
+  }),
+
+  local datasource = grafana.datasource,
+  local lokiGatewayUrl = 'http://enterprise-logs-gateway.loki.svc.cluster.local',
+  prometheus_datasource:: datasource.new('prometheus', prometheusUrl, type='prometheus', default=false),
+  loki_datasource:: datasource.new('loki', lokiGatewayUrl, type='loki', default=true) +
+                    datasource.withBasicAuth(tenant, '${PROVISIONED_TENANT_TOKEN}'),
+
+  grafanaNamespace: k.core.v1.namespace.new('grafana'),
+  grafana: grafana
+           + grafana.withAnonymous()
+           + grafana.withImage('grafana/grafana-enterprise:8.2.5')
+           + grafana.withGrafanaIniConfig({
+             sections+: {
+               server+: {
+                 http_port: 3000,
+               },
+               users+: {
+                 default_theme: 'light',
+               },
+               paths+: {
+                 provisioning: '/etc/grafana/provisioning',
+               },
+             },
+           })
+           + grafana.withEnterpriseLicenseText(importstr '../../secrets/grafana.jwt')
+           + grafana.addDatasource('prometheus', $.prometheus_datasource)
+           + grafana.addDatasource('loki', $.loki_datasource)
+           + {
+             local container = k.core.v1.container,
+             grafana_deployment+:
+               k.apps.v1.deployment.hostVolumeMount(
+                 name='enterprise-logs-app',
+                 hostPath='/var/lib/grafana/plugins/grafana-enterprise-logs-app/dist',
+                 path='/grafana-enterprise-logs-app',
+                 volumeMixin=k.core.v1.volume.hostPath.withType('Directory')
+               )
+               + k.apps.v1.deployment.emptyVolumeMount('grafana-var', '/var/lib/grafana')
+               + k.apps.v1.deployment.emptyVolumeMount('grafana-plugins', '/etc/grafana/provisioning/plugins')
+               + k.apps.v1.deployment.spec.template.spec.withInitContainersMixin([
+                 container.new('startup', 'alpine:latest') +
+                 container.withCommand([
+                   '/bin/sh',
+                   '-euc',
+                   |||
+                     mkdir -p /var/lib/grafana/plugins
+                     cp -r /grafana-enterprise-logs-app /var/lib/grafana/plugins/grafana-enterprise-logs-app
+                     chown -R 472:472 /var/lib/grafana/plugins
+
+                     cat > /etc/grafana/provisioning/plugins/enterprise-logs.yaml <<EOF
+                     apiVersion: 1
+                     apps:
+                       - type: grafana-enterprise-logs-app
+                         jsonData:
+                           backendUrl: %s
+                           base64EncodedAccessTokenSet: true
+                         secureJsonData:
+                           base64EncodedAccessToken: "$$(echo -n ":$$GEL_ADMIN_TOKEN" | base64 | tr -d '[:space:]')"
+                     EOF
+                   ||| % lokiGatewayUrl,
+                 ]) +
+                 container.withVolumeMounts([
+                   k.core.v1.volumeMount.new('enterprise-logs-app', '/grafana-enterprise-logs-app', false),
+                   k.core.v1.volumeMount.new('grafana-var', '/var/lib/grafana', false),
+                   k.core.v1.volumeMount.new('grafana-plugins', '/etc/grafana/provisioning/plugins', false),
+                 ]) +
+                 container.withImagePullPolicy('IfNotPresent') +
+                 container.mixin.securityContext.withPrivileged(true) +
+                 container.mixin.securityContext.withRunAsUser(0) +
+                 container.mixin.withEnv([
+                   envVar.fromSecretRef('GEL_ADMIN_TOKEN', adminTokenSecret, 'token'),
+                 ]),
+               ]) + k.apps.v1.deployment.mapContainers(
+                 function(c) c {
+                   env+: [
+                     envVar.new('GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS', 'grafana-enterprise-logs-app'),
+                     envVar.fromSecretRef('PROVISIONED_TENANT_TOKEN', '%s-%s' % [provisionedSecretPrefix, tenant], 'token-read'),
+                   ],
+                 }
+               ),
+           },
+}

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/helm-cluster",
+    "namespace": "environments/helm-cluster/main.jsonnet"
+  },
+  "spec": {
+    "apiServer": "https://0.0.0.0:43237",
+    "namespace": "k3d-helm-cluster",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -1,0 +1,14 @@
+---
+enterprise:
+  enabled: true
+  adminTokenSecret: "gel-admin-token"
+  provisioner:
+    provisionedSecretPrefix: "provisioned-secret"
+    tenants:
+      - loki
+monitoring:
+  selfMonitoring+:
+    tenant: "loki"
+  serviceMonitor:
+    labels:
+      release: "prometheus"

--- a/tools/dev/k3d/jsonnetfile.lock.json
+++ b/tools/dev/k3d/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "consul"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "enterprise-metrics"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "hi2ZpHKl7qWXmSZ46sAycjWEQK6oGsoECuDKQT1dA+k="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "etcd-operator"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "duHm6wmUju5KHQurOe6dnXoKgl5gTUsfGplgbmAOsHw="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "Y5nheroSOIwmE+djEVPq4OvvTxKenzdHhpEwaR3Ebjs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
-      "sum": "2++XoPslyz02LRgsxREWxjLgYgiCIqhAtXCyVSvYcoE="
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
     },
     {
       "source": {
@@ -78,7 +78,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {
@@ -88,7 +88,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -108,8 +108,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "be066653f33fcaa8467231f6334f6878b92fd8f9",
-      "sum": "fzESn29CRKzLap9jTpcUNSNBy7MzvzOxZo1LYWyIrGs="
+      "version": "e7f3020f5733ac3dd0a1998f49591a5afd24948d",
+      "sum": "YGiXub+RVwXffay0ejuoFXjkf13dinl5nD61DcpJHpc="
     },
     {
       "source": {
@@ -118,8 +118,8 @@
           "subdir": "1.20"
         }
       },
-      "version": "610803705e9ec295ef2e4eeaa6b2f8fc1419e5b1",
-      "sum": "67P8R8DnfIL1v+z+KThW2kIATcwn591elT5YiWZ1j/s="
+      "version": "21f1224e3d351cf85951221d91d015eef790ed48",
+      "sum": "Sj/Xxz4AvIDs3HI3uQ3TYOiAO2zcYs1veMBRFpPsc0Q="
     }
   ],
   "legacyImports": false

--- a/tools/dev/k3d/scripts/create_cluster.sh
+++ b/tools/dev/k3d/scripts/create_cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 current_dir="$(cd "$(dirname "$0")" && pwd)"
 k3d_dir="$(cd "${current_dir}/.." && pwd)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new k3d cluster which is a cluster that has all Loki dependencies for purposes of testing the helm charts using `helm install`. The other environments use the helm charts, but deploy them using `tanka` and therefore can't catch certain race conditions or issues that occur with helm installs.
