### PR TITLE
Loki: Stop running tickers on deletes

### DIFF
--- a/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_client.go
+++ b/pkg/storage/stores/indexshipper/compactor/deletion/delete_requests_client.go
@@ -94,6 +94,7 @@ func (c *deleteRequestsClient) Stop() {
 
 func (c *deleteRequestsClient) updateLoop() {
 	t := time.NewTicker(c.cacheDuration)
+	defer t.Stop()
 	for {
 		select {
 		case <-t.C:

--- a/pkg/storage/stores/indexshipper/compactor/generationnumber/gennumber_loader.go
+++ b/pkg/storage/stores/indexshipper/compactor/generationnumber/gennumber_loader.go
@@ -48,6 +48,7 @@ func NewGenNumberLoader(g CacheGenClient, registerer prometheus.Registerer) *Gen
 
 func (l *GenNumberLoader) loop() {
 	timer := time.NewTicker(reloadDuration)
+	defer timer.Stop()
 	for {
 		select {
 		case <-timer.C:


### PR DESCRIPTION
**What this PR does / why we need it**:
Calls `ticker.Stop()` to avoid leaking ticker resources for `GenNumberLoader` and `deleteRequestsClient`.