### PR TITLE
Loki: Process "Limited" queries sequentially and not in parallel

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -49,8 +49,8 @@ type Limits interface {
 
 type limits struct {
 	Limits
-	splitDuration           time.Duration
-	tsdbMaxQueryParallelism int
+	splitDuration       time.Duration
+	maxQueryParallelism int
 }
 
 func (l limits) QuerySplitDuration(user string) time.Duration {
@@ -58,7 +58,11 @@ func (l limits) QuerySplitDuration(user string) time.Duration {
 }
 
 func (l limits) TSDBMaxQueryParallelism(string) int {
-	return l.tsdbMaxQueryParallelism
+	return l.maxQueryParallelism
+}
+
+func (l limits) MaxQueryParallelism(string) int {
+	return l.maxQueryParallelism
 }
 
 // WithSplitByLimits will construct a Limits with a static split by duration.
@@ -69,11 +73,10 @@ func WithSplitByLimits(l Limits, splitBy time.Duration) Limits {
 	}
 }
 
-func WithSplitbyAndMaxParallelism(l Limits, splitby time.Duration, tsdbMaxQueryParallelism int) Limits {
+func WithMaxParallelism(l Limits, maxParallelism int) Limits {
 	return limits{
-		Limits:                  l,
-		splitDuration:           splitby,
-		tsdbMaxQueryParallelism: tsdbMaxQueryParallelism,
+		Limits:              l,
+		maxQueryParallelism: maxParallelism,
 	}
 }
 

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -49,34 +49,44 @@ type Limits interface {
 
 type limits struct {
 	Limits
-	splitDuration       time.Duration
-	maxQueryParallelism int
+	// Use pointers so nil value can indicate if the value was set.
+	splitDuration       *time.Duration
+	maxQueryParallelism *int
 }
 
 func (l limits) QuerySplitDuration(user string) time.Duration {
-	return l.splitDuration
+	if l.splitDuration == nil {
+		return l.Limits.QuerySplitDuration(user)
+	}
+	return *l.splitDuration
 }
 
-func (l limits) TSDBMaxQueryParallelism(string) int {
-	return l.maxQueryParallelism
+func (l limits) TSDBMaxQueryParallelism(user string) int {
+	if l.maxQueryParallelism == nil {
+		return l.Limits.TSDBMaxQueryParallelism(user)
+	}
+	return *l.maxQueryParallelism
 }
 
-func (l limits) MaxQueryParallelism(string) int {
-	return l.maxQueryParallelism
+func (l limits) MaxQueryParallelism(user string) int {
+	if l.maxQueryParallelism == nil {
+		return l.Limits.MaxQueryParallelism(user)
+	}
+	return *l.maxQueryParallelism
 }
 
 // WithSplitByLimits will construct a Limits with a static split by duration.
 func WithSplitByLimits(l Limits, splitBy time.Duration) Limits {
 	return limits{
 		Limits:        l,
-		splitDuration: splitBy,
+		splitDuration: &splitBy,
 	}
 }
 
 func WithMaxParallelism(l Limits, maxParallelism int) Limits {
 	return limits{
 		Limits:              l,
-		maxQueryParallelism: maxParallelism,
+		maxQueryParallelism: &maxParallelism,
 	}
 }
 

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -49,11 +49,16 @@ type Limits interface {
 
 type limits struct {
 	Limits
-	splitDuration time.Duration
+	splitDuration           time.Duration
+	tsdbMaxQueryParallelism int
 }
 
 func (l limits) QuerySplitDuration(user string) time.Duration {
 	return l.splitDuration
+}
+
+func (l limits) TSDBMaxQueryParallelism(string) int {
+	return l.tsdbMaxQueryParallelism
 }
 
 // WithSplitByLimits will construct a Limits with a static split by duration.
@@ -61,6 +66,14 @@ func WithSplitByLimits(l Limits, splitBy time.Duration) Limits {
 	return limits{
 		Limits:        l,
 		splitDuration: splitBy,
+	}
+}
+
+func WithSplitbyAndMaxParallelism(l Limits, splitby time.Duration, tsdbMaxQueryParallelism int) Limits {
+	return limits{
+		Limits:                  l,
+		splitDuration:           splitby,
+		tsdbMaxQueryParallelism: tsdbMaxQueryParallelism,
 	}
 }
 

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -36,6 +36,7 @@ func NewQueryShardMiddleware(
 	middlewareMetrics *queryrangebase.InstrumentMiddlewareMetrics,
 	shardingMetrics *logql.MapperMetrics,
 	limits Limits,
+	resolver logql.ShardResolver,
 ) queryrangebase.Middleware {
 	noshards := !hasShards(confs)
 
@@ -49,7 +50,7 @@ func NewQueryShardMiddleware(
 	}
 
 	mapperware := queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newASTMapperware(confs, next, logger, shardingMetrics, limits)
+		return newASTMapperware(confs, next, logger, shardingMetrics, limits, resolver)
 	})
 
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
@@ -71,24 +72,27 @@ func newASTMapperware(
 	logger log.Logger,
 	metrics *logql.MapperMetrics,
 	limits Limits,
+	resolver logql.ShardResolver,
 ) *astMapperware {
 	return &astMapperware{
-		confs:   confs,
-		logger:  log.With(logger, "middleware", "QueryShard.astMapperware"),
-		limits:  limits,
-		next:    next,
-		ng:      logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
-		metrics: metrics,
+		confs:         confs,
+		logger:        log.With(logger, "middleware", "QueryShard.astMapperware"),
+		limits:        limits,
+		next:          next,
+		ng:            logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
+		metrics:       metrics,
+		shardResolver: resolver,
 	}
 }
 
 type astMapperware struct {
-	confs   ShardingConfigs
-	logger  log.Logger
-	limits  Limits
-	next    queryrangebase.Handler
-	ng      *logql.DownstreamEngine
-	metrics *logql.MapperMetrics
+	confs         ShardingConfigs
+	logger        log.Logger
+	limits        Limits
+	next          queryrangebase.Handler
+	ng            *logql.DownstreamEngine
+	metrics       *logql.MapperMetrics
+	shardResolver logql.ShardResolver
 }
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
@@ -115,17 +119,23 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return nil, err
 	}
 
-	resolver, ok := shardResolverForConf(
-		ctx,
-		conf,
-		ast.ng.Opts().MaxLookBackPeriod,
-		ast.logger,
-		MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
-		r,
-		ast.next,
-	)
-	if !ok {
-		return ast.next.Do(ctx, r)
+	var resolver logql.ShardResolver
+	if ast.shardResolver != nil {
+		resolver = ast.shardResolver
+	} else {
+		var ok bool
+		resolver, ok = shardResolverForConf(
+			ctx,
+			conf,
+			ast.ng.Opts().MaxLookBackPeriod,
+			ast.logger,
+			MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
+			r,
+			ast.next,
+		)
+		if !ok {
+			return ast.next.Do(ctx, r)
+		}
 	}
 
 	mapper := logql.NewShardMapper(resolver, ast.metrics)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -167,6 +167,7 @@ func Test_astMapper(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
+		nil,
 	)
 
 	resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`{food="bar"}`))
@@ -200,6 +201,7 @@ func Test_ShardingByPass(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
+		nil,
 	)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`1+1`))
@@ -272,7 +274,8 @@ func Test_InstantSharding(t *testing.T) {
 			maxSeries:           math.MaxInt32,
 			maxQueryParallelism: 10,
 			queryTimeout:        time.Second,
-		})
+		},
+		nil)
 	response, err := sharding.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 		lock.Lock()
 		defer lock.Unlock()
@@ -553,6 +556,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				log.NewNopLogger(),
 				nilShardingMetrics,
 				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
+				nil,
 			)
 
 			resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), tc.req)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -359,6 +359,7 @@ func NewLimitedTripperware(
 		// Our defaults for splitting and parallelism are much too aggressive for large customers and result in
 		// potentially GB of logs being returned by all the shards and splits which will overwhelm the frontend
 		// Therefore we force max parallelism to one so that these queries are executed sequentially.
+		// Below we also fix the number of shards to a static number.
 		SplitByIntervalMiddleware(schema.Configs, WithMaxParallelism(limits, 1), codec, splitByTime, metrics.SplitByMetrics),
 	}
 
@@ -388,7 +389,9 @@ func NewLimitedTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				logql.ConstantShards(16),
+				// Too many shards on limited queries results in slowing down this type of query
+				// and overwhelming the frontend, therefore we fix the number of shards to prevent this.
+				logql.ConstantShards(32),
 			),
 		)
 	}

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -321,6 +321,7 @@ func NewLogFilterTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
 			),
 		)
 	}
@@ -379,18 +380,18 @@ func NewLimitedTripperware(
 		)
 	}
 
-	// TODO(ewelch): Disabling sharding for now because it creates too many shards for large volumes
-	//if cfg.ShardedQueries {
-	//	queryRangeMiddleware = append(queryRangeMiddleware,
-	//		NewQueryShardMiddleware(
-	//			log,
-	//			schema.Configs,
-	//			metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
-	//			metrics.MiddlewareMapperMetrics.shardMapper,
-	//			limits,
-	//		),
-	//	)
-	//}
+	if cfg.ShardedQueries {
+		queryRangeMiddleware = append(queryRangeMiddleware,
+			NewQueryShardMiddleware(
+				log,
+				schema.Configs,
+				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
+				metrics.MiddlewareMapperMetrics.shardMapper,
+				limits,
+				logql.ConstantShards(16),
+			),
+		)
+	}
 
 	if cfg.MaxRetries > 0 {
 		queryRangeMiddleware = append(
@@ -561,6 +562,7 @@ func NewMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
 			),
 		)
 	}
@@ -608,6 +610,7 @@ func NewInstantMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
 			),
 		)
 	}

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -357,8 +357,8 @@ func NewLimitedTripperware(
 		// Limited queries only need to fetch up to the requested line limit worth of logs,
 		// Our defaults for splitting and parallelism are much too aggressive for large customers and result in
 		// potentially GB of logs being returned by all the shards and splits which will overwhelm the frontend
-		// Therefore we limit to only query one hour of data at a time and
-		SplitByIntervalMiddleware(schema.Configs, WithSplitbyAndMaxParallelism(limits, 1*time.Hour, 1), codec, splitByTime, metrics.SplitByMetrics),
+		// Therefore we force max parallelism to one so that these queries are executed sequentially.
+		SplitByIntervalMiddleware(schema.Configs, WithMaxParallelism(limits, 1), codec, splitByTime, metrics.SplitByMetrics),
 	}
 
 	if cfg.CacheResults {

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -443,6 +443,10 @@ func TestPostQueries(t *testing.T) {
 			return nil, nil
 		}),
 		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Error("unexpected default roundtripper called")
+			return nil, nil
+		}),
+		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {
 			return nil, nil
 		}),
 		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

In #7510 we removed the bypass for "limited" queries.

A limited query is a logs query which has no filter expression `{app="foo"}`

Generally speaking these are very easy queries for Loki to return as it only needs to find 1000 lines.

However for a query which matches a LOT of streams and a LOT of data and runs over a long timeframe, because we bypassed the split by time and shard by time, that query was sent to execute on one querier only which would often result in overwhelming it with the amount of chunks that had to be loaded to properly sort to find the first 1000 lines.

Removing the bypass helped this by allowing the query to be executed over smaller timeframes and to shard so that each querier had to match fewer series.

This however had problems too, as a really large query over many days would be broken into many subqueries each with many shards. 

TSDB exacerbated this as it has dynamic sharding capability leading to potentially thousands of shards for each split by time.

If a tenant has configured a very high max query parallelism, all of these splits and shards can potentially be executed in parallel which could lead to gigabytes of data being sent back to the frontend to sort.

This PR makes a few changes to attempt to maintain the advantages of splitting by time and sharding, but prevent overwhelming on large timeframes and lots of data:

  * for limited queries we change the max parallelism to 1, such that the splits will be executed sequentially
  * we fix the number of shards to 32 so that we reduce pressure on a single querier but don't overwhelm the frontend.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
