### PR TITLE
Validate Loki timeouts align.

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2206,7 +2206,8 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 
 # Timeout when querying backends (ingesters or storage) during the execution of
 # a query request. If a specific per-tenant timeout is used, this timeout is
-# ignored.
+#  ignored.
+# Overrides querier:engine:timeout and querier:query_timeout.
 # CLI flag: -querier.query-timeout
 [query_timeout: <duration> | default = 1m]
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -266,7 +266,7 @@ func (c *Config) Validate() error {
 
 func ValidateConfigTimeouts(c *Config) error {
 	if c.Server.HTTPServerReadTimeout < time.Duration(c.LimitsConfig.QueryTimeout) {
-		return fmt.Errorf("invalid read timeout, the server read timeout (%s) must be larger than the limits timeout (%s)", c.Server.HTTPServerReadTimeout, c.LimitsConfig.QueryTimeout)
+		return fmt.Errorf("invalid read timeout, the server read timeout (%s) must be longer than the limits timeout (%s)", c.Server.HTTPServerReadTimeout, c.LimitsConfig.QueryTimeout)
 	}
 
 	if c.Server.HTTPServerWriteTimeout < time.Duration(c.LimitsConfig.QueryTimeout) {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -270,7 +270,7 @@ func ValidateConfigTimeouts(c *Config) error {
 	}
 
 	if c.Server.HTTPServerWriteTimeout < time.Duration(c.LimitsConfig.QueryTimeout) {
-		return fmt.Errorf("invalid write timeout, the server write timeout (%s) must be larger than the limtis timeout (%s)", c.Server.HTTPServerReadTimeout, c.LimitsConfig.QueryTimeout)
+		return fmt.Errorf("invalid write timeout, the server write timeout (%s) must be longer than the limits timeout (%s)", c.Server.HTTPServerReadTimeout, c.LimitsConfig.QueryTimeout)
 	}
 
 	return nil

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -93,7 +93,7 @@ type Limits struct {
 	MaxCacheFreshness          model.Duration `yaml:"max_cache_freshness_per_query" json:"max_cache_freshness_per_query"`
 	MaxQueriersPerTenant       int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryReadyIndexNumDays     int            `yaml:"query_ready_index_num_days" json:"query_ready_index_num_days"`
-	QueryTimeout               model.Duration `yaml:"query_timeout" json:"query_timeout"`
+	QueryTimeout               model.Duration `yaml:"query_timeout" json:"query_timeout" doc:"description=Timeout when querying backends (ingesters or storage) during the execution of\na query request. If a specific per-tenant timeout is used, this timeout is\nignored.\nOverrides querier:engine:timeout and querier:query_timeout."`
 
 	// Query frontend enforced limits. The default is actually parameterized by the queryrange config.
 	QuerySplitDuration  model.Duration `yaml:"split_queries_by_interval" json:"split_queries_by_interval"`


### PR DESCRIPTION
**What this PR does / why we need it**:
It should be impossible to define a server timeout that is smaller than the query timeout.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
