### PR TITLE
added missed binaries required to run `./tools/image-tag` script

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -707,6 +707,8 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
         image: 'alpine',
         depends_on: ['check-version-is-latest'],
         commands: [
+          'apk add --no-cache bash git',
+          'git fetch origin --tags',
           'RELEASE_TAG=$(./tools/image-tag)',
           'echo $PLUGIN_CONFIG_TEMPLATE > %s' % configFileName,
           // replace placeholders with RELEASE TAG

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1292,6 +1292,8 @@ steps:
     event:
     - tag
 - commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
   - RELEASE_TAG=$(./tools/image-tag)
   - echo $PLUGIN_CONFIG_TEMPLATE > updater-config.json
   - sed -i -E "s/\{\{release\}\}/$RELEASE_TAG/g" updater-config.json
@@ -1725,6 +1727,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: eb49b720f2c0552e8cd002c532a774a48b03372b8cbac769aacd80d4175bb700
+hmac: ae19447e0f2e91746c5b4e6a3dc469a08a63c44045f4b995a6980d0e401e071f
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:

[This drone step](https://drone.grafana.net/grafana/loki/20764/21/3) had to prepare a config for the `updater` to update loki helm chart with the latest image version automatically. However, it failed due to an error:
```
+ RELEASE_TAG=$(./tools/image-tag)
env: can't execute 'bash': No such file or directory
```
I forgot to install `bash` and `git` before running this script inside `alpine` container.
