### PR TITLE
Fixed a typo and made a small edit to the Helm monolithic setup doc. 

### DIFF
--- a/docs/sources/installation/helm/install-monolithic/index.md
+++ b/docs/sources/installation/helm/install-monolithic/index.md
@@ -12,14 +12,14 @@ keywords: []
 
 This Helm Chart installation runs the Grafana Loki *single binary* within a Kubernetes cluster.
 
-If the filesystem is set to `filesystem`, this chart configures Loki to run the `all` target in a [monolithic mode](../../../../fundamentals/architecture/deployment-modes/#monolithic-mode), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
+If the storage type is set to `filesystem`, this chart configures Loki to run the `all` target in a [monolithic mode](../../../../fundamentals/architecture/deployment-modes/#monolithic-mode), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
 
 It is not possible to install the single binary with a different storage type.
 
-**Before you begin:**
+**Before you begin: Software Requirements**
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
-- A running Kubernetes cluster.
+- A running Kubernetes cluster
 
 **To deploy Loki in monolithic mode:**
 


### PR DESCRIPTION
Its storage type, not filesystem type. Also "before you begin" seemed a bit vague given the list below, so I added that the list below was software requirements. 