### PR TITLE
logs more metadata when failing to recover head from WAL in TSDB

### DIFF
--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -524,11 +524,11 @@ func recoverHead(dir string, heads *tenantHeads, wals []WALIdentifier) error {
 				if len(rec.Chks.Chks) > 0 {
 					tenant, ok := seriesMap[rec.UserID]
 					if !ok {
-						return errors.New("found tsdb chunk metas without user in WAL replay")
+						return fmt.Errorf("found tsdb chunk metas without user in WAL replay (period=%s): %+v", id.String(), *rec)
 					}
 					x, ok := tenant[rec.Chks.Ref]
 					if !ok {
-						return errors.New("found tsdb chunk metas without series in WAL replay")
+						return fmt.Errorf("found tsdb chunk metas without series in WAL replay (period=%s): %+v", id.String(), *rec)
 					}
 					_ = heads.Append(rec.UserID, x.ls, x.fp, rec.Chks.Chks)
 				}
@@ -547,6 +547,10 @@ func recoverHead(dir string, heads *tenantHeads, wals []WALIdentifier) error {
 
 type WALIdentifier struct {
 	ts time.Time
+}
+
+func (w WALIdentifier) String() string {
+	return fmt.Sprint(w.ts.Unix())
 }
 
 func parseWALPath(p string) (id WALIdentifier, ok bool) {


### PR DESCRIPTION
Ran into this in a set of confusing circumstances. I haven't figured out the cause yet, so I'm adding some extra logging to get further next time I see it.