### PR TITLE
Test docs build on PRs

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -551,6 +551,15 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       make('check-doc', container=false) { depends_on: ['loki'] },
       make('validate-example-configs', container=false) { depends_on: ['loki'] },
       make('check-example-config-doc', container=false) { depends_on: ['clone'] },
+      {
+        name: 'build-docs-website',
+        image: 'grafana/docs-base:latest',
+        commands: [
+          'mkdir -p /hugo/content/docs/loki/latest',
+          'cp -r docs/sources/* /hugo/content/docs/loki/latest/',
+          'cd /hugo && make prod',
+        ],
+      },
     ],
   },
   pipeline('mixins') {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -210,6 +210,12 @@ steps:
   environment: {}
   image: grafana/loki-build-image:0.27.0
   name: check-example-config-doc
+- commands:
+  - mkdir -p /hugo/content/docs/loki/latest
+  - cp -r docs/sources/* /hugo/content/docs/loki/latest/
+  - cd /hugo && make prod
+  image: grafana/docs-base:latest
+  name: build-docs-website
 trigger:
   ref:
   - refs/heads/main
@@ -1667,6 +1673,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 58239f4ad12c6f5089ab3582f4086a6be2c3131778b71ddba9721b21fa03ce00
+hmac: b1c1f36ef727847ed4dc88f4b5fa2315545b55e524c10a5baa99baa155e58366
 
 ...


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**What this PR does / why we need it**:

Prevents merging PRs that have broken Hugo builds. Broken Hugo builds are not published to the grafana/website repository by the `publish-technical-documentation-*` workflows.