### PR TITLE
operator: Fix publishing operator bundle on quay.io

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -87,8 +87,8 @@ jobs:
      - name: Build and publish image on quay.io
        uses: docker/build-push-action@v4
        with:
-         context: ./operator
-         file: ./operator/bundle.Dockerfile
+         context: ./operator/bundle/openshift
+         file: ./operator/bundle/openshift/bundle.Dockerfile
          push: true
          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With #7308 the bundles directories moved into a separate location to support community and openshift bundles in parallel. However we are missing for considerable amount of time publishing the openshift bundle for dev usage.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
