### PR TITLE
Use golangci-lint v1.51.2 in build image

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -446,7 +446,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.28.0',
+    local build_image_tag = '0.28.1',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.28.0
+    - 0.28.1
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.28.0
+    - 0.28.1
     username:
       from_secret: docker_username
   when:
@@ -1675,6 +1675,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: de9f4851c4bfd1324e22a0cb983432801b59240128c1b162ea67c5cd814606c9
+hmac: e5f127d71d3dcb4ae93d348ff2641c9639bf0372640fd398328cff25eda62a9d
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.16.4 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
 
 FROM alpine:3.16.4 as buf
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Golangci-lint [1.50.0 OOMs](https://github.com/golangci/golangci-lint/issues/3538#issuecomment-1414341372) when used with go 1.20.1. This also updates the build image.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
