### PR TITLE
[helm] Fix read-only /tmp in 3 targets mode

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -105,6 +105,8 @@ spec:
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /etc/loki/runtime-config
+            - name: tmp
+              mountPath: /tmp
             - name: data
               mountPath: /var/loki
             {{- if .Values.enterprise.enabled }}
@@ -129,6 +131,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           {{- if .Values.loki.existingSecretForConfig }}
           secret:


### PR DESCRIPTION
Similar to https://github.com/grafana/loki/pull/7695 but for the backend template.

**What this PR does / why we need it**:
Read only /tmp errors in backend pods in 3 targets mode (loki helm chart simple scalable mode with legacyReadTarget: false ).

**Which issue(s) this PR fixes**:
Fixes [helm-charts#2191](https://github.com/grafana/helm-charts/issues/2191)

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
