### PR TITLE
Use gotestsum to run unit tests

### DIFF
--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -62,6 +62,10 @@ RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 FROM golang:1.19.2 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
+# Install gotestsum
+FROM golang:1.19.2 as gotestsum
+RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
+
 # Install tools used to compile jsonnet.
 FROM golang:1.19.2 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
@@ -88,6 +92,7 @@ COPY --from=faillint /go/bin/faillint /usr/bin/faillint
 COPY --from=delve /go/bin/dlv /usr/bin/dlv
 COPY --from=ghr /go/bin/ghr /usr/bin/ghr
 COPY --from=nfpm /go/bin/nfpm /usr/bin/nfpm
+COPY --from=gotestsum /go/bin/gotestsum /usr/bin/gotestsum
 COPY --from=jsonnet /go/bin/jb /usr/bin/jb
 COPY --from=jsonnet /go/bin/mixtool /usr/bin/mixtool
 COPY --from=jsonnet /go/bin/jsonnet /usr/bin/jsonnet
@@ -99,11 +104,12 @@ COPY --from=jsonnet /go/bin/jsonnet /usr/bin/jsonnet
 # It's possible this can be revisited in newer versions of Go if the behavior around GOPATH vs GO111MODULES changes
 RUN GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1
 RUN GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0
-    # Due to the lack of a proper release tag, we use the commit hash of
-    # https://github.com/golang/tools/releases v0.1.7
+# Due to the lack of a proper release tag, we use the commit hash of
+# https://github.com/golang/tools/releases v0.1.7
 RUN GO111MODULE=on go install golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69
 RUN GO111MODULE=on go install github.com/mitchellh/gox@9f71238 && rm -rf /go/pkg /go/src
 ENV GOCACHE=/go/cache
+ENV GOTEST="gotestsum --format testname --"
 
 COPY build.sh /
 RUN chmod +x /build.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Add gotestsum to the build image. Then use it to run the unit tests. The output format is easier to parse so we can get statistics about the builds.

Passing test cases look like this:

```
PASS pkg/storage/stores/shipper/index/compactor.TestTable_RecreateCompactedDB/compacted_db_old_enough (2.64s)
PASS pkg/storage/stores/shipper/index/compactor.TestTable_RecreateCompactedDB (10.26s)
PASS pkg/storage/stores/shipper/index/compactor.TestExtractIntervalFromTableName/0 (0.00s)
```

Failing test cases are shown at the end and are easier to parse:

```
=== FAIL: pkg/storage/stores/indexshipper/compactor/deletion TestGRPCGetCacheGenNumbers (unknown)
panic: Fail in goroutine after TestGRPCGetCacheGenNumbers/error_getting_from_store has completed

goroutine 293 [running]:
testing.(*common).Fail(0xc0005aa680)
        /usr/local/Cellar/go/1.19.4/libexec/src/testing/testing.go:824 +0xe5
...
```

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>