### PR TITLE
Helm: Fix loki helm chart podLog relabelings template nindent

### DIFF
--- a/production/helm/loki/templates/monitoring/pod-logs.yaml
+++ b/production/helm/loki/templates/monitoring/pod-logs.yaml
@@ -36,7 +36,7 @@ spec:
     - replacement: "{{ include "loki.fullname" $ }}"
       targetLabel: cluster
     {{- with .relabelings }}
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix loki helm chart to properly accept podLog relabelings by changing nindent from 8 to 4. This makes the podLog relabelings usable.

Other wise helm complains with
```
Error: UPGRADE FAILED: YAML parse error on loki/templates/monitoring/pod-logs.yaml: error converting YAML to JSON: yaml: line 32: mapping values are not allowed in this context
```

Don't think documentation is required because clearly nobody was using this.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
