### PR TITLE
operator: Add alertingrule tenant id label for all rules

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8748](https://github.com/grafana/loki/pull/8748) **periklis**: Add alertingrule tenant id label for all rules
 - [8800](https://github.com/grafana/loki/pull/8800) **aminesnow**: Promote AlertingRules, RecordingRules and RulerConfig from v1beta1 to v1
 - [8792](https://github.com/grafana/loki/pull/8792) **orenc1**: Improve documentation for LokiStack installation with ODF Object Storage
 - [8791](https://github.com/grafana/loki/pull/8791) **periklis**: Expand OLM skip range for OpenShift Logging 5.7 release (OpenShift)

--- a/operator/internal/manifests/internal/rules/marshal.go
+++ b/operator/internal/manifests/internal/rules/marshal.go
@@ -6,6 +6,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const tenantLabel = "tenantId"
+
 type alertingRuleSpec struct {
 	Groups []*lokiv1.AlertingRuleGroup `json:"groups"`
 }
@@ -18,6 +20,16 @@ type recordingRuleSpec struct {
 func MarshalAlertingRule(a lokiv1.AlertingRule) (string, error) {
 	ar := alertingRuleSpec{
 		Groups: a.Spec.Groups,
+	}
+
+	for _, group := range ar.Groups {
+		for _, rule := range group.Rules {
+			if rule.Labels == nil {
+				rule.Labels = map[string]string{}
+			}
+
+			rule.Labels[tenantLabel] = a.Spec.TenantID
+		}
 	}
 
 	content, err := yaml.Marshal(ar)

--- a/operator/internal/manifests/internal/rules/marshal.go
+++ b/operator/internal/manifests/internal/rules/marshal.go
@@ -18,8 +18,9 @@ type recordingRuleSpec struct {
 
 // MarshalAlertingRule returns the alerting rule groups marshaled into YAML or an error.
 func MarshalAlertingRule(a lokiv1.AlertingRule) (string, error) {
+	aa := a.DeepCopy()
 	ar := alertingRuleSpec{
-		Groups: a.Spec.Groups,
+		Groups: aa.Spec.Groups,
 	}
 
 	for _, group := range ar.Groups {
@@ -28,13 +29,13 @@ func MarshalAlertingRule(a lokiv1.AlertingRule) (string, error) {
 				rule.Labels = map[string]string{}
 			}
 
-			rule.Labels[tenantLabel] = a.Spec.TenantID
+			rule.Labels[tenantLabel] = aa.Spec.TenantID
 		}
 	}
 
 	content, err := yaml.Marshal(ar)
 	if err != nil {
-		return "", kverrors.Wrap(err, "failed to marshal alerting rule", "name", a.Name, "namespace", a.Namespace)
+		return "", kverrors.Wrap(err, "failed to marshal alerting rule", "name", aa.Name, "namespace", aa.Namespace)
 	}
 
 	return string(content), nil
@@ -42,13 +43,14 @@ func MarshalAlertingRule(a lokiv1.AlertingRule) (string, error) {
 
 // MarshalRecordingRule returns the recording rule groups marshaled into YAML or an error.
 func MarshalRecordingRule(a lokiv1.RecordingRule) (string, error) {
+	aa := a.DeepCopy()
 	ar := recordingRuleSpec{
-		Groups: a.Spec.Groups,
+		Groups: aa.Spec.Groups,
 	}
 
 	content, err := yaml.Marshal(ar)
 	if err != nil {
-		return "", kverrors.Wrap(err, "failed to marshal recording rule", "name", a.Name, "namespace", a.Namespace)
+		return "", kverrors.Wrap(err, "failed to marshal recording rule", "name", aa.Name, "namespace", aa.Namespace)
 	}
 
 	return string(content), nil

--- a/operator/internal/manifests/internal/rules/marshal_test.go
+++ b/operator/internal/manifests/internal/rules/marshal_test.go
@@ -1,7 +1,6 @@
 package rules_test
 
 import (
-	"fmt"
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
@@ -29,6 +28,7 @@ groups:
         labels:
           environment: production
           severity: page
+          tenantId: a-tenant
       - expr: |-
           sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
             /
@@ -42,10 +42,12 @@ groups:
         labels:
           environment: production
           severity: low
+          tenantId: a-tenant
 `
 
 	a := lokiv1.AlertingRule{
 		Spec: lokiv1.AlertingRuleSpec{
+			TenantID: "a-tenant",
 			Groups: []*lokiv1.AlertingRuleGroup{
 				{
 					Name:     "an-alert",
@@ -141,7 +143,6 @@ groups:
 	}
 
 	cfg, err := rules.MarshalRecordingRule(r)
-	fmt.Print(cfg)
 	require.NoError(t, err)
 	require.YAMLEq(t, expCfg, cfg)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The following PR adds a AlertingRule defaulting webhook is to populate the tenant ID to all rules to enable managing Alertmanager notifications per tenant.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
