### PR TITLE
Retention: add selector detail to docs

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -111,6 +111,8 @@ limits_config:
 ...
 ```
 
+**NOTE:** only label matchers can be used in the `selector` field of a `retention_stream` definition. Arbitrary LogQL expressions are not supported.
+
 Per tenant retention can be defined using the `/etc/overrides.yaml` files. For example:
 
 ```yaml
@@ -118,7 +120,7 @@ overrides:
     "29":
         retention_period: 168h
         retention_stream:
-        - selector: '{namespace="prod"}'
+        - selector: '{namespace="prod", container=~"(nginx|loki)"}'
           priority: 2
           period: 336h
         - selector: '{container="loki"}'
@@ -126,7 +128,7 @@ overrides:
           period: 72h
     "30":
         retention_stream:
-        - selector: '{container="nginx"}'
+        - selector: '{container="nginx", level="debug"}'
           priority: 1
           period: 24h
 ```

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -111,7 +111,7 @@ limits_config:
 ...
 ```
 
-**NOTE:** only label matchers can be used in the `selector` field of a `retention_stream` definition. Arbitrary LogQL expressions are not supported.
+**NOTE:** You can only use label matchers in the `selector` field of a `retention_stream` definition. Arbitrary LogQL expressions are not supported.
 
 Per tenant retention can be defined using the `/etc/overrides.yaml` files. For example:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds more detail around what can and cannot be used in a `selector` for retention. It was unclear whether arbitrary LogQL could be used or not; this makes it explicit.

Also added some additional matchers to the examples to show that it can be combinatorial.