### PR TITLE
logql: do not panic if operands of BinaryLabelFilter are noop filters

### DIFF
--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -105,6 +105,13 @@ func (b *BinaryLabelFilter) RequiredLabelNames() []string {
 }
 
 func (b *BinaryLabelFilter) String() string {
+	switch NoopLabelFilter {
+	case b.Left:
+		return b.Right.String()
+	case b.Right:
+		return b.Left.String()
+	}
+
 	var sb strings.Builder
 	sb.WriteString("( ")
 	sb.WriteString(b.Left.String())

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -415,7 +415,11 @@ func (e *LabelFilterExpr) Stage() (log.Stage, error) {
 }
 
 func (e *LabelFilterExpr) String() string {
-	return fmt.Sprintf("%s %s", OpPipe, e.LabelFilterer.String())
+	if s := e.LabelFilterer.String(); s != "" {
+		return fmt.Sprintf("%s %s", OpPipe, s)
+	}
+
+	return ""
 }
 
 type LineFmtExpr struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Stringer of `BinaryLabelFilter` doesn't handle `noopLableFilter` correctly. Calling it's `String` method on the following query `| foo =~ ".*" bar = "buzz"` results in `( , bar = "buzz")`, trying to parse this would lead to a panic.

[logs](https://admin-ops-us-east-0.grafana.net/grafana/explore?orgId=1&left=%7B%22datasource%22:%22loki-ops%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22loki-ops%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22loki-prod%5C%22,%20container%3D%5C%22query-frontend%5C%22%7D%20%7C%3D%20%5C%22httpRequest_remoteIp%5C%22%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-30m%22,%22to%22:%22now%22%7D%7D) from production
```
level=info ts=2023-03-14T11:15:07.89890025Z caller=roundtrip.go:209 org_id=208466 msg="executing query" type=instant query="sum by (httpRequest_remoteIp) (count_over_time({job=\"gcplog\", resource_type=\"http_load_balancer\", cluster=\"production-9478\"} | enforced_rulematch=~\"owasp.*\" | enforced_outcome!=\"EXEMPT\" method=~\".*\" | json |  httpRequest_requestUrl=~\".*.+.*\" [15m])) > 20"

panic: error cloning query: (sum by (httpRequest_remoteIp)(count_over_time({job="gcplog", resource_type="http_load_balancer", cluster="production-9478"} \| enforced_rulematch=~"owasp.*" \| ( enforced_outcome!="EXEMPT" ,  ) \| json \| httpRequest_requestUrl=~".*.+.*"[15m])) > 20): parse error at line 1, col 192: syntax error: unexpected ), expecting IDENTIFIER or (
```

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
