### PR TITLE
operator: Use lokistack-gateway replicas from size table

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
 - [7839](https://github.com/grafana/loki/pull/7839) **aminesnow**: Configure Alertmanager per-tenant
 - [7910](https://github.com/grafana/loki/pull/7910) **periklis**: Update Loki operand to v2.7.1
 - [7815](https://github.com/grafana/loki/pull/7815) **periklis**: Apply delete client changes for compat with release-2.7.x

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -213,7 +213,7 @@ func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 			Labels: l,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: pointer.Int32Ptr(opts.Stack.Template.Gateway.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -32,6 +32,9 @@ func TestNewGatewayDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 				Distributor: &lokiv1.LokiComponentSpec{
 					Replicas: rand.Int31(),
 				},
+				Gateway: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
 				Ingester: &lokiv1.LokiComponentSpec{
 					Replicas: rand.Int31(),
 				},
@@ -65,6 +68,9 @@ func TestNewGatewayDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *tes
 				Distributor: &lokiv1.LokiComponentSpec{
 					Replicas: rand.Int31(),
 				},
+				Gateway: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
 				Ingester: &lokiv1.LokiComponentSpec{
 					Replicas: rand.Int31(),
 				},
@@ -95,6 +101,9 @@ func TestGatewayConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 					Replicas: rand.Int31(),
 				},
 				Distributor: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Gateway: &lokiv1.LokiComponentSpec{
 					Replicas: rand.Int31(),
 				},
 				Ingester: &lokiv1.LokiComponentSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix using the replica count defined in the LokiStack size table for the lokistack-gateway deployment instead of defaulting to a one replica.

**Which issue(s) this PR fixes**:
[LOG-3478](https://issues.redhat.com/browse/LOG-3478)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
