### PR TITLE
Fix comparison in a delete request integration test

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -258,7 +258,7 @@ type DeleteRequest struct {
 	Status    string `json:"status"`
 }
 
-// GetDeleteRequest gets a delete request using the request ID
+// GetDeleteRequests returns all delete requests
 func (c *Client) GetDeleteRequests() (DeleteRequests, error) {
 	resp, err := c.Get("/loki/api/v1/delete")
 	if err != nil {

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -212,7 +212,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 	t.Run("read-delete-request", func(t *testing.T) {
 		deleteRequests, err := cliCompactor.GetDeleteRequests()
 		require.NoError(t, err)
-		require.Equal(t, client.DeleteRequests(expectedDeleteRequests), deleteRequests)
+		require.ElementsMatch(t, client.DeleteRequests(expectedDeleteRequests), deleteRequests)
 	})
 
 	// Query lines


### PR DESCRIPTION
**What this PR does / why we need it**:

This test failed due to the returned delete requests being in a different order. Note that these delete requests have the same start time.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>