### PR TITLE
Fix ruler deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ##### Fixes
 
+* [8453](https://github.com/grafana/loki/pull/8453) **masslessparticle** Fix deadlock in rulers.
 * [7784](https://github.com/grafana/loki/pull/7784) **isodude**: Fix default values of connect addresses for compactor and querier workers to work with IPv6.
 * [7880](https://github.com/grafana/loki/pull/7880) **sandeepsukhani**: consider range and offset in queries while looking for schema config for query sharding.
 * [7937](https://github.com/grafana/loki/pull/7937) **ssncferreira**: Deprecate CLI flag `-ruler.wal-cleaer.period` and replace it with `-ruler.wal-cleaner.period`.


### PR DESCRIPTION
A circular dependency between the Prometheus `rules.Manager` and the `MemStore` causes occasional deadlock in the rulers. 

Fixing the circular dependency is non-trivial because we rely on the `rules.Manager` to be the source-of-truth for rules storage. Instead, this PR moves retrieving rules to outside the `memStoreQuerier`. Rules are now retrieved and cached as part of the `run` loop. Rules are infrequently updated so the 5 minute lag between updates should be acceptable.
