### PR TITLE
[docs] Clarify for what version the Helm chart docs are applicable

### DIFF
--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -14,7 +14,7 @@ keywords:
 
 The [Helm](https://helm.sh/) chart allows you to configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 
-This guide contains the following sections:
+This guide references the Loki Helm chart version 3.x and contains the following sections:
 
 {{< section menuTitle="true" >}}
 

--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -12,6 +12,8 @@ keywords:
   - installation
 ---
 
+# Install Loki using Helm
+
 The [Helm](https://helm.sh/) chart allows you to configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 
 This guide references the Loki Helm chart version 3.x and contains the following sections:

--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -16,7 +16,7 @@ keywords:
 
 The [Helm](https://helm.sh/) chart allows you to configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 
-This guide references the Loki Helm chart version 3.x and contains the following sections:
+This guide references the Loki Helm chart version 3.0 or greater and contains the following sections:
 
 {{< section menuTitle="true" >}}
 

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -17,6 +17,11 @@ keywords: []
 
 This is the generated reference for the Loki Helm Chart values.
 
+> **Note:** This reference is for the Loki Helm chart version 3.x.
+> If you are using the `grafana/loki-stack` Helm chart from the community repo,
+> please refer to the `values.yaml` of the respective Github repository
+> [grafana/helm-charts](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack).
+
 <!-- Override default values table from helm-docs. See https://github.com/norwoodj/helm-docs/tree/master#advanced-table-rendering -->
 
 <table>

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -17,7 +17,7 @@ keywords: []
 
 This is the generated reference for the Loki Helm Chart values.
 
-> **Note:** This reference is for the Loki Helm chart version 3.x.
+> **Note:** This reference is for the Loki Helm chart version 3.0 or greater.
 > If you are using the `grafana/loki-stack` Helm chart from the community repo,
 > please refer to the `values.yaml` of the respective Github repository
 > [grafana/helm-charts](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack).

--- a/production/helm/loki/reference.md.gotmpl
+++ b/production/helm/loki/reference.md.gotmpl
@@ -17,6 +17,11 @@ keywords: []
 
 This is the generated reference for the Loki Helm Chart values.
 
+> **Note:** This reference is for the Loki Helm chart version 3.x.
+> If you are using the `grafana/loki-stack` Helm chart from the community repo,
+> please refer to the `values.yaml` of the respective Github repository
+> [grafana/helm-charts](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack).
+
 <!-- Override default values table from helm-docs. See https://github.com/norwoodj/helm-docs/tree/master#advanced-table-rendering -->
 {{ define "chart.valuesTableHtml" }}
 <table>

--- a/production/helm/loki/reference.md.gotmpl
+++ b/production/helm/loki/reference.md.gotmpl
@@ -17,7 +17,7 @@ keywords: []
 
 This is the generated reference for the Loki Helm Chart values.
 
-> **Note:** This reference is for the Loki Helm chart version 3.x.
+> **Note:** This reference is for the Loki Helm chart version 3.0 or greater.
 > If you are using the `grafana/loki-stack` Helm chart from the community repo,
 > please refer to the `values.yaml` of the respective Github repository
 > [grafana/helm-charts](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack).


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs and reference of the Helm chart in the documentation is only applicable for the Loki Helm chart `>= 3.0` and therefore does not apply to the `grafana/loki-stack` chart, which depends on the Loki Helm chart `^2.15.2` ([requirements.yaml](https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/requirements.yaml#L5)).

Also added a headline to the "Install Loki using Helm" index page, because it looks awkward without, see screenshot.

![2023-01-17_20-28-52](https://user-images.githubusercontent.com/281260/212994261-f817f556-4cbf-454f-920f-875c5c085689.png)


**Which issue(s) this PR fixes**:

Fixes: #8152

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>



**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
