### PR TITLE
Update fluent-plugin-grafana-loki to Ruby 3.2

### DIFF
--- a/clients/cmd/fluentd/Dockerfile
+++ b/clients/cmd/fluentd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.5 as build
+FROM ruby:3.2.0 as build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make BUILD_IN_CONTAINER=false fluentd-plugin
 
-FROM fluent/fluentd:v1.9.2-debian-1.0
+FROM fluent/fluentd:v1.14.0-debian-1.0
 ENV LOKI_URL "https://logs-prod-us-central1.grafana.net"
 
 COPY --from=build /src/loki/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb /fluentd/plugins/out_loki.rb

--- a/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/grafana/loki/'
   spec.license       = 'Apache-2.0'
 
-  spec.required_ruby_version = '~> 2.7'
+  spec.required_ruby_version = '>= 2.7'
 
   # test_files, files  = `git ls-files -z`.split("\x0").partition do |f|
   #   f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
**What this PR does / why we need it**:
The plugin works with Ruby 3.2 but its spec file limited it to Ruby versions < 3.0

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/8195

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
