### PR TITLE
Fetch all entries with logcli if limit==0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 ##### Enhancement
 
 * [8413](https://github.com/grafana/loki/pull/8413) **chaudum**: Try to load tenant-specific `schemaconfig-{orgID}.yaml` when using `--remote-schema` argument and fallback to global `schemaconfig.yaml`.
+* [8537](https://github.com/grafana/loki/pull/8537) **jeschkies**: Allow fetching all entries with `--limit=0`.
 
 #### Fluent Bit
 

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -170,7 +170,7 @@ func main() {
 		}
 
 		// `--limit` doesn't make sense when using `--stdin` flag.
-		rangeQuery.Limit = math.MaxInt // TODO(kavi): is it a good idea?
+		rangeQuery.Limit = 0
 	}
 
 	switch cmd {
@@ -362,7 +362,7 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 		return nil
 	})
 
-	cmd.Flag("limit", "Limit on number of entries to print.").Default("30").IntVar(&q.Limit)
+	cmd.Flag("limit", "Limit on number of entries to print. Setting it to 0 will fetch all entries.").Default("30").IntVar(&q.Limit)
 	if instant {
 		cmd.Arg("query", "eg 'rate({foo=\"bar\"} |~ \".*error.*\" [5m])'").Required().StringVar(&q.QueryString)
 		cmd.Flag("now", "Time at which to execute the instant query.").StringVar(&now)


### PR DESCRIPTION
**What this PR does / why we need it**:
So far logcli enforces a limit for fetching logs. However, sometimes users want to fetch all entries in a time range. This change allows to disable the limit by setting it to `0`. The entries are still fetched in batches. However, the batch loop is only stopped once no more results are returned.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
