### PR TITLE
Helm: Align ingress timeout and size limits.

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -530,6 +530,12 @@ http {
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;
 
+  client_max_body_size 4M;
+
+  proxy_read_timeout    600; ## 6 minutes
+  proxy_send_timeout    600;
+  proxy_connect_timeout 600;
+
   proxy_http_version    1.1;
 
   default_type application/octet-stream;


### PR DESCRIPTION
**What this PR does / why we need it**:
The limits configured in the NGinx ingress should align with the timeouts and limits withing Loki.

**Which issue(s) this PR fixes**:
Fixes #8203

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
