### PR TITLE
Helm: add sleep argument to helm makefile on local development

### DIFF
--- a/tools/dev/k3d/Makefile
+++ b/tools/dev/k3d/Makefile
@@ -6,48 +6,50 @@ IMAGE_TAG := $(shell ../../../tools/image-tag)
 EXISTING_REGISTRY_PORT := $(shell k3d registry list -o json | jq -r '.[] | select(.name == "k3d-grafana") | .portMappings."5000/tcp" | .[0].HostPort')
 REGISTRY_PORT ?= $(or $(EXISTING_REGISTRY_PORT),46453)
 
-# For verbose output, run make DEBUG=true <TARGET>
+# Time in seconds to wait for completion of cluster operation, run 'make SLEEP=10 <TARGET>'
+SLEEP := 5
+# For verbose output, run 'make DEBUG=true <TARGET>'
 DEBUG := false
 HELM := helm --debug=$(DEBUG)
 
 enterprise-logs: prepare-gel helm-cluster
 	$(MAKE) -C $(CURDIR) apply-enterprise-helm-cluster
-	echo "Waiting 5s for cluster to be ready for helm installation."
+	echo "Waiting $(SLEEP)s for cluster to be ready for helm installation."
 	echo "The helm install will take a while. It's useful to monitor progress using a tool like k9s."
-	# wait 5s for tk apply to finish and cluster is ready for helm install
-	sleep 5
+	# wait for tk apply to finish and cluster is ready for helm install
+	sleep $(SLEEP)
 	$(MAKE) -C $(CURDIR) helm-install-enterprise-logs
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
 enterprise-logs-ha-single-binary: prepare-gel helm-cluster
 	$(MAKE) -C $(CURDIR) apply-enterprise-helm-cluster
-	echo "Waiting 5s for cluster to be ready for helm installation."
+	echo "Waiting $(SLEEP)s for cluster to be ready for helm installation."
 	echo "The helm install will take a while. It's useful to monitor progress using a tool like k9s."
-	# wait 5s for tk apply to finish and cluster is ready for helm install
-	sleep 5
+	# wait for tk apply to finish and cluster is ready for helm install
+	sleep $(SLEEP)
 	$(MAKE) -C $(CURDIR) helm-install-enterprise-logs-ha-single-binary
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
 loki: prepare helm-cluster
 	$(MAKE) -C $(CURDIR) apply-loki-helm-cluster
-	echo "Waiting 5s for cluster to be ready for helm installation."
-	# wait 5s for tk apply to finish and cluster is ready for helm install
-	sleep 5
+	echo "Waiting $(SLEEP)s for cluster to be ready for helm installation."
+	# wait for tk apply to finish and cluster is ready for helm install
+	sleep $(SLEEP)
 	$(MAKE) -C $(CURDIR) helm-install-loki
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
 loki-ha-single-binary: prepare helm-cluster
 	$(MAKE) -C $(CURDIR) apply-loki-helm-cluster
-	echo "Waiting 5s for cluster to be ready for helm installation."
-	# wait 5s for tk apply to finish and cluster is ready for helm install
-	sleep 5
+	echo "Waiting $(SLEEP)s for cluster to be ready for helm installation."
+	# wait for tk apply to finish and cluster is ready for helm install
+	sleep $(SLEEP)
 	$(MAKE) -C $(CURDIR) helm-install-loki-ha-single-binary
 	echo "Helm installation finished. You can tear down this cluster with make down."
 
 helm-cluster: prepare
 	$(CURDIR)/scripts/create_cluster.sh helm-cluster $(REGISTRY_PORT)
-	# wait 5s for the cluster to be ready
-	sleep 5
+	# wait for the cluster to be ready
+	sleep $(SLEEP)
 
 apply-enterprise-helm-cluster:
 	tk apply --ext-code enterprise=true environments/helm-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `SLEEP` argument to configure the time in seconds to wait for helm cluster commands to apply.

In some cases, a sleep interval of 5s is not enough for the cluster to be ready for helm charts installation resulting in errors such as:
```
Error: INSTALLATION FAILED: Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": failed to call webhook: Post "https://prometheus-kube-prometheus-operator.k3d-helm-cluster.svc:443/admission-prometheusrules/mutate?timeout=10s": no endpoints available for service "prometheus-kube-prometheus-operator"
helm.go:84: [debug] Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": failed to call webhook: Post "https://prometheus-kube-prometheus-operator.k3d-helm-cluster.svc:443/admission-prometheusrules/mutate?timeout=10s": no endpoints available for service "prometheus-kube-prometheus-operator"
INSTALLATION FAILED
```

With this PR, it is possible to increase the number of seconds to wait between helm cluster commands:
```
> make SLEEP=10 enterprise-logs
```

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
