### PR TITLE
Loki: Add a `prepare-shutdown` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ##### Enhancements
 
+* [8786](https://github.com/grafana/loki/pull/8786) **DylanGuedes**: Ingester: add new /ingester/prepare_shutdown endpoint.
 * [8744](https://github.com/grafana/loki/pull/8744) **dannykopping**: Ruler: remote rule evaluation.
 * [8727](https://github.com/grafana/loki/pull/8727) **cstyan** **jeschkies**: Propagate per-request limit header to querier.
 * [8682](https://github.com/grafana/loki/pull/8682) **dannykopping**: Add fetched chunk size distribution metric `loki_chunk_fetcher_fetched_size_bytes`.

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -627,8 +627,8 @@ In microservices mode, the `/flush` endpoint is exposed by the ingester.
 POST /ingester/prepare_shutdown
 ```
 
-`/ingester/prepare_shutdown` will prepare the ingester to release resources on the next SIGTERM,
-where releasing resources means flushing data and unregistering from the ring.
+`/ingester/prepare_shutdown` will prepare the ingester to release resources on the next SIGTERM signal,
+where releasing resources means flushing data and unregistering from the ingester ring.
 This endpoint supersedes any YAML configurations and isn't necessary if the ingester is already
 configured to unregister from the ring or to flush on shutdown.
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -621,6 +621,17 @@ backing store. Mainly used for local testing.
 
 In microservices mode, the `/flush` endpoint is exposed by the ingester.
 
+### Tell ingester to release all resources on next SIGTERM
+
+```
+POST /ingester/prepare_shutdown
+```
+
+`/ingester/prepare_shutdown` will prepare the ingester to release resources on the next SIGTERM,
+where releasing resources means flushing data and unregistering from the ring.
+This endpoint supersede any YAML configurations and isn't necessary if the ingester is already
+configured to unregister from the ring or to flush on shutdown.
+
 ## Flush in-memory chunks and shut down
 
 ```

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -629,7 +629,7 @@ POST /ingester/prepare_shutdown
 
 `/ingester/prepare_shutdown` will prepare the ingester to release resources on the next SIGTERM,
 where releasing resources means flushing data and unregistering from the ring.
-This endpoint supersede any YAML configurations and isn't necessary if the ingester is already
+This endpoint supersedes any YAML configurations and isn't necessary if the ingester is already
 configured to unregister from the ring or to flush on shutdown.
 
 ## Flush in-memory chunks and shut down

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -570,7 +570,7 @@ func (i *Ingester) LegacyShutdownHandler(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// PrepareShutdown will handle the /prepare_shutdown endpoint.
+// PrepareShutdown will handle the /ingester/prepare_shutdown endpoint.
 //
 // Internally, when triggered, this handler will configure the ingester service to release their resources whenever a SIGTERM is received.
 // Releasing resources meaning flushing data, deleting tokens, and removing itself from the ring.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -182,6 +182,7 @@ type Interface interface {
 	// deprecated
 	LegacyShutdownHandler(w http.ResponseWriter, r *http.Request)
 	ShutdownHandler(w http.ResponseWriter, r *http.Request)
+	PrepareShutdown(w http.ResponseWriter, r *http.Request)
 }
 
 // Ingester builds chunks for incoming log streams.
@@ -578,16 +579,15 @@ func (i *Ingester) LegacyShutdownHandler(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// PrepareShutdownHTTPHandler will handle the /prepare_shutdown endpoint.
+// PrepareShutdown will handle the /prepare_shutdown endpoint.
 //
 // Internally, when triggered, this handler will configure the ingester service to release their resources whenever a SIGTERM is received.
 // Releasing resources meaning flushing data, deleting tokens, and removing itself from the ring.
-func (i *Ingester) PrepareShutdownHTTPHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		i.releaseResources.Store(true)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-	}
+func (i *Ingester) PrepareShutdown(w http.ResponseWriter, r *http.Request) {
+	level.Info(util_log.Logger).Log("msg", "preparing full ingester shutdown, resources will be released on SIGTERM")
+	i.releaseResources.Store(true)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 }
 
 // ShutdownHandler handles a graceful shutdown of the ingester service and

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -372,6 +372,8 @@ type Loki struct {
 	deleteClientMetrics *deletion.DeleteRequestClientMetrics
 
 	HTTPAuthMiddleware middleware.Interface
+
+	ingesterRelease *atomic.Bool
 }
 
 // New makes a new Loki.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -471,6 +471,9 @@ func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.Server.HTTP.Methods("POST").Path("/ingester/flush_shutdown").Handler(
 		httpMiddleware.Wrap(http.HandlerFunc(t.Ingester.LegacyShutdownHandler)),
 	)
+	t.Server.HTTP.Methods("POST").Path("/ingester/prepare_shutdown").Handler(
+		httpMiddleware.Wrap(http.HandlerFunc(t.Ingester.PrepareShutdown)),
+	)
 	t.Server.HTTP.Methods("POST").Path("/ingester/shutdown").Handler(
 		httpMiddleware.Wrap(http.HandlerFunc(t.Ingester.ShutdownHandler)),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new `/ingester/prepare_shutdown` endpoint. This new endpoint configures the ingester to release resources on the next SIGTERM.