### PR TITLE
Update publishing workflows to use PATs with fine-grained access control

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -28,7 +28,9 @@ jobs:
         uses: "actions/checkout@v3.1.0"
 
       - name: "Clone website-sync Action"
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+        # WEBSITE_SYNC_LOKI is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_LOKI }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
       - name: "Publish to website repository (next)"
         uses: "./.github/actions/website-sync"
@@ -37,6 +39,8 @@ jobs:
           repository: "grafana/website"
           branch: "master"
           host: "github.com"
-          github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+          # PUBLISH_TO_WEBSITE_LOKI is a fine-grained GitHub Personal Access Token that expires.
+          # It must be updated in the grafanabot GitHub account.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_LOKI }}"
           source_folder: "docs/sources"
           target_folder: "content/docs/loki/next"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: "Clone website-sync Action"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+        # WEBSITE_SYNC_LOKI is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_LOKI }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
       - name: "Publish to website repository (release)"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"
@@ -68,6 +70,8 @@ jobs:
           repository: "grafana/website"
           branch: "master"
           host: "github.com"
-          github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+          # PUBLISH_TO_WEBSITE_LOKI is a fine-grained GitHub Personal Access Token that expires.
+          # It must be updated in the grafanabot GitHub account.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_LOKI }}"
           source_folder: "docs/sources"
           target_folder: "content/docs/loki/${{ steps.target.outputs.target }}.x"


### PR DESCRIPTION
The required secrets have already been created by @slim-bean.

Internal documentation is in https://github.com/grafana/technical-documentation/pull/545.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
