### PR TITLE
Helm - Loki: fix fullname for services

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 4.4.0
+version: 4.4.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -449,7 +449,7 @@ Create the service endpoint including port for MinIO.
 
 {{/* Configure the correct name for the memberlist service */}}
 {{- define "loki.memberlist" -}}
-{{ include "loki.name" . }}-memberlist
+{{ include "loki.fullname" . }}-memberlist
 {{- end -}}
 
 {{/* Determine the public host for the Loki cluster */}}

--- a/production/helm/loki/templates/backend/_helpers-backend.tpl
+++ b/production/helm/loki/templates/backend/_helpers-backend.tpl
@@ -2,7 +2,7 @@
 backend fullname
 */}}
 {{- define "loki.backendFullname" -}}
-{{ include "loki.name" . }}-backend
+{{ include "loki.fullname" . }}-backend
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/gateway/_helpers-gateway.tpl
+++ b/production/helm/loki/templates/gateway/_helpers-gateway.tpl
@@ -2,7 +2,7 @@
 gateway fullname
 */}}
 {{- define "loki.gatewayFullname" -}}
-{{ include "loki.name" . }}-gateway
+{{ include "loki.fullname" . }}-gateway
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/loki-canary/_helpers.tpl
+++ b/production/helm/loki/templates/loki-canary/_helpers.tpl
@@ -2,7 +2,7 @@
 canary fullname
 */}}
 {{- define "loki-canary.fullname" -}}
-{{ include "loki.name" . }}-canary
+{{ include "loki.fullname" . }}-canary
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/read/_helpers-read.tpl
+++ b/production/helm/loki/templates/read/_helpers-read.tpl
@@ -2,7 +2,7 @@
 read fullname
 */}}
 {{- define "loki.readFullname" -}}
-{{ include "loki.name" . }}-read
+{{ include "loki.fullname" . }}-read
 {{- end }}
 
 {{/*

--- a/production/helm/loki/templates/write/_helpers-write.tpl
+++ b/production/helm/loki/templates/write/_helpers-write.tpl
@@ -2,7 +2,7 @@
 write fullname
 */}}
 {{- define "loki.writeFullname" -}}
-{{ include "loki.name" . }}-write
+{{ include "loki.fullname" . }}-write
 {{- end }}
 
 {{/*


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki services were created with the short name, but the ingress is referencing these services using the fullname.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
