### PR TITLE
[Helm] Add the ability to specify container lifecycle

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -760,6 +760,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>gateway.lifecycle</td>
+			<td>object</td>
+			<td>Lifecycle for the gateway container</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>gateway.nginxConfig.file</td>
 			<td>string</td>
 			<td>Config file contents for Nginx. Passed through the `tpl` function to allow templating</td>
@@ -2460,6 +2469,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>read.lifecycle</td>
+			<td>object</td>
+			<td>Lifecycle for the read container</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>read.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for read pods</td>
@@ -3058,6 +3076,15 @@ null
 			<td>Docker image tag for the write image. Overrides `loki.image.tag`</td>
 			<td><pre lang="json">
 null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.lifecycle</td>
+			<td>object</td>
+			<td>Lifecycle for the write container</td>
+			<td><pre lang="json">
+{}
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.8.1
+
+- [ENHANCEMENT] Add the ability to specify container lifecycle
+
 ## 3.8.0
 
 - [BUGFIX] Added `helm-weight` annotations to the tokengen and provisioner jobs to make sure tokengen always runs before provisioner

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 3.8.0
+version: 3.8.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.8.0](https://img.shields.io/badge/Version-3.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -60,6 +60,10 @@ spec:
             {{- toYaml .Values.gateway.readinessProbe | nindent 12 }}
           securityContext:
             {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
+          {{- with .Values.gateway.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/nginx

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -87,6 +87,10 @@ spec:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          {{- with .Values.read.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -79,6 +79,10 @@ spec:
             {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          {{- with .Values.write.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -753,6 +753,8 @@ write:
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the write pods
   extraEnvFrom: []
+  # -- Lifecycle for the write container
+  lifecycle: {}
   # -- Volume mounts to add to the write pods
   extraVolumeMounts: []
   # -- Volumes to add to the write pods
@@ -826,6 +828,8 @@ read:
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the read pods
   extraEnvFrom: []
+  # -- Lifecycle for the read container
+  lifecycle: {}
   # -- Volume mounts to add to the read pods
   extraVolumeMounts: []
   # -- Volumes to add to the read pods
@@ -1012,6 +1016,8 @@ gateway:
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the gateway pods
   extraEnvFrom: []
+  # -- Lifecycle for the gateway container
+  lifecycle: {}
   # -- Volumes to add to the gateway pods
   extraVolumes: []
   # -- Volume mounts to add to the gateway pods


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the ability to specify container lifecycle in helm chart. This is useful when pods are served by a load balancer that needs time to deregister terminating pods, as we can setup a preStop hook to wait a bit before terminating the container. Example:

```yaml
gateway:
  lifecycle:
    preStop:
      exec:
        command: ["/bin/sh", "-c", "sleep 30"]
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
