### PR TITLE
fix(helm): Use GHCR and bump nginx-unprivileged version

### DIFF
--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -974,11 +974,11 @@ gateway:
     type: RollingUpdate
   image:
     # -- The Docker registry for the gateway image
-    registry: docker.io
+    registry: ghcr.io
     # -- The gateway image repository
     repository: nginxinc/nginx-unprivileged
     # -- The gateway image tag
-    tag: 1.19-alpine
+    tag: 1.23-alpine
     # -- The gateway image pull policy
     pullPolicy: IfNotPresent
   # -- The name of the PriorityClass for gateway pods


### PR DESCRIPTION
**What this PR does / why we need it**:

There are no rate limits on GHCR, and also there's a newer version of nginx available.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
