### PR TITLE
Remove call to action from 2.7 release.

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -18,4 +18,3 @@ is then compressed and stored in chunks in object stores such as S3 or GCS, or
 even locally on the filesystem. A small index and highly compressed chunks
 simplifies the operation and significantly lowers the cost of Loki.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -8,8 +8,6 @@ aliases:
 
 # Getting started with Grafana Loki
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).
-
 This guide assists the reader to create and use a simple Loki cluster.
 The cluster is intended for testing, development, and evaluation;
 it will not meet most production requirements.

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -4,8 +4,6 @@ weight: 200
 ---
 # Installation
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).
-
 ## Installation methods
 
 Instructions for different methods of installing Loki and Promtail.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,8 +4,6 @@ This directory contains examples and example configuration for Loki and Promtail
 
 ## Hosted logs in Grafana Cloud
 
-You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).
-
 ## Getting started with Loki
 
 Configuration files in the `getting-started` directory are used by the [Loki getting started guide](https://grafana.com/docs/loki/latest/getting-started/).


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the hard-coded note about the Grafana Cloud option, because this information is now generated automatically on the docs site (and thus is being displayed twice).

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
