### PR TITLE
operator: Fix status not updating when state of pods changes

### DIFF
--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -739,7 +739,7 @@ const (
 	// ConditionReady defines the condition that all components in the Loki deployment are ready.
 	ConditionReady LokiStackConditionType = "Ready"
 
-	// ConditionPending defines the conditioin that some or all components are in pending state.
+	// ConditionPending defines the condition that some or all components are in pending state.
 	ConditionPending LokiStackConditionType = "Pending"
 
 	// ConditionFailed defines the condition that components in the Loki deployment failed to roll out.

--- a/operator/controllers/loki/internal/lokistack/certrotation_discovery.go
+++ b/operator/controllers/loki/internal/lokistack/certrotation_discovery.go
@@ -31,13 +31,8 @@ func AnnotateForRequiredCertRotation(ctx context.Context, k k8s.Client, name, na
 	}
 
 	ss := s.DeepCopy()
-	if ss.Annotations == nil {
-		ss.Annotations = make(map[string]string)
-	}
-
-	ss.Annotations[certRotationRequiredAtKey] = time.Now().UTC().Format(time.RFC3339)
-
-	if err := k.Update(ctx, ss); err != nil {
+	timeStamp := time.Now().UTC().Format(time.RFC3339)
+	if err := updateAnnotation(ctx, k, ss, certRotationRequiredAtKey, timeStamp); err != nil {
 		return kverrors.Wrap(err, fmt.Sprintf("failed to update lokistack `%s` annotation", certRotationRequiredAtKey), "key", key)
 	}
 

--- a/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
+++ b/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
@@ -11,6 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	annotationRulerConfigDiscoveredAt = "loki.grafana.com/rulerConfigDiscoveredAt"
+)
+
 // AnnotateForRulerConfig adds/updates the `loki.grafana.com/rulerConfigDiscoveredAt` annotation
 // to the named Lokistack in the same namespace of the RulerConfig. If no LokiStack is found, then
 // skip reconciliation.
@@ -28,13 +32,8 @@ func AnnotateForRulerConfig(ctx context.Context, k k8s.Client, name, namespace s
 	}
 
 	ss := s.DeepCopy()
-	if ss.Annotations == nil {
-		ss.Annotations = make(map[string]string)
-	}
-
-	ss.Annotations["loki.grafana.com/rulerConfigDiscoveredAt"] = time.Now().UTC().Format(time.RFC3339)
-
-	if err := k.Update(ctx, ss); err != nil {
+	timeStamp := time.Now().UTC().Format(time.RFC3339)
+	if err := updateAnnotation(ctx, k, ss, annotationRulerConfigDiscoveredAt, timeStamp); err != nil {
 		return kverrors.Wrap(err, "failed to update lokistack `rulerConfigDiscoveredAt` annotation", "key", key)
 	}
 

--- a/operator/controllers/loki/internal/lokistack/update.go
+++ b/operator/controllers/loki/internal/lokistack/update.go
@@ -1,0 +1,43 @@
+package lokistack
+
+import (
+	"context"
+
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
+	"github.com/grafana/loki/operator/internal/external/k8s"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func updateAnnotation(ctx context.Context, k k8s.Client, stack *lokiv1.LokiStack, key, value string) error {
+	if stack.Annotations == nil {
+		stack.Annotations = make(map[string]string)
+	}
+	stack.Annotations[key] = value
+
+	err := k.Update(ctx, stack)
+	switch {
+	case err == nil:
+		return nil
+	case errors.IsConflict(err):
+		// break into retry logic below on conflict
+		break
+	case err != nil:
+		return err
+	}
+
+	objectKey := client.ObjectKeyFromObject(stack)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k.Get(ctx, objectKey, stack); err != nil {
+			return err
+		}
+
+		if stack.Annotations == nil {
+			stack.Annotations = make(map[string]string)
+		}
+		stack.Annotations[key] = value
+
+		return k.Update(ctx, stack)
+	})
+}

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -76,6 +76,22 @@ var (
 		},
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	})
+	updateOrDeleteWithStatusPred = builder.WithPredicates(predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || statusDifferent(e)
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// DeleteStateUnknown evaluates to false only if the object
+			// has been confirmed as deleted by the api server.
+			return !e.DeleteStateUnknown
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	})
 )
 
 // LokiStackReconciler reconciles a LokiStack object
@@ -173,8 +189,8 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		Owns(&corev1.Secret{}, updateOrDeleteOnlyPred).
 		Owns(&corev1.ServiceAccount{}, updateOrDeleteOnlyPred).
 		Owns(&corev1.Service{}, updateOrDeleteOnlyPred).
-		Owns(&appsv1.Deployment{}, updateOrDeleteOnlyPred).
-		Owns(&appsv1.StatefulSet{}, updateOrDeleteOnlyPred).
+		Owns(&appsv1.Deployment{}, updateOrDeleteWithStatusPred).
+		Owns(&appsv1.StatefulSet{}, updateOrDeleteWithStatusPred).
 		Owns(&rbacv1.ClusterRole{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.Role{}, updateOrDeleteOnlyPred).
@@ -223,4 +239,17 @@ func (r *LokiStackReconciler) enqueueAllLokiStacksHandler() handler.EventHandler
 		r.Log.Info("Enqueued requests for all LokiStacks because of global resource change", "count", len(requests), "kind", obj.GetObjectKind())
 		return requests
 	})
+}
+
+func statusDifferent(e event.UpdateEvent) bool {
+	switch old := e.ObjectOld.(type) {
+	case *appsv1.Deployment:
+		newObject := e.ObjectNew.(*appsv1.Deployment)
+		return cmp.Diff(old.Status, newObject.Status) != ""
+	case *appsv1.StatefulSet:
+		newObject := e.ObjectNew.(*appsv1.StatefulSet)
+		return cmp.Diff(old.Status, newObject.Status) != ""
+	default:
+		return false
+	}
 }

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -110,13 +110,13 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			obj:           &appsv1.Deployment{},
 			index:         4,
 			ownCallsCount: 11,
-			pred:          updateOrDeleteOnlyPred,
+			pred:          updateOrDeleteWithStatusPred,
 		},
 		{
 			obj:           &appsv1.StatefulSet{},
 			index:         5,
 			ownCallsCount: 11,
-			pred:          updateOrDeleteOnlyPred,
+			pred:          updateOrDeleteWithStatusPred,
 		},
 		{
 			obj:           &rbacv1.ClusterRole{},

--- a/operator/internal/status/lokistack.go
+++ b/operator/internal/status/lokistack.go
@@ -7,11 +7,17 @@ import (
 	"github.com/ViaQ/logerr/v2/kverrors"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/external/k8s"
+	"k8s.io/client-go/util/retry"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	messageReady   = "All components ready"
+	messageFailed  = "Some LokiStack components failed"
+	messagePending = "Some LokiStack components pending on dependencies"
 )
 
 // DegradedError contains information about why the managed LokiStack has an invalid configuration.
@@ -28,183 +34,97 @@ func (e *DegradedError) Error() string {
 // SetReadyCondition updates or appends the condition Ready to the lokistack status conditions.
 // In addition it resets all other Status conditions to false.
 func SetReadyCondition(ctx context.Context, k k8s.Client, req ctrl.Request) error {
-	var s lokiv1.LokiStack
-	if err := k.Get(ctx, req.NamespacedName, &s); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
-	}
-
-	for _, cond := range s.Status.Conditions {
-		if cond.Type == string(lokiv1.ConditionReady) && cond.Status == metav1.ConditionTrue {
-			return nil
-		}
-	}
-
 	ready := metav1.Condition{
-		Type:               string(lokiv1.ConditionReady),
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Message:            "All components ready",
-		Reason:             string(lokiv1.ReasonReadyComponents),
+		Type:    string(lokiv1.ConditionReady),
+		Message: messageReady,
+		Reason:  string(lokiv1.ReasonReadyComponents),
 	}
 
-	index := -1
-	for i := range s.Status.Conditions {
-		// Reset all other conditions first
-		s.Status.Conditions[i].Status = metav1.ConditionFalse
-		s.Status.Conditions[i].LastTransitionTime = metav1.Now()
-
-		// Locate existing ready condition if any
-		if s.Status.Conditions[i].Type == string(lokiv1.ConditionReady) {
-			index = i
-		}
-	}
-
-	if index == -1 {
-		s.Status.Conditions = append(s.Status.Conditions, ready)
-	} else {
-		s.Status.Conditions[index] = ready
-	}
-
-	return k.Status().Update(ctx, &s, &client.UpdateOptions{})
+	return updateCondition(ctx, k, req, ready)
 }
 
 // SetFailedCondition updates or appends the condition Failed to the lokistack status conditions.
 // In addition it resets all other Status conditions to false.
 func SetFailedCondition(ctx context.Context, k k8s.Client, req ctrl.Request) error {
-	var s lokiv1.LokiStack
-	if err := k.Get(ctx, req.NamespacedName, &s); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
-	}
-
-	for _, cond := range s.Status.Conditions {
-		if cond.Type == string(lokiv1.ConditionFailed) && cond.Status == metav1.ConditionTrue {
-			return nil
-		}
-	}
-
 	failed := metav1.Condition{
-		Type:               string(lokiv1.ConditionFailed),
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Message:            "Some LokiStack components failed",
-		Reason:             string(lokiv1.ReasonFailedComponents),
+		Type:    string(lokiv1.ConditionFailed),
+		Message: messageFailed,
+		Reason:  string(lokiv1.ReasonFailedComponents),
 	}
 
-	index := -1
-	for i := range s.Status.Conditions {
-		// Reset all other conditions first
-		s.Status.Conditions[i].Status = metav1.ConditionFalse
-		s.Status.Conditions[i].LastTransitionTime = metav1.Now()
-
-		// Locate existing failed condition if any
-		if s.Status.Conditions[i].Type == string(lokiv1.ConditionFailed) {
-			index = i
-		}
-	}
-
-	if index == -1 {
-		s.Status.Conditions = append(s.Status.Conditions, failed)
-	} else {
-		s.Status.Conditions[index] = failed
-	}
-
-	return k.Status().Update(ctx, &s, &client.UpdateOptions{})
+	return updateCondition(ctx, k, req, failed)
 }
 
 // SetPendingCondition updates or appends the condition Pending to the lokistack status conditions.
 // In addition it resets all other Status conditions to false.
 func SetPendingCondition(ctx context.Context, k k8s.Client, req ctrl.Request) error {
-	var s lokiv1.LokiStack
-	if err := k.Get(ctx, req.NamespacedName, &s); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
-	}
-
-	for _, cond := range s.Status.Conditions {
-		if cond.Type == string(lokiv1.ConditionPending) && cond.Status == metav1.ConditionTrue {
-			return nil
-		}
-	}
-
 	pending := metav1.Condition{
-		Type:               string(lokiv1.ConditionPending),
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Message:            "Some LokiStack components pending on dependendies",
-		Reason:             string(lokiv1.ReasonPendingComponents),
+		Type:    string(lokiv1.ConditionPending),
+		Message: messagePending,
+		Reason:  string(lokiv1.ReasonPendingComponents),
 	}
 
-	index := -1
-	for i := range s.Status.Conditions {
-		// Reset all other conditions first
-		s.Status.Conditions[i].Status = metav1.ConditionFalse
-		s.Status.Conditions[i].LastTransitionTime = metav1.Now()
-
-		// Locate existing pending condition if any
-		if s.Status.Conditions[i].Type == string(lokiv1.ConditionPending) {
-			index = i
-		}
-	}
-
-	if index == -1 {
-		s.Status.Conditions = append(s.Status.Conditions, pending)
-	} else {
-		s.Status.Conditions[index] = pending
-	}
-
-	return k.Status().Update(ctx, &s, &client.UpdateOptions{})
+	return updateCondition(ctx, k, req, pending)
 }
 
 // SetDegradedCondition appends the condition Degraded to the lokistack status conditions.
 func SetDegradedCondition(ctx context.Context, k k8s.Client, req ctrl.Request, msg string, reason lokiv1.LokiStackConditionReason) error {
-	var s lokiv1.LokiStack
-	if err := k.Get(ctx, req.NamespacedName, &s); err != nil {
+	degraded := metav1.Condition{
+		Type:    string(lokiv1.ConditionDegraded),
+		Message: msg,
+		Reason:  string(reason),
+	}
+
+	return updateCondition(ctx, k, req, degraded)
+}
+
+func updateCondition(ctx context.Context, k k8s.Client, req ctrl.Request, condition metav1.Condition) error {
+	var stack lokiv1.LokiStack
+	if err := k.Get(ctx, req.NamespacedName, &stack); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
+		return kverrors.Wrap(err, "failed to lookup LokiStack", "name", req.NamespacedName)
 	}
 
-	reasonStr := string(reason)
-	for _, cond := range s.Status.Conditions {
-		if cond.Type == string(lokiv1.ConditionDegraded) && cond.Reason == reasonStr && cond.Status == metav1.ConditionTrue {
+	for _, c := range stack.Status.Conditions {
+		if c.Type == condition.Type &&
+			c.Reason == condition.Reason &&
+			c.Message == condition.Message &&
+			c.Status == metav1.ConditionTrue {
+			// resource already has desired condition
 			return nil
 		}
 	}
 
-	degraded := metav1.Condition{
-		Type:               string(lokiv1.ConditionDegraded),
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             reasonStr,
-		Message:            msg,
-	}
+	condition.Status = metav1.ConditionTrue
 
-	index := -1
-	for i := range s.Status.Conditions {
-		// Reset all other conditions first
-		s.Status.Conditions[i].Status = metav1.ConditionFalse
-		s.Status.Conditions[i].LastTransitionTime = metav1.Now()
-
-		// Locate existing pending condition if any
-		if s.Status.Conditions[i].Type == string(lokiv1.ConditionDegraded) {
-			index = i
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k.Get(ctx, req.NamespacedName, &stack); err != nil {
+			return err
 		}
-	}
 
-	if index == -1 {
-		s.Status.Conditions = append(s.Status.Conditions, degraded)
-	} else {
-		s.Status.Conditions[index] = degraded
-	}
+		now := metav1.Now()
+		condition.LastTransitionTime = now
 
-	return k.Status().Update(ctx, &s, &client.UpdateOptions{})
+		index := -1
+		for i := range stack.Status.Conditions {
+			// Reset all other conditions first
+			stack.Status.Conditions[i].Status = metav1.ConditionFalse
+			stack.Status.Conditions[i].LastTransitionTime = now
+
+			// Locate existing pending condition if any
+			if stack.Status.Conditions[i].Type == condition.Type {
+				index = i
+			}
+		}
+
+		if index == -1 {
+			stack.Status.Conditions = append(stack.Status.Conditions, condition)
+		} else {
+			stack.Status.Conditions[index] = condition
+		}
+
+		return k.Status().Update(ctx, &stack)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The operator sometimes fails to update the `.status` field of the `LokiStack` resource to reflect the current state of the associated Pods and set conditions accordingly.

I have identified two reasons for this during testing:

- Out-of-date cached copy of the resource leading to a conflict error
- Not listening to Pod status updates and subsequently not trying to update the status at all

For me, most of the conflicts happened in the controllers for the rules, trying to update the annotations, so I have added retry logic to these controllers.

Instead of adding another watcher for the Pod resource updates, I have updated the predicate used for Deployment and StatefulSet resources to also include updates that only affect the status field. This could be slimmed down to only look at certain fields that we are interested in (the replica counts) or simplified into looking at all changes, skipping the compare operation.

**Which issue(s) this PR fixes**:
[LOG-3430](https://issues.redhat.com/browse/LOG-3430)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
