### PR TITLE
skip compacting tables that do not fit in start and end date of desired schema config

### DIFF
--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -216,7 +216,7 @@ func TestDropLabelsPipeline(t *testing.T) {
 					{Name: "ts", Value: "2020-10-18T18:04:22.147378997Z"},
 					{Name: "caller", Value: "metrics.go:81"},
 					{Name: logqlmodel.ErrorLabel, Value: errJSON},
-					{Name: logqlmodel.ErrorDetailsLabel, Value: "expecting json object(6), but it is not"},
+					{Name: logqlmodel.ErrorDetailsLabel, Value: "Value looks like object, but can't find closing '}' symbol"},
 				},
 				{
 					{Name: "namespace", Value: "prod"},

--- a/pkg/storage/stores/indexshipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor_test.go
@@ -152,6 +152,53 @@ func Test_schemaPeriodForTable(t *testing.T) {
 	indexFromTime := func(t time.Time) string {
 		return fmt.Sprintf("%d", t.Unix()/int64(24*time.Hour/time.Second))
 	}
+	tsdbIndexTablePrefix := fmt.Sprintf("%stsdb_", indexTablePrefix)
+	schemaCfg := config.SchemaConfig{Configs: []config.PeriodConfig{
+		{
+			From:       dayFromTime(start),
+			IndexType:  "boltdb",
+			ObjectType: "filesystem",
+			Schema:     "v9",
+			IndexTables: config.PeriodicTableConfig{
+				Prefix: indexTablePrefix,
+				Period: time.Hour * 24,
+			},
+			RowShards: 16,
+		},
+		{
+			From:       dayFromTime(start.Add(25 * time.Hour)),
+			IndexType:  "boltdb",
+			ObjectType: "filesystem",
+			Schema:     "v12",
+			IndexTables: config.PeriodicTableConfig{
+				Prefix: indexTablePrefix,
+				Period: time.Hour * 24,
+			},
+			RowShards: 16,
+		},
+		{
+			From:       dayFromTime(start.Add(73 * time.Hour)),
+			IndexType:  "tsdb",
+			ObjectType: "filesystem",
+			Schema:     "v12",
+			IndexTables: config.PeriodicTableConfig{
+				Prefix: tsdbIndexTablePrefix,
+				Period: time.Hour * 24,
+			},
+			RowShards: 16,
+		},
+		{
+			From:       dayFromTime(start.Add(100 * time.Hour)),
+			IndexType:  "tsdb",
+			ObjectType: "filesystem",
+			Schema:     "v12",
+			IndexTables: config.PeriodicTableConfig{
+				Prefix: indexTablePrefix,
+				Period: time.Hour * 24,
+			},
+			RowShards: 16,
+		},
+	}}
 	tests := []struct {
 		name          string
 		config        config.SchemaConfig
@@ -163,14 +210,16 @@ func Test_schemaPeriodForTable(t *testing.T) {
 		{"first table", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start).Time.Time()), schemaCfg.Configs[0], true},
 		{"4 hour after first table", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start).Time.Time().Add(4*time.Hour)), schemaCfg.Configs[0], true},
 		{"second schema", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start.Add(28*time.Hour)).Time.Time()), schemaCfg.Configs[1], true},
-		{"third schema", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), schemaCfg.Configs[2], true},
+		{"third schema", schemaCfg, tsdbIndexTablePrefix + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), schemaCfg.Configs[2], true},
+		{"unexpected table prefix", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), config.PeriodConfig{}, false},
 		{"now", schemaCfg, indexTablePrefix + indexFromTime(time.Now()), schemaCfg.Configs[3], true},
+		{"unexpected table number", schemaCfg, tsdbIndexTablePrefix + indexFromTime(time.Now()), config.PeriodConfig{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, actualFound := schemaPeriodForTable(tt.config, tt.tableName)
-			require.Equal(t, tt.expected, actual)
 			require.Equal(t, tt.expectedFound, actualFound)
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/storage/stores/indexshipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor_test.go
@@ -104,9 +104,12 @@ func setupTestCompactor(t *testing.T, tempDir string) *Compactor {
 	c, err := NewCompactor(cfg, objectClient, config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:        config.DayTime{Time: model.Time(0)},
-				IndexType:   indexType,
-				IndexTables: config.PeriodicTableConfig{Prefix: indexTablePrefix},
+				From:      config.DayTime{Time: model.Time(0)},
+				IndexType: indexType,
+				IndexTables: config.PeriodicTableConfig{
+					Prefix: indexTablePrefix,
+					Period: config.ObjectStorageIndexRequiredPeriod,
+				},
 			},
 		},
 	}, nil, nil)
@@ -212,8 +215,8 @@ func Test_schemaPeriodForTable(t *testing.T) {
 		{"second schema", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start.Add(28*time.Hour)).Time.Time()), schemaCfg.Configs[1], true},
 		{"third schema", schemaCfg, tsdbIndexTablePrefix + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), schemaCfg.Configs[2], true},
 		{"unexpected table prefix", schemaCfg, indexTablePrefix + indexFromTime(dayFromTime(start.Add(75*time.Hour)).Time.Time()), config.PeriodConfig{}, false},
-		{"now", schemaCfg, indexTablePrefix + indexFromTime(time.Now()), schemaCfg.Configs[3], true},
 		{"unexpected table number", schemaCfg, tsdbIndexTablePrefix + indexFromTime(time.Now()), config.PeriodConfig{}, false},
+		{"now", schemaCfg, indexTablePrefix + indexFromTime(time.Now()), schemaCfg.Configs[3], true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Before compacting tables, we look up the schema config for them. If we do not find a schema config for a table, we skip them. However, the schema lookup code was considering the start time of the schema and not the end time.
This can cause the compactor to try compacting tables with the same prefix as one of the previous schemas, but the table interval falls into one of the subsequent schemas with a different config.

This PR fixes the issue and simplifies the code by reusing existing schema lookup code.
I have also updated test cases to verify the fix works.

**Checklist**
- [x] Tests updated

