### PR TITLE
Fixing broken link (404)

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -382,7 +382,8 @@ scrape_configs:
 ```
 
 Only the `brokers` and `topics` are required.
-Read the [configuration]({{< relref "configuration#kafka" >}}) section for more information.
+Read the [configuration]({{< relref "configuration/#kafka" >}}) section for more information.
+
 
 ## GELF
 


### PR DESCRIPTION
This was reported to the docs team via Slack.  Fixing broken link from Promtail Scaping file to Promtail Configuration file.
