### PR TITLE
Enalbe multi tenant queries on Helm test chart.

### DIFF
--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -57,7 +57,7 @@ local spec = (import './spec.json').spec;
   grafanaNamespace: k.core.v1.namespace.new('grafana'),
   grafana: grafana
            + grafana.withAnonymous()
-           + grafana.withImage('grafana/grafana-enterprise:9.1.0')
+           + grafana.withImage('grafana/grafana-enterprise:9.3.2')
            + grafana.withGrafanaIniConfig({
              sections+: {
                server+: {

--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -57,7 +57,7 @@ local spec = (import './spec.json').spec;
   grafanaNamespace: k.core.v1.namespace.new('grafana'),
   grafana: grafana
            + grafana.withAnonymous()
-           + grafana.withImage('grafana/grafana-enterprise:8.2.5')
+           + grafana.withImage('grafana/grafana-enterprise:9.1.0')
            + grafana.withGrafanaIniConfig({
              sections+: {
                server+: {

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -1,4 +1,8 @@
 ---
+loki:
+  querier:
+    multi_tenant_queries_enabled: true
+
 enterprise:
   enabled: true
   adminToken:


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch raises the Grafana Enterprise version and enables multi tenant queries on our test environment.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
