### PR TITLE
[helm] Bump to Loki 2.7.3

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1658,7 +1658,7 @@ true
 			<td>string</td>
 			<td>Overrides the image tag whose default is the chart's appVersion TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
 			<td><pre lang="json">
-"main-5e53303"
+"2.7.3"
 </pre>
 </td>
 		</tr>
@@ -2763,7 +2763,7 @@ null
 			<td>bool</td>
 			<td>Whether or not to use the 2 target type simple scalable mode (read, write) or the 3 target type (read, write, backend). Legacy refers to the 2 target type, so true will run two targets, false will run 3 targets.</td>
 			<td><pre lang="json">
-false
+true
 </pre>
 </td>
 		</tr>

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1658,7 +1658,7 @@ true
 			<td>string</td>
 			<td>Overrides the image tag whose default is the chart's appVersion TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
 			<td><pre lang="json">
-"2.7.3"
+null
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -18,6 +18,9 @@ Entries should include a reference to the pull request that introduced the chang
 - [BUGFIX] Fix rendering of namespace in provisioner job.
 - [ENHANCEMENT] Allow to configure `publishNotReadyAddresses` on memberlist service.
 - [BUGFIX] Correctly set `compactor_address` for 3 target scalable configuration.
+## 4.6
+
+- [Change] Bump Loki verstion to 2.7.3. Revert to 2 target simple scalable mode as default until third target ships in minor release.
 
 ## 4.5
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.7.2
-version: 4.5.1
+appVersion: 2.7.3
+version: 4.6.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.5.1](https://img.shields.io/badge/Version-4.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/ci/default-values.yaml
+++ b/production/helm/loki/ci/default-values.yaml
@@ -2,6 +2,8 @@
 loki:
   commonConfig:
     replication_factor: 1
+  image:
+    tag: "main-5e53303"
 read:
   replicas: 1
 write:

--- a/production/helm/loki/ci/enterprise.yaml
+++ b/production/helm/loki/ci/enterprise.yaml
@@ -11,6 +11,8 @@ enterprise:
 loki:
   commonConfig:
     replication_factor: 1
+  image:
+    tag: "main-5e53303"
 storage:
   type: local
 read:

--- a/production/helm/loki/ci/ingress-values.yaml
+++ b/production/helm/loki/ci/ingress-values.yaml
@@ -11,6 +11,8 @@ gateway:
 loki:
   commonConfig:
     replication_factor: 1
+  image:
+    tag: "main-5e53303"
 read:
   replicas: 1
 write:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -47,7 +47,7 @@ loki:
     # -- Overrides the image tag whose default is the chart's appVersion
     # TODO: needed for 3rd target backend functionality
     # revert to null or latest once this behavior is relased
-    tag: "main-5e53303"
+    tag: "2.7.3"
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   # -- Common annotations for all pods
@@ -812,7 +812,7 @@ read:
   # -- Whether or not to use the 2 target type simple scalable mode (read, write) or the
   # 3 target type (read, write, backend). Legacy refers to the 2 target type, so true will
   # run two targets, false will run 3 targets.
-  legacyReadTarget: false
+  legacyReadTarget: true
   # -- Additional CLI args for the read
   extraArgs: []
   # -- Environment variables to add to the read pods

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -47,7 +47,7 @@ loki:
     # -- Overrides the image tag whose default is the chart's appVersion
     # TODO: needed for 3rd target backend functionality
     # revert to null or latest once this behavior is relased
-    tag: "2.7.3"
+    tag: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   # -- Common annotations for all pods


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the loki version to 2.7.3, it also reverts back to 2 target mode as default for simple scalable since the third target has not yet been included in minor release.

**Special notes for your reviewer**:

The CI jobs are still using 3 target configurations, hence the custom loki image tag.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
