### PR TITLE
Helm: Split rules into more groups

### DIFF
--- a/production/helm/loki/src/rules.yaml.tpl
+++ b/production/helm/loki/src/rules.yaml.tpl
@@ -1,6 +1,6 @@
 ---
 groups:
-  - name: "loki_rules"
+  - name: "loki_api_1"
     rules:
     - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
         by (le, job))
@@ -29,6 +29,8 @@ groups:
       record: job:loki_request_duration_seconds_count:sum_rate
       labels:
         cluster: "{{ include "loki.fullname" $ }}"
+  - name: "loki_api_2"
+    rules:
     - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
         by (le, job, route))
       record: job_route:loki_request_duration_seconds:99quantile
@@ -56,6 +58,8 @@ groups:
       record: job_route:loki_request_duration_seconds_count:sum_rate
       labels:
         cluster: "{{ include "loki.fullname" $ }}"
+  - name: "loki_api_3"
+    rules:
     - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
         by (le, namespace, job, route))
       record: namespace_job_route:loki_request_duration_seconds:99quantile

--- a/production/loki-mixin-compiled-ssd/rules.yaml
+++ b/production/loki-mixin-compiled-ssd/rules.yaml
@@ -1,5 +1,5 @@
 groups:
-- name: loki_rules
+- name: loki_api_1
   rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, job))
@@ -16,6 +16,8 @@ groups:
     record: cluster_job:loki_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job)
     record: cluster_job:loki_request_duration_seconds_count:sum_rate
+- name: loki_api_2
+  rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, job, route))
     record: cluster_job_route:loki_request_duration_seconds:99quantile
@@ -32,6 +34,8 @@ groups:
     record: cluster_job_route:loki_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
     record: cluster_job_route:loki_request_duration_seconds_count:sum_rate
+- name: loki_api_3
+  rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, namespace, job, route))
     record: cluster_namespace_job_route:loki_request_duration_seconds:99quantile

--- a/production/loki-mixin-compiled/rules.yaml
+++ b/production/loki-mixin-compiled/rules.yaml
@@ -1,5 +1,5 @@
 groups:
-- name: loki_rules
+- name: loki_api_1
   rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, job))
@@ -16,6 +16,8 @@ groups:
     record: cluster_job:loki_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job)
     record: cluster_job:loki_request_duration_seconds_count:sum_rate
+- name: loki_api_2
+  rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, job, route))
     record: cluster_job_route:loki_request_duration_seconds:99quantile
@@ -32,6 +34,8 @@ groups:
     record: cluster_job_route:loki_request_duration_seconds_sum:sum_rate
   - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
     record: cluster_job_route:loki_request_duration_seconds_count:sum_rate
+- name: loki_api_3
+  rules:
   - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
       by (le, cluster, namespace, job, route))
     record: cluster_namespace_job_route:loki_request_duration_seconds:99quantile

--- a/production/loki-mixin/recording_rules.libsonnet
+++ b/production/loki-mixin/recording_rules.libsonnet
@@ -3,10 +3,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
 {
   prometheusRules+:: {
     groups+: [{
-      name: 'loki_rules',
+      name: 'loki_api_1',
       rules:
-        utils.histogramRules('loki_request_duration_seconds', [$._config.per_cluster_label, 'job']) +
-        utils.histogramRules('loki_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route']) +
+        utils.histogramRules('loki_request_duration_seconds', [$._config.per_cluster_label, 'job']),
+    }, {
+      name: 'loki_api_2',
+      rules:
+        utils.histogramRules('loki_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route']),
+    }, {
+      name: 'loki_api_3',
+      rules:
         utils.histogramRules('loki_request_duration_seconds', [$._config.per_cluster_label, 'namespace', 'job', 'route']),
     }],
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
Split our rules into more rule groups in case evaluation takes too long. This is similar to what Mimir does https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/rules.yaml.