### PR TITLE
Add timeout for waiting for component to start

### DIFF
--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -14,8 +14,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/multierror"
 	"github.com/prometheus/client_golang/prometheus"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since I cannot reproduce the frequently happening test timeouts of the integration tests (e.g. https://drone.grafana.net/grafana/loki/18547/3/5), I added a timeout to the component startup and additional debug logs. Maybe I get some more information about why the test hangs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**DO NOT REVIEW**

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
