### PR TITLE
Loki: Remove validation of matchers when performing label values lookup. (#8224)

### DIFF
--- a/pkg/logql/evaluator_test.go
+++ b/pkg/logql/evaluator_test.go
@@ -1,10 +1,11 @@
 package logql
 
 import (
-	"github.com/prometheus/prometheus/promql"
-	"github.com/stretchr/testify/require"
 	"math"
 	"testing"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
 )

--- a/pkg/logql/log/drop_labels.go
+++ b/pkg/logql/log/drop_labels.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
 type DropLabels struct {

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/buger/jsonparser"
+
 	"github.com/grafana/loki/pkg/logql/log/jsonexpr"
 	"github.com/grafana/loki/pkg/logql/log/logfmt"
 	"github.com/grafana/loki/pkg/logql/log/pattern"

--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -65,7 +65,7 @@ func (p *parser) Parse() (Expr, error) {
 
 // ParseExpr parses a string and returns an Expr.
 func ParseExpr(input string) (Expr, error) {
-	expr, err := parseExprWithoutValidation(input)
+	expr, err := ParseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func ParseExpr(input string) (Expr, error) {
 	return expr, nil
 }
 
-func parseExprWithoutValidation(input string) (expr Expr, err error) {
+func ParseExprWithoutValidation(input string) (expr Expr, err error) {
 	if len(input) >= maxInputSize {
 		return nil, logqlmodel.NewParseError(fmt.Sprintf("input size too long (%d > %d)", len(input), maxInputSize), 0, 0)
 	}
@@ -192,7 +192,7 @@ func validateSortGrouping(grouping *Grouping) error {
 
 // ParseLogSelector parses a log selector expression `{app="foo"} |= "filter"`
 func ParseLogSelector(input string, validate bool) (LogSelectorExpr, error) {
-	expr, err := parseExprWithoutValidation(input)
+	expr, err := ParseExprWithoutValidation(input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/require"
 )
 
 type mockCache struct {


### PR DESCRIPTION
This PR cherry-picks https://github.com/grafana/loki/commit/c8760f31e26acfe575d2f1e71ce6044c69606ca4 onto `k133` -- original PR description below:

**What this PR does / why we need it**:
the current validation fails on != style matchers when they are the only matchers present, requiring at least one `=` matcher.

However for looking up label values in TSDB, by design it uses a `desired_label != ""` style query, as such it should be allowed to also include these as matchers.

Additional matchers on this Label Value queries typically only exist with LBAC headers adding additional labels.

Signed-off-by: Edward Welch <edward.welch@grafana.com>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Edward Welch <edward.welch@grafana.com>
Signed-off-by: Christian Haudum <christian.haudum@gmail.com>
Co-authored-by: Owen Diehl <ow.diehl@gmail.com>
Co-authored-by: Danny Kopping <danny.kopping@grafana.com>
Co-authored-by: Christian Haudum <christian.haudum@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
