### PR TITLE
Loki: Add UsageStatsURL to usagestats Config

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2797,6 +2797,10 @@ Configuration for usage report.
 # Enable anonymous usage reporting.
 # CLI flag: -reporting.enabled
 [reporting_enabled: <boolean> | default = true]
+
+# URL to which reports are sent
+# CLI flag: -reporting.usage-stats-url
+[usage_stats_url: <string> | default = "https://stats.grafana.org/loki-usage-report"]
 ```
 
 ### common

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -40,13 +40,15 @@ var (
 )
 
 type Config struct {
-	Enabled bool `yaml:"reporting_enabled"`
-	Leader  bool `yaml:"-"`
+	Enabled       bool   `yaml:"reporting_enabled"`
+	Leader        bool   `yaml:"-"`
+	UsageStatsURL string `yaml:"usage_stats_url"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "reporting.enabled", true, "Enable anonymous usage reporting.")
+	f.StringVar(&cfg.UsageStatsURL, "reporting.usage-stats-url", usageStatsURL, "URL to which reports are sent")
 }
 
 type Reporter struct {
@@ -299,7 +301,7 @@ func (rep *Reporter) reportUsage(ctx context.Context, interval time.Time) error 
 	})
 	var errs multierror.MultiError
 	for backoff.Ongoing() {
-		if err := sendReport(ctx, rep.cluster, interval); err != nil {
+		if err := sendReport(ctx, rep.cluster, interval, rep.conf.UsageStatsURL); err != nil {
 			level.Info(rep.logger).Log("msg", "failed to send usage report", "retries", backoff.NumRetries(), "err", err)
 			errs.Add(err)
 			backoff.Wait()

--- a/pkg/usagestats/reporter_test.go
+++ b/pkg/usagestats/reporter_test.go
@@ -79,14 +79,13 @@ func Test_ReportLoop(t *testing.T) {
 		clusterIDs = append(clusterIDs, received.ClusterID)
 		rw.WriteHeader(http.StatusOK)
 	}))
-	usageStatsURL = server.URL
 
 	objectClient, err := local.NewFSObjectClient(local.FSConfig{
 		Directory: t.TempDir(),
 	})
 	require.NoError(t, err)
 
-	r, err := NewReporter(Config{Leader: true, Enabled: true}, kv.Config{
+	r, err := NewReporter(Config{Leader: true, Enabled: true, UsageStatsURL: server.URL}, kv.Config{
 		Store: "inmemory",
 	}, objectClient, log.NewLogfmtLogger(os.Stdout), prometheus.NewPedanticRegistry())
 	require.NoError(t, err)

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -45,13 +45,13 @@ type Report struct {
 }
 
 // sendReport sends the report to the stats server
-func sendReport(ctx context.Context, seed *ClusterSeed, interval time.Time) error {
+func sendReport(ctx context.Context, seed *ClusterSeed, interval time.Time, URL string) error {
 	report := buildReport(seed, interval)
 	out, err := jsoniter.MarshalIndent(report, "", " ")
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPost, usageStatsURL, bytes.NewBuffer(out))
+	req, err := http.NewRequest(http.MethodPost, URL, bytes.NewBuffer(out))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Reports used to be sent to a fixed URL usageStatsURL.
Now this url can be configurable while using the old url as a default.
Updated tests to use config for custom URLs instead of changing package variable.

**Which issue(s) this PR fixes**:
Fixes #6502

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
