### PR TITLE
Tools: add tool to determine which release (if any) a commit appears in

### DIFF
--- a/tools/which-release.sh
+++ b/tools/which-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+COMMIT=$1
+if [ -z "${COMMIT}" ]; then
+    echo "Usage: $0 <commit-ref>"
+    exit 2
+fi
+
+REMOTE=$(git remote -v | grep grafana/loki | awk '{print $1}' | head -n1)
+if [ -z "${REMOTE}" ]; then
+    echo "Could not find remote for grafana/loki"
+    exit 1
+fi
+
+RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release-" | sed "s|${REMOTE}/||")
+if [ -z "${RELEASES}" ]; then
+    echo "Commit was not found in any release"
+    exit 1
+fi
+
+
+echo "Commit was found in the following releases:"
+echo "${RELEASES}"

--- a/tools/which-release.sh
+++ b/tools/which-release.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 COMMIT=$1
-if [ -z "${COMMIT}" ]; then
+if [[ -z "${COMMIT}" ]]; then
     echo "Usage: $0 <commit-ref>"
     exit 2
 fi
 
 REMOTE=$(git remote -v | grep grafana/loki | awk '{print $1}' | head -n1)
-if [ -z "${REMOTE}" ]; then
+if [[ -z "${REMOTE}" ]]; then
     echo "Could not find remote for grafana/loki"
     exit 1
 fi
@@ -15,7 +15,7 @@ fi
 echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
 
 RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release-" | sed "s|${REMOTE}/||")
-if [ -z "${RELEASES}" ]; then
+if [[ -z "${RELEASES}" ]]; then
     echo "Commit was not found in any release"
     exit 1
 fi

--- a/tools/which-release.sh
+++ b/tools/which-release.sh
@@ -12,6 +12,8 @@ if [ -z "${REMOTE}" ]; then
     exit 1
 fi
 
+echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
+
 RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release-" | sed "s|${REMOTE}/||")
 if [ -z "${RELEASES}" ]; then
     echo "Commit was not found in any release"


### PR DESCRIPTION
I've often found myself needing to determine which release a particular PR appears in. This tool makes that easy, and it accepts the merge commit ref of the PR.

Example from https://github.com/grafana/loki/pull/7044, in which [a user is asking which version this feature appears in](https://github.com/grafana/loki/pull/7044#issuecomment-1455694087).

```bash
$ ./tools/which-release.sh 93a5a71                                 
Commit was found in the following releases:
  release-2.7.x
```