### PR TITLE
Helm: Add selector to backend's volumeClaimTemplates

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -149,4 +149,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.backend.persistence.size | quote }}
+        {{- with .Values.backend.persistence.selector }}
+        selector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The selector value in the backend's volumeClaimTemplates has no effect. `values.yaml` already contains the appropriate key: https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml#L913

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**
- [x ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
