### PR TITLE
fix(promtail): Fix cri tags extra new lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [7804](https://github.com/grafana/loki/pull/7804) **sandeepsukhani**: Use grpc for communicating with compactor for query time filtering of data requested for deletion.
 * [7817](https://github.com/grafana/loki/pull/7817) **kavirajk**: fix(memcached): panic on send on closed channel.
 * [7916](https://github.com/grafana/loki/pull/7916) **ssncferreira**: Add `doc-generator` tool to generate configuration flags documentation.
+* [7997](https://github.com/grafana/loki/pull/7997) **kavirajk**: fix(promtail): Fix cri tags extra new lines when joining partial lines
 
 ##### Fixes
 
@@ -53,7 +54,7 @@
 
 #### Jsonnet
 
-#### Build 
+#### Build
 
 * [7938](https://github.com/grafana/loki/pull/7938) **ssncferreira**: Add DroneCI pipeline step to validate configuration flags documentation generation.
 

--- a/clients/pkg/logentry/stages/extensions.go
+++ b/clients/pkg/logentry/stages/extensions.go
@@ -62,7 +62,7 @@ func (c *cri) Run(entry chan Entry) chan Entry {
 			if len(c.partialLines) >= c.maxPartialLines {
 				// Merge existing partialLines
 				newPartialLine := e.Line
-				e.Line = strings.Join(c.partialLines, "\n")
+				e.Line = strings.Join(c.partialLines, "")
 				level.Warn(c.base.logger).Log("msg", "cri stage: partial lines upperbound exceeded. merging it to single line", "threshold", MaxPartialLinesSize)
 				c.partialLines = c.partialLines[:0]
 				c.partialLines = append(c.partialLines, newPartialLine)
@@ -73,7 +73,7 @@ func (c *cri) Run(entry chan Entry) chan Entry {
 		}
 		if len(c.partialLines) > 0 {
 			c.partialLines = append(c.partialLines, e.Line)
-			e.Line = strings.Join(c.partialLines, "\n")
+			e.Line = strings.Join(c.partialLines, "")
 			c.partialLines = c.partialLines[:0]
 		}
 		return e, false

--- a/clients/pkg/logentry/stages/extensions_test.go
+++ b/clients/pkg/logentry/stages/extensions_test.go
@@ -107,48 +107,31 @@ func TestCRI_tags(t *testing.T) {
 		{
 			name: "tag P",
 			lines: []string{
-				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1",
-				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ",
 				"2019-05-07T18:57:55.904275087+00:00 stdout F log finished",
 				"2019-05-07T18:57:55.904275087+00:00 stdout F another full log",
 			},
 			expected: []string{
-				"partial line 1\npartial line 2\nlog finished",
+				"partial line 1 partial line 2 log finished",
 				"another full log",
 			},
 		},
 		{
 			name: "tag P exceeding MaxPartialLinesSize lines",
 			lines: []string{
-				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1",
-				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 1 ",
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 2 ",
 				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 3",
-				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 4", // this exceeds the `MaxPartialLinesSize` of 3
+				"2019-05-07T18:57:50.904275087+00:00 stdout P partial line 4 ", // this exceeds the `MaxPartialLinesSize` of 3
 				"2019-05-07T18:57:55.904275087+00:00 stdout F log finished",
 				"2019-05-07T18:57:55.904275087+00:00 stdout F another full log",
 			},
 			maxPartialLines: 3,
 			expected: []string{
-				"partial line 1\npartial line 2\npartial line 3",
-				"partial line 4\nlog finished",
+				"partial line 1 partial line 2 partial line 3",
+				"partial line 4 log finished",
 				"another full log",
-			},
-		},
-		{
-			name: "panic",
-			lines: []string{
-				"2019-05-07T18:57:50.904275087+00:00 stdout P panic: I'm pannicing",
-				"2019-05-07T18:57:50.904275087+00:00 stdout P ",
-				"2019-05-07T18:57:50.904275087+00:00 stdout P goroutine 1 [running]:",
-				"2019-05-07T18:57:55.904275087+00:00 stdout P main.main()",
-				"2019-05-07T18:57:55.904275087+00:00 stdout F 	/home/kavirajk/src/go-play/main.go:11 +0x27",
-			},
-			expected: []string{
-				`panic: I'm pannicing
-
-goroutine 1 [running]:
-main.main()
-	/home/kavirajk/src/go-play/main.go:11 +0x27`,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When re-creating single lines from multiple partial lines, `\n` should be avoided to join the partial lines.

Related: https://github.com/grafana/loki/pull/6177#discussion_r976113761

Example
if Original log line is 
```
{"a": "very long json field split in two lines"}
```

And got split into partial lines via CRI
```
2022-09-20T17:51:01.214529932Z stdout P {"a": "very long json field 
2022-09-20T17:51:01.214697597Z stdout F split in two lines"}
```
The result should be without \n when joining both of those lines.

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

**Which issue(s) this PR fixes**:
Fixes: https://github.com/grafana/loki/issues/7996

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Tests updated
- [x] `CHANGELOG.md` updated

