### PR TITLE
Loki: Remove validation of matchers when performing label values lookup.

### DIFF
--- a/pkg/logql/evaluator_test.go
+++ b/pkg/logql/evaluator_test.go
@@ -1,10 +1,11 @@
 package logql
 
 import (
-	"github.com/prometheus/prometheus/promql"
-	"github.com/stretchr/testify/require"
 	"math"
 	"testing"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
 )

--- a/pkg/logql/log/drop_labels.go
+++ b/pkg/logql/log/drop_labels.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
 type DropLabels struct {

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/buger/jsonparser"
+
 	"github.com/grafana/loki/pkg/logql/log/jsonexpr"
 	"github.com/grafana/loki/pkg/logql/log/logfmt"
 	"github.com/grafana/loki/pkg/logql/log/pattern"

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -65,7 +65,7 @@ func (p *parser) Parse() (Expr, error) {
 
 // ParseExpr parses a string and returns an Expr.
 func ParseExpr(input string) (Expr, error) {
-	expr, err := parseExprWithoutValidation(input)
+	expr, err := ParseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ParseExpr(input string) (Expr, error) {
 	return expr, nil
 }
 
-func parseExprWithoutValidation(input string) (expr Expr, err error) {
+func ParseExprWithoutValidation(input string) (expr Expr, err error) {
 	if len(input) >= maxInputSize {
 		return nil, logqlmodel.NewParseError(fmt.Sprintf("input size too long (%d > %d)", len(input), maxInputSize), 0, 0)
 	}
@@ -192,7 +192,7 @@ func validateSortGrouping(grouping *Grouping) error {
 
 // ParseLogSelector parses a log selector expression `{app="foo"} |= "filter"`
 func ParseLogSelector(input string, validate bool) (LogSelectorExpr, error) {
-	expr, err := parseExprWithoutValidation(input)
+	expr, err := ParseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/require"
 )
 
 type mockCache struct {

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -2,7 +2,7 @@ package indexgateway
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/go-kit/log"

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -226,7 +226,7 @@ func (g *Gateway) LabelValuesForMetricName(ctx context.Context, req *logproto.La
 
 		matcherExpr, ok := expr.(*syntax.MatchersExpr)
 		if !ok {
-			return nil, errors.New("invalid label matchers found")
+			return nil, fmt.Errorf("invalid label matchers found of type %T", expr)
 		}
 		matchers = matcherExpr.Mts
 	}

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -2,6 +2,7 @@ package indexgateway
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -218,10 +219,16 @@ func (g *Gateway) LabelValuesForMetricName(ctx context.Context, req *logproto.La
 	// An empty matchers string cannot be parsed,
 	// therefore we check the string representation of the the matchers.
 	if req.Matchers != syntax.EmptyMatchers {
-		matchers, err = syntax.ParseMatchers(req.Matchers)
+		expr, err := syntax.ParseExprWithoutValidation(req.Matchers)
 		if err != nil {
 			return nil, err
 		}
+
+		matcherExpr, ok := expr.(*syntax.MatchersExpr)
+		if !ok {
+			return nil, errors.New("invalid label matchers found")
+		}
+		matchers = matcherExpr.Mts
 	}
 	names, err := g.indexQuerier.LabelValuesForMetricName(ctx, instanceID, req.From, req.Through, req.MetricName, req.LabelName, matchers...)
 	if err != nil {


### PR DESCRIPTION
the curren validation fails on != style matchers when they are the only matchers present, requiring at least one `=` matcher.

However for looking up label values in TSDB, by design it uses a `desired_label != ""` style query, as such it should be allowed to also include these as matchers.

Additional matchers on this Label Value queries typically only exist with LBAC headers adding additional labels.

Signed-off-by: Edward Welch <edward.welch@grafana.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
