### PR TITLE
Integration Tests: allow loki logs to be optionally output in integration tests

### DIFF
--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -144,8 +144,8 @@ type Cluster struct {
 	waitGroup     sync.WaitGroup
 }
 
-func New(enableLogging bool, logLevel level.Value) *Cluster {
-	if enableLogging && logLevel != nil {
+func New(logLevel level.Value) *Cluster {
+	if logLevel != nil {
 		util_log.Logger = level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.Allow(logLevel))
 	}
 

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -16,6 +16,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/grafana/loki/pkg/loki"
 	"github.com/grafana/loki/pkg/util/cfg"
+	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -141,7 +144,11 @@ type Cluster struct {
 	waitGroup     sync.WaitGroup
 }
 
-func New() *Cluster {
+func New(enableLogging bool, logLevel level.Value) *Cluster {
+	if enableLogging && logLevel != nil {
+		util_log.Logger = level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.Allow(logLevel))
+	}
+
 	wrapRegistry()
 	sharedPath, err := os.MkdirTemp("", "loki-shared-data")
 	if err != nil {

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMicroServicesDeleteRequest(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 		storage.ResetBoltDBIndexClientWithShipper()

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMicroServicesDeleteRequest(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 		storage.ResetBoltDBIndexClientWithShipper()

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMicroServicesIngestQuery(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMicroServicesIngestQuery(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -34,7 +34,7 @@ func TestRemoteRuleEval(t *testing.T) {
 // In this test we stub out a remote-write receiver and check that the expected data is sent to it.
 // Both the local and the remote rule evaluation modes should produce the same result.
 func testRuleEval(t *testing.T, mode string) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	t.Cleanup(func() {
 		assert.NoError(t, clu.Cleanup())
 	})

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -34,7 +34,7 @@ func TestRemoteRuleEval(t *testing.T) {
 // In this test we stub out a remote-write receiver and check that the expected data is sent to it.
 // Both the local and the remote rule evaluation modes should produce the same result.
 func testRuleEval(t *testing.T, mode string) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	t.Cleanup(func() {
 		assert.NoError(t, clu.Cleanup())
 	})

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSimpleScalable_IngestQuery(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/loki_simple_scalable_test.go
+++ b/integration/loki_simple_scalable_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSimpleScalable_IngestQuery(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSingleBinaryIngestQuery(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/loki_single_binary_test.go
+++ b/integration/loki_single_binary_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSingleBinaryIngestQuery(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMultiTenantQuery(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMultiTenantQuery(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPerRequestLimits(t *testing.T) {
-	clu := cluster.New(false, nil)
+	clu := cluster.New(nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPerRequestLimits(t *testing.T) {
-	clu := cluster.New()
+	clu := cluster.New(false, nil)
 	defer func() {
 		assert.NoError(t, clu.Cleanup())
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:
Debugging integration tests can be difficult without Loki's logs being output.

Changing the call from `cluster.New()` to `cluster.New(level.WarnValue())` now allows the author the option to temporarily or permanently enable logging for their test, as well as configure a level filter to control the noise.