### PR TITLE
operator: Fix docs minio storage uses bucketnames instead of bucketname

### DIFF
--- a/operator/docs/lokistack/object_storage.md
+++ b/operator/docs/lokistack/object_storage.md
@@ -130,7 +130,7 @@ Loki Operator supports [AWS S3](https://aws.amazon.com/), [Azure](https://azure.
 
     ```console
     kubectl create secret generic lokistack-dev-minio \
-      --from-literal=bucketname="<BUCKET_NAME>" \
+      --from-literal=bucketnames="<BUCKET_NAME>" \
       --from-literal=endpoint="<MINIO_BUCKET_ENDPOINT>" \
       --from-literal=access_key_id="<MINIO_ACCESS_KEY_ID>" \
       --from-literal=access_key_secret="<MINIO_ACCESS_KEY_SECRET>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the documentation for the operator docs. for a successful installation using bucketname will fail. Configuring the secret with the key bucketnames should work. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
