### PR TITLE
Add loki-operator multi-arch image manifest

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -618,7 +618,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   fluentd(),
   logstash(),
   querytee(),
-  manifest(['promtail', 'loki', 'loki-canary']) {
+  manifest(['promtail', 'loki', 'loki-canary', 'loki-operator']) {
     trigger+: onTagOrMain,
   },
   pipeline('deploy') {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,8 +1,6 @@
 ---
 kind: pipeline
 name: loki-build-image
-node:
-  type: no-parallel
 steps:
 - image: plugins/docker
   name: test-image
@@ -1194,6 +1192,19 @@ steps:
     target: loki-canary
     username:
       from_secret: docker_username
+- depends_on:
+  - clone
+  - manifest-loki-canary
+  image: plugins/manifest
+  name: manifest-loki-operator
+  settings:
+    ignore_missing: false
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest.tmpl
+    target: loki-operator
+    username:
+      from_secret: docker_username
 trigger:
   event:
   - push
@@ -1622,6 +1633,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: fe9a2585353898836876a160d6817e1a954d79b72953fc89f25cb16d87c50432
+hmac: b07d95d16c5f0170c2f5c16a7b73a73b5c3989b531bf4a79e8487166cc8bf77b
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix missing manifest for Loki Operator multi-arch images published on Docker Hub.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
