### PR TITLE
Helm: Remove unrelease setting from Helm chart configuration file

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1881,7 +1881,6 @@ null
     "accountKey": null,
     "accountName": null,
     "requestTimeout": null,
-    "useFederatedToken": false,
     "useManagedIdentity": false,
     "userAssignedId": null
   },

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,13 +13,15 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
+## 4.6.1
+
 - [FEATURE] Add `gateway.nginxConfig.customReadUrl`, `gateway.nginxConfig.customWriteUrl` and `gateway.nginxConfig.customBackendUrl` to override read/write/backend paths.
 - [BUGFIX] Remove unreleased setting `useFederatedToken` from Azure configuration block.
 
 ## 4.6
 
 - [Change] Bump Loki version to 2.7.3. Revert to 2 target simple scalable mode as default until third target ships in minor release.
--
+
 ## 4.5.1
 
 - [BUGFIX] Fix rendering of namespace in provisioner job.

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,17 +13,18 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. Add your changelog bellow this line. This locator is used by CI pipeline to find the place where to put changelog entry.)
 
-- [FEATURE] add `gateway.nginxConfig.customReadUrl`, `gateway.nginxConfig.customWriteUrl` and `gateway.nginxConfig.customBackendUrl` to override read/write/backend paths.
-- [BUGFIX] Azure config: don't set `use_federated_token` when not needed. Avoids crashes when loki does not support this parameter.
+- [FEATURE] Add `gateway.nginxConfig.customReadUrl`, `gateway.nginxConfig.customWriteUrl` and `gateway.nginxConfig.customBackendUrl` to override read/write/backend paths.
+- [BUGFIX] Remove unreleased setting `useFederatedToken` from Azure configuration block.
 
+## 4.6
+
+- [Change] Bump Loki version to 2.7.3. Revert to 2 target simple scalable mode as default until third target ships in minor release.
+-
 ## 4.5.1
 
 - [BUGFIX] Fix rendering of namespace in provisioner job.
 - [ENHANCEMENT] Allow to configure `publishNotReadyAddresses` on memberlist service.
 - [BUGFIX] Correctly set `compactor_address` for 3 target scalable configuration.
-## 4.6
-
-- [Change] Bump Loki verstion to 2.7.3. Revert to 2 target simple scalable mode as default until third target ships in minor release.
 
 ## 4.5
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -4,7 +4,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.7.3
-version: 4.6.0
+version: 4.6.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -240,9 +240,6 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.chunks }}
   use_managed_identity: {{ .useManagedIdentity }}
-  {{- if .useFederatedToken }}
-  use_federated_token: {{ .useFederatedToken }}
-  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}
@@ -309,9 +306,6 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.ruler }}
   use_managed_identity: {{ .useManagedIdentity }}
-  {{- if .useFederatedToken }}
-  use_federated_token: {{ .useFederatedToken }}
-  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -249,7 +249,6 @@ loki:
       accountName: null
       accountKey: null
       useManagedIdentity: false
-      useFederatedToken: false
       userAssignedId: null
       requestTimeout: null
     filesystem:


### PR DESCRIPTION
**What this PR does / why we need it**:

While https://github.com/grafana/loki/pull/8513 partially fixes the issue by conditionally removing the setting from the generated Loki config, the setting is still present in the values.yaml and therefore suggests that it may be set to `true`. However, since the setting is still unreleased, we need to completely remove it from the Helm config.

**Which issue(s) this PR fixes**:
Fixes #8450

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
