### PR TITLE
fix remaining docs issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,7 +760,7 @@ validate-example-configs: loki
 generate-example-config-doc:
 	echo "Removing existing doc at loki/docs/configuration/examples.md and re-generating. . ."
 	# Title and Heading
-	echo -e "---\ntitle: Examples\n---\n # Loki Configuration Examples" > ./docs/sources/configuration/examples.md
+	echo -e "---\ntitle: Examples\ndescription: Loki Configuration Examples\n---\n # Examples" > ./docs/sources/configuration/examples.md
 	# Append each configuration and its file name to examples.md
 	for f in ./docs/sources/configuration/examples/*.yaml; do echo -e "\n## $$(basename $$f)\n\n\`\`\`yaml\n$$(cat $$f)\n\`\`\`\n" >> ./docs/sources/configuration/examples.md; done
 

--- a/docs/sources/configuration/examples.md
+++ b/docs/sources/configuration/examples.md
@@ -1,7 +1,8 @@
 ---
 title: Examples
+description: Loki Configuration Examples
 ---
- # Loki Configuration Examples
+ # Examples
 
 ## almost-zero-dependency.yaml
 

--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -75,7 +75,7 @@ We've added a user per-tenant limit called `tsdb_max_query_parallelism` in the `
 
 ### Dynamic Query Sharding
 
-Previously we would statically shard queries based on the index row shards configured [here]({{< relref "../../configuration/_index#period_config" >}}).
+Previously we would statically shard queries based on the index row shards configured [here]({{< relref "../../configuration/#period_config" >}}).
 TSDB does Dynamic Query Sharding based on how much data a query is going to be processing.
 We additionally store size(KB) and number of lines for each chunk in the TSDB index which is then used by the [Query Frontend]({{< relref "../../fundamentals/architecture/components#query-frontend" >}}) for planning the query.
 Based on our experience from operating many Loki clusters, we have configured TSDB to aim for processing 300-600 MBs of data per query shard.
@@ -83,4 +83,4 @@ This means with TSDB we will be running more, smaller queries.
 
 ### Index Caching not required
 
-TSDB is a compact and optimized format. Loki does not currently use an index cache for TSDB. If you are already using Loki with other index types, it is recommended to keep the index caching until all of your existing data falls out of [retention]({{< relref "./retention" >}}) or your configured `max_query_lookback` under [limits_config]({{< relref "../../configuration/_index#limits_config" >}}). After that, we suggest running without an index cache (it isn't used in TSDB).
+TSDB is a compact and optimized format. Loki does not currently use an index cache for TSDB. If you are already using Loki with other index types, it is recommended to keep the index caching until all of your existing data falls out of [retention]({{< relref "./retention" >}}) or your configured `max_query_lookback` under [limits_config]({{< relref "../../configuration/#limits_config" >}}). After that, we suggest running without an index cache (it isn't used in TSDB).


### PR DESCRIPTION
Turns out the `docs-validator` doesn't do an entire check of the docs. This PR fixes some build issues and some additional linting issues.
