### PR TITLE
S3: add support for s3 session token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [8259](https://github.com/grafana/loki/pull/8259) **mar4uk**: Extract push.proto from the logproto package to the separate module.
 * [7906](https://github.com/grafana/loki/pull/7906) **kavirajk**: Add API endpoint that formats LogQL expressions and support new `fmt` subcommand in `logcli` to format LogQL query.
 * [6675](https://github.com/grafana/loki/pull/6675) **btaani**: Add logfmt expression parser for selective extraction of labels from logfmt formatted logs
+* [8474](https://github.com/grafana/loki/pull/8474) **farodin91**: Add support for short-lived S3 session tokens
 
 ##### Fixes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3658,6 +3658,10 @@ dynamodb:
 # CLI flag: -s3.secret-access-key
 [secret_access_key: <string> | default = ""]
 
+# AWS Session Token
+# CLI flag: -s3.session-token
+[session_token: <string> | default = ""]
+
 # Disable https on s3 connection.
 # CLI flag: -s3.insecure
 [insecure: <boolean> | default = false]
@@ -3927,6 +3931,10 @@ The `s3_storage_config` block configures the connection to Amazon S3 object stor
 # AWS Secret Access Key
 # CLI flag: -<prefix>.storage.s3.secret-access-key
 [secret_access_key: <string> | default = ""]
+
+# AWS Session Token
+# CLI flag: -<prefix>.storage.s3.session-token
+[session_token: <string> | default = ""]
 
 # Disable https on s3 connection.
 # CLI flag: -<prefix>.storage.s3.insecure

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -44,6 +44,7 @@ func newS3Config(cfg Config) (s3.Config, error) {
 		Region:          cfg.Region,
 		AccessKey:       cfg.AccessKeyID,
 		SecretKey:       cfg.SecretAccessKey.String(),
+		SessionToken:    cfg.SessionToken.String(),
 		Insecure:        cfg.Insecure,
 		SSEConfig:       sseCfg,
 		PutUserMetadata: map[string]string{awsStorageClassHeader: cfg.StorageClass},

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Region           string         `yaml:"region"`
 	BucketName       string         `yaml:"bucket_name"`
 	SecretAccessKey  flagext.Secret `yaml:"secret_access_key"`
+	SessionToken     flagext.Secret `yaml:"session_token"`
 	AccessKeyID      string         `yaml:"access_key_id"`
 	Insecure         bool           `yaml:"insecure"`
 	SignatureVersion string         `yaml:"signature_version"`
@@ -76,6 +77,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
+	f.Var(&cfg.SessionToken, prefix+"s3.session-token", "S3 session token")
 	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.")
 	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.")

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -73,6 +73,7 @@ type S3Config struct {
 	Region           string              `yaml:"region"`
 	AccessKeyID      string              `yaml:"access_key_id"`
 	SecretAccessKey  flagext.Secret      `yaml:"secret_access_key"`
+	SessionToken     flagext.Secret      `yaml:"session_token"`
 	Insecure         bool                `yaml:"insecure"`
 	SSEEncryption    bool                `yaml:"sse_encryption"`
 	HTTPConfig       HTTPConfig          `yaml:"http_config"`
@@ -108,6 +109,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "AWS region to use.")
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "AWS Access Key ID")
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "AWS Secret Access Key")
+	f.Var(&cfg.SessionToken, prefix+"s3.session-token", "AWS Session Token")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 
 	// TODO Remove in Cortex 1.10.0
@@ -248,7 +250,7 @@ func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S
 	}
 
 	if cfg.AccessKeyID != "" && cfg.SecretAccessKey.String() != "" {
-		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey.String(), "")
+		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey.String(), cfg.SessionToken.String())
 		s3Config = s3Config.WithCredentials(creds)
 	}
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -176,5 +176,22 @@ secret_access_key: secret access key
 
 	require.Equal(t, underTest.AccessKeyID, "access key id")
 	require.Equal(t, underTest.SecretAccessKey.String(), "secret access key")
+	require.Equal(t, underTest.SessionToken.String(), "")
+
+}
+
+func Test_ConfigParsesCredentialsInlineWithSessionToken(t *testing.T) {
+	var underTest = S3Config{}
+	yamlCfg := `
+access_key_id: access key id
+secret_access_key: secret access key
+session_token: session token
+`
+	err := yaml.Unmarshal([]byte(yamlCfg), &underTest)
+	require.NoError(t, err)
+
+	require.Equal(t, underTest.AccessKeyID, "access key id")
+	require.Equal(t, underTest.SecretAccessKey.String(), "secret access key")
+	require.Equal(t, underTest.SessionToken.String(), "session token")
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to automate the access account rotation. This is that easy at moment with service accounts in minio. Our currently life time of tokens is 3 months with minio sts works this fine.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
