### PR TITLE
Swift: Allow to configure swift with the internal endpoint

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3984,6 +3984,10 @@ The `swift_storage_config` block configures the connection to OpenStack Object S
 # CLI flag: -<prefix>.swift.auth-url
 [auth_url: <string> | default = ""]
 
+# Set this to true to use the internal OpenStack Swift endpoint URL
+# CLI flag: -<prefix>.swift.internal
+[internal: <boolean> | default = false]
+
 # OpenStack Swift username.
 # CLI flag: -<prefix>.swift.username
 [username: <string> | default = ""]

--- a/pkg/storage/bucket/swift/config.go
+++ b/pkg/storage/bucket/swift/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	AuthVersion       int           `yaml:"auth_version"`
 	AuthURL           string        `yaml:"auth_url"`
+	Internal          bool          `yaml:"internal"`
 	Username          string        `yaml:"username"`
 	UserDomainName    string        `yaml:"user_domain_name"`
 	UserDomainID      string        `yaml:"user_domain_id"`
@@ -36,6 +37,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.AuthVersion, prefix+"swift.auth-version", 0, "OpenStack Swift authentication API version. 0 to autodetect.")
 	f.StringVar(&cfg.AuthURL, prefix+"swift.auth-url", "", "OpenStack Swift authentication URL")
+	f.BoolVar(&cfg.Internal, prefix+"swift.internal", false, "Set this to true to use the internal OpenStack Swift endpoint URL")
 	f.StringVar(&cfg.Username, prefix+"swift.username", "", "OpenStack Swift username.")
 	f.StringVar(&cfg.UserDomainName, prefix+"swift.user-domain-name", "", "OpenStack Swift user's domain name.")
 	f.StringVar(&cfg.UserDomainID, prefix+"swift.user-domain-id", "", "OpenStack Swift user's domain ID.")

--- a/pkg/storage/chunk/client/openstack/swift_object_client.go
+++ b/pkg/storage/chunk/client/openstack/swift_object_client.go
@@ -80,6 +80,7 @@ func createConnection(cfg SwiftConfig, hedgingCfg hedging.Config, hedging bool) 
 	c := &swift.Connection{
 		AuthVersion:    cfg.AuthVersion,
 		AuthUrl:        cfg.AuthURL,
+		Internal:       cfg.Internal,
 		ApiKey:         cfg.Password,
 		UserName:       cfg.Username,
 		UserId:         cfg.UserID,


### PR DESCRIPTION
This commit exposes the `internal` parameter of the swift client library in loki config. It allows to configure swift to use the internal endpoint of an openstack installation.

Fixes #8437

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
