### PR TITLE
promtail: Add `max-line-size` limit to drop on client side 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [8047](https://github.com/grafana/loki/pull/8047) **bboreham**: Dashboards: add k8s resource requests to CPU and memory panels.
 * [8061](https://github.com/grafana/loki/pull/8061) **kavirajk**: Remove circle from Loki OSS
 * [8131](https://github.com/grafana/loki/pull/8131) **jeschkies**: Compile Promtail ARM and ARM64 with journald support.
-* [8153](https://github.com/grafana/loki/pull/8061) **kavirajk**: promtail: Add `max-line-size` limit to drop on client side
+
 ##### Fixes
 
 * [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and regexp parsers.
@@ -47,6 +47,7 @@
 
 * [7619](https://github.com/grafana/loki/pull/7619) **cadrake**: Add ability to pass query params to heroku drain targets for relabelling.
 * [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client and new metric label for drop reason.
+* [8153](https://github.com/grafana/loki/pull/8061) **kavirajk**: promtail: Add `max-line-size` limit to drop on client side
 
 ##### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [8047](https://github.com/grafana/loki/pull/8047) **bboreham**: Dashboards: add k8s resource requests to CPU and memory panels.
 * [8061](https://github.com/grafana/loki/pull/8061) **kavirajk**: Remove circle from Loki OSS
 * [8131](https://github.com/grafana/loki/pull/8131) **jeschkies**: Compile Promtail ARM and ARM64 with journald support.
-
+* [8153](https://github.com/grafana/loki/pull/8061) **kavirajk**: promtail: Add `max-line-size` limit to drop on client side
 ##### Fixes
 
 * [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and regexp parsers.

--- a/clients/cmd/docker-driver/loki.go
+++ b/clients/cmd/docker-driver/loki.go
@@ -39,7 +39,7 @@ func New(logCtx logger.Info, logger log.Logger) (logger.Logger, error) {
 		return nil, err
 	}
 	m := client.NewMetrics(prometheus.DefaultRegisterer, nil)
-	c, err := client.New(m, cfg.clientConfig, nil, 0, logger)
+	c, err := client.New(m, cfg.clientConfig, nil, 0, 0, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/cmd/fluent-bit/client.go
+++ b/clients/cmd/fluent-bit/client.go
@@ -11,5 +11,5 @@ func NewClient(cfg *config, logger log.Logger, metrics *client.Metrics, streamLa
 	if cfg.bufferConfig.buffer {
 		return NewBuffer(cfg, logger, metrics, streamLagLabels)
 	}
-	return client.New(metrics, cfg.clientConfig, streamLagLabels, 0, logger)
+	return client.New(metrics, cfg.clientConfig, streamLagLabels, 0, 0, logger)
 }

--- a/clients/cmd/fluent-bit/dque.go
+++ b/clients/cmd/fluent-bit/dque.go
@@ -72,7 +72,7 @@ func newDque(cfg *config, logger log.Logger, metrics *client.Metrics, streamLagL
 		_ = q.queue.TurboOn()
 	}
 
-	q.loki, err = client.New(metrics, cfg.clientConfig, streamLagLabels, 0, logger)
+	q.loki, err = client.New(metrics, cfg.clientConfig, streamLagLabels, 0, 0, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/pkg/promtail/client/client.go
+++ b/clients/pkg/promtail/client/client.go
@@ -41,9 +41,10 @@ const (
 	TenantLabel     = "tenant"
 	DropReasonLabel = "reason"
 
-	DropReasonGeneric       = "ingester_error"
-	DropReasonRateLimited   = "rate_limited"
-	DropReasonStreamLimited = "stream_limited"
+	DropReasonGeneric             = "ingester_error"
+	DropReasonRateLimited         = "rate_limited"
+	DropReasonStreamLimited       = "stream_limited"
+	DropReasongMaxLineSizeLimited = "max_line_size_limited"
 )
 
 var DropReasons = []string{DropReasonGeneric, DropReasonRateLimited, DropReasonStreamLimited}
@@ -171,23 +172,24 @@ type client struct {
 	externalLabels model.LabelSet
 
 	// ctx is used in any upstream calls from the `client`.
-	ctx        context.Context
-	cancel     context.CancelFunc
-	maxStreams int
+	ctx         context.Context
+	cancel      context.CancelFunc
+	maxStreams  int
+	maxLineSize int
 }
 
 // Tripperware can wrap a roundtripper.
 type Tripperware func(http.RoundTripper) http.RoundTripper
 
 // New makes a new Client.
-func New(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams int, logger log.Logger) (Client, error) {
+func New(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams, maxLineSize int, logger log.Logger) (Client, error) {
 	if cfg.StreamLagLabels.String() != "" {
 		return nil, fmt.Errorf("client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored: %+v", cfg.StreamLagLabels.String())
 	}
-	return newClient(metrics, cfg, streamLagLabels, maxStreams, logger)
+	return newClient(metrics, cfg, streamLagLabels, maxStreams, maxLineSize, logger)
 }
 
-func newClient(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams int, logger log.Logger) (*client, error) {
+func newClient(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams, maxLineSize int, logger log.Logger) (*client, error) {
 
 	if cfg.URL.URL == nil {
 		return nil, errors.New("client needs target URL")
@@ -207,6 +209,7 @@ func newClient(metrics *Metrics, cfg Config, streamLagLabels []string, maxStream
 		ctx:            ctx,
 		cancel:         cancel,
 		maxStreams:     maxStreams,
+		maxLineSize:    maxLineSize,
 	}
 	if cfg.Name != "" {
 		c.name = cfg.Name
@@ -236,8 +239,8 @@ func newClient(metrics *Metrics, cfg Config, streamLagLabels []string, maxStream
 }
 
 // NewWithTripperware creates a new Loki client with a custom tripperware.
-func NewWithTripperware(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams int, logger log.Logger, tp Tripperware) (Client, error) {
-	c, err := newClient(metrics, cfg, streamLagLabels, maxStreams, logger)
+func NewWithTripperware(metrics *Metrics, cfg Config, streamLagLabels []string, maxStreams, maxLineSize int, logger log.Logger, tp Tripperware) (Client, error) {
+	c, err := newClient(metrics, cfg, streamLagLabels, maxStreams, maxLineSize, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +299,15 @@ func (c *client) run() {
 			if !ok {
 				return
 			}
+
 			e, tenantID := c.processEntry(e)
+
+			// drop the entry it's length is greater than maxLineSize. maxLineSize == 0 means disabled.
+			if c.maxLineSize != 0 && len(e.Line) > c.maxLineSize {
+				c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host, tenantID, DropReasongMaxLineSizeLimited).Inc()
+				break
+			}
+
 			batch, ok := batches[tenantID]
 
 			// If the batch doesn't exist yet, we create a new one with the entry

--- a/clients/pkg/promtail/client/client_test.go
+++ b/clients/pkg/promtail/client/client_test.go
@@ -313,7 +313,7 @@ func TestClient_Handle(t *testing.T) {
 			}
 
 			m := NewMetrics(reg, nil)
-			c, err := New(m, cfg, nil, 0, log.NewNopLogger())
+			c, err := New(m, cfg, nil, 0, 0, log.NewNopLogger())
 			require.NoError(t, err)
 
 			// Send all the input log entries
@@ -449,7 +449,7 @@ func TestClient_StopNow(t *testing.T) {
 				TenantID:       c.clientTenantID,
 			}
 			m := NewMetrics(reg, nil)
-			cl, err := New(m, cfg, nil, 0, log.NewNopLogger())
+			cl, err := New(m, cfg, nil, 0, 0, log.NewNopLogger())
 			require.NoError(t, err)
 
 			// Send all the input log entries
@@ -525,7 +525,7 @@ func Test_Tripperware(t *testing.T) {
 	var called bool
 	c, err := NewWithTripperware(metrics, Config{
 		URL: flagext.URLValue{URL: url},
-	}, nil, 0, log.NewNopLogger(), func(rt http.RoundTripper) http.RoundTripper {
+	}, nil, 0, 0, log.NewNopLogger(), func(rt http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			require.Equal(t, r.URL.String(), "http://foo.com")
 			called = true

--- a/clients/pkg/promtail/client/logger.go
+++ b/clients/pkg/promtail/client/logger.go
@@ -37,7 +37,7 @@ type logger struct {
 // NewLogger creates a new client logger that logs entries instead of sending them.
 func NewLogger(metrics *Metrics, streamLogLabels []string, log log.Logger, cfgs ...Config) (Client, error) {
 	// make sure the clients config is valid
-	c, err := NewMulti(metrics, streamLogLabels, log, 0, cfgs...)
+	c, err := NewMulti(metrics, streamLogLabels, log, 0, 0, cfgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/pkg/promtail/client/multi.go
+++ b/clients/pkg/promtail/client/multi.go
@@ -21,7 +21,7 @@ type MultiClient struct {
 }
 
 // NewMulti creates a new client
-func NewMulti(metrics *Metrics, streamLagLabels []string, logger log.Logger, maxStreams int, cfgs ...Config) (Client, error) {
+func NewMulti(metrics *Metrics, streamLagLabels []string, logger log.Logger, maxStreams, maxLineSize int, cfgs ...Config) (Client, error) {
 	var fake struct{}
 
 	if len(cfgs) == 0 {
@@ -30,7 +30,7 @@ func NewMulti(metrics *Metrics, streamLagLabels []string, logger log.Logger, max
 	clientsCheck := make(map[string]struct{})
 	clients := make([]Client, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		client, err := New(metrics, cfg, streamLagLabels, maxStreams, logger)
+		client, err := New(metrics, cfg, streamLagLabels, maxStreams, maxLineSize, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/clients/pkg/promtail/client/multi_test.go
+++ b/clients/pkg/promtail/client/multi_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestNewMulti(t *testing.T) {
-	_, err := NewMulti(nilMetrics, nil, util_log.Logger, 0, []Config{}...)
+	_, err := NewMulti(nilMetrics, nil, util_log.Logger, 0, 0, []Config{}...)
 	if err == nil {
 		t.Fatal("expected err but got nil")
 	}
@@ -46,7 +46,7 @@ func TestNewMulti(t *testing.T) {
 		ExternalLabels: lokiflag.LabelSet{LabelSet: model.LabelSet{"hi": "there"}},
 	}
 
-	clients, err := NewMulti(metrics, nil, util_log.Logger, 0, cc1, cc2)
+	clients, err := NewMulti(metrics, nil, util_log.Logger, 0, 0, cc1, cc2)
 	if err != nil {
 		t.Fatalf("expected err: nil got:%v", err)
 	}
@@ -69,7 +69,7 @@ func TestNewMulti(t *testing.T) {
 }
 
 func TestNewMulti_BlockDuplicates(t *testing.T) {
-	_, err := NewMulti(nilMetrics, nil, util_log.Logger, 0, []Config{}...)
+	_, err := NewMulti(nilMetrics, nil, util_log.Logger, 0, 0, []Config{}...)
 	if err == nil {
 		t.Fatal("expected err but got nil")
 	}
@@ -82,11 +82,11 @@ func TestNewMulti_BlockDuplicates(t *testing.T) {
 	}
 	cc1Copy := cc1
 
-	_, err = NewMulti(metrics, nil, util_log.Logger, 0, cc1, cc1Copy)
+	_, err = NewMulti(metrics, nil, util_log.Logger, 0, 0, cc1, cc1Copy)
 	require.Error(t, err, "expected NewMulti to reject duplicate client configs")
 
 	cc1Copy.Name = "copy"
-	clients, err := NewMulti(metrics, nil, util_log.Logger, 0, cc1, cc1Copy)
+	clients, err := NewMulti(metrics, nil, util_log.Logger, 0, 0, cc1, cc1Copy)
 	require.NoError(t, err, "expected NewMulti to reject duplicate client configs")
 
 	multi := clients.(*MultiClient)
@@ -148,9 +148,9 @@ func TestMultiClient_Handle(t *testing.T) {
 func TestMultiClient_Handle_Race(t *testing.T) {
 	u := flagext.URLValue{}
 	require.NoError(t, u.Set("http://localhost"))
-	c1, err := New(nilMetrics, Config{URL: u, BackoffConfig: backoff.Config{MaxRetries: 1}, Timeout: time.Microsecond}, nil, 0, log.NewNopLogger())
+	c1, err := New(nilMetrics, Config{URL: u, BackoffConfig: backoff.Config{MaxRetries: 1}, Timeout: time.Microsecond}, nil, 0, 0, log.NewNopLogger())
 	require.NoError(t, err)
-	c2, err := New(nilMetrics, Config{URL: u, BackoffConfig: backoff.Config{MaxRetries: 1}, Timeout: time.Microsecond}, nil, 0, log.NewNopLogger())
+	c2, err := New(nilMetrics, Config{URL: u, BackoffConfig: backoff.Config{MaxRetries: 1}, Timeout: time.Microsecond}, nil, 0, 0, log.NewNopLogger())
 	require.NoError(t, err)
 	clients := []Client{c1, c2}
 	m := &MultiClient{

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	ReadlineRateEnabled bool    `mapstructure:"readline_rate_enabled,omitempty" yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
 	ReadlineRateDrop    bool    `mapstructure:"readline_rate_drop,omitempty" yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
 	MaxStreams          int     `mapstructure:"max_streams" yaml:"max_streams" json:"max_streams"`
+	MaxLineSize         int     `mapstructure:"max_line_size" yaml:"max_line_size" json:"max_line_size"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -18,4 +19,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", false, "When true, enforces rate limiting on this instance of Promtail.")
 	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", true, "When true, exceeding the rate limit causes this instance of Promtail to discard log lines, rather than sending them to Loki.")
 	f.IntVar(&cfg.MaxStreams, prefix+"max-streams", 0, "Maximum number of active streams. 0 to disable.")
+	f.IntVar(&cfg.MaxLineSize, prefix+"max-line-size", 0, "Maximum log line length allowed without dropping. 0 to disable.")
 }

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -19,5 +19,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", false, "When true, enforces rate limiting on this instance of Promtail.")
 	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", true, "When true, exceeding the rate limit causes this instance of Promtail to discard log lines, rather than sending them to Loki.")
 	f.IntVar(&cfg.MaxStreams, prefix+"max-streams", 0, "Maximum number of active streams. 0 to disable.")
-	f.IntVar(&cfg.MaxLineSize, prefix+"max-line-size", 0, "Maximum log line length allowed without dropping. 0 to disable.")
+	f.IntVar(&cfg.MaxLineSize, prefix+"max-line-size", 0, "Maximum log line byte size allowed without dropping. 0 to disable.")
 }

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -140,7 +140,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 		}
 		cfg.PositionsConfig.ReadOnly = true
 	} else {
-		p.client, err = client.NewMulti(p.metrics, cfg.Options.StreamLagLabels, p.logger, cfg.LimitsConfig.MaxStreams, cfg.ClientConfigs...)
+		p.client, err = client.NewMulti(p.metrics, cfg.Options.StreamLagLabels, p.logger, cfg.LimitsConfig.MaxStreams, cfg.LimitsConfig.MaxLineSize, cfg.ClientConfigs...)
 		if err != nil {
 			return err
 		}

--- a/clients/pkg/promtail/targets/lokipush/pushtarget_test.go
+++ b/clients/pkg/promtail/targets/lokipush/pushtarget_test.go
@@ -85,7 +85,7 @@ func TestLokiPushTarget(t *testing.T) {
 		BatchSize: 100 * 1024,
 	}
 	m := client.NewMetrics(prometheus.DefaultRegisterer, nil)
-	pc, err := client.New(m, ccfg, nil, 0, logger)
+	pc, err := client.New(m, ccfg, nil, 0, 0, logger)
 	require.NoError(t, err)
 	defer pc.Stop()
 

--- a/docs/sources/installation/helm/install-scalable/index.md
+++ b/docs/sources/installation/helm/install-scalable/index.md
@@ -14,7 +14,7 @@ keywords: []
 
 This Helm Chart installation runs the Grafana Loki cluster within a Kubernetes cluster.
 
-If object storage is configured, this chart configures Loki to run `read` and `write` targets in a [scalable]({{< relref "../../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode" >}}), highly available architecture (3 replicas of each) designed to work with AWS S3 object storage. It will also configure meta-monitoring of metrics and logs.
+If object storge is configured, this chart configures Loki to run `read` and `write` targets in a [scalable mode](../../../../fundamentals/architecture/deployment-modes/#simple-scalable-deployment-mode), highly available architecture (3 replicas of each) designed to work with AWS S3 object storage. It will also configure meta-monitoring of metrics and logs.
 
 It is not possible to run the scalable mode with the `filesystem` storage.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
promtail: Add max-line-size limit to drop on client side 

Currently the workaround is to depend only on the loki server side limits.

This PR adds support in promtail to drop "too big" log lines. It also keep track of dropped lines in `promtail_dropped_entries` metric with reason `max_line_size_limited`.

**Which issue(s) this PR fixes**:
Fixes #8143 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated

