### PR TITLE
Fixing typo in 2.7.x branch.

### DIFF
--- a/docs/sources/installation/helm/install-scalable/index.md
+++ b/docs/sources/installation/helm/install-scalable/index.md
@@ -62,7 +62,7 @@ It is not possible to run the scalable mode with the `fulesystem` storage.
           insecure: false
       ```
 
-      Consult the [Reference](../reference) for configuring otehr storage providers.
+      Consult the [Reference](../reference) for configuring other storage providers.
 
     - Define the AWS S3 credentials in the file.
 


### PR DESCRIPTION
This typo is fixed in NEXT but doesn't appear to have been backported to LASTEST (2.7 branch) and was reported by a customer.
