### PR TITLE
Promtail: Stop ticker to avoid leaking

### DIFF
--- a/clients/pkg/promtail/positions/positions.go
+++ b/clients/pkg/promtail/positions/positions.go
@@ -152,6 +152,7 @@ func (p *positions) run() {
 	}()
 
 	ticker := time.NewTicker(p.cfg.SyncPeriod)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-p.quit:

--- a/clients/pkg/promtail/positions/positions_test.go
+++ b/clients/pkg/promtail/positions/positions_test.go
@@ -2,7 +2,6 @@ package positions
 
 import (
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -180,30 +179,4 @@ func Test_ReadOnly(t *testing.T) {
 		"/log/path/random.log": "17623",
 	}, out)
 
-}
-
-func TestPositionsLeaking(t *testing.T) {
-	memUsage := &runtime.MemStats{}
-	runtime.GC() // free resources before grabbing mem stats
-	runtime.ReadMemStats(memUsage)
-	currentAllocations := memUsage.HeapObjects
-
-	temp := tempFilename(t)
-	defer func() {
-		_ = os.Remove(temp)
-	}()
-	p, err := New(util_log.Logger, Config{
-		SyncPeriod:    20 * time.Nanosecond,
-		PositionsFile: temp,
-		ReadOnly:      true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p.Stop()
-
-	runtime.GC() // free resources before grabbing mem stats
-	runtime.ReadMemStats(memUsage)
-	require.Equal(t, currentAllocations, memUsage.HeapObjects)
 }

--- a/clients/pkg/promtail/positions/positions_test.go
+++ b/clients/pkg/promtail/positions/positions_test.go
@@ -2,6 +2,7 @@ package positions
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -179,4 +180,30 @@ func Test_ReadOnly(t *testing.T) {
 		"/log/path/random.log": "17623",
 	}, out)
 
+}
+
+func TestPositionsLeaking(t *testing.T) {
+	memUsage := &runtime.MemStats{}
+	runtime.GC() // free resources before grabbing mem stats
+	runtime.ReadMemStats(memUsage)
+	currentAllocations := memUsage.HeapObjects
+
+	temp := tempFilename(t)
+	defer func() {
+		_ = os.Remove(temp)
+	}()
+	p, err := New(util_log.Logger, Config{
+		SyncPeriod:    20 * time.Nanosecond,
+		PositionsFile: temp,
+		ReadOnly:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.Stop()
+
+	runtime.GC() // free resources before grabbing mem stats
+	runtime.ReadMemStats(memUsage)
+	require.Equal(t, currentAllocations, memUsage.HeapObjects)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
From [NewTicker docs](https://pkg.go.dev/time#NewTicker):
`Stop the ticker to release associated resources.`
So not calling `Stop` for Promtail positions is probably leading to leakage at some level. Not sure what is the impact of this, though.