### PR TITLE
helm: azure config: don't set use_federated_token if false

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the pull request that introduced the chang
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
 - [FEATURE] add `gateway.nginxConfig.customReadUrl`, `gateway.nginxConfig.customWriteUrl` and `gateway.nginxConfig.customBackendUrl` to override read/write/backend paths.
+- [BUGFIX] Azure config: don't set `use_federated_token` when not needed. Avoids crashes when loki does not support this parameter.
 
 ## 4.5.1
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -240,7 +240,9 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.chunks }}
   use_managed_identity: {{ .useManagedIdentity }}
+  {{- if .useFederatedToken }}
   use_federated_token: {{ .useFederatedToken }}
+  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}
@@ -307,7 +309,9 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.ruler }}
   use_managed_identity: {{ .useManagedIdentity }}
+  {{- if .useFederatedToken }}
   use_federated_token: {{ .useFederatedToken }}
+  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting `use_federated_token` in azure config crashes with current Loki version (2.7.3). Support for this parameter is in `main` but not released yet.
As `use_federated_token`'s default value will be `false`, let's not set it in config when it's `false`.

This way, the helm chart works on Azure with current Loki versions (if people don't set this parameter), and is compatible with future versions when this parameter will be supported.

**Which issue(s) this PR fixes**:
Fixes #8450

**Special notes for your reviewer**:
N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
