### PR TITLE
[Draft] Make loki aware of nested rules directories

### DIFF
--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -70,7 +70,7 @@ func (l *Client) ListAllUsers(ctx context.Context) ([]string, error) {
 		if d.Type()&fs.FileMode(os.ModeSymlink) != 0 {
 			fi, err := os.Stat(p)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "unable to stat file %s", p)
 			}
 			isDir = fi.IsDir()
 		} else {
@@ -86,7 +86,7 @@ func (l *Client) ListAllUsers(ctx context.Context) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		println(err)
+		return nil, errors.Wrapf(err, "failed to walk the file tree located at %s", l.cfg.Directory)
 	}
 
 	return result, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki currently stores the rules in the following directory on the ruler pod:

`/base/userID/rules.yaml`

However, on the operator side, if rules size exceed 1MB, they are split across multiple config maps, which should mount to different directories on the pod, for example, the rules will be split into different nested directories for each userID:

`/base/configMap-x/userID/rules.yaml`, `/base/configMap-y/userID/rules.yaml`

This PR makes Loki aware of any nesting caused by the operator, and reads the rules in their new path that contains the config map name.


**Which issue(s) this PR fixes**:
Prerequisite to #7451 

**Special notes for your reviewer**:
This PR is currently a draft. one unit test (`TestClient_LoadAllRuleGroups`) still fails in case there's no config map name in the rule path. Since loki reads the user IDs from the rule path, when a new directory is introduced to the path (CM name in this case), it is read as a userID, which is not correct.

The only workaround I am thinking of is introducing a fixed prefix to the config map name so that it is ignored if read by loki.

cc @periklis @xperimental 

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
