### PR TITLE
Correct template and LID

### DIFF
--- a/docs/sources/lids/0001-Introduction.md
+++ b/docs/sources/lids/0001-Introduction.md
@@ -1,5 +1,5 @@
 ---
-title: 0001: Introducing LIDs
+title: "0001: Introducing LIDs"
 ---
 
 # Introduction of LIDs

--- a/docs/sources/lids/template.md
+++ b/docs/sources/lids/template.md
@@ -1,5 +1,5 @@
 ---
-title: XXXX: Title
+title: "XXXX: Title"
 ---
 
 # Title


### PR DESCRIPTION
The extra colon causes a YAML parsing failure, see https://github.com/grafana/loki/actions/runs/3905966435/jobs/6678935989
