### PR TITLE
Promtail: Add event log message stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [8233](https://github.com/grafana/loki/pull/8233) **nicoche**: promtail: Add `max-line-size-truncate` limit to truncate too long lines on client side
 * [7462](https://github.com/grafana/loki/pull/7462) **MarNicGit**: Allow excluding event message from Windows Event Log entries.
 * [7597](https://github.com/grafana/loki/pull/7597) **redbaron**: allow ratelimiting by label
+* [8382](https://github.com/grafana/loki/pull/8382) **kelnage**: Promtail: Add event log message stage
 
 ##### Fixes
 

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -105,7 +105,7 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 	}
 	lines := strings.Split(s, "\r\n")
 	for _, line := range lines {
-		parts := RegexSplitKeyValue.Split(line, 2)
+		parts := strings.SplitN(line, ":", 2)
 		if len(parts) < 2 {
 			level.Warn(m.logger).Log("msg", "invalid line parsed from message", "line", line)
 			continue
@@ -126,6 +126,9 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 			mkey += "_extracted"
 		}
 		mval := parts[1]
+		if len(mval) > 0 {
+			mval = mval[1:]
+		}
 		if !model.LabelValue(mval).IsValid() {
 			if Debug {
 				level.Debug(m.logger).Log("msg", "invalid value parsed from message", "value", mval)

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -152,13 +152,13 @@ func SanitizeLabelName(input string) string {
 	if len(input) == 0 {
 		return "_"
 	}
-	var valid_sb strings.Builder
+	var validSb strings.Builder
 	for i, b := range input {
 		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) {
-			valid_sb.WriteRune('_')
+			validSb.WriteRune('_')
 		} else {
-			valid_sb.WriteRune(b)
+			validSb.WriteRune(b)
 		}
 	}
-	return valid_sb.String()
+	return validSb.String()
 }

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -98,18 +98,14 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 	}
 	s, err := getString(value)
 	if err != nil {
-		if Debug {
-			level.Debug(m.logger).Log("msg", "invalid label value parsed", "value", value)
-		}
+		level.Warn(m.logger).Log("msg", "invalid label value parsed", "value", value)
 		return err
 	}
 	lines := strings.Split(s, "\r\n")
 	for _, line := range lines {
 		parts := regexp.MustCompile(": ?").Split(line, 2)
 		if len(parts) < 2 {
-			if Debug {
-				level.Debug(m.logger).Log("msg", "invalid line parsed from message", "line", line)
-			}
+			level.Warn(m.logger).Log("msg", "invalid line parsed from message", "line", line)
 			continue
 		}
 		mkey := parts[0]

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -21,6 +21,7 @@ const (
 type EventLogMessageConfig struct {
 	Source            *string `mapstructure:"source"`
 	DropInvalidLabels bool    `mapstructure:"drop_invalid_labels"`
+	OverwriteExisting bool    `mapstructure:"overwrite_existing"`
 }
 
 type eventLogMessageStage struct {
@@ -116,15 +117,15 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 		if !model.LabelName(mkey).IsValid() {
 			if m.cfg.DropInvalidLabels {
 				if Debug {
-					level.Debug(m.logger).Log("msg", "invalid key parsed from message", "key", mkey)
+					level.Debug(m.logger).Log("msg", "invalid label parsed from message", "key", mkey)
 				}
 				continue
 			}
 			mkey = SanitizeLabelName(mkey)
 		}
-		if _, ok := extracted[mkey]; ok {
+		if _, ok := extracted[mkey]; ok && !m.cfg.OverwriteExisting {
 			if Debug {
-				level.Debug(m.logger).Log("msg", "extracted key that already existed, ignoring", "key", mkey)
+				level.Debug(m.logger).Log("msg", "extracted label that already existed, ignoring", "key", mkey)
 			}
 			continue
 		}

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -125,10 +125,7 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 				"key", mkey)
 			mkey += "_extracted"
 		}
-		mval := parts[1]
-		if len(mval) > 0 {
-			mval = mval[1:]
-		}
+		mval := strings.TrimSpace(parts[1])
 		if !model.LabelValue(mval).IsValid() {
 			if Debug {
 				level.Debug(m.logger).Log("msg", "invalid value parsed from message", "value", mval)

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -1,0 +1,138 @@
+package stages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/mitchellh/mapstructure"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	defaultSource                    = "message"
+	ErrInvalidMessageSourceLabelName = "invalid label name: %s"
+)
+
+type EventLogMessageConfig struct {
+	Source *string `mapstructure:"source"`
+}
+
+type eventLogMessageStage struct {
+	cfg    *EventLogMessageConfig
+	logger log.Logger
+}
+
+func validateEventLogMessageStage(c *EventLogMessageConfig) error {
+	if c == nil {
+		// An empty config is allowed, use defaults (denoted by a nil Source
+		c = &EventLogMessageConfig{Source: nil}
+		return nil
+	}
+	if c.Source == nil {
+		// A nil Source is also allowed, will use default value
+		return nil
+	}
+	if !model.LabelName(*c.Source).IsValid() {
+		return fmt.Errorf(ErrInvalidMessageSourceLabelName, *c.Source)
+	}
+	return nil
+}
+
+func newEventLogMessageStage(logger log.Logger, config interface{}) (Stage, error) {
+	cfg, err := parseEventLogMessageStage(config)
+	if err != nil {
+		return nil, err
+	}
+	// validate config (i.e., check that source is a valid log label)
+	validateEventLogMessageStage(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &eventLogMessageStage{
+		cfg:    cfg,
+		logger: log.With(logger, "component", "stage", "type", "event_log_message"),
+	}, nil
+}
+
+func parseEventLogMessageStage(config interface{}) (*EventLogMessageConfig, error) {
+	cfg := &EventLogMessageConfig{}
+	err := mapstructure.Decode(config, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (m *eventLogMessageStage) Run(in chan Entry) chan Entry {
+	out := make(chan Entry)
+	key := defaultSource
+	if m.cfg.Source != nil {
+		key = *m.cfg.Source
+	}
+	go func() {
+		defer close(out)
+		for e := range in {
+			err := m.processEntry(e.Extracted, key)
+			if err != nil {
+				continue
+			}
+			out <- e
+		}
+	}()
+	return out
+}
+
+func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, key string) error {
+	value, ok := extracted[key]
+	if !ok {
+		if Debug {
+			level.Debug(m.logger).Log("msg", "source does not exist in the set of extracted values", "source", key)
+		}
+		return nil
+	}
+	s, err := getString(value)
+	if err != nil {
+		if Debug {
+			level.Debug(m.logger).Log("msg", "invalid label value parsed", "value", value)
+		}
+		return err
+	}
+	lines := strings.Split(s, "\r\n")
+	for _, line := range lines {
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) < 2 {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "invalid line parsed from message", "line", line)
+			}
+			continue
+		}
+		mkey := parts[0]
+		if !model.LabelName(mkey).IsValid() {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "invalid key parsed from message", "key", mkey)
+			}
+			continue
+		}
+		if _, ok := extracted[mkey]; ok {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "message contained key that already existed, ignoring", "key", mkey)
+			}
+			continue
+		}
+		mval := parts[1]
+		if !model.LabelValue(mval).IsValid() {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "invalid value parsed from message", "value", mval)
+			}
+			continue
+		}
+		extracted[mkey] = mval
+	}
+	return nil
+}
+
+func (m *eventLogMessageStage) Name() string {
+	return StageTypeEventLogMessage
+}

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -123,9 +123,9 @@ func (m *eventLogMessageStage) processEntry(extracted map[string]interface{}, ke
 			mkey = SanitizeLabelName(mkey)
 		}
 		if _, ok := extracted[mkey]; ok && !m.cfg.OverwriteExisting {
-			level.Info(m.logger).Log("msg", "extracted label that already existed, ignoring value from source",
-				"key", mkey, "oldval", extracted[mkey], "newval", parts[1])
-			continue
+			level.Info(m.logger).Log("msg", "extracted key that already existed, appending _extracted to key",
+				"key", mkey)
+			mkey += "_extracted"
 		}
 		mval := parts[1]
 		if !model.LabelValue(mval).IsValid() {

--- a/clients/pkg/logentry/stages/eventlogmessage.go
+++ b/clients/pkg/logentry/stages/eventlogmessage.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -16,8 +15,6 @@ const (
 	defaultSource                = "message"
 	ErrEmptyEvtLogMsgStageConfig = "empty event log message stage configuration"
 )
-
-var RegexSplitKeyValue = regexp.MustCompile(": ?")
 
 type EventLogMessageConfig struct {
 	Source            *string `mapstructure:"source"`

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -340,6 +341,7 @@ func TestEventLogMessage_invalidString(t *testing.T) {
 
 var inputJustKey = "Key 1:"
 var inputBoth = "Key 1: Value 1"
+var RegexSplitKeyValue = regexp.MustCompile(": ?")
 
 func BenchmarkSplittingKeyValuesRegex(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -277,7 +277,6 @@ var testEvtLogMsgInvalidOverwriteMessage = "message: a new message"
 
 func TestEventLogMessage_invalid(t *testing.T) {
 	t.Parallel()
-	Debug = true
 
 	tests := map[string]struct {
 		config          string

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -1,0 +1,313 @@
+package stages
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var testEvtLogMsgYamlDefaults = `
+pipeline_stages:
+- eventlogmessage: {}
+`
+
+var testEvtLogMsgYamlCustomSource = `
+pipeline_stages:
+- eventlogmessage:
+    source: Message
+`
+
+var testEvtLogMsgYamlDropInvalidLabels = `
+pipeline_stages:
+- eventlogmessage:
+    drop_invalid_labels: true
+`
+
+var testEvtLogMsgSimple = "Key1: Value 1\r\nKey2: Value 2\r\nKey3: Value: 3"
+var testEvtLogMsgInvalidLabels = "Key 1: Value 1\r\n0Key2: Value 2\r\nKey@3: Value 3\r\n: Value 4"
+
+func TestEventLogMessage_simple(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config          string
+		sourcekey       string
+		msgdata         string
+		extractedValues map[string]interface{}
+	}{
+		"successfully ran a pipeline with sample event log message stage using default source": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgSimple,
+			map[string]interface{}{
+				"Key1": "Value 1",
+				"Key2": "Value 2",
+				"Key3": "Value: 3",
+			},
+		},
+		"successfully ran a pipeline with sample event log message stage using custom source": {
+			testEvtLogMsgYamlCustomSource,
+			"Message",
+			testEvtLogMsgSimple,
+			map[string]interface{}{
+				"Key1": "Value 1",
+				"Key2": "Value 2",
+				"Key3": "Value: 3",
+			},
+		},
+		"successfully ran a pipeline with sample event log message stage containing invalid labels": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgInvalidLabels,
+			map[string]interface{}{
+				"Key_1": "Value 1",
+				"_Key2": "Value 2",
+				"Key_3": "Value 3",
+				"_":     "Value 4",
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+		testData.extractedValues[testData.sourcekey] = testData.msgdata
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(util_log.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			assert.NoError(t, err, "Expected pipeline creation to not result in error")
+			out := processEntries(pl,
+				newEntry(map[string]interface{}{testData.sourcekey: testData.msgdata}, nil, testData.msgdata, time.Now()))[0]
+			assert.Equal(t, testData.extractedValues, out.Extracted)
+		})
+	}
+}
+
+func TestEventLogMessageConfig_validate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config        interface{}
+		wantExprCount int
+		err           error
+	}{
+		"invalid source": {
+			map[string]interface{}{
+				"source": "The Message!",
+			},
+			0,
+			fmt.Errorf(ErrInvalidEvtLogMsgSourceLabelName, "The Message!"),
+		},
+		"empty source": {
+			map[string]interface{}{
+				"source": "",
+			},
+			0,
+			fmt.Errorf(ErrInvalidEvtLogMsgSourceLabelName, ""),
+		},
+	}
+	for tName, tt := range tests {
+		tt := tt
+		t.Run(tName, func(t *testing.T) {
+			c, err := parseEventLogMessageConfig(tt.config)
+			assert.NoError(t, err, "failed to create config: %s", err)
+			validateErr := validateEventLogMessageConfig(c)
+			if tt.err != nil {
+				assert.NotNil(t, validateErr, "JSONConfig.validate() expected error = %v, but got nil", tt.err)
+			}
+			if err != nil {
+				assert.Equal(t, tt.err.Error(), validateErr.Error(), "JSONConfig.validate() expected error = %v, actual error = %v", tt.err, validateErr)
+			}
+		})
+	}
+}
+
+var testEvtLogMsgNetworkConn = "Network connection detected:\r\nRuleName: Usermode\r\n" +
+	"UtcTime: 2023-01-31 08:07:23.782\r\nProcessGuid: {44ffd2c7-cc3a-63d8-2002-000000000d00}\r\n" +
+	"ProcessId: 7344\r\nImage: C:\\Users\\User\\promtail\\promtail-windows-amd64.exe\r\n" +
+	"User: WINTEST2211\\User\r\nProtocol: tcp\r\nInitiated: true\r\nSourceIsIpv6: false\r\n" +
+	"SourceIp: 10.0.2.15\r\nSourceHostname: WinTest2211..\r\nSourcePort: 49992\r\n" +
+	"SourcePortName: -\r\nDestinationIsIpv6: false\r\nDestinationIp: 34.117.8.58\r\n" +
+	"DestinationHostname: 58.8.117.34.bc.googleusercontent.com\r\nDestinationPort: 443\r\n" +
+	"DestinationPortName: https"
+
+func TestEventLogMessage_Real(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config          string
+		sourcekey       string
+		msgdata         string
+		extractedValues map[string]interface{}
+	}{
+		"successfully ran a pipeline with network event log message stage using default source": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgNetworkConn,
+			map[string]interface{}{
+				"Network_connection_detected": "",
+				"RuleName":                    "Usermode",
+				"UtcTime":                     "2023-01-31 08:07:23.782",
+				"ProcessGuid":                 "{44ffd2c7-cc3a-63d8-2002-000000000d00}",
+				"ProcessId":                   "7344",
+				"Image":                       "C:\\Users\\User\\promtail\\promtail-windows-amd64.exe",
+				"User":                        "WINTEST2211\\User",
+				"Protocol":                    "tcp",
+				"Initiated":                   "true",
+				"SourceIsIpv6":                "false",
+				"SourceIp":                    "10.0.2.15",
+				"SourceHostname":              "WinTest2211..",
+				"SourcePort":                  "49992",
+				"SourcePortName":              "-",
+				"DestinationIsIpv6":           "false",
+				"DestinationIp":               "34.117.8.58",
+				"DestinationHostname":         "58.8.117.34.bc.googleusercontent.com",
+				"DestinationPort":             "443",
+				"DestinationPortName":         "https",
+			},
+		},
+		"successfully ran a pipeline with network event log message stage using custom source": {
+			testEvtLogMsgYamlCustomSource,
+			"Message",
+			testEvtLogMsgNetworkConn,
+			map[string]interface{}{
+				"Network_connection_detected": "",
+				"RuleName":                    "Usermode",
+				"UtcTime":                     "2023-01-31 08:07:23.782",
+				"ProcessGuid":                 "{44ffd2c7-cc3a-63d8-2002-000000000d00}",
+				"ProcessId":                   "7344",
+				"Image":                       "C:\\Users\\User\\promtail\\promtail-windows-amd64.exe",
+				"User":                        "WINTEST2211\\User",
+				"Protocol":                    "tcp",
+				"Initiated":                   "true",
+				"SourceIsIpv6":                "false",
+				"SourceIp":                    "10.0.2.15",
+				"SourceHostname":              "WinTest2211..",
+				"SourcePort":                  "49992",
+				"SourcePortName":              "-",
+				"DestinationIsIpv6":           "false",
+				"DestinationIp":               "34.117.8.58",
+				"DestinationHostname":         "58.8.117.34.bc.googleusercontent.com",
+				"DestinationPort":             "443",
+				"DestinationPortName":         "https",
+			},
+		},
+		"successfully ran a pipeline with network event log message stage dropping invalid labels": {
+			testEvtLogMsgYamlDropInvalidLabels,
+			"message",
+			testEvtLogMsgNetworkConn,
+			map[string]interface{}{
+				"RuleName":            "Usermode",
+				"UtcTime":             "2023-01-31 08:07:23.782",
+				"ProcessGuid":         "{44ffd2c7-cc3a-63d8-2002-000000000d00}",
+				"ProcessId":           "7344",
+				"Image":               "C:\\Users\\User\\promtail\\promtail-windows-amd64.exe",
+				"User":                "WINTEST2211\\User",
+				"Protocol":            "tcp",
+				"Initiated":           "true",
+				"SourceIsIpv6":        "false",
+				"SourceIp":            "10.0.2.15",
+				"SourceHostname":      "WinTest2211..",
+				"SourcePort":          "49992",
+				"SourcePortName":      "-",
+				"DestinationIsIpv6":   "false",
+				"DestinationIp":       "34.117.8.58",
+				"DestinationHostname": "58.8.117.34.bc.googleusercontent.com",
+				"DestinationPort":     "443",
+				"DestinationPortName": "https",
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+		testData.extractedValues[testData.sourcekey] = testData.msgdata
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(util_log.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			assert.NoError(t, err, "Expected pipeline creation to not result in error")
+			out := processEntries(pl,
+				newEntry(map[string]interface{}{testData.sourcekey: testData.msgdata}, nil, testData.msgdata, time.Now()))[0]
+			assert.Equal(t, testData.extractedValues, out.Extracted)
+		})
+	}
+}
+
+var testEvtLogMsgInvalidStructure = "\n\rwhat; is this?\n\r"
+var testEvtLogMsgInvalidValue = "Key1: " + string([]byte{0xff, 0xfe, 0xfd})
+var testEvtLogMsgInvalidOverwriteMessage = "message: a new message"
+
+func TestEventLogMessage_invalid(t *testing.T) {
+	t.Parallel()
+	Debug = true
+
+	tests := map[string]struct {
+		config          string
+		sourcekey       string
+		msgdata         string
+		extractedValues map[string]interface{}
+	}{
+		"successfully ran a pipeline with an invalid event log message": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgInvalidStructure,
+			map[string]interface{}{},
+		},
+		"successfully ran a pipeline with sample event log message stage on the wrong default source": {
+			testEvtLogMsgYamlDefaults,
+			"notmessage",
+			testEvtLogMsgSimple,
+			map[string]interface{}{},
+		},
+		"successfully ran a pipeline with sample event log message stage dropping invalid labels": {
+			testEvtLogMsgYamlDropInvalidLabels,
+			"message",
+			testEvtLogMsgInvalidLabels,
+			map[string]interface{}{},
+		},
+		"successfully ran a pipeline with an invalid event log message value (not UTF-8)": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgInvalidValue,
+			map[string]interface{}{},
+		},
+		"successfully ran a pipeline with an invalid event log message overwriting an existing key": {
+			testEvtLogMsgYamlDefaults,
+			"message",
+			testEvtLogMsgInvalidOverwriteMessage,
+			map[string]interface{}{},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+		testData.extractedValues[testData.sourcekey] = testData.msgdata
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			pl, err := NewPipeline(util_log.Logger, loadConfig(testData.config), nil, prometheus.DefaultRegisterer)
+			assert.NoError(t, err, "Expected pipeline creation to not result in error")
+			out := processEntries(pl,
+				newEntry(map[string]interface{}{testData.sourcekey: testData.msgdata}, nil, testData.msgdata, time.Now()))[0]
+			assert.Equal(t, testData.extractedValues, out.Extracted)
+		})
+	}
+}
+
+func TestEventLogMessage_invalidString(t *testing.T) {
+	t.Parallel()
+
+	pl, err := NewPipeline(util_log.Logger, loadConfig(testEvtLogMsgYamlDefaults), nil, prometheus.DefaultRegisterer)
+	assert.NoError(t, err, "Expected pipeline creation to not result in error")
+	out := processEntries(pl,
+		newEntry(map[string]interface{}{"message": nil}, nil, "", time.Now()))
+	assert.Len(t, out, 0, "No output should be produced with a nil input")
+}

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -135,13 +135,13 @@ func TestEventLogMessageConfig_validate(t *testing.T) {
 			map[string]interface{}{
 				"source": "The Message!",
 			},
-			fmt.Errorf(ErrInvalidEvtLogMsgSourceLabelName, "The Message!"),
+			fmt.Errorf(ErrInvalidLabelName, "The Message!"),
 		},
 		"empty source": {
 			map[string]interface{}{
 				"source": "",
 			},
-			fmt.Errorf(ErrInvalidEvtLogMsgSourceLabelName, ""),
+			fmt.Errorf(ErrInvalidLabelName, ""),
 		},
 	}
 	for tName, tt := range tests {

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -87,7 +87,8 @@ func TestEventLogMessage_simple(t *testing.T) {
 			"message",
 			testEvtLogMsgOverwriteTest,
 			map[string]interface{}{
-				"test": "existing value",
+				"test":           "existing value",
+				"test_extracted": "new value",
 			},
 		},
 		"successfully ran a pipeline with sample event log message stage overwriting existing labels": {
@@ -307,12 +308,6 @@ func TestEventLogMessage_invalid(t *testing.T) {
 			testEvtLogMsgYamlDefaults,
 			"message",
 			testEvtLogMsgInvalidValue,
-			map[string]interface{}{},
-		},
-		"successfully ran a pipeline with an invalid event log message overwriting an existing key": {
-			testEvtLogMsgYamlDefaults,
-			"message",
-			testEvtLogMsgInvalidOverwriteMessage,
 			map[string]interface{}{},
 		},
 	}

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -359,11 +359,11 @@ func BenchmarkSplittingKeyValuesRegex(b *testing.B) {
 func BenchmarkSplittingKeyValuesSplitTrim(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var val string
-		resultKey := strings.SplitN(":", inputJustKey, 2)
+		resultKey := strings.SplitN(inputJustKey, ":", 2)
 		if len(resultKey) > 1 {
 			val = strings.TrimLeft(resultKey[1], " ")
 		}
-		resultKeyValue := RegexSplitKeyValue.Split(inputBoth, 2)
+		resultKeyValue := strings.SplitN(inputBoth, ":", 2)
 		if len(resultKey) > 1 {
 			val = strings.TrimLeft(resultKeyValue[1], " ")
 		}
@@ -374,11 +374,11 @@ func BenchmarkSplittingKeyValuesSplitTrim(b *testing.B) {
 func BenchmarkSplittingKeyValuesSplitSubstr(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var val string
-		resultKey := strings.SplitN(":", inputJustKey, 2)
+		resultKey := strings.SplitN(inputJustKey, ":", 2)
 		if len(resultKey) > 1 && len(resultKey[1]) > 0 {
 			val = resultKey[1][1:]
 		}
-		resultKeyValue := RegexSplitKeyValue.Split(inputBoth, 2)
+		resultKeyValue := strings.SplitN(inputBoth, ":", 2)
 		if len(resultKey) > 1 && len(resultKey[1]) > 0 {
 			val = resultKeyValue[1][1:]
 		}

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -275,7 +275,6 @@ func TestEventLogMessage_Real(t *testing.T) {
 
 var testEvtLogMsgInvalidStructure = "\n\rwhat; is this?\n\r"
 var testEvtLogMsgInvalidValue = "Key1: " + string([]byte{0xff, 0xfe, 0xfd})
-var testEvtLogMsgInvalidOverwriteMessage = "message: a new message"
 
 func TestEventLogMessage_invalid(t *testing.T) {
 	t.Parallel()

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -37,9 +37,11 @@ pipeline_stages:
     overwrite_existing: true
 `
 
-var testEvtLogMsgSimple = "Key1: Value 1\r\nKey2: Value 2\r\nKey3: Value: 3"
-var testEvtLogMsgInvalidLabels = "Key 1: Value 1\r\n0Key2: Value 2\r\nKey@3: Value 3\r\n: Value 4"
-var testEvtLogMsgOverwriteTest = "test: new value"
+var (
+	testEvtLogMsgSimple        = "Key1: Value 1\r\nKey2: Value 2\r\nKey3: Value: 3"
+	testEvtLogMsgInvalidLabels = "Key 1: Value 1\r\n0Key2: Value 2\r\nKey@3: Value 3\r\n: Value 4"
+	testEvtLogMsgOverwriteTest = "test: new value"
+)
 
 func TestEventLogMessage_simple(t *testing.T) {
 	t.Parallel()
@@ -275,8 +277,10 @@ func TestEventLogMessage_Real(t *testing.T) {
 	}
 }
 
-var testEvtLogMsgInvalidStructure = "\n\rwhat; is this?\n\r"
-var testEvtLogMsgInvalidValue = "Key1: " + string([]byte{0xff, 0xfe, 0xfd})
+var (
+	testEvtLogMsgInvalidStructure = "\n\rwhat; is this?\n\r"
+	testEvtLogMsgInvalidValue     = "Key1: " + string([]byte{0xff, 0xfe, 0xfd})
+)
 
 func TestEventLogMessage_invalid(t *testing.T) {
 	t.Parallel()
@@ -339,9 +343,11 @@ func TestEventLogMessage_invalidString(t *testing.T) {
 	assert.Len(t, out, 0, "No output should be produced with a nil input")
 }
 
-var inputJustKey = "Key 1:"
-var inputBoth = "Key 1: Value 1"
-var RegexSplitKeyValue = regexp.MustCompile(": ?")
+var (
+	inputJustKey       = "Key 1:"
+	inputBoth          = "Key 1: Value 1"
+	RegexSplitKeyValue = regexp.MustCompile(": ?")
+)
 
 func BenchmarkSplittingKeyValuesRegex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -363,11 +369,11 @@ func BenchmarkSplittingKeyValuesSplitTrim(b *testing.B) {
 		var val string
 		resultKey := strings.SplitN(inputJustKey, ":", 2)
 		if len(resultKey) > 1 {
-			val = strings.TrimLeft(resultKey[1], " ")
+			val = strings.TrimSpace(resultKey[1])
 		}
 		resultKeyValue := strings.SplitN(inputBoth, ":", 2)
 		if len(resultKey) > 1 {
-			val = strings.TrimLeft(resultKeyValue[1], " ")
+			val = strings.TrimSpace(resultKeyValue[1])
 		}
 		_ = val
 	}

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -129,7 +129,7 @@ func TestEventLogMessageConfig_validate(t *testing.T) {
 			map[string]interface{}{
 				"source": 1,
 			},
-			errors.New("'source' expected type 'string', got unconvertible type 'int', value: '1'"),
+			errors.New("1 error(s) decoding:\n\n* 'source' expected type 'string', got unconvertible type 'int', value: '1'"),
 		},
 		"invalid source": {
 			map[string]interface{}{

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 var testEvtLogMsgYamlDefaults = `
@@ -133,9 +134,9 @@ func TestEventLogMessageConfig_validate(t *testing.T) {
 		},
 		"invalid source": {
 			map[string]interface{}{
-				"source": "The Message!",
+				"source": "the message",
 			},
-			fmt.Errorf(ErrInvalidLabelName, "The Message!"),
+			fmt.Errorf(ErrInvalidLabelName, "the message"),
 		},
 		"empty source": {
 			map[string]interface{}{

--- a/clients/pkg/logentry/stages/eventlogmessage_test.go
+++ b/clients/pkg/logentry/stages/eventlogmessage_test.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,4 +336,52 @@ func TestEventLogMessage_invalidString(t *testing.T) {
 	out := processEntries(pl,
 		newEntry(map[string]interface{}{"message": nil}, nil, "", time.Now()))
 	assert.Len(t, out, 0, "No output should be produced with a nil input")
+}
+
+var inputJustKey = "Key 1:"
+var inputBoth = "Key 1: Value 1"
+
+func BenchmarkSplittingKeyValuesRegex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var val string
+		resultKey := RegexSplitKeyValue.Split(inputJustKey, 2)
+		if len(resultKey) > 1 {
+			val = resultKey[1]
+		}
+		resultKeyValue := RegexSplitKeyValue.Split(inputBoth, 2)
+		if len(resultKeyValue) > 1 {
+			val = resultKeyValue[1]
+		}
+		_ = val
+	}
+}
+
+func BenchmarkSplittingKeyValuesSplitTrim(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var val string
+		resultKey := strings.SplitN(":", inputJustKey, 2)
+		if len(resultKey) > 1 {
+			val = strings.TrimLeft(resultKey[1], " ")
+		}
+		resultKeyValue := RegexSplitKeyValue.Split(inputBoth, 2)
+		if len(resultKey) > 1 {
+			val = strings.TrimLeft(resultKeyValue[1], " ")
+		}
+		_ = val
+	}
+}
+
+func BenchmarkSplittingKeyValuesSplitSubstr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var val string
+		resultKey := strings.SplitN(":", inputJustKey, 2)
+		if len(resultKey) > 1 && len(resultKey[1]) > 0 {
+			val = resultKey[1][1:]
+		}
+		resultKeyValue := RegexSplitKeyValue.Split(inputBoth, 2)
+		if len(resultKey) > 1 && len(resultKey[1]) > 0 {
+			val = resultKeyValue[1][1:]
+		}
+		_ = val
+	}
 }

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -15,28 +15,29 @@ import (
 )
 
 const (
-	StageTypeJSON         = "json"
-	StageTypeLogfmt       = "logfmt"
-	StageTypeRegex        = "regex"
-	StageTypeReplace      = "replace"
-	StageTypeMetric       = "metrics"
-	StageTypeLabel        = "labels"
-	StageTypeLabelDrop    = "labeldrop"
-	StageTypeTimestamp    = "timestamp"
-	StageTypeOutput       = "output"
-	StageTypeDocker       = "docker"
-	StageTypeCRI          = "cri"
-	StageTypeMatch        = "match"
-	StageTypeTemplate     = "template"
-	StageTypePipeline     = "pipeline"
-	StageTypeTenant       = "tenant"
-	StageTypeDrop         = "drop"
-	StageTypeLimit        = "limit"
-	StageTypeMultiline    = "multiline"
-	StageTypePack         = "pack"
-	StageTypeLabelAllow   = "labelallow"
-	StageTypeStaticLabels = "static_labels"
-	StageTypeDecolorize   = "decolorize"
+	StageTypeJSON            = "json"
+	StageTypeLogfmt          = "logfmt"
+	StageTypeRegex           = "regex"
+	StageTypeReplace         = "replace"
+	StageTypeMetric          = "metrics"
+	StageTypeLabel           = "labels"
+	StageTypeLabelDrop       = "labeldrop"
+	StageTypeTimestamp       = "timestamp"
+	StageTypeOutput          = "output"
+	StageTypeDocker          = "docker"
+	StageTypeCRI             = "cri"
+	StageTypeMatch           = "match"
+	StageTypeTemplate        = "template"
+	StageTypePipeline        = "pipeline"
+	StageTypeTenant          = "tenant"
+	StageTypeDrop            = "drop"
+	StageTypeLimit           = "limit"
+	StageTypeMultiline       = "multiline"
+	StageTypePack            = "pack"
+	StageTypeLabelAllow      = "labelallow"
+	StageTypeStaticLabels    = "static_labels"
+	StageTypeDecolorize      = "decolorize"
+	StageTypeEventLogMessage = "eventlogmessage"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -212,6 +213,11 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeDecolorize:
 		s, err = newDecolorizeStage(cfg)
+		if err != nil {
+			return nil, err
+		}
+	case StageTypeEventLogMessage:
+		s, err = newEventLogMessageStage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -204,6 +204,7 @@ Parsing stages:
   - [cri]({{<relref "stages/cri/">}}): Extract data by parsing the log line using the standard CRI format.
   - [regex]({{<relref "stages/regex/">}}): Extract data using a regular expression.
   - [json]({{<relref "stages/json/">}}): Extract data by parsing the log line as JSON.
+  - [eventlogmessage]({{relref "stages/eventlogmessage/"}}): Extract data by parsing the Message field from the Windows Event Log.
 
 Transform stages:
 

--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -204,7 +204,7 @@ Parsing stages:
   - [cri]({{<relref "stages/cri/">}}): Extract data by parsing the log line using the standard CRI format.
   - [regex]({{<relref "stages/regex/">}}): Extract data using a regular expression.
   - [json]({{<relref "stages/json/">}}): Extract data by parsing the log line as JSON.
-  - [eventlogmessage]({{relref "stages/eventlogmessage/"}}): Extract data by parsing the Message field from the Windows Event Log.
+  - [eventlogmessage]({{<relref "stages/eventlogmessage/">}}): Extract data by parsing the Message field from the Windows Event Log.
 
 Transform stages:
 

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -194,6 +194,9 @@ resuming the target without skipping logs.
 
 Read the [configuration]({{< relref "configuration#windows_events" >}}) section for more information.
 
+See the [eventlogmessage]({{<relref "stages/eventlogmessage/>}}) stage for extracting
+data from the `message`.
+
 ## GCP Log scraping
 
 Promtail supports scraping cloud resource logs such as GCS bucket logs, load balancer logs, and Kubernetes cluster logs from GCP.

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -194,7 +194,7 @@ resuming the target without skipping logs.
 
 Read the [configuration]({{< relref "configuration#windows_events" >}}) section for more information.
 
-See the [eventlogmessage]({{<relref "stages/eventlogmessage/>}}) stage for extracting
+See the [eventlogmessage]({{<relref "stages/eventlogmessage/">}}) stage for extracting
 data from the `message`.
 
 ## GCP Log scraping

--- a/docs/sources/clients/promtail/stages/eventlogmessage.md
+++ b/docs/sources/clients/promtail/stages/eventlogmessage.md
@@ -14,9 +14,11 @@ eventlogmessage:
   # used by the windows_events scraper
   [source: <string> | default = message]
 
-  # When true, if previously extracted data exists for a key
-  # found in the Message, it will be overwriten by the value
-  # in the Message. Otherwise any such data will be ignored.
+  # If previously extracted data exists for a key that occurs
+  # in the Message, when true, the previous value will be
+  # overwriten by the value in the Message. Otherwise,
+  # '_extracted' will be appended to the key that is used for
+  # the value in the Message.
   [overwrite_existing: <bool> | default = false]
 
   # When true, keys extracted from the Message that are not
@@ -31,10 +33,7 @@ type conversions; downstream stages will need to perform correct type
 conversion of these values as necessary. Please refer to the
 [the `template` stage]({{<relref "template">}}) for how to do this.
 
-
-## Example
-
-### Combined with json
+## Example combined with json
 
 For the given pipeline:
 

--- a/docs/sources/clients/promtail/stages/eventlogmessage.md
+++ b/docs/sources/clients/promtail/stages/eventlogmessage.md
@@ -1,0 +1,69 @@
+---
+title: eventlogmessage
+description: eventlogmessage stage
+---
+# eventlogmessage
+
+The `eventlogmessage` stage is a parsing stage that extracts data from the Message string that appears in the Windows Event Log.
+
+## Schema
+
+```yaml
+eventlogmessage:
+  # Name from extracted data to parse, defaulting to the name
+  # used by the windows_events scraper
+  [source: <string> | default = message]
+
+  # When true, if previously extracted data exists for a key
+  # found in the Message, it will be overwriten by the value
+  # in the Message. Otherwise any such data will be ignored.
+  [overwrite_existing: <bool> | default = false]
+
+  # When true, keys extracted from the Message that are not
+  # valid labels will be dropped, otherwise they will be
+  # automatically converted into valid labels replacing invalid
+  # characters with underscores
+  [drop_invalid_labels: <bool> | default = false]
+```
+
+The extracted data can hold non-string values and this stage does not do any
+type conversions; downstream stages will need to perform correct type
+conversion of these values as necessary. Please refer to the
+[the `template` stage]({{<relref "template">}}) for how to do this.
+
+
+## Example
+
+### Combined with json
+
+For the given pipeline:
+
+```yaml
+- json:
+    expressions:
+	  message:
+	  Overwritten:
+- eventlogmessage:
+    source: message
+    overwrite_existing: true
+```
+
+Given the following log line:
+
+```
+{"event_id": 1, "Overwritten": "old", "message": "Message type:\r\nOverwritten: new\r\nImage: C:\\Users\\User\\promtail.exe"}
+```
+
+The first stage would create the following key-value pairs in the set of
+extracted data:
+
+- `message`: `Message type:\r\nOverwritten: new\r\nImage: C:\Users\User\promtail.exe`
+- `Overwritten`: `old`
+
+The second stage will parse the value of `message` from the extracted data
+and append/overwrite the following key-value pairs to the set of extracted data:
+
+- `Image`: `C:\\Users\\User\\promtail.exe`
+- `Message_type`: (empty string)
+- `Overwritten`: `new`
+

--- a/docs/sources/clients/promtail/stages/eventlogmessage.md
+++ b/docs/sources/clients/promtail/stages/eventlogmessage.md
@@ -41,8 +41,8 @@ For the given pipeline:
 ```yaml
 - json:
     expressions:
-	  message:
-	  Overwritten:
+      message:
+      Overwritten:
 - eventlogmessage:
     source: message
     overwrite_existing: true


### PR DESCRIPTION
**What this PR does / why we need it**:
The Windows Event Log includes a field named `Message` that include a large amount of additional data, stored in a simple key-value format: 
* key-value pairs are separated with Windows-style `\r\n` newlines,
* the key and value are separated with `: ` (or just `:` if the key has no associated value).

The key-value data in the `Message` field is commonly utilised when investigating Windows events, e.g., in security use-cases, but the existing `windows_events` pipeline stage keeps the Message data as a string, leading to requiring significant effort at the query time to extract that data to be used in field filters.

This PR request introduces a new promtail stage that parses a specified Source (defaulting to `message` used by the `windows_events`) and extracts all the key-value pairs into the extracted fields, which can then be used in latter stages in the pipeline. An example configuration I am currently testing is as follows:

```yaml
- job_name: windows
  windows_events:
    use_incoming_timestamp: false
    bookmark_path: "./bookmark.xml"
    eventlog_name: "Microsoft-Windows-Sysmon/Operational"
    labels:
      job: windows
  pipeline_stages:
  - json:
      expressions:
        message:
  - eventlogmessage:
      source: message
      overwrite_existing: true
  - pack:
      labels:
        - CommandLine
        - Image
        - EventID
        - ParentImage
        - ScriptBlockText
        - ParentCommandLine
```

**Special notes for your reviewer**:

I have a few aspects that I wasn't sure about and would appreciate your feedback on:
* I noted a number of other stages included a map of fields to extract (as well as optionally renaming them). I decided against this approach as there is a large range of different fields that a Message might/might not contain and automatically renaming any fields that were not valid labels (replacing invalid characters with underscores)
* There is a possibility this stage will extract fields from the Message that already exist in the data. By default, the stage does not overwrite those existing fields (unless configured otherwise) - but I suppose it could take the approach used in Loki of adding `_extracted` to the field name as a default action - would that make sense?
* I decided against using the whole string as the input by default as the event log contains a large number of other fields that will generally be relevant (such as the event\_id).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
