### PR TITLE
Do not exit when using `stream_lag_labels` setting

### DIFF
--- a/clients/cmd/promtail/main.go
+++ b/clients/cmd/promtail/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"reflect"
 	"sync"
-
 	// embed time zone data
 	_ "time/tzdata"
 
@@ -153,8 +152,7 @@ func main() {
 
 	clientMetrics := client.NewMetrics(prometheus.DefaultRegisterer)
 	if config.Options.StreamLagLabels.String() != "" {
-		level.Error(util_log.Logger).Log("msg", "client config stream_lag_labels is deprecated and the associated metric has been removed", "stream_lag_labels", config.Options.StreamLagLabels.String())
-		os.Exit(1)
+		level.Warn(util_log.Logger).Log("msg", "the stream_lag_labels setting is deprecated and the associated metric has been removed", "stream_lag_labels", config.Options.StreamLagLabels.String())
 	}
 	newConfigFunc := func() (*promtail_config.Config, error) {
 		mtx.Lock()

--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -44,8 +44,7 @@ type Config struct {
 	// prevent HOL blocking in multitenant deployments.
 	DropRateLimitedBatches bool `yaml:"drop_rate_limited_batches"`
 
-	// deprecated use StreamLagLabels from config.Config instead
-	StreamLagLabels flagext.StringSliceCSV `yaml:"stream_lag_labels"`
+	StreamLagLabels flagext.StringSliceCSV `yaml:"stream_lag_labels" doc:"deprecated"`
 }
 
 // RegisterFlags with prefix registers flags where every name is prefixed by

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -24,7 +24,7 @@ import (
 
 // Options contains cross-cutting promtail configurations
 type Options struct {
-	StreamLagLabels dskit_flagext.StringSliceCSV `mapstructure:"stream_lag_labels,omitempty" yaml:"stream_lag_labels,omitempty"`
+	StreamLagLabels dskit_flagext.StringSliceCSV `mapstructure:"stream_lag_labels,omitempty" yaml:"stream_lag_labels,omitempty" doc:"deprecated"`
 }
 
 // Config for promtail, describing what files to watch.

--- a/clients/pkg/promtail/config/config_test.go
+++ b/clients/pkg/promtail/config/config_test.go
@@ -37,8 +37,6 @@ scrape_configs:
 limits_config:
   readline_rate: 100
   readline_burst: 200
-options:
-  stream_lag_labels: foo
 `
 
 func Test_Load(t *testing.T) {

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1960,6 +1960,7 @@ sync_period: "10s"
 ## options_config
 
 ```yaml
+# Deprecated.
 # A comma-separated list of labels to include in the stream lag metric
 # `promtail_stream_lag_seconds`. The default value is "filename". A "host" label is
 # always included. The stream lag metric indicates which streams are falling behind

--- a/tools/kafka/README.md
+++ b/tools/kafka/README.md
@@ -98,7 +98,6 @@ backoff_config:
   max_retries: 10
 timeout: 10s
 tenant_id: ""
-stream_lag_labels: filename
 
 level=info ts=2021-11-02T10:44:14.137894Z caller=server.go:260 http=[::]:9080 grpc=[::]:59237 msg="server listening on addresses"
 level=info ts=2021-11-02T10:44:14.138059Z caller=main.go:119 msg="Starting Promtail" version="(version=, branch=, revision=)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for more graceful degredation when using deprecated `stream_lag_labels` setting.
Also removed hanging references to the setting.