### PR TITLE
WAL: remove ePool that is unused

### DIFF
--- a/pkg/ingester/wal/recordpool.go
+++ b/pkg/ingester/wal/recordpool.go
@@ -18,8 +18,9 @@ func NewRecordPool() *ResettingPool {
 		},
 		bPool: &sync.Pool{
 			New: func() interface{} {
-				buf := make([]byte, 0, 1<<10) // 1kb
-				return &buf
+				buf := new([]byte)            // Attempt to force allocation on heap.
+				*buf = make([]byte, 0, 1<<10) // 1kb
+				return buf
 			},
 		},
 	}

--- a/pkg/ingester/wal/recordpool.go
+++ b/pkg/ingester/wal/recordpool.go
@@ -2,13 +2,10 @@ package wal
 
 import (
 	"sync"
-
-	"github.com/grafana/loki/pkg/logproto"
 )
 
 type ResettingPool struct {
 	rPool *sync.Pool // records
-	ePool *sync.Pool // entries
 	bPool *sync.Pool // bytes
 }
 
@@ -17,11 +14,6 @@ func NewRecordPool() *ResettingPool {
 		rPool: &sync.Pool{
 			New: func() interface{} {
 				return &Record{}
-			},
-		},
-		ePool: &sync.Pool{
-			New: func() interface{} {
-				return make([]logproto.Entry, 0, 512)
 			},
 		},
 		bPool: &sync.Pool{
@@ -36,22 +28,11 @@ func NewRecordPool() *ResettingPool {
 func (p *ResettingPool) GetRecord() *Record {
 	rec := p.rPool.Get().(*Record)
 	rec.Reset()
-	for _, ref := range rec.RefEntries {
-		p.PutEntries(ref.Entries)
-	}
 	return rec
 }
 
 func (p *ResettingPool) PutRecord(r *Record) {
 	p.rPool.Put(r)
-}
-
-func (p *ResettingPool) GetEntries() []logproto.Entry {
-	return p.ePool.Get().([]logproto.Entry)
-}
-
-func (p *ResettingPool) PutEntries(es []logproto.Entry) {
-	p.ePool.Put(es[:0]) // nolint:staticcheck
 }
 
 func (p *ResettingPool) GetBytes() *[]byte {


### PR DESCRIPTION
**What this PR does / why we need it**:

Nothing is ever fetched from the pool - `GetEntries()` is never called. And the loop to call `PutEntries()` follows a call where the slice it ranges over is reset to empty, so that loop never added anything to the pool.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
