### PR TITLE
Loki: Add `/loki/api/v1/retention_simulation` endpoint

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1089,6 +1089,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler))
 		t.Server.HTTP.Path("/loki/api/v1/delete").Methods("DELETE").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler))
 		t.Server.HTTP.Path("/loki/api/v1/cache/generation_numbers").Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler))
+		t.Server.HTTP.Path("/loki/api/v1/simulate_retention").Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.SimulateRetentionHandler))
 		grpc.RegisterCompactorServer(t.Server.GRPC, t.compactor.DeleteRequestsGRPCHandler)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new `/loki/api/v1/simulate_retention` endpoint
* Endpoint expects a `since` parameter that represents a period used on the simulation
* It works by simulating a chunk with `creationTime=now`. This simulated chunk is then passed to our internal retention validation that will consider `now=creationTime+since`.
* Ex: in a scenario where the user retention configured is `30d` and the endpoint is called with `since=15d`:
  * A chunk will be created with `creationTime=now`
  * The retention checker will consider `now=creationTime+since`=`now+15d`, forcing the comparison to consider an interval equal to `15d`
  * Since the retention is `30d` and the interval is `15d`, the endpoint will return that the chunk wouldn't be deleted
