### PR TITLE
operator: Use gRPC instead of http for compactor communications

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8265](https://github.com/grafana/loki/pull/8265) **Red-GV**: Use gRPC compactor service instead of http for retention
 - [8038](https://github.com/grafana/loki/pull/8038) **aminesnow**: Add watch on the Alertmanager in OCP's user-workload-monitoring namespace
 - [8173](https://github.com/grafana/loki/pull/8173) **periklis**: Remove custom webhook cert mounts for OLM-based deployment (OpenShift)
 - [8001](https://github.com/grafana/loki/pull/8001) **aminesnow**: Add API validation to Alertmanager header auth config

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -137,9 +137,8 @@ func ConfigOptions(opt Options) config.Options {
 		Namespace: opt.Namespace,
 		Name:      opt.Name,
 		Compactor: config.Address{
-			FQDN:     fqdn(NewCompactorHTTPService(opt).GetName(), opt.Namespace),
-			Port:     httpPort,
-			Protocol: protocol,
+			FQDN: fqdn(NewCompactorGRPCService(opt).GetName(), opt.Namespace),
+			Port: grpcPort,
 		},
 		FrontendWorker: config.Address{
 			FQDN: fqdn(NewQueryFrontendGRPCService(opt).GetName(), opt.Namespace),

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -28,7 +28,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -194,9 +194,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -265,7 +264,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -462,9 +461,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -537,9 +535,8 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -607,7 +604,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -827,9 +824,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -945,7 +941,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1165,9 +1161,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -1284,7 +1279,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1517,9 +1512,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -1653,7 +1647,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1910,9 +1904,8 @@ overrides:
 			Port: 9095,
 		},
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		StorageDirectory: "/tmp/loki",
 		MaxConcurrent: MaxConcurrent{
@@ -1967,7 +1960,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -2213,9 +2206,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -2366,7 +2358,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -2621,9 +2613,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -2692,7 +2683,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -2966,9 +2957,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -45,7 +45,7 @@ common:
       region_name: {{ .Region }}
       container_name: {{ .Container }}
     {{- end }}
-  compactor_address: {{ .Compactor.Protocol }}://{{ .Compactor.FQDN }}:{{ .Compactor.Port }}
+  compactor_grpc_address: {{ .Compactor.FQDN }}:{{ .Compactor.Port }}
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the Loki configuration to use the gRPC service for the compactor instead of the HTTP one. In doing so, this mitigates an issue where the compactor and querier have TLS handshake errors when retention is active.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
