### PR TITLE
Modify debug loki build to work on any architecture, including ARM

### DIFF
--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,16 +1,24 @@
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
-FROM grafana/loki-build-image:0.28.1 as build
-ARG GOARCH="amd64"
+
+FROM golang:1.20.1-alpine as goenv
+RUN go env GOARCH > /goarch && \
+    go env GOARM > /goarm && \
+    go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM --platform=linux/amd64 $BUILD_IMAGE as build
+COPY --from=goenv /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false loki-debug
+RUN make clean && \
+    GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-debug
 
 FROM       alpine:3.16.4
 RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
-COPY       --from=build /usr/bin/dlv /usr/bin/dlv
+COPY       --from=goenv /go/bin/dlv /usr/bin/dlv
 COPY       cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml
 EXPOSE     3100
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On my M1 Pro, `make loki-debug-image` produces the following output:

```bash
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

This is because we run `delve` as the entrypoint for the debug image, and `delve` is being copied from `loki-build-image` which is exclusively built as `amd64` (we should make this a multi-arch image... created https://github.com/grafana/loki/issues/8759).

This change will work with whichever host OS is building the image and download `delve` using that architecture instead of relying on the `loki-build-image` version.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
If you're on an `amd64` machine, please run `make loki-debug-image` and run the resultant image to make sure that things still work as before.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
