### PR TITLE
Update index metrics

### DIFF
--- a/pkg/storage/stores/index/metrics.go
+++ b/pkg/storage/stores/index/metrics.go
@@ -15,6 +15,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Namespace: "loki",
 			Name:      "index_request_duration_seconds",
 			Help:      "Time (in seconds) spent in serving index query requests",
+			Buckets:   prometheus.ExponentialBucketsRange(0.005, 100, 12),
 		}, []string{"operation", "status_code"}),
 	}
 }

--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client.go
@@ -105,9 +105,9 @@ type GatewayClient struct {
 // Otherwise, it creates a single GRPC connection to an Index Gateway instance running in simple mode.
 func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, logger log.Logger) (*GatewayClient, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "loki_boltdb_shipper",
-		Name:      "store_gateway_request_duration_seconds",
-		Help:      "Time (in seconds) spent serving requests when using boltdb shipper store gateway",
+		Namespace: "loki",
+		Name:      "index_gateway_request_duration_seconds",
+		Help:      "Time (in seconds) spent serving requests when using the index gateway",
 		Buckets:   instrument.DefBuckets,
 	}, []string{"operation", "status_code"})
 	if r != nil {


### PR DESCRIPTION
* Renames a metric that was poorly named and suggested it was only available for the boltdb-shipper. This is breaking, but I didn't find any references in our included mixin/etc. 
* Increases histogram bucket ranges to allow measuring beyond 10s p99s for index queries.