### PR TITLE
Helm: add debug option to helm command for verbose output on local development

### DIFF
--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -6,6 +6,10 @@ IMAGE_TAG := $(shell ../../../tools/image-tag)
 EXISTING_REGISTRY_PORT := $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
 REGISTRY_PORT ?= $(or $(EXISTING_REGISTRY_PORT),46453)
 
+# For verbose output, run make DEBUG=true <TARGET>
+DEBUG := false
+HELM := helm --debug=$(DEBUG)
+
 enterprise-logs: prepare-gel helm-cluster
 	$(MAKE) -C $(CURDIR) apply-enterprise-helm-cluster
 	echo "Waiting 5s for cluster to be ready for helm installation."
@@ -55,12 +59,12 @@ down:
 	k3d cluster delete helm-cluster
 
 add-repos:
-	helm repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts
-	helm repo add --force-update grafana https://grafana.github.io/helm-charts
-	helm repo add --force-update minio https://charts.min.io/
+	$(HELM) repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts
+	$(HELM) repo add --force-update grafana https://grafana.github.io/helm-charts
+	$(HELM) repo add --force-update minio https://charts.min.io/
 
 update-repos: add-repos
-	helm repo update
+	$(HELM) repo update
 	tk tool charts vendor
 	jb update
 
@@ -111,37 +115,37 @@ build-latest-image:
 
 HELM_DIR := $(shell cd $(CURDIR)/../../../production/helm/loki && pwd)
 helm-install-enterprise-logs:
-	helm install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"
+	$(HELM) install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"
 
 helm-upgrade-enterprise-logs:
-	helm upgrade enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"
+	$(HELM) upgrade enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs.yaml"
 
 helm-uninstall-enterprise-logs:
-	helm uninstall enterprise-logs-test-fixture -n loki
+	$(HELM) uninstall enterprise-logs-test-fixture -n loki
 
 helm-install-enterprise-logs-ha-single-binary:
-	helm install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
+	$(HELM) install enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
 
 helm-upgrade-enterprise-logs-ha-single-binary:
-	helm upgrade enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
+	$(HELM) upgrade enterprise-logs-test-fixture "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/enterprise-logs-ha-single-binary.yaml"
 
 helm-uninstall-enterprise-logs-ha-single-binary:
-	helm uninstall enterprise-logs-test-fixture -n loki
+	$(HELM) uninstall enterprise-logs-test-fixture -n loki
 
 helm-install-loki:
-	helm install loki "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki.yaml"
+	$(HELM) install loki "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki.yaml"
 
 helm-upgrade-loki:
-	helm upgrade loki "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/loki.yaml"
+	$(HELM) upgrade loki "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/loki.yaml"
 
 helm-uninstall-loki:
-	helm uninstall loki -n loki
+	$(HELM) uninstall loki -n loki
 
 helm-install-loki-ha-single-binary:
-	helm install loki-single-binary "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
+	$(HELM) install loki-single-binary "$(HELM_DIR)" -n loki --create-namespace --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
 
 helm-upgrade-loki-ha-single-binary:
-	helm upgrade loki-single-binary "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
+	$(HELM) upgrade loki-single-binary "$(HELM_DIR)" -n loki --values "$(CURDIR)/environments/helm-cluster/values/loki-ha-single-binary.yaml"
 
 helm-uninstall-loki-binary:
-	helm uninstall loki-single-binary -n loki
+	$(HELM) uninstall loki-single-binary -n loki


### PR DESCRIPTION
**What this PR does / why we need it**:

Add --debug flag to helm command on tools/dev/k3d

The --debug flag can be especially useful when (un)installing helm charts.

## Example enterprise-logs

### Debug off

The installation of the enterprise-logs takes some minutes due to the required initial job execution, mainly `tokengen` and `provisioner`. Therefore, when debugging it can be extremely useful to know which step is currently in execution and if there was any failure.

```
> make helm-install-enterprise-logs // equivalent to 'make DEBUG=false helm-install-enterprise-logs
helm --debug=false install enterprise-logs-test-fixture "/Users/ssncf/Documents/grafana/git/loki/production/helm/loki" -n loki --create-namespace --values "/Users/ssncf/Documents/grafana/git/loki/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml"
... (minutes of execution)
<summary in case of success, or error in case of failure and backoff retry mechanisms>
```

### Debug on

```
> make DEBUG=true helm-install-enterprise-logs
helm --debug=true install enterprise-logs-test-fixture "/Users/ssncf/Documents/grafana/git/loki/production/helm/loki" -n loki --create-namespace --values "/Users/ssncf/Documents/grafana/git/loki/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml"
...
client.go:540: [debug] Watching for changes to Job enterprise-logs-tokengen with timeout of 5m0s
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: ADDED
client.go:607: [debug] enterprise-logs-tokengen: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: MODIFIED
client.go:607: [debug] enterprise-logs-tokengen: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: MODIFIED
client.go:607: [debug] enterprise-logs-tokengen: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: MODIFIED
client.go:607: [debug] enterprise-logs-tokengen: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: MODIFIED
client.go:607: [debug] enterprise-logs-tokengen: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-tokengen: MODIFIED
client.go:310: [debug] Starting delete for "enterprise-logs-provisioner" Job
client.go:339: [debug] jobs.batch "enterprise-logs-provisioner" not found
client.go:128: [debug] creating 1 resource(s)
client.go:540: [debug] Watching for changes to Job enterprise-logs-provisioner with timeout of 5m0s
client.go:568: [debug] Add/Modify event for enterprise-logs-provisioner: ADDED
client.go:607: [debug] enterprise-logs-provisioner: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-provisioner: MODIFIED
client.go:607: [debug] enterprise-logs-provisioner: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:568: [debug] Add/Modify event for enterprise-logs-provisioner: MODIFIED
client.go:607: [debug] enterprise-logs-provisioner: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
...
```
