### PR TITLE
promtail: Add doc for `max-line-size` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 * [7619](https://github.com/grafana/loki/pull/7619) **cadrake**: Add ability to pass query params to heroku drain targets for relabelling.
 * [7973](https://github.com/grafana/loki/pull/7973) **chodges15**: Add configuration to drop rate limited batches in Loki client and new metric label for drop reason.
-* [8153](https://github.com/grafana/loki/pull/8061) **kavirajk**: promtail: Add `max-line-size` limit to drop on client side
+* [8153](https://github.com/grafana/loki/pull/8153) **kavirajk**: promtail: Add `max-line-size` limit to drop on client side
 * [8096](https://github.com/grafana/loki/pull/8096) **kavirajk**: doc(promtail): Doc about how log rotate works with promtail
 
 

--- a/clients/pkg/promtail/limit/config.go
+++ b/clients/pkg/promtail/limit/config.go
@@ -2,15 +2,17 @@ package limit
 
 import (
 	"flag"
+
+	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 type Config struct {
-	ReadlineRate        float64 `mapstructure:"readline_rate" yaml:"readline_rate" json:"readline_rate"`
-	ReadlineBurst       int     `mapstructure:"readline_burst" yaml:"readline_burst" json:"readline_burst"`
-	ReadlineRateEnabled bool    `mapstructure:"readline_rate_enabled,omitempty" yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
-	ReadlineRateDrop    bool    `mapstructure:"readline_rate_drop,omitempty" yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
-	MaxStreams          int     `mapstructure:"max_streams" yaml:"max_streams" json:"max_streams"`
-	MaxLineSize         int     `mapstructure:"max_line_size" yaml:"max_line_size" json:"max_line_size"`
+	ReadlineRate        float64          `mapstructure:"readline_rate" yaml:"readline_rate" json:"readline_rate"`
+	ReadlineBurst       int              `mapstructure:"readline_burst" yaml:"readline_burst" json:"readline_burst"`
+	ReadlineRateEnabled bool             `mapstructure:"readline_rate_enabled,omitempty" yaml:"readline_rate_enabled,omitempty"  json:"readline_rate_enabled"`
+	ReadlineRateDrop    bool             `mapstructure:"readline_rate_drop,omitempty" yaml:"readline_rate_drop,omitempty"  json:"readline_rate_drop"`
+	MaxStreams          int              `mapstructure:"max_streams" yaml:"max_streams" json:"max_streams"`
+	MaxLineSize         flagext.ByteSize `mapstructure:"max_line_size" yaml:"max_line_size" json:"max_line_size"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -19,5 +21,5 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.ReadlineRateEnabled, prefix+"limit.readline-rate-enabled", false, "When true, enforces rate limiting on this instance of Promtail.")
 	f.BoolVar(&cfg.ReadlineRateDrop, prefix+"limit.readline-rate-drop", true, "When true, exceeding the rate limit causes this instance of Promtail to discard log lines, rather than sending them to Loki.")
 	f.IntVar(&cfg.MaxStreams, prefix+"max-streams", 0, "Maximum number of active streams. 0 to disable.")
-	f.IntVar(&cfg.MaxLineSize, prefix+"max-line-size", 0, "Maximum log line byte size allowed without dropping. 0 to disable.")
+	f.Var(&cfg.MaxLineSize, prefix+"max-line-size", "Maximum log line byte size allowed without dropping. Example: 256kb, 2M. 0 to disable.")
 }

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -140,7 +140,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 		}
 		cfg.PositionsConfig.ReadOnly = true
 	} else {
-		p.client, err = client.NewMulti(p.metrics, cfg.Options.StreamLagLabels, p.logger, cfg.LimitsConfig.MaxStreams, cfg.LimitsConfig.MaxLineSize, cfg.ClientConfigs...)
+		p.client, err = client.NewMulti(p.metrics, cfg.Options.StreamLagLabels, p.logger, cfg.LimitsConfig.MaxStreams, cfg.LimitsConfig.MaxLineSize.Val(), cfg.ClientConfigs...)
 		if err != nil {
 			return err
 		}

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1940,6 +1940,9 @@ The optional `limits_config` block configures global limits for this instance of
 # to avoid OOM scenarios.
 # 0 means it is disabled.
 [max_streams: <int> | default = 0]
+
+Maximum log line byte size allowed without dropping. Example: 256kb, 2M. 0 to disable.
+[max_line_size: <int> | default = 0]
 ```
 
 ## target_config


### PR DESCRIPTION
Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

**What this PR does / why we need it**:
Follow up from #8153

Changes:
* Change type of the flag from `int` to `flagext.ByteSize` (to be consistent with similar flag in `distributor`)
* Add doc to promtail config page
* Fix changelog entries

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] `CHANGELOG.md` updated

