### PR TITLE
Revert "[loki-canary] Support passing loki address as environment variable (#8024)"

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -18,12 +19,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/version"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/loki/pkg/canary/comparator"
 	"github.com/grafana/loki/pkg/canary/reader"
 	"github.com/grafana/loki/pkg/canary/writer"
 	_ "github.com/grafana/loki/pkg/util/build"
+)
+
+const (
+	defaultMinBackoff = 500 * time.Millisecond
+	defaultMaxBackoff = 5 * time.Minute
+	defaultMaxRetries = 10
 )
 
 type canary struct {
@@ -36,52 +42,52 @@ type canary struct {
 
 func main() {
 
-	lName := kingpin.Flag("labelname", "The label name for this instance of loki-canary to use in the log selector").Default("name").String()
-	lVal := kingpin.Flag("labelvalue", "The unique label value for this instance of loki-canary to use in the log selector").Default("loki-canary").String()
-	sName := kingpin.Flag("streamname", "The stream name for this instance of loki-canary to use in the log selector").Default("stream").String()
-	sValue := kingpin.Flag("streamvalue", "The unique stream value for this instance of loki-canary to use in the log selector").Default("stdout").String()
-	port := kingpin.Flag("port", "Port which loki-canary should expose metrics").Default("3500").Int()
-	addr := kingpin.Flag("addr", "The Loki server URL:Port, e.g. loki:3100").Default("").Envar("LOKI_ADDRESS").String()
-	push := kingpin.Flag("push", "Push the logs directly to given Loki address").Default("false").Bool()
-	useTLS := kingpin.Flag("tls", "Does the loki connection use TLS?").Default("false").Bool()
-	certFile := kingpin.Flag("cert-file", "Client PEM encoded X.509 certificate for optional use with TLS connection to Loki").Default("").String()
-	keyFile := kingpin.Flag("key-file", "Client PEM encoded X.509 key for optional use with TLS connection to Loki").Default("").String()
-	caFile := kingpin.Flag("ca-file", "Client certificate authority for optional use with TLS connection to Loki").Default("").String()
-	insecureSkipVerify := kingpin.Flag("insecure", "Allow insecure TLS connections").Default("false").Bool()
-	user := kingpin.Flag("user", "Loki username.").Default("").Envar("LOKI_USERNAME").String()
-	pass := kingpin.Flag("pass", "Loki password. This credential should have both read and write permissions to Loki endpoints").Default("").Envar("LOKI_PASSWORD").String()
-	tenantID := kingpin.Flag("tenant-id", "Tenant ID to be set in X-Scope-OrgID header.").Default("").String()
-	writeTimeout := kingpin.Flag("write-timeout", "How long to wait write response from Loki").Default("10s").Duration()
-	writeMinBackoff := kingpin.Flag("write-min-backoff", "Initial backoff time before first retry ").Default("500ms").Duration()
-	writeMaxBackoff := kingpin.Flag("write-max-backoff", "Maximum backoff time between retries ").Default("5m").Duration()
-	writeMaxRetries := kingpin.Flag("write-max-retries", "Maximum number of retries when push a log entry ").Default("10").Int()
-	queryTimeout := kingpin.Flag("query-timeout", "How long to wait for a query response from Loki").Default("10s").Duration()
+	lName := flag.String("labelname", "name", "The label name for this instance of loki-canary to use in the log selector")
+	lVal := flag.String("labelvalue", "loki-canary", "The unique label value for this instance of loki-canary to use in the log selector")
+	sName := flag.String("streamname", "stream", "The stream name for this instance of loki-canary to use in the log selector")
+	sValue := flag.String("streamvalue", "stdout", "The unique stream value for this instance of loki-canary to use in the log selector")
+	port := flag.Int("port", 3500, "Port which loki-canary should expose metrics")
+	addr := flag.String("addr", "", "The Loki server URL:Port, e.g. loki:3100")
+	push := flag.Bool("push", false, "Push the logs directly to given Loki address")
+	useTLS := flag.Bool("tls", false, "Does the loki connection use TLS?")
+	certFile := flag.String("cert-file", "", "Client PEM encoded X.509 certificate for optional use with TLS connection to Loki")
+	keyFile := flag.String("key-file", "", "Client PEM encoded X.509 key for optional use with TLS connection to Loki")
+	caFile := flag.String("ca-file", "", "Client certificate authority for optional use with TLS connection to Loki")
+	insecureSkipVerify := flag.Bool("insecure", false, "Allow insecure TLS connections")
+	user := flag.String("user", "", "Loki username.")
+	pass := flag.String("pass", "", "Loki password. This credential should have both read and write permissions to Loki endpoints")
+	tenantID := flag.String("tenant-id", "", "Tenant ID to be set in X-Scope-OrgID header.")
+	writeTimeout := flag.Duration("write-timeout", 10*time.Second, "How long to wait write response from Loki")
+	writeMinBackoff := flag.Duration("write-min-backoff", defaultMinBackoff, "Initial backoff time before first retry ")
+	writeMaxBackoff := flag.Duration("write-max-backoff", defaultMaxBackoff, "Maximum backoff time between retries ")
+	writeMaxRetries := flag.Int("write-max-retries", defaultMaxRetries, "Maximum number of retries when push a log entry ")
+	queryTimeout := flag.Duration("query-timeout", 10*time.Second, "How long to wait for a query response from Loki")
 
-	interval := kingpin.Flag("interval", "Duration between log entries").Default("1s").Duration()
-	outOfOrderPercentage := kingpin.Flag("out-of-order-percentage", "Percentage (0-100) of log entries that should be sent out of order.").Default("0").Int()
-	outOfOrderMin := kingpin.Flag("out-of-order-min", "Minimum amount of time to go back for out of order entries (in seconds).").Default("30s").Duration()
-	outOfOrderMax := kingpin.Flag("out-of-order-max", "Maximum amount of time to go back for out of order entries (in seconds).").Default("60s").Duration()
+	interval := flag.Duration("interval", 1000*time.Millisecond, "Duration between log entries")
+	outOfOrderPercentage := flag.Int("out-of-order-percentage", 0, "Percentage (0-100) of log entries that should be sent out of order.")
+	outOfOrderMin := flag.Duration("out-of-order-min", 30*time.Second, "Minimum amount of time to go back for out of order entries (in seconds).")
+	outOfOrderMax := flag.Duration("out-of-order-max", 60*time.Second, "Maximum amount of time to go back for out of order entries (in seconds).")
 
-	size := kingpin.Flag("size", "Size in bytes of each log line").Default("100").Int()
-	wait := kingpin.Flag("wait", "Duration to wait for log entries on websocket before querying loki for them").Default("60s").Duration()
-	maxWait := kingpin.Flag("max-wait", "Duration to keep querying Loki for missing websocket entries before reporting them missing").Default("5m").Duration()
-	pruneInterval := kingpin.Flag("pruneinterval", "Frequency to check sent vs received logs, "+
-		"also the frequency which queries for missing logs will be dispatched to loki").Default("60s").Duration()
-	buckets := kingpin.Flag("buckets", "Number of buckets in the response_latency histogram").Default("10").Int()
+	size := flag.Int("size", 100, "Size in bytes of each log line")
+	wait := flag.Duration("wait", 60*time.Second, "Duration to wait for log entries on websocket before querying loki for them")
+	maxWait := flag.Duration("max-wait", 5*time.Minute, "Duration to keep querying Loki for missing websocket entries before reporting them missing")
+	pruneInterval := flag.Duration("pruneinterval", 60*time.Second, "Frequency to check sent vs received logs, "+
+		"also the frequency which queries for missing logs will be dispatched to loki")
+	buckets := flag.Int("buckets", 10, "Number of buckets in the response_latency histogram")
 
-	metricTestInterval := kingpin.Flag("metric-test-interval", "The interval the metric test query should be run").Default("1h").Duration()
-	metricTestQueryRange := kingpin.Flag("metric-test-range", "The range value [24h] used in the metric test instant-query."+
-		" Note: this value is truncated to the running time of the canary until this value is reached").Default("24h").Duration()
+	metricTestInterval := flag.Duration("metric-test-interval", 1*time.Hour, "The interval the metric test query should be run")
+	metricTestQueryRange := flag.Duration("metric-test-range", 24*time.Hour, "The range value [24h] used in the metric test instant-query."+
+		" Note: this value is truncated to the running time of the canary until this value is reached")
 
-	spotCheckInterval := kingpin.Flag("spot-check-interval", "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
-		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached").Default("15m").Duration()
-	spotCheckMax := kingpin.Flag("spot-check-max", "How far back to check a spot check entry before dropping it").Default("4h").Duration()
-	spotCheckQueryRate := kingpin.Flag("spot-check-query-rate", "Interval that the canary will query Loki for the current list of all spot check entries").Default("1m").Duration()
-	spotCheckWait := kingpin.Flag("spot-check-initial-wait", "How long should the spot check query wait before starting to check for entries").Default("10s").Duration()
+	spotCheckInterval := flag.Duration("spot-check-interval", 15*time.Minute, "Interval that a single result will be kept from sent entries and spot-checked against Loki, "+
+		"e.g. 15min default one entry every 15 min will be saved and then queried again every 15min until spot-check-max is reached")
+	spotCheckMax := flag.Duration("spot-check-max", 4*time.Hour, "How far back to check a spot check entry before dropping it")
+	spotCheckQueryRate := flag.Duration("spot-check-query-rate", 1*time.Minute, "Interval that the canary will query Loki for the current list of all spot check entries")
+	spotCheckWait := flag.Duration("spot-check-initial-wait", 10*time.Second, "How long should the spot check query wait before starting to check for entries")
 
-	printVersion := kingpin.Flag("version", "Print this builds version information").Default("false").Bool()
+	printVersion := flag.Bool("version", false, "Print this builds version information")
 
-	kingpin.Parse()
+	flag.Parse()
 
 	if *printVersion {
 		fmt.Println(version.Print("loki-canary"))
@@ -89,7 +95,7 @@ func main() {
 	}
 
 	if *addr == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Must specify a Loki address with -addr or set the environemnt variable LOKI_ADDRESS\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Must specify a Loki address with -addr\n")
 		os.Exit(1)
 	}
 

--- a/docs/sources/operations/loki-canary.md
+++ b/docs/sources/operations/loki-canary.md
@@ -271,10 +271,9 @@ $ make loki-canary-image
 
 ## Configuration
 
-The address of Loki must be passed in with the `-addr` flag or by setting the
-environment variable `LOKI_ADDRESS`, and if your Loki server uses TLS, `-tls=true`
-must also be provided. Note that using TLS will cause the WebSocket connection
-to use `wss://` instead of `ws://`.
+The address of Loki must be passed in with the `-addr` flag, and if your Loki
+server uses TLS, `-tls=true` must also be provided. Note that using TLS will
+cause the WebSocket connection to use `wss://` instead of `ws://`.
 
 The `-labelname` and `-labelvalue` flags should also be provided, as these are
 used by Loki Canary to filter the log stream to only process logs for the
@@ -302,7 +301,7 @@ All options:
 
 ```
   -addr string
-    	The Loki server URL:Port, e.g. loki:3100. Loki address can also be set using the environment variable LOKI_ADDRESS.
+    	The Loki server URL:Port, e.g. loki:3100
   -buckets int
     	Number of buckets in the response_latency histogram (default 10)
   -ca-file string
@@ -332,7 +331,7 @@ All options:
   -out-of-order-percentage int
     	Percentage (0-100) of log entries that should be sent out of order.
   -pass string
-    	Loki password. This credential should have both read and write permissions to Loki endpoints. Password can also be set using the environment variable LOKI_PASSWORD.
+    	Loki password. This credential should have both read and write permissions to Loki endpoints
   -port int
     	Port which loki-canary should expose metrics (default 3500)
   -pruneinterval duration
@@ -360,7 +359,7 @@ All options:
   -tls
     	Does the loki connection use TLS?
   -user string
-    	Loki username. Username can also be set using the environment variable LOKI_USERNAME.
+    	Loki username.
   -version
     	Print this builds version information
   -wait duration


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts commit f9ed9cb7d98dcdaa6fe2f1b7e97ca86af2864121 which introduced breaking config changes for the Loki canary. The relevant change introduced support for configuring a new `LOKI_ADDRESS` canary environment variable by adopting a new library for flags.

This is the easiest path forward to avoid forcing breaking config changes on canary operators; such a change is likely better suited to join other configuration changes in a future major Loki release.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Related PR:
- https://github.com/grafana/loki/pull/8024

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
