### PR TITLE
Use GiB and bytes for sizing tool.

### DIFF
--- a/docs/sources/installation/sizing/index.md
+++ b/docs/sources/installation/sizing/index.md
@@ -25,7 +25,7 @@ This tool helps to generate a Helm Charts `values.yaml` file based on specified
   </select>
 
   <label class="icon question" v-on:mouseover="help='ingest'" v-on:mouseleave="help=null">Ingest</label>
-  <input v-model="ingest" name="ingest" placeholder="Desired ingest in TB/day" type="number" max="1000" min="0"/>
+  <input v-model="ingest" name="ingest" placeholder="Desired ingest in GiB/day" type="number" max="1048576" min="0"/>
 
   <label class="icon question" v-on:mouseover="help='retention'" v-on:mouseleave="help=null">Log retention period</label>
   <input v-model="retention" name="retention" placeholder="Desired retention period in days" type="number" min="0"/>
@@ -102,7 +102,8 @@ createApp({
 
   computed: {
     helmURL() {
-      return `${API_URL}/helm?node-type=${encodeURIComponent(this.node)}&ingest=${encodeURIComponent(this.ingest)}&retention=${encodeURIComponent(this.retention)}&queryperf=${encodeURIComponent(this.queryperf)}`
+      const bytesDayIngest = this.ingest * 1024 * 1024 * 1024
+      return `${API_URL}/helm?node-type=${encodeURIComponent(this.node)}&ingest=${encodeURIComponent(bytesDayIngest)}&retention=${encodeURIComponent(this.retention)}&queryperf=${encodeURIComponent(this.queryperf)}`
     }
   },
 

--- a/pkg/sizing/algorithm.go
+++ b/pkg/sizing/algorithm.go
@@ -20,9 +20,10 @@ const (
 	Super QueryPerf = "super"
 )
 
-func calculateClusterSize(nt NodeType, tbDayIngest int, qperf QueryPerf) ClusterSize {
-	// 1 Petabyte per day is maximum
-	bytesDayIngest := math.Min(float64(tbDayIngest), 1000.0) * 1e12
+func calculateClusterSize(nt NodeType, bytesDayIngest float64, qperf QueryPerf) ClusterSize {
+
+	// 1 Petabyte per day is maximum. We use decimal prefix https://en.wikipedia.org/wiki/Binary_prefix
+	bytesDayIngest = math.Min(bytesDayIngest, 1e12)
 	bytesSecondIngest := bytesDayIngest / 86400
 	numWriteReplicasNeeded := math.Ceil(bytesSecondIngest / nt.writePod.rateBytesSecond)
 

--- a/pkg/sizing/algorithm_test.go
+++ b/pkg/sizing/algorithm_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_AlgorithTest_Algorith(t *testing.T) {
+func Test_AlgorithmTest_Algorithm(t *testing.T) {
 	f := func(ingest float64) bool {
 		if ingest < 0 {
 			ingest = -ingest

--- a/pkg/sizing/algorithm_test.go
+++ b/pkg/sizing/algorithm_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_AlgorithTest_Algorith(t *testing.T) {
-	f := func(ingest int) bool {
+	f := func(ingest float64) bool {
 		if ingest < 0 {
 			ingest = -ingest
 		}

--- a/pkg/sizing/http.go
+++ b/pkg/sizing/http.go
@@ -67,7 +67,7 @@ func (h *Handler) GenerateHelmValues(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 
-	cluster := calculateClusterSize(msg.NodeType, msg.Ingest, msg.QueryPerformance)
+	cluster := calculateClusterSize(msg.NodeType, float64(msg.Ingest), msg.QueryPerformance)
 	helm := constructHelmValues(cluster, msg.NodeType)
 
 	enc := yaml.NewEncoder(w)


### PR DESCRIPTION
**What this PR does / why we need it**:
The cluster sizing tool should use bytes as units internally to avoid the confusion between decimal and binary prefixes such as GiB and GB.

The frontend should use GiB since not all users will have terrabytes per day for their ingestion.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
