### PR TITLE
store: write overlapping chunks to multiple stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [7937](https://github.com/grafana/loki/pull/7937) **ssncferreira**: Deprecate CLI flag `-ruler.wal-cleaer.period` and replace it with `-ruler.wal-cleaner.period`.
 * [7906](https://github.com/grafana/loki/pull/7906) **kavirajk**: Add API endpoint that formats LogQL expressions and support new `fmt` subcommand in `logcli` to format LogQL query.
 * [7966](https://github.com/grafana/loki/pull/7966) **sandeepsukhani**: Fix query-frontend request load balancing when using k8s service.
+* [7988](https://github.com/grafana/loki/pull/7988) **ashwanthgoli** store: write overlapping chunks to multiple stores.
 
 ##### Changes
 

--- a/pkg/storage/stores/series_store_write.go
+++ b/pkg/storage/stores/series_store_write.go
@@ -61,12 +61,21 @@ func (c *Writer) Put(ctx context.Context, chunks []chunk.Chunk) error {
 func (c *Writer) PutOne(ctx context.Context, from, through model.Time, chk chunk.Chunk) error {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.PutOne")
 	defer log.Finish()
-	writeChunk := true
+
+	var (
+		writeChunk = true
+		overlap    bool
+	)
+
+	// always write the chunk if it spans multiple periods to ensure that it gets added to all the stores
+	if chk.From < from || chk.Through > through {
+		overlap = true
+	}
 
 	// If this chunk is in cache it must already be in the database so we don't need to write it again
 	found, _, _, _ := c.fetcher.Cache().Fetch(ctx, []string{c.schemaCfg.ExternalKey(chk.ChunkRef)})
 
-	if len(found) > 0 {
+	if !overlap && len(found) > 0 {
 		writeChunk = false
 		DedupedChunksTotal.Inc()
 	}
@@ -87,12 +96,13 @@ func (c *Writer) PutOne(ctx context.Context, from, through model.Time, chk chunk
 			return err
 		}
 	}
+
 	if err := c.indexWriter.IndexChunk(ctx, chk); err != nil {
 		return err
 	}
 
-	// we already have the chunk in the cache so don't write it back to the cache.
-	if writeChunk {
+	// write it back to the cache if it's not found.
+	if len(found) == 0 {
 		if cacheErr := c.fetcher.WriteBackCache(ctx, chunks); cacheErr != nil {
 			level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
 		}

--- a/pkg/storage/stores/series_store_write.go
+++ b/pkg/storage/stores/series_store_write.go
@@ -75,7 +75,7 @@ func (c *Writer) PutOne(ctx context.Context, from, through model.Time, chk chunk
 	// If this chunk is in cache it must already be in the database so we don't need to write it again
 	found, _, _, _ := c.fetcher.Cache().Fetch(ctx, []string{c.schemaCfg.ExternalKey(chk.ChunkRef)})
 
-	if !overlap && len(found) > 0 {
+	if len(found) > 0 && !overlap {
 		writeChunk = false
 		DedupedChunksTotal.Inc()
 	}
@@ -101,7 +101,7 @@ func (c *Writer) PutOne(ctx context.Context, from, through model.Time, chk chunk
 		return err
 	}
 
-	// write it back to the cache if it's not found.
+	// write chunk to the cache if it's not found.
 	if len(found) == 0 {
 		if cacheErr := c.fetcher.WriteBackCache(ctx, chunks); cacheErr != nil {
 			level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -20,7 +20,7 @@ type mockCache struct {
 }
 
 func (m *mockCache) Store(_ context.Context, _ []string, _ [][]byte) error {
-	m.called += 1
+	m.called++
 	return nil
 }
 
@@ -46,7 +46,7 @@ type mockIndexWriter struct {
 }
 
 func (m *mockIndexWriter) IndexChunk(ctx context.Context, chk chunk.Chunk) error {
-	m.called += 1
+	m.called++
 	return nil
 }
 
@@ -55,7 +55,7 @@ type mockChunksClient struct {
 }
 
 func (m *mockChunksClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
-	m.called += 1
+	m.called++
 	return nil
 }
 

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -1,0 +1,163 @@
+package stores
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/pkg/chunkenc"
+	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
+	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCache struct {
+	called int
+	data   map[string]string
+}
+
+func (m *mockCache) Store(_ context.Context, _ []string, _ [][]byte) error {
+	m.called += 1
+	return nil
+}
+
+func (m *mockCache) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string, err error) {
+	for _, key := range keys {
+		val, ok := m.data[key]
+		if !ok {
+			missing = append(missing, key)
+			continue
+		}
+		found = append(found, key)
+		bufs = append(bufs, []byte(val))
+	}
+
+	return
+}
+
+func (m *mockCache) Stop()                         {}
+func (m *mockCache) GetCacheType() stats.CacheType { return stats.ChunkCache }
+
+type mockIndexWriter struct {
+	called int
+}
+
+func (m *mockIndexWriter) IndexChunk(ctx context.Context, chk chunk.Chunk) error {
+	m.called += 1
+	return nil
+}
+
+type mockChunksClient struct {
+	called int
+}
+
+func (m *mockChunksClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
+	m.called += 1
+	return nil
+}
+
+func (m *mockChunksClient) Stop() {
+}
+func (m *mockChunksClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
+	panic("GetChunks not implemented")
+}
+func (m *mockChunksClient) DeleteChunk(ctx context.Context, userID, chunkID string) error {
+	panic("DeleteChunk not implemented")
+}
+func (m *mockChunksClient) IsChunkNotFoundErr(err error) bool {
+	panic("IsChunkNotFoundErr not implemented")
+}
+
+func TestChunkWriter_PutOne(t *testing.T) {
+	schemaConfig := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
+			},
+		},
+	}
+
+	memchk := chunkenc.NewMemChunk(chunkenc.EncGZIP, chunkenc.UnorderedHeadBlockFmt, 256*1024, 0)
+	chk := chunk.NewChunk("fake", model.Fingerprint(0), []labels.Label{{Name: "foo", Value: "bar"}}, chunkenc.NewFacade(memchk, 0, 0), 100, 400)
+
+	for name, tc := range map[string]struct {
+		from, through                                                             model.Time
+		populateCache                                                             bool
+		expectedWriteChunkCalls, expectedIndexWriteCalls, expectedWriteCacheCalls int
+	}{
+		"found_in_cache": {
+			from:                    0,
+			through:                 500,
+			populateCache:           true,
+			expectedWriteChunkCalls: 0,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 0,
+		},
+		"not_found_in_cache": {
+			from:                    0,
+			through:                 500,
+			expectedWriteChunkCalls: 1,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 1,
+		},
+		"overlapping_chunk_right": {
+			from:                    0,
+			through:                 200,
+			expectedWriteChunkCalls: 1,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 1,
+		},
+		"overlapping_chunk_left": {
+			from:                    200,
+			through:                 500,
+			expectedWriteChunkCalls: 1,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 1,
+		},
+		"overlapping_chunk_whole": {
+			from:                    200,
+			through:                 300,
+			expectedWriteChunkCalls: 1,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 1,
+		},
+		"overlapping_chunk_found_in_cache": {
+			from:                    200,
+			through:                 500,
+			populateCache:           true,
+			expectedWriteChunkCalls: 1,
+			expectedIndexWriteCalls: 1,
+			expectedWriteCacheCalls: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cache := &mockCache{}
+			if tc.populateCache {
+				cacheKey := schemaConfig.ExternalKey(chk.ChunkRef)
+				cache = &mockCache{
+					data: map[string]string{
+						cacheKey: "foo",
+					},
+				}
+			}
+
+			idx := &mockIndexWriter{}
+			client := &mockChunksClient{}
+
+			f, err := fetcher.New(cache, false, schemaConfig, client, 1, 1)
+			require.NoError(t, err)
+
+			cw := NewChunkWriter(f, schemaConfig, idx, true)
+
+			err = cw.PutOne(context.Background(), tc.from, tc.through, chk)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedWriteCacheCalls, cache.called)
+			require.Equal(t, tc.expectedIndexWriteCalls, idx.called)
+			require.Equal(t, tc.expectedWriteChunkCalls, client.called)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ashwanth Goli <iamashwanth@gmail.com>

**What this PR does / why we need it**:
When a chunk falls on the period boundary it should be written to both the stores as it gets referred to by the indexes on both sides. But we currently skip the writes for subsequent periods if the chunk is found in the cache. This PR ensures that overlapping chunks get written to both the stores

**Which issue(s) this PR fixes**:
Fixes #7847 

**Special notes for your reviewer**:
Downside of this approach is that we end up writing the overlapping chunk multiple times, once from each instance in the replica set. But these duplicate writes would be infrequent given this occurs only on schema changes

**Checklist**
- [X] Reviewed the `CONTRIBUTING.md` guide
- [X] Tests updated
- [x] `CHANGELOG.md` updated
