### PR TITLE
support single & double hyphen arguments in version printing

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -38,12 +38,11 @@ type ConfigWrapper struct {
 }
 
 func PrintVersion(args []string) bool {
-	for _, a := range args {
-		if a == "-"+versionFlag {
-			return true
-		}
-	}
-	return false
+	var printVersion bool
+	f := flag.NewFlagSet("version parsing", flag.ContinueOnError)
+	f.BoolVar(&printVersion, versionFlag, false, "Print this builds version information")
+	_ = f.Parse(args)
+	return printVersion
 }
 
 func (c *ConfigWrapper) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
Small fix for an annoyance due special case parsing for the `version` flag. Previously we looked for `-version`, now we use the the flag library to support both `--version|-version`