### PR TITLE
Use portable output redirection

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
+PODMAN = $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
 BUILD_IN_CONTAINER ?= true
 


### PR DESCRIPTION
&>/dev/null is a bashism

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
