### PR TITLE
Do not run release stage when check stage fails

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -665,21 +665,11 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   },
   promtail_win(),
   logql_analyzer(),
-  pipeline('release-test') {
-    trigger+: {
-      event: ['pull_request', 'tag'],
-    },
-    depends_on : ['check'],
-    steps: [
-      run('test-command',
-          commands=['printf "Should not show when check fails"'],
-         ),
-    ],
-  },
   pipeline('release') {
     trigger+: {
       event: ['pull_request', 'tag'],
     },
+    depends_on+: ['check'],
     image_pull_secrets: [pull_secret.name],
     volumes+: [
       {

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -665,6 +665,17 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   },
   promtail_win(),
   logql_analyzer(),
+  pipeline('release-test') {
+    trigger+: {
+      event: ['pull_request', 'tag'],
+    },
+    depends_on : ['check'],
+    steps: [
+      run('test-command',
+          commands=['printf "Should not show when check fails"'],
+         ),
+    ],
+  },
   pipeline('release') {
     trigger+: {
       event: ['pull_request', 'tag'],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1336,6 +1336,26 @@ trigger:
   - refs/tags/v*
   - refs/pull/*/head
 ---
+depends_on:
+- check
+kind: pipeline
+name: release-test
+steps:
+- commands:
+  - printf "Should not show when check fails"
+  environment: {}
+  image: grafana/loki-build-image:0.27.0
+  name: test-command
+trigger:
+  event:
+  - pull_request
+  - tag
+  ref:
+  - refs/heads/main
+  - refs/heads/k???
+  - refs/tags/v*
+  - refs/pull/*/head
+---
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -1665,6 +1685,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 768eb915af5b1cf14a24de3d4a2bbf9ed583404d7a391468d4d8e26b2b65b06c
+hmac: cfd5cde6082c3710aa55d4d40dc234c0a881e320898d7fa9ef0787ce264c8eef
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1338,24 +1338,6 @@ trigger:
 ---
 depends_on:
 - check
-kind: pipeline
-name: release-test
-steps:
-- commands:
-  - printf "Should not show when check fails"
-  environment: {}
-  image: grafana/loki-build-image:0.27.0
-  name: test-command
-trigger:
-  event:
-  - pull_request
-  - tag
-  ref:
-  - refs/heads/main
-  - refs/heads/k???
-  - refs/tags/v*
-  - refs/pull/*/head
----
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -1685,6 +1667,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: cfd5cde6082c3710aa55d4d40dc234c0a881e320898d7fa9ef0787ce264c8eef
+hmac: 58239f4ad12c6f5089ab3582f4086a6be2c3131778b71ddba9721b21fa03ce00
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a `depends_on` condition to the release stage so no releases are done if the check fails.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>