### PR TITLE
helm: add tmp as emptyDir to backend

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -129,6 +129,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: { }
         - name: config
           {{- if .Values.loki.existingSecretForConfig }}
           secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
For the retention, a writable tmp dir is needed in the backend

**Which issue(s) this PR fixes**:
Fixes #8207

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
