### PR TITLE
WAL: store pointers in record pool

### DIFF
--- a/clients/pkg/promtail/wal/wal.go
+++ b/clients/pkg/promtail/wal/wal.go
@@ -76,17 +76,17 @@ func (w *wrapper) Log(record *wal.Record) error {
 
 // logBatched logs to the WAL both series and records, batching the operation to prevent unnecessary page flushes.
 func (w *wrapper) logBatched(record *wal.Record) error {
-	seriesBuf := recordPool.GetBytes()[:0]
-	entriesBuf := recordPool.GetBytes()[:0]
+	seriesBuf := recordPool.GetBytes()
+	entriesBuf := recordPool.GetBytes()
 	defer func() {
 		recordPool.PutBytes(seriesBuf)
 		recordPool.PutBytes(entriesBuf)
 	}()
 
-	seriesBuf = record.EncodeSeries(seriesBuf)
-	entriesBuf = record.EncodeEntries(wal.CurrentEntriesRec, entriesBuf)
+	*seriesBuf = record.EncodeSeries(*seriesBuf)
+	*entriesBuf = record.EncodeEntries(wal.CurrentEntriesRec, *entriesBuf)
 	// Always write series then entries
-	if err := w.wal.Log(seriesBuf, entriesBuf); err != nil {
+	if err := w.wal.Log(*seriesBuf, *entriesBuf); err != nil {
 		return err
 	}
 	return nil
@@ -94,22 +94,22 @@ func (w *wrapper) logBatched(record *wal.Record) error {
 
 // logSingle logs to the WAL series and records in separate WAL operation. This causes a page flush after each operation.
 func (w *wrapper) logSingle(record *wal.Record) error {
-	buf := recordPool.GetBytes()[:0]
+	buf := recordPool.GetBytes()
 	defer func() {
 		recordPool.PutBytes(buf)
 	}()
 
 	// Always write series then entries.
 	if len(record.Series) > 0 {
-		buf = record.EncodeSeries(buf)
-		if err := w.wal.Log(buf); err != nil {
+		*buf = record.EncodeSeries(*buf)
+		if err := w.wal.Log(*buf); err != nil {
 			return err
 		}
-		buf = buf[:0]
+		*buf = (*buf)[:0]
 	}
 	if len(record.RefEntries) > 0 {
-		buf = record.EncodeEntries(wal.CurrentEntriesRec, buf)
-		if err := w.wal.Log(buf); err != nil {
+		*buf = record.EncodeEntries(wal.CurrentEntriesRec, *buf)
+		if err := w.wal.Log(*buf); err != nil {
 			return err
 		}
 

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -110,28 +110,28 @@ func (w *walWrapper) Log(record *wal.Record) error {
 	case <-w.quit:
 		return nil
 	default:
-		buf := recordPool.GetBytes()[:0]
+		buf := recordPool.GetBytes()
 		defer func() {
 			recordPool.PutBytes(buf)
 		}()
 
 		// Always write series then entries.
 		if len(record.Series) > 0 {
-			buf = record.EncodeSeries(buf)
-			if err := w.wal.Log(buf); err != nil {
+			*buf = record.EncodeSeries(*buf)
+			if err := w.wal.Log(*buf); err != nil {
 				return err
 			}
 			w.metrics.walRecordsLogged.Inc()
-			w.metrics.walLoggedBytesTotal.Add(float64(len(buf)))
-			buf = buf[:0]
+			w.metrics.walLoggedBytesTotal.Add(float64(len(*buf)))
+			*buf = (*buf)[:0]
 		}
 		if len(record.RefEntries) > 0 {
-			buf = record.EncodeEntries(wal.CurrentEntriesRec, buf)
-			if err := w.wal.Log(buf); err != nil {
+			*buf = record.EncodeEntries(wal.CurrentEntriesRec, *buf)
+			if err := w.wal.Log(*buf); err != nil {
 				return err
 			}
 			w.metrics.walRecordsLogged.Inc()
-			w.metrics.walLoggedBytesTotal.Add(float64(len(buf)))
+			w.metrics.walLoggedBytesTotal.Add(float64(len(*buf)))
 		}
 		return nil
 	}

--- a/pkg/ingester/wal/encoding_test.go
+++ b/pkg/ingester/wal/encoding_test.go
@@ -166,11 +166,11 @@ func Benchmark_EncodeEntries(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
-	buf := recordPool.GetBytes()[:0]
+	buf := recordPool.GetBytes()
 	defer recordPool.PutBytes(buf)
 
 	for n := 0; n < b.N; n++ {
-		record.EncodeEntries(CurrentEntriesRec, buf)
+		*buf = record.EncodeEntries(CurrentEntriesRec, *buf)
 	}
 }
 

--- a/pkg/ingester/wal/recordpool.go
+++ b/pkg/ingester/wal/recordpool.go
@@ -26,7 +26,8 @@ func NewRecordPool() *ResettingPool {
 		},
 		bPool: &sync.Pool{
 			New: func() interface{} {
-				return make([]byte, 0, 1<<10) // 1kb
+				buf := make([]byte, 0, 1<<10) // 1kb
+				return &buf
 			},
 		},
 	}
@@ -53,10 +54,11 @@ func (p *ResettingPool) PutEntries(es []logproto.Entry) {
 	p.ePool.Put(es[:0]) // nolint:staticcheck
 }
 
-func (p *ResettingPool) GetBytes() []byte {
-	return p.bPool.Get().([]byte)
+func (p *ResettingPool) GetBytes() *[]byte {
+	return p.bPool.Get().(*[]byte)
 }
 
-func (p *ResettingPool) PutBytes(b []byte) {
-	p.bPool.Put(b[:0]) // nolint:staticcheck
+func (p *ResettingPool) PutBytes(b *[]byte) {
+	*b = (*b)[:0]
+	p.bPool.Put(b)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Storing a slice in `sync.Pool` wastes 24 bytes every time it is returned to the heap; see https://staticcheck.io/docs/checks#SA6002

Storing a pointer to a slice allows the Pool to work without waste.

This came up in discussion about the benchmark in #8489 - with this change the memory usage comes down:
```
name                                                      old time/op    new time/op    delta
Writer_WriteEntries/1000_lines,_1_different_label_sets-4    7.37ms ±13%    7.45ms ± 9%     ~     (p=0.841 n=5+5)

name                                                      old alloc/op   new alloc/op   delta
Writer_WriteEntries/1000_lines,_1_different_label_sets-4     727kB ± 0%     679kB ± 0%   -6.63%  (p=0.008 n=5+5)

name                                                      old allocs/op  new allocs/op  delta
Writer_WriteEntries/1000_lines,_1_different_label_sets-4     12.0k ± 0%     10.0k ± 0%  -16.68%  (p=0.000 n=5+4)
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
