### PR TITLE
Promtail: Fix the default value for a Mechanism field in SASL auth config

### DIFF
--- a/clients/pkg/promtail/targets/kafka/target_syncer.go
+++ b/clients/pkg/promtail/targets/kafka/target_syncer.go
@@ -159,8 +159,8 @@ func withSASLAuthentication(cfg sarama.Config, authCfg scrapeconfig.KafkaAuthent
 		sarama.SASLTypeSCRAMSHA256,
 		sarama.SASLTypePlaintext,
 	}
-	if !util.StringsContain(supportedMechanism, string(authCfg.SASLConfig.Mechanism)) {
-		return nil, fmt.Errorf("error unsupported sasl mechanism: %s", authCfg.SASLConfig.Mechanism)
+	if !util.StringsContain(supportedMechanism, string(cfg.Net.SASL.Mechanism)) {
+		return nil, fmt.Errorf("error unsupported sasl mechanism: %s", cfg.Net.SASL.Mechanism)
 	}
 
 	if cfg.Net.SASL.Mechanism == sarama.SASLTypeSCRAMSHA512 {

--- a/clients/pkg/promtail/targets/kafka/target_syncer_test.go
+++ b/clients/pkg/promtail/targets/kafka/target_syncer_test.go
@@ -282,8 +282,24 @@ func Test_withAuthentication(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, false, mTLSCfg.Net.SASL.Enable)
 
-	// SASL/PLAIN
+	// SASL/PLAIN default mechanism "PLAIN"
 	saslCfg, err := withAuthentication(*cfg, scrapeconfig.KafkaAuthentication{
+		Type: scrapeconfig.KafkaAuthenticationTypeSASL,
+		SASLConfig: scrapeconfig.KafkaSASLConfig{
+			User:     "user",
+			Password: flagext.SecretWithValue("pass"),
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, false, saslCfg.Net.TLS.Enable)
+	assert.Equal(t, true, saslCfg.Net.SASL.Enable)
+	assert.Equal(t, "user", saslCfg.Net.SASL.User)
+	assert.Equal(t, "pass", saslCfg.Net.SASL.Password)
+	assert.Equal(t, sarama.SASLTypePlaintext, string(saslCfg.Net.SASL.Mechanism))
+	assert.NoError(t, saslCfg.Validate())
+
+	// SASL/PLAIN
+	saslCfg, err = withAuthentication(*cfg, scrapeconfig.KafkaAuthentication{
 		Type: scrapeconfig.KafkaAuthenticationTypeSASL,
 		SASLConfig: scrapeconfig.KafkaSASLConfig{
 			Mechanism: sarama.SASLTypePlaintext,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows using a default value for a Mechanism field in the SASL auth config, as specified in the documentation.

Without this change, the error `error unsupported sasl mechanism:` is returned if the Mechanism field is not provided in a scrape config and Promtail doesn't start.

**Which issue(s) this PR fixes**:
Not available

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
