### PR TITLE
[RFR] fix vector() function produces wrong timestamp on instant query

### DIFF
--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -258,7 +258,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 				return false
 			}
 			return true
-		}, 10*time.Second, 1*time.Second)
+		}, 20*time.Second, 1*time.Second)
 
 		// Check metrics
 		metrics, err := cliCompactor.Metrics()

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -258,7 +258,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 				return false
 			}
 			return true
-		}, 20*time.Second, 1*time.Second)
+		}, 10*time.Second, 1*time.Second)
 
 		// Check metrics
 		metrics, err := cliCompactor.Metrics()

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -431,7 +431,7 @@ func (q *query) evalVector(_ context.Context, expr *syntax.VectorExpr) (promql_p
 
 	if GetRangeType(q.params) == InstantType {
 		return promql.Vector{promql.Sample{
-			Point:  promql.Point{T: s.T, V: value},
+			Point:  promql.Point{T: q.params.Start().UnixNano() / int64(time.Millisecond), V: value},
 			Metric: labels.Labels{},
 		}}, nil
 	}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -430,7 +430,10 @@ func (q *query) evalVector(_ context.Context, expr *syntax.VectorExpr) (promql_p
 	}
 
 	if GetRangeType(q.params) == InstantType {
-		return s, nil
+		return promql.Vector{promql.Sample{
+			Point:  promql.Point{T: s.T, V: value},
+			Metric: labels.Labels{},
+		}}, nil
 	}
 
 	return PopulateMatrixFromScalar(s, q.params), nil

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -431,7 +431,7 @@ func (q *query) evalVector(_ context.Context, expr *syntax.VectorExpr) (promql_p
 
 	if GetRangeType(q.params) == InstantType {
 		return promql.Vector{promql.Sample{
-			Point:  promql.Point{T: q.params.Start().UnixNano() / int64(time.Millisecond), V: value},
+			Point:  promql.Point{T: q.params.Start().UnixMilli(), V: value},
 			Metric: labels.Labels{},
 		}}, nil
 	}

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -643,7 +643,10 @@ func TestEngine_LogsInstantQuery(t *testing.T) {
 			time.Unix(60, 0), logproto.FORWARD, 100,
 			nil,
 			nil,
-			promql.Scalar{T: 60 * 1000, V: 2},
+			promql.Vector{promql.Sample{
+				Point:  promql.Point{T: 60 * 1000, V: 2},
+				Metric: labels.Labels{},
+			}},
 		},
 		{
 			// single comparison

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2302,6 +2302,37 @@ func TestEngine_LogsInstantQuery_IllegalLogql(t *testing.T) {
 	require.EqualError(t, err, expectEvalSampleErr.Error())
 }
 
+func TestEngine_LogsInstantQuery_Vector(t *testing.T) {
+	eng := NewEngine(EngineOpts{}, &statsQuerier{}, NoLimits, log.NewNopLogger())
+	now := time.Now()
+	queueTime := 2 * time.Nanosecond
+	logqlVector := `vector(5)`
+	q := eng.Query(LiteralParams{
+		qs:        logqlVector,
+		start:     now,
+		end:       now,
+		step:      0,
+		interval:  time.Second * 30,
+		direction: logproto.BACKWARD,
+		limit:     1000,
+	})
+	ctx := context.WithValue(context.Background(), httpreq.QueryQueueTimeHTTPHeader, queueTime)
+	_, err := q.Exec(user.InjectOrgID(ctx, "fake"))
+
+	require.NoError(t, err)
+
+	qry, ok := q.(*query)
+	require.Equal(t, ok, true)
+	vectorExpr := syntax.NewVectorExpr("5")
+
+	data, err := qry.evalSample(ctx, vectorExpr)
+	require.NoError(t, err)
+	result, ok := data.(promql.Vector)
+	require.Equal(t, ok, true)
+	require.Equal(t, result[0].V, float64(5))
+	require.Equal(t, result[0].T, now.UnixNano()/int64(time.Millisecond))
+}
+
 type errorIteratorQuerier struct {
 	samples []iter.SampleIterator
 	entries []iter.EntryIterator

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -232,7 +232,7 @@ func (ev *DefaultEvaluator) StepEvaluator(
 		if err != nil {
 			return nil, err
 		}
-		return newVectorIterator(val, q.Step().Milliseconds(), q.Start().UnixNano()/int64(time.Millisecond), q.End().UnixNano()/int64(time.Millisecond)), nil
+		return newVectorIterator(val, q.Step().Milliseconds(), q.Start().UnixMilli(), q.End().UnixMilli()), nil
 	default:
 		return nil, EvaluatorUnsupportedType(e, ev)
 	}

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -232,7 +232,7 @@ func (ev *DefaultEvaluator) StepEvaluator(
 		if err != nil {
 			return nil, err
 		}
-		return newVectorIterator(val, q.Step().Nanoseconds(), q.Start().UnixNano(), q.End().UnixNano()), nil
+		return newVectorIterator(val, q.Step().Milliseconds(), q.Start().UnixNano()/int64(time.Millisecond), q.End().UnixNano()/int64(time.Millisecond)), nil
 	default:
 		return nil, EvaluatorUnsupportedType(e, ev)
 	}
@@ -944,34 +944,34 @@ func literalStepEvaluator(
 
 // vectorIterator return simple vector like (1).
 type vectorIterator struct {
-	step, end, current int64
-	val                float64
+	stepMs, endMs, currentMs int64
+	val                      float64
 }
 
 func newVectorIterator(val float64,
-	step, start, end int64) *vectorIterator {
-	if step == 0 {
-		step = 1
+	stepMs, startMs, endMs int64) *vectorIterator {
+	if stepMs == 0 {
+		stepMs = 1
 	}
 	return &vectorIterator{
-		val:     val,
-		step:    step,
-		end:     end,
-		current: start - step,
+		val:       val,
+		stepMs:    stepMs,
+		endMs:     endMs,
+		currentMs: startMs - stepMs,
 	}
 }
 
 func (r *vectorIterator) Next() (bool, int64, promql.Vector) {
-	r.current = r.current + r.step
-	if r.current > r.end {
+	r.currentMs = r.currentMs + r.stepMs
+	if r.currentMs > r.endMs {
 		return false, 0, nil
 	}
 	results := make(promql.Vector, 0)
 	vectorPoint := promql.Sample{
-		Point: promql.Point{T: r.current, V: r.val},
+		Point: promql.Point{T: r.currentMs, V: r.val},
 	}
 	results = append(results, vectorPoint)
-	return true, r.current, results
+	return true, r.currentMs, results
 }
 
 func (r *vectorIterator) Close() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix vector() function produces wrong timestamp on instant query
**Which issue(s) this PR fixes**:
Fixes #8240

**Special notes for your reviewer**:
**error snapshot**
error timestamp in grafana 7.x
![image](https://user-images.githubusercontent.com/9583245/216038312-bcaf078e-4892-4c73-8a32-b59fae14487a.png)
error timestamp in grafana 9.x
![image](https://user-images.githubusercontent.com/9583245/216045145-5ac1938e-9aae-4429-af1b-ebbcac096835.png)


**with this PR**
fix logql:
` vector(5)
`![image](https://user-images.githubusercontent.com/9583245/216041127-bbf5aa0a-6db0-4610-bf25-a6ebc96e5bf9.png)

with this PR
fix logql:
```
sum(count_over_time({namespace="traefik"}[5m]))
     or
     vector(5)
```
![image](https://user-images.githubusercontent.com/9583245/216043179-8fb9c0cb-27d7-4931-b8f5-4c47963680a0.png)


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
