### PR TITLE
Helm: Remove image override for GEL in values.yaml

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -369,9 +369,9 @@ null
 		<tr>
 			<td>enterprise.image.tag</td>
 			<td>string</td>
-			<td>Docker image tag TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
+			<td>Docker image tag</td>
 			<td><pre lang="json">
-"main-96f32b9f"
+"nil"
 </pre>
 </td>
 		</tr>
@@ -1683,7 +1683,7 @@ true
 		<tr>
 			<td>loki.image.tag</td>
 			<td>string</td>
-			<td>Overrides the image tag whose default is the chart's appVersion TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
+			<td>Overrides the image tag whose default is the chart's appVersion</td>
 			<td><pre lang="json">
 null
 </pre>

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -45,8 +45,6 @@ loki:
     # -- Docker image repository
     repository: grafana/loki
     # -- Overrides the image tag whose default is the chart's appVersion
-    # TODO: needed for 3rd target backend functionality
-    # revert to null or latest once this behavior is relased
     tag: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
@@ -361,9 +359,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    # TODO: needed for 3rd target backend functionality
-    # revert to null or latest once this behavior is relased
-    tag: main-96f32b9f
+    tag: nil
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For Loki, the image override has already be removed in https://github.com/grafana/loki/commit/e6fb32b214740cf56da1a697c671e21b0b788eeb (Loki 2.7.3)

GEL `1.6.2` uses Loki `2.7.3`.

Both Loki and GEL should work with the third target (`backend`).

**Special notes for your reviewer**:

DO NOT MERGE YET
REQUIRES GEL 1.6.2 TO BE RELEASED