### PR TITLE
Prepare 2.7.3 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ##### Fixes
 
-* [8120](https://github.com/grafana/loki/pull/8232) **TaehyunHwang** Fix version info issue that shows wrong version.
-
 ##### Changes
 
 #### Promtail
@@ -30,6 +28,18 @@
 
 ### Dependencies
 
+## 2.7.3 (2023-02-01)
+
+#### Loki
+
+##### Fixes
+
+* [8340](https://github.com/grafana/loki/pull/8340) **MasslessParticle** Fix bug in compactor that caused panics when `startTime` and `endTime` of a delete request are equal.
+
+#### Build
+
+* [8120](https://github.com/grafana/loki/pull/8232) **TaehyunHwang** Fix build issue that caused `--version` to show wrong version for Loki and Promtail binaries.
+
 ## 2.7.2 (2023-01-25)
 
 #### Loki
@@ -39,12 +49,6 @@
 * [7926](https://github.com/grafana/loki/pull/7926) **MichelHollands**: Fix bug in validation of `pattern` and `regexp` parsers where missing or empty parameters caused panics.
 * [7720](https://github.com/grafana/loki/pull/7720) **sandeepsukhani**: Fix bugs in processing delete requests with line filters.
 * [7708](https://github.com/grafana/loki/pull/7708) **DylanGuedes**: Fix bug in multi-tenant querying.
-
-### Notes
-
-This release was created from a branch starting at commit `706c22e9e40b0156031f214b63dc6ed4e210abc1` but it may also contain backported changes from main.
-
-Check the history of the branch `release-2.7.x`.
 
 ### Dependencies
 

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -33,7 +33,12 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 
 ## Bug fixes
 
-### 2.7.2
+### 2.7.3 (2023-02-01)
+
+* Fixed a bug in compactor that caused divide-by-zero panics when `startTime` and `endTime` of a delete request were equal.
+* Fixed the output of the `--version` command that showed an incorrect version information.
+
+### 2.7.2 (2023-01-25)
 
 * Fixed bug in validation of `pattern` and `regexp` parsers where missing or empty parameters for these parsers caused panics.
 * Fixed bugs in processing delete requests with line filters:
@@ -43,7 +48,7 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 * Fixed bug in multi-tenant querying that caused HTTP 400 responses when multiple tenants where used in `X-Scope-OrgID` header like so `tenant-a|tenant-b`.
 * Upgraded Go build version and Docker container base images to 1.19.5 to mitigate [GO-2022-1144](https://pkg.go.dev/vuln/GO-2022-1144) vulnerability.
 
-### 2.7.1 
+### 2.7.1 (2022-12-09)
 
 * Add single compactor http client for delete and gennumber clients. This fixes a bug caused by the accidental introduction of different HTTP clients for compactor and gennumber operations that resulted in 404s when only the gennumber middlewares were enabled:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the new Loki version 2.7.3

---

This new release consists a fix for the build system, which was introduced once we moved building the binaries off CircleCI to Drone.

DroneCI checks out the commit of the tag directly and therefore did not have the tag information at hand when running `./tools/image-tag`.