### PR TITLE
Reimplement Unpack in terms of jsonparser rather than jsoniter

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"unicode/utf8"
 
 	"github.com/buger/jsonparser"
@@ -518,11 +517,9 @@ func (u *UnpackParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 	if lbs.ParserLabelHints().NoLabels() {
 		return line, true
 	}
-	u.lbsBuffer = u.lbsBuffer[:0]
-	it := jsoniter.ConfigFastest.BorrowIterator(line)
-	defer jsoniter.ConfigFastest.ReturnIterator(it)
 
-	entry, err := u.unpack(it, line, lbs)
+	u.lbsBuffer = u.lbsBuffer[:0]
+	entry, err := u.unpack(line, lbs)
 	if err != nil {
 		lbs.SetErr(errJSON)
 		lbs.SetErrorDetails(err.Error())
@@ -531,25 +528,31 @@ func (u *UnpackParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 	return entry, true
 }
 
-func (u *UnpackParser) unpack(it *jsoniter.Iterator, entry []byte, lbs *LabelsBuilder) ([]byte, error) {
+func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) {
 	// we only care about object and values.
-	if nextType := it.WhatIsNext(); nextType != jsoniter.ObjectValue {
+	if entry[0] != '{' {
 		return nil, errUnexpectedJSONObject
 	}
+
 	var isPacked bool
-	_ = it.ReadMapCB(func(iter *jsoniter.Iterator, field string) bool {
-		switch iter.WhatIsNext() {
-		case jsoniter.StringValue:
-			// we only unpack map[string]string. Anything else is skipped.
-			if field == logqlmodel.PackedEntryKey {
-				// todo(ctovena): we should just reslice the original line since the property is contiguous
-				// but jsoniter doesn't allow us to do this right now.
-				// https://github.com/buger/jsonparser might do a better job at this.
-				entry = []byte(iter.ReadString())
+	err := jsonparser.ObjectEach(entry, func(key, value []byte, typ jsonparser.ValueType, _ int) error {
+		switch typ {
+		case jsonparser.String:
+			if unsafeGetString(key) == logqlmodel.PackedEntryKey {
+				// Inlined bytes escape to save allocs
+				var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
+				bU, err := jsonparser.Unescape(value, stackbuf[:])
+				if err != nil {
+					return err
+				}
+
+				entry = bU
 				isPacked = true
-				return true
+				return nil
 			}
-			key, ok := u.keys.Get(unsafeGetBytes(field), func() (string, bool) {
+
+			key, ok := u.keys.Get(key, func() (string, bool) {
+				field := unsafeGetString(key)
 				if !lbs.ParserLabelHints().ShouldExtract(field) {
 					return "", false
 				}
@@ -559,20 +562,22 @@ func (u *UnpackParser) unpack(it *jsoniter.Iterator, entry []byte, lbs *LabelsBu
 				return field, true
 			})
 			if !ok {
-				iter.Skip()
-				return true
+				return nil
 			}
 
 			// append to the buffer of labels
-			u.lbsBuffer = append(u.lbsBuffer, key, iter.ReadString())
+			u.lbsBuffer = append(u.lbsBuffer, key, unescapeJSONString(value))
 		default:
-			iter.Skip()
+			return nil
 		}
-		return true
+
+		return nil
 	})
-	if it.Error != nil && it.Error != io.EOF {
-		return nil, it.Error
+
+	if err != nil {
+		return nil, err
 	}
+
 	// flush the buffer if we found a packed entry.
 	if isPacked {
 		for i := 0; i < len(u.lbsBuffer); i = i + 2 {

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -978,8 +978,8 @@ func Test_unpackParser_Parse(t *testing.T) {
 			l, _ := j.Process(0, tt.line, b)
 			sort.Sort(tt.wantLbs)
 			require.Equal(t, tt.wantLbs, b.LabelsResult().Labels())
-			require.Equal(t, tt.wantLine, l)
 			require.Equal(t, string(tt.wantLine), string(l))
+			require.Equal(t, tt.wantLine, l)
 			require.Equal(t, copy, string(tt.line), "the original log line should not be mutated")
 		})
 	}


### PR DESCRIPTION
This PR reimplements the functionality  of `Unpack` using the `jsonparser` library rather than `jsoniter` 

Benchmarks:
```
name                                            old time/op    new time/op    delta
_Parser/unpack/no_labels_hints-8                   900ns ± 4%     309ns ± 3%  -65.62%  (p=0.000 n=10+10)
_Parser/unpack/labels_hints-8                     1.06µs ±12%    0.32µs ± 2%  -69.72%  (p=0.000 n=9+10)
_Parser/unpack-not_json_line/no_labels_hints-8    37.5ns ± 8%    10.6ns ± 3%  -71.70%  (p=0.000 n=9+9)
_Parser/unpack-not_json_line/labels_hints-8       39.6ns ±11%    10.3ns ± 2%  -74.00%  (p=0.000 n=10+9)

name                                            old alloc/op   new alloc/op   delta
_Parser/unpack/no_labels_hints-8                    536B ± 0%       80B ± 0%  -85.07%  (p=0.000 n=10+10)
_Parser/unpack/labels_hints-8                       536B ± 0%       80B ± 0%  -85.07%  (p=0.000 n=10+10)
_Parser/unpack-not_json_line/no_labels_hints-8     0.00B          0.00B          ~     (all equal)
_Parser/unpack-not_json_line/labels_hints-8        0.00B          0.00B          ~     (all equal)

name                                            old allocs/op  new allocs/op  delta
_Parser/unpack/no_labels_hints-8                    17.0 ± 0%       4.0 ± 0%  -76.47%  (p=0.000 n=10+10)
_Parser/unpack/labels_hints-8                       17.0 ± 0%       4.0 ± 0%  -76.47%  (p=0.000 n=10+10)
_Parser/unpack-not_json_line/no_labels_hints-8      0.00           0.00          ~     (all equal)
_Parser/unpack-not_json_line/labels_hints-8         0.00           0.00          ~     (all equal)
```
