### PR TITLE
fix bug: one line duplicate log after retry

### DIFF
--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -115,7 +115,7 @@ func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.Lo
 
 			for _, entry := range stream.Entries {
 				out.FormatAndPrintln(entry.Timestamp, labels, 0, entry.Line)
-				lastReceivedTimestamp = entry.Timestamp
+				lastReceivedTimestamp = entry.Timestamp.Add(1 * time.Nanosecond)
 			}
 
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: 
When use loki-cli tail to query the real-time log, if server close the websocket connection the client will try to reconnect to the websocket server. And the parameter 'start' will use the last received timestamp. However, if we use the last received timestamp, the last log will duplicate after retry successfully. So we should add 1 nanosecond to the last received timestamp as next time query parameter.

**Which issue(s) this PR fixes**:
Fixes #8692

**Checklist**
- [ ] Reviewed the /pkg/logcli/query/tail.go(https://github.com/grafana/loki/blob/main/pkg/logcli/query/tail.go) 
