### PR TITLE
Alerts: Exclude '/schedulerpb.SchedulerForQuerier/QuerierLoop' route in LokiRequestLatency alert

### DIFF
--- a/production/loki-mixin-compiled-ssd/alerts.yaml
+++ b/production/loki-mixin-compiled-ssd/alerts.yaml
@@ -26,7 +26,7 @@ groups:
       message: |
         {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
     expr: |
-      namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
+      namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"} > 1
     for: 15m
     labels:
       severity: critical

--- a/production/loki-mixin-compiled/alerts.yaml
+++ b/production/loki-mixin-compiled/alerts.yaml
@@ -26,7 +26,7 @@ groups:
       message: |
         {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
     expr: |
-      namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
+      namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"} > 1
     for: 15m
     labels:
       severity: critical

--- a/production/loki-mixin/alerts.libsonnet
+++ b/production/loki-mixin/alerts.libsonnet
@@ -39,7 +39,7 @@
           {
             alert: 'LokiRequestLatency',
             expr: |||
-              namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
+              namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"} > 1
             |||,
             'for': '15m',
             labels: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Excludes the route `/schedulerpb.SchedulerForQuerier/QuerierLoop` from the `LokiRequestLatency` alert query config. We have found that this route often has extremely high request latencies which will trigger the alert constantly for us. Looking through the source code it seems like it is expected to have high request latencies for this route and so in our configuration have excluded the route. We can see that this route is also being excluded in the [respective mimir config](https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/alerts.yaml#L33) so believe it might be relevant to exclude here in loki as well

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
