### PR TITLE
Skip image validation

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -17,5 +17,6 @@ jobs:
         run: >
           doc-validator
           --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
+          --skip-image-validation
           ./docs/sources
           /docs/loki/latest


### PR DESCRIPTION
In the future, all images will be stored in GCS and not in the repository and this linting rule will be removed.

Until then, skip insisting that all images are in page bundles.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
