### PR TITLE
Bump version of `fluent-plugin-grafana-loki` to 1.2.20

### DIFF
--- a/clients/cmd/fluentd/Makefile
+++ b/clients/cmd/fluentd/Makefile
@@ -4,7 +4,7 @@ SHELL    = /usr/bin/env bash -o pipefail
 # needs to match the name in fluent-plugin-grafana-loki.gemspec
 NAME    := fluent-plugin-grafana-loki
 # needs to match the version in fluent-plugin-grafana-loki.gemspec
-VERSION := 1.2.19
+VERSION := 1.2.20
 
 clean:
 	rm -f $(NAME)-*.gem

--- a/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.19'
+  spec.version = '1.2.20'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

**What this PR does / why we need it**:

Bump version so we can publish a new gem to RubyGems