### PR TITLE
Revert "fix(logql): remove __error_details__ label on drop __error__ or other way around"

### DIFF
--- a/docs/sources/logql/log_queries.md
+++ b/docs/sources/logql/log_queries.md
@@ -593,8 +593,6 @@ the result will be
 {} INFO GET / loki.net 200
 ```
 
-**Note:** `|drop __error__` or `|drop __error__="some error"` will also drop `__error__details__` label. Similarly, `|drop __error_details__` or `|drop __error_details__="some error details"` will also drop `__error__` label.
-
 Example with regex and multiple names
 
 For the query `{job="varlogs"}|json|drop level, path, app=~"some-api.*"`, with below log lines

--- a/pkg/logql/log/drop_labels.go
+++ b/pkg/logql/log/drop_labels.go
@@ -47,14 +47,13 @@ func isErrorDetailsLabel(name string) bool {
 	return name == logqlmodel.ErrorDetailsLabel
 }
 
-func resetError(lbls *LabelsBuilder) {
-	lbls.ResetError()
-	lbls.ResetErrorDetails()
-}
-
 func dropLabelNames(name string, lbls *LabelsBuilder) {
-	if isErrorLabel(name) || isErrorDetailsLabel(name) {
-		resetError(lbls)
+	if isErrorLabel(name) {
+		lbls.ResetError()
+		return
+	}
+	if isErrorDetailsLabel(name) {
+		lbls.ResetErrorDetails()
 		return
 	}
 	if _, ok := lbls.Get(name); ok {
@@ -68,14 +67,14 @@ func dropLabelMatches(matcher *labels.Matcher, lbls *LabelsBuilder) {
 	if isErrorLabel(name) {
 		value = lbls.GetErr()
 		if matcher.Matches(value) {
-			resetError(lbls)
+			lbls.ResetError()
 		}
 		return
 	}
 	if isErrorDetailsLabel(name) {
 		value = lbls.GetErrorDetails()
 		if matcher.Matches(value) {
-			resetError(lbls)
+			lbls.ResetErrorDetails()
 		}
 		return
 	}

--- a/pkg/logql/log/drop_labels_test.go
+++ b/pkg/logql/log/drop_labels_test.go
@@ -49,6 +49,10 @@ func Test_DropLabels(t *testing.T) {
 					labels.MustNewMatcher(labels.MatchEqual, logqlmodel.ErrorLabel, errJSON),
 					"",
 				},
+				{
+					nil,
+					"__error_details__",
+				},
 			},
 			errJSON,
 			"json error",
@@ -93,27 +97,6 @@ func Test_DropLabels(t *testing.T) {
 					labels.MustNewMatcher(labels.MatchRegexp, logqlmodel.ErrorDetailsLabel, "expecting json.*"),
 					"",
 				},
-			},
-			errJSON,
-			"expecting json object but it is not",
-			labels.Labels{
-				{Name: "app", Value: "foo"},
-				{Name: "namespace", Value: "prod"},
-				{Name: "pod_uuid", Value: "foo"},
-			},
-			labels.Labels{
-				{Name: "app", Value: "foo"},
-				{Name: "namespace", Value: "prod"},
-				{Name: "pod_uuid", Value: "foo"},
-			},
-		},
-		{
-			"using both __error_details__ and __error__ should have expected labels ",
-			[]DropLabel{
-				{
-					labels.MustNewMatcher(labels.MatchRegexp, logqlmodel.ErrorDetailsLabel, "expecting json.*"),
-					"",
-				},
 				{
 					nil,
 					"__error__",
@@ -138,6 +121,10 @@ func Test_DropLabels(t *testing.T) {
 				{
 					labels.MustNewMatcher(labels.MatchEqual, logqlmodel.ErrorLabel, errJSON),
 					"",
+				},
+				{
+					nil,
+					"__error_details__",
 				},
 				{
 					nil,

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -153,6 +153,10 @@ func TestDropLabelsPipeline(t *testing.T) {
 						nil,
 						"__error__",
 					},
+					{
+						nil,
+						"__error_details__",
+					},
 				}),
 			},
 			[][]byte{
@@ -218,6 +222,7 @@ func TestDropLabelsPipeline(t *testing.T) {
 					{Name: "namespace", Value: "prod"},
 					{Name: "pod_uuid", Value: "foo"},
 					{Name: "pod_deployment_ref", Value: "foobar"},
+					{Name: logqlmodel.ErrorDetailsLabel, Value: "logfmt syntax error at pos 2 : unexpected '\"'"},
 				},
 			},
 		},


### PR DESCRIPTION
Reverts grafana/loki#8150

I was talking with @adityacs about reverting this PR and found the following:

Looking at why tests don’t keep `__error_details__` when `__error__` is dropped and I found this line of code:
```go
// LabelsResult returns the LabelsResult from the builder.
// No grouping is applied and the cache is used when possible.
func (b *LabelsBuilder) LabelsResult() LabelsResult {
	// unchanged path.
	if len(b.del) == 0 && len(b.add) == 0 && b.err == "" {
		return b.currentResult
	}
	return b.toResult(b.labels())
}```

https://github.com/grafana/loki/blob/main/pkg/logql/log/labels.go#L314
We only add err details when err isn’t empty anyway, so I guess we’ll revert for simplicity but just keep the same functionality