### PR TITLE
 Fix flaky `TestMicroServicesDeleteRequest` integration test

### DIFF
--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -247,7 +247,17 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 		require.Eventually(t, func() bool {
 			deleteRequests, err := cliCompactor.GetDeleteRequests()
 			require.NoError(t, err)
-			return assert.ElementsMatch(t, client.DeleteRequests(expectedDeleteRequests), deleteRequests)
+
+		outer:
+			for i := range deleteRequests {
+				for j := range expectedDeleteRequests {
+					if deleteRequests[i] == expectedDeleteRequests[j] {
+						continue outer
+					}
+				}
+				return false
+			}
+			return true
 		}, 10*time.Second, 1*time.Second)
 
 		// Check metrics

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -247,13 +247,7 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 		require.Eventually(t, func() bool {
 			deleteRequests, err := cliCompactor.GetDeleteRequests()
 			require.NoError(t, err)
-			require.Len(t, deleteRequests, len(expectedDeleteRequests))
-			for i := range deleteRequests {
-				if deleteRequests[i] != expectedDeleteRequests[i] {
-					return false
-				}
-			}
-			return true
+			return assert.ElementsMatch(t, client.DeleteRequests(expectedDeleteRequests), deleteRequests)
 		}, 10*time.Second, 1*time.Second)
 
 		// Check metrics


### PR DESCRIPTION
Returned elements may not be in order. Therefore checking if elements match.
