### PR TITLE
Sizing Tool: Set the minimum replias to 3.

### DIFF
--- a/pkg/sizing/algorithm.go
+++ b/pkg/sizing/algorithm.go
@@ -28,6 +28,9 @@ func calculateClusterSize(nt NodeType, bytesDayIngest float64, qperf QueryPerf) 
 	bytesSecondIngest := bytesDayIngest / 86400
 	numWriteReplicasNeeded := math.Ceil(bytesSecondIngest / nt.writePod.rateBytesSecond)
 
+	// High availability requires at least 3 replicas.
+	numWriteReplicasNeeded = math.Max(3, numWriteReplicasNeeded)
+
 	//Hack based on current 4-1 mem to cpu ratio and base machine w/ 4 cores and 1 write/read
 	writeReplicasPerNode := float64(nt.cores / 4)
 	fullyWritePackedNodes := math.Floor(numWriteReplicasNeeded / writeReplicasPerNode)
@@ -61,6 +64,10 @@ func calculateClusterSize(nt NodeType, bytesDayIngest float64, qperf QueryPerf) 
 	actualReadReplicasAdded := actualNodesAddedForReads * readReplicasPerEmptyNode
 
 	totalReadReplicas := actualReadReplicasAdded + baselineReadReplicas
+
+	// High availability requires at least 3 replicas.
+	totalReadReplicas = math.Max(3, totalReadReplicas)
+
 	totalReadThroughputBytesSec := totalReadReplicas * nt.readPod.rateBytesSecond
 
 	totalNodesNeeded := nodesNeededForWrites + actualNodesAddedForReads

--- a/pkg/sizing/algorithm_test.go
+++ b/pkg/sizing/algorithm_test.go
@@ -50,3 +50,17 @@ func Test_CoresNodeInvariant(t *testing.T) {
 		}
 	}
 }
+
+func Test_MinimumReplicas(t *testing.T) {
+	for _, queryPerformance := range []QueryPerf{Basic, Super} {
+		for _, ingest := range []float64{1, 1000} {
+			for _, cloud := range NodeTypesByProvider {
+				for _, node := range cloud {
+					size := calculateClusterSize(node, ingest, queryPerformance)
+					require.GreaterOrEqual(t, size.TotalReadReplicas, 3)
+					require.GreaterOrEqual(t, size.TotalWriteReplicas, 3)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The sizing tool should set the minimum replicas to three so that high availability is enabled.

**Which issue(s) this PR fixes**:
Fixes #8296

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
