### PR TITLE
Match version flag using regex

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -38,11 +39,13 @@ type ConfigWrapper struct {
 }
 
 func PrintVersion(args []string) bool {
-	var printVersion bool
-	f := flag.NewFlagSet("version parsing", flag.ContinueOnError)
-	f.BoolVar(&printVersion, versionFlag, false, "Print this builds version information")
-	_ = f.Parse(args)
-	return printVersion
+	pattern := regexp.MustCompile(`^-+` + versionFlag + `$`)
+	for _, a := range args {
+		if pattern.MatchString(a) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *ConfigWrapper) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
Using the flag parser results in a confusing message being printed

```
flag provided but not defined: -config.file
Usage of version parsing:
  -version
        Print this builds version information
```

**What this PR does / why we need it**:
Corrects a minor bug introduced by #8199
