### PR TITLE
Fix logcli parallel download deadlock.

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -273,7 +273,7 @@ type parallelJob struct {
 func newParallelJob(q *Query) *parallelJob {
 	return &parallelJob{
 		q:    q,
-		done: make(chan struct{}),
+		done: make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The query jobs would block on `func (j *parallelJob) run` because the done channel was not buffered. That means the goroutine had to wait for the channel to be read.

**Which issue(s) this PR fixes**:
Fixes deadlock introduced in https://github.com/grafana/loki/pull/8518.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
