### PR TITLE
Helm - Loki: Fix empty starting line in runtimeConfig

### DIFF
--- a/production/helm/loki/templates/runtime-configmap.yaml
+++ b/production/helm/loki/templates/runtime-configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "loki.labels" . | nindent 4 }}
 data:
   runtime-config.yaml: |
-    {{ tpl (toYaml .Values.loki.runtimeConfig) . | nindent 4 }}
+    {{- tpl (toYaml .Values.loki.runtimeConfig) . | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `runtime` ConfigMap in the Loki Helm chart (introduced in https://github.com/grafana/loki/commit/7aa596752d33e8a0445aec59c23642b83baf4328) starts with an empty line because it improperly removes the current line.

```yaml
---
# Source: loki/templates/runtime-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: loki-runtime
data:
  runtime-config.yaml: |
    
    {}
```

While this generates technically valid YAML, it looks weird and interacts badly with some tools. E.g.:

- Python ruamel.yaml library: https://stackoverflow.com/questions/75584262/ruamel-yaml-adds-incorrect-indentation-indicator
- VS Code which is set to trim whitespace on save (yellow highlighting is for objects, not strings):

<img width="213" alt="Screenshot 2023-02-28 at 21 13 10" src="https://user-images.githubusercontent.com/4059732/221967899-719622c8-7393-4336-8c07-934e85a94a30.png">

This PR removes this empty start line:

```yaml
---
# Source: loki/templates/runtime-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: loki-runtime
data:
  runtime-config.yaml: |
    {}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:



**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
