### PR TITLE
DynamoDB: Accept a KMS key for DynamoDB tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,11 +760,18 @@ validate-example-configs: loki
 # Dynamically generate ./docs/sources/configuration/examples.md using the example configs that we provide.
 # This target should be run if any of our example configs change.
 generate-example-config-doc:
-	echo "Removing existing doc at loki/docs/configuration/examples.md and re-generating. . ."
+	$(eval CONFIG_DOC_PATH=$(DOC_SOURCES_PATH)/configuration)
+	$(eval CONFIG_EXAMPLES_PATH=$(CONFIG_DOC_PATH)/examples)
+	echo "Removing existing doc at $(CONFIG_DOC_PATH)/examples.md and re-generating. . ."
 	# Title and Heading
-	echo -e "---\ntitle: Examples\ndescription: Loki Configuration Examples\n---\n # Examples" > ./docs/sources/configuration/examples.md
+	echo -e "---\ntitle: Examples\ndescription: Loki Configuration Examples\n---\n # Examples" > $(CONFIG_DOC_PATH)/examples.md
 	# Append each configuration and its file name to examples.md
-	for f in ./docs/sources/configuration/examples/*.yaml; do echo -e "\n## $$(basename $$f)\n\n\`\`\`yaml\n$$(cat $$f)\n\`\`\`\n" >> ./docs/sources/configuration/examples.md; done
+	for f in $$(find $(CONFIG_EXAMPLES_PATH)/*.yaml -printf "%f\n" | sort -k1n); do \
+		echo -e "\n## $$f\n\n\`\`\`yaml\n" >> $(CONFIG_DOC_PATH)/examples.md; \
+		cat $(CONFIG_EXAMPLES_PATH)/$$f >> $(CONFIG_DOC_PATH)/examples.md; \
+		echo -e "\n\`\`\`\n" >> $(CONFIG_DOC_PATH)/examples.md; \
+	done
+
 
 # Fail our CI build if changes are made to example configurations but our doc is not updated
 check-example-config-doc: generate-example-config-doc

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3622,6 +3622,11 @@ dynamodb:
     # CLI flag: -dynamodb.max-retries
     [max_retries: <int> | default = 20]
 
+  # KMS key used for encrypting DynamoDB items.  DynamoDB will use an Amazon
+  # owned KMS key if not provided.
+  # CLI flag: -dynamodb.kms-key-id
+  [kms_key_id: <string> | default = ""]
+
 # S3 endpoint URL with escaped Key and Secret encoded. If only region is
 # specified as a host, proper endpoint will be deduced. Use
 # inmemory:///<bucket-name> to use a mock in-memory implementation.

--- a/docs/sources/configuration/examples.md
+++ b/docs/sources/configuration/examples.md
@@ -4,9 +4,35 @@ description: Loki Configuration Examples
 ---
  # Examples
 
+## alibaba-cloud-storage-config.yaml
+
+```yaml
+
+# This partial configuration uses Alibaba for chunk storage
+
+schema_config:
+  configs:
+  - from: 2020-05-15
+    object_store: alibabacloud
+    schema: v11
+    index:
+      prefix: loki_index_
+      period: 168h
+
+storage_config:
+  alibabacloud:
+    bucket: <bucket>
+    endpoint: <endpoint>
+    access_key_id: <access_key_id>
+    secret_access_key: <secret_access_key>
+
+```
+
+
 ## 1-Local-Configuration-Example.yaml
 
 ```yaml
+
 auth_enabled: false
 
 server:
@@ -35,6 +61,7 @@ schema_config:
 ## 2-S3-Cluster-Example.yaml
 
 ```yaml
+
 # This is a complete configuration to deploy Loki backed by a s3-Comaptible API
 # like MinIO for storage. Loki components will use memberlist ring to shard and
 # the index will be shipped to storage via boltdb-shipper.
@@ -86,6 +113,7 @@ compactor:
 ## 3-S3-Without-Credentials-Snippet.yaml
 
 ```yaml
+
 # If you don't wish to hard-code S3 credentials you can also configure an EC2
 # instance role by changing the `storage_config` section
 
@@ -109,6 +137,7 @@ storage_config:
 ## 4-BOS-Example.yaml
 
 ```yaml
+
 schema_config:
   configs:
     - from: 2020-05-15
@@ -140,6 +169,7 @@ compactor:
 ## 5-S3-And-DynamoDB-Snippet.yaml
 
 ```yaml
+
 # This partial configuration uses S3 for chunk storage and uses DynamoDB for index storage
 
 schema_config:
@@ -162,6 +192,7 @@ storage_config:
 ## 6-Cassandra-Snippet.yaml
 
 ```yaml
+
 # This is a partial config that uses the local filesystem for chunk storage and Cassandra for index storage
 
 schema_config:
@@ -191,6 +222,7 @@ storage_config:
 ## 7-Schema-Migration-Snippet.yaml
 
 ```yaml
+
 schema_config:
   configs:
     # Starting from 2018-04-15 Loki should store indexes on Cassandra
@@ -219,6 +251,7 @@ schema_config:
 ## 8-GCS-Snippet.yaml
 
 ```yaml
+
 # This partial configuration uses GCS for chunk storage and uses BigTable for index storage
 
 schema_config:
@@ -244,6 +277,7 @@ storage_config:
 ## 9-Expanded-S3-Snippet.yaml
 
 ```yaml
+
 # S3 configuration supports an expanded configuration. 
 # Either an `s3` endpoint URL can be used, or an expanded configuration can be used.
 
@@ -273,25 +307,29 @@ storage_config:
 ```
 
 
-## alibaba-cloud-storage-config.yaml
+## 10-S3-And-DynamoDB-With-KMS-Snippet.yaml
 
 ```yaml
-# This partial configuration uses Alibaba for chunk storage
+
+# This partial configuration uses S3 for chunk storage and uses DynamoDB for index storage and a KMS CMK for encryption
 
 schema_config:
   configs:
   - from: 2020-05-15
-    object_store: alibabacloud
+    store: aws
+    object_store: s3
     schema: v11
     index:
-      prefix: loki_index_
-      period: 168h
-
+      prefix: loki_
 storage_config:
-  alibabacloud:
-    bucket: <bucket>
-    endpoint: <endpoint>
-    access_key_id: <access_key_id>
-    secret_access_key: <secret_access_key>
+  aws:
+    s3: s3://access_key:secret_access_key@region/bucket_name
+    sse_encryption: true
+    sse:
+      type: SSE-KMS
+      kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab
+    dynamodb:
+      dynamodb_url: dynamodb://access_key:secret_access_key@region
+      kms_key_id: 0987dcba-09fe-87dc-65ba-ab0987654321
 ```
 

--- a/docs/sources/configuration/examples/10-S3-And-DynamoDB-With-KMS-Snippet.yaml
+++ b/docs/sources/configuration/examples/10-S3-And-DynamoDB-With-KMS-Snippet.yaml
@@ -1,0 +1,20 @@
+# This partial configuration uses S3 for chunk storage and uses DynamoDB for index storage and a KMS CMK for encryption
+
+schema_config:
+  configs:
+  - from: 2020-05-15
+    store: aws
+    object_store: s3
+    schema: v11
+    index:
+      prefix: loki_
+storage_config:
+  aws:
+    s3: s3://access_key:secret_access_key@region/bucket_name
+    sse_encryption: true
+    sse:
+      type: SSE-KMS
+      kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab
+    dynamodb:
+      dynamodb_url: dynamodb://access_key:secret_access_key@region
+      kms_key_id: 0987dcba-09fe-87dc-65ba-ab0987654321

--- a/pkg/storage/chunk/client/aws/dynamodb_storage_client.go
+++ b/pkg/storage/chunk/client/aws/dynamodb_storage_client.go
@@ -64,6 +64,7 @@ type DynamoDBConfig struct {
 	ChunkGangSize          int                      `yaml:"chunk_gang_size"`
 	ChunkGetMaxParallelism int                      `yaml:"chunk_get_max_parallelism"`
 	BackoffConfig          backoff.Config           `yaml:"backoff_config"`
+	KMSKeyID               string                   `yaml:"kms_key_id"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -77,6 +78,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.BackoffConfig.MinBackoff, "dynamodb.min-backoff", 100*time.Millisecond, "Minimum backoff time")
 	f.DurationVar(&cfg.BackoffConfig.MaxBackoff, "dynamodb.max-backoff", 50*time.Second, "Maximum backoff time")
 	f.IntVar(&cfg.BackoffConfig.MaxRetries, "dynamodb.max-retries", 20, "Maximum number of times to retry an operation")
+	f.StringVar(&cfg.KMSKeyID, "dynamodb.kms-key-id", "", "KMS key used for encrypting DynamoDB items.  DynamoDB will use an Amazon owned KMS key if not provided.")
 	cfg.Metrics.RegisterFlags(f)
 }
 


### PR DESCRIPTION
This change adds a `kms_key_id` configuration to the `storage_config.aws.dynamodb` config.  This is used when creating DynamoDB tables to enable SSE using the specified KMS key.

**What this PR does / why we need it**:
Currently DynamoDB tables can only be encrypted using Amazon Owned KMS keys, and this has security and compliance drawbacks that make it not usable in some environments

**Which issue(s) this PR fixes**:
Fixes #8466

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
