### PR TITLE
Helm: Add initContainers to write, backend, singleBinary templates

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -112,6 +112,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>backend.initContainers</td>
+			<td>list</td>
+			<td>Init containers to add to the backend pods</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>backend.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for backend pods</td>
@@ -3052,6 +3061,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>singleBinary.initContainers</td>
+			<td>list</td>
+			<td>Init containers to add to the single binary pods</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>singleBinary.nodeSelector</td>
 			<td>object</td>
 			<td>Node selector for single binary pods</td>
@@ -3551,6 +3569,15 @@ null
 			<td>Docker image tag for the write image. Overrides `loki.image.tag`</td>
 			<td><pre lang="json">
 null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.initContainers</td>
+			<td>list</td>
+			<td>Init containers to add to the write pods</td>
+			<td><pre lang="json">
+[]
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -46,6 +46,12 @@ spec:
       securityContext:
         {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds }}
+      {{- if .Values.backend.initContainers }}
+      initContainers:
+        {{- with .Values.backend.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: backend
           image: {{ include "loki.image" . }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -53,6 +53,12 @@ spec:
       securityContext:
         {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.singleBinary.terminationGracePeriodSeconds }}
+      {{- if .Values.singleBinary.initContainers }}
+      initContainers:
+        {{- with .Values.singleBinary.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: single-binary
           image: {{ include "loki.image" . }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -54,6 +54,12 @@ spec:
       securityContext:
         {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.write.terminationGracePeriodSeconds }}
+      {{- if .Values.write.initContainers }}
+      initContainers:
+        {{- with .Values.write.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: write
           image: {{ include "loki.image" . }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -674,6 +674,8 @@ write:
   extraEnvFrom: []
   # -- Lifecycle for the write container
   lifecycle: {}
+  # -- Init containers to add to the write pods
+  initContainers: []
   # -- Volume mounts to add to the write pods
   extraVolumeMounts: []
   # -- Volumes to add to the write pods
@@ -875,6 +877,8 @@ backend:
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the backend pods
   extraEnvFrom: []
+  # -- Init containers to add to the backend pods
+  initContainers: []
   # -- Volume mounts to add to the backend pods
   extraVolumeMounts: []
   # -- Volumes to add to the backend pods
@@ -950,6 +954,8 @@ singleBinary:
   extraEnv: []
   # -- Environment variables from secrets or configmaps to add to the single binary pods
   extraEnvFrom: []
+  # -- Init containers to add to the single binary pods
+  initContainers: []
   # -- Volume mounts to add to the single binary pods
   extraVolumeMounts: []
   # -- Volumes to add to the single binary pods


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the possibility to add initContainers to  write, backend and singleBinary's stateful set. 

This was required for us to initialize the volume with appropriate access modes. We use Amazon EFS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**
- [x ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
