### PR TITLE
Fix namespace rendering in provisioner job

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
+## 4.5.1
+
+- [BUGFIX] Fix rendering of namespace in provisioner job.
+
 ## 4.5
 
 - [ENHANCEMENT] Single binary mode is now possible for more than 1 replica, with a gateway and object storage backend.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.2
-version: 4.5.0
+version: 4.5.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 4.5.1](https://img.shields.io/badge/Version-4.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/provisioner/job-provisioner.yaml
+++ b/production/helm/loki/templates/provisioner/job-provisioner.yaml
@@ -99,11 +99,12 @@ spec:
               {{- end }}
               {{- $namespace := $.Release.Namespace }}
               {{- with .Values.monitoring.selfMonitoring.tenant }}
+              {{- $secretNamespace := tpl .secretNamespace $ }}
               kubectl --namespace "{{ $namespace }}" create secret generic "{{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}" \
                 --from-literal=username="{{ .name }}" \
                 --from-literal=password="$(cat /bootstrap/token-self-monitoring)"
-              {{- if not (eq .secretNamespace $namespace) }}
-              kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}" \
+              {{- if not (eq $secretNamespace $namespace) }}
+              kubectl --namespace "{{ $secretNamespace }}" create secret generic "{{ include "enterprise-logs.selfMonitoringTenantSecret" $ }}" \
                 --from-literal=username="{{ .name }}" \
                 --from-literal=password="$(cat /bootstrap/token-self-monitoring)"
               {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix rendering of namespace in provisioner job template when a `secertNamespace` is provided that's different from the release namespace.

**Which issue(s) this PR fixes**:
Fixes #8403

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
