### PR TITLE
Helm: Fix components notes

### DIFF
--- a/production/helm/loki/templates/NOTES.txt
+++ b/production/helm/loki/templates/NOTES.txt
@@ -19,4 +19,7 @@ Installed components:
 {{- end }}
 * read
 * write
+{{- if not .Values.read.legacyReadTarget }}
+* backend
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Add component `backend` in the list of installed components on helm notes, based on `read.legacyReadTarget` value, just like backend statefulset.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
