### PR TITLE
[loki-canary] Support passing loki address as environment variable

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -95,7 +95,11 @@ func main() {
 	}
 
 	if *addr == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Must specify a Loki address with -addr\n")
+		*addr = os.Getenv("LOKI_ADDRESS")
+	}
+
+	if *addr == "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Must specify a Loki address with -addr or set the environemnt variable LOKI_ADDRESS\n")
 		os.Exit(1)
 	}
 

--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Loki Canary
-description: Loki Canary is a standalone app that audits the log-capturing performance of a Grafana Loki cluster. 
+description: Loki Canary is a standalone app that audits the log-capturing performance of a Grafana Loki cluster.
 weight: 60
 ---
 # Loki Canary
@@ -272,9 +272,10 @@ $ make loki-canary-image
 
 ## Configuration
 
-The address of Loki must be passed in with the `-addr` flag, and if your Loki
-server uses TLS, `-tls=true` must also be provided. Note that using TLS will
-cause the WebSocket connection to use `wss://` instead of `ws://`.
+The address of Loki must be passed in with the `-addr` flag or by setting the
+environment variable `LOKI_ADDRESS`, and if your Loki server uses TLS, `-tls=true`
+must also be provided. Note that using TLS will cause the WebSocket connection
+to use `wss://` instead of `ws://`.
 
 The `-labelname` and `-labelvalue` flags should also be provided, as these are
 used by Loki Canary to filter the log stream to only process logs for the
@@ -302,7 +303,7 @@ All options:
 
 ```
   -addr string
-    	The Loki server URL:Port, e.g. loki:3100
+    	The Loki server URL:Port, e.g. loki:3100. Loki address can also be set using the environment variable LOKI_ADDRESS.
   -buckets int
     	Number of buckets in the response_latency histogram (default 10)
   -ca-file string


### PR DESCRIPTION
**What this PR does / why we need it**:

- Set config `addr` from environment variables `LOKI_ADDRESS`. The precedence is command-line argument > environment.


**Which issue(s) this PR fixes**:
Fixes #8021 

**Special notes for your reviewer**:
CHANGELOG was already updated in a previous PR #8052, and was missed to revert in #8184. Hence there are no changes required in CHANGELOG.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
