### PR TITLE
refactor(lambda-promtail): apply terraform best practices

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -1,92 +1,157 @@
 data "aws_region" "current" {}
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda"
+#-------------------------------------------------------------------------------
+# IAM role assigned to the lambda function
+#-------------------------------------------------------------------------------
 
-  assume_role_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Action" : "sts:AssumeRole",
-        "Principal" : {
-          "Service" : "lambda.amazonaws.com"
-        },
-        "Effect" : "Allow",
-      }
-    ]
-  })
+resource "aws_iam_role" "this" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-data "aws_iam_policy_document" "logs" {
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+#-------------------------------------------------------------------------------
+# IAM policy assigned to lambda IAM role to be able to execute in VPC
+#-------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc_execution" {
+  count = length(var.lambda_vpc_subnets) > 0 ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = data.aws_iam_policy.lambda_vpc_execution[0].arn
+}
+
+data "aws_iam_policy" "lambda_vpc_execution" {
+  count = length(var.lambda_vpc_subnets) > 0 ? 1 : 0
+
+  name = "AWSLambdaVPCAccessExecutionRole"
+}
+
+#-------------------------------------------------------------------------------
+# IAM policies attached to lambda IAM role
+#-------------------------------------------------------------------------------
+
+# CloudWatch
+
+# These permissions are also included in the AWSLambdaVPCAccessExecutionRole IAM Policy
+resource "aws_iam_role_policy" "lambda_cloudwatch" {
+  count = length(var.lambda_vpc_subnets) == 0 ? 1 : 0
+
+  name   = "cloudwatch"
+  role   = aws_iam_role.this.name
+  policy = data.aws_iam_policy_document.lambda_cloudwatch[0].json
+}
+
+# These permissions are also included in the AWSLambdaVPCAccessExecutionRole IAM Policy
+data "aws_iam_policy_document" "lambda_cloudwatch" {
+  count = length(var.lambda_vpc_subnets) == 0 ? 1 : 0
+
   statement {
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
-    resources = ["arn:aws:logs:*:*:*"]
+    resources = [
+      aws_cloudwatch_log_group.this.arn,
+    ]
   }
+}
 
-  dynamic "statement" {
-    for_each = var.bucket_names
-    content {
-      actions = [
-        "s3:GetObject",
-      ]
-      resources = ["arn:aws:s3:::${statement.value}/*"]
-    }
-  }
+# KMS
+
+resource "aws_iam_role_policy" "lambda_kms" {
+  count = var.kms_key_arn != "" ? 1 : 0
+
+  name   = "kms"
+  role   = aws_iam_role.this.name
+  policy = data.aws_iam_policy_document.lambda_kms[0].json
+}
+
+data "aws_iam_policy_document" "lambda_kms" {
+  count = var.kms_key_arn != "" ? 1 : 0
 
   statement {
     actions = [
       "kms:Decrypt",
     ]
-    resources = ["arn:aws:kms:*:*:*"]
+    resources = [
+      var.kms_key_arn,
+    ]
   }
+}
+
+# S3
+
+resource "aws_iam_role_policy" "lambda_s3" {
+  count = length(var.bucket_names) > 0 ? 1 : 0
+
+  name   = "s3"
+  role   = aws_iam_role.this.name
+  policy = data.aws_iam_policy_document.lambda_s3[0].json
+}
+
+data "aws_iam_policy_document" "lambda_s3" {
+  count = length(var.bucket_names) > 0 ? 1 : 0
 
   statement {
     actions = [
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:CreateNetworkInterface",
-      "ec2:DeleteNetworkInterface",
-      "ec2:DescribeInstances",
-      "ec2:AttachNetworkInterface",
+      "s3:GetObject",
     ]
-    resources = ["*"]
+    resources = [
+      for _, bucket_name in var.bucket_names : "arn:aws:s3:::${bucket_name}/*"
+    ]
   }
+
+}
+
+# Kinesis
+
+resource "aws_iam_role_policy" "lambda_kinesis" {
+  count = length(var.kinesis_stream_name) > 0 ? 1 : 0
+
+  name   = "kinesis"
+  role   = aws_iam_role.this.name
+  policy = data.aws_iam_policy_document.lambda_kinesis[0].json
+}
+
+data "aws_iam_policy_document" "lambda_kinesis" {
+  count = length(var.kinesis_stream_name) > 0 ? 1 : 0
 
   statement {
     actions = [
       "kinesis:*",
     ]
-    resources = ["*"]
+    resources = [
+      for _, stream in aws_kinesis_stream.this : stream.arn
+    ]
   }
 }
 
-resource "aws_iam_role_policy" "logs" {
-  name   = "lambda-logs"
-  role   = aws_iam_role.iam_for_lambda.name
-  policy = data.aws_iam_policy_document.logs.json
-}
+#-------------------------------------------------------------------------------
+# Lambda function
+#-------------------------------------------------------------------------------
 
-data "aws_iam_policy" "lambda_vpc_execution" {
-  name = "AWSLambdaVPCAccessExecutionRole"
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_vpc_execution" {
-  role       = aws_iam_role.iam_for_lambda.name
-  policy_arn = data.aws_iam_policy.lambda_vpc_execution.arn
-}
-
-resource "aws_cloudwatch_log_group" "lambda_promtail" {
-  name              = "/aws/lambda/lambda_promtail"
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.name}"
   retention_in_days = 14
 }
 
-resource "aws_lambda_function" "lambda_promtail" {
+resource "aws_lambda_function" "this" {
   image_uri     = var.lambda_promtail_image
-  function_name = "lambda_promtail"
-  role          = aws_iam_role.iam_for_lambda.arn
+  function_name = var.name
+  role          = aws_iam_role.this.arn
   kms_key_arn   = var.kms_key_arn
 
   timeout      = 60
@@ -117,20 +182,34 @@ resource "aws_lambda_function" "lambda_promtail" {
   }
 
   depends_on = [
-    aws_iam_role_policy.logs,
+    aws_iam_role_policy.lambda_s3,
+    aws_iam_role_policy.lambda_kms,
+    aws_iam_role_policy.lambda_kinesis,
+    aws_iam_role_policy.lambda_cloudwatch,
+
     aws_iam_role_policy_attachment.lambda_vpc_execution,
+
+    # Ensure function is created after, and destroyed before, the log-group
+    # This prevents the log-group from being re-created by an invocation of the lambda-function
+    aws_cloudwatch_log_group.this,
   ]
 }
 
-resource "aws_lambda_function_event_invoke_config" "lambda_promtail_invoke_config" {
-  function_name          = aws_lambda_function.lambda_promtail.function_name
+resource "aws_lambda_function_event_invoke_config" "this" {
+  function_name          = aws_lambda_function.this.function_name
   maximum_retry_attempts = 2
 }
 
+#-------------------------------------------------------------------------------
+# Subscribe to CloudWatch log-groups
+#-------------------------------------------------------------------------------
+
 resource "aws_lambda_permission" "lambda_promtail_allow_cloudwatch" {
+  count = length(var.log_group_names) > 0 ? 1 : 0
+
   statement_id  = "lambda-promtail-allow-cloudwatch"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_promtail.function_name
+  function_name = aws_lambda_function.this.function_name
   principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
 }
 
@@ -138,25 +217,54 @@ resource "aws_lambda_permission" "lambda_promtail_allow_cloudwatch" {
 # However, if you need to provide an actual filter_pattern for a specific log group you should
 # copy this block and modify it accordingly.
 resource "aws_cloudwatch_log_subscription_filter" "lambdafunction_logfilter" {
-  for_each        = var.log_group_names
+  for_each = var.log_group_names
+
   name            = "lambdafunction_logfilter_${each.value}"
   log_group_name  = each.value
-  destination_arn = aws_lambda_function.lambda_promtail.arn
+  destination_arn = aws_lambda_function.this.arn
+
   # required but can be empty string
   filter_pattern = ""
-  depends_on     = [aws_iam_role_policy.logs]
 }
 
-resource "aws_lambda_permission" "allow-s3-invoke-lambda-promtail" {
-  for_each      = var.bucket_names
+#-------------------------------------------------------------------------------
+# Subscribe to S3-objects
+#-------------------------------------------------------------------------------
+
+resource "aws_lambda_permission" "allow_s3_invoke_lambda_promtail" {
+  for_each = var.bucket_names
+
+  statement_id  = "lambda-promtail-allow-s3-bucket-${each.value}"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_promtail.arn
+  function_name = aws_lambda_function.this.arn
   principal     = "s3.amazonaws.com"
   source_arn    = "arn:aws:s3:::${each.value}"
 }
 
-resource "aws_kinesis_stream" "kinesis_stream" {
-  for_each         = var.kinesis_stream_name
+resource "aws_s3_bucket_notification" "this" {
+  for_each = var.bucket_names
+
+  bucket = each.value
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.this.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "AWSLogs/"
+    filter_suffix       = ".log.gz"
+  }
+
+  depends_on = [
+    aws_lambda_permission.allow_s3_invoke_lambda_promtail
+  ]
+}
+
+#-------------------------------------------------------------------------------
+# Subscribe to Kinesis-streams
+#-------------------------------------------------------------------------------
+
+resource "aws_kinesis_stream" "this" {
+  for_each = var.kinesis_stream_name
+
   name             = each.value
   shard_count      = 1
   retention_period = 48
@@ -171,24 +279,10 @@ resource "aws_kinesis_stream" "kinesis_stream" {
   }
 }
 
-resource "aws_lambda_event_source_mapping" "kinesis_event_source" {
-  for_each          = var.kinesis_stream_name
-  event_source_arn  = aws_kinesis_stream.kinesis_stream[each.key].arn
-  function_name     = aws_lambda_function.lambda_promtail.arn
+resource "aws_lambda_event_source_mapping" "this" {
+  for_each = aws_kinesis_stream.this
+
+  event_source_arn  = each.value.arn
+  function_name     = aws_lambda_function.this.arn
   starting_position = "LATEST"
-  depends_on        = [aws_kinesis_stream.kinesis_stream]
-}
-
-resource "aws_s3_bucket_notification" "push-to-lambda-promtail" {
-  for_each = var.bucket_names
-  bucket   = each.value
-
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.lambda_promtail.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "AWSLogs/"
-    filter_suffix       = ".log.gz"
-  }
-
-  depends_on = [aws_lambda_permission.allow-s3-invoke-lambda-promtail]
 }

--- a/tools/lambda-promtail/moves.tf
+++ b/tools/lambda-promtail/moves.tf
@@ -1,0 +1,19 @@
+moved {
+  from = aws_iam_role.iam_for_lambda
+  to   = aws_iam_role.this
+}
+
+moved {
+  from = aws_cloudwatch_log_group.lambda_promtail
+  to   = aws_cloudwatch_log_group.this
+}
+
+moved {
+  from = aws_lambda_function.lambda_promtail
+  to   = aws_lambda_function.this
+}
+
+moved {
+  from = aws_lambda_function_event_invoke_config.lambda_promtail_invoke_config
+  to   = aws_lambda_function_event_invoke_config.this
+}

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -1,3 +1,9 @@
+variable "name" {
+  type        = string
+  description = "Name used for created AWS resources."
+  default     = "lambda_promtail"
+}
+
 variable "write_address" {
   type        = string
   description = "This is the Loki Write API compatible endpoint that you want to write logs to, either promtail or Loki."


### PR DESCRIPTION
**What this PR does / why we need it**:

I would like to offer this PR as a suggestion to improve the lambda-promtail terraform-module. I forked it to be able to deploy it more than once in an AWS account. I also applied terraform best-practices. I was hoping that perhaps these changes could be merged into upstream as well.

Unlike https://github.com/grafana/loki/pull/8549 , I unfortunately did not end up making a separate commit for each change. 

If you would like me to create one or more issue(s) to address the points below, I'd be happy to do that as well.

List of improvements:

1. Added `var.name` (defaults to lambda-promtail) so that this module can be deployed multiple times in the same AWS account. This allows us to define unique, non-conflicting names for:
    * the Lambda function
    * the CloudWatch log-group
    * the IAM role
2. Split IAM role policies per component; only assign permissions when required
3. Scope down permissions of the IAM role policies
4. During terraform-destroy, ensure CloudWatch log-group is removed **after** the lambda-function. An accidental invocation of the function could re-create an already destroyed log-group, leaving an orphaned log-group

List of style changes:

1. Rename resources to `this` when there is only one instance of this resource-type
2. Add newline after `count|before_each` and before `depends_on`
3. Group resources together and add a section comment
4. Add missing(?) statement-id to S3 AWS lambda permission

Misc.

1. I added a `moves.tf` file to facilitate moving renamed resources in existing terraform statefiles. This prevents some resources from recreated. Can also be removed.

These changes are backwards compatible, even though some resources will end up being re-created. A `terraform apply` should succeed (it did for me).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)