### PR TITLE
fixes bug with queryIngesterWithin logic in asyncStore ingester stats…

### DIFF
--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -1,8 +1,10 @@
 package logproto
 
 import (
+	"strings"
 	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
 
+	"github.com/dustin/go-humanize"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -43,4 +45,18 @@ func (m *IndexStatsResponse) AddChunk(_ model.Fingerprint, chk index.ChunkMeta) 
 
 func (m *IndexStatsResponse) Stats() IndexStatsResponse {
 	return *m
+}
+
+// Helper function for returning the key value pairs
+// to be passed to a logger
+func (m *IndexStatsResponse) LoggingKeyValues() []interface{} {
+	if m == nil {
+		return nil
+	}
+	return []interface{}{
+		"bytes", strings.Replace(humanize.Bytes(m.Bytes), " ", "", 1),
+		"chunks", m.Chunks,
+		"streams", m.Streams,
+		"entries", m.Entries,
+	}
 }

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -101,17 +101,16 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 
 		results = append(results, casted.Response)
 		level.Debug(sp).Log(
-			"msg", "queried index",
-			"type", "single",
-			"matchers", matchers,
-			"bytes", strings.Replace(humanize.Bytes(casted.Response.Bytes), " ", "", 1),
-			"chunks", casted.Response.Chunks,
-			"streams", casted.Response.Streams,
-			"entries", casted.Response.Entries,
-			"duration", time.Since(start),
-			"from", adjustedFrom.Time(),
-			"through", adjustedThrough.Time(),
-			"length", adjustedThrough.Sub(adjustedFrom),
+			append(
+				casted.Response.LoggingKeyValues(),
+				"msg", "queried index",
+				"type", "single",
+				"matchers", matchers,
+				"duration", time.Since(start),
+				"from", adjustedFrom.Time(),
+				"through", adjustedThrough.Time(),
+				"length", adjustedThrough.Sub(adjustedFrom),
+			)...,
 		)
 		return nil
 	}); err != nil {
@@ -125,17 +124,16 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 		bytesPerShard = combined.Bytes / uint64(factor)
 	}
 	level.Debug(sp).Log(
-		"msg", "queried index",
-		"type", "combined",
-		"len", len(results),
-		"bytes", strings.Replace(humanize.Bytes(combined.Bytes), " ", "", 1),
-		"chunks", combined.Chunks,
-		"streams", combined.Streams,
-		"entries", combined.Entries,
-		"max_parallelism", r.maxParallelism,
-		"duration", time.Since(start),
-		"factor", factor,
-		"bytes_per_shard", strings.Replace(humanize.Bytes(bytesPerShard), " ", "", 1),
+		append(
+			combined.LoggingKeyValues(),
+			"msg", "queried index",
+			"type", "combined",
+			"len", len(results),
+			"max_parallelism", r.maxParallelism,
+			"duration", time.Since(start),
+			"factor", factor,
+			"bytes_per_shard", strings.Replace(humanize.Bytes(bytesPerShard), " ", "", 1),
+		)...,
 	)
 	return factor, nil
 }

--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
@@ -50,6 +51,12 @@ func NewAsyncStore(cfg AsyncStoreCfg, store stores.Store, scfg config.SchemaConf
 	}
 }
 
+// queryIngesters uses the queryIngestersWithin flag but will always query them when it's 0.
+func (a *AsyncStore) shouldQueryIngesters(through, now model.Time) bool {
+	// don't query ingesters if the query does not overlap with queryIngestersWithin.
+	return a.queryIngestersWithin == 0 || through.After(now.Add(-a.queryIngestersWithin))
+}
+
 func (a *AsyncStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
 	spanLogger := spanlogger.FromContext(ctx)
 
@@ -66,13 +73,10 @@ func (a *AsyncStore) GetChunkRefs(ctx context.Context, userID string, from, thro
 	var ingesterChunks []string
 
 	go func() {
-		if a.queryIngestersWithin != 0 {
-			// don't query ingesters if the query does not overlap with queryIngestersWithin.
-			if !through.After(model.Now().Add(-a.queryIngestersWithin)) {
-				level.Debug(util_log.Logger).Log("msg", "skipping querying ingesters for chunk ids", "query-from", from, "query-through", through)
-				errs <- nil
-				return
-			}
+		if !a.shouldQueryIngesters(through, model.Now()) {
+			level.Debug(util_log.Logger).Log("msg", "skipping querying ingesters for chunk ids", "query-from", from, "query-through", through)
+			errs <- nil
+			return
 		}
 
 		var err error
@@ -100,28 +104,44 @@ func (a *AsyncStore) GetChunkRefs(ctx context.Context, userID string, from, thro
 }
 
 func (a *AsyncStore) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
-	if a.queryIngestersWithin != 0 {
-		// don't query ingesters if the query does not overlap with queryIngestersWithin.
-		if !through.After(model.Now().Add(-a.queryIngestersWithin)) {
-			return a.Store.Stats(ctx, userID, from, through, matchers...)
-		}
-	}
 
+	logger := util_log.WithContext(ctx, util_log.Logger)
+	matchersStr := syntax.MatchersString(matchers)
 	type f func() (*stats.Stats, error)
-	jobs := []f{
-		f(func() (*stats.Stats, error) {
-			return a.ingesterQuerier.Stats(ctx, userID, from, through, matchers...)
-		}),
-		f(func() (*stats.Stats, error) {
-			return a.Store.Stats(ctx, userID, from, through, matchers...)
-		}),
-	}
-	resps := make([]*stats.Stats, len(jobs))
+	var jobs []f
 
+	if a.shouldQueryIngesters(through, model.Now()) {
+		jobs = append(jobs, f(func() (*stats.Stats, error) {
+			stats, err := a.ingesterQuerier.Stats(ctx, userID, from, through, matchers...)
+			level.Debug(logger).Log(
+				append(
+					stats.LoggingKeyValues(),
+					"msg", "queried statistics",
+					"matchers", matchersStr,
+					"source", "ingesters",
+				)...,
+			)
+			return stats, err
+		}))
+	}
+	jobs = append(jobs, f(func() (*stats.Stats, error) {
+		stats, err := a.Store.Stats(ctx, userID, from, through, matchers...)
+		level.Debug(logger).Log(
+			append(
+				stats.LoggingKeyValues(),
+				"msg", "queried statistics",
+				"matchers", matchersStr,
+				"source", "store",
+			)...,
+		)
+		return stats, err
+	}))
+
+	resps := make([]*stats.Stats, len(jobs))
 	if err := concurrency.ForEachJob(
 		ctx,
 		len(jobs),
-		2,
+		len(jobs),
 		func(ctx context.Context, i int) error {
 			resp, err := jobs[i]()
 			resps[i] = resp

--- a/pkg/storage/async_store_test.go
+++ b/pkg/storage/async_store_test.go
@@ -263,6 +263,7 @@ func TestAsyncStore_QueryIngestersWithin(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+
 			store := newStoreMock()
 			store.On("GetChunkRefs", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([][]chunk.Chunk{}, []*fetcher.Fetcher{}, nil)
 


### PR DESCRIPTION
Fixes a previous mistake in the logic calculating when to skip querying ingesters in the async store Statistics method. Notably `through.After` should be `through.Before` when skipping querying ingesters as that's when there's no overlap with the `query-ingesters-within` period:

```go
	// OLD CODE BELOW
	if a.queryIngestersWithin != 0 {
		// don't query ingesters if the query does not overlap with queryIngestersWithin.
		if !through.After(model.Now().Add(-a.queryIngestersWithin)) { // <----- should be through.Before
			return a.Store.Stats(ctx, userID, from, through, matchers...)
		}
	}
```

 I discovered the problem while debugging querier OOMs during a boltdb-shipper -> tsdb migration and ultimately found this happened under the following circumstances:

* Queries over high volumes of _recent_ data wouldn't query ingesters for index metadata
* Without index metadata, we only checked storage metadata
* There is a delay before we ship the index to storage, meaning we don't see it if ingesters are skipped
* Calculating ideal shard factors without recent data for queries that only touch recent data _dramatically_ underestimates the desired shard factor
* Queries aren't split enough and get scheduled onto too few querier replicas
* They oom. We had some fun examples like a single replica trying to download 419,000 chunks/query

To be clear, this is still a hypothesis, but a plausible one, especially after finding the boolean logic error this PR fixes.

Instead of changing this one line, I took the opportunity to refactor this into a shared utility used by our other `GetChunkRefs` method which is already tested, ensuring the logic works as expected. I also added some more logging visibility into this code so we can understand what the difference is when querying statistics from storage vs ingesters. Finally, I added a helper to prepare our `Stats` objects to be logged which is now used in a few places.