### PR TITLE
Loki: Log hashed queries emitted by `metrics.go`

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -203,10 +203,11 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	log, ctx := spanlogger.New(ctx, "query.Exec")
 	defer log.Finish()
 
+	queryHash := hashedQuery(q.params.Query())
 	if GetRangeType(q.params) == InstantType {
-		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query())
+		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query(), "query_hash", queryHash)
 	} else {
-		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step())
+		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step(), "query_hash", queryHash)
 	}
 
 	rangeType := GetRangeType(q.params)

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -1,10 +1,12 @@
 package logql
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -2477,6 +2479,73 @@ func benchmarkRangeQuery(testsize int64, b *testing.B) {
 				b.Fatal("unexpected nil result")
 			}
 		}
+	}
+}
+
+// TestHashingStability tests logging stability between engine and RecordRangeAndInstantQueryMetrics methods.
+func TestHashingStability(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "fake")
+	params := LiteralParams{
+		start:     time.Unix(0, 0),
+		end:       time.Unix(5, 0),
+		step:      60 * time.Second,
+		direction: logproto.FORWARD,
+		limit:     1000,
+	}
+
+	queryWithEngine := func() string {
+		buf := bytes.NewBufferString("")
+		logger := log.NewLogfmtLogger(buf)
+		eng := NewEngine(EngineOpts{}, getLocalQuerier(4), NoLimits, logger)
+		query := eng.Query(params)
+		_, err := query.Exec(ctx)
+		require.NoError(t, err)
+		return buf.String()
+	}
+
+	queryDirectly := func() string {
+		statsResult := stats.Result{
+			Summary: stats.Summary{
+				BytesProcessedPerSecond: 100000,
+				QueueTime:               0.000000002,
+				ExecTime:                25.25,
+				TotalBytesProcessed:     100000,
+				TotalEntriesReturned:    10,
+			},
+		}
+		buf := bytes.NewBufferString("")
+		logger := log.NewLogfmtLogger(buf)
+		RecordRangeAndInstantQueryMetrics(ctx, logger, params, "200", statsResult, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
+		return buf.String()
+	}
+
+	for _, test := range []struct {
+		qs string
+	}{
+		{`sum by(query_hash) (count_over_time({app="myapp",env="myenv"} |= "error" |= "metrics.go" | logfmt [10s]))`},
+		{`sum (count_over_time({app="myapp",env="myenv"} |= "error" |= "metrics.go" | logfmt [10s])) by(query_hash)`},
+	} {
+		params.qs = test.qs
+		expectedQueryHash := hashedQuery(test.qs)
+
+		// check that both places will end up having the same query hash, even though they're emitting different log lines.
+		require.Regexp(t,
+			regexp.MustCompile(
+				fmt.Sprintf(
+					`level=info org_id=fake msg="executing query" type=range query=.* length=5s step=1m0s query_hash=%d.*`, expectedQueryHash,
+				),
+			),
+			queryWithEngine(),
+		)
+
+		require.Regexp(t,
+			regexp.MustCompile(
+				fmt.Sprintf(
+					`level=info org_id=fake latency=slow query=".*" query_hash=%d query_type=metric range_type=range.*\n`, expectedQueryHash,
+				),
+			),
+			queryDirectly(),
+		)
 	}
 }
 

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -2,6 +2,7 @@ package logql
 
 import (
 	"context"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -108,11 +109,12 @@ func RecordRangeAndInstantQueryMetrics(
 
 	queryTags, _ := ctx.Value(httpreq.QueryTagsHTTPHeader).(string) // it's ok to be empty.
 
-	logValues := make([]interface{}, 0, 20)
+	logValues := make([]interface{}, 0, 21)
 
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.
 		"query", p.Query(),
+		"query_hash", hashedQuery(p.Query()),
 		"query_type", queryType,
 		"range_type", rt,
 		"length", p.End().Sub(p.Start()),
@@ -160,6 +162,12 @@ func RecordRangeAndInstantQueryMetrics(
 	ingesterLineTotal.Add(float64(stats.Ingester.TotalLinesSent))
 
 	recordUsageStats(queryType, stats)
+}
+
+func hashedQuery(query string) uint32 {
+	h := fnv.New32()
+	_, _ = h.Write([]byte(query))
+	return h.Sum32()
 }
 
 func RecordLabelQueryMetrics(

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -109,7 +109,7 @@ func RecordRangeAndInstantQueryMetrics(
 
 	queryTags, _ := ctx.Value(httpreq.QueryTagsHTTPHeader).(string) // it's ok to be empty.
 
-	logValues := make([]interface{}, 0, 21)
+	logValues := make([]interface{}, 0, 30)
 
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -191,7 +191,9 @@ func Test_testToKeyValues(t *testing.T) {
 func TestQueryHashing(t *testing.T) {
 	h1 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
 	h2 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
+	// check that it capture differences of order.
 	require.NotEqual(t, h1, h2)
 	h3 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	// check that it evaluate same queries as same hashes, even if evaluated at different timestamps.
 	require.Equal(t, h1, h3)
 }

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -85,7 +85,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Regexp(t,
 		regexp.MustCompile(fmt.Sprintf(
-			`level=info org_id=foo traceID=%s latency=slow query=".*" query_type=filter range_type=range length=1h0m0s .*\n`,
+			`level=info org_id=foo traceID=%s latency=slow query=".*" query_hash=.* query_type=filter range_type=range length=1h0m0s .*\n`,
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		)),
 		buf.String())
@@ -186,4 +186,12 @@ func Test_testToKeyValues(t *testing.T) {
 			assert.Equal(t, c.exp, got)
 		})
 	}
+}
+
+func TestQueryHashing(t *testing.T) {
+	h1 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	h2 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
+	require.NotEqual(t, h1, h2)
+	h3 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	require.Equal(t, h1, h3)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a new `query_hash` label pair to queries logged by `metrics.go`. As the name suggests, `query_hash` is just the hashed version of the query being logged.
  - Especially useful when grouping results/behavior of different queries. Ex, you can easily find specific query patterns with `sum by(query_hash)` .

Ex:
```
level=info ts=2023-01-23T14:45:52.743780661Z caller=metrics.go:149 component=frontend org_id=fake latency=fast query="{stream=\"stdout\",pod=\"loki-canary-abcde\"}" query_hash=1360642565 query_type=limited range_type=range length=20s start_delta=58m27.642790018s end_delta=58m7.64279027s step=1s duration=4.761564089s status=200 limit=1000 returned_lines=0 throughput=78kB total_bytes=369kB total_entries=41 store_chunks_download_time=3.037076ms queue_time=1m5.039459998s subqueries=18 cache_chunk_req=3 cache_chunk_hit=3 cache_chunk_bytes_stored=0 cache_chunk_bytes_fetched=2881268 cache_chunk_download_time=2.49811ms cache_index_req=33 cache_index_hit=33 cache_index_download_time=61.548315ms cache_result_req=1 cache_result_hit=0 cache_result_download_time=217.84µs
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
