### PR TITLE
Helm: Add missing azure check

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -292,7 +292,7 @@ azure:
 
 {{/* Predicate function to determin if custom ruler config should be included */}}
 {{- define "loki.shouldIncludeRulerConfig" }}
-{{- or (not (empty .Values.loki.rulerConfig)) (.Values.minio.enabled) (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") }}
+{{- or (not (empty .Values.loki.rulerConfig)) (.Values.minio.enabled) (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "azure") }}
 {{- end }}
 
 {{/* Loki ruler config */}}


### PR DESCRIPTION
In Azure storage case, storage ruler config is correctly prepared, but not included.

**What this PR does / why we need it**:
The recently added support for azure blob storage is not fully functional in simple install. Code is there but not used because of a missing check update. The fix is trivial.

**Which issue(s) this PR fixes**:
Fixes #8097 

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
