### PR TITLE
Change delimiter in  test  "sed" command to ':'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ lint:
 ########
 
 test: all
-	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s/$$/ ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}/" | tee test_results.txt
+	$(GOTEST) -covermode=atomic -coverprofile=coverage.txt -p=4 ./... | sed "s:$$: ${DRONE_STEP_NAME} ${DRONE_SOURCE_BRANCH}:" | tee test_results.txt
 
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)


### PR DESCRIPTION
The current delimiter is `/` which breaks when a branch name contains that character. `:` is disallowed in branch names so should serve as a suitable delimiter

This is the same as https://github.com/grafana/loki/pull/8107 but the branch name doesn't include a `/`. That shouldn't be an issue after this is merged