### PR TITLE
operator: Cleanup ruler resources when disabled

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main
 
 - [8336](https://github.com/grafana/loki/pull/8336) **periklis**: Update Loki operand to v2.7.2
+- [8308](https://github.com/grafana/loki/pull/8308) **aminesnow**: operator: Cleanup ruler resources when disabled
 - [8253](https://github.com/grafana/loki/pull/8253) **aminesnow**: Add watch on the Alertmanager in openshift-monitoring and decouple it from the user-workload AM
 - [8265](https://github.com/grafana/loki/pull/8265) **Red-GV**: Use gRPC compactor service instead of http for retention
 - [8038](https://github.com/grafana/loki/pull/8038) **aminesnow**: Add watch on the Alertmanager in OCP's user-workload-monitoring namespace

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Main
 
-- [8336](https://github.com/grafana/loki/pull/8336) **periklis**: Update Loki operand to v2.7.2
 - [8308](https://github.com/grafana/loki/pull/8308) **aminesnow**: operator: Cleanup ruler resources when disabled
+- [8336](https://github.com/grafana/loki/pull/8336) **periklis**: Update Loki operand to v2.7.2
 - [8253](https://github.com/grafana/loki/pull/8253) **aminesnow**: Add watch on the Alertmanager in openshift-monitoring and decouple it from the user-workload AM
 - [8265](https://github.com/grafana/loki/pull/8265) **Red-GV**: Use gRPC compactor service instead of http for retention
 - [8038](https://github.com/grafana/loki/pull/8038) **aminesnow**: Add watch on the Alertmanager in OCP's user-workload-monitoring namespace

--- a/operator/internal/handlers/internal/rules/cleanup.go
+++ b/operator/internal/handlers/internal/rules/cleanup.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"context"
+
+	"github.com/ViaQ/logerr/v2/kverrors"
+	"github.com/grafana/loki/operator/internal/manifests"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RemoveRulesConfigMap removes the rules configmap if it exists.
+func RemoveRulesConfigMap(ctx context.Context, req ctrl.Request, c client.Client) error {
+	// Check if the CM exists before proceeding.
+	key := client.ObjectKey{Name: manifests.RulesConfigMapName(req.Name), Namespace: req.Namespace}
+
+	var rulesCm corev1.ConfigMap
+	if err := c.Get(ctx, key, &rulesCm); err != nil {
+		if apierrors.IsNotFound(err) {
+			// resource doesnt exist, so nothing to do.
+			return nil
+		}
+		return kverrors.Wrap(err, "failed to lookup configmap", "name", key)
+	}
+
+	if err := c.Delete(ctx, &rulesCm, &client.DeleteOptions{}); err != nil {
+		return kverrors.Wrap(err, "failed to delete configmap",
+			"name", rulesCm.Name,
+			"namespace", rulesCm.Namespace,
+		)
+	}
+
+	return nil
+}
+
+// RemoveRuler removes the ruler statefulset if it exists.
+func RemoveRuler(ctx context.Context, req ctrl.Request, c client.Client) error {
+	// Check if the Statefulset exists before proceeding.
+	key := client.ObjectKey{Name: manifests.RulerName(req.Name), Namespace: req.Namespace}
+
+	var ruler appsv1.StatefulSet
+	if err := c.Get(ctx, key, &ruler); err != nil {
+		if apierrors.IsNotFound(err) {
+			// resource doesnt exist, so nothing to do.
+			return nil
+		}
+		return kverrors.Wrap(err, "failed to lookup Statefulset", "name", key)
+	}
+
+	if err := c.Delete(ctx, &ruler, &client.DeleteOptions{}); err != nil {
+		return kverrors.Wrap(err, "failed to delete statefulset",
+			"name", ruler.Name,
+			"namespace", ruler.Namespace,
+		)
+	}
+
+	return nil
+}

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ViaQ/logerr/v2/kverrors"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -250,6 +251,19 @@ func CreateOrUpdateLokiStack(
 			ll.Error(err, "failed to check OCP User Workload AlertManager")
 			return err
 		}
+	} else {
+		// Clean up ruler resources
+		err = removeRulesConfigMap(ctx, req, k)
+		if err != nil {
+			ll.Error(err, "failed to remove rules configmap")
+			return err
+		}
+
+		err = removeRuler(ctx, req, k)
+		if err != nil {
+			ll.Error(err, "failed to remove ruler statefulset")
+			return err
+		}
 	}
 
 	certRotationRequiredAt := ""
@@ -415,4 +429,50 @@ func isNamespaceScoped(obj client.Object) bool {
 	default:
 		return true
 	}
+}
+
+func removeRulesConfigMap(ctx context.Context, req ctrl.Request, c client.Client) error {
+	// Check if the CM exists before proceeding.
+	key := client.ObjectKey{Name: manifests.RulesConfigMapName(req.Name), Namespace: req.Namespace}
+
+	var rulesCm corev1.ConfigMap
+	if err := c.Get(ctx, key, &rulesCm); err != nil {
+		if apierrors.IsNotFound(err) {
+			// resource doesnt exist, so nothing to do.
+			return nil
+		}
+		return kverrors.Wrap(err, "failed to lookup configmap", "name", key)
+	}
+
+	if err := c.Delete(ctx, &rulesCm, &client.DeleteOptions{}); err != nil {
+		return kverrors.Wrap(err, "failed to delete configmap",
+			"name", rulesCm.Name,
+			"namespace", rulesCm.Namespace,
+		)
+	}
+
+	return nil
+}
+
+func removeRuler(ctx context.Context, req ctrl.Request, c client.Client) error {
+	// Check if the Statefulset exists before proceeding.
+	key := client.ObjectKey{Name: manifests.RulerName(req.Name), Namespace: req.Namespace}
+
+	var ruler appsv1.StatefulSet
+	if err := c.Get(ctx, key, &ruler); err != nil {
+		if apierrors.IsNotFound(err) {
+			// resource doesnt exist, so nothing to do.
+			return nil
+		}
+		return kverrors.Wrap(err, "failed to lookup Statefulset", "name", key)
+	}
+
+	if err := c.Delete(ctx, &ruler, &client.DeleteOptions{}); err != nil {
+		return kverrors.Wrap(err, "failed to delete statefulset",
+			"name", ruler.Name,
+			"namespace", ruler.Namespace,
+		)
+	}
+
+	return nil
 }

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ViaQ/logerr/v2/kverrors"
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -253,13 +252,13 @@ func CreateOrUpdateLokiStack(
 		}
 	} else {
 		// Clean up ruler resources
-		err = removeRulesConfigMap(ctx, req, k)
+		err = rules.RemoveRulesConfigMap(ctx, req, k)
 		if err != nil {
 			ll.Error(err, "failed to remove rules configmap")
 			return err
 		}
 
-		err = removeRuler(ctx, req, k)
+		err = rules.RemoveRuler(ctx, req, k)
 		if err != nil {
 			ll.Error(err, "failed to remove ruler statefulset")
 			return err
@@ -429,50 +428,4 @@ func isNamespaceScoped(obj client.Object) bool {
 	default:
 		return true
 	}
-}
-
-func removeRulesConfigMap(ctx context.Context, req ctrl.Request, c client.Client) error {
-	// Check if the CM exists before proceeding.
-	key := client.ObjectKey{Name: manifests.RulesConfigMapName(req.Name), Namespace: req.Namespace}
-
-	var rulesCm corev1.ConfigMap
-	if err := c.Get(ctx, key, &rulesCm); err != nil {
-		if apierrors.IsNotFound(err) {
-			// resource doesnt exist, so nothing to do.
-			return nil
-		}
-		return kverrors.Wrap(err, "failed to lookup configmap", "name", key)
-	}
-
-	if err := c.Delete(ctx, &rulesCm, &client.DeleteOptions{}); err != nil {
-		return kverrors.Wrap(err, "failed to delete configmap",
-			"name", rulesCm.Name,
-			"namespace", rulesCm.Namespace,
-		)
-	}
-
-	return nil
-}
-
-func removeRuler(ctx context.Context, req ctrl.Request, c client.Client) error {
-	// Check if the Statefulset exists before proceeding.
-	key := client.ObjectKey{Name: manifests.RulerName(req.Name), Namespace: req.Namespace}
-
-	var ruler appsv1.StatefulSet
-	if err := c.Get(ctx, key, &ruler); err != nil {
-		if apierrors.IsNotFound(err) {
-			// resource doesnt exist, so nothing to do.
-			return nil
-		}
-		return kverrors.Wrap(err, "failed to lookup Statefulset", "name", key)
-	}
-
-	if err := c.Delete(ctx, &ruler, &client.DeleteOptions{}); err != nil {
-		return kverrors.Wrap(err, "failed to delete statefulset",
-			"name", ruler.Name,
-			"namespace", ruler.Namespace,
-		)
-	}
-
-	return nil
 }

--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -10,6 +10,7 @@ import (
 
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
+	lokiv1beta1 "github.com/grafana/loki/operator/apis/loki/v1beta1"
 	"github.com/grafana/loki/operator/internal/external/k8s/k8sfakes"
 	"github.com/grafana/loki/operator/internal/handlers"
 	"github.com/grafana/loki/operator/internal/status"
@@ -19,6 +20,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +73,26 @@ var (
 			"clientID":     []byte("client-123"),
 			"clientSecret": []byte("client-secret-xyz"),
 			"issuerCAPath": []byte("/tmp/test/ca.pem"),
+		},
+	}
+
+	rulesCM = corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-stack-rules",
+			Namespace: "some-ns",
+		},
+	}
+
+	rulerSS = appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-stack-ruler",
+			Namespace: "some-ns",
 		},
 	}
 
@@ -1362,4 +1384,141 @@ func TestCreateOrUpdateLokiStack_MissingTenantsSpec_SetDegraded(t *testing.T) {
 	// make sure error is returned
 	require.Error(t, err)
 	require.Equal(t, degradedErr, err)
+}
+
+func TestCreateOrUpdateLokiStack_RemovesRulerResourcesWhenDisabled(t *testing.T) {
+	sw := &k8sfakes.FakeStatusWriter{}
+	k := &k8sfakes.FakeClient{}
+	r := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-stack",
+			Namespace: "some-ns",
+		},
+	}
+
+	stack := lokiv1.LokiStack{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "LokiStack",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-stack",
+			Namespace: "some-ns",
+			UID:       "b23f9a38-9672-499f-8c29-15ede74d3ece",
+		},
+		Spec: lokiv1.LokiStackSpec{
+			Size: lokiv1.SizeOneXExtraSmall,
+			Storage: lokiv1.ObjectStorageSpec{
+				Schemas: []lokiv1.ObjectStorageSchema{
+					{
+						Version:       lokiv1.ObjectStorageSchemaV11,
+						EffectiveDate: "2020-10-11",
+					},
+				},
+				Secret: lokiv1.ObjectStorageSecretSpec{
+					Name: defaultSecret.Name,
+					Type: lokiv1.ObjectStorageSecretS3,
+				},
+			},
+			Rules: &lokiv1.RulesSpec{
+				Enabled: true,
+			},
+			Tenants: &lokiv1.TenantsSpec{
+				Mode: "dynamic",
+				Authentication: []lokiv1.AuthenticationSpec{
+					{
+						TenantName: "test",
+						TenantID:   "1234",
+						OIDC: &lokiv1.OIDCSpec{
+							Secret: &lokiv1.TenantSecretSpec{
+								Name: defaultGatewaySecret.Name,
+							},
+						},
+					},
+				},
+				Authorization: &lokiv1.AuthorizationSpec{
+					OPA: &lokiv1.OPASpec{
+						URL: "some-url",
+					},
+				},
+			},
+		},
+	}
+
+	k.GetStub = func(_ context.Context, name types.NamespacedName, out client.Object, _ ...client.GetOption) error {
+		_, ok := out.(*lokiv1beta1.RulerConfig)
+		if ok {
+			return apierrors.NewNotFound(schema.GroupResource{}, "no ruler config")
+		}
+		if r.Name == name.Name && r.Namespace == name.Namespace {
+			k.SetClientObject(out, &stack)
+			return nil
+		}
+		if defaultSecret.Name == name.Name {
+			k.SetClientObject(out, &defaultSecret)
+			return nil
+		}
+		if defaultGatewaySecret.Name == name.Name {
+			k.SetClientObject(out, &defaultGatewaySecret)
+			return nil
+		}
+		return apierrors.NewNotFound(schema.GroupResource{}, "something wasn't found")
+	}
+
+	k.CreateStub = func(_ context.Context, o client.Object, _ ...client.CreateOption) error {
+		assert.Equal(t, r.Namespace, o.GetNamespace())
+		return nil
+	}
+
+	k.StatusStub = func() client.StatusWriter { return sw }
+
+	k.DeleteStub = func(_ context.Context, o client.Object, _ ...client.DeleteOption) error {
+		assert.Equal(t, r.Namespace, o.GetNamespace())
+		return nil
+	}
+
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), logger, r, k, scheme, featureGates)
+	require.NoError(t, err)
+
+	// make sure create was called
+	require.NotZero(t, k.CreateCallCount())
+
+	// make sure delete not called
+	require.Zero(t, k.DeleteCallCount())
+
+	// Disable the ruler
+	stack.Spec.Rules.Enabled = false
+
+	// Get should return ruler resources
+	k.GetStub = func(_ context.Context, name types.NamespacedName, out client.Object, _ ...client.GetOption) error {
+		_, ok := out.(*lokiv1beta1.RulerConfig)
+		if ok {
+			return apierrors.NewNotFound(schema.GroupResource{}, "no ruler config")
+		}
+		if rulesCM.Name == name.Name {
+			k.SetClientObject(out, &rulesCM)
+			return nil
+		}
+		if rulerSS.Name == name.Name {
+			k.SetClientObject(out, &rulerSS)
+			return nil
+		}
+		if r.Name == name.Name && r.Namespace == name.Namespace {
+			k.SetClientObject(out, &stack)
+			return nil
+		}
+		if defaultSecret.Name == name.Name {
+			k.SetClientObject(out, &defaultSecret)
+			return nil
+		}
+		if defaultGatewaySecret.Name == name.Name {
+			k.SetClientObject(out, &defaultGatewaySecret)
+			return nil
+		}
+		return apierrors.NewNotFound(schema.GroupResource{}, "something wasn't found")
+	}
+	err = handlers.CreateOrUpdateLokiStack(context.TODO(), logger, r, k, scheme, featureGates)
+	require.NoError(t, err)
+
+	// make sure delete was called twice (delete rules configmap and ruler statefulset)
+	require.Equal(t, 2, k.DeleteCallCount())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a the removal of ruler resources when it has been disabled.

**Which issue(s) this PR fixes**:
[LOG-3507](https://issues.redhat.com/browse/LOG-3507)


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
