### PR TITLE
Helm - Loki: Introduce runtimeConfig

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1792,6 +1792,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>loki.runtimeConfig</td>
+			<td>object</td>
+			<td>Provides a reloadable runtime configuration file for some specific configuration</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>loki.schemaConfig</td>
 			<td>object</td>
 			<td>Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 4.1.1
+
+- [FEATURE] Added `loki.runtimeConfig` helm values to provide a reloadable runtime configuration.
+
 ## 4.1
 
 - [BUGFIX] Fix bug in provisioner job that caused the self-monitoring tenant secret to be created with an empty token.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 4.3.0
+version: 4.4.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -82,6 +82,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             - name: data
               mountPath: /var/loki
             {{- if .Values.enterprise.enabled }}
@@ -114,6 +116,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -90,6 +90,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             - name: tmp
               mountPath: /tmp
             - name: data
@@ -128,6 +130,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -101,6 +101,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             - name: tmp
               mountPath: /tmp
             - name: data
@@ -137,6 +139,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/runtime-configmap.yaml
+++ b/production/helm/loki/templates/runtime-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.name" . }}-runtime
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+data:
+  runtime-config.yaml: |
+    {{ tpl (toYaml .Values.loki.runtimeConfig) . | nindent 4 }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -90,6 +90,8 @@ spec:
               mountPath: /tmp
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             {{- if .Values.singleBinary.persistence.enabled }}
             - name: storage
               mountPath: /var/loki
@@ -126,6 +128,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -60,6 +60,8 @@ spec:
               mountPath: /shared
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             - name: license
               mountPath: /etc/loki/license
           env:
@@ -110,6 +112,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         - name: license
           secret:
           {{- if .Values.enterprise.useExternalLicense }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -93,6 +93,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
             - name: data
               mountPath: /var/loki
             {{- if .Values.enterprise.enabled }}
@@ -125,6 +127,9 @@ spec:
           configMap:
             name: {{ include "loki.name" . }}
           {{- end }}
+        - name: runtime-config
+          configMap:
+            name: {{ template "loki.name" . }}-runtime
         {{- if .Values.enterprise.enabled }}
         - name: license
           secret:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -113,6 +113,9 @@ loki:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
 
+    runtime_config:
+      file: /etc/loki/runtime-config/runtime-config.yaml
+
     {{- with .Values.loki.memcached.chunk_cache }}
     {{- if and .enabled (or .host .addresses) }}
     chunk_store_config:
@@ -212,6 +215,9 @@ loki:
     reject_old_samples_max_age: 168h
     max_cache_freshness_per_query: 10m
     split_queries_by_interval: 15m
+
+  # -- Provides a reloadable runtime configuration file for some specific configuration
+  runtimeConfig: {}
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration
   commonConfig:


### PR DESCRIPTION
This is completely inspired by similar value available in [loki-distributed](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed) via https://github.com/grafana/helm-charts/pull/1827, which is itself  largely inspired by similar value in [mimir-distributed](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) helm chart.

The idea is to have a dedicated configmap to handle [runtime_config](https://grafana.com/docs/loki/latest/configuration/#runtime-configuration-file), alway present even if empty. This way, having it seperately from main config, components pods are guaranteed not to restart for any changes.

```yaml
runtimeConfig:
  overrides:
    tenant1:
      ingestion_rate_mb: 10
      max_streams_per_user: 100000
      max_chunks_per_query: 100000
    tenant2:
      max_streams_per_user: 1000000
      max_chunks_per_query: 1000000

  multi_kv_config:
      mirror-enabled: false
      primary: consul
```

Fixes #7918

Some questionable details:

1. Like in `loki-distributed`/`mimir-distributed`, `runtimeConfig` is available at values root (`.Values.runtimeConfig`). I feel a bit uncomfortable with this, i would have preferred `.Values.loki.runtimeConfig`, but having kind-of compatibility with `loki-distributed`/`mimir-distributed` may be more desirable.
2. `mimir-distributed` uses `/data` for mounting data and `/var/mimir` for mounting runtime config. As `loki` uses `/var/loki` for mounting its data, i've decided to stay in `/var` directory and uses `/var/loki-runtime` for its runtime config.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
