### PR TITLE
[helm] set compactor address

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1566,6 +1566,7 @@ true
 			<td>Check https://grafana.com/docs/loki/latest/configuration/#common_config for more info on how to provide a common configuration</td>
 			<td><pre lang="json">
 {
+  "compactor_address": "{{ include \"loki.compactorAddress\" . }}",
   "path_prefix": "/var/loki",
   "replication_factor": 3
 }

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -17,6 +17,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [BUGFIX] Fix rendering of namespace in provisioner job.
 - [ENHANCEMENT] Allow to configure `publishNotReadyAddresses` on memberlist service.
+- [BUGFIX] Correctly set `compactor_address` for 3 target scalable configuration.
 
 ## 4.5
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -674,3 +674,18 @@ enableServiceLinks: false
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Determine compactor address based on target configuration */}}
+{{- define "loki.compactorAddress" -}}
+{{- $isSimpleScalable := eq (include "loki.deployment.isScalable" .) "true" -}}
+{{- $compactorAddress := include "loki.backendFullname" . -}}
+{{- if and $isSimpleScalable .Values.read.legacyReadTarget -}}
+{{/* 2 target configuration */}}
+{{- $compactorAddress = include "loki.readFullname" . -}}
+{{- else if (not $isSimpleScalable) -}}
+{{/* single binary */}}
+{{- $compactorAddress = include "loki.singleBinaryFullname" . -}}
+{{- end -}}
+{{- printf "%s" $compactorAddress }}
+{{- end }}
+

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -16,6 +16,7 @@
 
 {{- $singleBinaryReplicas := int .Values.singleBinary.replicas }}
 {{- $isUsingFilesystem := eq (include "loki.isUsingObjectStorage" .) "false" }}
+{{- $isUsingObjectStorage := eq (include "loki.isUsingObjectStorage" .) "true" }}
 {{- $atLeastOneScalableReplica := or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0) }}
 
 {{- if and $isUsingFilesystem (gt $singleBinaryReplicas 1) }}
@@ -25,4 +26,3 @@
 {{- if and $isUsingFilesystem (and (eq $singleBinaryReplicas 0) $atLeastOneScalableReplica) }}
 {{- fail "Cannot run Scalable targets (backend, read, write) without an object storage backend."}}
 {{- end }}
-

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -16,7 +16,6 @@
 
 {{- $singleBinaryReplicas := int .Values.singleBinary.replicas }}
 {{- $isUsingFilesystem := eq (include "loki.isUsingObjectStorage" .) "false" }}
-{{- $isUsingObjectStorage := eq (include "loki.isUsingObjectStorage" .) "true" }}
 {{- $atLeastOneScalableReplica := or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0) }}
 
 {{- if and $isUsingFilesystem (gt $singleBinaryReplicas 1) }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -223,6 +223,7 @@ loki:
   commonConfig:
     path_prefix: /var/loki
     replication_factor: 3
+    compactor_address: '{{ include "loki.compactorAddress" . }}'
 
   # -- Storage config. Providing this will automatically populate all necessary storage configs in the templated config.
   storage:


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to set the compactor address when running 3 target scalable mode as the querier is no longer co-located with the compactor.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
