### PR TITLE
Emit help message when check-mod fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,7 +661,8 @@ else
 	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod tidy
 	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod vendor
 endif
-	@git diff --exit-code -- go.sum go.mod vendor/
+	@git diff --exit-code -- go.sum go.mod vendor/ || \
+	    (echo "Run 'go mod download && go mod verify && go mod tidy && go mod vendor' and check in changes to vendor/ to fix failed check-mod."; exit 1)
 
 
 lint-jsonnet:


### PR DESCRIPTION
**What this PR does / why we need it**:
The check-mod stage failed on me but I wasn't sure how to fix it. Emitting a message should yield faster iterations.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
