### PR TITLE
[Docs] Fixing broken link.

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -377,8 +377,9 @@ scrape_configs:
         target_label: message_key
 ```
 
-Only the `brokers` and `topics` is required.
-see the [configuration](../../configuration/#kafka) section for more information.
+Only the `brokers` and `topics` are required.
+Read the [configuration]({{< relref "configuration/#kafka" >}}) section for more information.
+
 
 ## GELF
 


### PR DESCRIPTION
Manual backport for #8688 to 2.7.x branch.
