### PR TITLE
Expand which-release to cover weekly builds as well

### DIFF
--- a/tools/which-release.sh
+++ b/tools/which-release.sh
@@ -2,24 +2,30 @@
 
 COMMIT=$1
 if [[ -z "${COMMIT}" ]]; then
-    echo "Usage: $0 <commit-ref>"
-    exit 2
+  echo "Usage: $0 <commit-ref>"
+  exit 2
 fi
 
 REMOTE=$(git remote -v | grep grafana/loki | awk '{print $1}' | head -n1)
 if [[ -z "${REMOTE}" ]]; then
-    echo "Could not find remote for grafana/loki"
-    exit 1
+  echo "Could not find remote for grafana/loki"
+  exit 1
 fi
 
 echo "It is recommended that you run \`git fetch -ap ${REMOTE}\` to ensure you get a correct result."
 
 RELEASES=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/release-" | sed "s|${REMOTE}/||")
 if [[ -z "${RELEASES}" ]]; then
-    echo "Commit was not found in any release"
-    exit 1
+  echo "Commit was not found in any public release"
+else
+  echo "Commit was found in the following releases:"
+  echo "${RELEASES}"
 fi
 
-
-echo "Commit was found in the following releases:"
-echo "${RELEASES}"
+BUILDS=$(git branch -r --contains "${COMMIT}" | grep "${REMOTE}" | grep "/k" | sed "s|${REMOTE}/||")
+if [[ -z "${BUILDS}" ]]; then
+  echo "Commit was not found in any weekly builds"
+else
+  echo "Commit was found in the following weekly builds:"
+  echo "${BUILDS}"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Expanding tool introduced in https://github.com/grafana/loki/pull/8706

**Special notes for your reviewer**:
Knowing which, if any, weekly builds the commit is in can also be useful.