### PR TITLE
correctly calculate max shards

### DIFF
--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -124,10 +124,8 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 	}
 
 	combined := stats.MergeStats(results...)
-	factor := guessShardFactor(combined)
-	if r.maxShards >= 0 && factor > r.maxShards {
-		factor = r.maxShards
-	}
+	factor := guessShardFactor(combined, r.maxShards)
+
 	var bytesPerShard = combined.Bytes
 	if factor > 0 {
 		bytesPerShard = combined.Bytes / uint64(factor)
@@ -157,7 +155,7 @@ const (
 // is at least two, the range of data per shard is (maxBytesPerShard/2, maxBytesPerShard]
 // For instance, for a maxBytesPerShard of 500MB and a query touching 1000MB, we split into two shards of 500MB.
 // If there are 1004MB, we split into four shards of 251MB.
-func guessShardFactor(stats stats.Stats) int {
+func guessShardFactor(stats stats.Stats, maxShards int) int {
 	minShards := float64(stats.Bytes) / float64(maxBytesPerShard)
 
 	// round up to nearest power of 2
@@ -166,8 +164,21 @@ func guessShardFactor(stats stats.Stats) int {
 	// Since x^0 == 1 and we only support factors of 2
 	// reset this edge case manually
 	factor := int(math.Pow(2, power))
+	if maxShards > 0 {
+		factor = min(factor, maxShards)
+	}
+
+	// shortcut: no need to run any sharding logic when factor=1
+	// as it's the same as no sharding
 	if factor == 1 {
 		factor = 0
 	}
 	return factor
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/pkg/querier/queryrange/shard_resolver_test.go
+++ b/pkg/querier/queryrange/shard_resolver_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestGuessShardFactor(t *testing.T) {
 	for _, tc := range []struct {
-		stats stats.Stats
-		exp   int
+		stats     stats.Stats
+		maxShards int
+		exp       int
 	}{
 		{
 			// no data == no sharding
@@ -43,9 +44,30 @@ func TestGuessShardFactor(t *testing.T) {
 				Bytes: maxBytesPerShard,
 			},
 		},
+		{
+			maxShards: 8,
+			exp:       4,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
+		{
+			maxShards: 2,
+			exp:       2,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
+		{
+			maxShards: 1,
+			exp:       0,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc.stats), func(t *testing.T) {
-			require.Equal(t, tc.exp, guessShardFactor(tc.stats))
+			require.Equal(t, tc.exp, guessShardFactor(tc.stats, tc.maxShards))
 		})
 	}
 }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/grafana/loki/pull/8487 which had the effect of always enforcing shard factor of 1 when max-shards was intended to be disabled: https://github.com/grafana/loki/pull/8487