### PR TITLE
Remove creationTimestamp: null

### DIFF
--- a/operator/bundle/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operator/bundle/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operator/bundle/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operator/bundle/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki.grafana.com_alertingrules.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_alertingrules.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki.grafana.com_recordingrules.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_recordingrules.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/bundle/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager

--- a/operator/config/crd/bases/config.grafana.com_projectconfigs.yaml
+++ b/operator/config/crd/bases/config.grafana.com_projectconfigs.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
   name: projectconfigs.config.grafana.com
 spec:
   group: config.grafana.com

--- a/operator/config/crd/bases/loki.grafana.com_alertingrules.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_alertingrules.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: alertingrules.loki.grafana.com
 spec:
   group: loki.grafana.com

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: lokistacks.loki.grafana.com
 spec:
   group: loki.grafana.com

--- a/operator/config/crd/bases/loki.grafana.com_recordingrules.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_recordingrules.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: recordingrules.loki.grafana.com
 spec:
   group: loki.grafana.com

--- a/operator/config/crd/bases/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_rulerconfigs.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: rulerconfigs.loki.grafana.com
 spec:
   group: loki.grafana.com

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: lokistack-manager
 rules:
 - nonResourceURLs:

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/tools/helm.yaml
+++ b/tools/helm.yaml
@@ -20,7 +20,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: cluster-admin
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"


### PR DESCRIPTION
CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L179

Signed-off-by: Anton Patsev <patsev.anton@gmail.com>

Which of these should I fill out in this PR ?
Should i change version operator?

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
