### PR TITLE
Add docker-driver pipeline

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -758,6 +758,14 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
           }) { when: { event: ['tag'] } },
     ],
   },
+  pipeline('docker-driver') {
+    trigger+: onPRs,
+    steps: [
+      make('docker-driver', container=false) {
+        depends_on: ['clone'],
+      },
+    ],
+  },
 ]
 + [
   lambda_promtail(arch)

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -759,10 +759,19 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     ],
   },
   pipeline('docker-driver') {
-    trigger+: onTagOrMain,
+    trigger+: onPRs, // onTagOrMain,
     steps: [
-      make('docker-driver', container=false) {
+      {
+        name: 'build and push',
+        image: 'grafana/loki-build-image:%s' % build_image_version,
         depends_on: ['clone'],
+        environment: {
+          DOCKER_USERNAME: { from_secret: docker_username_secret.name },
+          DOCKER_PASSWORD: { from_secret: docker_password_secret.name },
+        },
+        commands: [
+          'make docker-driver-push',
+        ],
         volumes: [
           {
             name: 'docker',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -763,6 +763,21 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     steps: [
       make('docker-driver', container=false) {
         depends_on: ['clone'],
+        volumes: [
+          {
+            name: 'docker',
+            path: '/var/run/docker.sock',
+          },
+        ],
+        privileged: true,
+      },
+    ],
+    volumes: [
+      {
+        name: 'docker',
+        host: {
+          path: '/var/run/docker.sock',
+        },
       },
     ],
   },

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -759,7 +759,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     ],
   },
   pipeline('docker-driver') {
-    trigger+: onPRs, // onTagOrMain,
+    trigger+: onTagOrMain,
     steps: [
       {
         name: 'build and push',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -759,7 +759,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     ],
   },
   pipeline('docker-driver') {
-    trigger+: onPRs,
+    trigger+: onTagOrMain,
     steps: [
       make('docker-driver', container=false) {
         depends_on: ['clone'],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1432,7 +1432,8 @@ steps:
     path: /var/run/docker.sock
 trigger:
   event:
-  - pull_request
+  - push
+  - tag
   ref:
   - refs/heads/main
   - refs/heads/k???
@@ -1660,6 +1661,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 7799ee9b0080648d97b138da28648e4a2c5b4eb17346086c884f15f1cee7fe07
+hmac: c27d4a04e02cbd1a5a3cf0c55e173a2eaf627f04dd459c2c957de4f808934991
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1420,20 +1420,23 @@ kind: pipeline
 name: docker-driver
 steps:
 - commands:
-  - make BUILD_IN_CONTAINER=false docker-driver
+  - make docker-driver-push
   depends_on:
   - clone
-  environment: {}
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
   image: grafana/loki-build-image:0.26.0
-  name: docker-driver
+  name: build and push
   privileged: true
   volumes:
   - name: docker
     path: /var/run/docker.sock
 trigger:
   event:
-  - push
-  - tag
+  - pull_request
   ref:
   - refs/heads/main
   - refs/heads/k???
@@ -1661,6 +1664,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: c27d4a04e02cbd1a5a3cf0c55e173a2eaf627f04dd459c2c957de4f808934991
+hmac: 5670c2aa589c1426a5209a42f5e4085aab36d374239b9a493c238a056757f04f
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1416,6 +1416,25 @@ volumes:
     path: /var/run/docker.sock
   name: docker
 ---
+kind: pipeline
+name: docker-driver
+steps:
+- commands:
+  - make BUILD_IN_CONTAINER=false docker-driver
+  depends_on:
+  - clone
+  environment: {}
+  image: grafana/loki-build-image:0.26.0
+  name: docker-driver
+trigger:
+  event:
+  - pull_request
+  ref:
+  - refs/heads/main
+  - refs/heads/k???
+  - refs/tags/v*
+  - refs/pull/*/head
+---
 depends_on:
 - check
 kind: pipeline
@@ -1633,6 +1652,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 62f0aea10366a3c443c26cdc0b088eae7825d731a8651165148b2c102c1ffc93
+hmac: cf9befd8184779d58aafb1c27ff1a6154752298b959173ccb7051877788c1d5a
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1436,7 +1436,8 @@ steps:
     path: /var/run/docker.sock
 trigger:
   event:
-  - pull_request
+  - push
+  - tag
   ref:
   - refs/heads/main
   - refs/heads/k???
@@ -1664,6 +1665,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 5670c2aa589c1426a5209a42f5e4085aab36d374239b9a493c238a056757f04f
+hmac: 199921967d959534bbc5df76733d2175979aa04da4494dd8938aebc75a874d4e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1426,6 +1426,10 @@ steps:
   environment: {}
   image: grafana/loki-build-image:0.26.0
   name: docker-driver
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 trigger:
   event:
   - pull_request
@@ -1434,6 +1438,10 @@ trigger:
   - refs/heads/k???
   - refs/tags/v*
   - refs/pull/*/head
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 depends_on:
 - check
@@ -1652,6 +1660,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: cf9befd8184779d58aafb1c27ff1a6154752298b959173ccb7051877788c1d5a
+hmac: 7799ee9b0080648d97b138da28648e4a2c5b4eb17346086c884f15f1cee7fe07
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,13 @@ clients/cmd/docker-driver/docker-driver:
 	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
 
 docker-driver-push: docker-driver
+ifndef DOCKER_PASSWORD
+	$(error env var DOCKER_PASSWORD is undefined)
+endif
+ifndef DOCKER_USERNAME
+	$(error env var DOCKER_USERNAME is undefined)
+endif
+	echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
 	docker plugin push $(LOKI_DOCKER_DRIVER):$(PLUGIN_TAG)$(PLUGIN_ARCH)
 	docker plugin push $(LOKI_DOCKER_DRIVER):main$(PLUGIN_ARCH)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Copy the docker-driver pipeline from CirclCI to drone. This was tested by running with a trigger that creates an image on every branch: see the 'docker-driver' step in the https://drone.grafana.net/grafana/loki/18655 run.
See https://hub.docker.com/r/grafana/loki-docker-driver/tags for the built images: main and main-63360ab.

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>