### PR TITLE
Update doc-validator to latest release

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v1.8.0"
+      image: "grafana/doc-validator:v1.9.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
- Adds support for mailto scheme in links
- Makes some errata more user friendly

https://github.com/grafana/technical-documentation/releases/tag/doc-validator%2Fv1.9.0

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
