### PR TITLE
Use latest release of doc-validator image

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:53w6qa25dqyiv9h3pscylb7yvyyj8vdh"
+      image: "grafana/doc-validator:v1.8.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
- Fixes regression where non-Markdown files are considered for linting.
- Uses a canonical algorithm for converting headings to anchor identifiers taken from the Hugo source.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
