### PR TITLE
Helm Chart release automation (step 1)

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -11,6 +11,8 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+[//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
+
 ## 4.4.2
 
 - [CHANGE] Bump Loki version to 2.7.2 and GEL version to 1.6.1


### PR DESCRIPTION
Added automated update locator to helm chart changelog. it will be used to automate helm chart update on Loki/GEL release. Drone CI will put changelog entry to the next line after locator.

Signed-off-by: Vladyslav Diachenko <vlad.diachenko@grafana.com>
