### PR TITLE
Short circuit parsers

### DIFF
--- a/docs/sources/logql/log_queries/_index.md
+++ b/docs/sources/logql/log_queries/_index.md
@@ -285,7 +285,7 @@ For instance, the pipeline `| json` will produce the following mapping:
 
 In case of errors, for instance if the line is not in the expected format, the log line won't be filtered but instead will get a new `__error__` label added.
 
-If an extracted label key name already exists in the original log stream, the extracted label key will be suffixed with the `_extracted` keyword to make the distinction between the two labels. You can forcefully override the original label using a [label formatter expression](#labels-format-expression). However if an extracted key appears twice, only the latest label value will be kept.
+If an extracted label key name already exists in the original log stream, the extracted label key will be suffixed with the `_extracted` keyword to make the distinction between the two labels. You can forcefully override the original label using a [label formatter expression](#labels-format-expression). However, if an extracted key appears twice, only the first label value will be kept.
 
 Loki supports  [JSON](#json), [logfmt](#logfmt), [pattern](#pattern), [regexp](#regular-expression) and [unpack](#unpack) parsers.
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -35,6 +35,11 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ### Loki
 
+#### Change in LogQL behavior
+
+When there are duplicate labels in a log line, only the first value will be kept. Previously only the last value
+was kept
+
 #### Default retention_period has changed
 
 This change will affect you if you have:

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -38,7 +38,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 #### Change in LogQL behavior
 
 When there are duplicate labels in a log line, only the first value will be kept. Previously only the last value
-was kept
+was kept.
 
 #### Default retention_period has changed
 

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -240,7 +240,7 @@ func (b *LabelsBuilder) Set(n, v string) *LabelsBuilder {
 
 	// Sometimes labels are set and later modified. Only record
 	// each label once
-	b.parserKeyHints.RecordExtracted(n)
+	b.parserKeyHints.RecordExtracted()
 	return b
 }
 

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -93,6 +93,10 @@ type LabelsBuilder struct {
 
 // NewBaseLabelsBuilderWithGrouping creates a new base labels builder with grouping to compute results.
 func NewBaseLabelsBuilderWithGrouping(groups []string, parserKeyHints ParserHint, without, noLabels bool) *BaseLabelsBuilder {
+	if parserKeyHints == nil {
+		parserKeyHints = noParserHints
+	}
+
 	return &BaseLabelsBuilder{
 		del:            make([]string, 0, 5),
 		add:            make([]labels.Label, 0, 16),
@@ -137,6 +141,7 @@ func (b *LabelsBuilder) Reset() {
 	b.add = b.add[:0]
 	b.err = ""
 	b.errDetails = ""
+	b.parserKeyHints.Reset()
 }
 
 // ParserLabelHints returns a limited list of expected labels to extract for metric queries.
@@ -233,6 +238,9 @@ func (b *LabelsBuilder) Set(n, v string) *LabelsBuilder {
 	}
 	b.add = append(b.add, labels.Label{Name: n, Value: v})
 
+	// Sometimes labels are set and later modified. Only record
+	// each label once
+	b.parserKeyHints.RecordExtracted(n)
 	return b
 }
 

--- a/pkg/logql/log/labels.go
+++ b/pkg/logql/log/labels.go
@@ -240,7 +240,7 @@ func (b *LabelsBuilder) Set(n, v string) *LabelsBuilder {
 
 	// Sometimes labels are set and later modified. Only record
 	// each label once
-	b.parserKeyHints.RecordExtracted()
+	b.parserKeyHints.RecordExtracted(n)
 	return b
 }
 

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -50,7 +50,7 @@ type lineSampleExtractor struct {
 // Multiple log stages are run before converting the log line.
 func NewLineSampleExtractor(ex LineExtractor, stages []Stage, groups []string, without, noLabels bool) (SampleExtractor, error) {
 	s := ReduceStages(stages)
-	hints := newParserHint(s.RequiredLabelNames(), groups, without, noLabels, "")
+	hints := NewParserHint(s.RequiredLabelNames(), groups, without, noLabels, "")
 	return &lineSampleExtractor{
 		Stage:            s,
 		LineExtractor:    ex,
@@ -138,7 +138,7 @@ func LabelExtractorWithStages(
 		sort.Strings(groups)
 	}
 	preStage := ReduceStages(preStages)
-	hints := newParserHint(append(preStage.RequiredLabelNames(), postFilter.RequiredLabelNames()...), groups, without, noLabels, labelName)
+	hints := NewParserHint(append(preStage.RequiredLabelNames(), postFilter.RequiredLabelNames()...), groups, without, noLabels, labelName)
 	return &labelSampleExtractor{
 		preStage:         preStage,
 		conversionFn:     convFn,

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -66,6 +66,7 @@ func (j *JSONParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, 
 
 	if err := jsonparser.ObjectEach(line, j.parseObject); err != nil {
 		if errors.Is(err, errFoundAllLabels) {
+			// Short-circuited
 			return line, true
 		}
 
@@ -95,6 +96,8 @@ func (j *JSONParser) parseObject(key, value []byte, dataType jsonparser.ValueTyp
 	}
 
 	if j.lbs.ParserLabelHints().AllRequiredExtracted() {
+		// Not actually an error. Parsing can be short-circuited
+		// and this tells jsonparser to stop parsing
 		return errFoundAllLabels
 	}
 

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -362,10 +362,6 @@ func (l *PatternParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byt
 		}
 
 		lbs.Set(name, string(m))
-
-		if lbs.ParserLabelHints().AllRequiredExtracted() {
-			return line, true
-		}
 	}
 	return line, true
 }

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -244,6 +244,10 @@ func (r *RegexpParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 				if lbs.BaseHas(sanitize) {
 					sanitize = fmt.Sprintf("%s%s", sanitize, duplicateSuffix)
 				}
+				if !lbs.ParserLabelHints().ShouldExtract(sanitize) {
+					return "", false
+				}
+
 				return sanitize, true
 			})
 			if !ok {
@@ -280,14 +284,16 @@ func (l *LogfmtParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 	for l.dec.ScanKeyval() {
 		key, ok := l.keys.Get(l.dec.Key(), func() (string, bool) {
 			sanitized := sanitizeLabelKey(string(l.dec.Key()), true)
-			if !lbs.ParserLabelHints().ShouldExtract(sanitized) {
-				return "", false
-			}
 			if len(sanitized) == 0 {
 				return "", false
 			}
+
 			if lbs.BaseHas(sanitized) {
 				sanitized = fmt.Sprintf("%s%s", sanitized, duplicateSuffix)
+			}
+
+			if !lbs.ParserLabelHints().ShouldExtract(sanitized) {
+				return "", false
 			}
 			return sanitized, true
 		})
@@ -347,11 +353,12 @@ func (l *PatternParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byt
 	names := l.names[:len(matches)]
 	for i, m := range matches {
 		name := names[i]
-		if !lbs.parserKeyHints.ShouldExtract(name) {
-			continue
-		}
 		if lbs.BaseHas(name) {
 			name = name + duplicateSuffix
+		}
+
+		if !lbs.parserKeyHints.ShouldExtract(name) {
+			continue
 		}
 
 		lbs.Set(name, string(m))
@@ -450,7 +457,12 @@ func (l *LogfmtExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilde
 		if _, ok := l.expressions[key]; ok {
 			if lbs.BaseHas(key) {
 				key = key + duplicateSuffix
+				if !lbs.ParserLabelHints().ShouldExtract(key) {
+					// Don't extract duplicates if we don't have to
+					break
+				}
 			}
+
 			lbs.Set(key, string(val))
 
 			if lbs.ParserLabelHints().AllRequiredExtracted() {
@@ -542,18 +554,18 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 		}
 
 		identifier := j.ids[idx]
-		if !lbs.ParserLabelHints().ShouldExtract(identifier) {
-			// It's possible that something was asked for that
-			// shouldn't actually be extracted
-			return
-		}
-
 		key, _ := j.keys.Get(unsafeGetBytes(identifier), func() (string, bool) {
 			if lbs.BaseHas(identifier) {
 				identifier = identifier + duplicateSuffix
 			}
 			return identifier, true
 		})
+
+		if !lbs.ParserLabelHints().ShouldExtract(key) {
+			// It's possible that something was asked for that
+			// shouldn't actually be extracted
+			return
+		}
 
 		switch typ {
 		case jsonparser.Null:
@@ -647,14 +659,13 @@ func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) 
 				isPacked = true
 				return nil
 			}
-
 			key, ok := u.keys.Get(key, func() (string, bool) {
 				field := unsafeGetString(key)
-				if !lbs.ParserLabelHints().ShouldExtract(field) {
-					return "", false
-				}
 				if lbs.BaseHas(field) {
 					field = field + duplicateSuffix
+				}
+				if !lbs.ParserLabelHints().ShouldExtract(field) {
+					return "", false
 				}
 				return field, true
 			})

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -553,11 +553,6 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 			return
 		}
 
-		matches++
-		if lbs.ParserLabelHints().AllRequiredExtracted() {
-			return
-		}
-
 		identifier := j.ids[idx]
 		key, _ := j.keys.Get(unsafeGetBytes(identifier), func() (string, bool) {
 			if lbs.BaseHas(identifier) {
@@ -566,18 +561,14 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 			return identifier, true
 		})
 
-		if !lbs.ParserLabelHints().ShouldExtract(key) {
-			// It's possible that something was asked for that
-			// shouldn't actually be extracted
-			return
-		}
-
 		switch typ {
 		case jsonparser.Null:
 			lbs.Set(key, "")
 		default:
 			lbs.Set(key, unsafeGetString(data))
 		}
+
+		matches++
 	}, j.paths...)
 
 	// Ensure there's a label for every value

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -553,6 +553,11 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 			return
 		}
 
+		matches++
+		if lbs.ParserLabelHints().AllRequiredExtracted() {
+			return
+		}
+
 		identifier := j.ids[idx]
 		key, _ := j.keys.Get(unsafeGetBytes(identifier), func() (string, bool) {
 			if lbs.BaseHas(identifier) {
@@ -573,8 +578,6 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 		default:
 			lbs.Set(key, unsafeGetString(data))
 		}
-
-		matches++
 	}, j.paths...)
 
 	// Ensure there's a label for every value

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -29,7 +29,7 @@ type ParserHint interface {
 
 	// Holds state about what's already been extracted for the associated
 	// labels. This assumes that only required labels are ever extracted
-	RecordExtracted(key string)
+	RecordExtracted()
 	AllRequiredExtracted() bool
 	Reset()
 	// PreserveError returns true when parsing errors were specifically requested
@@ -72,7 +72,7 @@ func (p *parserHint) NoLabels() bool {
 	return p.noLabels || p.AllRequiredExtracted()
 }
 
-func (p *parserHint) RecordExtracted(key string) {
+func (p *parserHint) RecordExtracted() {
 	p.extracted++
 }
 

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var noParserHints = &parserHint{}
+var noParserHints = &Hints{}
 
 // ParserHint are hints given to LogQL parsers.
 // This is specially useful for parser that extract implicitly all possible label keys.
@@ -36,14 +36,14 @@ type ParserHint interface {
 	PreserveError() bool
 }
 
-type parserHint struct {
+type Hints struct {
 	noLabels            bool
 	requiredLabels      []string
 	shouldPreserveError bool
 	extracted      int
 }
 
-func (p *parserHint) ShouldExtract(key string) bool {
+func (p *Hints) ShouldExtract(key string) bool {
 	if len(p.requiredLabels) == 0 {
 		return true
 	}
@@ -55,7 +55,7 @@ func (p *parserHint) ShouldExtract(key string) bool {
 	return false
 }
 
-func (p *parserHint) ShouldExtractPrefix(prefix string) bool {
+func (p *Hints) ShouldExtractPrefix(prefix string) bool {
 	if len(p.requiredLabels) == 0 {
 		return true
 	}
@@ -68,32 +68,32 @@ func (p *parserHint) ShouldExtractPrefix(prefix string) bool {
 	return false
 }
 
-func (p *parserHint) NoLabels() bool {
+func (p *Hints) NoLabels() bool {
 	return p.noLabels || p.AllRequiredExtracted()
 }
 
-func (p *parserHint) RecordExtracted() {
+func (p *Hints) RecordExtracted() {
 	p.extracted++
 }
 
-func (p *parserHint) AllRequiredExtracted() bool {
+func (p *Hints) AllRequiredExtracted() bool {
 	if len(p.requiredLabels) == 0 {
 		return false
 	}
 	return p.extracted == len(p.requiredLabels)
 }
 
-func (p *parserHint) Reset() {
+func (p *Hints) Reset() {
 	p.extracted = 0
 }
 
 // NewParserHint creates a new parser hint using the list of labels that are seen and required in a query.
-func (p *parserHint) PreserveError() bool {
+func (p *Hints) PreserveError() bool {
 	return p.shouldPreserveError
 }
 
 // NewParserHint creates a new parser hint using the list of labels that are seen and required in a query.
-func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, metricLabelName string) *parserHint {
+func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, metricLabelName string) *Hints {
 	hints := make([]string, 0, 2*(len(requiredLabelNames)+len(groups)+1))
 	hints = appendLabelHints(hints, requiredLabelNames...)
 	hints = appendLabelHints(hints, groups...)
@@ -102,9 +102,9 @@ func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, 
 
 	if noLabels {
 		if len(hints) > 0 {
-			return &parserHint{requiredLabels: hints, shouldPreserveError: containsError(hints)}
+			return &Hints{requiredLabels: hints, shouldPreserveError: containsError(hints)}
 		}
-		return &parserHint{noLabels: true}
+		return &Hints{noLabels: true}
 	}
 	// we don't know what is required when a without clause is used.
 	// Same is true when there's no grouping.
@@ -112,7 +112,7 @@ func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, 
 	if without || len(groups) == 0 {
 		return noParserHints
 	}
-	return &parserHint{requiredLabels: hints, shouldPreserveError: containsError(hints)}
+	return &Hints{requiredLabels: hints, shouldPreserveError: containsError(hints)}
 }
 
 func containsError(hints []string) bool {

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -236,13 +236,13 @@ func Test_ParserHints(t *testing.T) {
 
 func TestRecordingExtractedLabels(t *testing.T) {
 	p := log.NewParserHint([]string{"1", "2", "3"}, nil, false, true, "")
-	p.RecordExtracted("1")
-	p.RecordExtracted("2")
+	p.RecordExtracted()
+	p.RecordExtracted()
 
 	require.False(t, p.AllRequiredExtracted())
 	require.False(t, p.NoLabels())
 
-	p.RecordExtracted("3")
+	p.RecordExtracted()
 
 	require.True(t, p.AllRequiredExtracted())
 	require.True(t, p.NoLabels())

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -236,13 +236,13 @@ func Test_ParserHints(t *testing.T) {
 
 func TestRecordingExtractedLabels(t *testing.T) {
 	p := log.NewParserHint([]string{"1", "2", "3"}, nil, false, true, "")
-	p.RecordExtracted()
-	p.RecordExtracted()
+	p.RecordExtracted("1")
+	p.RecordExtracted("2")
 
 	require.False(t, p.AllRequiredExtracted())
 	require.False(t, p.NoLabels())
 
-	p.RecordExtracted()
+	p.RecordExtracted("3")
 
 	require.True(t, p.AllRequiredExtracted())
 	require.True(t, p.NoLabels())

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -2,6 +2,7 @@
 package log_test
 
 import (
+	"github.com/grafana/loki/pkg/logql/log"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -231,4 +232,22 @@ func Test_ParserHints(t *testing.T) {
 			require.Equal(t, tt.expectLbs, lbsResString)
 		})
 	}
+}
+
+func TestRecordingExtractedLabels(t *testing.T) {
+	p := log.NewParserHint([]string{"1", "2", "3"}, nil, false, true, "")
+	p.RecordExtracted("1")
+	p.RecordExtracted("2")
+
+	require.False(t, p.AllRequiredExtracted())
+	require.False(t, p.NoLabels())
+
+	p.RecordExtracted("3")
+
+	require.True(t, p.AllRequiredExtracted())
+	require.True(t, p.NoLabels())
+
+	p.Reset()
+	require.False(t, p.AllRequiredExtracted())
+	require.False(t, p.NoLabels())
 }

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -156,14 +156,6 @@ func TestKeyShortCircuit(t *testing.T) {
 		{"json", NewJSONParser(), simpleJsn},
 		{"logfmt", NewLogfmtParser(), logFmt},
 		{"logfmt-expression", mustStage(NewLogfmtExpressionParser([]LabelExtractionExpr{NewLabelExtractionExpr("name", "name")})), logFmt},
-		{"pattern", mustStage(NewPatternParser(`<data> <size> <style> <name> <hOffset> <_>`)), logFmt},
-		{"json-expression", mustStage(NewJSONExpressionParser([]LabelExtractionExpr{
-			NewLabelExtractionExpr("data", "data"),
-			NewLabelExtractionExpr("size", "size"),
-			NewLabelExtractionExpr("style", "style"),
-			NewLabelExtractionExpr("name", "name"),
-			NewLabelExtractionExpr("onMouseUp", "onMouseUp"),
-		})), simpleJsn},
 	}
 	for _, tt := range tests {
 		lbs.Reset()

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -137,12 +137,13 @@ func TestKeyShortCircuit(t *testing.T) {
       "size": 36,
       "style": "bold",
       "name": "text1",
+      "name": "duplicate",
       "hOffset": 250,
       "vOffset": 100,
       "alignment": "center",
       "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
     }`)
-	logFmt := []byte(`data="ClickHere" size=36 style=bold name=text1 hOffset=250 vOffset=100 alignment=center onMouseUp="sun1.opacity = (sun1.opacity / 100) * 90;"`)
+	logFmt := []byte(`data="ClickHere" size=36 style=bold name=text1 name=duplicate hOffset=250 vOffset=100 alignment=center onMouseUp="sun1.opacity = (sun1.opacity / 100) * 90;"`)
 
 	hints := &fakeParseHints{label: "name"}
 	lbs := NewBaseLabelsBuilder().ForLabels(labels.Labels{}, 0)
@@ -186,7 +187,7 @@ func (p *fakeParseHints) ShouldExtractPrefix(prefix string) bool {
 func (p *fakeParseHints) NoLabels() bool {
 	return false
 }
-func (p *fakeParseHints) RecordExtracted() {
+func (p *fakeParseHints) RecordExtracted(_ string) {
 	p.count++
 }
 func (p *fakeParseHints) AllRequiredExtracted() bool {

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -100,7 +100,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 				{Name: "__error_details__", Value: "Value looks like object, but can't find closing '}' symbol"},
 				{Name: "__preserve_error__", Value: "true"},
 			},
-			newParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, ""),
 		},
 		{
 			"duplicate extraction",
@@ -196,6 +196,9 @@ func (p *fakeParseHints) AllRequiredExtracted() bool {
 func (p *fakeParseHints) Reset() {
 	p.checkCount = 0
 	p.count = 0
+}
+func (p *fakeParseHints) PreserveError() bool {
+	return false
 }
 
 func TestJSONExpressionParser(t *testing.T) {
@@ -465,7 +468,7 @@ func TestJSONExpressionParser(t *testing.T) {
 				{Name: logqlmodel.ErrorLabel, Value: errJSON},
 				{Name: logqlmodel.PreserveErrorLabel, Value: "true"},
 			},
-			newParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, ""),
 		},
 		{
 			"empty line",
@@ -762,7 +765,7 @@ func Test_logfmtParser_Parse(t *testing.T) {
 				{Name: "__error_details__", Value: "logfmt syntax error at pos 8 : unexpected '='"},
 				{Name: "__preserve_error__", Value: "true"},
 			},
-			newParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, ""),
 		},
 		{
 			"utf8 error rune",
@@ -1139,7 +1142,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				{Name: "__preserve_error__", Value: "true"},
 			},
 			[]byte(`"app":"foo","namespace":"prod","_entry":"some message","pod":{"uid":"1"}`),
-			newParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, ""),
 		},
 		{
 			"not a map",

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -624,12 +624,6 @@ func BenchmarkKeyExtraction(b *testing.B) {
 		{"json", NewJSONParser(), simpleJsn},
 		{"logfmt", NewLogfmtParser(), logFmt},
 		{"logfmt-expression", mustStage(NewLogfmtExpressionParser([]LabelExtractionExpr{NewLabelExtractionExpr("name", "name")})), logFmt},
-		{"pattern", mustStage(NewPatternParser(`<_> <style> <name> <hOffset> <_>`)), logFmt},
-		{"json-expression", mustStage(NewJSONExpressionParser([]LabelExtractionExpr{
-			NewLabelExtractionExpr("size", "size"),
-			NewLabelExtractionExpr("name", "name"),
-			NewLabelExtractionExpr("onMouseUp", "onMouseUp"),
-		})), simpleJsn},
 	}
 	for _, bb := range benchmarks {
 		b.Run(bb.name, func(b *testing.B) {


### PR DESCRIPTION
In many cases we only need a few labels from a line. Because most of our parsers parse lines incrementally, we can stop parsing a line after we have all the labels we want from it.

This pr uses `ParserHints` to keep track of the number of extracted labels. It also provides a way for parsers to know when they should stop parsing.  

Notes:
- parsers had inconsistent ordering between the `ShouldExtract` call and adding the `_extracted` label to duplicates. This PR makes appending `_extracted` always happen before `ShouldExtract` to keep counts of what is extracted compared to expected labels consistent.

Next Steps:
- When the user specifies a query with a grouping containing the `_extracted` label but there is no duplicate between the passed line and labels, short circuiting will not work. I'll address this in a follow up PR.

Benchmarks:
To try and show a balanced view of what this buys us, this pr picks a label our of the middle of a line. In a best case this might be much better. In the worst case, we have to parse the whole line.

```
benchstat short_circuit_old.txt short_circuit_new.txt
name                               old time/op    new time/op    delta
KeyExtraction/json-8                  456ns ± 3%     256ns ± 2%  -43.84%  (p=0.000 n=9+10)
KeyExtraction/logfmt-8                347ns ± 4%     171ns ± 2%  -50.86%  (p=0.000 n=10+10)
KeyExtraction/logfmt-expression-8     552ns ± 2%     368ns ± 2%  -33.23%  (p=0.000 n=9+10)

name                               old alloc/op   new alloc/op   delta
KeyExtraction/json-8                  5.00B ± 0%     5.00B ± 0%     ~     (all equal)
KeyExtraction/logfmt-8                5.00B ± 0%     5.00B ± 0%     ~     (all equal)
KeyExtraction/logfmt-expression-8     16.0B ± 0%     16.0B ± 0%     ~     (all equal)

name                               old allocs/op  new allocs/op  delta
KeyExtraction/json-8                   1.00 ± 0%      1.00 ± 0%     ~     (all equal)
KeyExtraction/logfmt-8                 1.00 ± 0%      1.00 ± 0%     ~     (all equal)
KeyExtraction/logfmt-expression-8      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```
