### PR TITLE
loki chart: fix service/ingress mapping

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,7 +13,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
-- [BUGFIX] Fix service/Ingress mapping
+- [BUGFIX] Fix service/ingress mapping
 
 ## 4.8.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+- [BUGFIX] Fix service/Ingress mapping
+
 ## 4.8.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.6.2

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -441,9 +441,9 @@ Params:
 */}}
 {{- define "loki.ingress.serviceName" -}}
 {{- if (eq .svcName "singleBinary") }}
-{{- printf "%s" (include "loki.fullname" .ctx) }}
+{{- printf "%s" (include "loki.name" .ctx) }}
 {{- else }}
-{{- printf "%s-%s" (include "loki.fullname" .ctx) .svcName }}
+{{- printf "%s-%s" (include "loki.name" .ctx) .svcName }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If you currently deploy the Loki chart under a release name other than "loki" errors occur which is why loki is not accessible via Ingress.

The problem looks like this:

> $ k describe ingress xyz-loki-app
> Name:             xyz-loki-app
> Labels:           app.kubernetes.io/instance=xyz-loki-app
>                   app.kubernetes.io/managed-by=Helm
>                   app.kubernetes.io/name=loki
> [...]
> Rules:
>   Host                                      Path  Backends
>   ----                                      ----  --------
>   loki.example.com
>                                             /api/prom/tail              xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /loki/api/v1/tail           xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /loki/api                   xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /api/prom/rules             xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /loki/api/v1/rules          xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /prometheus/api/v1/rules    xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /prometheus/api/v1/alerts   xyz-loki-app-read:3100 (<error: endpoints "xyz-loki-app-read" not found>)
>                                             /api/prom/push              xyz-loki-app-write:3100 (<error: endpoints "xyz-loki-app-write" not found>)
>                                             /loki/api/v1/push           xyz-loki-app-write:3100 (<error: endpoints "xyz-loki-app-write" not found>)

The name of the services is: loki-read & loki-write.

I found [another PR with the same problem](https://github.com/grafana/loki/pull/8234) but with a different approach, so I would suggest here to solve the name problem without the question if .name or .fullname should be used. 

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
