### PR TITLE
Label matcher optimizations

### DIFF
--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -367,7 +367,7 @@ func parseRegexpLabelFilter(m *labels.Matcher) (LabelFilterer, bool) {
 	reg = reg.Simplify()
 
 	// attempt to improve regex with tricks
-	return simplifyLabelFilterRegex(reg, m)
+	return simplifyLabelFilterRegex(reg)
 	//if !ok {
 	//	allNonGreedy(reg)
 	//	m.Value = reg.String()
@@ -375,7 +375,7 @@ func parseRegexpLabelFilter(m *labels.Matcher) (LabelFilterer, bool) {
 	//}
 }
 
-func simplifyLabelFilterRegex(reg *syntax.Regexp, m *labels.Matcher) (LabelFilterer, bool) {
+func simplifyLabelFilterRegex(reg *syntax.Regexp) (LabelFilterer, bool) {
 	switch reg.Op {
 	case syntax.OpStar:
 		if reg.Sub[0].Op == syntax.OpAnyCharNotNL {
@@ -383,12 +383,6 @@ func simplifyLabelFilterRegex(reg *syntax.Regexp, m *labels.Matcher) (LabelFilte
 		}
 	case syntax.OpEmptyMatch:
 		return NoopLabelFilter, true
-	case syntax.OpLiteral:
-		concatMatcher, err := labels.NewMatcher(m.Type, m.Name, fmt.Sprintf(".*%s.*", reg.String()))
-		if err != nil {
-			return nil, false
-		}
-		return &StringLabelFilter{concatMatcher}, true
 	}
 	return nil, false
 }

--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -329,7 +329,7 @@ func (n *NumericLabelFilter) String() string {
 
 type StringLabelFilter struct {
 	*labels.Matcher
-	checkExists bool
+	onlyCheckExists bool
 }
 
 // NewStringLabelFilter creates a new label filterer which compares string label.
@@ -353,7 +353,7 @@ func (s *StringLabelFilter) Process(_ int64, line []byte, lbs *LabelsBuilder) ([
 		value, _ = lbs.Get(s.Name)
 	}
 
-	if s.checkExists {
+	if s.onlyCheckExists {
 		return line, len(value) > 0
 	}
 	return line, s.Matches(value)

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -357,7 +357,7 @@ func TestStringLabelFilter(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		filter      *StringLabelFilter
+		filter      LabelFilterer
 		labels      labels.Labels
 		shouldMatch bool
 	}{
@@ -419,4 +419,18 @@ func TestStringLabelFilter(t *testing.T) {
 			assert.Equal(t, tc.shouldMatch, ok)
 		})
 	}
+}
+
+func TestCreateStringFilterSimplifications(t *testing.T) {
+	t.Run("it returns a no-op filter for empty and .* regex matches", func(t *testing.T) {
+		for _, re := range []string{".*", ""} {
+			f := NewStringLabelFilter(&labels.Matcher{
+				Type:  labels.MatchRegexp,
+				Name:  "label-name",
+				Value: re,
+			})
+
+			require.Equal(t, NoopLabelFilter, f)
+		}
+	})
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -433,4 +433,30 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			require.Equal(t, NoopLabelFilter, f)
 		}
 	})
+
+	t.Run("it returns a no-op filter for empty and .* regex matches", func(t *testing.T) {
+		lbls := NewBaseLabelsBuilder().ForLabels(
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+			}, 0)
+
+		f := NewStringLabelFilter(&labels.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  "foo",
+			Value: ".+",
+		}).(*StringLabelFilter)
+		require.True(t, f.checkExists)
+
+		_, res := f.Process(0, []byte("line"), lbls)
+		require.True(t, res)
+
+		f = NewStringLabelFilter(&labels.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  "bar",
+			Value: ".+",
+		}).(*StringLabelFilter)
+
+		_, res = f.Process(0, []byte("line"), lbls)
+		require.False(t, res)
+	})
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -447,7 +447,7 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			Name:  "foo",
 			Value: ".+",
 		}).(*StringLabelFilter)
-		require.True(t, f.checkExists)
+		require.True(t, f.onlyCheckExists)
 
 		_, res := f.Process(0, []byte("line"), lbls)
 		require.True(t, res)
@@ -461,4 +461,38 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 		_, res = f.Process(0, []byte("line"), lbls)
 		require.False(t, res)
 	})
+}
+
+var result bool
+
+func BenchmarkEmptyFilters(b *testing.B) {
+	lbls := NewBaseLabelsBuilder().ForLabels(
+		labels.Labels{
+			{Name: "foo", Value: "bar"},
+		},
+		0,
+	)
+
+	f := NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "label-name", ".*"))
+
+	line := []byte("line")
+	for n := 0; n < b.N; n++ {
+		_, result = f.Process(0, line, lbls)
+	}
+}
+
+func BenchmarkExistsFilters(b *testing.B) {
+	lbls := NewBaseLabelsBuilder().ForLabels(
+		labels.Labels{
+			{Name: "foo", Value: "bar"},
+		},
+		0,
+	)
+
+	f := NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "label-name", ".+"))
+
+	line := []byte("line")
+	for n := 0; n < b.N; n++ {
+		_, result = f.Process(0, line, lbls)
+	}
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -433,15 +433,4 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			require.Equal(t, NoopLabelFilter, f)
 		}
 	})
-
-	t.Run("it rewrites literal matches as 'contains' matches", func(t *testing.T) {
-		// Prometheus matchers optimize 'contains' to a string test without any regex
-		// https://github.com/prometheus/prometheus/blob/8c8de46003d1800c9d40121b4a5e5de8582ef6e1/pkg/labels/regexp.go#L51-L62
-		f := NewStringLabelFilter(&labels.Matcher{
-			Type:  labels.MatchRegexp,
-			Name:  "label-name",
-			Value: "literal"})
-
-		require.Equal(t, ".*literal.*", f.(*StringLabelFilter).Value)
-	})
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -438,7 +438,9 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 		lbls := NewBaseLabelsBuilder().ForLabels(
 			labels.Labels{
 				{Name: "foo", Value: "bar"},
-			}, 0)
+			},
+			0,
+		)
 
 		f := NewStringLabelFilter(&labels.Matcher{
 			Type:  labels.MatchRegexp,

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -433,4 +433,15 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			require.Equal(t, NoopLabelFilter, f)
 		}
 	})
+
+	t.Run("it rewrites literal matches as 'contains' matches", func(t *testing.T) {
+		// Prometheus matchers optimize 'contains' to a string test without any regex
+		// https://github.com/prometheus/prometheus/blob/8c8de46003d1800c9d40121b4a5e5de8582ef6e1/pkg/labels/regexp.go#L51-L62
+		f := NewStringLabelFilter(&labels.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  "label-name",
+			Value: "literal"})
+
+		require.Equal(t, ".*literal.*", f.(*StringLabelFilter).Value)
+	})
 }

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -446,8 +446,7 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			Type:  labels.MatchRegexp,
 			Name:  "foo",
 			Value: ".+",
-		}).(*StringLabelFilter)
-		require.True(t, f.onlyCheckExists)
+		}).(*existsLabelFilter)
 
 		_, res := f.Process(0, []byte("line"), lbls)
 		require.True(t, res)
@@ -456,7 +455,7 @@ func TestCreateStringFilterSimplifications(t *testing.T) {
 			Type:  labels.MatchRegexp,
 			Name:  "bar",
 			Value: ".+",
-		}).(*StringLabelFilter)
+		}).(*existsLabelFilter)
 
 		_, res = f.Process(0, []byte("line"), lbls)
 		require.False(t, res)
@@ -490,6 +489,22 @@ func BenchmarkExistsFilters(b *testing.B) {
 	)
 
 	f := NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "label-name", ".+"))
+
+	line := []byte("line")
+	for n := 0; n < b.N; n++ {
+		_, result = f.Process(0, line, lbls)
+	}
+}
+
+func BenchmarkLiteralFilters(b *testing.B) {
+	lbls := NewBaseLabelsBuilder().ForLabels(
+		labels.Labels{
+			{Name: "foo", Value: "bar"},
+		},
+		0,
+	)
+
+	f := NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "label-name", "in"))
 
 	line := []byte("line")
 	for n := 0; n < b.N; n++ {

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -82,7 +82,7 @@ func (m MultiStageExpr) stages() ([]log.Stage, error) {
 		if err != nil {
 			return nil, logqlmodel.NewStageError(e.String(), err)
 		}
-		if p == log.NoopStage {
+		if p == log.NoopStage || p == log.NoopLabelFilter {
 			continue
 		}
 		c = append(c, p)


### PR DESCRIPTION
These are some low-hanging optimizations to regex label matchers that already exist for our line-filter matchers:
- Replace `.*` matchers with a noop
- Replace `.+` with `len(value) > 0
- Rewrite greedy regexes to be non-greedy
- replace `literals` with `strings.Contain`

Benchmarks:
```
Replace .* with noop
name            old time/op    new time/op    delta
EmptyFilters-8    45.2ns ± 3%     1.8ns ± 3%  -95.93%  (p=0.000 n=8+8)

name            old alloc/op   new alloc/op   delta
EmptyFilters-8     0.00B          0.00B          ~     (all equal)

name            old allocs/op  new allocs/op  delta
EmptyFilters-8      0.00           0.00          ~     (all equal)
```

```
Replace .+ with len > 0
name             old time/op    new time/op    delta
ExistsFilters-8    10.6ns ±13%     4.5ns ± 8%  -57.78%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
ExistsFilters-8     0.00B          0.00B          ~     (all equal)

name             old allocs/op  new allocs/op  delta
ExistsFilters-8      0.00           0.00          ~     (all equal)
```

```
Replace literal with strings.Contain
name              old time/op    new time/op    delta
LiteralFilters-8    10.6ns ± 8%     6.0ns ± 1%  -43.50%  (p=0.000 n=10+8)

name              old alloc/op   new alloc/op   delta
LiteralFilters-8     0.00B          0.00B          ~     (all equal)

name              old allocs/op  new allocs/op  delta
LiteralFilters-8      0.00           0.00          ~     (all equal)
```

greedy -> non-greedy optimizations are benchmarked in this PR: https://github.com/grafana/loki/pull/4775