### PR TITLE
helm: values to override read/write/backend paths in gateway config

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1016,7 +1016,7 @@ false
 </td>
 		</tr>
 		<tr>
-			<td>gateway.nginxConfig.customLokiBackendUrl</td>
+			<td>gateway.nginxConfig.customBackendUrl</td>
 			<td>string</td>
 			<td>Override Backend URL</td>
 			<td><pre lang="json">
@@ -1025,7 +1025,7 @@ null
 </td>
 		</tr>
 		<tr>
-			<td>gateway.nginxConfig.customLokiReadUrl</td>
+			<td>gateway.nginxConfig.customReadUrl</td>
 			<td>string</td>
 			<td>Override Read URL</td>
 			<td><pre lang="json">
@@ -1034,7 +1034,7 @@ null
 </td>
 		</tr>
 		<tr>
-			<td>gateway.nginxConfig.customLokiWriteUrl</td>
+			<td>gateway.nginxConfig.customWriteUrl</td>
 			<td>string</td>
 			<td>Override Write URL</td>
 			<td><pre lang="json">

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1016,6 +1016,33 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>gateway.nginxConfig.customLokiBackendUrl</td>
+			<td>string</td>
+			<td>Override Backend URL</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.nginxConfig.customLokiReadUrl</td>
+			<td>string</td>
+			<td>Override Read URL</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.nginxConfig.customLokiWriteUrl</td>
+			<td>string</td>
+			<td>Override Write URL</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>gateway.nginxConfig.file</td>
 			<td>string</td>
 			<td>Config file contents for Nginx. Passed through the `tpl` function to allow templating</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
+- [FEATURE] add `gateway.nginxConfig.customLokiReadUrl`, `gateway.nginxConfig.customLokiWriteUrl` and `gateway.nginxConfig.customLokiBackendUrl` to override read/write/backend paths.
+
 ## 4.5.1
 
 - [BUGFIX] Fix rendering of namespace in provisioner job.

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
-- [FEATURE] add `gateway.nginxConfig.customLokiReadUrl`, `gateway.nginxConfig.customLokiWriteUrl` and `gateway.nginxConfig.customLokiBackendUrl` to override read/write/backend paths.
+- [FEATURE] add `gateway.nginxConfig.customReadUrl`, `gateway.nginxConfig.customWriteUrl` and `gateway.nginxConfig.customBackendUrl` to override read/write/backend paths.
 
 ## 4.5.1
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -592,14 +592,14 @@ http {
     {{- $readUrl     := printf "http://%s.%s.svc.%s:3100" $readHost    .Release.Namespace .Values.global.clusterDomain }}
     {{- $backendUrl  := printf "http://%s.%s.svc.%s:3100" $backendHost .Release.Namespace .Values.global.clusterDomain }}
 
-    {{- if .Values.gateway.nginxConfig.customLokiWriteUrl }}
-    {{- $writeUrl  = .Values.gateway.nginxConfig.customLokiWriteUrl }}
+    {{- if .Values.gateway.nginxConfig.customWriteUrl }}
+    {{- $writeUrl  = .Values.gateway.nginxConfig.customWriteUrl }}
     {{- end }}
-    {{- if .Values.gateway.nginxConfig.customLokiReadUrl }}
-    {{- $readUrl = .Values.gateway.nginxConfig.customLokiReadUrl }}
+    {{- if .Values.gateway.nginxConfig.customReadUrl }}
+    {{- $readUrl = .Values.gateway.nginxConfig.customReadUrl }}
     {{- end }}
-    {{- if .Values.gateway.nginxConfig.customLokiBackendUrl }}
-    {{- $backendUrl = .Values.gateway.nginxConfig.customLokiBackendUrl }}
+    {{- if .Values.gateway.nginxConfig.customBackendUrl }}
+    {{- $backendUrl = .Values.gateway.nginxConfig.customBackendUrl }}
     {{- end }}
 
     location = /api/prom/push {

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -588,73 +588,87 @@ http {
     {{- $writeHost = include "loki.singleBinaryFullname" .}}
     {{- end }}
 
+    {{- $writeUrl    := printf "http://%s.%s.svc.%s:3100" $writeHost   .Release.Namespace .Values.global.clusterDomain }}
+    {{- $readUrl     := printf "http://%s.%s.svc.%s:3100" $readHost    .Release.Namespace .Values.global.clusterDomain }}
+    {{- $backendUrl  := printf "http://%s.%s.svc.%s:3100" $backendHost .Release.Namespace .Values.global.clusterDomain }}
+
+    {{- if .Values.gateway.nginxConfig.customLokiWriteUrl }}
+    {{- $writeUrl  = .Values.gateway.nginxConfig.customLokiWriteUrl }}
+    {{- end }}
+    {{- if .Values.gateway.nginxConfig.customLokiReadUrl }}
+    {{- $readUrl = .Values.gateway.nginxConfig.customLokiReadUrl }}
+    {{- end }}
+    {{- if .Values.gateway.nginxConfig.customLokiBackendUrl }}
+    {{- $backendUrl = .Values.gateway.nginxConfig.customLokiBackendUrl }}
+    {{- end }}
+
     location = /api/prom/push {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     location = /api/prom/tail {
-      proxy_pass       http://{{ $readHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
 
     location ~ /api/prom/.* {
-      proxy_pass       http://{{ $readHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $readUrl }}$request_uri;
     }
 
     location ~ /prometheus/api/v1/alerts.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
     location ~ /prometheus/api/v1/rules.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
     location ~ /ruler/.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
     location = /loki/api/v1/push {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     location = /loki/api/v1/tail {
-      proxy_pass       http://{{ $readHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
 
     location ~ /compactor/.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
     location ~ /distributor/.* {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     location ~ /ring {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     location ~ /ingester/.* {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     location ~ /store-gateway/.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
     location ~ /query-scheduler/.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
     location ~ /scheduler/.* {
-      proxy_pass       http://{{ $backendHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
     location ~ /loki/api/.* {
-      proxy_pass       http://{{ $readHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $readUrl }}$request_uri;
     }
 
     location ~ /admin/api/.* {
-      proxy_pass       http://{{ $writeHost }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+      proxy_pass       {{ $writeUrl }}$request_uri;
     }
 
     {{- with .Values.gateway.nginxConfig.serverSnippet }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1197,6 +1197,12 @@ gateway:
     serverSnippet: ""
     # -- Allows appending custom configuration to the http block
     httpSnippet: ""
+    # -- Override Read URL
+    customLokiReadUrl: null
+    # -- Override Write URL
+    customLokiWriteUrl: null
+    # -- Override Backend URL
+    customLokiBackendUrl: null
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1198,11 +1198,11 @@ gateway:
     # -- Allows appending custom configuration to the http block
     httpSnippet: ""
     # -- Override Read URL
-    customLokiReadUrl: null
+    customReadUrl: null
     # -- Override Write URL
-    customLokiWriteUrl: null
+    customWriteUrl: null
     # -- Override Backend URL
-    customLokiBackendUrl: null
+    customBackendUrl: null
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |


### PR DESCRIPTION
**What this PR does / why we need it**:

With this PR we could override the generated read/write/backend URLs for the gateway.

For instance, here I show the differences in proxy_pass definitions when overriding these paths:
```
[loki]$ helm template . | grep proxy_pass
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
[loki]$ cat values-custom.yaml 
gateway:
  nginxConfig:
    customLokiReadUrl: "https://myproxy/read"
    customLokiBackendUrl: "https://myproxy/backend"
    customLokiWriteUrl: "https://myproxy/write"
[loki]$ helm template . -f values-custom.yaml | grep proxy_pass
          proxy_pass       https://myproxy/write$request_uri;
          proxy_pass       https://myproxy/read$request_uri;
          proxy_pass       https://myproxy/read$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/write$request_uri;
          proxy_pass       https://myproxy/read$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/write$request_uri;
          proxy_pass       https://myproxy/write$request_uri;
          proxy_pass       https://myproxy/write$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/backend$request_uri;
          proxy_pass       https://myproxy/read$request_uri;
          proxy_pass       https://myproxy/write$request_uri;
[loki]$ 
```

**Which issue(s) this PR fixes**:
Fixes #8488 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
