### PR TITLE
Fix minio tokengen race

### DIFF
--- a/production/helm/loki/Chart.lock
+++ b/production/helm/loki/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: minio
-  repository: https://charts.min.io/
-  version: 4.0.12
 - name: grafana-agent-operator
   repository: https://grafana.github.io/helm-charts
   version: 0.2.3
-digest: sha256:74ef214ca08874662ab403a2e5eea39df26ad690962fa19f9ff69cf551550ff2
-generated: "2022-09-14T10:22:56.1397723-06:00"
+digest: sha256:5fd743a5276564f867a6308ca87e2ca6117992b8e4ce5b2e7746441918fd9dc0
+generated: "2022-12-20T15:39:31.858198895-07:00"

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -24,3 +24,4 @@ dependencies:
     condition: monitoring.selfMonitoring.grafanaAgent.installOperator
 maintainers:
   - name: trevorwhitney
+  - name: jeschkies

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -12,11 +12,6 @@ sources:
   - https://grafana.com/docs/loki/latest/
 icon: https://grafana.com/docs/loki/latest/logo_and_name.png
 dependencies:
-  - name: minio
-    alias: minio
-    version: 4.0.12
-    repository: https://charts.min.io/
-    condition: minio.enabled
   - name: grafana-agent-operator
     alias: grafana-agent-operator
     version: 0.2.3

--- a/production/helm/loki/templates/NOTES.txt
+++ b/production/helm/loki/templates/NOTES.txt
@@ -14,9 +14,6 @@ Installed components:
 {{- if .Values.gateway.enabled }}
 * gateway
 {{- end }}
-{{- if .Values.minio.enabled }}
-* minio 
-{{- end }}
 * read
 * write
 {{- end }}

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -153,15 +153,7 @@ Docker image name for kubectl container
 Generated storage config for loki common config
 */}}
 {{- define "loki.commonStorageConfig" -}}
-{{- if .Values.minio.enabled -}}
-s3:
-  endpoint: {{ include "loki.minio" $ }}
-  bucketnames: {{ $.Values.loki.storage.bucketNames.chunks }}
-  secret_access_key: {{ $.Values.minio.rootPassword }}
-  access_key_id: {{ $.Values.minio.rootUser }}
-  s3forcepathstyle: true
-  insecure: true
-{{- else if eq .Values.loki.storage.type "s3" -}}
+{{- if eq .Values.loki.storage.type "s3" -}}
 {{- with .Values.loki.storage.s3 }}
 s3:
   {{- with .s3 }}
@@ -235,11 +227,7 @@ filesystem:
 Storage config for ruler
 */}}
 {{- define "loki.rulerStorageConfig" -}}
-{{- if .Values.minio.enabled -}}
-type: "s3"
-s3:
-  bucketnames: {{ $.Values.loki.storage.bucketNames.ruler }}
-{{- else if eq .Values.loki.storage.type "s3" -}}
+{{- if eq .Values.loki.storage.type "s3" -}}
 {{- with .Values.loki.storage.s3 }}
 type: "s3"
 s3:
@@ -292,7 +280,7 @@ azure:
 
 {{/* Predicate function to determin if custom ruler config should be included */}}
 {{- define "loki.shouldIncludeRulerConfig" }}
-{{- or (not (empty .Values.loki.rulerConfig)) (.Values.minio.enabled) (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+{{- or (not (empty .Values.loki.rulerConfig)) (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
 {{- end }}
 
 {{/* Loki ruler config */}}
@@ -424,15 +412,6 @@ Params:
 {{- printf "%s" (include "loki.fullname" .ctx) }}
 {{- else }}
 {{- printf "%s-%s" (include "loki.fullname" .ctx) .svcName }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the service endpoint including port for MinIO.
-*/}}
-{{- define "loki.minio" -}}
-{{- if .Values.minio.enabled -}}
-{{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString) -}}
 {{- end -}}
 {{- end -}}
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -304,7 +304,7 @@ enterprise:
   # enterprise specific sections of the config.yaml file
   config: |
     {{- if .Values.enterprise.adminApi.enabled }}
-    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "azure") }}
+    {{- if or (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "azure") }}
     admin_client:
       storage:
         s3:
@@ -1257,32 +1257,3 @@ networkPolicy:
 
 tracing:
   jaegerAgentHost: ""
-
-# -------------------------------------
-# Configuration for `minio` child chart
-# -------------------------------------
-minio:
-  enabled: false
-  replicas: 1
-  # Minio requires 2 to 16 drives for erasure code (drivesPerNode * replicas)
-  # https://docs.min.io/docs/minio-erasure-code-quickstart-guide
-  # Since we only have 1 replica, that means 2 drives must be used.
-  drivesPerNode: 2
-  rootUser: enterprise-logs
-  rootPassword: supersecret
-  buckets:
-    - name: chunks
-      policy: none
-      purge: false
-    - name: ruler
-      policy: none
-      purge: false
-    - name: admin
-      policy: none
-      purge: false
-  persistence:
-    size: 5Gi
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi

--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -22,7 +22,7 @@ helm-cluster: prepare
 	$(CURDIR)/scripts/create_cluster.sh helm-cluster $(REGISTRY_PORT)
 	# wait 5s for the cluster to be ready
 	sleep 5
-	$(MAKE) -C $(CURDIR) apply-helm-cluster
+	# $(MAKE) -C $(CURDIR) apply-helm-cluster
 	
 apply-enterprise-logs:
 	tk apply --ext-str registry="k3d-grafana:$(REGISTRY_PORT)" environments/enterprise-logs

--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -1,7 +1,8 @@
 .PHONY: loki-distributed down add-repos update-repos prepare build-latest-image
 
 IMAGE_TAG := $(shell ../../../tools/image-tag)
-REGISTRY_PORT ?= $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
+EXISTING_REGISTRY_PORT := $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
+REGISTRY_PORT ?= $(or $(EXISTING_REGISTRY_PORT),46453)
 
 loki-distributed: prepare build-latest-image
 	$(CURDIR)/scripts/create_cluster.sh loki-distributed $(REGISTRY_PORT)
@@ -14,18 +15,30 @@ enterprise-logs: prepare
 	# wait 5s for the cluster to be ready
 	sleep 5
 	$(MAKE) -C $(CURDIR) apply-enterprise-logs
+
+helm-cluster: prepare
+	ls -la $(CURDIR)
+	ls -la $(CURDIR)/scripts
+	$(CURDIR)/scripts/create_cluster.sh helm-cluster $(REGISTRY_PORT)
+	# wait 5s for the cluster to be ready
+	sleep 5
+	$(MAKE) -C $(CURDIR) apply-helm-cluster
 	
 apply-enterprise-logs:
 	tk apply --ext-str registry="k3d-grafana:$(REGISTRY_PORT)" environments/enterprise-logs
 
+apply-helm-cluster:
+	tk apply --ext-str registry="k3d-grafana:$(REGISTRY_PORT)" environments/helm-cluster
+
 down:
 	k3d cluster delete loki-distributed
 	k3d cluster delete enterprise-logs
+	k3d cluster delete helm-cluster
 
 add-repos:
 	helm repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add --force-update grafana https://grafana.github.io/helm-charts
-	helm repo add --force-update minio https://helm.min.io
+	helm repo add --force-update minio https://charts.min.io/
 
 update-repos: add-repos
 	helm repo update
@@ -65,3 +78,7 @@ build-latest-image:
 	make -C $(CURDIR)/../../.. loki-image
 	docker tag grafana/loki:$(IMAGE_TAG) grafana.k3d.localhost:$(REGISTRY_PORT)/loki:latest
 	docker push grafana.k3d.localhost:$(REGISTRY_PORT)/loki:latest
+
+HELM_DIR := $(shell cd $(CURDIR)/../../../production/helm/loki && pwd)
+helm-install-enterprise-logs:
+	helm install loki "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"

--- a/tools/dev/k3d/README.md
+++ b/tools/dev/k3d/README.md
@@ -10,12 +10,12 @@ In order to use the make targets in this directory, make sure you have the follo
 * [jq](https://stedolan.github.io/jq/)
 * [helm](https://helm.sh/docs/intro/install/) >= 3.9
 
-**Note**: in case docker is unable to resolve the local k3d registry hostname, add the following entry to the `/etc/hosts` file:
+**Note**: in case Docker is unable to resolve the local k3d registry hostname, add the following entry to the `/etc/hosts` file:
 ```
 127.0.0.1 k3d-grafana
 ```
 
-## Spinning Up An Environment
+## To Spin Up An Environment
 
 Each environment has it's own make target. To bring up `loki-distributed`, for example, run:
 
@@ -23,10 +23,26 @@ Each environment has it's own make target. To bring up `loki-distributed`, for e
 make loki-distributed
 ```
 
-## Tearing Down An Environment
+## To tear Down An Environment
 
 The `down` make target will tear down all environments.
 
 ```bash
 make down
 ```
+
+## To Use Custom Docker Image
+
+1. Define the registry port `export REGISTRY_PORT=7000`
+1. Build or pull the image.
+2. Tag the image with the registry prepended `docker tag us.gcr.io/kubernetes-dev/enterprise-logs:main-4d37d3ea "k3d-grafana.localhost:${REGISTRY_PORT}/grafana/enterprise-logs:main-4d37d3ea"`
+3. Push the image to the local registry `docker push "k3d-grafana.localhost:${REGISTRY_PORT}/grafana/enterprise-logs:main-4d37d3ea"`
+4. Define the image in the Helm Chart values
+   ```yaml
+   enterprise:
+   enabled: true
+   version: main-4d37d3ea
+   image:
+     registry: k3d-grafana:7000
+     repository: grafana/enterprise-logs
+   ```

--- a/tools/dev/k3d/environments/helm-cluster/README.md
+++ b/tools/dev/k3d/environments/helm-cluster/README.md
@@ -1,0 +1,12 @@
+# Empty Helm Cluster
+
+This is a cluster designed for testing out helm charts. It is meant for running `helm install` against. It provides the required dependencies of the helm chart and nothing else (ie. minio is installed by the helm chart). This differs from the other envs that, while also using the helm chart, use `tanka` to deploy those charts.
+
+## Using
+
+From the `k3d` directory, run the following commands
+
+```bash
+make helm-cluster
+make helm-install-enterprise-logs
+```

--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -1,0 +1,130 @@
+local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
+local tanka = import 'github.com/grafana/jsonnet-libs/tanka-util/main.libsonnet';
+
+local grafana = import 'grafana/grafana.libsonnet';
+local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
+local helm = tanka.helm.new(std.thisFile);
+
+local spec = (import './spec.json').spec;
+
+{
+  local prometheusServerName = self.prometheus.service_prometheus_kube_prometheus_prometheus.metadata.name,
+  local prometheusUrl = 'http://%s:9090' % prometheusServerName,
+
+  local provisionedSecretPrefix = 'provisioned-secret',
+  local adminTokenSecret = 'gel-admin-token',
+
+  local tenant = 'loki',
+
+  _config+:: {
+    namespace: spec.namespace,
+    adminTokenSecret: adminTokenSecret,
+  },
+
+  lokiNamespace: k.core.v1.namespace.new('loki'),
+  gelLicenseSecret: k.core.v1.secret.new('gel-license', {}, type='Opaque')
+                    + k.core.v1.secret.withStringData({
+                      'license.jwt': importstr '../../secrets/gel.jwt',
+                    })
+                    + k.core.v1.secret.metadata.withNamespace('loki'),
+
+  prometheus: helm.template('prometheus', '../../charts/kube-prometheus-stack', {
+    namespace: $._config.namespace,
+    values+: {
+      grafana+: {
+        enabled: false,
+      },
+      prometheus: {
+        prometheusSpec: {
+          serviceMonitorSelector: {
+            matchLabels: {
+              release: 'prometheus',
+            },
+          },
+        },
+      },
+    },
+    kubeVersion: 'v1.18.0',
+    noHooks: false,
+  }),
+
+  local datasource = grafana.datasource,
+  local lokiGatewayUrl = 'http://enterprise-logs-gateway.loki.svc.cluster.local',
+  prometheus_datasource:: datasource.new('prometheus', prometheusUrl, type='prometheus', default=false),
+  loki_datasource:: datasource.new('loki', lokiGatewayUrl, type='loki', default=true) +
+                    datasource.withBasicAuth(tenant, '${PROVISIONED_TENANT_TOKEN}'),
+
+  grafanaNamespace: k.core.v1.namespace.new('grafana'),
+  grafana: grafana
+           + grafana.withAnonymous()
+           + grafana.withImage('grafana/grafana-enterprise:8.2.5')
+           + grafana.withGrafanaIniConfig({
+             sections+: {
+               server+: {
+                 http_port: 3000,
+               },
+               users+: {
+                 default_theme: 'light',
+               },
+               paths+: {
+                 provisioning: '/etc/grafana/provisioning',
+               },
+             },
+           })
+           + grafana.withEnterpriseLicenseText(importstr '../../secrets/grafana.jwt')
+           + grafana.addDatasource('prometheus', $.prometheus_datasource)
+           + grafana.addDatasource('loki', $.loki_datasource)
+           + {
+             local container = k.core.v1.container,
+             grafana_deployment+:
+               k.apps.v1.deployment.hostVolumeMount(
+                 name='enterprise-logs-app',
+                 hostPath='/var/lib/grafana/plugins/grafana-enterprise-logs-app/dist',
+                 path='/grafana-enterprise-logs-app',
+                 volumeMixin=k.core.v1.volume.hostPath.withType('Directory')
+               )
+               + k.apps.v1.deployment.emptyVolumeMount('grafana-var', '/var/lib/grafana')
+               + k.apps.v1.deployment.emptyVolumeMount('grafana-plugins', '/etc/grafana/provisioning/plugins')
+               + k.apps.v1.deployment.spec.template.spec.withInitContainersMixin([
+                 container.new('startup', 'alpine:latest') +
+                 container.withCommand([
+                   '/bin/sh',
+                   '-euc',
+                   |||
+                     mkdir -p /var/lib/grafana/plugins
+                     cp -r /grafana-enterprise-logs-app /var/lib/grafana/plugins/grafana-enterprise-logs-app
+                     chown -R 472:472 /var/lib/grafana/plugins
+
+                     cat > /etc/grafana/provisioning/plugins/enterprise-logs.yaml <<EOF
+                     apiVersion: 1
+                     apps:
+                       - type: grafana-enterprise-logs-app
+                         jsonData:
+                           backendUrl: %s
+                           base64EncodedAccessTokenSet: true
+                         secureJsonData:
+                           base64EncodedAccessToken: "$$(echo -n ":$$GEL_ADMIN_TOKEN" | base64 | tr -d '[:space:]')"
+                     EOF
+                   ||| % lokiGatewayUrl,
+                 ]) +
+                 container.withVolumeMounts([
+                   k.core.v1.volumeMount.new('enterprise-logs-app', '/grafana-enterprise-logs-app', false),
+                   k.core.v1.volumeMount.new('grafana-var', '/var/lib/grafana', false),
+                   k.core.v1.volumeMount.new('grafana-plugins', '/etc/grafana/provisioning/plugins', false),
+                 ]) +
+                 container.withImagePullPolicy('IfNotPresent') +
+                 container.mixin.securityContext.withPrivileged(true) +
+                 container.mixin.securityContext.withRunAsUser(0) +
+                 container.mixin.withEnv([
+                   envVar.fromSecretRef('GEL_ADMIN_TOKEN', adminTokenSecret, 'token'),
+                 ]),
+               ]) + k.apps.v1.deployment.mapContainers(
+                 function(c) c {
+                   env+: [
+                     envVar.new('GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS', 'grafana-enterprise-logs-app'),
+                     envVar.fromSecretRef('PROVISIONED_TENANT_TOKEN', '%s-%s' % [provisionedSecretPrefix, tenant], 'token-read'),
+                   ],
+                 }
+               ),
+           },
+}

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/helm-cluster",
+    "namespace": "environments/helm-cluster/main.jsonnet"
+  },
+  "spec": {
+    "apiServer": "https://0.0.0.0:43237",
+    "namespace": "k3d-helm-cluster",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -6,7 +6,7 @@
     "namespace": "environments/helm-cluster/main.jsonnet"
   },
   "spec": {
-    "apiServer": "https://0.0.0.0:42813",
+    "apiServer": "https://0.0.0.0:40295",
     "namespace": "k3d-helm-cluster",
     "resourceDefaults": {},
     "expectVersions": {}

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -6,7 +6,7 @@
     "namespace": "environments/helm-cluster/main.jsonnet"
   },
   "spec": {
-    "apiServer": "https://0.0.0.0:43237",
+    "apiServer": "https://0.0.0.0:42813",
     "namespace": "k3d-helm-cluster",
     "resourceDefaults": {},
     "expectVersions": {}

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -1,11 +1,26 @@
 ---
+loki:
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+    s3:
+      endpoint: minio.minio.svc.cluster.local:9000
+      secretAccessKey: supersecret
+      accessKeyId: loki
+      s3ForcePathStyle: true
+      insecure: true
 enterprise:
   enabled: true
-  adminTokenSecret: "gel-admin-token"
+  adminTokenSecret: gel-admin-token
   provisioner:
-    provisionedSecretPrefix: "provisioned-secret"
+    provisionedSecretPrefix: provisioned-secret
     tenants:
       - loki
+  useExternalLicense: true
+  externalLicenseName: gel-license
+  cluster_name: enterprise-logs-test-fixture
 monitoring:
   selfMonitoring+:
     tenant: "loki"

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -1,0 +1,14 @@
+---
+enterprise:
+  enabled: true
+  adminTokenSecret: "gel-admin-token"
+  provisioner:
+    provisionedSecretPrefix: "provisioned-secret"
+    tenants:
+      - loki
+monitoring:
+  selfMonitoring+:
+    tenant: "loki"
+  serviceMonitor:
+    labels:
+      release: "prometheus"

--- a/tools/dev/k3d/jsonnetfile.lock.json
+++ b/tools/dev/k3d/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "consul"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "enterprise-metrics"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "hi2ZpHKl7qWXmSZ46sAycjWEQK6oGsoECuDKQT1dA+k="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "etcd-operator"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "duHm6wmUju5KHQurOe6dnXoKgl5gTUsfGplgbmAOsHw="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "Y5nheroSOIwmE+djEVPq4OvvTxKenzdHhpEwaR3Ebjs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
-      "sum": "2++XoPslyz02LRgsxREWxjLgYgiCIqhAtXCyVSvYcoE="
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
     },
     {
       "source": {
@@ -78,7 +78,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {
@@ -88,7 +88,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "9d68b0200c682fde2eca8b6b7cc738fc08d663cc",
+      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -108,8 +108,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "be066653f33fcaa8467231f6334f6878b92fd8f9",
-      "sum": "fzESn29CRKzLap9jTpcUNSNBy7MzvzOxZo1LYWyIrGs="
+      "version": "e7f3020f5733ac3dd0a1998f49591a5afd24948d",
+      "sum": "YGiXub+RVwXffay0ejuoFXjkf13dinl5nD61DcpJHpc="
     },
     {
       "source": {
@@ -118,8 +118,8 @@
           "subdir": "1.20"
         }
       },
-      "version": "610803705e9ec295ef2e4eeaa6b2f8fc1419e5b1",
-      "sum": "67P8R8DnfIL1v+z+KThW2kIATcwn591elT5YiWZ1j/s="
+      "version": "21f1224e3d351cf85951221d91d015eef790ed48",
+      "sum": "Sj/Xxz4AvIDs3HI3uQ3TYOiAO2zcYs1veMBRFpPsc0Q="
     }
   ],
   "legacyImports": false

--- a/tools/dev/k3d/scripts/create_cluster.sh
+++ b/tools/dev/k3d/scripts/create_cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 current_dir="$(cd "$(dirname "$0")" && pwd)"
 k3d_dir="$(cd "${current_dir}/.." && pwd)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes MinIO from the loki helm chart. This was meant as a convenience, but there's currently no good way to determine the helm run order of jobs defined by the loki helm chart and those of the subchart. As a result, when using minio, it can often occur that the make buckets job doesn't run before the tokengen, which will cause the whole deployment to fail as the provisioner depends on the admin token generated in the tokengen job.

I think it's reasonable to expect people to bring their own object storage.

*Other possible solutions*
I'm not sure how helm hook weights work between charts and their dependencies. We may be able to solve this with hook weights, and is worth testing before merging this.

TODO: 
* I need to update the docs to reflect this change.

**Special notes for your reviewer**:
This is built on https://github.com/grafana/loki/pull/7984 and includes changes from that PR.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
