### PR TITLE
Helm: Expose single binary service configuration in values

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3136,6 +3136,87 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>singleBinary.service.annotations</td>
+			<td>object</td>
+			<td>Annotations for the single binary service</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.clusterIP</td>
+			<td>string</td>
+			<td>ClusterIP of the single binary service</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.grpcNodePort</td>
+			<td>int</td>
+			<td>GRPC node port if service type is NodePort</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.grpcPort</td>
+			<td>int</td>
+			<td>GRPC port of the single binary service</td>
+			<td><pre lang="json">
+9095
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.labels</td>
+			<td>object</td>
+			<td>Labels for single binary service</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.loadBalancerIP</td>
+			<td>string</td>
+			<td>Load balancer IPO address if service type is LoadBalancer</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.nodePort</td>
+			<td>int</td>
+			<td>Node port if service type is NodePort</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.port</td>
+			<td>int</td>
+			<td>Port of the single binary service</td>
+			<td><pre lang="json">
+3100
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>singleBinary.service.type</td>
+			<td>string</td>
+			<td>Type of the single binary service</td>
+			<td><pre lang="json">
+"ClusterIP"
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>singleBinary.targetModule</td>
 			<td>string</td>
 			<td>Comma-separated list of Loki modules to load for the single binary</td>

--- a/production/helm/loki/templates/single-binary/service.yaml
+++ b/production/helm/loki/templates/single-binary/service.yaml
@@ -7,16 +7,35 @@ metadata:
   name: {{ include "loki.name" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
+    {{- with .Values.singleBinary.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.singleBinary.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.singleBinary.service.type }}
+  {{- with .Values.singleBinary.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.singleBinary.service.type) .Values.singleBinary.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.singleBinary.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: http-metrics
-      port: 3100
+      port: {{ .Values.singleBinary.service.port }}
       targetPort: http-metrics
+      {{- if and (eq "NodePort" .Values.singleBinary.service.type) .Values.singleBinary.service.nodePort }}
+      nodePort: {{ .Values.singleBinary.service.nodePort }}
+      {{- end }}
       protocol: TCP
     - name: grpc
-      port: 9095
+      port: {{ .Values.singleBinary.service.grpcPort }}
       targetPort: grpc
+      {{- if and (eq "NodePort" .Values.singleBinary.service.type) .Values.singleBinary.service.grpcNodePort }}
+      nodePort: {{ .Values.singleBinary.service.grpcNodePort }}
+      {{- end }}
       protocol: TCP
   selector:
     {{- include "loki.singleBinarySelectorLabels" . | nindent 4 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -902,6 +902,25 @@ singleBinary:
     storageClass: null
     # -- Selector for persistent disk
     selector: null
+  service:
+    # -- Port of the single binary service
+    port: 3100
+    # -- GRPC port of the single binary service
+    grpcPort: 9095
+    # -- Type of the single binary service
+    type: ClusterIP
+    # -- ClusterIP of the single binary service
+    clusterIP: null
+    # -- (int) Node port if service type is NodePort
+    nodePort: null
+    # -- (int) GRPC node port if service type is NodePort
+    grpcNodePort: null
+    # -- Load balancer IPO address if service type is LoadBalancer
+    loadBalancerIP: null
+    # -- Annotations for the single binary service
+    annotations: {}
+    # -- Labels for single binary service
+    labels: {}
 
 # Use either this ingress or the gateway, but not both at once.
 # If you enable this, make sure to disable the gateway.


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes service configuration used in single-binary mode via `values.yaml`. This way it is just as configurable as the gateway Service in simple-scalable mode.

**Which issue(s) this PR fixes**:
Fixes #8146

**Special notes for your reviewer**:
Like I mentioned in #8146, this service has an extra port for gRPC that the gateway Service does not have. The solution I came up with is just to add `grpcPort` and `grpcNodePort` but I didn't know if this was desirable or not. Otherwise this this should behave exactly the same as before with the current defaults (I confirmed this via `helm diff`).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
