### PR TITLE
Only print logger error when required

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -169,8 +169,9 @@ func CheckFatal(location string, err error, logger log.Logger) {
 	fmt.Fprintln(os.Stderr, errStr)
 
 	logger.Log("err", errStr)
-	err = Flush()
-	fmt.Fprintln(os.Stderr, "Could not flush logger", err)
+	if err = Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "Could not flush logger", err)
+	}
 	os.Exit(1)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a slight clarity regression in https://github.com/grafana/loki/pull/7924/files

The warning about the logger being unable to flush would be logged regardless of whether there was an error or not.