### PR TITLE
Loki: Change the behavior of the 0 value for retention_period to disable retention.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [8151](https://github.com/grafana/loki/pull/8151) **sandeepsukhani** fix log deletion with line filters.
 * [8448](https://github.com/grafana/loki/pull/8448) **chaudum**: Fix bug in LogQL parser that caused certain queries that contain a vector expression to fail.
 * [8448](https://github.com/grafana/loki/pull/8665) **sandeepsukhani**: deletion: fix issue in processing delete requests with tsdb index
+* [8753](https://github.com/grafana/loki/pull/8753) **slim-bean** A zero value for retention_period will now disable retention.
 
 ##### Changes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2333,9 +2333,10 @@ ruler_remote_write_sigv4_config:
 # CLI flag: -compactor.deletion-mode
 [deletion_mode: <string> | default = "filter-and-delete"]
 
-# Retention to apply for the store, if the retention is enabled on the compactor
-# side.
-# A zero value of 0 or 0s disables retention.
+# Retention period to apply to stored data, only applies if retention_enabled is
+# true in the compactor config. As of version 2.8.0, a zero value of 0 or 0s
+# disables retention. In previous releases, Loki did not properly honor a zero
+# value to disable retention and a really large value should be used instead.
 # CLI flag: -store.retention
 [retention_period: <duration> | default = 0s]
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2335,8 +2335,9 @@ ruler_remote_write_sigv4_config:
 
 # Retention to apply for the store, if the retention is enabled on the compactor
 # side.
+# A zero value of 0 or 0s disables retention.
 # CLI flag: -store.retention
-[retention_period: <duration> | default = 31d]
+[retention_period: <duration> | default = 0s]
 
 # Per-stream retention to apply, if the retention is enable on the compactor
 # side.

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -21,6 +21,8 @@ Log entry deletion relies on configuration of the custom logs retention workflow
 
 Enable log entry deletion by setting `retention_enabled` to true in the compactor's configuration and setting and `deletion_mode` to `filter-only` or `filter-and-delete` in the runtime config.
 
+> **Warning:** Please be very careful when enabling retention, it's strongly recommended to enable versioning on your objects in object storage to allow for recovery from accidental misconfiguration of a retention setting. If you wish to enable delete capability but do not want to enforce any retention, make sure you configure retention_period with a value of `0s`. 
+
 Because it is a runtime configuration, `deletion_mode` can be set per-tenant, if desired.
 
 With `filter-only`, log lines matching the query in the delete request are filtered out when querying Loki. They are not removed from storage.

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -21,7 +21,7 @@ Log entry deletion relies on configuration of the custom logs retention workflow
 
 Enable log entry deletion by setting `retention_enabled` to true in the compactor's configuration and setting and `deletion_mode` to `filter-only` or `filter-and-delete` in the runtime config.
 
-> **Warning:** Please be very careful when enabling retention, it's strongly recommended to enable versioning on your objects in object storage to allow for recovery from accidental misconfiguration of a retention setting. If you wish to enable delete capability but do not want to enforce any retention, make sure you configure retention_period with a value of `0s`. 
+> **Warning:** Be very careful when enabling retention. It is strongly recommended that you also enable versioning on your objects in object storage to allow you to recover from accidental misconfiguration of a retention setting. If you want to enable deletion but not not want to enforce retention, configure the `retention_period` setting with a value of `0s`.
 
 Because it is a runtime configuration, `deletion_mode` can be set per-tenant, if desired.
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -33,6 +33,31 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Loki
+
+#### Default retention_period has changed
+
+This change will affect you if you have:
+```yaml
+compactor:
+  retention_enabled: true
+```
+
+And did *not* define a `retention_period` in `limits_config`, thus relying on the previous default of `744h`
+
+In this release the default has been changed to `0s`.
+
+A value of `0s` is the same as "retain forever" or "disable retention".
+
+If, **and only if**, you wish to retain the previous default of 744h, apply this config.
+```yaml
+limits_config:
+  retention_period: 744h
+```
+
+**Please note:** In previous versions, the zero value of `0` or `0s` will result in **immediate deletion of all logs**,
+only in 2.8 and forward releases does the zero value disable retention.
+
 ### Promtail
 
 #### The go build tag `promtail_journal_enabled` was introduced

--- a/pkg/loki/runtime_config_test.go
+++ b/pkg/loki/runtime_config_test.go
@@ -43,7 +43,7 @@ overrides:
               period: 24h
               priority: 5
 `)
-	require.Equal(t, 31*24*time.Hour, overrides.RetentionPeriod("1"))    // default
+	require.Equal(t, time.Duration(0), overrides.RetentionPeriod("1"))   // default
 	require.Equal(t, 2*30*24*time.Hour, overrides.RetentionPeriod("29")) // overrides
 	require.Equal(t, []validation.StreamRetention(nil), overrides.StreamRetention("1"))
 	require.Equal(t, []validation.StreamRetention{

--- a/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
@@ -53,6 +53,10 @@ func NewExpirationChecker(limits Limits) ExpirationChecker {
 func (e *expirationChecker) Expired(ref ChunkEntry, now model.Time) (bool, filter.Func) {
 	userID := unsafeGetString(ref.UserID)
 	period := e.tenantsRetention.RetentionPeriodFor(userID, ref.Labels)
+	// The 0 value should disable retention
+	if period <= 0 {
+		return false, nil
+	}
 	return now.Sub(ref.Through) > period, nil
 }
 

--- a/pkg/storage/stores/indexshipper/compactor/retention/expiration_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/expiration_test.go
@@ -55,30 +55,53 @@ func defaultLimitsTestConfig() validation.Limits {
 	return limits
 }
 
-func overridesTestConfig() validation.Overrides {
+func overridesTestConfig(defaultLimits validation.Limits, tenantLimits validation.TenantLimits) (*validation.Overrides, error) {
+	return validation.NewOverrides(defaultLimits, tenantLimits)
+}
 
-	validation.NewOverrides(defaultLimitsTestConfig(), nil)
+type fakeOverrides struct {
+	tenantLimits map[string]*validation.Limits
+}
+
+func (f fakeOverrides) TenantLimits(userID string) *validation.Limits {
+	return f.tenantLimits[userID]
+}
+
+func (f fakeOverrides) AllByUserID() map[string]*validation.Limits {
+	//TODO implement me
+	panic("implement me")
 }
 
 func Test_expirationChecker_Expired(t *testing.T) {
-	e := NewExpirationChecker(&fakeLimits{
-		perTenant: map[string]retentionLimit{
-			"1": {
-				retentionPeriod: time.Hour,
-				streamRetention: []validation.StreamRetention{
-					{Period: model.Duration(2 * time.Hour), Priority: 10, Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
-					{Period: model.Duration(2 * time.Hour), Priority: 1, Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba.+")}},
-				},
-			},
-			"2": {
-				retentionPeriod: 24 * time.Hour,
-				streamRetention: []validation.StreamRetention{
-					{Period: model.Duration(1 * time.Hour), Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
-					{Period: model.Duration(2 * time.Hour), Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba.")}},
-				},
-			},
+	// Set a default retention of 0 which should disable it
+	dur, _ := model.ParseDuration("0s")
+	d := defaultLimitsTestConfig()
+	d.RetentionPeriod = dur
+
+	// Override tenant 1 and tenant 2
+	t1 := defaultLimitsTestConfig()
+	t1.RetentionPeriod = model.Duration(time.Hour)
+	t1.StreamRetention = []validation.StreamRetention{
+		{Period: model.Duration(2 * time.Hour), Priority: 10, Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+		{Period: model.Duration(2 * time.Hour), Priority: 1, Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba.+")}},
+	}
+	t2 := defaultLimitsTestConfig()
+	t2.RetentionPeriod = model.Duration(24 * time.Hour)
+	t2.StreamRetention = []validation.StreamRetention{
+		{Period: model.Duration(1 * time.Hour), Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}},
+		{Period: model.Duration(2 * time.Hour), Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba.")}},
+	}
+
+	f := fakeOverrides{
+		tenantLimits: map[string]*validation.Limits{
+			"1": &t1,
+			"2": &t2,
 		},
-	})
+	}
+	o, err := overridesTestConfig(d, f)
+	require.NoError(t, err)
+
+	e := NewExpirationChecker(o)
 	tests := []struct {
 		name string
 		ref  ChunkEntry
@@ -101,17 +124,22 @@ func Test_expirationChecker_Expired(t *testing.T) {
 }
 
 func Test_expirationChecker_Expired_zeroValue(t *testing.T) {
-	d, _ := time.ParseDuration("0s")
-	e := NewExpirationChecker(&fakeLimits{
-		defaultLimit: retentionLimit{
-			retentionPeriod: d,
+
+	// Default retention should be zero
+	d := defaultLimitsTestConfig()
+
+	// Override tenant 2 to have 24 hour retention
+	tl := defaultLimitsTestConfig()
+	dur, _ := model.ParseDuration("24h")
+	tl.RetentionPeriod = dur
+	f := fakeOverrides{
+		tenantLimits: map[string]*validation.Limits{
+			"2": &tl,
 		},
-		perTenant: map[string]retentionLimit{
-			"2": {
-				retentionPeriod: 24 * time.Hour,
-			},
-		},
-	})
+	}
+	o, err := overridesTestConfig(d, f)
+	require.NoError(t, err)
+	e := NewExpirationChecker(o)
 	tests := []struct {
 		name string
 		ref  ChunkEntry
@@ -119,6 +147,7 @@ func Test_expirationChecker_Expired_zeroValue(t *testing.T) {
 	}{
 		{"tenant with no override should not delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), false},
 		{"tenant with no override, REALLY old chunk should not delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-10000*time.Hour+(1*time.Hour)), model.Now().Add(-10000*time.Hour)), false},
+		{"tenant with override chunk less than retention should not delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-3*time.Hour), model.Now().Add(-2*time.Hour)), false},
 		{"tenant with override should delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), true},
 	}
 	for _, tt := range tests {
@@ -131,26 +160,39 @@ func Test_expirationChecker_Expired_zeroValue(t *testing.T) {
 }
 func Test_expirationChecker_Expired_zeroValueOverride(t *testing.T) {
 
-	// Set a default retention
-	d, _ := time.ParseDuration("24h")
-	e := NewExpirationChecker(&fakeLimits{
-		defaultLimit: retentionLimit{
-			retentionPeriod: d,
+	// Set a default retention of 24h
+	dur, _ := model.ParseDuration("24h")
+	d := defaultLimitsTestConfig()
+	d.RetentionPeriod = dur
+
+	// Override tenant 2 to have zero value for retention from default
+	t2 := defaultLimitsTestConfig()
+	t2.RetentionPeriod = 0
+
+	// Override tenant 3 to have zero value without unit
+	t3 := defaultLimitsTestConfig()
+	dur, _ = model.ParseDuration("0")
+	t3.RetentionPeriod = dur
+
+	f := fakeOverrides{
+		tenantLimits: map[string]*validation.Limits{
+			"2": &t2,
+			"3": &t3,
 		},
-		perTenant: map[string]retentionLimit{
-			"2": {
-				retentionPeriod: 0,
-			},
-		},
-	})
+	}
+
+	o, err := overridesTestConfig(d, f)
+	require.NoError(t, err)
+
+	e := NewExpirationChecker(o)
 	tests := []struct {
 		name string
 		ref  ChunkEntry
 		want bool
 	}{
 		{"tenant with no override should delete", newChunkEntry("1", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), true},
-		{"tenant with override should note delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), false},
-		{"tenant with override, REALLY old chunk should not delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-10000*time.Hour+(1*time.Hour)), model.Now().Add(-10000*time.Hour)), false},
+		{"tenant with override should not delete", newChunkEntry("2", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), false},
+		{"tenant with zero value without unit should not delete", newChunkEntry("3", `{foo="buzz"}`, model.Now().Add(-31*time.Hour), model.Now().Add(-30*time.Hour)), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/retention_test.go
@@ -194,7 +194,8 @@ func Test_EmptyTable(t *testing.T) {
 
 	tables := store.indexTables()
 	require.Len(t, tables, 1)
-	empty, _, err := markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: 0}, "2": {retentionPeriod: 0}}}), nil, util_log.Logger)
+	// Set a very low retention to make sure all chunks are marked for deletion which will create an empty table.
+	empty, _, err := markForDelete(context.Background(), 0, tables[0].name, noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: time.Second}, "2": {retentionPeriod: time.Second}}}), nil, util_log.Logger)
 	require.NoError(t, err)
 	require.True(t, empty)
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -239,7 +239,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.file (runtime_config.file in YAML).")
 	_ = l.RetentionPeriod.Set("0s")
-	f.Var(&l.RetentionPeriod, "store.retention", "Retention to apply for the store, if the retention is enabled on the compactor side. Default is 0s which is equivalent to no retention.")
+	f.Var(&l.RetentionPeriod, "store.retention", "Retention period to apply to stored data, only applies if retention_enabled is true in the compactor config. As of version 2.8.0, a zero value of 0 or 0s disables retention. In previous releases, Loki did not properly honor a zero value to disable retention and a really large value should be used instead.")
 
 	_ = l.PerTenantOverridePeriod.Set("10s")
 	f.Var(&l.PerTenantOverridePeriod, "limits.per-user-override-period", "Feature renamed to 'runtime configuration'; flag deprecated in favor of -runtime-config.reload-period (runtime_config.period in YAML).")

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -238,8 +238,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when shuffle-sharding is enabled in the ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.file (runtime_config.file in YAML).")
-	_ = l.RetentionPeriod.Set("744h")
-	f.Var(&l.RetentionPeriod, "store.retention", "Retention to apply for the store, if the retention is enabled on the compactor side.")
+	_ = l.RetentionPeriod.Set("0s")
+	f.Var(&l.RetentionPeriod, "store.retention", "Retention to apply for the store, if the retention is enabled on the compactor side. Default is 0s which is equivalent to no retention.")
 
 	_ = l.PerTenantOverridePeriod.Set("10s")
 	f.Var(&l.PerTenantOverridePeriod, "limits.per-user-override-period", "Feature renamed to 'runtime configuration'; flag deprecated in favor of -runtime-config.reload-period (runtime_config.period in YAML).")


### PR DESCRIPTION
**What this PR does / why we need it**:

Issue #8359 exposed a very unfortunate inconsistency in a Loki config where the zero value did not disable a feature.

By convention in Loki the zero value for a config typically "disables" it.

This PR changes the retention_period to honor the zero value of `0` or `0s` to disable retention.

**Which issue(s) this PR fixes**:
Fixes #8359

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
