### PR TITLE
tsdb: sample chunk info from tsdb index to limit the amount of chunkrefs we read from index

### DIFF
--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -48,7 +48,7 @@ func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableN
 	}()
 
 	builder := NewBuilder()
-	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		builder.AddSeries(lbls.Copy(), fp, chks)
 	}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
 	if err != nil {
@@ -197,7 +197,7 @@ func setupBuilder(ctx context.Context, userID string, sourceIndexSet compactor.I
 
 	// add users index from multi-tenant indexes to the builder
 	for _, idx := range multiTenantIndexes {
-		err := idx.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+		err := idx.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 			builder.AddSeries(withoutTenantLabel(lbls.Copy()), fp, chks)
 		}, withTenantLabelMatcher(userID, []*labels.Matcher{})...)
 		if err != nil {
@@ -229,7 +229,7 @@ func setupBuilder(ctx context.Context, userID string, sourceIndexSet compactor.I
 			}
 		}()
 
-		err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
+		err = indexFile.(*TSDBFile).Index.(*TSDBIndex).forSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 			builder.AddSeries(lbls.Copy(), fp, chks)
 		}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
 		if err != nil {

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -747,7 +748,7 @@ func (t *tenantHeads) forAll(fn func(user string, ls labels.Labels, fp uint64, c
 					chks []index.ChunkMeta
 				)
 
-				fp, err := idx.Series(ps.At(), &ls, &chks)
+				fp, err := idx.Series(ps.At(), 0, math.MaxInt64, &ls, &chks)
 
 				if err != nil {
 					return errors.Wrapf(err, "iterating postings for tenant: %s", user)

--- a/pkg/storage/stores/tsdb/head_read.go
+++ b/pkg/storage/stores/tsdb/head_read.go
@@ -133,17 +133,15 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int6
 
 	queryBounds := newBounds(model.Time(from), model.Time(through))
 
+	*chks = (*chks)[:0]
 	s.Lock()
-	filteredChks := make([]index.ChunkMeta, 0, len(s.chks))
 	for _, chk := range s.chks {
 		if !Overlap(chk, queryBounds) {
 			continue
 		}
-		filteredChks = append(filteredChks, chk)
+		*chks = append(*chks, chk)
 	}
 	s.Unlock()
-
-	*chks = append((*chks)[:0], filteredChks...)
 
 	return s.fp, nil
 }

--- a/pkg/storage/stores/tsdb/index/index_test.go
+++ b/pkg/storage/stores/tsdb/index/index_test.go
@@ -17,20 +17,23 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/grafana/loki/pkg/util/encoding"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/tsdb/encoding"
+	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -185,7 +188,7 @@ func TestIndexRW_Postings(t *testing.T) {
 	var c []ChunkMeta
 
 	for i := 0; p.Next(); i++ {
-		_, err := ir.Series(p.At(), &l, &c)
+		_, err := ir.Series(p.At(), 0, math.MaxInt64, &l, &c)
 
 		require.NoError(t, err)
 		require.Equal(t, 0, len(c))
@@ -200,7 +203,7 @@ func TestIndexRW_Postings(t *testing.T) {
 			return errors.Errorf("unexpected key length for label indices table %d", len(key))
 		}
 
-		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
+		d := tsdb_enc.NewDecbufAt(ir.b, int(off), castagnoliTable)
 		vals := []string{}
 		nc := d.Be32int()
 		if nc != 1 {
@@ -304,7 +307,7 @@ func TestPostingsMany(t *testing.T) {
 		var lbls labels.Labels
 		var metas []ChunkMeta
 		for it.Next() {
-			_, err := ir.Series(it.At(), &lbls, &metas)
+			_, err := ir.Series(it.At(), 0, math.MaxInt64, &lbls, &metas)
 			require.NoError(t, err)
 			got = append(got, lbls.Get("i"))
 		}
@@ -420,7 +423,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 
 			ref := gotp.At()
 
-			_, err := ir.Series(ref, &lset, &chks)
+			_, err := ir.Series(ref, 0, math.MaxInt64, &lset, &chks)
 			require.NoError(t, err)
 
 			err = mi.Series(expp.At(), &explset, &expchks)
@@ -467,7 +470,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
 	b := RealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 
-	db := encoding.NewDecbufUvarintAt(b, 0, castagnoliTable)
+	db := tsdb_enc.NewDecbufUvarintAt(b, 0, castagnoliTable)
 	require.Error(t, db.Err())
 }
 
@@ -543,4 +546,396 @@ func TestSymbols(t *testing.T) {
 func TestDecoder_Postings_WrongInput(t *testing.T) {
 	_, _, err := (&Decoder{}).Postings([]byte("the cake is a lie"))
 	require.Error(t, err)
+}
+
+func TestDecoder_ChunkSamples(t *testing.T) {
+	dir := t.TempDir()
+
+	lbls := []labels.Labels{
+		{{Name: "fizz", Value: "buzz"}},
+		{{Name: "ping", Value: "pong"}},
+	}
+
+	symbols := map[string]struct{}{}
+	for _, lset := range lbls {
+		for _, l := range lset {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		}
+	}
+
+	now := model.Now()
+
+	for name, tc := range map[string]struct {
+		chunkMetas           []ChunkMeta
+		expectedChunkSamples []chunkSample
+	}{
+		"no overlapping chunks": {
+			chunkMetas: []ChunkMeta{
+				{
+					MinTime: int64(now),
+					MaxTime: int64(now.Add(30 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(40 * time.Minute)),
+					MaxTime: int64(now.Add(80 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(90 * time.Minute)),
+					MaxTime: int64(now.Add(120 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(130 * time.Minute)),
+					MaxTime: int64(now.Add(150 * time.Minute)),
+				},
+			},
+			expectedChunkSamples: []chunkSample{
+				{
+					largestMaxt:   int64(now.Add(30 * time.Minute)),
+					idx:           0,
+					prevChunkMaxt: 0,
+				},
+				{
+					largestMaxt:   int64(now.Add(120 * time.Minute)),
+					idx:           2,
+					prevChunkMaxt: int64(now.Add(80 * time.Minute)),
+				},
+				{
+					largestMaxt:   int64(now.Add(150 * time.Minute)),
+					idx:           3,
+					prevChunkMaxt: int64(now.Add(120 * time.Minute)),
+				},
+			},
+		},
+		"overlapping chunks": {
+			chunkMetas: []ChunkMeta{
+				{
+					MinTime: int64(now),
+					MaxTime: int64(now.Add(30 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(20 * time.Minute)),
+					MaxTime: int64(now.Add(80 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(70 * time.Minute)),
+					MaxTime: int64(now.Add(120 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(100 * time.Minute)),
+					MaxTime: int64(now.Add(110 * time.Minute)),
+				},
+			},
+			expectedChunkSamples: []chunkSample{
+				{
+					largestMaxt:   int64(now.Add(30 * time.Minute)),
+					idx:           0,
+					prevChunkMaxt: 0,
+				},
+				{
+					largestMaxt:   int64(now.Add(120 * time.Minute)),
+					idx:           2,
+					prevChunkMaxt: int64(now.Add(80 * time.Minute)),
+				},
+				{
+					largestMaxt:   int64(now.Add(120 * time.Minute)),
+					idx:           3,
+					prevChunkMaxt: int64(now.Add(120 * time.Minute)),
+				},
+			},
+		},
+		"first chunk overlapping all chunks": {
+			chunkMetas: []ChunkMeta{
+				{
+					MinTime: int64(now),
+					MaxTime: int64(now.Add(180 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(20 * time.Minute)),
+					MaxTime: int64(now.Add(80 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(70 * time.Minute)),
+					MaxTime: int64(now.Add(120 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(110 * time.Minute)),
+					MaxTime: int64(now.Add(150 * time.Minute)),
+				},
+			},
+			expectedChunkSamples: []chunkSample{
+				{
+					largestMaxt:   int64(now.Add(180 * time.Minute)),
+					idx:           0,
+					prevChunkMaxt: 0,
+				},
+				{
+					largestMaxt:   int64(now.Add(180 * time.Minute)),
+					idx:           3,
+					prevChunkMaxt: int64(now.Add(120 * time.Minute)),
+				},
+			},
+		},
+		"large gaps between chunks": {
+			chunkMetas: []ChunkMeta{
+				{
+					MinTime: int64(now),
+					MaxTime: int64(now.Add(30 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(200 * time.Minute)),
+					MaxTime: int64(now.Add(280 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(500 * time.Minute)),
+					MaxTime: int64(now.Add(520 * time.Minute)),
+				},
+				{
+					MinTime: int64(now.Add(800 * time.Minute)),
+					MaxTime: int64(now.Add(835 * time.Minute)),
+				},
+			},
+			expectedChunkSamples: []chunkSample{
+				{
+					largestMaxt:   int64(now.Add(30 * time.Minute)),
+					idx:           0,
+					prevChunkMaxt: 0,
+				},
+				{
+					largestMaxt:   int64(now.Add(280 * time.Minute)),
+					idx:           1,
+					prevChunkMaxt: int64(now.Add(30 * time.Minute)),
+				},
+				{
+					largestMaxt:   int64(now.Add(520 * time.Minute)),
+					idx:           2,
+					prevChunkMaxt: int64(now.Add(280 * time.Minute)),
+				},
+				{
+					largestMaxt:   int64(now.Add(835 * time.Minute)),
+					idx:           3,
+					prevChunkMaxt: int64(now.Add(520 * time.Minute)),
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			iw, err := NewWriter(context.Background(), filepath.Join(dir, name))
+			require.NoError(t, err)
+
+			syms := []string{}
+			for s := range symbols {
+				syms = append(syms, s)
+			}
+			sort.Strings(syms)
+			for _, s := range syms {
+				require.NoError(t, iw.AddSymbol(s))
+			}
+
+			for i, l := range lbls {
+				err = iw.AddSeries(storage.SeriesRef(i), l, model.Fingerprint(l.Hash()), tc.chunkMetas...)
+				require.NoError(t, err)
+			}
+
+			err = iw.Close()
+			require.NoError(t, err)
+
+			ir, err := NewFileReader(filepath.Join(dir, name))
+			require.NoError(t, err)
+
+			postings, err := ir.Postings("fizz", nil, "buzz")
+			require.NoError(t, err)
+
+			require.True(t, postings.Next())
+			var lset labels.Labels
+			var chks []ChunkMeta
+
+			// there should be no chunk samples
+			require.Nil(t, ir.dec.chunksSample[postings.At()])
+
+			// read series so that chunk samples get built
+			_, err = ir.Series(postings.At(), 0, math.MaxInt64, &lset, &chks)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.chunkMetas, chks)
+			require.Equal(t, lset, lbls[0])
+
+			// there should be chunk samples for only the series we read
+			require.Len(t, ir.dec.chunksSample, 1)
+			require.NotNil(t, ir.dec.chunksSample[postings.At()])
+			require.Len(t, ir.dec.chunksSample[postings.At()].chunks, len(tc.expectedChunkSamples))
+
+			// build decoder for the series we read to verify the samples
+			offset := postings.At() * 16
+			d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(ir.b, int(offset), castagnoliTable))
+			require.NoError(t, d.Err())
+
+			// read chunk metadata to positing the decoder at the beginning of first chunk
+			d.Be64()
+			k := d.Uvarint()
+
+			for i := 0; i < k; i++ {
+				d.Uvarint()
+				d.Uvarint()
+			}
+			require.Equal(t, len(tc.chunkMetas), d.Uvarint())
+			for i, cs := range ir.dec.chunksSample[postings.At()].chunks {
+				require.Equal(t, tc.expectedChunkSamples[i].idx, cs.idx)
+				require.Equal(t, tc.expectedChunkSamples[i].largestMaxt, cs.largestMaxt)
+				require.Equal(t, tc.expectedChunkSamples[i].prevChunkMaxt, cs.prevChunkMaxt)
+
+				dw := encoding.DecWrap(tsdb_enc.Decbuf{B: d.Get()})
+				dw.Skip(cs.offset)
+				chunkMeta := ChunkMeta{}
+				require.NoError(t, readChunkMeta(&dw, cs.prevChunkMaxt, &chunkMeta))
+				require.Equal(t, tc.chunkMetas[tc.expectedChunkSamples[i].idx], chunkMeta)
+			}
+
+			require.NoError(t, ir.Close())
+		})
+	}
+}
+
+func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
+	for name, tc := range map[string]struct {
+		chunkSamples           chunkSamples
+		queryMint              int64
+		expectedChunkSampleIdx int
+	}{
+		"mint greater than largestMaxt": {
+			chunkSamples: chunkSamples{
+				chunks: []chunkSample{
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+					{
+						largestMaxt:   200,
+						idx:           5,
+						offset:        5,
+						prevChunkMaxt: 50,
+					},
+				},
+			},
+			queryMint:              250,
+			expectedChunkSampleIdx: -1,
+		},
+		"mint smaller than first largestMaxt": {
+			chunkSamples: chunkSamples{
+				chunks: []chunkSample{
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+					{
+						largestMaxt:   200,
+						idx:           5,
+						offset:        5,
+						prevChunkMaxt: 50,
+					},
+				},
+			},
+			queryMint:              50,
+			expectedChunkSampleIdx: 0,
+		},
+		"intermediate chunk sample": {
+			chunkSamples: chunkSamples{
+				chunks: []chunkSample{
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+					{
+						largestMaxt:   200,
+						idx:           5,
+						offset:        5,
+						prevChunkMaxt: 50,
+					},
+					{
+						largestMaxt:   350,
+						idx:           7,
+						offset:        7,
+						prevChunkMaxt: 150,
+					},
+					{
+						largestMaxt:   500,
+						idx:           9,
+						offset:        9,
+						prevChunkMaxt: 250,
+					},
+				},
+			},
+			queryMint:              250,
+			expectedChunkSampleIdx: 1,
+		},
+		"mint matching samples largestMaxt": {
+			chunkSamples: chunkSamples{
+				chunks: []chunkSample{
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+					{
+						largestMaxt:   200,
+						idx:           5,
+						offset:        5,
+						prevChunkMaxt: 50,
+					},
+					{
+						largestMaxt:   350,
+						idx:           7,
+						offset:        7,
+						prevChunkMaxt: 150,
+					},
+					{
+						largestMaxt:   500,
+						idx:           9,
+						offset:        9,
+						prevChunkMaxt: 250,
+					},
+				},
+			},
+			queryMint:              350,
+			expectedChunkSampleIdx: 1,
+		},
+		"same chunk sampled": {
+			chunkSamples: chunkSamples{
+				chunks: []chunkSample{
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+					{
+						largestMaxt:   100,
+						idx:           0,
+						offset:        0,
+						prevChunkMaxt: 0,
+					},
+				},
+			},
+			queryMint:              50,
+			expectedChunkSampleIdx: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			chunkSample := tc.chunkSamples.getChunkSampleForQueryStarting(tc.queryMint)
+			if tc.expectedChunkSampleIdx == -1 {
+				require.Nil(t, chunkSample)
+				return
+			}
+
+			require.NotNil(t, chunkSample)
+			require.Equal(t, tc.chunkSamples.chunks[tc.expectedChunkSampleIdx], *chunkSample)
+		})
+	}
 }

--- a/pkg/storage/stores/tsdb/index/index_test.go
+++ b/pkg/storage/stores/tsdb/index/index_test.go
@@ -798,12 +798,12 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 
 func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 	for name, tc := range map[string]struct {
-		chunkSamples           chunkSamples
+		chunkSamples           *chunkSamples
 		queryMint              int64
 		expectedChunkSampleIdx int
 	}{
 		"mint greater than largestMaxt": {
-			chunkSamples: chunkSamples{
+			chunkSamples: &chunkSamples{
 				chunks: []chunkSample{
 					{
 						largestMaxt:   100,
@@ -823,7 +823,7 @@ func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 			expectedChunkSampleIdx: -1,
 		},
 		"mint smaller than first largestMaxt": {
-			chunkSamples: chunkSamples{
+			chunkSamples: &chunkSamples{
 				chunks: []chunkSample{
 					{
 						largestMaxt:   100,
@@ -843,7 +843,7 @@ func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 			expectedChunkSampleIdx: 0,
 		},
 		"intermediate chunk sample": {
-			chunkSamples: chunkSamples{
+			chunkSamples: &chunkSamples{
 				chunks: []chunkSample{
 					{
 						largestMaxt:   100,
@@ -875,7 +875,7 @@ func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 			expectedChunkSampleIdx: 1,
 		},
 		"mint matching samples largestMaxt": {
-			chunkSamples: chunkSamples{
+			chunkSamples: &chunkSamples{
 				chunks: []chunkSample{
 					{
 						largestMaxt:   100,
@@ -907,7 +907,7 @@ func TestChunkSamples_getChunkSampleForQueryStarting(t *testing.T) {
 			expectedChunkSampleIdx: 1,
 		},
 		"same chunk sampled": {
-			chunkSamples: chunkSamples{
+			chunkSamples: &chunkSamples{
 				chunks: []chunkSample{
 					{
 						largestMaxt:   100,

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -204,15 +204,13 @@ func (c *IndexClient) Stats(ctx context.Context, userID string, from, through mo
 		acc = &stats.Stats{}
 	}
 
-	queryBounds := newBounds(from, through)
-
 	for idx, interval := range intervals {
 		if err := c.idx.Stats(ctx, userID, interval.Start, interval.End, acc, shard, func(chk index.ChunkMeta) bool {
 			// for the first split, purely do overlap check to also include chunks having
 			// start time earlier than start time of the table interval we are querying.
 			// for all other splits, consider only chunks that have from >= interval.Start
 			// so that we start after the start time of the index table we are querying.
-			if Overlap(queryBounds, chk) && (idx == 0 || chk.From() >= interval.Start) {
+			if idx == 0 || chk.From() >= interval.Start {
 				return true
 			}
 			return false

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -163,8 +163,8 @@ func TestIndexClient_Stats(t *testing.T) {
 				Start: indexStartYesterday,
 				End:   indexStartToday + 1000,
 			},
-			expectedNumChunks:  298, // 2 chunks not included at indexStartYesterday since start time is not inclusive
-			expectedNumEntries: 298,
+			expectedNumChunks:  300,
+			expectedNumEntries: 300,
 			expectedNumStreams: 2,
 		},
 		{
@@ -173,8 +173,8 @@ func TestIndexClient_Stats(t *testing.T) {
 				Start: indexStartToday,
 				End:   indexStartToday + 1000,
 			},
-			expectedNumChunks:  99, // 1 chunk not included at indexStartToday since start time is not inclusive
-			expectedNumEntries: 99,
+			expectedNumChunks:  100,
+			expectedNumEntries: 100,
 			expectedNumStreams: 1,
 		},
 		{
@@ -183,8 +183,8 @@ func TestIndexClient_Stats(t *testing.T) {
 				Start: indexStartToday + 50,
 				End:   indexStartToday + 60,
 			},
-			expectedNumChunks:  9, // start and end are not inclusive
-			expectedNumEntries: 9,
+			expectedNumChunks:  10, // end time not inclusive
+			expectedNumEntries: 10,
 			expectedNumStreams: 1,
 		},
 		{

--- a/pkg/storage/stores/tsdb/querier.go
+++ b/pkg/storage/stores/tsdb/querier.go
@@ -66,7 +66,7 @@ type IndexReader interface {
 	// Series populates the given labels and chunk metas for the series identified
 	// by the reference.
 	// Returns storage.ErrNotFound if the ref does not resolve to a known series.
-	Series(ref storage.SeriesRef, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
+	Series(ref storage.SeriesRef, from int64, through int64, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
 
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)

--- a/pkg/storage/stores/tsdb/querier_test.go
+++ b/pkg/storage/stores/tsdb/querier_test.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -113,12 +114,12 @@ func TestQueryIndex(t *testing.T) {
 	)
 
 	require.True(t, p.Next())
-	_, err = reader.Series(p.At(), &ls, &chks)
+	_, err = reader.Series(p.At(), 0, math.MaxInt64, &ls, &chks)
 	require.Nil(t, err)
 	require.Equal(t, cases[0].labels.String(), ls.String())
 	require.Equal(t, cases[0].chunks, chks)
 	require.True(t, p.Next())
-	_, err = reader.Series(p.At(), &ls, &chks)
+	_, err = reader.Series(p.At(), 0, math.MaxInt64, &ls, &chks)
 	require.Nil(t, err)
 	require.Equal(t, cases[1].labels.String(), ls.String())
 	require.Equal(t, cases[1].chunks, chks)

--- a/pkg/storage/stores/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/tsdb/single_file_index_test.go
@@ -2,8 +2,10 @@ package tsdb
 
 import (
 	"context"
+	"math/rand"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
@@ -200,4 +202,55 @@ func TestSingleIdx(t *testing.T) {
 		})
 	}
 
+}
+
+func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
+	now := model.Now()
+	queryFrom, queryThrough := now.Add(3*time.Hour).Add(time.Millisecond), now.Add(5*time.Hour).Add(-time.Millisecond)
+	queryBounds := newBounds(queryFrom, queryThrough)
+	numChunksToMatch := 0
+
+	var chunkMetas []index.ChunkMeta
+	// build a chunk for every second with randomized chunk length
+	for from, through := now, now.Add(24*time.Hour); from <= through; from = from.Add(time.Second) {
+		// randomize chunk length between 1-120 mins
+		chunkLenMin := rand.Intn(120)
+		if chunkLenMin == 0 {
+			chunkLenMin = 1
+		}
+		chunkMeta := index.ChunkMeta{
+			MinTime:  int64(from),
+			MaxTime:  int64(from.Add(time.Duration(chunkLenMin) * time.Minute)),
+			Checksum: uint32(from),
+			Entries:  1,
+		}
+		chunkMetas = append(chunkMetas, chunkMeta)
+		if Overlap(chunkMeta, queryBounds) {
+			numChunksToMatch++
+		}
+	}
+
+	tempDir := b.TempDir()
+	tsdbIndex := BuildIndex(b, tempDir, []LoadableSeries{
+		{
+			Labels: mustParseLabels(`{foo="bar", fizz="buzz"}`),
+			Chunks: chunkMetas,
+		},
+		{
+			Labels: mustParseLabels(`{foo="bar", ping="pong"}`),
+			Chunks: chunkMetas,
+		},
+		{
+			Labels: mustParseLabels(`{foo1="bar1", ping="pong"}`),
+			Chunks: chunkMetas,
+		},
+	})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		chkRefs, err := tsdbIndex.GetChunkRefs(context.Background(), "fake", queryFrom, queryThrough, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.NoError(b, err)
+		require.Len(b, chkRefs, numChunksToMatch*2)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously we used to read the info of all the chunks from the index and then filter it out in a layer above within the tsdb code. This wastes a lot of resources when there are too many chunks in the index, but we just need a few of them based on the query range.

Before jumping into how and why I went with chunk sampling, here are some points to consider:
* Chunks in the index are sorted by the start time of the chunk. Since this does not tell us much about the end time of the chunks, we can only skip chunks that start after the end time of the query, which still would make us process lots of chunks when the query touches chunks that are near the end of the table boundary.
* Data is written to tsdb with variable length encoding. This means we can't skip/jump chunks since each chunk info might vary in the number of bytes we write.

Here is how I have implemented the sampling approach:
* Chunks are sampled considering their end times from the index and stored in memory.
* Here is how `chunkSample` is defined:
```
type chunkSample struct {
	largestMaxt   int64 // holds largest chunk end time we have seen so far. In other words all the earlier chunks have maxt <= largestMaxt
	idx           int   // index of the chunk in the list which helps with determining position of sampled chunk
	offset        int   // offset is relative to beginning chunk info block i.e after series labels info and chunk count etc
	prevChunkMaxt int64 // chunk times are stored as deltas. This is used for calculating mint of sampled chunk
}
```
* When a query comes in, we will find `chunkSample`, which has the largest "largestMaxt" that is less than the given query start time. In other words, find a chunk sample which skips all/most of the chunks that end before the query start time.
* Once we have found a chunk sample which skips all/most of the chunks that end before the query start, we will sequentially go through chunks and consider only the once that overlap with the query range. We will stop processing chunks as soon as we see a chunk that starts after the end time of the query since the chunks are sorted by start time.
* Sampling of chunks is done lazily for only the series that are queried, so we do not waste any resources on sampling series that are not queried.
* To avoid sampling too many chunks, I am sampling chunks at `1h` steps i.e given a sampled chunk with chunk end time `t`, the next chunk would be sampled with end time >= `t + 1h`. This means typically, we should have ~28 chunks sampled for each series queried from each index file, considering 2h default chunk length and chunks overlapping multiple tables.

Here are the benchmark results showing the difference it makes:
```
benchmark                              old ns/op     new ns/op     delta
BenchmarkTSDBIndex_GetChunkRefs-10     12420741      4764309       -61.64%
BenchmarkTSDBIndex_GetChunkRefs-10     12412014      4794156       -61.37%
BenchmarkTSDBIndex_GetChunkRefs-10     12382716      4748571       -61.65%
BenchmarkTSDBIndex_GetChunkRefs-10     12391397      4691054       -62.14%
BenchmarkTSDBIndex_GetChunkRefs-10     12272200      5023567       -59.07%

benchmark                              old allocs     new allocs     delta
BenchmarkTSDBIndex_GetChunkRefs-10     345653         40             -99.99%
BenchmarkTSDBIndex_GetChunkRefs-10     345653         40             -99.99%
BenchmarkTSDBIndex_GetChunkRefs-10     345653         40             -99.99%
BenchmarkTSDBIndex_GetChunkRefs-10     345653         40             -99.99%
BenchmarkTSDBIndex_GetChunkRefs-10     345653         40             -99.99%

benchmark                              old bytes     new bytes     delta
BenchmarkTSDBIndex_GetChunkRefs-10     27286536      6398855       -76.55%
BenchmarkTSDBIndex_GetChunkRefs-10     27286571      6399276       -76.55%
BenchmarkTSDBIndex_GetChunkRefs-10     27286566      6400699       -76.54%
BenchmarkTSDBIndex_GetChunkRefs-10     27286561      6399158       -76.55%
BenchmarkTSDBIndex_GetChunkRefs-10     27286580      6399643       -76.55%
```

**Checklist**
- [x] Tests updated
