### PR TITLE
Add elotl promtail configuration to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+# Elotl notes
+
+Used to build custom promtail image with our own Grafana instance URL backed in.
+
+We do this to make it a bit harder for people to spam us by getting the URL.
+
+To build the image run:
+
+    $ make promtail-image IMAGE_PREFIX=elotl IMAGE_TAG=$(git describe --dirty --tags --match 'v*')
+    $ docker push elotl/promtail:$(git describe --dirty --tags --match 'v*')
+
+To update the latest image in the repository:
+
+    $ docker tag elotl/promtail:$(git describe --dirty --tags --match 'v*') elot/promtail:latest
+    $ docker push elotl/promtail:latest
+
+---
+
 <p align="center"><img src="docs/sources/logo_and_name.png" alt="Loki Logo"></p>
 
 <a href="https://drone.grafana.net/grafana/loki"><img src="https://drone.grafana.net/api/badges/grafana/loki/status.svg" alt="Drone CI" /></a>

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get update && \
 RUN apt-get install -t bullseye-backports -qy libsystemd-dev && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY --from=build /src/loki/clients/cmd/promtail/promtail /usr/bin/promtail
-COPY clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
+COPY clients/cmd/promtail/promtail-elotl-config.yaml /etc/promtail/config.yml
 ENTRYPOINT ["/usr/bin/promtail"]
 CMD ["-config.file=/etc/promtail/config.yml"]

--- a/clients/cmd/promtail/promtail-elotl-config.yaml
+++ b/clients/cmd/promtail/promtail-elotl-config.yaml
@@ -1,0 +1,16 @@
+server:
+  http_listen_port: 0
+  grpc_listen_port: 0
+  log_level: "debug"
+positions:
+  filename: /tmp/positions.yaml
+client:
+  url: "https://333814:eyJvIjoiNzUxODQxIiwibiI6Imx1bmEtdGVsZW1ldHJ5LWRlZmF1bHQiLCJrIjoiMlVPTzk3d2tWdjUzNDhuMmI1VkUyS2N2IiwibSI6eyJyIjoidXMifX0=@logs-prod3.grafana.net/api/prom/push"
+scrape_configs:
+- job_name: luna
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: luna
+      __path__: /logs/luna*


### PR DESCRIPTION
We bake our Grafana Loki instance URL in the container image to make it a tad harder for users to extract it.

1. Add Yaml configuration
2. Change Dockerfile & Update Makefile
3. Add instructions in README