### PR TITLE
[helm] fix race between minio bucket job and enterprise tokengen job

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,9 @@ Entries should include a reference to the pull request that introduced the chang
 ## 3.8.2
 
 - [FEATURE] Added `extraObjects` helm values to extra manifests.
+## 3.9.0
+
+- [BUGFIX] Fix race condition between minio create bucket job and enterprise tokengen job
 
 ## 3.8.1
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 3.8.2
+version: 3.9.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 3.8.2](https://img.shields.io/badge/Version-3.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-weight": "15"
 spec:
   backoffLimit: 6
   completions: 1

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "10"
 spec:
   backoffLimit: 6
   completions: 1

--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -66,11 +66,11 @@ secrets: secrets/grafana.jwt secrets/gel.jwt
 
 secrets/grafana.jwt:
 	mkdir -p secrets/
-	op document get "loki/grafana.jwt" > $(CURDIR)/secrets/grafana.jwt
+	op document get "loki/grafana.jwt" --output=$(CURDIR)/secrets/grafana.jwt
 
 secrets/gel.jwt:
 	mkdir -p secrets/
-	op document get "loki/gel.jwt" > $(CURDIR)/secrets/gel.jwt
+	op document get "loki/gel.jwt" --output=$(CURDIR)/secrets/gel.jwt
 
 prepare: create-registry update-repos secrets
 
@@ -81,4 +81,4 @@ build-latest-image:
 
 HELM_DIR := $(shell cd $(CURDIR)/../../../production/helm/loki && pwd)
 helm-install-enterprise-logs:
-	helm install loki "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"
+	helm install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -2,6 +2,8 @@
 enterprise:
   enabled: true
   adminTokenSecret: "gel-admin-token"
+  useExternalLicense: true
+  externalLicenseName: gel-license
   provisioner:
     provisionedSecretPrefix: "provisioned-secret"
     tenants:
@@ -12,3 +14,5 @@ monitoring:
   serviceMonitor:
     labels:
       release: "prometheus"
+minio:
+  enabled: true

--- a/tools/dev/k3d/jsonnetfile.lock.json
+++ b/tools/dev/k3d/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "consul"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "enterprise-metrics"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "hi2ZpHKl7qWXmSZ46sAycjWEQK6oGsoECuDKQT1dA+k="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "etcd-operator"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "duHm6wmUju5KHQurOe6dnXoKgl5gTUsfGplgbmAOsHw="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "Y5nheroSOIwmE+djEVPq4OvvTxKenzdHhpEwaR3Ebjs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
     },
     {
@@ -78,7 +78,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {
@@ -88,7 +88,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "d68f9a6e0b1af7c4c4056dc2b43fb8f3bac01f43",
+      "version": "bb39488d030dd783ac8ceaa1ff936be14be993f0",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -118,8 +118,8 @@
           "subdir": "1.20"
         }
       },
-      "version": "21f1224e3d351cf85951221d91d015eef790ed48",
-      "sum": "Sj/Xxz4AvIDs3HI3uQ3TYOiAO2zcYs1veMBRFpPsc0Q="
+      "version": "4613c97af18622848e4ffac3c4a78a9349f1d716",
+      "sum": "KZac8iaWuW0tiN54OE9uE+Squ6SVnOHz6Wk2QgmPe3o="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces https://github.com/grafana/loki/pull/7985. It solves the same problem, which is the race condition between the minio create bucket job and the enterprise tokengen job, but without removing minio.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
