### PR TITLE
operator: Fix gateway's nodeSelector and tolerations

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8707](https://github.com/grafana/loki/pull/8707) **aminesnow**: Fix gateway's nodeSelector and tolerations
 - [8666](https://github.com/grafana/loki/pull/8666) **xperimental**: Fix version inconsistency in generated OpenShift bundle
 - [8578](https://github.com/grafana/loki/pull/8578) **xperimental**: Refactor status update to reduce API calls
 - [8577](https://github.com/grafana/loki/pull/8577) **Red-GV**: Store gateway tenant information in secret instead of configmap

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -198,6 +198,11 @@ func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 		},
 	}
 
+	if opts.Stack.Template != nil && opts.Stack.Template.Gateway != nil {
+		podSpec.Tolerations = opts.Stack.Template.Gateway.Tolerations
+		podSpec.NodeSelector = opts.Stack.Template.Gateway.NodeSelector
+	}
+
 	l := ComponentLabels(LabelGatewayComponent, opts.Name)
 	a := commonAnnotations(sha1C, opts.CertRotationRequiredAt)
 

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -54,6 +54,51 @@ func TestNewGatewayDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 	require.Equal(t, annotations[expected], sha1C)
 }
 
+func TestNewGatewayDeployment_HasNodeSelector(t *testing.T) {
+	toleration := []corev1.Toleration{
+		{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	selector := map[string]string{
+		"foo": "bar",
+	}
+	dpl := NewGatewayDeployment(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				Compactor: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Distributor: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Gateway: &lokiv1.LokiComponentSpec{
+					Replicas:     rand.Int31(),
+					NodeSelector: selector,
+					Tolerations:  toleration,
+				},
+				Ingester: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Querier: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				QueryFrontend: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+			},
+		},
+	}, "deadbeef")
+
+	require.Equal(t, dpl.Spec.Template.Spec.NodeSelector, selector)
+	require.ElementsMatch(t, dpl.Spec.Template.Spec.Tolerations, toleration)
+}
+
 func TestNewGatewayDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
 	sha1C := "deadbeef"
 	ss := NewGatewayDeployment(Options{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the problem of the `Gateway` not taking into account the `nodeSelector` and `tolerations` fields set by the `LokiStack`.

**Which issue(s) this PR fixes**:
Fixes [LOG-3713](https://issues.redhat.com/browse/LOG-3713)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
