### PR TITLE
operator: Remove custom webhook cert mounts for OLM-based deployment

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8173](https://github.com/grafana/loki/pull/8173) **periklis**: Remove custom webhook cert mounts for OLM-based deployment (OpenShift)
 - [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config
 - [8087](https://github.com/grafana/loki/pull/8087) **xperimental**: Fix status not updating when state of pods changes
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table

--- a/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: loki-operator-webhook-service
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1491,9 +1491,6 @@ spec:
                     drop:
                     - ALL
                 volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
-                  name: webhook-cert
-                  readOnly: true
                 - mountPath: /controller_manager_config.yaml
                   name: manager-config
                   subPath: controller_manager_config.yaml
@@ -1526,10 +1523,6 @@ spec:
                 runAsNonRoot: true
               terminationGracePeriodSeconds: 10
               volumes:
-              - name: webhook-cert
-                secret:
-                  defaultMode: 420
-                  secretName: loki-operator-webhook-service
               - configMap:
                   name: loki-operator-manager-config
                 name: manager-config

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -40,7 +40,6 @@ patchesStrategicMerge:
 - manager_run_flags_patch.yaml
 - manager_webhook_patch.yaml
 - prometheus_service_monitor_patch.yaml
-- webhook_service_annotations_patch.yaml
 
 images:
 - name: controller

--- a/operator/config/overlays/openshift/manager_webhook_patch.yaml
+++ b/operator/config/overlays/openshift/manager_webhook_patch.yaml
@@ -11,12 +11,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-cert
-          readOnly: true
-      volumes:
-      - name: webhook-cert
-        secret:
-          defaultMode: 420
-          secretName: loki-operator-webhook-service

--- a/operator/config/overlays/openshift/webhook_service_annotations_patch.yaml
+++ b/operator/config/overlays/openshift/webhook_service_annotations_patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: loki-operator-webhook-service
-  name: webhook-service
-  namespace: system


### PR DESCRIPTION
**What this PR does / why we need it**:
When installing the Loki Operator via OLM latter is reconciling the webhook creation dynamically by creating/owning/rotating the mandatory Server Certificate for accessing validating/mutating webhooks by the Kubernetes APIServer. In contrary our present approach/believe was that we need to instruct the Service and Certificate creation for the `loki-operator-webhook-service` generated by the operator-sdk. Although this service is part of the bundle it will remain obsolete on OpenShift clusters because OLM will generate its own `loki-operator-controller-manager-service` and Secret `loki-operator-controller-manager-cert`.

**Which issue(s) this PR fixes**:
[LOG-3431](https://issues.redhat.com/browse/LOG-3431)

**Special notes for your reviewer**:
FYI, we keep the generation of the `loki-operator-webhook-service` in the kustomize config to be able to generate the Service and Certificate using cert-manager when using the Community Loki Operator.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
