### PR TITLE
Print duration in error messages with more readable.

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -683,10 +683,10 @@ func validateQueryTimeRangeLimits(ctx context.Context, userID string, limits tim
 	}
 	maxQueryLength := limits.MaxQueryLength(ctx, userID)
 	if maxQueryLength > 0 && (through).Sub(from) > maxQueryLength {
-		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, util_validation.ErrQueryTooLong, (through).Sub(from), maxQueryLength)
+		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, util_validation.ErrQueryTooLong, (through).Sub(from), model.Duration(maxQueryLength))
 	}
 	if through.Before(from) {
-		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, "this data is no longer available, it is past now - max_query_lookback (%s)", maxQueryLookback)
+		return time.Time{}, time.Time{}, httpgrpc.Errorf(http.StatusBadRequest, util_validation.ErrQueryTooOld, model.Duration(maxQueryLookback))
 	}
 	return from, through, nil
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -207,9 +207,9 @@ func TestQuerier_validateQueryRequest(t *testing.T) {
 	_, err = q.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: &request})
 	require.NoError(t, err)
 
-	request.Start = request.End.Add(-3 * time.Minute)
+	request.Start = request.End.Add(-3*time.Minute - 2*time.Second)
 	_, err = q.SelectLogs(ctx, logql.SelectLogParams{QueryRequest: &request})
-	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, "the query time range exceeds the limit (query length: 3m0s, limit: 2m0s)"), err)
+	require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, "the query time range exceeds the limit (query length: 3m2s, limit: 2m)"), err)
 }
 
 func TestQuerier_SeriesAPI(t *testing.T) {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -172,7 +172,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r queryrangebase.Request) (que
 	if maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, lengthCapture); maxQueryLength > 0 {
 		queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
 		if queryLen > maxQueryLength {
-			return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, maxQueryLength)
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, model.Duration(maxQueryLength))
 		}
 	}
 

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -137,7 +137,7 @@ func (c *storeEntry) validateQueryTimeRange(ctx context.Context, userID string, 
 
 	maxQueryLength := c.limits.MaxQueryLength(ctx, userID)
 	if maxQueryLength > 0 && (*through).Sub(*from) > maxQueryLength {
-		return false, errors.QueryError(fmt.Sprintf(validation.ErrQueryTooLong, (*through).Sub(*from), model.Time(maxQueryLength)))
+		return false, errors.QueryError(fmt.Sprintf(validation.ErrQueryTooLong, model.Duration((*through).Sub(*from)), model.Duration(maxQueryLength)))
 	}
 
 	now := model.Now()

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -137,7 +137,7 @@ func (c *storeEntry) validateQueryTimeRange(ctx context.Context, userID string, 
 
 	maxQueryLength := c.limits.MaxQueryLength(ctx, userID)
 	if maxQueryLength > 0 && (*through).Sub(*from) > maxQueryLength {
-		return false, errors.QueryError(fmt.Sprintf(validation.ErrQueryTooLong, (*through).Sub(*from), maxQueryLength))
+		return false, errors.QueryError(fmt.Sprintf(validation.ErrQueryTooLong, (*through).Sub(*from), model.Time(maxQueryLength)))
 	}
 
 	now := model.Now()

--- a/pkg/storage/stores/indexshipper/compactor/compactor_test.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor_test.go
@@ -31,7 +31,7 @@ func dayFromTime(t model.Time) config.DayTime {
 }
 
 var (
-	start     = model.Now().Add(-30 * 24 * time.Hour)
+	start = model.Now().Add(-30 * 24 * time.Hour)
 )
 
 func setupTestCompactor(t *testing.T, tempDir string) *Compactor {

--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -629,7 +629,7 @@ func TestChunkStoreError(t *testing.T) {
 			query:   "foo",
 			from:    model.Time(0),
 			through: model.Time(0).Add(31 * 24 * time.Hour),
-			err:     "the query time range exceeds the limit (query length: 744h0m0s, limit: 720h0m0s)",
+			err:     "the query time range exceeds the limit (query length: 31d, limit: 30d)",
 		},
 		{
 			query:   "{foo=\"bar\"}",

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -4,6 +4,8 @@ const (
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
 
+	ErrQueryTooOld = "this data is no longer available, it is past now - max_query_lookback (%s)"
+
 	// RateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
 	RateLimited = "rate_limited"


### PR DESCRIPTION
**What this PR does / why we need it**:
The old error messages would print only up to hours. E.g. `169h30s`. This change will print it as `7d1h30s`. See [model.Duration](https://github.com/prometheus/common/blob/66b493f42b757378fbad83e42b0ed441d425a17b/model/time.go#L259-L290) for details.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
