### PR TITLE
Promtail: GCP PubSub retry receive in the event of an error

### DIFF
--- a/clients/pkg/promtail/targets/gcplog/pull_target.go
+++ b/clients/pkg/promtail/targets/gcplog/pull_target.go
@@ -89,6 +89,7 @@ func (t *pullTarget) run() error {
 	sub := t.ps.SubscriptionInProject(t.config.Subscription, t.config.ProjectID)
 	go func() {
 		for {
+			level.Info(t.logger).Log("msg", "connecting and listening for messages")
 			err := sub.Receive(t.ctx, func(ctx context.Context, m *pubsub.Message) {
 				t.msgs <- m
 			})
@@ -102,6 +103,7 @@ func (t *pullTarget) run() error {
 				t.metrics.gcplogErrors.WithLabelValues(t.config.ProjectID).Inc()
 				t.metrics.gcplogTargetLastSuccessScrape.WithLabelValues(t.config.ProjectID, t.config.Subscription).SetToCurrentTime()
 			}
+			// Arbitrary but I don't think we want to retry in a tight loop.
 			time.Sleep(5 * time.Second)
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Edward Welch <edward.welch@grafana.com>

**What this PR does / why we need it**:

It looks like if there is an error receiving from pubsub we would exit the receive goroutine and no longer retry messages, this PR should address this.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
