### PR TITLE
[Helm] Allow to configure publishNotReadyAddresses on memberlist service

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1902,6 +1902,15 @@ true
 </td>
 		</tr>
 		<tr>
+			<td>memberlist.service.publishNotReadyAddresses</td>
+			<td>bool</td>
+			<td></td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>migrate</td>
 			<td>object</td>
 			<td>Options that may be necessary when performing a migration from another helm chart</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 4.5.1
 
 - [BUGFIX] Fix rendering of namespace in provisioner job.
+- [ENHANCEMENT] Allow to configure `publishNotReadyAddresses` on memberlist service.
 
 ## 4.5
 

--- a/production/helm/loki/templates/service-memberlist.yaml
+++ b/production/helm/loki/templates/service-memberlist.yaml
@@ -13,6 +13,9 @@ spec:
       port: 7946
       targetPort: http-memberlist
       protocol: TCP
+  {{- with .Values.memberlist.service.publishNotReadyAddresses }}
+  publishNotReadyAddresses: {{ . }}
+  {{- end }}
   selector:
     {{- include "loki.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1040,6 +1040,11 @@ ingress:
 #       - loki.example.com
 #      secretName: loki-distributed-tls
 
+# Configuration for the memberlist service
+memberlist:
+  service:
+    publishNotReadyAddresses: false
+
 # Configuration for the gateway
 gateway:
   # -- Specifies whether the gateway should be enabled


### PR DESCRIPTION
Signed-off-by: Jan-Otto Kröpke <jok@cloudeteer.de>

**What this PR does / why we need it**:

Faster memberlist join

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

By reading the documentation
```
% k explain service.spec.publishNotReadyAddresses
KIND:     Service
VERSION:  v1

FIELD:    publishNotReadyAddresses <boolean>

DESCRIPTION:
     publishNotReadyAddresses indicates that any agent which deals with
     endpoints for this Service should disregard any indications of
     ready/not-ready. The primary use case for setting this field is for a
     StatefulSet's Headless Service to propagate SRV DNS records for its Pods
     for the purpose of peer discovery. The Kubernetes controllers that generate
     Endpoints and EndpointSlice resources for Services interpret this to mean
     that all endpoints are considered "ready" even if the Pods themselves are
     not. Agents which consume only Kubernetes generated endpoints through the
     Endpoints or EndpointSlice resources can safely assume this behavior.
```
this property is designed for a use case like loki-memberlist. But I have NO idea, if this is valid. Is it fine for loki, if a non ready replica is joining the memberlist? 

For single binary/single instance deployment, I'm always see a lot of memberlist can not be resolved errors.

<details>
<summary>Details</summary>

```
ts=2023-02-07T20:22:17.378740674Z caller=memberlist_logger.go:74 level=warn msg="Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host"
level=warn ts=2023-02-07T20:22:17.378806174Z caller=memberlist_client.go:598 msg="joining memberlist cluster: failed to reach any nodes" retries=1 err="1 error occurred:\n\t* Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host\n\n"
level=info ts=2023-02-07T20:22:19.648704384Z caller=scheduler.go:682 msg="this scheduler is in the ReplicationSet, will now accept requests."
level=info ts=2023-02-07T20:22:19.651069175Z caller=worker.go:209 msg="adding connection" addr=10.244.1.54:9095
ts=2023-02-07T20:22:19.905526717Z caller=memberlist_logger.go:74 level=warn msg="Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host"
level=warn ts=2023-02-07T20:22:19.905574592Z caller=memberlist_client.go:598 msg="joining memberlist cluster: failed to reach any nodes" retries=2 err="1 error occurred:\n\t* Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host\n\n"
level=info ts=2023-02-07T20:22:26.649448054Z caller=frontend_scheduler_worker.go:107 msg="adding connection to scheduler" addr=10.244.1.54:9095
ts=2023-02-07T20:22:26.860459762Z caller=memberlist_logger.go:74 level=warn msg="Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host"
level=warn ts=2023-02-07T20:22:26.860601512Z caller=memberlist_client.go:598 msg="joining memberlist cluster: failed to reach any nodes" retries=3 err="1 error occurred:\n\t* Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host\n\n"
level=info ts=2023-02-07T20:22:30.990303666Z caller=compactor.go:330 msg="compactor is JOINING in the ring"
level=info ts=2023-02-07T20:22:31.992794292Z caller=compactor.go:340 msg="waiting until compactor is ACTIVE in the ring"
level=info ts=2023-02-07T20:22:32.132009Z caller=compactor.go:344 msg="compactor is ACTIVE in the ring"
level=info ts=2023-02-07T20:22:32.132211917Z caller=loki.go:489 msg="Loki started"
level=info ts=2023-02-07T20:22:37.132549669Z caller=compactor.go:405 msg="this instance has been chosen to run the compactor, starting compactor"
level=info ts=2023-02-07T20:22:37.132922711Z caller=compactor.go:434 msg="waiting 10m0s for ring to stay stable and previous compactions to finish before starting compactor"
ts=2023-02-07T20:22:38.79015667Z caller=memberlist_logger.go:74 level=warn msg="Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host"
level=warn ts=2023-02-07T20:22:38.790265712Z caller=memberlist_client.go:598 msg="joining memberlist cluster: failed to reach any nodes" retries=4 err="1 error occurred:\n\t* Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host\n\n"
ts=2023-02-07T20:22:55.812588636Z caller=memberlist_logger.go:74 level=warn msg="Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host"
level=warn ts=2023-02-07T20:22:55.812735636Z caller=memberlist_client.go:598 msg="joining memberlist cluster: failed to reach any nodes" retries=5 err="1 error occurred:\n\t* Failed to resolve loki-memberlist: lookup loki-memberlist on 10.96.0.10:53: no such host\n\n"
```

</details>

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
