### PR TITLE
Ruler: add rule evaluation jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,13 @@
 * [7978](https://github.com/grafana/loki/pull/7978) **chaudum**: Shut down query frontend gracefully to allow inflight requests to complete.
 * [8047](https://github.com/grafana/loki/pull/8047) **bboreham**: Dashboards: add k8s resource requests to CPU and memory panels.
 * [8061](https://github.com/grafana/loki/pull/8061) **kavirajk**: Remove circle from Loki OSS
-* [8092](https://github.com/grafana/loki/pull/8092) **dannykopping**: add rule-based sharding to ruler.
+* [8092](https://github.com/grafana/loki/pull/8092) **dannykopping**: Ruler: add rule-based sharding to ruler.
 * [8131](https://github.com/grafana/loki/pull/8131) **jeschkies**: Compile Promtail ARM and ARM64 with journald support.
 * [8212](https://github.com/grafana/loki/pull/8212) **kavirajk**: ingester: Add `ingester_memory_streams_labels_bytes metric` for more visibility of size of metadata of in-memory streams.
 * [8271](https://github.com/grafana/loki/pull/8271) **kavirajk**: logql: Support urlencode and urldecode template functions
 * [8259](https://github.com/grafana/loki/pull/8259) **mar4uk**: Extract push.proto from the logproto package to the separate module.
 * [7906](https://github.com/grafana/loki/pull/7906) **kavirajk**: Add API endpoint that formats LogQL expressions and support new `fmt` subcommand in `logcli` to format LogQL query.
+* [8307](https://github.com/grafana/loki/pull/8307) **dannykopping**: Ruler: add rule evaluation jitter
 
 ##### Fixes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -927,6 +927,12 @@ alertmanager_client:
 # CLI flag: -ruler.resend-delay
 [resend_delay: <duration> | default = 1m]
 
+# Upper bound of random duration to wait before rule evaluation; this is to
+# avoid contention during concurrent execution of rules. This is most relevant
+# when using the 'by-ruler' sharding algorithm. Set 0 to disable.
+# CLI flag: -ruler.evaluation-jitter
+[evaluation_jitter: <duration> | default = 0s]
+
 # Distribute rule evaluation using ring backend.
 # CLI flag: -ruler.enable-sharding
 [enable_sharding: <boolean> | default = false]

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -203,7 +203,7 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	log, ctx := spanlogger.New(ctx, "query.Exec")
 	defer log.Finish()
 
-	queryHash := hashedQuery(q.params.Query())
+	queryHash := HashQueryString(q.params.Query())
 	if GetRangeType(q.params) == InstantType {
 		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query(), "query_hash", queryHash)
 	} else {

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2526,7 +2526,7 @@ func TestHashingStability(t *testing.T) {
 		{`sum (count_over_time({app="myapp",env="myenv"} |= "error" |= "metrics.go" | logfmt [10s])) by(query_hash)`},
 	} {
 		params.qs = test.qs
-		expectedQueryHash := hashedQuery(test.qs)
+		expectedQueryHash := HashQueryString(test.qs)
 
 		// check that both places will end up having the same query hash, even though they're emitting different log lines.
 		require.Regexp(t,

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -114,7 +114,7 @@ func RecordRangeAndInstantQueryMetrics(
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.
 		"query", p.Query(),
-		"query_hash", hashedQuery(p.Query()),
+		"query_hash", HashQueryString(p.Query()),
 		"query_type", queryType,
 		"range_type", rt,
 		"length", p.End().Sub(p.Start()),
@@ -164,7 +164,7 @@ func RecordRangeAndInstantQueryMetrics(
 	recordUsageStats(queryType, stats)
 }
 
-func hashedQuery(query string) uint32 {
+func HashQueryString(query string) uint32 {
 	h := fnv.New32()
 	_, _ = h.Write([]byte(query))
 	return h.Sum32()

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -189,11 +189,11 @@ func Test_testToKeyValues(t *testing.T) {
 }
 
 func TestQueryHashing(t *testing.T) {
-	h1 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
-	h2 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
+	h1 := HashQueryString(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	h2 := HashQueryString(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
 	// check that it capture differences of order.
 	require.NotEqual(t, h1, h2)
-	h3 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	h3 := HashQueryString(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
 	// check that it evaluate same queries as same hashes, even if evaluated at different timestamps.
 	require.Equal(t, h1, h3)
 }

--- a/pkg/ruler/base/ruler.go
+++ b/pkg/ruler/base/ruler.go
@@ -103,6 +103,8 @@ type Config struct {
 	// Minimum amount of time to wait before resending an alert to Alertmanager.
 	ResendDelay time.Duration `yaml:"resend_delay"`
 
+	EvaluationJitter time.Duration `yaml:"evaluation_jitter"`
+
 	// Enable sharding rule groups.
 	EnableSharding   bool          `yaml:"enable_sharding"`
 	ShardingStrategy string        `yaml:"sharding_strategy"`
@@ -183,6 +185,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.OutageTolerance, "ruler.for-outage-tolerance", time.Hour, `Max time to tolerate outage for restoring "for" state of alert.`)
 	f.DurationVar(&cfg.ForGracePeriod, "ruler.for-grace-period", 10*time.Minute, `Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than the grace period.`)
 	f.DurationVar(&cfg.ResendDelay, "ruler.resend-delay", time.Minute, `Minimum amount of time to wait before resending an alert to Alertmanager.`)
+	// TODO(dannyk): set this to a non-zero value once "by-rule" sharding is enabled by default
+	f.DurationVar(&cfg.EvaluationJitter, "ruler.evaluation-jitter", 0, "Upper bound of random duration to wait before rule evaluation; this is to avoid contention during concurrent execution of rules. This is most relevant when using the 'by-ruler' sharding algorithm. Set 0 to disable.")
 
 	f.Var(&cfg.EnabledTenants, "ruler.enabled-tenants", "Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.")
 	f.Var(&cfg.DisabledTenants, "ruler.disabled-tenants", "Comma separated list of tenants whose rules this ruler cannot evaluate. If specified, a ruler that would normally pick the specified tenant(s) for processing will ignore them instead. Subject to sharding.")

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -100,6 +100,8 @@ type Limits struct {
 	MinShardingLookback model.Duration `yaml:"min_sharding_lookback" json:"min_sharding_lookback"`
 
 	// Ruler defaults and limits.
+
+	// TODO(dannyk): this setting is misnamed and probably deprecatable.
 	RulerEvaluationDelay        model.Duration                   `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
 	RulerMaxRulesPerRuleGroup   int                              `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
 	RulerMaxRuleGroupsPerTenant int                              `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that we have [rule-based sharding](https://github.com/grafana/loki/pull/8092/), all rules on a ruler will execute concurrently. Generally this should not be a problem, but with a large number of rules with the same interval (the default, for example) this could cause some contention and scheduler latency.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
It would be better to apply the jitter to each rule and not evaluate a new random jitter with each evaluation, but we don't have access to the rules in the manager (we reuse Prometheus' rule engine).

I considered keeping a map to memoise jitters based on the query string, but this seemed inelegant.
I also considered using the query string, the only part of the rule definition we have access to in this context, hashing that and then computing a jitter so it's stable. This seems overly complex for what we need, given that we need to somehow compute a value from 0 to 1 from a `uint32` FNV hash to multiply by the defined maximum jitter to get a reasonable distribution of jitters. We'd also still have to this on every rule evaluation, or memoise the result...

In the end, I just went with the simplest option.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
