### PR TITLE
Remove template alias from Helm chart reference

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -2,8 +2,6 @@
 title: Helm Chart Values
 menuTitle: Helm Chart Values
 description: Reference for Helm Chart values.
-aliases:
-  - /docs/writers-toolkit/latest/templates/reference-template
 weight: 100
 keywords: []
 ---

--- a/production/helm/loki/reference.md.gotmpl
+++ b/production/helm/loki/reference.md.gotmpl
@@ -2,8 +2,6 @@
 title: Helm Chart Values
 menuTitle: Helm Chart Values
 description: Reference for Helm Chart values.
-aliases:
-  - /docs/writers-toolkit/latest/templates/reference-template
 weight: 100
 keywords: []
 ---


### PR DESCRIPTION
With its inclusion, the page tries to redirect
https://grafana.com/docs/writers-toolkit/latest/templates/reference-template/ to https://grafana.com/docs/loki/latest/installation/helm/reference/

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
