### PR TITLE
operator: update assume-no-moving-gc to fix go 1.20

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -146,7 +146,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230209150437-ee73d164e760 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

assume-no-moving-gc makes the program exit if the current go version was not explicitly specified in it as safe. This version adds go 1.20 to the list of safe versions which fixes running loki when built with go 1.20.

**Which issue(s) this PR fixes**:
Fixes #8399

**Special notes for your reviewer**:

split from #8495 as requested by @periklis

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
