### PR TITLE
operator: Add alerting style guide validation

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8743](https://github.com/grafana/loki/pull/8743) **periklis**: Add alerting style guide validation
 - [8800](https://github.com/grafana/loki/pull/8800) **aminesnow**: Promote AlertingRules, RecordingRules and RulerConfig from v1beta1 to v1
 - [8792](https://github.com/grafana/loki/pull/8792) **orenc1**: Improve documentation for LokiStack installation with ODF Object Storage
 - [8791](https://github.com/grafana/loki/pull/8791) **periklis**: Expand OLM skip range for OpenShift Logging 5.7 release (OpenShift)

--- a/operator/apis/loki/v1/v1.go
+++ b/operator/apis/loki/v1/v1.go
@@ -59,4 +59,12 @@ var (
 	// ErrRuleMustMatchNamespace indicates that an expression used in an alerting or recording rule is missing
 	// matchers for a namespace.
 	ErrRuleMustMatchNamespace = errors.New("rule needs to have a matcher for the namespace")
+	// ErrSeverityLabelMissing indicates that an alerting rule is missing the severity label
+	ErrSeverityLabelMissing = errors.New("rule requires label: severity")
+	// ErrSeverityLabelInvalid indicates that an alerting rule has an invalid value for the summary label
+	ErrSeverityLabelInvalid = errors.New("rule severity label value invalid, allowed values: critical, warning, info")
+	// ErrSummaryAnnotationMissing indicates that an alerting rule is missing the summary annotation
+	ErrSummaryAnnotationMissing = errors.New("rule requires annotation: summary")
+	// ErrDescriptionAnnotationMissing indicates that an alerting rule is missing the description annotation
+	ErrDescriptionAnnotationMissing = errors.New("rule requires annotation: description")
 )

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-39f2856
-    createdAt: "2023-03-15T09:56:48Z"
+    createdAt: "2023-03-15T10:50:46Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-03-15T10:11:27Z"
+    createdAt: "2023-03-15T10:50:48Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/hack/lokirules_ocp.yaml
+++ b/operator/hack/lokirules_ocp.yaml
@@ -19,9 +19,10 @@ spec:
               > 0.01
           for: 10s
           labels:
-            severity: page
+            severity: critical
           annotations:
             summary: High Loki Operator Reconciliation Errors
+            description: High Loki Operator Reconciliation Errors
 ---
 apiVersion: loki.grafana.com/v1
 kind: RecordingRule

--- a/operator/internal/validation/openshift/alertingrule.go
+++ b/operator/internal/validation/openshift/alertingrule.go
@@ -36,7 +36,7 @@ func AlertingRuleValidator(_ context.Context, alertingRule *lokiv1.AlertingRule)
 
 			if err := validateRuleLabels(rule.Labels); err != nil {
 				allErrs = append(allErrs, field.Invalid(
-					field.NewPath("Spec").Child("Groups").Index(i).Child("Rules").Index(j).Child("Labels"),
+					field.NewPath("spec", "groups").Index(i).Child("rules").Index(j).Child("labels"),
 					rule.Labels,
 					err.Error(),
 				))
@@ -44,7 +44,7 @@ func AlertingRuleValidator(_ context.Context, alertingRule *lokiv1.AlertingRule)
 
 			if err := validateRuleAnnotations(rule.Annotations); err != nil {
 				allErrs = append(allErrs, field.Invalid(
-					field.NewPath("Spec").Child("Groups").Index(i).Child("Rules").Index(j).Child("Annotations"),
+					field.NewPath("spec", "groups").Index(i).Child("rules").Index(j).Child("annotations"),
 					rule.Annotations,
 					err.Error(),
 				))

--- a/operator/internal/validation/openshift/alertingrule.go
+++ b/operator/internal/validation/openshift/alertingrule.go
@@ -33,6 +33,22 @@ func AlertingRuleValidator(_ context.Context, alertingRule *lokiv1.AlertingRule)
 					err.Error(),
 				))
 			}
+
+			if err := validateRuleLabels(rule.Labels); err != nil {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("Spec").Child("Groups").Index(i).Child("Rules").Index(j).Child("Labels"),
+					rule.Labels,
+					err.Error(),
+				))
+			}
+
+			if err := validateRuleAnnotations(rule.Annotations); err != nil {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("Spec").Child("Groups").Index(i).Child("Rules").Index(j).Child("Annotations"),
+					rule.Annotations,
+					err.Error(),
+				))
+			}
 		}
 	}
 

--- a/operator/internal/validation/openshift/alertingrule_test.go
+++ b/operator/internal/validation/openshift/alertingrule_test.go
@@ -284,7 +284,7 @@ func TestAlertingRuleValidator(t *testing.T) {
 			wantErrors: []*field.Error{
 				{
 					Type:     field.ErrorTypeInvalid,
-					Field:    "Spec.Groups[0].Rules[0].Labels",
+					Field:    "spec.groups[0].rules[0].labels",
 					BadValue: nilMap,
 					Detail:   lokiv1.ErrSeverityLabelMissing.Error(),
 				},
@@ -320,7 +320,7 @@ func TestAlertingRuleValidator(t *testing.T) {
 			wantErrors: []*field.Error{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "Spec.Groups[0].Rules[0].Labels",
+					Field: "spec.groups[0].rules[0].labels",
 					BadValue: map[string]string{
 						severityLabelName: "page",
 					},
@@ -357,7 +357,7 @@ func TestAlertingRuleValidator(t *testing.T) {
 			wantErrors: []*field.Error{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "Spec.Groups[0].Rules[0].Annotations",
+					Field: "spec.groups[0].rules[0].annotations",
 					BadValue: map[string]string{
 						descriptionAnnotationName: "alert description",
 					},
@@ -394,7 +394,7 @@ func TestAlertingRuleValidator(t *testing.T) {
 			wantErrors: []*field.Error{
 				{
 					Type:  field.ErrorTypeInvalid,
-					Field: "Spec.Groups[0].Rules[0].Annotations",
+					Field: "spec.groups[0].rules[0].annotations",
 					BadValue: map[string]string{
 						summaryAnnotationName: "alert summary",
 					},

--- a/operator/internal/validation/openshift/common.go
+++ b/operator/internal/validation/openshift/common.go
@@ -7,7 +7,6 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 
 	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/grafana/loki/pkg/logql/syntax"
 )
 

--- a/operator/internal/validation/openshift/common.go
+++ b/operator/internal/validation/openshift/common.go
@@ -6,8 +6,8 @@ import (
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds extended validation for the default [OpenShift Alerts Style Guide](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide), i.e.:
- Allowed severity label values: `critical`, `warning` and `info`
- Mandatory annotations: `summary` and `description`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
