### PR TITLE
[chore] Fix various linter errors

### DIFF
--- a/clients/pkg/promtail/targets/heroku/target_test.go
+++ b/clients/pkg/promtail/targets/heroku/target_test.go
@@ -100,7 +100,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testPayload},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "some_job_name",
@@ -145,7 +145,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testLogLine1, testLogLine2},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "multiple_line_job",
@@ -215,7 +215,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			args: args{
 				RequestBodies: []string{testLogLine1},
 				RequestParams: map[string][]string{
-					"some_query_param": []string{"app_123", "app_456"},
+					"some_query_param": {"app_123", "app_456"},
 				},
 				Labels: model.LabelSet{
 					"job": "relabeling_job",

--- a/pkg/ingester/stream_rate_calculator.go
+++ b/pkg/ingester/stream_rate_calculator.go
@@ -35,7 +35,7 @@ type StreamRateCalculator struct {
 
 func NewStreamRateCalculator() *StreamRateCalculator {
 	calc := &StreamRateCalculator{
-		size:     defaultStripeSize,
+		size: defaultStripeSize,
 		// Lookup pattern: tenant -> fingerprint -> rate
 		samples:  make([]map[string]map[uint64]logproto.StreamRate, defaultStripeSize),
 		locks:    make([]stripeLock, defaultStripeSize),

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -3,10 +3,10 @@ package logql
 import (
 	"context"
 	"fmt"
-	"github.com/gogo/protobuf/proto"
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
 func Test_SplitRangeInterval(t *testing.T) {

--- a/pkg/logql/syntax/prettier.go
+++ b/pkg/logql/syntax/prettier.go
@@ -327,7 +327,7 @@ func (e *VectorExpr) Pretty(level int) string {
 	return commonPrefixIndent(level, e)
 }
 
-// Grouping is techincally not expression type. But used in both range and vector aggregations (`by` and `without` clause)
+// Grouping is technically not expression type. But used in both range and vector aggregations (`by` and `without` clause)
 // So by implenting `Pretty` for Grouping, we can re use it for both.
 // NOTE: indent is ignored for `Grouping`, because grouping always stays in the same line of it's parent expression.
 

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -286,7 +286,7 @@ func maxRangeVectorAndOffsetDuration(q string) (time.Duration, time.Duration, er
 	if _, ok := expr.(syntax.SampleExpr); !ok {
 		return 0, 0, nil
 	}
-	
+
 	var maxRVDuration, maxOffset time.Duration
 	expr.Walk(func(e interface{}) {
 		if r, ok := e.(*syntax.LogRange); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

These changes have been generated using `make lint`.

```console
$ golangci-lint --version
golangci-lint has version 1.50.0 built from 704109c6 on 2022-10-04T10:25:07Z
```

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>