### PR TITLE
[loki-canary] Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 #### Loki
 
 ##### Enhancements
-* [8024](https://github.com/grafana/loki/pull/8024) **jijotj**: Support passing loki address as environment variable
 * [7951](https://github.com/grafana/loki/pull/7951) **MichelHollands**: Add a count template function to line_format and label_format.
 * [7380](https://github.com/grafana/loki/pull/7380) **liguozhong**: metrics query: range vector support streaming agg when no overlap.
 * [7684](https://github.com/grafana/loki/pull/7684) **kavirajk**: Add missing `embedded-cache` config under `cache_config` doc.
@@ -59,6 +58,9 @@
 #### Fluent Bit
 
 #### Loki Canary
+
+##### Enhancements
+* [8024](https://github.com/grafana/loki/pull/8024) **jijotj**: Support passing loki address as environment variable
 
 #### Jsonnet
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 #8024 added an enhancement to loki-canary to pickup config from env variables. However the change was wrongly added under loki instead of loki-canary in the changelog. This PR fixes the changelog.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
