### PR TITLE
make query-frontend service grpc lb friendly

### DIFF
--- a/production/ksonnet/loki/query-frontend.libsonnet
+++ b/production/ksonnet/loki/query-frontend.libsonnet
@@ -60,5 +60,5 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     service.mixin.metadata.withName('query-frontend-headless'),
 
   query_frontend_service:
-    k.util.serviceFor($.query_frontend_deployment, $._config.service_ignored_labels),
+    $.util.grpclbServiceFor($.query_frontend_deployment),
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR #7966, I made changes to Query Frontend service. Part of it was creating a new service.
To make the service properly load balance grpc requests, we need to use `grpclbServiceFor`, but since we do not use grpc in QF, I went with the usual method, i.e. I used `serviceFor`. Thinking more about it, I think there is no harm in keeping it grpc LB friendly, and it would save us from any possible bugs if we make QF accept queries via grpc.