### PR TITLE
[helm] Single binary object storage

### DIFF
--- a/docs/sources/installation/helm/install-monolithic/index.md
+++ b/docs/sources/installation/helm/install-monolithic/index.md
@@ -12,9 +12,7 @@ keywords: []
 
 This Helm Chart installation runs the Grafana Loki *single binary* within a Kubernetes cluster.
 
-If the storage type is set to `filesystem`, this chart configures Loki to run the `all` target in a [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode">}}), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
-
-It is not possible to install the single binary with a different storage type.
+If the `singleBinary.replicas` value is set to something greater than 0, it will configure Loki to run the `all` target in a [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode">}}), designed to work with a filesystem storage. If using just 1 replica, this *single binary* deployment will be configured to use object storage. If you would like to run *single binary* in a replicated, highly available mode, you must supply an object storage configuration and set `singleBinary.replicas` to a value greater than or equal to 2.
 
 **Before you begin: Software Requirements**
 
@@ -35,9 +33,9 @@ It is not possible to install the single binary with a different storage type.
     helm repo update
     ```
 
-1. Configure the `filesystem` storage:
+1. Create the configuration file `values.yaml`:
 
-    - Create the configuration file `values.yaml`:
+    - If running a single replica of Loki, configure the `filesystem` storage:
 
       ```yaml
       loki:
@@ -45,6 +43,25 @@ It is not possible to install the single binary with a different storage type.
           replication_factor: 1
         storage:
           type: 'filesystem'
+      singleBinary:
+        replicas: 1
+      ```
+
+    - If running Loki with a replication factor greater than 1, set the desired number replicas and provide object storage credentials:
+
+      ```yaml
+      loki:
+        commonConfig:
+          replication_factor: 3
+        storage:
+          type: 's3'
+          s3:
+            endpoint: foo.aws.com
+            bucketnames: loki-chunks
+            secret_access_key: supersecret
+            access_key_id: secret
+      singleBinary:
+        replicas: 3
       ```
 
 1. Deploy the Loki cluster using one of these commands.
@@ -58,5 +75,5 @@ It is not possible to install the single binary with a different storage type.
     - Deploy with the defined configuration in a custom Kubernetes cluster namespace:
 
         ```bash
-        helm install --values values.yaml loki --namespace=loki grafana/loki-simple-scalable
+        helm install --values values.yaml loki --namespace=loki grafana/loki
         ```

--- a/docs/sources/installation/helm/install-monolithic/index.md
+++ b/docs/sources/installation/helm/install-monolithic/index.md
@@ -12,7 +12,8 @@ keywords: []
 
 This Helm Chart installation runs the Grafana Loki *single binary* within a Kubernetes cluster.
 
-If the `singleBinary.replicas` value is set to something greater than 0, it will configure Loki to run the `all` target in a [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode">}}), designed to work with a filesystem storage. If using just 1 replica, this *single binary* deployment will be configured to use object storage. If you would like to run *single binary* in a replicated, highly available mode, you must supply an object storage configuration and set `singleBinary.replicas` to a value greater than or equal to 2.
+If you set the `singleBinary.replicas` value to 1, this chart configures Loki to run the `all` target in a [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode">}}), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
+If you set the `singleBinary.replicas` value to 2 or more, this chart configures Loki to run a *single binary* in a replicated, highly available mode.  When running replicas of a single binary, you must configure object storage.
 
 **Before you begin: Software Requirements**
 

--- a/docs/sources/installation/helm/monitor-and-alert/index.md
+++ b/docs/sources/installation/helm/monitor-and-alert/index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/installation/helm/monitoring
 weight: 100
 keywords:
-  - monitoring
+  - monitoring 
   - alert
   - alerting
 ---
@@ -17,7 +17,7 @@ By default this Helm Chart configures meta-monitoring of metrics (service monito
 
 The `ServiceMonitor` resource works with either the Prometheus Operator or the Grafana Agent Operator, and defines how Loki's metrics should be scraped. Scraping this Loki cluster using the scrape config defined in the `ServiceMonitor` resource is required for the included dashboards to work. A `MetricsInstance` can be configured to write the metrics to a remote Prometheus instance such as Grafana Cloud Metrics.
 
-_Self monitoring_ is enabled by default. This will deploy a `GrafanaAgent`, `LogsInstance`, and `PodLogs` resource which will instruct the Grafana Agent Operator (installed seperately) on how to scrape this Loki cluster's logs and send them back to itself. Scraping this Loki cluster using the scrape config defined in the `PodLogs` resource is required for the included dashboards to work.
+*Self monitoring* is enabled by default. This will deploy a `GrafanaAgent`, `LogsInstance`, and `PodLogs` resource which will instruct the Grafana Agent Operator (installed seperately) on how to scrape this Loki cluster's logs and send them back to itself. Scraping this Loki cluster using the scrape config defined in the `PodLogs` resource is required for the included dashboards to work.
 
 Rules and alerts are automatically deployed.
 
@@ -26,63 +26,8 @@ Rules and alerts are automatically deployed.
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
 - A running Kubernetes cluster with a running Loki deployment.
 - A running Grafana instance.
-- A running Prometheus Operator installed using the `kube-prometheus-stack` Helm chart.
-
-**Prometheus Operator Prequisites**
-
-The dashboards require certain metric labels to display Kubernetes metrics. The best way to accomplish this is to install the `kube-prometheus-stack` Helm chart with the following values file, replacing `CLUSTER_NAME` with the name of your cluster. The cluster name is what you specify during the helm installation, so a cluster installed with the command `helm install loki-cluster grafana/loki` would be called `loki-cluster`.
-
-```yaml
-kubelet:
-  serviceMonitor:
-    cAdvisorRelabelings:
-      - action: replace
-        replacement: <CLUSTER_NAME>
-        targetLabel: cluster
-      - targetLabel: metrics_path
-        sourceLabels:
-          - "__metrics_path__"
-      - targetLabel: "instance"
-        sourceLabels:
-          - "node"
-
-defaultRules:
-  additionalRuleLabels:
-    cluster: <CLUSTER_NAME>
-
-"kube-state-metrics":
-  prometheus:
-    monitor:
-      relabelings:
-        - action: replace
-          replacement: <CLUSTER_NAME>
-          targetLabel: cluster
-        - targetLabel: "instance"
-          sourceLabels:
-            - "__meta_kubernetes_pod_node_name"
-
-"prometheus-node-exporter":
-  prometheus:
-    monitor:
-      relabelings:
-        - action: replace
-          replacement: <CLUSTER_NAME>
-          targetLabel: cluster
-        - targetLabel: "instance"
-          sourceLabels:
-            - "__meta_kubernetes_pod_node_name"
-
-prometheus:
-  monitor:
-    relabelings:
-      - action: replace
-        replacement: <CLUSTER_NAME>
-        targetLabel: cluster
-```
-
-The `kube-prometheus-stack` installs `ServicMonitor` and `PrometheusRule` resources for monitoring Kubernetes, and it depends on the `kube-state-metrics` and `prometheus-node-exporter` helm charts which also install `ServiceMonitor` resources for collecting `kubelet` and `node-exporter` metrics. The above values file adds the necessary additional labels required for these metrics to work with the included dashboards.
-
-If you are using this helm chart in an environment which does not allow for the installation of `kube-prometheus-stack` or custom CRDs, you should run `helm template` on the `kube-prometheus-stack` helm chart with the above values file, and review all generated `ServiceMonitor` and `PrometheusRule` resources. These resources may have to be modified with the correct ports and selectors to find the various services such as `kubelet` and `node-exporter` in your environment.
+- A running Prometheus operator in order for recording rules for the dashboards
+  to work.
 
 **To install the dashboards:**
 
@@ -130,16 +75,17 @@ If you are using this helm chart in an environment which does not allow for the 
                expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
    ```
 
+
 **To disable monitoring:**
 
 1. Modify the configuration file `values.yaml`:
 
    ```yaml
    selfMonitoring:
-     enabled: false
+       enabled: false
 
    serviceMonitor:
-     enabled: false
+       enabled: false
    ```
 
 **To use a remote Prometheus and Loki instance such as Grafana Cloud**
@@ -154,8 +100,8 @@ If you are using this helm chart in an environment which does not allow for the 
      name: primary-credentials-metrics
      namespace: default
    stringData:
-     username: "<instance ID>"
-     password: "<API key>"
+     username: '<instance ID>'
+     password: '<API key>'
    ---
    apiVersion: v1
    kind: Secret
@@ -163,8 +109,8 @@ If you are using this helm chart in an environment which does not allow for the 
      name: primary-credentials-logs
      namespace: default
    stringData:
-     username: "<instance ID>"
-     password: "<API key>"
+     username: '<instance ID>'
+     password: '<API key>'
    ```
 
 2. Add the secret to Kubernetes with `kubectl create -f secret.yaml`.
@@ -193,19 +139,19 @@ If you are using this helm chart in an environment which does not allow for the 
 
    ```yaml
    monitoring:
-   ---
+   ...
    selfMonitoring:
      enabled: true
      logsInstance:
        clients:
-         - url: <logs remote write endpoint>
-           basicAuth:
-             username:
-               name: primary-credentials-logs
-               key: username
-             password:
-               name: primary-credentials-logs
-               key: password
+       - url: <logs remote write endpoint>
+         basicAuth:
+           username:
+             name: primary-credentials-logs
+             key: username
+           password:
+             name: primary-credentials-logs
+             key: password
    lokiCanary:
      enabled: false
    ```

--- a/docs/sources/installation/helm/monitor-and-alert/index.md
+++ b/docs/sources/installation/helm/monitor-and-alert/index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/installation/helm/monitoring
 weight: 100
 keywords:
-  - monitoring 
+  - monitoring
   - alert
   - alerting
 ---
@@ -15,9 +15,9 @@ keywords:
 
 By default this Helm Chart configures meta-monitoring of metrics (service monitoring) and logs (self monitoring).
 
-The `ServiceMonitor` resource works with either the Prometheus Operator or the Grafana Agent Operator, and defines how Loki's metrics should be scraped. Scraping this Loki cluster using the scrape config defined in the `ServiceMonitor` resource is required for the included dashboards to work. A `MetricsInstance` can be configured to write the metrics to a remote Prometheus instance such as Grafana Cloud Metrics.
+The `ServiceMonitor` resource works with either the Prometheus Operator or the Grafana Agent Operator, and defines how Loki's metrics should be scraped. Scraping this Loki cluster using the scrape config defined in the `SerivceMonitor` resource is required for the included dashboards to work. A `MetricsInstance` can be configured to write the metrics to a remote Prometheus instance such as Grafana Cloud Metrics.
 
-*Self monitoring* is enabled by default. This will deploy a `GrafanaAgent`, `LogsInstance`, and `PodLogs` resource which will instruct the Grafana Agent Operator (installed seperately) on how to scrape this Loki cluster's logs and send them back to itself. Scraping this Loki cluster using the scrape config defined in the `PodLogs` resource is required for the included dashboards to work.
+_Self monitoring_ is enabled by default. This will deploy a `GrafanaAgent`, `LogsInstance`, and `PodLogs` resource which will instruct the Grafana Agent Operator (installed seperately) on how to scrape this Loki cluster's logs and send them back to itself. Scraping this Loki cluster using the scrape config defined in the `PodLogs` resource is required for the included dashboards to work.
 
 Rules and alerts are automatically deployed.
 
@@ -26,8 +26,63 @@ Rules and alerts are automatically deployed.
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
 - A running Kubernetes cluster with a running Loki deployment.
 - A running Grafana instance.
-- A running Prometheus operator in order for recording rules for the dashboards
-  to work.
+- A running Prometheus Operator installed using the `kube-prometheus-stack` Helm chart.
+
+**Prometheus Operator Prequisites**
+
+The dashboards require certain metric labels to display Kubernetes metrics. The best way to accomplish this is to install the `kube-prometheus-stack` Helm chart with the following values file, replacing `CLUSTER_NAME` with the name of your cluster. The cluster name is what you specify during the helm installation, so a cluster installed with the command `helm install loki-cluster grafana/loki` would be called `loki-cluster`.
+
+```yaml
+kubelet:
+  serviceMonitor:
+    cAdvisorRelabelings:
+      - action: replace
+        replacement: <CLUSTER_NAME>
+        targetLabel: cluster
+      - targetLabel: metrics_path
+        sourceLabels:
+          - "__metrics_path__"
+      - targetLabel: "instance"
+        sourceLabels:
+          - "node"
+
+defaultRules:
+  additionalRuleLabels:
+    cluster: <CLUSTER_NAME>
+
+"kube-state-metrics":
+  prometheus:
+    monitor:
+      relabelings:
+        - action: replace
+          replacement: <CLUSTER_NAME>
+          targetLabel: cluster
+        - targetLabel: "instance"
+          sourceLabels:
+            - "__meta_kubernetes_pod_node_name"
+
+"prometheus-node-exporter":
+  prometheus:
+    monitor:
+      relabelings:
+        - action: replace
+          replacement: <CLUSTER_NAME>
+          targetLabel: cluster
+        - targetLabel: "instance"
+          sourceLabels:
+            - "__meta_kubernetes_pod_node_name"
+
+prometheus:
+  monitor:
+    relabelings:
+      - action: replace
+        replacement: <CLUSTER_NAME>
+        targetLabel: cluster
+```
+
+The `kube-prometheus-stack` installs `ServicMonitor` and `PrometheusRule` resources for monitoring Kubernetes, and it depends on the `kube-state-metrics` and `prometheus-node-exporter` helm charts which also install `ServiceMonitor` resources for collecting `kubelet` and `node-exporter` metrics. The above values file adds the necessary additional labels required for these metrics to work with the included dashboards.
+
+If you are using this helm chart in an environment which does not allow for the installation of `kube-prometheus-stack` or custom CRDs, you should run `helm template` on the `kube-prometheus-stack` helm chart with the above values file, and review all generated `ServiceMonitor` and `PrometheusRule` resources. These resources may have to be modified with the correct ports and selectors to find the various services such as `kubelet` and `node-exporter` in your environment.
 
 **To install the dashboards:**
 
@@ -75,17 +130,16 @@ Rules and alerts are automatically deployed.
                expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
    ```
 
-
 **To disable monitoring:**
 
 1. Modify the configuration file `values.yaml`:
 
    ```yaml
    selfMonitoring:
-       enabled: false
+     enabled: false
 
    serviceMonitor:
-       enabled: false
+     enabled: false
    ```
 
 **To use a remote Prometheus and Loki instance such as Grafana Cloud**
@@ -100,8 +154,8 @@ Rules and alerts are automatically deployed.
      name: primary-credentials-metrics
      namespace: default
    stringData:
-     username: '<instance ID>'
-     password: '<API key>'
+     username: "<instance ID>"
+     password: "<API key>"
    ---
    apiVersion: v1
    kind: Secret
@@ -109,8 +163,8 @@ Rules and alerts are automatically deployed.
      name: primary-credentials-logs
      namespace: default
    stringData:
-     username: '<instance ID>'
-     password: '<API key>'
+     username: "<instance ID>"
+     password: "<API key>"
    ```
 
 2. Add the secret to Kubernetes with `kubectl create -f secret.yaml`.
@@ -139,19 +193,19 @@ Rules and alerts are automatically deployed.
 
    ```yaml
    monitoring:
-   ...
+   ---
    selfMonitoring:
      enabled: true
      logsInstance:
        clients:
-       - url: <logs remote write endpoint>
-         basicAuth:
-           username:
-             name: primary-credentials-logs
-             key: username
-           password:
-             name: primary-credentials-logs
-             key: password
+         - url: <logs remote write endpoint>
+           basicAuth:
+             username:
+               name: primary-credentials-logs
+               key: username
+             password:
+               name: primary-credentials-logs
+               key: password
    lokiCanary:
      enabled: false
    ```

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3167,7 +3167,7 @@ null
 			<td>int</td>
 			<td>Number of replicas for the single binary</td>
 			<td><pre lang="json">
-1
+0
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,12 +13,13 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
-## 4.4.2
-
-- [CHANGE] Bump Loki version to 2.7.2 and GEL version to 1.6.1
 ## 4.5
 
 - [ENHANCEMENT] Single binary mode is now possible for more than 1 replica, with a gateway and object storage backend.
+
+## 4.4.2
+
+- [CHANGE] Bump Loki version to 2.7.2 and GEL version to 1.6.1
 
 ## 4.4.1
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,9 @@ Entries should include a reference to the pull request that introduced the chang
 ## 4.4.2
 
 - [CHANGE] Bump Loki version to 2.7.2 and GEL version to 1.6.1
+## 4.5
+
+- [ENHANCEMENT] Single binary mode is now possible for more than 1 replica, with a gateway and object storage backend.
 
 ## 4.4.1
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.7.3
-version: 4.4.2
+appVersion: 2.7.2
+version: 4.5.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.4.2](https://img.shields.io/badge/Version-4.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/gateway/configmap-gateway.yaml
+++ b/production/helm/loki/templates/gateway/configmap-gateway.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and .Values.gateway.enabled $isSimpleScalable }}
+{{- if and .Values.gateway.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable .Values.gateway.enabled }}
+{{- if .Values.gateway.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/production/helm/loki/templates/gateway/hpa.yaml
+++ b/production/helm/loki/templates/gateway/hpa.yaml
@@ -1,6 +1,5 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
-{{- if and $isSimpleScalable .Values.gateway.autoscaling.enabled }}
+{{- if .Values.gateway.autoscaling.enabled }}
 {{- if $autoscalingv2 }}
 apiVersion: autoscaling/v2
 {{- else }}

--- a/production/helm/loki/templates/gateway/ingress-gateway.yaml
+++ b/production/helm/loki/templates/gateway/ingress-gateway.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable .Values.gateway.enabled -}}
+{{- if and .Values.gateway.enabled -}}
 {{- if .Values.gateway.ingress.enabled -}}
 {{- $ingressApiIsStable := eq (include "loki.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "loki.ingress.supportsIngressClassName" .) "true" -}}

--- a/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/production/helm/loki/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable .Values.gateway.enabled }}
+{{- if and .Values.gateway.enabled }}
 {{- if gt (int .Values.gateway.replicas) 1 }}
 apiVersion: {{ include "loki.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget

--- a/production/helm/loki/templates/gateway/secret-gateway.yaml
+++ b/production/helm/loki/templates/gateway/secret-gateway.yaml
@@ -1,6 +1,5 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
 {{- with .Values.gateway }}
-{{- if and $isSimpleScalable .enabled .basicAuth.enabled (not .basicAuth.existingSecret) }}
+{{- if and .enabled .basicAuth.enabled (not .basicAuth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/production/helm/loki/templates/gateway/service-gateway.yaml
+++ b/production/helm/loki/templates/gateway/service-gateway.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{- if and $isSimpleScalable .Values.gateway.enabled }}
+{{- if .Values.gateway.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
+++ b/production/helm/loki/templates/single-binary/_helpers-single-binary.tpl
@@ -22,3 +22,13 @@ singleBinary priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/* singleBinary replicas calculation */}}
+{{- define "loki.singleBinaryReplicas" -}}
+{{- $replicas := 1 }}
+{{- $usingObjectStorage := eq (include "loki.isUsingObjectStorage" .) "true" }}
+{{- if and $usingObjectStorage (gt (int .Values.singleBinary.replicas) 1)}}
+{{- $replicas = int .Values.singleBinary.replicas -}}
+{{- end }}
+{{- printf "%d" $replicas }}
+{{- end }}

--- a/production/helm/loki/templates/single-binary/service.yaml
+++ b/production/helm/loki/templates/single-binary/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "loki.name" . }}
+  name: {{ include "loki.singleBinaryFullname" . }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 spec:

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "loki.singleBinaryLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
 spec:
-  replicas: {{ .Values.singleBinary.replicas }}
+  replicas: {{ include "loki.singleBinaryReplicas" . }}
   podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:

--- a/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrole-tokengen.yaml
@@ -1,5 +1,5 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{ if and $isSimpleScalable .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/clusterrolebinding-tokengen.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{ if and $isSimpleScalable .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/production/helm/loki/templates/tokengen/job-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/job-tokengen.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{ if and $isSimpleScalable .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
+++ b/production/helm/loki/templates/tokengen/serviceaccount-tokengen.yaml
@@ -1,5 +1,4 @@
-{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
-{{ if and $isSimpleScalable .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
+{{ if and .Values.enterprise.tokengen.enabled .Values.enterprise.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -18,7 +18,7 @@
 {{- fail "Cannot run more than 1 Single Binary replica without an object storage backend."}}
 {{- end }}
 
-{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (or (gt (int .Values.backend.replicas) 0) (gt (int (.Values.read.replicas) 0)) (gt (int .Values.write.replicas) 0)) }}
+{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0)) }}
 {{- fail "Cannot run Scalable targets (backend, read, write) without an object storage backend."}}
 {{- end }}
 

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -14,11 +14,15 @@
 {{- fail "Helm test requires a prometheusAddress for an instance scraping the Loki canary's metrics"}}
 {{- end }}
 
-{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (gt (int .Values.singleBinary.replicas) 1) }}
+{{- $singleBinaryReplicas := int .Values.singleBinary.replicas }}
+{{- $isUsingFilesystem := eq (include "loki.isUsingObjectStorage" .) "false" }}
+{{- $atLeastOneScalableReplica := or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0) }}
+
+{{- if and $isUsingFilesystem (gt $singleBinaryReplicas 1) }}
 {{- fail "Cannot run more than 1 Single Binary replica without an object storage backend."}}
 {{- end }}
 
-{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0)) }}
+{{- if and $isUsingFilesystem (and (eq $singleBinaryReplicas 0) $atLeastOneScalableReplica) }}
 {{- fail "Cannot run Scalable targets (backend, read, write) without an object storage backend."}}
 {{- end }}
 

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -14,3 +14,11 @@
 {{- fail "Helm test requires a prometheusAddress for an instance scraping the Loki canary's metrics"}}
 {{- end }}
 
+{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (gt (int .Values.singleBinary.replicas) 1) }}
+{{- fail "Cannot run more than 1 Single Binary replica without an object storage backend."}}
+{{- end }}
+
+{{- if and (eq (include "loki.isUsingObjectStorage" .) "false") (or (gt (int .Values.backend.replicas) 0) (gt (int (.Values.read.replicas) 0)) (gt (int .Values.write.replicas) 0)) }}
+{{- fail "Cannot run Scalable targets (backend, read, write) without an object storage backend."}}
+{{- end }}
+

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -924,7 +924,7 @@ backend:
 # Configuration for the single binary node(s)
 singleBinary:
   # -- Number of replicas for the single binary
-  replicas: 1
+  replicas: 0
   autoscaling:
     # -- Enable autoscaling, this is only used if `queryIndex.enabled: true`
     enabled: false

--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -15,12 +15,29 @@ enterprise-logs: prepare-gel helm-cluster
 	$(MAKE) -C $(CURDIR) helm-install-enterprise-logs
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
+enterprise-logs-ha-single-binary: prepare-gel helm-cluster
+	$(MAKE) -C $(CURDIR) apply-enterprise-helm-cluster
+	echo "Waiting 5s for cluster to be ready for helm installation."
+	echo "The helm install will take a while. It's useful to monitor progress using a tool like k9s."
+	# wait 5s for tk apply to finish and cluster is ready for helm install
+	sleep 5
+	$(MAKE) -C $(CURDIR) helm-install-enterprise-logs-ha-single-binary
+	echo "Helm installation finished. You can tear down this cluster with make down."
+
 loki: prepare helm-cluster
 	$(MAKE) -C $(CURDIR) apply-loki-helm-cluster
 	echo "Waiting 5s for cluster to be ready for helm installation."
 	# wait 5s for tk apply to finish and cluster is ready for helm install
 	sleep 5
 	$(MAKE) -C $(CURDIR) helm-install-loki
+	echo "Helm installation finished. You can tear down this cluster with make down."
+
+loki-ha-single-binary: prepare helm-cluster
+	$(MAKE) -C $(CURDIR) apply-loki-helm-cluster
+	echo "Waiting 5s for cluster to be ready for helm installation."
+	# wait 5s for tk apply to finish and cluster is ready for helm install
+	sleep 5
+	$(MAKE) -C $(CURDIR) helm-install-loki-ha-single-binary
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
 helm-cluster: prepare
@@ -102,6 +119,15 @@ helm-upgrade-enterprise-logs:
 helm-uninstall-enterprise-logs:
 	helm uninstall enterprise-logs-test-fixture -n loki
 
+helm-install-enterprise-logs-ha-single-binary:
+	helm install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
+
+helm-upgrade-enterprise-logs-ha-single-binary:
+	helm upgrade enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
+
+helm-uninstall-enterprise-logs-ha-single-binary:
+	helm uninstall enterprise-logs-test-fixture -n loki
+
 helm-install-loki:
 	helm install loki "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki.yaml"
 
@@ -110,3 +136,12 @@ helm-upgrade-loki:
 
 helm-uninstall-loki:
 	helm uninstall loki -n loki
+
+helm-install-loki-ha-single-binary:
+	helm install loki-single-binary "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
+
+helm-upgrade-loki-ha-single-binary:
+	helm upgrade loki-single-binary "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
+
+helm-uninstall-loki-binary:
+	helm uninstall loki-single-binary -n loki

--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -2,6 +2,8 @@ local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet'
 local tanka = import 'github.com/grafana/jsonnet-libs/tanka-util/main.libsonnet';
 local container = k.core.v1.container;
 local configMap = k.core.v1.configMap;
+local deployment = k.apps.v1.deployment;
+local volume = k.core.v1.volume;
 
 local grafana = import 'grafana/grafana.libsonnet';
 local envVar = if std.objectHasAll(k.core.v1, 'envVar') then k.core.v1.envVar else k.core.v1.container.envType;
@@ -152,10 +154,20 @@ local tenant = 'loki';
             + grafana.addDatasource('prometheus', $.prometheus_datasource)
             + grafana.addDatasource('loki', $.loki_datasource) + {
     grafana_deployment+:
-      k.apps.v1.deployment.emptyVolumeMount('grafana-var', '/var/lib/grafana')
-      + k.apps.v1.deployment.emptyVolumeMount('grafana-plugins', '/etc/grafana/provisioning/plugins')
-      + k.apps.v1.deployment.configVolumeMount('%s-dashboards-1' % dashboardsPrefix, '/var/lib/grafana/dashboards/loki-1')
-      + k.apps.v1.deployment.configVolumeMount('%s-dashboards-2' % dashboardsPrefix, '/var/lib/grafana/dashboards/loki-2'),
+      deployment.emptyVolumeMount('grafana-var', '/var/lib/grafana')
+      + deployment.emptyVolumeMount('grafana-plugins', '/etc/grafana/provisioning/plugins')
+      + deployment.configVolumeMount(
+        '%s-dashboards-1' % dashboardsPrefix,
+        '/var/lib/grafana/dashboards/loki-1',
+        {},
+        volume.configMap.withOptional(true)  //no dashboards for single binary mode
+      )
+      + deployment.configVolumeMount(
+        '%s-dashboards-2' % dashboardsPrefix,
+        '/var/lib/grafana/dashboards/loki-2',
+        {},
+        volume.configMap.withOptional(true)  //no dashboards for single binary mode
+      ),
 
     dashboard_provisioning_config_map:
       configMap.new('grafana-dashboard-provisioning') +

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml
@@ -1,0 +1,35 @@
+---
+loki:
+  querier:
+    multi_tenant_queries_enabled: true
+singleBinary:
+  replicas: 3
+enterprise:
+  enabled: true
+  adminToken:
+    secret: "gel-admin-token"
+    additionalNamespaces:
+      - k3d-helm-cluster
+  useExternalLicense: true
+  externalLicenseName: gel-license
+  provisioner:
+    provisionedSecretPrefix: "provisioned-secret"
+    additionalTenants:
+      - name: team-a
+        namespace: k3d-helm-cluster
+monitoring:
+  dashboards:
+    namespace: k3d-helm-cluster
+  selfMonitoring:
+    tenant:
+      name: loki
+      secretNamespace: k3d-helm-cluster
+  serviceMonitor:
+    labels:
+      release: "prometheus"
+  rules:
+    namespace: k3d-helm-cluster
+    labels:
+      release: "prometheus"
+minio:
+  enabled: true

--- a/tools/dev/k3d/environments/helm-cluster/values/loki-ha-single-binary.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/loki-ha-single-binary.yaml
@@ -1,4 +1,6 @@
 ---
+singleBinary:
+  replicas: 3
 monitoring:
   dashboards:
     namespace: k3d-helm-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR allows an operator to install Loki in Single Binary mode in an HA fashion, meaning more than 1 Single Binary replica. In order for this to work, it is not possible to specify an object storage backend when running in Single Binary mode. The gateway is also now always enabled, for both Single Binary and Scalable modes.

**Which issue(s) this PR fixes**:
Fixes #8269 #8185

**Special notes for your reviewer**:

This PR builds off #8261, will rebase after that is merged and diff will be smaller.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
