### PR TITLE
Update rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

### DIFF
--- a/tools/helm.yaml
+++ b/tools/helm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helm
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: helm


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole

Signed-off-by: Anton Patsev <patsev.anton@gmail.com>

Which of these should I fill out in this PR ?

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
