### PR TITLE
Helm: Update tokengen to only create kubectl secret if admin token file does not exist

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 3.8.2
+
+- [ENHANCEMENT] Update `tokengen` to only create kubectl secret if admin token file does not exist
+
 ## 3.8.1
 
 - [ENHANCEMENT] Add the ability to specify container lifecycle

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.7.0
-version: 3.8.1
+appVersion: 2.8.0
+version: 3.8.2
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.8.2](https://img.shields.io/badge/Version-3.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -75,7 +75,7 @@ spec:
           image: {{ include "loki.kubectlImage" . }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
           command:
-            - /bin/bash
+            - ! test -f /shared/admin-token && /bin/bash
             - -euc
             - |
               kubectl create secret generic "{{ include "enterprise-logs.adminTokenSecret" . }}" --from-file=token=/shared/admin-token


### PR DESCRIPTION
**What this PR does / why we need it**:
Update tokengen to only create kubectl secret if admin token file does not exist.

When installing GEL with the grafana-loki helm chart (with enterprise enabled), if you uninstall it and reinstall it again it fails because the enterprise-logs-admin-token secret already exists:
```
Defaulted container "create-secret" out of: create-secret, loki (init)
error: failed to create secret secrets "enterprise-logs-admin-token" already exists
```

The solution consists in only creating the kubectl secret if the token file does not yet exist.