### PR TITLE
[chore] Improve fetching tags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ BUILD_IMAGE_VERSION := 0.27.1
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-FETCH_TAGS :=$(shell ./tools/fetch-tags)
+# Fetch all tags before retrieving branch/tag information from Git
+_ := $(shell git fetch origin --tags)
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries

--- a/tools/fetch-tags
+++ b/tools/fetch-tags
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-git fetch --tags --all


### PR DESCRIPTION
This is an improvement to https://github.com/grafana/loki/pull/8232

Instead of using a separate file, it uses an inline shell command. Use the same command as in the `image-tag` step in DroneCI https://github.com/grafana/loki/blob/main/.drone/drone.yml#L293

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
