### PR TITLE
Update build image and use in drone yaml

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: compare-coverage
   when:
     event:
@@ -158,7 +158,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: report-coverage
   when:
     event:
@@ -168,7 +168,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -176,7 +176,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -187,28 +187,28 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: check-example-config-doc
 trigger:
   ref:
@@ -235,7 +235,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: loki-mixin-check
   when:
     event:
@@ -260,7 +260,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1347,7 +1347,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1355,7 +1355,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1381,7 +1381,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.25.0
+  image: grafana/loki-build-image:0.26.0
   name: publish
   when:
     event:
@@ -1620,6 +1620,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 12435dae603e73b3afd6cf014e723b8ff84c04d4476917c72d5f9b81251d43ad
+hmac: fe9a2585353898836876a160d6817e1a954d79b72953fc89f25cb16d87c50432
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.25.0
+BUILD_IMAGE_VERSION := 0.26.0
 
 # Docker image info
 IMAGE_PREFIX ?= grafana


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the build image version to 0.26.
Use this in drone.yaml.

**Special notes for your reviewer**:
This uses the new test setup from https://github.com/grafana/loki/pull/8022

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
