### PR TITLE
Helm: Use image tag for version labels in kubernetes resources

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -79,8 +79,8 @@ Common labels
 {{- define "loki.labels" -}}
 helm.sh/chart: {{ include "loki.chart" . }}
 {{ include "loki.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if or (.Chart.AppVersion) (.Values.loki.image.tag) }}
+app.kubernetes.io/version: {{ .Values.loki.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that the value of the `app.kubernetes.io/version` label in Kubernetes is the same as the image tag for Loki when set instead of always pinning it to the hardcoded `AppVersion` of the chart.

**Which issue(s) this PR fixes**:
Fixes #8077

**Special notes for your reviewer**:
None

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
