### PR TITLE
production: Add missing string formatter token to nginx.conf config map

### DIFF
--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -50,7 +50,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
             listen               80;
             auth_basic           “Prometheus”;
             auth_basic_user_file /etc/nginx/secrets/.htpasswd;
-            proxy_set_header     X-Scope-OrgID %(gateway_tenant_id);
+            proxy_set_header     X-Scope-OrgID %(gateway_tenant_id)s;
 
             location = /api/prom/push {
               proxy_pass       http://distributor.%(namespace)s.svc.cluster.local:%(http_listen_port)s$request_uri;


### PR DESCRIPTION
The `nginx.conf` config map server settings has a `proxy_set_header` line setting the X-Scope-OrgID using the gateway tenant ID. The Jsonnet string formatter is missing the `s` token.

**What this PR does / why we need it**:
Adds missing formatter token to the `nginx.conf` config map that's causing an `Unrecognized conversion type: ;` when trying to deploy.

**Which issue(s) this PR fixes**:
Fixes issue from PR #[7624](https://github.com/grafana/loki/pull/7624)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
