### PR TITLE
Helm: ensure valid label values when version has digest

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.0
-version: 4.4.0
+version: 4.4.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix this:
```console
$ helm install loki grafana/loki \
  --set loki.image.tag=2.7.1@sha256:d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb61606b42a8d41a557
ServiceAccount "loki" is invalid: [
  metadata.labels: Invalid value: "2.7.1@sha256:d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb61606b42a8d41a557": must be no more than 63 characters,
  metadata.labels: Invalid value: "2.7.1@sha256:d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb61606b42a8d41a557": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
],
Service "loki" is invalid: [
  metadata.labels: Invalid value: "2.7.1@sha256:d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb61606b42a8d41a557": must be no more than 63 characters,
  metadata.labels: Invalid value: "2.7.1@sha256:d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb61606b42a8d41a557": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
],
[...]
```

To ensure it is allowed, and leads to:

```yaml    
      app.kubernetes.io/version: "2.7.1-sha256-d69f377ecfdbb3f72086a180dcd7c2f02c795cf1867bbeb616"
```

See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

(see also https://gitlab.com/kubitus-project/kubitus-installer/-/jobs/3649809256)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
