### PR TITLE
lambda-promtail: remove duplicate key in terraform config sample

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -116,7 +116,6 @@ resource "aws_lambda_function" "lambda_promtail" {
       TENANT_ID       = var.tenant_id
       SKIP_TLS_VERIFY = var.skip_tls_verify
       PRINT_LOG_LINE = var.print_log_line
-      SKIP_TLS_VERIFY = var.skip_tls_verify
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a duplicate key in the terraform configuration sample

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This is a trivial PR