### PR TITLE
helm: Add `appProtocol: tcp` to headless grpc ports

### DIFF
--- a/production/helm/loki/templates/read/service-read-headless.yaml
+++ b/production/helm/loki/templates/read/service-read-headless.yaml
@@ -20,6 +20,7 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      appProtocol: tcp
   selector:
     {{- include "loki.readSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/production/helm/loki/templates/write/service-write-headless.yaml
+++ b/production/helm/loki/templates/write/service-write-headless.yaml
@@ -20,6 +20,7 @@ spec:
       port: 9095
       targetPort: grpc
       protocol: TCP
+      appProtocol: tcp
   selector:
     {{- include "loki.writeSelectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This sets the `appProtocol` of the headless services of the `loki` helm chart to `tcp`.

This is needed when deploying the helm chart in combination with Istio due to it's protocol selection breaking the routing between replicas of the satefulsets.

This is in line with [the documentation](https://grafana.com/docs/loki/latest/operations/troubleshooting/#running-loki-with-istio-sidecars) for running Loki and Istio (#6205).

Note that this only applies to Istio >= 1.10 due to https://istio.io/latest/blog/2021/statefulsets-made-easier/

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
