### PR TITLE
Loki: only log "executing query" once per query in the frontend

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -119,7 +119,7 @@ type EngineOpts struct {
 	// only used for instant log queries.
 	MaxLookBackPeriod time.Duration `yaml:"max_look_back_period"`
 
-	// LogExecutingQuery will control if we log the query name when Exec is called.
+	// LogExecutingQuery will control if we log the query when Exec is called.
 	LogExecutingQuery bool `yaml:"-"`
 }
 

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -118,12 +118,17 @@ type EngineOpts struct {
 	// MaxLookBackPeriod is the maximum amount of time to look back for log lines.
 	// only used for instant log queries.
 	MaxLookBackPeriod time.Duration `yaml:"max_look_back_period"`
+
+	// LogExecutingQuery will control if we log the query name when Exec is called.
+	LogExecutingQuery bool `yaml:"-"`
 }
 
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	// TODO: remove this configuration after next release.
 	f.DurationVar(&opts.Timeout, prefix+".engine.timeout", DefaultEngineTimeout, "Use querier.query-timeout instead. Timeout for query execution.")
 	f.DurationVar(&opts.MaxLookBackPeriod, prefix+".engine.max-lookback-period", 30*time.Second, "The maximum amount of time to look back for log lines. Used only for instant log queries.")
+	// Log executing query by default
+	opts.LogExecutingQuery = true
 }
 
 func (opts *EngineOpts) applyDefault() {
@@ -138,6 +143,7 @@ type Engine struct {
 	logger    log.Logger
 	evaluator Evaluator
 	limits    Limits
+	opts      EngineOpts
 }
 
 // NewEngine creates a new LogQL Engine.
@@ -152,6 +158,7 @@ func NewEngine(opts EngineOpts, q Querier, l Limits, logger log.Logger) *Engine 
 		evaluator: NewDefaultEvaluator(q, opts.MaxLookBackPeriod),
 		limits:    l,
 		Timeout:   queryTimeout,
+		opts:      opts,
 	}
 }
 
@@ -164,8 +171,9 @@ func (ng *Engine) Query(params Params) Query {
 		parse: func(_ context.Context, query string) (syntax.Expr, error) {
 			return syntax.ParseExpr(query)
 		},
-		record: true,
-		limits: ng.limits,
+		record:       true,
+		logExecQuery: ng.opts.LogExecutingQuery,
+		limits:       ng.limits,
 	}
 }
 
@@ -176,12 +184,13 @@ type Query interface {
 }
 
 type query struct {
-	logger    log.Logger
-	params    Params
-	parse     func(context.Context, string) (syntax.Expr, error)
-	limits    Limits
-	evaluator Evaluator
-	record    bool
+	logger       log.Logger
+	params       Params
+	parse        func(context.Context, string) (syntax.Expr, error)
+	limits       Limits
+	evaluator    Evaluator
+	record       bool
+	logExecQuery bool
 }
 
 func (q *query) resultLength(res promql_parser.Value) int {
@@ -203,11 +212,13 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	log, ctx := spanlogger.New(ctx, "query.Exec")
 	defer log.Finish()
 
-	queryHash := hashedQuery(q.params.Query())
-	if GetRangeType(q.params) == InstantType {
-		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query(), "query_hash", queryHash)
-	} else {
-		level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step(), "query_hash", queryHash)
+	if q.logExecQuery {
+		queryHash := HashedQuery(q.params.Query())
+		if GetRangeType(q.params) == InstantType {
+			level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "instant", "query", q.params.Query(), "query_hash", queryHash)
+		} else {
+			level.Info(logutil.WithContext(ctx, q.logger)).Log("msg", "executing query", "type", "range", "query", q.params.Query(), "length", q.params.End().Sub(q.params.Start()), "step", q.params.Step(), "query_hash", queryHash)
+		}
 	}
 
 	rangeType := GetRangeType(q.params)

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2496,7 +2496,7 @@ func TestHashingStability(t *testing.T) {
 	queryWithEngine := func() string {
 		buf := bytes.NewBufferString("")
 		logger := log.NewLogfmtLogger(buf)
-		eng := NewEngine(EngineOpts{}, getLocalQuerier(4), NoLimits, logger)
+		eng := NewEngine(EngineOpts{LogExecutingQuery: true}, getLocalQuerier(4), NoLimits, logger)
 		query := eng.Query(params)
 		_, err := query.Exec(ctx)
 		require.NoError(t, err)

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2526,7 +2526,7 @@ func TestHashingStability(t *testing.T) {
 		{`sum (count_over_time({app="myapp",env="myenv"} |= "error" |= "metrics.go" | logfmt [10s])) by(query_hash)`},
 	} {
 		params.qs = test.qs
-		expectedQueryHash := hashedQuery(test.qs)
+		expectedQueryHash := HashedQuery(test.qs)
 
 		// check that both places will end up having the same query hash, even though they're emitting different log lines.
 		require.Regexp(t,

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -114,7 +114,7 @@ func RecordRangeAndInstantQueryMetrics(
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.
 		"query", p.Query(),
-		"query_hash", hashedQuery(p.Query()),
+		"query_hash", HashedQuery(p.Query()),
 		"query_type", queryType,
 		"range_type", rt,
 		"length", p.End().Sub(p.Start()),
@@ -164,7 +164,7 @@ func RecordRangeAndInstantQueryMetrics(
 	recordUsageStats(queryType, stats)
 }
 
-func hashedQuery(query string) uint32 {
+func HashedQuery(query string) uint32 {
 	h := fnv.New32()
 	_, _ = h.Write([]byte(query))
 	return h.Sum32()
@@ -213,6 +213,11 @@ func RecordLabelQueryMetrics(
 	ingesterLineTotal.Add(float64(stats.Ingester.TotalLinesSent))
 }
 
+func PrintMatches(matches []string) string {
+	// not using comma (,) as separator as matcher may already have comma (e.g: `{a="b", c="d"}`)
+	return strings.Join(matches, ":")
+}
+
 func RecordSeriesQueryMetrics(
 	ctx context.Context,
 	log log.Logger,
@@ -240,7 +245,7 @@ func RecordSeriesQueryMetrics(
 		"length", end.Sub(start),
 		"duration", time.Duration(int64(stats.Summary.ExecTime*float64(time.Second))),
 		"status", status,
-		"match", strings.Join(match, ":"), // not using comma (,) as separator as matcher may already have comma (e.g: `{a="b", c="d"}`)
+		"match", PrintMatches(match),
 		"throughput", strings.Replace(humanize.Bytes(uint64(stats.Summary.BytesProcessedPerSecond)), " ", "", 1),
 		"total_bytes", strings.Replace(humanize.Bytes(uint64(stats.Summary.TotalBytesProcessed)), " ", "", 1),
 		"total_entries", stats.Summary.TotalEntriesReturned,

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -189,11 +189,11 @@ func Test_testToKeyValues(t *testing.T) {
 }
 
 func TestQueryHashing(t *testing.T) {
-	h1 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
-	h2 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
+	h1 := HashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	h2 := HashedQuery(`{app="myapp",env="myenv"} |= "error" |= logfmt |= "metrics.go"`)
 	// check that it capture differences of order.
 	require.NotEqual(t, h1, h2)
-	h3 := hashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
+	h3 := HashedQuery(`{app="myapp",env="myenv"} |= "error" |= "metrics.go" |= logfmt`)
 	// check that it evaluate same queries as same hashes, even if evaluated at different timestamps.
 	require.Equal(t, h1, h3)
 }

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -77,7 +77,7 @@ func newASTMapperware(
 		logger:  log.With(logger, "middleware", "QueryShard.astMapperware"),
 		limits:  limits,
 		next:    next,
-		ng:      logql.NewDownstreamEngine(logql.EngineOpts{}, DownstreamHandler{next: next, limits: limits}, limits, logger),
+		ng:      logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
 		metrics: metrics,
 	}
 }

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -437,6 +437,7 @@ func TestPostQueries(t *testing.T) {
 	req = req.WithContext(user.InjectOrgID(context.Background(), "1"))
 	require.NoError(t, err)
 	_, err = newRoundTripper(
+		util_log.Logger,
 		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {
 			t.Error("unexpected default roundtripper called")
 			return nil, nil

--- a/pkg/querier/queryrange/split_by_range.go
+++ b/pkg/querier/queryrange/split_by_range.go
@@ -34,7 +34,7 @@ func NewSplitByRangeMiddleware(logger log.Logger, limits Limits, metrics *logql.
 			logger: log.With(logger, "middleware", "InstantQuery.splitByRangeVector"),
 			next:   next,
 			limits: limits,
-			ng: logql.NewDownstreamEngine(logql.EngineOpts{}, DownstreamHandler{
+			ng: logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{
 				limits: limits,
 				next:   next,
 			}, limits, logger),


### PR DESCRIPTION

Signed-off-by: Edward Welch <edward.welch@grafana.com>

**What this PR does / why we need it**:

This is a continuation of #7469

I had to add a way to disable logging of the "executing query" line from the Engine in the query frontend because this is called for every split by time and shard created by our roundtrippers leading to many "executing query" lines for a single query which is not desired.

Added the "executing query" line to the roundtripper and it now covers: range, instant, series, and labels queries.

It should now also only log one line per query making it possible to correlate this to the "metrics.go" line for a finished query to help debug queries which don't finish because of OOM crash.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
