### PR TITLE
operator: Fix docs for OpenShift Data Foundation storage uses bucketnames instead of bucketname

### DIFF
--- a/operator/docs/lokistack/object_storage.md
+++ b/operator/docs/lokistack/object_storage.md
@@ -165,7 +165,7 @@ Loki Operator supports [AWS S3](https://aws.amazon.com/), [Azure](https://azure.
 
     ```console
     kubectl create secret generic lokistack-dev-odf \
-      --from-literal=bucketname="<BUCKET_NAME>" \
+      --from-literal=bucketnames="<BUCKET_NAME>" \
       --from-literal=endpoint="https://s3.openshift-storage.svc" \
       --from-literal=access_key_id="<ACCESS_KEY_ID>" \
       --from-literal=access_key_secret="<ACCESS_KEY_SECRET>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the documentation for the operator docs. for a successful installation using bucketname will fail. Configuring the secret with the key bucketnames should work.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
