### PR TITLE
Backport #8278 and #8279 (update Go version to 1.19.5)

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.24.2',
+    local build_image_tag = '0.27.1',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: check-generated-files
 - commands:
   - cd ..
@@ -109,7 +109,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: clone-main
 - commands:
   - make BUILD_IN_CONTAINER=false test
@@ -117,7 +117,7 @@ steps:
   - clone
   - clone-main
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: test
 - commands:
   - cd ../loki-main
@@ -125,7 +125,7 @@ steps:
   depends_on:
   - clone-main
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: test-main
 - commands:
   - make BUILD_IN_CONTAINER=false compare-coverage old=../loki-main/test_results.txt
@@ -135,7 +135,7 @@ steps:
   - test
   - test-main
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: compare-coverage
 - commands:
   - pull=$(echo $CI_COMMIT_REF | awk -F '/' '{print $3}')
@@ -148,7 +148,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: report-coverage
 - commands:
   - make BUILD_IN_CONTAINER=false lint
@@ -156,7 +156,7 @@ steps:
   - clone
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -165,7 +165,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -177,21 +177,21 @@ steps:
   - clone
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: check-example-config-doc
 trigger:
   ref:
@@ -218,7 +218,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: loki-mixin-check
 trigger:
   ref:
@@ -238,7 +238,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1325,7 +1325,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1333,7 +1333,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1359,7 +1359,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.24.2
+  image: grafana/loki-build-image:0.27.1
   name: publish
   when:
     event:
@@ -1598,6 +1598,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: c7435abd18c3fd3d444abb1932041df8fa463bb3de99de7c4b757c0ca9d3fa38
+hmac: 005e039eade09df9d73ab4e65d06e173a12cfb3ebb591da0913543e7110459b2
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.24.2
+    - 0.27.1
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.24.2
+    - 0.27.1
     username:
       from_secret: docker_username
   when:
@@ -1598,6 +1598,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 10a927057c7db78c0bdc2085b7b0c66e4f187c4939dbd13e304957bf03acc917
+hmac: c7435abd18c3fd3d444abb1932041df8fa463bb3de99de7c4b757c0ca9d3fa38
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.24.2
+BUILD_IMAGE_VERSION := 0.27.1
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-bullseye as build
+FROM golang:1.19.5-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-bullseye as build
+FROM golang:1.19.5-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .
-FROM golang:1.19.2-alpine as goenv
+FROM golang:1.19.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image as build
+FROM grafana/loki-build-image:0.27.1 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.19.2-alpine as goenv
+FROM golang:1.19.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:1.19.2-alpine as goenv
+FROM golang:1.19.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
 
-FROM grafana/loki-build-image as build
+FROM grafana/loki-build-image:0.27.1 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.5 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.19.2-alpine as goenv
+FROM golang:1.19.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.19.2 as helm
+FROM golang:1.19.5 as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.19.2 as drone
+FROM golang:1.19.5 as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,28 +47,32 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 #	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.19.2 as faillint
-RUN GO111MODULE=on go install github.com/fatih/faillint@v1.10.0
+FROM golang:1.19.5 as faillint
+RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
-FROM golang:1.19.2 as delve
-RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@v1.7.3
+FROM golang:1.19.5 as delve
+RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.19.2 as ghr
+FROM golang:1.19.5 as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.19.2 as nfpm
+FROM golang:1.19.5 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
+# Install gotestsum
+FROM golang:1.19.5 as gotestsum
+RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
+
 # Install tools used to compile jsonnet.
-FROM golang:1.19.2 as jsonnet
+FROM golang:1.19.5 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.19.2-buster
+FROM golang:1.19.5-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.24.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.27.1
 
 FROM golang:1.19.1-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# The BSD version of the sed command in MacOS doesn't work with this script.
+# Please install gnu-sed via `brew install gnu-sed`.
+# The gsed command becomes available then.
+SED="sed"
+if command -v gsed &> /dev/null ; then
+  echo "Using gsed"
+  SED="gsed"
+fi
+
+VERSION="${1-}"
+if [[ -z "${VERSION}" ]]; then
+  >&2 echo "Usage: $0 <version>"
+  exit 1
+fi
+
+echo "Updating golang base images to '${VERSION}'"
+
+find cmd clients tools loki-build-image -type f -name 'Dockerfile*' -exec grep -lE "FROM golang:[0-9\.]+" {} \; |
+  while read -r x; do
+    echo "Updating ${x}"
+    ${SED} -i -re "s,golang:[0-9\.]+,golang:${VERSION},g" "${x}"
+  done
+
+echo "Don't forget to update the sha156 hash in clients/cmd/fluent-bit/Dockerfile."

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -25,4 +25,4 @@ find cmd clients tools loki-build-image -type f -name 'Dockerfile*' -exec grep -
     ${SED} -i -re "s,golang:[0-9\.]+,golang:${VERSION},g" "${x}"
   done
 
-echo "Don't forget to update the sha156 hash in clients/cmd/fluent-bit/Dockerfile."
+echo "Don't forget to update the sha256 hash in clients/cmd/fluent-bit/Dockerfile."

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-alpine AS build-image
+FROM golang:1.19.5-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a combined backport of #8278 and #8279. When done against `main`, updating the Go version and therefore also the Loki build image is a two-step process. However, when backporting this the two PRs against `main` can be combined into a single step, because the new version of the build image is already built and available.
