### PR TITLE
[jsonnet] add support for topology spread for multi zone ingesters

### DIFF
--- a/production/ksonnet/README.md
+++ b/production/ksonnet/README.md
@@ -6,9 +6,11 @@ See the [Tanka Installation Docs](../../docs/sources/installation/tanka.md)
 To use multizone ingesters use following config fields
    ```
     _config+: {
-        multi_zone_ingester_enabled: false,
-        multi_zone_ingester_migration_enabled: false,
-        multi_zone_ingester_replicas: 0,
-        multi_zone_ingester_max_unavailable: 25,
+        multi_zone+: {
+            enabled: false,
+            migration_enabled: false,
+            num_replicas: 0,
+            max_unavailable: 25,
+        }
    }
    ```

--- a/production/ksonnet/loki/multi-zone.libsonnet
+++ b/production/ksonnet/loki/multi-zone.libsonnet
@@ -17,29 +17,38 @@
   },
 
   _config+: {
-    multi_zone_ingester_enabled: true,
-    multi_zone_ingester_migration_enabled: false,
-    multi_zone_ingester_replication_write_path_enabled: true,
-    multi_zone_ingester_replication_read_path_enabled: true,
-    multi_zone_ingester_replicas: 0,
-    multi_zone_ingester_max_unavailable: std.max(1, std.floor($._config.multi_zone_ingester_replicas / 9)),
-    multi_zone_default_ingester_zone: false,
-    multi_zone_ingester_exclude_default: false,
+    multi_zone_ingesters: {
+      enabled: true,
+      migration_enabled: false,
+      replication_write_path_enabled: true,
+      replication_read_path_enabled: true,
+      num_replicas: 0,
+      max_unavailable: std.max(1, std.floor($._config.multi_zone_ingester.num_replicas / 9)),
+      default_ingester_zone: false,
+      exclude_default_zone: false,
+      // If use_topology_spread is true, ingesters can run on nodes already running ingesters but will be
+      // spread through the available nodes using a TopologySpreadConstraints with a max skew
+      // of topology_spread_max_skew.
+      // See: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+      // If use_topology_spread is false, ingesters will not be scheduled on nodes already running ingesters.
+      use_topology_spread: true,
+      topology_spread_max_skew: 1,
+    },
   },
 
   // Zone-aware replication.
-  distributor_args+:: if !($._config.multi_zone_ingester_enabled && $._config.multi_zone_ingester_replication_write_path_enabled) then {} else {
+  distributor_args+:: if !($._config.multi_zone_ingester.enabled && $._config.multi_zone_ingester.replication_write_path_enabled) then {} else {
     'distributor.zone-awareness-enabled': 'true',
   },
 
   ruler_args+:: (
-    if !($._config.multi_zone_ingester_enabled && $._config.multi_zone_ingester_replication_write_path_enabled) then {} else {
+    if !($._config.multi_zone_ingesterenabled && $._config.multi_zone_ingester.replication_write_path_enabled) then {} else {
       'distributor.zone-awareness-enabled': 'true',
     }
   ),
 
   querier_args+:: (
-    if !($._config.multi_zone_ingester_enabled && $._config.multi_zone_ingester_replication_read_path_enabled) then {} else {
+    if !($._config.multi_zone_ingesterenabled && $._config.multi_zone_ingester.replication_read_path_enabled) then {} else {
       'distributor.zone-awareness-enabled': 'true',
     }
   ),
@@ -73,13 +82,24 @@
     // deploy multiple ingesters from the same zone on the same node.
     $.newIngesterStatefulSet(name, container, with_anti_affinity=false) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'ingester' }) +
-    statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_ingester_max_unavailable) }) +
+    statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_ingester.max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'ingester' }) +
     statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': 'ingester' }) +
     statefulSet.mixin.spec.updateStrategy.withType('OnDelete') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
     statefulSet.spec.withVolumeClaimTemplatesMixin($.ingester_wal_pvc) +
-    statefulSet.mixin.spec.withReplicas(std.ceil($._config.multi_zone_ingester_replicas / 3)) +
+    statefulSet.mixin.spec.withReplicas(std.ceil($._config.multi_zone_ingester.num_replicas / 3)) +
+    (
+      if $._config.multi_zone_ingester.use_topology_spread then
+        statefulSet.spec.template.spec.withTopologySpreadConstraints(
+          // Evenly spread queriers among available nodes.
+          topologySpreadConstraints.labelSelector.withMatchLabels({ name: name }) +
+          topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +
+          topologySpreadConstraints.withWhenUnsatisfiable('ScheduleAnyway') +
+          topologySpreadConstraints.withMaxSkew($._config.multi_zone_ingester.topology_spread_max_skew),
+        )
+      else {}
+    ) +
     (if !std.isObject($._config.node_selector) then {} else statefulSet.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     if $._config.ingester_allow_multiple_replicas_on_same_node then {} else {
       spec+:
@@ -104,34 +124,34 @@
     $.util.serviceFor(sts, $._config.service_ignored_labels) +
     service.mixin.spec.withClusterIp('None'),  // Headless.
 
-  ingester_zone_a_container:: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_a_container:: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneContainer('a', $.ingester_zone_a_args),
 
-  ingester_zone_a_statefulset: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_a_statefulset: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneStatefulSet('a', $.ingester_zone_a_container),
 
-  ingester_zone_a_service: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_a_service: if !$._config.multi_zone_ingesterenabled then {} else
     $.newIngesterZoneService($.ingester_zone_a_statefulset),
 
-  ingester_zone_b_container:: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_b_container:: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneContainer('b', $.ingester_zone_b_args),
 
-  ingester_zone_b_statefulset: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_b_statefulset: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneStatefulSet('b', $.ingester_zone_b_container),
 
-  ingester_zone_b_service: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_b_service: if !$._config.multi_zone_ingesterenabled then {} else
     $.newIngesterZoneService($.ingester_zone_b_statefulset),
 
-  ingester_zone_c_container:: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_c_container:: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneContainer('c', $.ingester_zone_c_args),
 
-  ingester_zone_c_statefulset: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_c_statefulset: if !$._config.multi_zone_ingesterenabled then {} else
     self.newIngesterZoneStatefulSet('c', $.ingester_zone_c_container),
 
-  ingester_zone_c_service: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_zone_c_service: if !$._config.multi_zone_ingesterenabled then {} else
     $.newIngesterZoneService($.ingester_zone_c_statefulset),
 
-  ingester_rollout_pdb: if !$._config.multi_zone_ingester_enabled then {} else
+  ingester_rollout_pdb: if !$._config.multi_zone_ingesterenabled then {} else
     podDisruptionBudget.new('ingester-rollout-pdb') +
     podDisruptionBudget.mixin.metadata.withLabels({ name: 'ingester-rollout-pdb' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ 'rollout-group': 'ingester' }) +
@@ -140,28 +160,28 @@
   // Single-zone ingesters shouldn't be configured when multi-zone is enabled.
   ingester_statefulset:
     // Remove the default "ingester" StatefulSet if multi-zone is enabled and no migration is in progress.
-    if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled
+    if $._config.multi_zone_ingesterenabled && !$._config.multi_zone_ingester.migration_enabled
     then {}
     else super.ingester_statefulset,
 
   ingester_service:
     // Remove the default "ingester" service if multi-zone is enabled and no migration is in progress.
-    if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled
+    if $._config.multi_zone_ingesterenabled && !$._config.multi_zone_ingester.migration_enabled
     then {}
     else super.ingester_service,
 
   ingester_pdb:
     // Keep it if multi-zone is disabled.
-    if !$._config.multi_zone_ingester_enabled
+    if !$._config.multi_zone_ingesterenabled
     then super.ingester_pdb
     // We don’t want Kubernetes to terminate any "ingester" StatefulSet's pod while migration is in progress.
-    else if $._config.multi_zone_ingester_migration_enabled
+    else if $._config.multi_zone_ingester.migration_enabled
     then super.ingester_pdb + podDisruptionBudget.mixin.spec.withMaxUnavailable(0)
     // Remove it if multi-zone is enabled and no migration is in progress.
     else {},
 
   // Rollout operator.
-  local rollout_operator_enabled = $._config.multi_zone_ingester_enabled,
+  local rollout_operator_enabled = $._config.multi_zone_ingesterenabled,
 
   rollout_operator_args:: {
     'kubernetes.namespace': $._config.namespace,
@@ -218,11 +238,11 @@
   rollout_operator_service_account: if !rollout_operator_enabled then {} else
     serviceAccount.new('rollout-operator'),
 } + {
-  distributor_args+:: if $._config.multi_zone_ingester_exclude_default then {
+  distributor_args+:: if $._config.multi_zone_ingester.exclude_default_zone then {
     'distributor.excluded-zones': 'zone-default',
   } else {},
 
-  ruler_args+:: if $._config.multi_zone_ingester_exclude_default then {
+  ruler_args+:: if $._config.multi_zone_ingester.exclude_default_zone then {
     'distributor.excluded-zones': 'zone-default',
   } else {},
 }


### PR DESCRIPTION
adds jsonnet config for topology spread support (note that I've defaulted it's usage to true) of multi zone ingesters

also refactored the multi zone config fields for better organization/shorter names

Signed-off-by: Callum Styan <callumstyan@gmail.com>