### PR TITLE
Fix: Ensure query limits tripperware wraps frontend.

### DIFF
--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/loki/integration/client"
 	"github.com/grafana/loki/integration/cluster"
-
 	"github.com/grafana/loki/pkg/util/querylimits"
 )
 

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -135,7 +135,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 		cliQueryFrontendLimited := client.New(tenantID, "", tQueryFrontend.HTTPURL(), queryLimitsPolicy)
 		cliQueryFrontendLimited.Now = now
 
-		_, err := cliQueryFrontend.LabelNames(context.Background())
+		_, err := cliQueryFrontendLimited.LabelNames(context.Background())
 		require.ErrorContains(t, err, "the query time range exceeds the limit (query length")
 	})
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -680,7 +680,10 @@ func (t *Loki) setupModuleManager() error {
 		deps[QueryLimitsInterceptors] = []string{}
 
 		// Ensure query limits tripperware embeds the query frontend
-		// tripperware after it's been created.
+		// tripperware after it's been created. Any additional
+		// middleware/tripperware you want to add to the querier or
+		// frontend must happen inject a dependence on the query limits
+		// tripperware.
 		deps[QueryLimitsTripperware] = []string{QueryFrontendTripperware}
 
 		deps[Querier] = append(deps[Querier], QueryLimiter)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -674,12 +674,24 @@ func (t *Loki) setupModuleManager() error {
 		mm.RegisterModule(QueryLimitsInterceptors, t.initQueryLimitsInterceptors, modules.UserInvisibleModule)
 		mm.RegisterModule(QueryLimitsTripperware, t.initQueryLimitsTripperware, modules.UserInvisibleModule)
 
-		deps[Querier] = append(deps[Querier], QueryLimiter)
-		deps[QueryFrontend] = append(deps[QueryFrontend], QueryLimitsTripperware)
-
+		// Ensure query limiter embeds overrides after they've been
+		// created.
 		deps[QueryLimiter] = []string{Overrides}
 		deps[QueryLimitsInterceptors] = []string{}
+
+		// Ensure query limits tripperware embeds the query frontend
+		// tripperware after it's been created.
 		deps[QueryLimitsTripperware] = []string{QueryFrontendTripperware}
+
+		deps[Querier] = append(deps[Querier], QueryLimiter)
+
+		// The frontend receives a tripperware. Make sure it uses the
+		// wrapped one.
+		deps[QueryFrontend] = append(deps[QueryFrontend], QueryLimitsTripperware)
+
+		// query frontend tripperware uses t.Overrides. Make sure it
+		// uses the one wrapped by query limiter.
+		deps[QueryFrontendTripperware] = append(deps[QueryFrontendTripperware], QueryLimiter)
 
 		if err := mm.AddDependency(Server, QueryLimitsInterceptors); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
The query frontend would not enforce the per-request query limits because the injected tripperware was wrapped *after* the frontend has been created. That is a bug. The order must be changed so that the `queryrange.LimitsMiddleware` runs *after* the `querylimits.limitsMiddleware`.

**Which issue(s) this PR fixes**:
Fixes #8790


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
