### PR TITLE
Prepare release 2.7.2 - Part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,17 @@
 
 ##### Enhancements
 
-* [7684](https://github.com/grafana/loki/pull/7684) **kavirajk**: Add missing `embedded-cache` config under `cache_config` doc.
-* [6360](https://github.com/grafana/loki/pull/6099) **liguozhong**: Hide error message when ctx timeout occurs in s3.getObject
-* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize filter to easily parse colored logs.
-
 ##### Fixes
-
-* [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: fix bugs in processing delete requests with line filters.
-
-* [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix multitenant querying.
 
 ##### Changes
 
 #### Promtail
-
-* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize stage to Promtail to easily parse colored logs.
 
 ##### Enhancements
 
 ##### Fixes
 
 ##### Changes
-* [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude Promtail journald code from binary.
 
 #### Fluent Bit
 
@@ -37,30 +26,58 @@
 
 ### Notes
 
-This release was created from a branch starting at commit FIXME but it may also contain backported changes from main.
+### Dependencies
 
-Check the history of the branch FIXME.
+## 2.7.2 (2023-01-25)
+
+#### Loki
+
+##### Fixes
+
+* [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix bug in validation of `pattern` and `regexp` parsers where missing or empty parameters caused panics.
+* [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: Fix bugs in processing delete requests with line filters.
+* [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix bug in multi-tenant querying.
+
+### Notes
+
+This release was created from a branch starting at commit `706c22e9e40b0156031f214b63dc6ed4e210abc1` but it may also contain backported changes from main.
+
+Check the history of the branch `release-2.7.x`.
 
 ### Dependencies
 
-* Go Version: 1.19
+* Go version: 1.19.5
 
-## 2.7.1
+## 2.7.1 (2022-12-09)
 
 #### Loki
 
 ##### Enhancements
 
+* [6360](https://github.com/grafana/loki/pull/6360) **liguozhong**: Hide error message when context timeout occurs in `s3.getObject`
+* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize filter to easily parse colored logs.
 * [7804](https://github.com/grafana/loki/pull/7804) **sandeepsukhani**: Use grpc for communicating with compactor for query time filtering of data requested for deletion.
+* [7684](https://github.com/grafana/loki/pull/7684) **kavirajk**: Add missing `embedded-cache` config under `cache_config` reference documentation.
 
 ##### Fixes
 
-* [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix validation for pattern and regexp parsers.
 * [7453](https://github.com/grafana/loki/pull/7453) **periklis**: Add single compactor http client for delete and gennumber clients
 
 ##### Changes
 
 * [7877](https://github.com/grafana/loki/pull/7877)A **trevorwhitney**: Due to a known bug with experimental new delete mode feature, the default delete mode has been changed to `filter-only`.
+
+#### Promtail
+
+##### Enhancements
+
+* [7602](https://github.com/grafana/loki/pull/7602) **vmax**: Add decolorize stage to Promtail to easily parse colored logs.
+
+##### Fixes
+
+##### Changes
+
+* [7587](https://github.com/grafana/loki/pull/7587) **mar4uk**: Add go build tag `promtail_journal_enabled` to include/exclude Promtail journald code from binary.
 
 ## 2.7.0
 

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -33,6 +33,16 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 
 ## Bug fixes
 
+### 2.7.2
+
+* Fixed bug in validation of `pattern` and `regexp` parsers where missing or empty parameters for these parsers caused panics.
+* Fixed bugs in processing delete requests with line filters:
+  * Whole chunks covered by delete requests with a line filter were incorrectly skipped.
+  * Chunks partially covered by delete requests with a line filter were not properly processed.
+    The part that was not covered by the delete request was rewritten with a line filter, while the part that was covered by the delete request was completely deleted.
+* Fixed bug in multi-tenant querying that caused HTTP 400 responses when multiple tenants where used in `X-Scope-OrgID` header like so `tenant-a|tenant-b`.
+* Upgraded Go build version and Docker container base images to 1.19.5 to mitigate [GO-2022-1144](https://pkg.go.dev/vuln/GO-2022-1144) vulnerability.
+
 ### 2.7.1 
 
 * Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were enabled:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prepares the release `2.7.2`. It ...

* ... updates the CHANGELOG
* ... updates the release notes
~* ... updates the versions in the `production/` folder~
~* ... updates the versions in the installation docs~

**Notes for reviewers**

I am not sure why we cannot update the version in ksonnet https://github.com/grafana/loki/blob/main/docs/sources/maintaining/release.md?plain=1#L59-L63

The third commit of this PR however updates the versions in the ksonnet folder.

**Update:**

I removed the version updates in the production/ and docs/ folders. There is a separate PR for that, which will be merged after the new images are built.