### PR TITLE
Loki: Fix version info issue that shows wrong version (#7669, #8055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [7925](https://github.com/grafana/loki/pull/7925) **sandeepsukhani**: Fix bugs in logs results caching causing query-frontend to return logs outside of query window.
 * [8120](https://github.com/grafana/loki/pull/8120) **ashwanthgoli** fix panic on hitting /scheduler/ring when ring is disabled.
 * [8251](https://github.com/grafana/loki/pull/8251) **sandeepsukhani** index-store: fix indexing of chunks overlapping multiple schemas.
+* [8120](https://github.com/grafana/loki/pull/8232) **TaehyunHwang** Fix version info issue that shows wrong version.
 
 ##### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ BUILD_IMAGE_VERSION := 0.27.0
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
+FETCH_TAGS :=$(shell ./tools/fetch-tags)
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries

--- a/tools/fetch-tags
+++ b/tools/fetch-tags
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git fetch --tags --all


### PR DESCRIPTION
**What this PR does / why we need it**:

* It should fetch all tags before extracting tag info to ldflag of the build.

  * This issue could happen if a build tag like v2.7.1 was not fetched properly and then the build process was running. 
  * The following promtail is https://github.com/grafana/loki/releases/download/v2.7.1/promtail-darwin-arm64.zip

     <img width="1727" alt="image" src="https://user-images.githubusercontent.com/42465090/213915185-5096b4cc-a19c-49af-8b90-04739b429e80.png">

  * If there's no tag on the exact commit to publish, then <kbd>BRANCH</kbd> variable becomes HEAD, so the <kbd>VERSION</kbd> variable becomes like "HEAD-e0af1cc".

    * https://github.com/grafana/loki/blob/86dcc8231bed247fc29a5f5e25c6bb184d08fa71/tools/image-tag#L7-L21
    * https://github.com/grafana/loki/blob/86dcc8231bed247fc29a5f5e25c6bb184d08fa71/Makefile#L35

**Which issue(s) this PR fixes**:
* Fixes #7669, #8055 

**Special notes for your reviewer**:
* This can happen when the version tag was not fetched properly before the build process.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
