### PR TITLE
operator: Allow multiple matchers for multi-tenancy with Network tenant

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8192](https://github.com/grafana/loki/pull/8192) **jotak**: Allow multiple matchers for multi-tenancy with Network tenant (OpenShift)
 - [8800](https://github.com/grafana/loki/pull/8800) **aminesnow**: Promote AlertingRules, RecordingRules and RulerConfig from v1beta1 to v1
 - [8792](https://github.com/grafana/loki/pull/8792) **orenc1**: Improve documentation for LokiStack installation with ODF Object Storage
 - [8791](https://github.com/grafana/loki/pull/8791) **periklis**: Expand OLM skip range for OpenShift Logging 5.7 release (OpenShift)

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -523,6 +523,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",
 										"--opa.package=lokistack",
+										"--opa.matcher=SrcK8S_Namespace,DstK8S_Namespace",
+										"--opa.matcher-op=or",
 										`--openshift.mappings=network=loki.grafana.com`,
 									},
 									Ports: []corev1.ContainerPort{
@@ -625,6 +627,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 										"--web.internal.listen=:8083",
 										"--web.healthchecks.url=http://localhost:8082",
 										"--opa.package=lokistack",
+										"--opa.matcher=SrcK8S_Namespace,DstK8S_Namespace",
+										"--opa.matcher-op=or",
 										"--tls.internal.server.cert-file=/var/run/tls/http/server/tls.crt",
 										"--tls.internal.server.key-file=/var/run/tls/http/server/tls.key",
 										"--tls.min-version=min-version",

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	envRelatedImageOPA     = "RELATED_IMAGE_OPA"
-	defaultOPAImage        = "quay.io/observatorium/opa-openshift:latest"
-	opaContainerName       = "opa"
-	opaDefaultPackage      = "lokistack"
-	opaDefaultAPIGroup     = "loki.grafana.com"
-	opaMetricsPortName     = "opa-metrics"
-	opaDefaultLabelMatcher = "kubernetes_namespace_name"
+	envRelatedImageOPA      = "RELATED_IMAGE_OPA"
+	defaultOPAImage         = "quay.io/observatorium/opa-openshift:latest"
+	opaContainerName        = "opa"
+	opaDefaultPackage       = "lokistack"
+	opaDefaultAPIGroup      = "loki.grafana.com"
+	opaMetricsPortName      = "opa-metrics"
+	opaDefaultLabelMatcher  = "kubernetes_namespace_name"
+	opaNetworkLabelMatchers = "SrcK8S_Namespace,DstK8S_Namespace"
 )
 
 func newOPAOpenShiftContainer(mode lokiv1.ModeType, secretVolumeName, tlsDir, minTLSVersion, ciphers string, withTLS bool) corev1.Container {
@@ -48,6 +49,11 @@ func newOPAOpenShiftContainer(mode lokiv1.ModeType, secretVolumeName, tlsDir, mi
 	if mode != lokiv1.OpenshiftNetwork {
 		args = append(args, []string{
 			fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatcher),
+		}...)
+	} else {
+		args = append(args, []string{
+			fmt.Sprintf("--opa.matcher=%s", opaNetworkLabelMatchers),
+			"--opa.matcher-op=or",
 		}...)
 	}
 


### PR DESCRIPTION
Use netobserv-specific matchers for network tenant.

This is just WIP at the moment, just opening a PR to discuss & validate the approach
cc @periklis 

Related PRs:
- https://github.com/observatorium/api/pull/440
- https://github.com/observatorium/opa-openshift/pull/15

**What this PR does / why we need it**:

To extend multi-tenancy in the loki-operator for openshift to new use cases, here for [NetObserv](https://github.com/netobserv/network-observability-operator). Note that it could probably be made more configurable for new/future use cases - not addressed in this PoC, but perhaps something to think about.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
