### PR TITLE
add dockerd_sd_configs to instead docker_sd_configs

### DIFF
--- a/clients/pkg/promtail/discovery/dockerd/dockerd.go
+++ b/clients/pkg/promtail/discovery/dockerd/dockerd.go
@@ -1,0 +1,320 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dockerd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+
+const (
+	dockerLabel                     = model.MetaLabelPrefix + "docker_"
+	dockerLabelContainerPrefix      = dockerLabel + "container_"
+	dockerLabelContainerID          = dockerLabelContainerPrefix + "id"
+	dockerLabelContainerName        = dockerLabelContainerPrefix + "name"
+	dockerLabelContainerNetworkMode = dockerLabelContainerPrefix + "network_mode"
+	dockerLabelContainerLabelPrefix = dockerLabelContainerPrefix + "label_"
+	dockerLabelNetworkPrefix        = dockerLabel + "network_"
+	dockerLabelNetworkIP            = dockerLabelNetworkPrefix + "ip"
+	dockerLabelPortPrefix           = dockerLabel + "port_"
+	dockerLabelPortPrivate          = dockerLabelPortPrefix + "private"
+	dockerLabelPortPublic           = dockerLabelPortPrefix + "public"
+	dockerLabelPortPublicIP         = dockerLabelPortPrefix + "public_ip"
+)
+
+// Filter represent a filter that can be passed to Docker Swarm to reduce the
+// amount of data received.
+type Filter struct {
+	Name   string   `yaml:"name"`
+	Values []string `yaml:"values"`
+}
+
+// DefaultDockerSDConfig is the default Docker SD configuration.
+var DefaultDockerSDConfig = DockerDSDConfig{
+	RefreshInterval:    model.Duration(60 * time.Second),
+	Port:               80,
+	Filters:            []Filter{},
+	HostNetworkingHost: "localhost",
+	HTTPClientConfig:   config.DefaultHTTPClientConfig,
+}
+
+func init() {
+	discovery.RegisterConfig(&DockerDSDConfig{})
+}
+
+// DockerSDConfig is the configuration for Docker (non-swarm) based service discovery.
+type DockerDSDConfig struct {
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
+
+	Host               string   `yaml:"host"`
+	Port               int      `yaml:"port"`
+	Filters            []Filter `yaml:"filters"`
+	HostNetworkingHost string   `yaml:"host_networking_host"`
+
+	RefreshInterval model.Duration `yaml:"refresh_interval"`
+}
+
+// Name returns the name of the Config.
+func (*DockerDSDConfig) Name() string { return "dockerd" }
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *DockerDSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDockerDiscovery(c, opts.Logger)
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (c *DockerDSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *DockerDSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultDockerSDConfig
+	type plain DockerDSDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+	if c.Host == "" {
+		return fmt.Errorf("host missing")
+	}
+	if _, err = url.Parse(c.Host); err != nil {
+		return err
+	}
+	return c.HTTPClientConfig.Validate()
+}
+
+type DockerDiscovery struct {
+	*refresh.Discovery
+	client             *client.Client
+	port               int
+	hostNetworkingHost string
+	filters            filters.Args
+	Logger             log.Logger
+}
+
+// NewDockerDiscovery returns a new DockerDiscovery which periodically refreshes its targets.
+func NewDockerDiscovery(conf *DockerDSDConfig, logger log.Logger) (*DockerDiscovery, error) {
+	var err error
+
+	d := &DockerDiscovery{
+		port:               conf.Port,
+		hostNetworkingHost: conf.HostNetworkingHost,
+		Logger:             logger,
+	}
+
+	hostURL, err := url.Parse(conf.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []client.Opt{
+		client.WithHost(conf.Host),
+		client.WithAPIVersionNegotiation(),
+	}
+
+	d.filters = filters.NewArgs()
+	for _, f := range conf.Filters {
+		for _, v := range f.Values {
+			d.filters.Add(f.Name, v)
+		}
+	}
+
+	// There are other protocols than HTTP supported by the Docker daemon, like
+	// unix, which are not supported by the HTTP client. Passing HTTP client
+	// options to the Docker client makes those non-HTTP requests fail.
+	if hostURL.Scheme == "http" || hostURL.Scheme == "https" {
+		rt, err := config.NewRoundTripperFromConfig(conf.HTTPClientConfig, "docker_sd")
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts,
+			client.WithHTTPClient(&http.Client{
+				Transport: rt,
+				Timeout:   time.Duration(conf.RefreshInterval),
+			}),
+			client.WithScheme(hostURL.Scheme),
+			client.WithHTTPHeaders(map[string]string{
+				"User-Agent": userAgent,
+			}),
+		)
+	}
+
+	d.client, err = client.NewClientWithOpts(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up docker client: %w", err)
+	}
+
+	d.Discovery = refresh.NewDiscovery(
+		logger,
+		"docker",
+		time.Duration(conf.RefreshInterval),
+		d.refresh,
+	)
+	return d, nil
+}
+
+func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	tg := &targetgroup.Group{
+		Source: "Docker",
+	}
+
+	containers, err := d.client.ContainerList(ctx, types.ContainerListOptions{Filters: d.filters})
+	if err != nil {
+		return nil, fmt.Errorf("error while listing containers: %w", err)
+	}
+
+	networkLabels, err := getNetworksLabels(ctx, d.client, dockerLabel)
+	if err != nil {
+		return nil, fmt.Errorf("error while computing network labels: %w", err)
+	}
+
+	for _, c := range containers {
+		commonLabels := map[string]string{
+			dockerLabelContainerID:          c.ID,
+			dockerLabelContainerName:        c.Names[0],
+			dockerLabelContainerNetworkMode: c.HostConfig.NetworkMode,
+		}
+
+		for k, v := range c.Labels {
+			ln := strutil.SanitizeLabelName(k)
+			commonLabels[dockerLabelContainerLabelPrefix+ln] = v
+		}
+		containerAdd := false
+		for _, n := range c.NetworkSettings.Networks {
+			var added bool
+			for _, p := range c.Ports {
+				if p.Type != "tcp" {
+					continue
+				}
+
+				labels := model.LabelSet{
+					dockerLabelNetworkIP:   model.LabelValue(n.IPAddress),
+					dockerLabelPortPrivate: model.LabelValue(strconv.FormatUint(uint64(p.PrivatePort), 10)),
+				}
+
+				if p.PublicPort > 0 {
+					labels[dockerLabelPortPublic] = model.LabelValue(strconv.FormatUint(uint64(p.PublicPort), 10))
+					labels[dockerLabelPortPublicIP] = model.LabelValue(p.IP)
+				}
+
+				for k, v := range commonLabels {
+					labels[model.LabelName(k)] = model.LabelValue(v)
+				}
+
+				for k, v := range networkLabels[n.NetworkID] {
+					labels[model.LabelName(k)] = model.LabelValue(v)
+				}
+
+				addr := net.JoinHostPort(n.IPAddress, strconv.FormatUint(uint64(p.PrivatePort), 10))
+				labels[model.AddressLabel] = model.LabelValue(addr)
+				tg.Targets = append(tg.Targets, labels)
+				added = true
+			}
+
+			if !added {
+				// Use fallback port when no exposed ports are available or if all are non-TCP
+				labels := model.LabelSet{
+					dockerLabelNetworkIP: model.LabelValue(n.IPAddress),
+				}
+
+				for k, v := range commonLabels {
+					labels[model.LabelName(k)] = model.LabelValue(v)
+				}
+
+				for k, v := range networkLabels[n.NetworkID] {
+					labels[model.LabelName(k)] = model.LabelValue(v)
+				}
+
+				// Containers in host networking mode don't have ports,
+				// so they only end up here, not in the previous loop.
+				var addr string
+				if c.HostConfig.NetworkMode != "host" {
+					addr = net.JoinHostPort(n.IPAddress, strconv.FormatUint(uint64(d.port), 10))
+				} else {
+					addr = d.hostNetworkingHost
+				}
+
+				labels[model.AddressLabel] = model.LabelValue(addr)
+				tg.Targets = append(tg.Targets, labels)
+			}
+			containerAdd = true
+		}
+		if !containerAdd {
+			labels := model.LabelSet{}
+			for k, v := range commonLabels {
+				labels[model.LabelName(k)] = model.LabelValue(v)
+			}
+			addr := d.hostNetworkingHost
+			labels[model.AddressLabel] = model.LabelValue(addr)
+			tg.Targets = append(tg.Targets, labels)
+
+		}
+	}
+
+	return []*targetgroup.Group{tg}, nil
+}
+
+// networks
+const (
+	labelNetworkPrefix      = "network_"
+	labelNetworkID          = labelNetworkPrefix + "id"
+	labelNetworkName        = labelNetworkPrefix + "name"
+	labelNetworkScope       = labelNetworkPrefix + "scope"
+	labelNetworkInternal    = labelNetworkPrefix + "internal"
+	labelNetworkIngress     = labelNetworkPrefix + "ingress"
+	labelNetworkLabelPrefix = labelNetworkPrefix + "label_"
+)
+
+func getNetworksLabels(ctx context.Context, client *client.Client, labelPrefix string) (map[string]map[string]string, error) {
+	networks, err := client.NetworkList(ctx, types.NetworkListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	labels := make(map[string]map[string]string, len(networks))
+	for _, network := range networks {
+		labels[network.ID] = map[string]string{
+			labelPrefix + labelNetworkID:       network.ID,
+			labelPrefix + labelNetworkName:     network.Name,
+			labelPrefix + labelNetworkScope:    network.Scope,
+			labelPrefix + labelNetworkInternal: fmt.Sprintf("%t", network.Internal),
+			labelPrefix + labelNetworkIngress:  fmt.Sprintf("%t", network.Ingress),
+		}
+		for k, v := range network.Labels {
+			ln := strutil.SanitizeLabelName(k)
+			labels[network.ID][labelPrefix+labelNetworkLabelPrefix+ln] = v
+		}
+	}
+
+	return labels, nil
+}

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/clients/pkg/promtail/discovery/consulagent"
+	"github.com/grafana/loki/clients/pkg/promtail/discovery/dockerd"
 )
 
 // Config describes a job to scrape.
@@ -66,6 +67,8 @@ type ServiceDiscoveryConfig struct {
 	DigitalOceanSDConfigs []*digitalocean.SDConfig `mapstructure:"digitalocean_sd_configs,omitempty" yaml:"digitalocean_sd_configs,omitempty"`
 	// List of Docker Swarm service discovery configurations.
 	DockerSwarmSDConfigs []*moby.DockerSwarmSDConfig `mapstructure:"dockerswarm_sd_configs,omitempty" yaml:"dockerswarm_sd_configs,omitempty"`
+	// List of Docker service discovery configurations.
+	DockerDSDConfigs []*dockerd.DockerDSDConfig `mapstructure:"dockerd_sd_configs,omitempty" yaml:"dockerd_sd_configs,omitempty"`
 	// List of Serverset service discovery configurations.
 	ServersetSDConfigs []*zookeeper.ServersetSDConfig `mapstructure:"serverset_sd_configs,omitempty" yaml:"serverset_sd_configs,omitempty"`
 	// NerveSDConfigs is a list of Nerve service discovery configurations.
@@ -106,6 +109,9 @@ func (cfg ServiceDiscoveryConfig) Configs() (res discovery.Configs) {
 		res = append(res, x)
 	}
 	for _, x := range cfg.DockerSwarmSDConfigs {
+		res = append(res, x)
+	}
+	for _, x := range cfg.DockerDSDConfigs {
 		res = append(res, x)
 	}
 	for _, x := range cfg.ServersetSDConfigs {

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -397,6 +397,12 @@ consulagent_sd_configs:
 # the same host as Promtail.
 docker_sd_configs:
   [ - <docker_sd_config> ... ]
+
+# Describes how to use the Docker daemon API to discover containers running on
+# the same host as Promtail.it's just for instead docker_sd_configs,
+# this model can discovery all containers of the host.
+dockerd_sd_configs:
+  [ - <docker_sd_config> ... ]
 ```
 
 ### pipeline_stages


### PR DESCRIPTION
**What this PR does / why we need it**:
use dockerd_sd_configs to instead docker_sd_configs .
dockerd_sd_configs use the same configuration with docker_sd_configs model.
dockerd_sd_configs not impact docker_sd_configs.
**Which issue(s) this PR fixes**:
Fixes #8388 
the docker filter not fixed.it's related to the docker version.
**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
