### PR TITLE
deletion: fix issue in processing delete requests with tsdb index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [8251](https://github.com/grafana/loki/pull/8251) **sandeepsukhani** index-store: fix indexing of chunks overlapping multiple schemas.
 * [8151](https://github.com/grafana/loki/pull/8151) **sandeepsukhani** fix log deletion with line filters.
 * [8448](https://github.com/grafana/loki/pull/8448) **chaudum**: Fix bug in LogQL parser that caused certain queries that contain a vector expression to fail.
+* [8448](https://github.com/grafana/loki/pull/8665) **sandeepsukhani**: deletion: fix issue in processing delete requests with tsdb index
 
 ##### Changes
 

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -355,7 +355,12 @@ func (c *compactedIndex) ToIndexFile() (index_shipper.Index, error) {
 	c.deleteChunks = nil
 
 	for _, chk := range c.indexChunks {
-		err := c.builder.InsertChunk(chk.Metric.String(), index.ChunkMeta{
+		// TSDB doesnt need the __name__="log" convention the old chunk store index used.
+		b := labels.NewBuilder(chk.Metric)
+		b.Del(labels.MetricName)
+		ls := b.Labels(nil)
+
+		err := c.builder.InsertChunk(ls.String(), index.ChunkMeta{
 			Checksum: chk.Checksum,
 			MinTime:  int64(chk.From),
 			MaxTime:  int64(chk.Through),

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -691,6 +691,24 @@ func TestCompactedIndex(t *testing.T) {
 				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
 			},
 		},
+		"__name__ label should get dropped while indexing chunks": {
+			addChunks: []chunk.Chunk{
+				{
+					Metric:   labels.NewBuilder(testCtx.lbls1).Set(labels.MetricName, "log").Labels(nil),
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(11), testCtx.shiftTableStart(11))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+				{
+					Metric:   testCtx.lbls1,
+					ChunkRef: chunkMetaToChunkRef(testCtx.userID, buildChunkMetas(testCtx.shiftTableStart(12), testCtx.shiftTableStart(12))[0], testCtx.lbls1),
+					Data:     dummyChunkData{},
+				},
+			},
+			finalExpectedChunks: map[string]index.ChunkMetas{
+				testCtx.lbls1.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(12)),
+				testCtx.lbls2.String(): buildChunkMetas(testCtx.shiftTableStart(0), testCtx.shiftTableStart(20)),
+			},
+		},
 		"add some chunks out of table interval to a stream": {
 			addChunks: []chunk.Chunk{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:
When a delete request creates a new chunk from an existing chunk, we index it to the index store.
In TSDB, we [drop](https://github.com/grafana/loki/blob/944b488bd2506012d149fc363401f9b7d51af3e7/pkg/storage/stores/tsdb/head_manager.go#L235-L237) `__name__` label, which was being added to chunkrefs for historical reasons.
However, this was not done while indexing chunks from the deletion code, causing deletion to fail with the error [chunk insertion is only allowed on existing streams](https://github.com/grafana/loki/blob/619c2212f58c645661c7a004c084b839e91aec1b/pkg/storage/stores/tsdb/builder.go#L67).

This PR handles the issue by dropping the `__name__` label and adding relevant tests.

**Special notes for your reviewer**:
I will add an integration test for deletion with TSDB once we have PR https://github.com/grafana/loki/pull/7754 merged since it does some groundwork to run integration tests with both `boltdb-shipper` and `tsdb`.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated
