### PR TITLE
Iterators: re-implement mergeEntryIterator using loser.Tree for performance

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -1,7 +1,6 @@
 package iter
 
 import (
-	"container/heap"
 	"context"
 	"io"
 	"math"
@@ -57,39 +56,6 @@ func (i *streamIterator) Close() error {
 	return nil
 }
 
-type iteratorHeap []EntryIterator
-
-func (h iteratorHeap) Len() int            { return len(h) }
-func (h iteratorHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h iteratorHeap) Peek() EntryIterator { return h[0] }
-func (h *iteratorHeap) Push(x interface{}) {
-	*h = append(*h, x.(EntryIterator))
-}
-
-func (h *iteratorHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
-}
-
-type iteratorSortHeap struct {
-	iteratorHeap
-	byAscendingTime bool
-}
-
-func (h iteratorSortHeap) Less(i, j int) bool {
-	t1, t2 := h.iteratorHeap[i].Entry().Timestamp.UnixNano(), h.iteratorHeap[j].Entry().Timestamp.UnixNano()
-	if t1 == t2 {
-		return h.iteratorHeap[i].StreamHash() < h.iteratorHeap[j].StreamHash()
-	}
-	if h.byAscendingTime {
-		return t1 < t2
-	}
-	return t1 > t2
-}
-
 // HeapIterator iterates over a heap of iterators with ability to push new iterators and get some properties like time of entry at peek and len
 // Not safe for concurrent use
 type HeapIterator interface {
@@ -101,16 +67,8 @@ type HeapIterator interface {
 
 // mergeEntryIterator iterates over a heap of iterators and merge duplicate entries.
 type mergeEntryIterator struct {
-	heap interface {
-		heap.Interface
-		Peek() EntryIterator
-	}
-	is []EntryIterator
-	// pushBuffer contains the list of iterators that needs to be pushed to the heap
-	// This is to avoid allocations.
-	pushBuffer []EntryIterator
-	prefetched bool
-	stats      *stats.Context
+	tree  *loser.Tree[sortFields, EntryIterator]
+	stats *stats.Context
 
 	// buffer of entries to be returned by Next()
 	// We buffer entries with the same timestamp to correctly dedupe them.
@@ -124,104 +82,64 @@ type mergeEntryIterator struct {
 // This means using this iterator with a single iterator will result in the same result as the input iterator.
 // If you don't need to deduplicate entries, use `NewSortEntryIterator` instead.
 func NewMergeEntryIterator(ctx context.Context, is []EntryIterator, direction logproto.Direction) HeapIterator {
-	result := &mergeEntryIterator{is: is, stats: stats.FromContext(ctx)}
-	switch direction {
-	case logproto.BACKWARD:
-		result.heap = &iteratorSortHeap{iteratorHeap: make([]EntryIterator, 0, len(is)), byAscendingTime: false}
-	case logproto.FORWARD:
-		result.heap = &iteratorSortHeap{iteratorHeap: make([]EntryIterator, 0, len(is)), byAscendingTime: true}
-	default:
-		panic("bad direction")
-	}
-
+	maxVal, less := treeLess(direction)
+	result := &mergeEntryIterator{stats: stats.FromContext(ctx)}
+	result.tree = loser.New(is, maxVal, sortFieldsAt, less, result.closeEntry)
 	result.buffer = make([]entryWithLabels, 0, len(is))
-	result.pushBuffer = make([]EntryIterator, 0, len(is))
 	return result
 }
 
-// prefetch iterates over all inner iterators to merge together, calls Next() on
-// each of them to prefetch the first entry and pushes of them - who are not
-// empty - to the heap
-func (i *mergeEntryIterator) prefetch() {
-	if i.prefetched {
-		return
-	}
-
-	i.prefetched = true
-	for _, it := range i.is {
-		i.requeue(it, false)
-	}
-
-	// We can now clear the list of input iterators to merge, given they have all
-	// been processed and the non empty ones have been pushed to the heap
-	i.is = nil
-}
-
-// requeue pushes the input ei EntryIterator to the heap, advancing it via an ei.Next()
-// call unless the advanced input parameter is true. In this latter case it expects that
-// the iterator has already been advanced before calling requeue().
-//
-// If the iterator has no more entries or an error occur while advancing it, the iterator
-// is not pushed to the heap and any possible error captured, so that can be get via Error().
-func (i *mergeEntryIterator) requeue(ei EntryIterator, advanced bool) {
-	if advanced || ei.Next() {
-		heap.Push(i.heap, ei)
-		return
-	}
-
-	if err := ei.Error(); err != nil {
+func (i *mergeEntryIterator) closeEntry(e EntryIterator) {
+	if err := e.Error(); err != nil {
 		i.errs = append(i.errs, err)
 	}
-	util.LogError("closing iterator", ei.Close)
+	util.LogError("closing iterator", e.Close)
+
 }
 
 func (i *mergeEntryIterator) Push(ei EntryIterator) {
-	i.requeue(ei, false)
+	i.tree.Push(ei)
 }
 
-// Next pop iterators from the heap until it finds an entry with a different timestamp or stream hash.
-// For each iterators we also buffer entries with the current timestamp and stream hash deduping as we loop.
-// If the iterator is not fully exhausted, it is pushed back to the heap.
+// Next fetches entries from the tree until it finds an entry with a different timestamp or stream hash.
+// Generally i.buffer has one or more entries with the same timestamp and stream hash,
+// followed by one more item where the timestamp or stream hash was different.
 func (i *mergeEntryIterator) Next() bool {
-	i.prefetch()
-
-	if len(i.buffer) != 0 {
-		i.nextFromBuffer()
-		return true
+	if len(i.buffer) < 2 {
+		i.fillBuffer()
 	}
-
-	if i.heap.Len() == 0 {
+	if len(i.buffer) == 0 {
 		return false
 	}
+	i.nextFromBuffer()
 
-	// shortcut for the last iterator.
-	if i.heap.Len() == 1 {
-		i.currEntry.Entry = i.heap.Peek().Entry()
-		i.currEntry.labels = i.heap.Peek().Labels()
-		i.currEntry.streamHash = i.heap.Peek().StreamHash()
+	return true
+}
 
-		if !i.heap.Peek().Next() {
-			i.heap.Pop()
-		}
-		return true
+func (i *mergeEntryIterator) fillBuffer() {
+	if !i.tree.Next() {
+		return
 	}
+	// At this point we have zero or one items in i.buffer, and the next item is available from i.tree.
 
 	// We support multiple entries with the same timestamp, and we want to
-	// preserve their original order. We look at all the top entries in the
-	// heap with the same timestamp, and pop the ones whose common value
-	// occurs most often.
-Outer:
-	for i.heap.Len() > 0 {
-		next := i.heap.Peek()
+	// preserve their original order.
+	// Entries with identical timestamp and line are removed as duplicates.
+	for {
+		next := i.tree.Winner()
 		entry := next.Entry()
-		if len(i.buffer) > 0 &&
+		previous := i.buffer
+		i.buffer = append(i.buffer, entryWithLabels{
+			Entry:      entry,
+			labels:     next.Labels(),
+			streamHash: next.StreamHash(),
+		})
+		if len(i.buffer) > 1 &&
 			(i.buffer[0].streamHash != next.StreamHash() ||
 				!i.buffer[0].Entry.Timestamp.Equal(entry.Timestamp)) {
 			break
 		}
 
-		heap.Pop(i.heap)
-		previous := i.buffer
 		var dupe bool
 		for _, t := range previous {
 			if t.Entry.Line == entry.Line {
@@ -230,52 +148,24 @@ Outer:
 				break
 			}
 		}
-		if !dupe {
-			i.buffer = append(i.buffer, entryWithLabels{
-				Entry:      entry,
-				labels:     next.Labels(),
-				streamHash: next.StreamHash(),
-			})
+		if dupe {
+			i.buffer = previous
 		}
-	inner:
-		for {
-			if !next.Next() {
-				continue Outer
-			}
-			entry := next.Entry()
-			if next.StreamHash() != i.buffer[0].streamHash ||
-				!entry.Timestamp.Equal(i.buffer[0].Entry.Timestamp) {
-				break
-			}
-			for _, t := range previous {
-				if t.Entry.Line == entry.Line {
-					i.stats.AddDuplicates(1)
-					continue inner
-				}
-			}
-			i.buffer = append(i.buffer, entryWithLabels{
-				Entry:      entry,
-				labels:     next.Labels(),
-				streamHash: next.StreamHash(),
-			})
+		if !i.tree.Next() {
+			break
 		}
-		i.pushBuffer = append(i.pushBuffer, next)
 	}
-
-	for _, ei := range i.pushBuffer {
-		heap.Push(i.heap, ei)
-	}
-	i.pushBuffer = i.pushBuffer[:0]
-
-	i.nextFromBuffer()
-
-	return true
 }
 
 func (i *mergeEntryIterator) nextFromBuffer() {
 	i.currEntry.Entry = i.buffer[0].Entry
 	i.currEntry.labels = i.buffer[0].labels
 	i.currEntry.streamHash = i.buffer[0].streamHash
+	if len(i.buffer) == 2 {
+		i.buffer[0] = i.buffer[1]
+		i.buffer = i.buffer[:1]
+		return
+	}
 	if len(i.buffer) == 1 {
 		i.buffer = i.buffer[:0]
 		return
@@ -305,26 +195,27 @@ func (i *mergeEntryIterator) Error() error {
 }
 
 func (i *mergeEntryIterator) Close() error {
-	for i.heap.Len() > 0 {
-		if err := i.heap.Pop().(EntryIterator).Close(); err != nil {
-			return err
-		}
-	}
+	i.tree.Close()
 	i.buffer = nil
-	return nil
+	return i.Error()
 }
 
 func (i *mergeEntryIterator) Peek() time.Time {
-	i.prefetch()
-
-	return i.heap.Peek().Entry().Timestamp
+	if len(i.buffer) == 0 {
+		i.fillBuffer()
+	}
+	if len(i.buffer) == 0 {
+		return time.Time{}
+	}
+	return i.buffer[0].Timestamp
 }
 
 // IsEmpty returns true if there are no more entries to pull.
 func (i *mergeEntryIterator) IsEmpty() bool {
-	i.prefetch()
-
-	return i.heap.Len() == 0
+	if len(i.buffer) == 0 {
+		i.fillBuffer()
+	}
+	return len(i.buffer) == 0
 }
 
 type entrySortIterator struct {

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -95,7 +95,7 @@ func (h iteratorSortHeap) Less(i, j int) bool {
 type HeapIterator interface {
 	EntryIterator
 	Peek() time.Time
-	Len() int
+	IsEmpty() bool
 	Push(EntryIterator)
 }
 
@@ -320,11 +320,11 @@ func (i *mergeEntryIterator) Peek() time.Time {
 	return i.heap.Peek().Entry().Timestamp
 }
 
-// Len returns the number of inner iterators on the heap, still having entries
-func (i *mergeEntryIterator) Len() int {
+// IsEmpty returns true if there are no more entries to pull.
+func (i *mergeEntryIterator) IsEmpty() bool {
 	i.prefetch()
 
-	return i.heap.Len()
+	return i.heap.Len() == 0
 }
 
 type entrySortIterator struct {

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -165,8 +165,8 @@ func TestMergeIteratorPrefetch(t *testing.T) {
 	type tester func(t *testing.T, i HeapIterator)
 
 	tests := map[string]tester{
-		"prefetch on Len() when called as first method": func(t *testing.T, i HeapIterator) {
-			assert.Equal(t, 2, i.Len())
+		"prefetch on IsEmpty() when called as first method": func(t *testing.T, i HeapIterator) {
+			assert.Equal(t, false, i.IsEmpty())
 		},
 		"prefetch on Peek() when called as first method": func(t *testing.T, i HeapIterator) {
 			assert.Equal(t, time.Unix(0, 0), i.Peek())

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -520,8 +520,8 @@ func Test_DuplicateCount(t *testing.T) {
 		{
 			"replication 2 b",
 			[]EntryIterator{
-				NewStreamIterator(stream),
-				NewStreamIterator(stream),
+				mustReverseStreamIterator(NewStreamIterator(stream)),
+				mustReverseStreamIterator(NewStreamIterator(stream)),
 			},
 			logproto.BACKWARD,
 			3,
@@ -556,9 +556,9 @@ func Test_DuplicateCount(t *testing.T) {
 		{
 			"replication 3 b",
 			[]EntryIterator{
-				NewStreamIterator(stream),
-				NewStreamIterator(stream),
-				NewStreamIterator(stream),
+				mustReverseStreamIterator(NewStreamIterator(stream)),
+				mustReverseStreamIterator(NewStreamIterator(stream)),
+				mustReverseStreamIterator(NewStreamIterator(stream)),
 				NewStreamIterator(logproto.Stream{
 					Entries: []logproto.Entry{
 						{

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -886,15 +886,21 @@ func TestDedupeMergeEntryIterator(t *testing.T) {
 			}),
 		}, logproto.FORWARD)
 	require.True(t, it.Next())
-	require.Equal(t, "0", it.Entry().Line)
+	lines := []string{it.Entry().Line}
 	require.Equal(t, time.Unix(1, 0), it.Entry().Timestamp)
 	require.True(t, it.Next())
-	require.Equal(t, "2", it.Entry().Line)
+	lines = append(lines, it.Entry().Line)
 	require.Equal(t, time.Unix(1, 0), it.Entry().Timestamp)
 	require.True(t, it.Next())
-	require.Equal(t, "1", it.Entry().Line)
+	lines = append(lines, it.Entry().Line)
 	require.Equal(t, time.Unix(1, 0), it.Entry().Timestamp)
 	require.True(t, it.Next())
-	require.Equal(t, "3", it.Entry().Line)
+	lines = append(lines, it.Entry().Line)
 	require.Equal(t, time.Unix(2, 0), it.Entry().Timestamp)
+	// Two orderings are consistent with the inputs.
+	if lines[0] == "1" {
+		require.Equal(t, []string{"1", "0", "2", "3"}, lines)
+	} else {
+		require.Equal(t, []string{"0", "2", "1", "3"}, lines)
+	}
 }

--- a/pkg/querier/tail.go
+++ b/pkg/querier/tail.go
@@ -243,7 +243,7 @@ func (t *Tailer) next() bool {
 	t.streamMtx.Lock()
 	defer t.streamMtx.Unlock()
 
-	if t.openStreamIterator.Len() == 0 || !time.Now().After(t.openStreamIterator.Peek().Add(t.delayFor)) || !t.openStreamIterator.Next() {
+	if t.openStreamIterator.IsEmpty() || !time.Now().After(t.openStreamIterator.Peek().Add(t.delayFor)) || !t.openStreamIterator.Next() {
 		return false
 	}
 

--- a/pkg/querier/tail_test.go
+++ b/pkg/querier/tail_test.go
@@ -218,7 +218,7 @@ func isTailerOpenStreamsConsumed(tailer *Tailer) bool {
 	tailer.streamMtx.Lock()
 	defer tailer.streamMtx.Unlock()
 
-	return tailer.openStreamIterator.Len() == 0 || tailer.openStreamIterator.Peek() == time.Unix(0, 0)
+	return tailer.openStreamIterator.IsEmpty() || tailer.openStreamIterator.Peek() == time.Unix(0, 0)
 }
 
 func countEntriesInStreams(streams []logproto.Stream) int {

--- a/pkg/util/loser/tree.go
+++ b/pkg/util/loser/tree.go
@@ -76,6 +76,9 @@ func (t *Tree[E, S]) Next() bool {
 		t.initialize()
 		return t.nodes[t.nodes[0].index].index != -1
 	}
+	if t.nodes[t.nodes[0].index].index == -1 { // already exhausted
+		return false
+	}
 	t.moveNext(t.nodes[0].index)
 	t.replayGames(t.nodes[0].index)
 	return t.nodes[t.nodes[0].index].index != -1

--- a/pkg/util/loser/tree.go
+++ b/pkg/util/loser/tree.go
@@ -126,3 +126,38 @@ func (t *Tree[E, S]) playGame(a, b int) (loser, winner int) {
 }
 
 func parent(i int) int { return i / 2 }
+
+// Add a new sequence to the merge set
+func (t *Tree[E, S]) Push(sequence S) {
+	// First, see if we can replace one that was previously finished.
+	for newPos := len(t.nodes) / 2; newPos < len(t.nodes); newPos++ {
+		if t.nodes[newPos].index == -1 {
+			t.nodes[newPos].index = newPos
+			t.nodes[newPos].items = sequence
+			t.moveNext(newPos)
+			t.nodes[0].index = -1 // flag for re-initialize on next call to Next()
+			return
+		}
+	}
+	// We need to expand the tree. Pick the next biggest power of 2 to amortise resizing cost.
+	size := 1
+	for ; size <= len(t.nodes)/2; size *= 2 {
+	}
+	newPos := size + len(t.nodes)/2
+	newNodes := make([]node[E, S], size*2)
+	// Copy data over and fix up the indexes.
+	for i, n := range t.nodes[len(t.nodes)/2:] {
+		newNodes[i+size] = n
+		newNodes[i+size].index = i + size
+	}
+	t.nodes = newNodes
+	t.nodes[newPos].index = newPos
+	t.nodes[newPos].items = sequence
+	// Mark all the empty nodes we have added as finished.
+	for i := newPos + 1; i < len(t.nodes); i++ {
+		t.nodes[i].index = -1
+		t.nodes[i].value = t.maxVal
+	}
+	t.moveNext(newPos)
+	t.nodes[0].index = -1 // flag for re-initialize on next call to Next()
+}

--- a/pkg/util/loser/tree.go
+++ b/pkg/util/loser/tree.go
@@ -17,6 +17,7 @@ func New[E any, S Sequence](sequences []S, maxVal E, at func(S) E, less func(E, 
 	}
 	for i, s := range sequences {
 		t.nodes[i+nSequences].items = s
+		t.moveNext(i + nSequences) // Must call Next on each item so that At() has a value.
 	}
 	if nSequences > 0 {
 		t.nodes[0].index = -1 // flag to be initialized on first call to Next().
@@ -85,7 +86,6 @@ func (t *Tree[E, S]) initialize() {
 	// Initialize leaf nodes as winners to start.
 	for i := len(t.nodes) / 2; i < len(t.nodes); i++ {
 		winners[i] = i
-		t.moveNext(i) // Must call Next on each item so that At() has a value.
 	}
 	for i := len(t.nodes) - 2; i > 0; i -= 2 {
 		// At each stage the winners play each other, and we record the loser in the node.

--- a/pkg/util/loser/tree_test.go
+++ b/pkg/util/loser/tree_test.go
@@ -55,62 +55,63 @@ func checkIterablesEqual[E any, S1 loser.Sequence, S2 loser.Sequence](t *testing
 	}
 }
 
+var testCases = []struct {
+	name string
+	args []*List
+	want *List
+}{
+	{
+		name: "empty input",
+		want: NewList(),
+	},
+	{
+		name: "one list",
+		args: []*List{NewList(1, 2, 3, 4)},
+		want: NewList(1, 2, 3, 4),
+	},
+	{
+		name: "two lists",
+		args: []*List{NewList(3, 4, 5), NewList(1, 2)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "two lists, first empty",
+		args: []*List{NewList(), NewList(1, 2)},
+		want: NewList(1, 2),
+	},
+	{
+		name: "two lists, second empty",
+		args: []*List{NewList(1, 2), NewList()},
+		want: NewList(1, 2),
+	},
+	{
+		name: "two lists b",
+		args: []*List{NewList(1, 2), NewList(3, 4, 5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "two lists c",
+		args: []*List{NewList(1, 3), NewList(2, 4, 5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "three lists",
+		args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+}
+
 func TestMerge(t *testing.T) {
-	tests := []struct {
-		name string
-		args []*List
-		want *List
-	}{
-		{
-			name: "empty input",
-			want: NewList(),
-		},
-		{
-			name: "one list",
-			args: []*List{NewList(1, 2, 3, 4)},
-			want: NewList(1, 2, 3, 4),
-		},
-		{
-			name: "two lists",
-			args: []*List{NewList(3, 4, 5), NewList(1, 2)},
-			want: NewList(1, 2, 3, 4, 5),
-		},
-		{
-			name: "two lists, first empty",
-			args: []*List{NewList(), NewList(1, 2)},
-			want: NewList(1, 2),
-		},
-		{
-			name: "two lists, second empty",
-			args: []*List{NewList(1, 2), NewList()},
-			want: NewList(1, 2),
-		},
-		{
-			name: "two lists b",
-			args: []*List{NewList(1, 2), NewList(3, 4, 5)},
-			want: NewList(1, 2, 3, 4, 5),
-		},
-		{
-			name: "two lists c",
-			args: []*List{NewList(1, 3), NewList(2, 4, 5)},
-			want: NewList(1, 2, 3, 4, 5),
-		},
-		{
-			name: "three lists",
-			args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
-			want: NewList(1, 2, 3, 4, 5),
-		},
-	}
-	for _, tt := range tests {
+	at := func(s *List) uint64 { return s.At() }
+	less := func(a, b uint64) bool { return a < b }
+	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			at := func(s *List) uint64 { return s.At() }
-			less := func(a, b uint64) bool { return a < b }
 			numCloses := 0
 			close := func(s *List) {
 				numCloses++
 			}
 			lt := loser.New(tt.args, math.MaxUint64, at, less, close)
-			at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
 			checkIterablesEqual(t, tt.want, lt, at, at2, less)
 			if numCloses != len(tt.args) {
 				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)

--- a/pkg/util/loser/tree_test.go
+++ b/pkg/util/loser/tree_test.go
@@ -119,3 +119,25 @@ func TestMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestPush(t *testing.T) {
+	at := func(s *List) uint64 { return s.At() }
+	less := func(a, b uint64) bool { return a < b }
+	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			numCloses := 0
+			close := func(s *List) {
+				numCloses++
+			}
+			lt := loser.New(nil, math.MaxUint64, at, less, close)
+			for _, s := range tt.args {
+				lt.Push(s)
+			}
+			checkIterablesEqual(t, tt.want, lt, at, at2, less)
+			if numCloses != len(tt.args) {
+				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Building on #8351, this re-implements `mergeEntryIterator` using `loser.Tree`; the benchmark says it goes much faster but uses a bit more memory (while building the tree).

```
name                       old time/op    new time/op    delta
SortIterator/merge_sort-4    10.7ms ± 4%     2.9ms ± 2%  -72.74%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
SortIterator/merge_sort-4    11.2kB ± 0%    21.7kB ± 0%  +93.45%  (p=0.008 n=5+5)

name                       old allocs/op  new allocs/op  delta
SortIterator/merge_sort-4      6.00 ± 0%      7.00 ± 0%  +16.67%  (p=0.008 n=5+5)
```

The implementation is very different: rather than relying on iterators supporting `Peek()`, `mergeEntryIterator` now pulls items into its buffer until it finds one with a different timestamp or stream, and always works off what is in the buffer.
The comment `"[we] pop the ones whose common value occurs most often."` did not appear to match the previous implementation, and no attempt was made to match this comment.

A `Push()` function was added to `loser.Tree` to support live-streaming. This works by finding or making an empty slot, then re-running the initialize function to find the new winner.  A consequence is that the previous "winner" value is lost after calling
`Push()`, and users must call `Next()` to see the next item.

A couple of tests had to be amended to avoid assuming particular behaviour of the implementation; I recommend that reviewers consider these closely.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
