### PR TITLE
[logcli] set default instead of error for parallel-max-workers validation

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -428,12 +428,13 @@ func newQuery(instant bool, cmd *kingpin.CmdClause) *query.Query {
 
 			q.Start = mustParse(from, defaultStart)
 			q.End = mustParse(to, defaultEnd)
+
+			if q.ParallelMaxWorkers < 1 {
+				log.Println("parallel-max-workers must be greater than 0, defaulting to 1.")
+				q.ParallelMaxWorkers = 1
+			}
 		}
 		q.Quiet = *quiet
-
-		if q.ParallelMaxWorkers < 1 {
-			return fmt.Errorf("parallel-max-workers must be greater than 0")
-		}
 
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes regression reported here: https://github.com/grafana/loki/pull/8518#issuecomment-1446014229

@dannykopping can you please verify that it fixes the issue for you?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
