### PR TITLE
Loki Getting Started: Fix example query that was not working

### DIFF
--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -74,27 +74,27 @@ Enter your query into the **Log browser** box, and click on the blue **Run query
 
 To see all the log lines that flog has generated:
 ```
-{container="evaluate-loki_flog_1"}
+{container="evaluate-loki-flog-1"}
 ```
 
 The flog app will generate log lines for invented HTTP requests.
 To see all `GET` log lines, enter the query:
 
 ```
-{container="evaluate-loki_flog_1"} |= "GET"
+{container="evaluate-loki-flog-1"} |= "GET"
 ```
 For `POST` methods:
 ```
-{container="evaluate-loki_flog_1"} |= "POST"
+{container="evaluate-loki-flog-1"} |= "POST"
 ```
 
 To see every log line with a 401 status (unauthorized error): 
 ```
-{container="evaluate-loki_flog_1"} | json | status="401"
+{container="evaluate-loki-flog-1"} | json | status="401"
 ```
 To see every log line other than those that contain the value 401: 
 ```
-{container="evaluate-loki_flog_1"} != "401"
+{container="evaluate-loki-flog-1"} != "401"
 ```
 
 Refer to [query examples]({{<relref "../logql/query_examples">}}) for more examples.


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously example query was `evaluate-loki_flog_1` this was not the label used in flog. This results in query not returning any logs which beginners may be unsure of the cause of the issue. This might also be an issue if flog was running in the background and logs are not displayed.

Changed to `evaluate-loki-flog-1`.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Trivial fix to "Getting Started" documentation

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
