### PR TITLE
Correct query_timeout default value for 2.7.0

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2222,7 +2222,7 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # a query request. If a specific per-tenant timeout is used, this timeout is
 # ignored.
 # CLI flag: -querier.query-timeout
-[query_timeout: <duration> | default = 1m]
+[query_timeout: <duration> | default = 0s]
 
 # Split queries by a time interval and execute in parallel. The value 0 disables
 # splitting by time. This also determines how cache keys are chosen when result


### PR DESCRIPTION
According to 2.7.0 release notes:

https://grafana.com/docs/loki/latest/upgrading/#270 

default value for querier.query-timeout is 0s, instead of 1m, as in previous versions.

**What this PR does / why we need it**:
It corrects default value of [querier.query-timeout] in the documentation for the latest version.

**Which issue(s) this PR fixes**:
Fixes #8673

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
