### PR TITLE
Loki: add lines processed to metrics.go

### DIFF
--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -127,6 +127,8 @@ func RecordRangeAndInstantQueryMetrics(
 		"returned_lines", returnedLines,
 		"throughput", strings.Replace(humanize.Bytes(uint64(stats.Summary.BytesProcessedPerSecond)), " ", "", 1),
 		"total_bytes", strings.Replace(humanize.Bytes(uint64(stats.Summary.TotalBytesProcessed)), " ", "", 1),
+		"lines_per_second", stats.Summary.LinesProcessedPerSecond,
+		"total_lines", stats.Summary.TotalLinesProcessed,
 		"total_entries", stats.Summary.TotalEntriesReturned,
 		"store_chunks_download_time", stats.ChunksDownloadTime(),
 		"queue_time", logql_stats.ConvertSecondsToNanoseconds(stats.Summary.QueueTime),


### PR DESCRIPTION
**What this PR does / why we need it**:

Typically `throughput` and `total_bytes` are the most common fields in the `metrics.go` log line which we look at for query performance. 

However, there are cases where query performance is better measured by `total_lines` and `lines_per_second` (e.g. when processing a lot of high volume but relatively short log lines) and having this information in metrics.go can be very helpful.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
