### PR TITLE
Fix chunks-inspect reports zstd compressed chunks as lz4-256k

### DIFF
--- a/cmd/chunks-inspect/loki.go
+++ b/cmd/chunks-inspect/loki.go
@@ -43,7 +43,7 @@ var (
 	enclz4_1M   = Encoding{code: 6, name: "lz4-1M", readerFn: func(reader io.Reader) (io.Reader, error) { return lz4.NewReader(reader), nil }}
 	enclz4_4M   = Encoding{code: 7, name: "lz4-4M", readerFn: func(reader io.Reader) (io.Reader, error) { return lz4.NewReader(reader), nil }}
 	encFlate    = Encoding{code: 8, name: "flate", readerFn: func(reader io.Reader) (io.Reader, error) { return flate.NewReader(reader), nil }}
-	encZstd     = Encoding{code: 9, name: "lz4-256k", readerFn: func(reader io.Reader) (io.Reader, error) {
+	encZstd     = Encoding{code: 9, name: "zstd", readerFn: func(reader io.Reader) (io.Reader, error) {
 		r, err := zstd.NewReader(reader)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the `chunks-inspect` command correctly report Zstandard compressed chunks as `zstd` encoding.

**Which issue(s) this PR fixes**:
The `chunks-inspect` command falsely reports Zstandard compressed chunks as `lz4-256k`.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
