### PR TITLE
[helm] Fix self-monitoring tenant secret

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 4.1
+
+- [BUGFIX] Fix bug in provisioner job that caused the self-monitoring tenant secret to be created with an empty token.
+
 ## 4.0
 
 - [FEATURE] Added `enterprise.adminToken.additionalNamespaces` which are a list of additional namespaces to create secrets containing the GEL admin token in. This is especially useful if your Grafana instance is in another namespace.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 4.0.0
+version: 4.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: {{ .Values.enterprise.provisioner.image.pullPolicy }}
           command:
             - /bin/sh
-            - -euc
+            - -exuc
             - |
               {{- range .Values.enterprise.provisioner.additionalTenants }}
               /usr/bin/enterprise-logs-provisioner \
@@ -90,7 +90,7 @@ spec:
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
           command:
             - /bin/bash
-            - -euc
+            - -exuc
             - |
               {{- range .Values.enterprise.provisioner.additionalTenants }}
               kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ include "enterprise-logs.provisionedSecretPrefix" $ }}-{{ .name }}" \
@@ -101,11 +101,11 @@ spec:
               {{- with .Values.monitoring.selfMonitoring.tenant }}
               kubectl --namespace "{{ $namespace }}" create secret generic "{{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}" \
                 --from-literal=username="{{ .name }}" \
-                --from-literal=password="$(cat /bootstrap/token-canary)"
+                --from-literal=password="$(cat /bootstrap/token-self-monitoring)"
               {{- if not (eq .secretNamespace $namespace) }}
               kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}" \
                 --from-literal=username="{{ .name }}" \
-                --from-literal=password="$(cat /bootstrap/token-canary)"
+                --from-literal=password="$(cat /bootstrap/token-self-monitoring)"
               {{- end }}
               {{- end }}
           volumeMounts:

--- a/tools/dev/k3d/README.md
+++ b/tools/dev/k3d/README.md
@@ -1,16 +1,18 @@
 # Deploy Loki to k3d for Local Development
 
-## Pre-requisites 
+## Pre-requisites
 
 In order to use the make targets in this directory, make sure you have the following tools installed:
-* [kubectl](https://kubernetes.io/docs/tasks/tools/)
-* [k3d](https://k3d.io/v4.4.8/)
-* [tanka](https://github.com/grafana/tanka)
-* [jsonnet](https://jsonnet.org/)
-* [jq](https://stedolan.github.io/jq/)
-* [helm](https://helm.sh/docs/intro/install/) >= 3.9
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [k3d](https://k3d.io/v4.4.8/)
+- [tanka](https://github.com/grafana/tanka)
+- [jsonnet](https://jsonnet.org/)
+- [jq](https://stedolan.github.io/jq/)
+- [helm](https://helm.sh/docs/intro/install/) >= 3.9
 
 **Note**: in case docker is unable to resolve the local k3d registry hostname, add the following entry to the `/etc/hosts` file:
+
 ```
 127.0.0.1 k3d-grafana
 ```
@@ -30,3 +32,14 @@ The `down` make target will tear down all environments.
 ```bash
 make down
 ```
+
+## Helm
+
+The `helm-cluster` environment is designed for spinning up a cluster with just Grafana and Prometheus Operator that can be `helm installed` into. First spin up the cluster, then run the `make` targets for installing the desired configuration.
+
+### Enterprise Logs
+
+1. `make helm-cluster`
+1. `make helm-install-enterprise-logs`
+
+   This step will take a while. The `provisioner` is dependent on the `tokengen` job and for the Admin API to be in a healthy state. Be patient and it will evenutally complete. Once the `provisioner` job has completed, the Loki Canaries will come online, and Grafana will start, as both are waiting on secrets provisioned by the `provisioner`.

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -6,7 +6,7 @@
     "namespace": "environments/helm-cluster/main.jsonnet"
   },
   "spec": {
-    "apiServer": "https://0.0.0.0:39135",
+    "apiServer": "https://0.0.0.0:40141",
     "namespace": "k3d-helm-cluster",
     "resourceDefaults": {},
     "expectVersions": {}

--- a/tools/dev/k3d/jsonnetfile.lock.json
+++ b/tools/dev/k3d/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "consul"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "enterprise-metrics"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "hi2ZpHKl7qWXmSZ46sAycjWEQK6oGsoECuDKQT1dA+k="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "etcd-operator"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "duHm6wmUju5KHQurOe6dnXoKgl5gTUsfGplgbmAOsHw="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "Y5nheroSOIwmE+djEVPq4OvvTxKenzdHhpEwaR3Ebjs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
     },
     {
@@ -78,7 +78,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {
@@ -88,7 +88,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "02bd2cbc7c71bbffeb807b58d1b45b58230b3224",
+      "version": "a924ab1b5fd4e6eacd7235a20978d050a27bdb65",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -118,8 +118,8 @@
           "subdir": "1.20"
         }
       },
-      "version": "4613c97af18622848e4ffac3c4a78a9349f1d716",
-      "sum": "KZac8iaWuW0tiN54OE9uE+Squ6SVnOHz6Wk2QgmPe3o="
+      "version": "2ff9e542231fce1ba6d880d1157c81724f176bc6",
+      "sum": "K8hAiyQ4ELAsln24tcwTf/++hKM/3YvLXsOYN0zD8eM="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/8081 introduced a bug that caused the `provisioner` job to create an incorrect secret for the self-monitoring tenant used by the canary. This fixes that bug, as well as adding a readme on how to use the `helm-cluster` k3d env.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
