### PR TITLE
[chore] Sort imports so that linter does not complain

### DIFF
--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
 func Test_SplitRangeInterval(t *testing.T) {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_request.go
@@ -2,12 +2,13 @@ package deletion
 
 import (
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 	"github.com/grafana/loki/pkg/util/filter"
 	util_log "github.com/grafana/loki/pkg/util/log"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 type DeleteRequest struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Sorts the imports correctly according to linter requirements.