### PR TITLE
Define `MaxQueryRange` for fakeLimits and limiter to fully implement the logql.Limits interface

### DIFF
--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -594,6 +594,10 @@ func (f fakeLimits) MaxQueryLength(string) time.Duration {
 	return f.maxQueryLength
 }
 
+func (f fakeLimits) MaxQueryRange(string) time.Duration {
+	return 24 * time.Hour
+}
+
 func (f fakeLimits) MaxQueryParallelism(string) int {
 	return f.maxQueryParallelism
 }


### PR DESCRIPTION
Signed-off-by: JordanRushing <rushing.jordan@gmail.com>

**What this PR does / why we need it**:
This PR defines `MaxQueryRange` to implement the `logql.Limits` interface for `fakeLimits` and `limiter` structs to fix builds/tests in #8343.

**Which issue(s) this PR fixes**:
Fixes CI for #8343

**Special notes for your reviewer**:
N/A

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
