### PR TITLE
Use organization ISSUE_COMMANDS_TOKEN with reduced scope

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -16,6 +16,6 @@ jobs:
         run: npm install --production --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands
-        with:          
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+        with:
+          token: ${{secrets.ISSUE_COMMANDS_TOKEN}}
           configPath: issue_commands


### PR DESCRIPTION
The GH_BOT_ACCESS_TOKEN has permissions beyond those required for addToProject and other API commands that the issue_commands workflow uses.

The new token is set at an organization level so it does not require repository administrators to rotate the token. It also has the minimal classic PAT permissions to facilitate the workflow.

It has expiry but that expiry is reported via email to the engineering organization and the IT Helpdesk have permissions to regenerate the token when expiration is imminent.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
