### PR TITLE
logql: Support `urlencode` and `urldecode` template functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [8061](https://github.com/grafana/loki/pull/8061) **kavirajk**: Remove circle from Loki OSS
 * [8131](https://github.com/grafana/loki/pull/8131) **jeschkies**: Compile Promtail ARM and ARM64 with journald support.
 * [8212](https://github.com/grafana/loki/pull/8212) **kavirajk**: ingester: Add `ingester_memory_streams_labels_bytes metric` for more visibility of size of metadata of in-memory streams.
+* [8271](https://github.com/grafana/loki/pull/8271) **kavirajk**: logql: Support urlencode and urldecode template functions
 
 ##### Fixes
 

--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -716,3 +716,33 @@ Example of a query to print how many times XYZ occurs in a line:
 ```logql
 {job="xyzlog"} | line_format `{{ __line__ | count "XYZ"}}`
 ```
+
+## urlencode
+
+Use this function to encode the URL(s) in log messages.
+
+Signature:
+
+`urlencode(string) string`
+
+Examples:
+
+```template
+"{{ .request_url | urlencode }}"
+`{{ urlencode  .request_url}}`
+```
+
+## urldecode
+
+Use this function to decode the URL(s) in log messages.
+
+Signature:
+
+`urldecode(string) string`
+
+Examples:
+
+```template
+"{{ .request_url | urldecode }}"
+`{{ urldecode  .request_url}}`
+```

--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"strings"
 	"text/template"
 	"text/template/parse"
@@ -57,6 +58,8 @@ var (
 			matches := r.FindAllStringIndex(s, -1)
 			return len(matches), nil
 		},
+		"urldecode": url.QueryUnescape,
+		"urlencode": url.QueryEscape,
 	}
 
 	// sprig template functions

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -112,6 +112,28 @@ func Test_lineFormatter_Format(t *testing.T) {
 			nil,
 		},
 		{
+			"urlencode",
+			newMustLineFormatter(`{{.foo | urlencode }} {{ urlencode .foo }}`), // assert both syntax forms
+			labels.Labels{
+				{Name: "foo", Value: `/loki/api/v1/query?query=sum(count_over_time({stream_filter="some_stream",environment="prod", host=~"someec2.*"}`},
+			},
+			0,
+			[]byte("%2Floki%2Fapi%2Fv1%2Fquery%3Fquery%3Dsum%28count_over_time%28%7Bstream_filter%3D%22some_stream%22%2Cenvironment%3D%22prod%22%2C+host%3D~%22someec2.%2A%22%7D %2Floki%2Fapi%2Fv1%2Fquery%3Fquery%3Dsum%28count_over_time%28%7Bstream_filter%3D%22some_stream%22%2Cenvironment%3D%22prod%22%2C+host%3D~%22someec2.%2A%22%7D"),
+			labels.Labels{{Name: "foo", Value: `/loki/api/v1/query?query=sum(count_over_time({stream_filter="some_stream",environment="prod", host=~"someec2.*"}`}},
+			nil,
+		},
+		{
+			"urldecode",
+			newMustLineFormatter(`{{.foo | urldecode }} {{ urldecode .foo }}`), // assert both syntax forms
+			labels.Labels{
+				{Name: "foo", Value: `%2Floki%2Fapi%2Fv1%2Fquery%3Fquery%3Dsum%28count_over_time%28%7Bstream_filter%3D%22some_stream%22%2Cenvironment%3D%22prod%22%2C+host%3D~%22someec2.%2A%22%7D`},
+			},
+			0,
+			[]byte(`/loki/api/v1/query?query=sum(count_over_time({stream_filter="some_stream",environment="prod", host=~"someec2.*"} /loki/api/v1/query?query=sum(count_over_time({stream_filter="some_stream",environment="prod", host=~"someec2.*"}`),
+			labels.Labels{{Name: "foo", Value: `%2Floki%2Fapi%2Fv1%2Fquery%3Fquery%3Dsum%28count_over_time%28%7Bstream_filter%3D%22some_stream%22%2Cenvironment%3D%22prod%22%2C+host%3D~%22someec2.%2A%22%7D`}},
+			nil,
+		},
+		{
 			"repeat",
 			newMustLineFormatter(`{{ "foo" | repeat 3 }}`),
 			labels.Labels{{Name: "foo", Value: "BLIp"}, {Name: "bar", Value: "blop"}},


### PR DESCRIPTION
Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

**What this PR does / why we need it**:
Usage:
1. {{.foo | urlencode }} {{ urlencode .foo }}
2. {{.foo | urldecode }} {{ urldecode .foo }}

Example:
1. {instance="loki"} |= "routes" | logfmt | {{ .url | urldecode}}

**Which issue(s) this PR fixes**:
Fixes #8220 

**Special notes for your reviewer**:
**NOTE** some tools or languages treats `/` as safe and will not encode it. But Go encode including character `/`. 

e.g: 
encoding '/loki' will return following in Go
```bash
go-play$ head main.go 
package main

import (
	"fmt"
	"net/url"
)

func main() {
	fmt.Println(url.QueryEscape("/loki"))
}
go-play$ go run main.go 
%2Floki

```

But return following in Python
```bash
In [9]: import urllib.parse

In [10]: urllib.parse.quote('/loki')
Out[10]: '/loki'

In [11]: urllib.parse.quote('/loki', safe='')
Out[11]: '%2Floki'

In [12]: 

```

But while decoding, Go accepts both as valid.
```bash
go-play$ head -n 11 main.go 
package main

import (
	"fmt"
	"net/url"
)

func main() {
	fmt.Println(url.QueryUnescape("/loki"))
	fmt.Println(url.QueryUnescape("%2Floki"))
}
go-play$ go run main.go 
/loki <nil>
/loki <nil>

```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
