### PR TITLE
Loki: set a maximum number of shards for "limited" queries instead of fixed number

### DIFF
--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -167,7 +167,7 @@ func Test_astMapper(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-		nil,
+		0,
 	)
 
 	resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`{food="bar"}`))
@@ -201,7 +201,7 @@ func Test_ShardingByPass(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
-		nil,
+		0,
 	)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`1+1`))
@@ -275,7 +275,7 @@ func Test_InstantSharding(t *testing.T) {
 			maxQueryParallelism: 10,
 			queryTimeout:        time.Second,
 		},
-		nil)
+		0)
 	response, err := sharding.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 		lock.Lock()
 		defer lock.Unlock()
@@ -556,7 +556,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				log.NewNopLogger(),
 				nilShardingMetrics,
 				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-				nil,
+				0,
 			)
 
 			resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), tc.req)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -321,7 +321,7 @@ func NewLogFilterTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}
@@ -391,7 +391,7 @@ func NewLimitedTripperware(
 				limits,
 				// Too many shards on limited queries results in slowing down this type of query
 				// and overwhelming the frontend, therefore we fix the number of shards to prevent this.
-				logql.ConstantShards(32),
+				32,
 			),
 		)
 	}
@@ -565,7 +565,7 @@ func NewMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}
@@ -613,7 +613,7 @@ func NewInstantMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}


### PR DESCRIPTION
Signed-off-by: Edward Welch <edward.welch@grafana.com>

**What this PR does / why we need it**:

This is a modification to #8482, instead of fixing the number of shards we will set a maximum value.

Using a fixed shard count resulted in oversharding of queries which had very little data.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
