### PR TITLE
Querier/Ruler: add histogram to track fetched chunk size distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ##### Enhancements
 
+* [8682](https://github.com/grafana/loki/pull/8682) **dannykopping**: Add fetched chunk size distribution metric `loki_chunk_fetcher_fetched_size_bytes`.
 * [8532](https://github.com/grafana/loki/pull/8532) **justcompile**: Adds Storage Class option to S3 objects
 * [7951](https://github.com/grafana/loki/pull/7951) **MichelHollands**: Add a count template function to line_format and label_format.
 * [7380](https://github.com/grafana/loki/pull/7380) **liguozhong**: metrics query: range vector support streaming agg when no overlap.

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
@@ -185,7 +184,7 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk, keys []
 	}
 
 	for _, buf := range cacheBufs {
-		chunkFetchedSize.With(labels.FromStrings("source", "cache").Map()).Observe(float64(len(buf)))
+		chunkFetchedSize.WithLabelValues("cache").Observe(float64(len(buf)))
 	}
 
 	fromCache, missing, err := c.processCacheResponse(ctx, chunks, cacheHits, cacheBufs)
@@ -204,7 +203,7 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk, keys []
 	for _, c := range fromStorage {
 		bytes += c.Size()
 
-		chunkFetchedSize.With(labels.FromStrings("source", "store").Map()).Observe(float64(c.Size()))
+		chunkFetchedSize.WithLabelValues("store").Observe(float64(c.Size()))
 	}
 
 	st := stats.FromContext(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
We are looking at making some changes to the chunk caching strategy, and we need this data to know what size chunks we're typically requesting. For example, if the overwhelming majority of chunks are small we may decide to cache only small chunks to decrease the number of requests to the object store; we could fit more chunks in cache this way, which may have a positive performance impact.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I picked buckets that I thought would be useful, and even included a bucket that is above the recommended chunk target size since some users may be setting it that high.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
