### PR TITLE
Changes from linter

### DIFF
--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -38,7 +38,7 @@ const (
 	StageTypeStaticLabels    = "static_labels"
 	StageTypeDecolorize      = "decolorize"
 	StageTypeEventLogMessage = "eventlogmessage"
-  StageTypeGeoIP           = "geoip"
+	StageTypeGeoIP           = "geoip"
 )
 
 // Processor takes an existing set of labels, timestamp and log entry and returns either a possibly mutated
@@ -219,10 +219,10 @@ func New(logger log.Logger, jobName *string, stageType string,
 		}
 	case StageTypeEventLogMessage:
 		s, err = newEventLogMessageStage(logger, cfg)
-    if err != nil {
+		if err != nil {
 			return nil, err
 		}
-  case StageTypeGeoIP:
+	case StageTypeGeoIP:
 		s, err = newGeoIPStage(logger, cfg)
 		if err != nil {
 			return nil, err

--- a/clients/pkg/promtail/client/manager_test.go
+++ b/clients/pkg/promtail/client/manager_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/wal"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/server"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/file"
 	"github.com/grafana/loki/clients/pkg/promtail/wal"
+
 	"github.com/grafana/loki/pkg/tracing"
 	"github.com/grafana/loki/pkg/util/flagext"
 )

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 	"github.com/grafana/loki/clients/pkg/promtail/utils"
 	"github.com/grafana/loki/clients/pkg/promtail/wal"
+
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 

--- a/clients/pkg/promtail/utils/entries.go
+++ b/clients/pkg/promtail/utils/entries.go
@@ -65,7 +65,7 @@ func (eh *FanoutEntryHandler) Chan() chan<- api.Entry {
 	return eh.entries
 }
 
-// Stop only stops the channel FanoutEntryHandler exposes. It then waits for the entry being processed to be sent succesfully.
+// Stop only stops the channel FanoutEntryHandler exposes. It then waits for the entry being processed to be sent successfully.
 // If it times out, it hard stops all sending routines.
 func (eh *FanoutEntryHandler) Stop() {
 	eh.once.Do(func() {

--- a/clients/pkg/promtail/utils/entries_test.go
+++ b/clients/pkg/promtail/utils/entries_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 

--- a/clients/pkg/promtail/wal/reader.go
+++ b/clients/pkg/promtail/wal/reader.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
+
 	"github.com/grafana/loki/pkg/ingester/wal"
 	"github.com/grafana/loki/pkg/util"
 	walUtils "github.com/grafana/loki/pkg/util/wal"

--- a/clients/pkg/promtail/wal/writer_test.go
+++ b/clients/pkg/promtail/wal/writer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
+
 	"github.com/grafana/loki/pkg/logproto"
 )
 

--- a/pkg/logql/log/ip.go
+++ b/pkg/logql/log/ip.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"unicode"
 
+	"net/netip"
+
 	"github.com/prometheus/prometheus/model/labels"
 	"go4.org/netipx"
-	"net/netip"
 )
 
 var (

--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -2,12 +2,13 @@ package log
 
 import (
 	"fmt"
-	"github.com/dustin/go-humanize"
-	"github.com/prometheus/prometheus/model/labels"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/dustin/go-humanize"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/logqlmodel"
 )

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -2,9 +2,10 @@ package log
 
 import (
 	"fmt"
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"sort"
 	"testing"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -7,12 +7,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
-	"github.com/grafana/loki/pkg/logql/syntax"
-	ruler "github.com/grafana/loki/pkg/ruler/base"
-	"github.com/grafana/loki/pkg/ruler/rulespb"
-	"github.com/grafana/loki/pkg/ruler/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -27,6 +21,13 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/template"
 	"github.com/weaveworks/common/user"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/logql/syntax"
+	ruler "github.com/grafana/loki/pkg/ruler/base"
+	"github.com/grafana/loki/pkg/ruler/rulespb"
+	"github.com/grafana/loki/pkg/ruler/util"
 )
 
 // RulesLimits is the one function we need from limits.Overrides, and

--- a/pkg/ruler/grouploader.go
+++ b/pkg/ruler/grouploader.go
@@ -2,14 +2,16 @@ package ruler
 
 import (
 	"bytes"
-	"github.com/grafana/loki/pkg/logql/syntax"
+	"os"
+	"sync"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"gopkg.in/yaml.v3"
-	"os"
-	"sync"
+
+	"github.com/grafana/loki/pkg/logql/syntax"
 )
 
 type GroupLoader struct{}

--- a/pkg/ruler/grouploader_test.go
+++ b/pkg/ruler/grouploader_test.go
@@ -2,14 +2,15 @@ package ruler
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-	"os"
-	"strings"
-	"testing"
 )
 
 func Test_GroupLoader(t *testing.T) {

--- a/pkg/ruler/memstore.go
+++ b/pkg/ruler/memstore.go
@@ -3,9 +3,10 @@ package ruler
 import (
 	"context"
 	"errors"
-	"github.com/prometheus/prometheus/model/rulefmt"
 	"sync"
 	"time"
+
+	"github.com/prometheus/prometheus/model/rulefmt"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/ruler/memstore_test.go
+++ b/pkg/ruler/memstore_test.go
@@ -2,10 +2,11 @@ package ruler
 
 import (
 	"context"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/rulefmt"
 	"testing"
 	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/rulefmt"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"


### PR DESCRIPTION
**What this PR does / why we need it**:
We had a few outstanding linter issues, and running `make lint` fixes them all automatically.