### PR TITLE
[lambda-promtail] allow generic logs to be pulled from s3, add a test for s3 log parsing

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/kinesis_test.go
+++ b/tools/lambda-promtail/lambda-promtail/kinesis_test.go
@@ -17,10 +17,17 @@ type MockBatch struct {
 }
 
 func (b *MockBatch) add(ctx context.Context, e entry) error {
-	b.streams[e.labels.String()] = &logproto.Stream{
-		Labels: e.labels.String(),
+	if b.streams[e.labels.String()] == nil {
+		b.streams[e.labels.String()] = &logproto.Stream{
+			Labels: e.labels.String(),
+		}
+		b.streams[e.labels.String()].Entries = []logproto.Entry{e.entry}
+		return nil
+
 	}
+	b.streams[e.labels.String()].Entries = append(b.streams[e.labels.String()].Entries, e.entry)
 	return nil
+
 }
 
 func (b *MockBatch) flushBatch(ctx context.Context) error {

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 const (
@@ -31,7 +30,7 @@ var (
 	username, password, extraLabelsRaw, tenantID, bearerToken string
 	keepStream                                                bool
 	batchSize                                                 int
-	s3Clients                                                 map[string]*s3.Client
+	s3Clients                                                 map[string]S3Client
 	extraLabels                                               model.LabelSet
 )
 
@@ -83,7 +82,7 @@ func setupArguments() {
 		batchSize, _ = strconv.Atoi(batch)
 	}
 
-	s3Clients = make(map[string]*s3.Client)
+	s3Clients = make(map[string]S3Client)
 }
 
 func parseExtraLabels(extraLabelsRaw string) (model.LabelSet, error) {
@@ -146,7 +145,8 @@ func handler(ctx context.Context, ev map[string]interface{}) error {
 
 	switch evt := event.(type) {
 	case *events.S3Event:
-		return processS3Event(ctx, evt)
+		_, err := processS3Event(ctx, evt)
+		return err
 	case *events.CloudwatchLogsEvent:
 		return processCWEvent(ctx, evt)
 	case *events.KinesisEvent:

--- a/tools/lambda-promtail/lambda-promtail/s3_test.go
+++ b/tools/lambda-promtail/lambda-promtail/s3_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/loki/pkg/logproto"
+)
+
+type MockS3Client struct {
+	obj s3.GetObjectOutput
+}
+
+func NewMockS3Client(s string) *MockS3Client {
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	w.Write([]byte("hello, world\n"))
+	w.Close()
+	reader := bytes.NewReader(b.Bytes())
+	return &MockS3Client{
+		obj: s3.GetObjectOutput{
+			Body: io.NopCloser(reader),
+		},
+	}
+}
+
+func (c MockS3Client) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return &c.obj, nil
+}
+
+func TestParseS3Log(t *testing.T) {
+	// if no timestamp is found we'll asign time.Now(), so later in this
+	// test we can check that the timestamp is > time.Now()
+	now := time.Now()
+	s3Clients = make(map[string]S3Client)
+	b := &MockBatch{
+		streams: map[string]*logproto.Stream{},
+	}
+	s3Clients["us-central-0"] = NewMockS3Client("this is a test")
+	a := events.S3Entity{
+		Bucket: events.S3Bucket{
+			Name:          "asdf",
+			OwnerIdentity: events.S3UserIdentity{PrincipalID: "hello"},
+			Arn:           "12345",
+		},
+		Object: events.S3Object{Key: "qwerty"},
+	}
+	parseS3Record(context.Background(),
+		events.S3EventRecord{
+			S3:        a,
+			AWSRegion: "us-central-0",
+		},
+		b)
+	for _, a := range b.streams {
+		assert.True(t, a.Entries[0].Timestamp.After(now), "")
+	}
+}


### PR DESCRIPTION
This has come up a few times; confusion around whether or not lambda-promtail can pull any generic logs from S3, or only AWS Load Balancer logs. If I understand the original implementation, it's only the parsing of the timestamp that ends up dropping logs that don't match the expected format.

I've also added a basic test of parsing an s3 log event.

Signed-off-by: Callum Styan <callumstyan@gmail.com>