### PR TITLE
Ensure a delete request interval of at least a second

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
@@ -121,11 +121,7 @@ func shardDeleteRequestsByInterval(startTime, endTime model.Time, query, userID 
 func (dm *DeleteRequestHandler) interval(params url.Values, startTime, endTime model.Time) (time.Duration, error) {
 	qr := params.Get("max_interval")
 	if qr == "" {
-		if dm.maxInterval == 0 {
-			return endTime.Sub(startTime), nil
-		}
-
-		return min(endTime.Sub(startTime), dm.maxInterval), nil
+		return dm.intervalFromStartAndEnd(startTime, endTime)
 	}
 
 	interval, err := time.ParseDuration(qr)
@@ -142,6 +138,18 @@ func (dm *DeleteRequestHandler) interval(params url.Values, startTime, endTime m
 	}
 
 	return interval, nil
+}
+
+func (dm *DeleteRequestHandler) intervalFromStartAndEnd(startTime, endTime model.Time) (time.Duration, error) {
+	interval := endTime.Sub(startTime)
+	if interval < time.Second {
+		return 0, errors.New("difference between start time and end time must be at lest one second")
+	}
+
+	if dm.maxInterval == 0 {
+		return interval, nil
+	}
+	return min(interval, dm.maxInterval), nil
 }
 
 func min(a, b time.Duration) time.Duration {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler.go
@@ -143,7 +143,7 @@ func (dm *DeleteRequestHandler) interval(params url.Values, startTime, endTime m
 func (dm *DeleteRequestHandler) intervalFromStartAndEnd(startTime, endTime model.Time) (time.Duration, error) {
 	interval := endTime.Sub(startTime)
 	if interval < time.Second {
-		return 0, errors.New("difference between start time and end time must be at lest one second")
+		return 0, errors.New("difference between start time and end time must be at least one second")
 	}
 
 	if dm.maxInterval == 0 {

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
@@ -170,6 +170,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "1ms", "invalid max_interval: valid time units are 's', 'm', 'h'\n"},
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "1h", "max_interval can't be greater than 1m0s\n"},
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "30s", "max_interval can't be greater than the interval to be deleted (1s)\n"},
+			{"org-id", `{foo="bar"}`, "0000000000", "0000000000", "", "difference between start time and end time must be at lest one second\n"},
 		} {
 			t.Run(strings.TrimSpace(tc.error), func(t *testing.T) {
 				req := buildRequest(tc.orgID, tc.query, tc.startTime, tc.endTime)

--- a/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/request_handler_test.go
@@ -170,7 +170,7 @@ func TestAddDeleteRequestHandler(t *testing.T) {
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "1ms", "invalid max_interval: valid time units are 's', 'm', 'h'\n"},
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "1h", "max_interval can't be greater than 1m0s\n"},
 			{"org-id", `{foo="bar"}`, "0000000000", "0000000001", "30s", "max_interval can't be greater than the interval to be deleted (1s)\n"},
-			{"org-id", `{foo="bar"}`, "0000000000", "0000000000", "", "difference between start time and end time must be at lest one second\n"},
+			{"org-id", `{foo="bar"}`, "0000000000", "0000000000", "", "difference between start time and end time must be at least one second\n"},
 		} {
 			t.Run(strings.TrimSpace(tc.error), func(t *testing.T) {
 				req := buildRequest(tc.orgID, tc.query, tc.startTime, tc.endTime)


### PR DESCRIPTION
This PR enforces that a the duration of a delete request covers at least 1 second.

Delete requests are designed with second-precision in mind. Without this fix, users are able to submit requests where `startTime == endTime`. In addition to logically ambiguous, it causes a divide-by-zero panic. 