### PR TITLE
Revert "Loki: Fix memchunk headblock filter"

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1005,10 +1005,7 @@ func (hb *headBlock) Iterator(ctx context.Context, direction logproto.Direction,
 	baseHash := pipeline.BaseLabels().Hash()
 	process := func(e entry) {
 		// apply time filtering
-		if e.t < mint || e.t > maxt {
-			return
-		}
-		if e.t == maxt && mint != maxt {
+		if e.t < mint || e.t >= maxt {
 			return
 		}
 		stats.AddHeadChunkBytes(int64(len(e.s)))

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -911,6 +911,8 @@ func TestMemChunk_IteratorBounds(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("mint:%d,maxt:%d,direction:%s", tt.mint.UnixNano(), tt.maxt.UnixNano(), tt.direction),
 			func(t *testing.T) {
+				t.Parallel()
+
 				tt := tt
 				c := createChunk()
 


### PR DESCRIPTION
Reverts grafana/loki#8591

This altered an internal API. We execute queries that are inclusive of start and exclusive of end: `[start,end)` and shouldn't break this. We use other ways to ensure `start==end` still works, such as by using the lookback-period to alter the range of queries: 
https://github.com/grafana/loki/blob/main/pkg/logql/evaluator.go#L179-L181