### PR TITLE
operator: Add API validation to Alertmanager header auth config

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [8087](https://github.com/grafana/loki/pull/8087) **xperimental**: Fix status not updating when state of pods changes
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
 - [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config
+- [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
 - [7839](https://github.com/grafana/loki/pull/7839) **aminesnow**: Configure Alertmanager per-tenant
 - [7910](https://github.com/grafana/loki/pull/7910) **periklis**: Update Loki operand to v2.7.1
 - [7815](https://github.com/grafana/loki/pull/7815) **periklis**: Apply delete client changes for compat with release-2.7.x

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Main
 
+- [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config
 - [8087](https://github.com/grafana/loki/pull/8087) **xperimental**: Fix status not updating when state of pods changes
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
-- [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
 - [7839](https://github.com/grafana/loki/pull/7839) **aminesnow**: Configure Alertmanager per-tenant
 - [7910](https://github.com/grafana/loki/pull/7910) **periklis**: Update Loki operand to v2.7.1

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [8087](https://github.com/grafana/loki/pull/8087) **xperimental**: Fix status not updating when state of pods changes
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
+- [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config
 - [7839](https://github.com/grafana/loki/pull/7839) **aminesnow**: Configure Alertmanager per-tenant
 - [7910](https://github.com/grafana/loki/pull/7910) **periklis**: Update Loki operand to v2.7.1
 - [7815](https://github.com/grafana/loki/pull/7815) **periklis**: Apply delete client changes for compat with release-2.7.x

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -110,6 +110,8 @@ type FeatureGates struct {
 	AlertingRuleWebhook bool `json:"alertingRuleWebhook,omitempty"`
 	// RecordingRuleWebhook enables the RecordingRule CR validation webhook.
 	RecordingRuleWebhook bool `json:"recordingRuleWebhook,omitempty"`
+	// RulerConfigWebhook enables the RulerConfig CR validation webhook.
+	RulerConfigWebhook bool `json:"rulerConfigWebhook,omitempty"`
 
 	// When DefaultNodeAffinity is enabled the operator will set a default node affinity on all pods.
 	// This will limit scheduling of the pods to Nodes with Linux.

--- a/operator/apis/loki/v1beta1/rulerconfig_types.go
+++ b/operator/apis/loki/v1beta1/rulerconfig_types.go
@@ -522,6 +522,7 @@ type RulerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:webhook:path=/validate-loki-grafana-com-v1beta1-rulerconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=loki.grafana.com,resources=rulerconfigs,verbs=create;update,versions=v1beta1,name=vrulerconfig.loki.grafana.com,admissionReviewVersions=v1
 
 // RulerConfig is the Schema for the rulerconfigs API
 //

--- a/operator/apis/loki/v1beta1/v1beta1.go
+++ b/operator/apis/loki/v1beta1/v1beta1.go
@@ -53,8 +53,8 @@ var (
 	ErrSchemaRetroactivelyRemoved = errors.New("Cannot retroactively remove schema(s)")
 	// ErrSchemaRetroactivelyChanged when a schema has been retroactively changed
 	ErrSchemaRetroactivelyChanged = errors.New("Cannot retroactively change schema")
-	// ErrHeaderAuthCredentials when both Credentials and CredentialsFile are used in a header authentication client.
-	ErrHeaderAuthCredentials = errors.New("Both Credentials and CredentialsFile cannot be defined")
+	// ErrHeaderAuthCredentialsConflict when both Credentials and CredentialsFile are used in a header authentication client.
+	ErrHeaderAuthCredentialsConflict = errors.New("Both Credentials and CredentialsFile cannot be defined")
 
 	// ErrRuleMustMatchNamespace indicates that an expression used in an alerting or recording rule is missing
 	// matchers for a namespace.

--- a/operator/apis/loki/v1beta1/v1beta1.go
+++ b/operator/apis/loki/v1beta1/v1beta1.go
@@ -54,7 +54,7 @@ var (
 	// ErrSchemaRetroactivelyChanged when a schema has been retroactively changed
 	ErrSchemaRetroactivelyChanged = errors.New("Cannot retroactively change schema")
 	// ErrHeaderAuthCredentials when both Credentials and CredentialsFile are used in a header authentication client.
-	ErrHeaderAuthCredentials = errors.New("Credentials and CredentialsFile are mutually exclusive")
+	ErrHeaderAuthCredentials = errors.New("Both Credentials and CredentialsFile cannot be defined")
 
 	// ErrRuleMustMatchNamespace indicates that an expression used in an alerting or recording rule is missing
 	// matchers for a namespace.

--- a/operator/apis/loki/v1beta1/v1beta1.go
+++ b/operator/apis/loki/v1beta1/v1beta1.go
@@ -54,7 +54,7 @@ var (
 	// ErrSchemaRetroactivelyChanged when a schema has been retroactively changed
 	ErrSchemaRetroactivelyChanged = errors.New("Cannot retroactively change schema")
 	// ErrHeaderAuthCredentialsConflict when both Credentials and CredentialsFile are used in a header authentication client.
-	ErrHeaderAuthCredentialsConflict = errors.New("Both Credentials and CredentialsFile cannot be defined")
+	ErrHeaderAuthCredentialsConflict = errors.New("credentials and credentialsFile cannot be used at the same time")
 
 	// ErrRuleMustMatchNamespace indicates that an expression used in an alerting or recording rule is missing
 	// matchers for a namespace.

--- a/operator/apis/loki/v1beta1/v1beta1.go
+++ b/operator/apis/loki/v1beta1/v1beta1.go
@@ -53,6 +53,8 @@ var (
 	ErrSchemaRetroactivelyRemoved = errors.New("Cannot retroactively remove schema(s)")
 	// ErrSchemaRetroactivelyChanged when a schema has been retroactively changed
 	ErrSchemaRetroactivelyChanged = errors.New("Cannot retroactively change schema")
+	// ErrHeaderAuthCredentials when both Credentials and CredentialsFile are used in a header authentication client.
+	ErrHeaderAuthCredentials = errors.New("Credentials and CredentialsFile are mutually exclusive")
 
 	// ErrRuleMustMatchNamespace indicates that an expression used in an alerting or recording rule is missing
 	// matchers for a namespace.

--- a/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -49,6 +49,7 @@ data:
       lokiStackWebhook: true
       alertingRuleWebhook: true
       recordingRuleWebhook: true
+      rulerConfigWebhook: true
       #
       # OpenShift feature gates
       #

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1666,3 +1666,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-loki-grafana-com-v1beta1-recordingrule
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: loki-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vrulerconfig.loki.grafana.com
+    rules:
+    - apiGroups:
+      - loki.grafana.com
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - rulerconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-loki-grafana-com-v1beta1-rulerconfig

--- a/operator/config/crd/bases/config.grafana.com_projectconfigs.yaml
+++ b/operator/config/crd/bases/config.grafana.com_projectconfigs.yaml
@@ -72,6 +72,8 @@ spec:
                 type: boolean
               enableRecordingRuleWebhook:
                 type: boolean
+              enableRulerConfigWebhook:
+                type: boolean
               enableServiceMonitors:
                 type: boolean
               enableTlsGrpcServices:

--- a/operator/config/overlays/development/controller_manager_config.yaml
+++ b/operator/config/overlays/development/controller_manager_config.yaml
@@ -26,3 +26,4 @@ featureGates:
   lokiStackWebhook: false
   alertingRuleWebhook: false
   recordingRuleWebhook: false
+  rulerConfigWebhook: false

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -46,6 +46,7 @@ featureGates:
   lokiStackWebhook: true
   alertingRuleWebhook: true
   recordingRuleWebhook: true
+  rulerConfigWebhook: true
   #
   # OpenShift feature gates
   #

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -65,3 +65,23 @@ webhooks:
     resources:
     - recordingrules
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-loki-grafana-com-v1beta1-rulerconfig
+  failurePolicy: Fail
+  name: vrulerconfig.loki.grafana.com
+  rules:
+  - apiGroups:
+    - loki.grafana.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rulerconfigs
+  sideEffects: None

--- a/operator/internal/validation/rulerconfig.go
+++ b/operator/internal/validation/rulerconfig.go
@@ -17,9 +17,7 @@ import (
 var _ admission.CustomValidator = &RulerConfigValidator{}
 
 // RulerConfigValidator implements a custom validator for RulerConfig resources.
-type RulerConfigValidator struct {
-	ExtendedValidator func(context.Context, *lokiv1beta1.RulerConfig) field.ErrorList
-}
+type RulerConfigValidator struct{}
 
 // SetupWebhookWithManager registers the RulerConfigValidator as a validating webhook
 // with the controller-runtime manager or returns an error.
@@ -61,12 +59,12 @@ func (v *RulerConfigValidator) validate(ctx context.Context, obj runtime.Object)
 		// Credentials and CredentialsFile are mutually exclusive
 		if ha.Credentials != nil && ha.CredentialsFile != nil {
 			allErrs = append(allErrs, field.Invalid(
-				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
+				field.NewPath("spec", "alertmanager", "client", "headerAuth", "credentials"),
 				ha.Credentials,
 				lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 			))
 			allErrs = append(allErrs, field.Invalid(
-				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+				field.NewPath("spec", "alertmanager", "client", "headerAuth", "credentialsFile"),
 				ha.CredentialsFile,
 				lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 			))
@@ -81,21 +79,17 @@ func (v *RulerConfigValidator) validate(ctx context.Context, obj runtime.Object)
 			// Credentials and CredentialsFile are mutually exclusive
 			if oha.Credentials != nil && oha.CredentialsFile != nil {
 				allErrs = append(allErrs, field.Invalid(
-					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					field.NewPath("spec", "overrides", tenant, "alertmanager", "client", "headerAuth", "credentials"),
 					oha.Credentials,
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				))
 				allErrs = append(allErrs, field.Invalid(
-					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					field.NewPath("spec", "overrides", tenant, "alertmanager", "client", "headerAuth", "credentialsFile"),
 					oha.CredentialsFile,
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				))
 			}
 		}
-	}
-
-	if v.ExtendedValidator != nil {
-		allErrs = append(allErrs, v.ExtendedValidator(ctx, rulerConfig)...)
 	}
 
 	if len(allErrs) == 0 {

--- a/operator/internal/validation/rulerconfig.go
+++ b/operator/internal/validation/rulerconfig.go
@@ -1,0 +1,110 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	lokiv1beta1 "github.com/grafana/loki/operator/apis/loki/v1beta1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ admission.CustomValidator = &RulerConfigValidator{}
+
+// RulerConfigValidator implements a custom validator for RulerConfig resources.
+type RulerConfigValidator struct {
+	ExtendedValidator func(context.Context, *lokiv1beta1.RulerConfig) field.ErrorList
+}
+
+// SetupWebhookWithManager registers the RulerConfigValidator as a validating webhook
+// with the controller-runtime manager or returns an error.
+func (v *RulerConfigValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&lokiv1beta1.RulerConfig{}).
+		WithValidator(v).
+		Complete()
+}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *RulerConfigValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return v.validate(ctx, obj)
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *RulerConfigValidator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) error {
+	return v.validate(ctx, newObj)
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *RulerConfigValidator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	// No validation on delete
+	return nil
+}
+
+func (v *RulerConfigValidator) validate(ctx context.Context, obj runtime.Object) error {
+	rulerConfig, ok := obj.(*lokiv1beta1.RulerConfig)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("object is not of type RulerConfig: %t", obj))
+	}
+
+	var allErrs field.ErrorList
+
+	// Check if header auth is defined in AlertManagerSpec
+	am := rulerConfig.Spec.AlertManagerSpec
+	if am != nil && am.Client != nil && am.Client.HeaderAuth != nil {
+		ha := am.Client.HeaderAuth
+		// Credentials and CredentialsFile are mutually exclusive
+		if ha.Credentials != nil && ha.CredentialsFile != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
+				ha.Credentials,
+				lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+			))
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+				ha.CredentialsFile,
+				lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+			))
+		}
+	}
+
+	// Check if header auth is defined in AlertManagerOverrides
+	for tenant, override := range rulerConfig.Spec.Overrides {
+		amo := override.AlertManagerOverrides
+		if amo != nil && amo.Client != nil && amo.Client.HeaderAuth != nil {
+			oha := amo.Client.HeaderAuth
+			// Credentials and CredentialsFile are mutually exclusive
+			if oha.Credentials != nil && oha.CredentialsFile != nil {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					oha.Credentials,
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				))
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					oha.CredentialsFile,
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				))
+			}
+		}
+	}
+
+	if v.ExtendedValidator != nil {
+		allErrs = append(allErrs, v.ExtendedValidator(ctx, rulerConfig)...)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "loki.grafana.com", Kind: "RulerConfig"},
+		rulerConfig.Name,
+		allErrs,
+	)
+}

--- a/operator/internal/validation/rulerconfig.go
+++ b/operator/internal/validation/rulerconfig.go
@@ -63,12 +63,12 @@ func (v *RulerConfigValidator) validate(ctx context.Context, obj runtime.Object)
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
 				ha.Credentials,
-				lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 			))
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
 				ha.CredentialsFile,
-				lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 			))
 		}
 	}
@@ -83,12 +83,12 @@ func (v *RulerConfigValidator) validate(ctx context.Context, obj runtime.Object)
 				allErrs = append(allErrs, field.Invalid(
 					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
 					oha.Credentials,
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				))
 				allErrs = append(allErrs, field.Invalid(
 					field.NewPath("Spec").Child("Overrides").Child(tenant).Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
 					oha.CredentialsFile,
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				))
 			}
 		}

--- a/operator/internal/validation/rulerconfig_test.go
+++ b/operator/internal/validation/rulerconfig_test.go
@@ -146,22 +146,22 @@ var rctt = []struct {
 				field.Invalid(
 					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
 					"creds",
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
 					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
 					"creds-file",
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
 					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
 					"creds1",
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
 					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
 					"creds-file1",
-					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 			},
 		),

--- a/operator/internal/validation/rulerconfig_test.go
+++ b/operator/internal/validation/rulerconfig_test.go
@@ -1,0 +1,196 @@
+package validation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/loki/operator/apis/loki/v1beta1"
+	lokiv1beta1 "github.com/grafana/loki/operator/apis/loki/v1beta1"
+	"github.com/grafana/loki/operator/internal/validation"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+var rctt = []struct {
+	desc string
+	spec v1beta1.RulerConfigSpec
+	err  *apierrors.StatusError
+}{
+	{
+		desc: "valid spec with no AM credentials",
+		spec: v1beta1.RulerConfigSpec{
+			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
+				Client: &lokiv1beta1.AlertManagerClientConfig{
+					BasicAuth: &lokiv1beta1.AlertManagerClientBasicAuth{
+						Username: pointer.String("user"),
+						Password: pointer.String("pass"),
+					},
+				},
+			},
+			Overrides: map[string]lokiv1beta1.RulerOverrides{
+				"tenant": {
+					AlertManagerOverrides: &lokiv1beta1.AlertManagerSpec{
+						Client: &lokiv1beta1.AlertManagerClientConfig{
+							BasicAuth: &lokiv1beta1.AlertManagerClientBasicAuth{
+								Username: pointer.String("user1"),
+								Password: pointer.String("pass1"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		desc: "valid spec with Credentials",
+		spec: v1beta1.RulerConfigSpec{
+			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
+				Client: &lokiv1beta1.AlertManagerClientConfig{
+					HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+						Credentials: pointer.String("creds"),
+					},
+				},
+			},
+			Overrides: map[string]lokiv1beta1.RulerOverrides{
+				"tenant": {
+					AlertManagerOverrides: &lokiv1beta1.AlertManagerSpec{
+						Client: &lokiv1beta1.AlertManagerClientConfig{
+							HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+								Credentials: pointer.String("creds1"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		desc: "valid spec with CredentialsFile",
+		spec: v1beta1.RulerConfigSpec{
+			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
+				Client: &lokiv1beta1.AlertManagerClientConfig{
+					HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+						CredentialsFile: pointer.String("creds-file"),
+					},
+				},
+			},
+			Overrides: map[string]lokiv1beta1.RulerOverrides{
+				"tenant": {
+					AlertManagerOverrides: &lokiv1beta1.AlertManagerSpec{
+						Client: &lokiv1beta1.AlertManagerClientConfig{
+							HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+								CredentialsFile: pointer.String("creds-file1"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		desc: "both Credentials and CredentialsFile defined",
+		spec: v1beta1.RulerConfigSpec{
+			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
+				Client: &lokiv1beta1.AlertManagerClientConfig{
+					HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+						Credentials:     pointer.String("creds"),
+						CredentialsFile: pointer.String("creds-file"),
+					},
+				},
+			},
+			Overrides: map[string]lokiv1beta1.RulerOverrides{
+				"tenant": {
+					AlertManagerOverrides: &lokiv1beta1.AlertManagerSpec{
+						Client: &lokiv1beta1.AlertManagerClientConfig{
+							HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+								Credentials:     pointer.String("creds1"),
+								CredentialsFile: pointer.String("creds-file1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		err: apierrors.NewInvalid(
+			schema.GroupKind{Group: "loki.grafana.com", Kind: "RulerConfig"},
+			"testing-ruler",
+			field.ErrorList{
+				field.Invalid(
+					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					"creds",
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				),
+				field.Invalid(
+					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					"creds-file",
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				),
+				field.Invalid(
+					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					"creds1",
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				),
+				field.Invalid(
+					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					"creds-file1",
+					lokiv1beta1.ErrHeaderAuthCredentials.Error(),
+				),
+			},
+		),
+	},
+}
+
+func TestRulerConfigValidationWebhook_ValidateCreate(t *testing.T) {
+	for _, tc := range rctt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			l := &v1beta1.RulerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-ruler",
+				},
+				Spec: tc.spec,
+			}
+
+			v := &validation.RulerConfigValidator{}
+			err := v.ValidateCreate(ctx, l)
+			if err != nil {
+				require.Equal(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRulerConfigValidationWebhook_ValidateUpdate(t *testing.T) {
+	for _, tc := range rctt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			l := &v1beta1.RulerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-ruler",
+				},
+				Spec: tc.spec,
+			}
+
+			v := &validation.RulerConfigValidator{}
+			err := v.ValidateUpdate(ctx, &v1beta1.RulerConfig{}, l)
+			if err != nil {
+				require.Equal(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/operator/internal/validation/rulerconfig_test.go
+++ b/operator/internal/validation/rulerconfig_test.go
@@ -22,7 +22,7 @@ var rctt = []struct {
 	err  *apierrors.StatusError
 }{
 	{
-		desc: "valid spec with no AM credentials",
+		desc: "valid spec with no AM header credentials",
 		spec: v1beta1.RulerConfigSpec{
 			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
 				Client: &lokiv1beta1.AlertManagerClientConfig{

--- a/operator/internal/validation/rulerconfig_test.go
+++ b/operator/internal/validation/rulerconfig_test.go
@@ -144,22 +144,22 @@ var rctt = []struct {
 			"testing-ruler",
 			field.ErrorList{
 				field.Invalid(
-					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					field.NewPath("spec", "alertmanager", "client", "headerAuth", "credentials"),
 					"creds",
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
-					field.NewPath("Spec").Child("AlertManagerSpec").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					field.NewPath("spec", "alertmanager", "client", "headerAuth", "credentialsFile"),
 					"creds-file",
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
-					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("Credentials"),
+					field.NewPath("spec", "overrides", "tenant", "alertmanager", "client", "headerAuth", "credentials"),
 					"creds1",
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),
 				field.Invalid(
-					field.NewPath("Spec").Child("Overrides").Child("tenant").Child("AlertManagerOverrides").Child("Client").Child("HeaderAuth").Child("CredentialsFile"),
+					field.NewPath("spec", "overrides", "tenant", "alertmanager", "client", "headerAuth", "credentialsFile"),
 					"creds-file1",
 					lokiv1beta1.ErrHeaderAuthCredentialsConflict.Error(),
 				),

--- a/operator/internal/validation/rulerconfig_test.go
+++ b/operator/internal/validation/rulerconfig_test.go
@@ -93,6 +93,29 @@ var rctt = []struct {
 		},
 	},
 	{
+		desc: "valid spec with CredentialsFile override",
+		spec: v1beta1.RulerConfigSpec{
+			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{
+				Client: &lokiv1beta1.AlertManagerClientConfig{
+					HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+						Credentials: pointer.String("creds"),
+					},
+				},
+			},
+			Overrides: map[string]lokiv1beta1.RulerOverrides{
+				"tenant": {
+					AlertManagerOverrides: &lokiv1beta1.AlertManagerSpec{
+						Client: &lokiv1beta1.AlertManagerClientConfig{
+							HeaderAuth: &lokiv1beta1.AlertManagerClientHeaderAuth{
+								CredentialsFile: pointer.String("creds-file1"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		desc: "both Credentials and CredentialsFile defined",
 		spec: v1beta1.RulerConfigSpec{
 			AlertManagerSpec: &lokiv1beta1.AlertManagerSpec{

--- a/operator/main.go
+++ b/operator/main.go
@@ -160,6 +160,13 @@ func main() {
 		logger.Error(err, "unable to create controller", "controller", "rulerconfig")
 		os.Exit(1)
 	}
+	if ctrlCfg.Gates.RulerConfigWebhook {
+		v := &validation.RulerConfigValidator{}
+		if err = v.SetupWebhookWithManager(mgr); err != nil {
+			logger.Error(err, "unable to create webhook", "webhook", "rulerconfig")
+			os.Exit(1)
+		}
+	}
 	if ctrlCfg.Gates.BuiltInCertManagement.Enabled {
 		if err = (&lokictrl.CertRotationReconciler{
 			Client:       mgr.GetClient(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Following #7839, this PR adds a validation on the Alertmanager `HeaderAuth` configuration in `RulerConfig`. This validation insures that `Credentials` and `CredentialsFile` are mutually exclusive and thus not defined in the same time.

**Which issue(s) this PR fixes:**
https://issues.redhat.com/browse/LOG-3443

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
