### PR TITLE
Recut k136

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -49,18 +49,44 @@ type Limits interface {
 
 type limits struct {
 	Limits
-	splitDuration time.Duration
+	// Use pointers so nil value can indicate if the value was set.
+	splitDuration       *time.Duration
+	maxQueryParallelism *int
 }
 
 func (l limits) QuerySplitDuration(user string) time.Duration {
-	return l.splitDuration
+	if l.splitDuration == nil {
+		return l.Limits.QuerySplitDuration(user)
+	}
+	return *l.splitDuration
+}
+
+func (l limits) TSDBMaxQueryParallelism(user string) int {
+	if l.maxQueryParallelism == nil {
+		return l.Limits.TSDBMaxQueryParallelism(user)
+	}
+	return *l.maxQueryParallelism
+}
+
+func (l limits) MaxQueryParallelism(user string) int {
+	if l.maxQueryParallelism == nil {
+		return l.Limits.MaxQueryParallelism(user)
+	}
+	return *l.maxQueryParallelism
 }
 
 // WithSplitByLimits will construct a Limits with a static split by duration.
 func WithSplitByLimits(l Limits, splitBy time.Duration) Limits {
 	return limits{
 		Limits:        l,
-		splitDuration: splitBy,
+		splitDuration: &splitBy,
+	}
+}
+
+func WithMaxParallelism(l Limits, maxParallelism int) Limits {
+	return limits{
+		Limits:              l,
+		maxQueryParallelism: &maxParallelism,
 	}
 }
 

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -36,6 +36,7 @@ func NewQueryShardMiddleware(
 	middlewareMetrics *queryrangebase.InstrumentMiddlewareMetrics,
 	shardingMetrics *logql.MapperMetrics,
 	limits Limits,
+	resolver logql.ShardResolver,
 ) queryrangebase.Middleware {
 	noshards := !hasShards(confs)
 
@@ -49,7 +50,7 @@ func NewQueryShardMiddleware(
 	}
 
 	mapperware := queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newASTMapperware(confs, next, logger, shardingMetrics, limits)
+		return newASTMapperware(confs, next, logger, shardingMetrics, limits, resolver)
 	})
 
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
@@ -71,24 +72,27 @@ func newASTMapperware(
 	logger log.Logger,
 	metrics *logql.MapperMetrics,
 	limits Limits,
+	resolver logql.ShardResolver,
 ) *astMapperware {
 	return &astMapperware{
-		confs:   confs,
-		logger:  log.With(logger, "middleware", "QueryShard.astMapperware"),
-		limits:  limits,
-		next:    next,
-		ng:      logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
-		metrics: metrics,
+		confs:         confs,
+		logger:        log.With(logger, "middleware", "QueryShard.astMapperware"),
+		limits:        limits,
+		next:          next,
+		ng:            logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
+		metrics:       metrics,
+		shardResolver: resolver,
 	}
 }
 
 type astMapperware struct {
-	confs   ShardingConfigs
-	logger  log.Logger
-	limits  Limits
-	next    queryrangebase.Handler
-	ng      *logql.DownstreamEngine
-	metrics *logql.MapperMetrics
+	confs         ShardingConfigs
+	logger        log.Logger
+	limits        Limits
+	next          queryrangebase.Handler
+	ng            *logql.DownstreamEngine
+	metrics       *logql.MapperMetrics
+	shardResolver logql.ShardResolver
 }
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
@@ -111,17 +115,23 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return nil, err
 	}
 
-	resolver, ok := shardResolverForConf(
-		ctx,
-		conf,
-		ast.ng.Opts().MaxLookBackPeriod,
-		ast.logger,
-		MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
-		r,
-		ast.next,
-	)
-	if !ok {
-		return ast.next.Do(ctx, r)
+	var resolver logql.ShardResolver
+	if ast.shardResolver != nil {
+		resolver = ast.shardResolver
+	} else {
+		var ok bool
+		resolver, ok = shardResolverForConf(
+			ctx,
+			conf,
+			ast.ng.Opts().MaxLookBackPeriod,
+			ast.logger,
+			MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
+			r,
+			ast.next,
+		)
+		if !ok {
+			return ast.next.Do(ctx, r)
+		}
 	}
 
 	mapper := logql.NewShardMapper(resolver, ast.metrics)

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -36,7 +36,7 @@ func NewQueryShardMiddleware(
 	middlewareMetrics *queryrangebase.InstrumentMiddlewareMetrics,
 	shardingMetrics *logql.MapperMetrics,
 	limits Limits,
-	resolver logql.ShardResolver,
+	maxShards int,
 ) queryrangebase.Middleware {
 	noshards := !hasShards(confs)
 
@@ -50,7 +50,7 @@ func NewQueryShardMiddleware(
 	}
 
 	mapperware := queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return newASTMapperware(confs, next, logger, shardingMetrics, limits, resolver)
+		return newASTMapperware(confs, next, logger, shardingMetrics, limits, maxShards)
 	})
 
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
@@ -72,27 +72,27 @@ func newASTMapperware(
 	logger log.Logger,
 	metrics *logql.MapperMetrics,
 	limits Limits,
-	resolver logql.ShardResolver,
+	maxShards int,
 ) *astMapperware {
 	return &astMapperware{
-		confs:         confs,
-		logger:        log.With(logger, "middleware", "QueryShard.astMapperware"),
-		limits:        limits,
-		next:          next,
-		ng:            logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
-		metrics:       metrics,
-		shardResolver: resolver,
+		confs:     confs,
+		logger:    log.With(logger, "middleware", "QueryShard.astMapperware"),
+		limits:    limits,
+		next:      next,
+		ng:        logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
+		metrics:   metrics,
+		maxShards: maxShards,
 	}
 }
 
 type astMapperware struct {
-	confs         ShardingConfigs
-	logger        log.Logger
-	limits        Limits
-	next          queryrangebase.Handler
-	ng            *logql.DownstreamEngine
-	metrics       *logql.MapperMetrics
-	shardResolver logql.ShardResolver
+	confs     ShardingConfigs
+	logger    log.Logger
+	limits    Limits
+	next      queryrangebase.Handler
+	ng        *logql.DownstreamEngine
+	metrics   *logql.MapperMetrics
+	maxShards int
 }
 
 func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
@@ -115,23 +115,18 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return nil, err
 	}
 
-	var resolver logql.ShardResolver
-	if ast.shardResolver != nil {
-		resolver = ast.shardResolver
-	} else {
-		var ok bool
-		resolver, ok = shardResolverForConf(
-			ctx,
-			conf,
-			ast.ng.Opts().MaxLookBackPeriod,
-			ast.logger,
-			MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
-			r,
-			ast.next,
-		)
-		if !ok {
-			return ast.next.Do(ctx, r)
-		}
+	resolver, ok := shardResolverForConf(
+		ctx,
+		conf,
+		ast.ng.Opts().MaxLookBackPeriod,
+		ast.logger,
+		MinWeightedParallelism(ctx, tenants, ast.confs, ast.limits, model.Time(r.GetStart()), model.Time(r.GetEnd())),
+		ast.maxShards,
+		r,
+		ast.next,
+	)
+	if !ok {
+		return ast.next.Do(ctx, r)
 	}
 
 	mapper := logql.NewShardMapper(resolver, ast.metrics)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -167,7 +167,7 @@ func Test_astMapper(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-		nil,
+		0,
 	)
 
 	resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`{food="bar"}`))
@@ -201,7 +201,7 @@ func Test_ShardingByPass(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
-		nil,
+		0,
 	)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`1+1`))
@@ -275,7 +275,7 @@ func Test_InstantSharding(t *testing.T) {
 			maxQueryParallelism: 10,
 			queryTimeout:        time.Second,
 		},
-		nil)
+		0)
 	response, err := sharding.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 		lock.Lock()
 		defer lock.Unlock()
@@ -556,7 +556,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				log.NewNopLogger(),
 				nilShardingMetrics,
 				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-				nil,
+				0,
 			)
 
 			resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), tc.req)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -167,6 +167,7 @@ func Test_astMapper(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
+		nil,
 	)
 
 	resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`{food="bar"}`))
@@ -200,6 +201,7 @@ func Test_ShardingByPass(t *testing.T) {
 		log.NewNopLogger(),
 		nilShardingMetrics,
 		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
+		nil,
 	)
 
 	_, err := mware.Do(user.InjectOrgID(context.Background(), "1"), defaultReq().WithQuery(`1+1`))
@@ -272,7 +274,8 @@ func Test_InstantSharding(t *testing.T) {
 			maxSeries:           math.MaxInt32,
 			maxQueryParallelism: 10,
 			queryTimeout:        time.Second,
-		})
+		},
+		nil)
 	response, err := sharding.Wrap(queryrangebase.HandlerFunc(func(c context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
 		lock.Lock()
 		defer lock.Unlock()
@@ -553,6 +556,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				log.NewNopLogger(),
 				nilShardingMetrics,
 				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
+				nil,
 			)
 
 			resp, err := mware.Do(user.InjectOrgID(context.Background(), "1"), tc.req)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -321,7 +321,7 @@ func NewLogFilterTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}
@@ -391,7 +391,7 @@ func NewLimitedTripperware(
 				limits,
 				// Too many shards on limited queries results in slowing down this type of query
 				// and overwhelming the frontend, therefore we fix the number of shards to prevent this.
-				logql.ConstantShards(32),
+				32,
 			),
 		)
 	}
@@ -565,7 +565,7 @@ func NewMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}
@@ -613,7 +613,7 @@ func NewInstantMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
-				nil,
+				0, // 0 is unlimited shards
 			),
 		)
 	}

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -76,6 +76,11 @@ func NewTripperware(
 		return nil, nil, err
 	}
 
+	limitedTripperware, err := NewLimitedTripperware(cfg, log, limits, schema, LokiCodec, c, metrics)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// NOTE: When we would start caching response from non-metric queries we would have to consider cache gen headers as well in
 	// MergeResponse implementation for Loki codecs same as it is done in Cortex at https://github.com/cortexproject/cortex/blob/21bad57b346c730d684d6d0205efef133422ab28/pkg/querier/queryrange/query_range.go#L170
 	logFilterTripperware, err := NewLogFilterTripperware(cfg, log, limits, schema, LokiCodec, c, metrics)
@@ -99,26 +104,28 @@ func NewTripperware(
 	}
 	return func(next http.RoundTripper) http.RoundTripper {
 		metricRT := metricsTripperware(next)
+		limitedRT := limitedTripperware(next)
 		logFilterRT := logFilterTripperware(next)
 		seriesRT := seriesTripperware(next)
 		labelsRT := labelsTripperware(next)
 		instantRT := instantMetricTripperware(next)
-		return newRoundTripper(log, next, logFilterRT, metricRT, seriesRT, labelsRT, instantRT, limits)
+		return newRoundTripper(log, next, limitedRT, logFilterRT, metricRT, seriesRT, labelsRT, instantRT, limits)
 	}, c, nil
 }
 
 type roundTripper struct {
 	logger log.Logger
 
-	next, log, metric, series, labels, instantMetric http.RoundTripper
+	next, limited, log, metric, series, labels, instantMetric http.RoundTripper
 
 	limits Limits
 }
 
 // newRoundTripper creates a new queryrange roundtripper
-func newRoundTripper(logger log.Logger, next, log, metric, series, labels, instantMetric http.RoundTripper, limits Limits) roundTripper {
+func newRoundTripper(logger log.Logger, next, limited, log, metric, series, labels, instantMetric http.RoundTripper, limits Limits) roundTripper {
 	return roundTripper{
 		logger:        logger,
+		limited:       limited,
 		log:           log,
 		limits:        limits,
 		metric:        metric,
@@ -154,12 +161,16 @@ func (r roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			return r.metric.RoundTrip(req)
 		case syntax.LogSelectorExpr:
 			// Note, this function can mutate the request
-			_, err := transformRegexQuery(req, e)
+			expr, err := transformRegexQuery(req, e)
 			if err != nil {
 				return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 			}
 			if err := validateLimits(req, rangeQuery.Limit, r.limits); err != nil {
 				return nil, err
+			}
+			// Only filter expressions are query sharded
+			if !expr.HasFilter() {
+				return r.limited.RoundTrip(req)
 			}
 			return r.log.RoundTrip(req)
 
@@ -310,6 +321,77 @@ func NewLogFilterTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
+			),
+		)
+	}
+
+	if cfg.MaxRetries > 0 {
+		queryRangeMiddleware = append(
+			queryRangeMiddleware, queryrangebase.InstrumentMiddleware("retry", metrics.InstrumentMiddlewareMetrics),
+			queryrangebase.NewRetryMiddleware(log, cfg.MaxRetries, metrics.RetryMiddlewareMetrics),
+		)
+	}
+
+	return func(next http.RoundTripper) http.RoundTripper {
+		if len(queryRangeMiddleware) > 0 {
+			return NewLimitedRoundTripper(next, codec, limits, schema.Configs, queryRangeMiddleware...)
+		}
+		return next
+	}, nil
+}
+
+// NewLimitedTripperware creates a new frontend tripperware responsible for handling log requests which are label matcher only, no filter expression.
+func NewLimitedTripperware(
+	cfg Config,
+	log log.Logger,
+	limits Limits,
+	schema config.SchemaConfig,
+	codec queryrangebase.Codec,
+	c cache.Cache,
+	metrics *Metrics,
+) (queryrangebase.Tripperware, error) {
+	queryRangeMiddleware := []queryrangebase.Middleware{
+		StatsCollectorMiddleware(),
+		NewLimitsMiddleware(limits),
+		queryrangebase.InstrumentMiddleware("split_by_interval", metrics.InstrumentMiddlewareMetrics),
+		// Limited queries only need to fetch up to the requested line limit worth of logs,
+		// Our defaults for splitting and parallelism are much too aggressive for large customers and result in
+		// potentially GB of logs being returned by all the shards and splits which will overwhelm the frontend
+		// Therefore we force max parallelism to one so that these queries are executed sequentially.
+		// Below we also fix the number of shards to a static number.
+		SplitByIntervalMiddleware(schema.Configs, WithMaxParallelism(limits, 1), codec, splitByTime, metrics.SplitByMetrics),
+	}
+
+	if cfg.CacheResults {
+		queryCacheMiddleware := NewLogResultCache(
+			log,
+			limits,
+			c,
+			func(r queryrangebase.Request) bool {
+				return !r.GetCachingOptions().Disabled
+			},
+			cfg.Transformer,
+			metrics.LogResultCacheMetrics,
+		)
+		queryRangeMiddleware = append(
+			queryRangeMiddleware,
+			queryrangebase.InstrumentMiddleware("log_results_cache", metrics.InstrumentMiddlewareMetrics),
+			queryCacheMiddleware,
+		)
+	}
+
+	if cfg.ShardedQueries {
+		queryRangeMiddleware = append(queryRangeMiddleware,
+			NewQueryShardMiddleware(
+				log,
+				schema.Configs,
+				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
+				metrics.MiddlewareMapperMetrics.shardMapper,
+				limits,
+				// Too many shards on limited queries results in slowing down this type of query
+				// and overwhelming the frontend, therefore we fix the number of shards to prevent this.
+				logql.ConstantShards(32),
 			),
 		)
 	}
@@ -483,6 +565,7 @@ func NewMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
 			),
 		)
 	}
@@ -530,6 +613,7 @@ func NewInstantMetricTripperware(
 				metrics.InstrumentMiddlewareMetrics, // instrumentation is included in the sharding middleware
 				metrics.MiddlewareMapperMetrics.shardMapper,
 				limits,
+				nil,
 			),
 		)
 	}

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -443,6 +443,10 @@ func TestPostQueries(t *testing.T) {
 			return nil, nil
 		}),
 		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Error("unexpected default roundtripper called")
+			return nil, nil
+		}),
+		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {
 			return nil, nil
 		}),
 		queryrangebase.RoundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -28,6 +28,7 @@ func shardResolverForConf(
 	defaultLookback time.Duration,
 	logger log.Logger,
 	maxParallelism int,
+	maxShards int,
 	r queryrangebase.Request,
 	handler queryrangebase.Handler,
 ) (logql.ShardResolver, bool) {
@@ -39,6 +40,7 @@ func shardResolverForConf(
 			from:            model.Time(r.GetStart()),
 			through:         model.Time(r.GetEnd()),
 			maxParallelism:  maxParallelism,
+			maxShards:       maxShards,
 			defaultLookback: defaultLookback,
 		}, true
 	}
@@ -55,6 +57,7 @@ type dynamicShardResolver struct {
 
 	from, through   model.Time
 	maxParallelism  int
+	maxShards       int
 	defaultLookback time.Duration
 }
 
@@ -119,6 +122,9 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, error) {
 
 	combined := stats.MergeStats(results...)
 	factor := guessShardFactor(combined)
+	if r.maxShards >= 0 && factor > r.maxShards {
+		factor = r.maxShards
+	}
 	var bytesPerShard = combined.Bytes
 	if factor > 0 {
 		bytesPerShard = combined.Bytes / uint64(factor)

--- a/pkg/querier/queryrange/shard_resolver_test.go
+++ b/pkg/querier/queryrange/shard_resolver_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestGuessShardFactor(t *testing.T) {
 	for _, tc := range []struct {
-		stats stats.Stats
-		exp   int
+		stats     stats.Stats
+		maxShards int
+		exp       int
 	}{
 		{
 			// no data == no sharding
@@ -43,9 +44,30 @@ func TestGuessShardFactor(t *testing.T) {
 				Bytes: maxBytesPerShard,
 			},
 		},
+		{
+			maxShards: 8,
+			exp:       4,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
+		{
+			maxShards: 2,
+			exp:       2,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
+		{
+			maxShards: 1,
+			exp:       0,
+			stats: stats.Stats{
+				Bytes: maxBytesPerShard * 4,
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc.stats), func(t *testing.T) {
-			require.Equal(t, tc.exp, guessShardFactor(tc.stats))
+			require.Equal(t, tc.exp, guessShardFactor(tc.stats, tc.maxShards))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Recutting k136 release to have these fixes:
- [correctly calculate max shards](https://github.com/grafana/loki/commit/495c511d777af2a0ea4a3c349d09cb643e253e05)
- https://github.com/grafana/loki/pull/8482
- https://github.com/grafana/loki/pull/8487

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
