### PR TITLE
Removing backend target from SSD docker setup

### DIFF
--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -53,14 +53,10 @@ ruler:
   enable_api: true
   wal:
     dir: /tmp/ruler-wal
-  evaluation:
-    mode: remote
-    query_frontend:
-      address: dns:///loki-read:9095
   storage:
     type: local
     local:
-      directory: /etc/loki/rules
+      directory: /loki/rules
   rule_path: /tmp/prom-rules
   remote_write:
     enabled: true

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -118,6 +118,7 @@ services:
     image: grafana/loki:2.7.3
     volumes:
       - ./config:/etc/loki/
+      - ./rules:/loki/rules:ro
     ports:
       - "3100"
       - "7946"
@@ -127,7 +128,7 @@ services:
       #  - SYS_PTRACE
       #security_opt:
       #  - apparmor=unconfined
-    command: "-config.file=/etc/loki/loki.yaml -target=read -legacy-read-mode=false"
+    command: "-config.file=/etc/loki/loki.yaml -target=read"
     networks:
       - loki
     restart: always
@@ -150,28 +151,6 @@ services:
       # security_opt:
       #   - apparmor=unconfined
     command: "-config.file=/etc/loki/loki.yaml -target=write"
-    networks:
-      - loki
-    restart: always
-    deploy:
-      mode: replicated
-      replicas: 3
-
-  loki-backend:
-    image: grafana/loki:2.7.3
-    volumes:
-      - ./config:/etc/loki/
-      - ./rules:/etc/loki/rules
-    ports:
-      - "3100"
-      - "7946"
-      # uncomment to use interactive debugging
-      #- "60000-60002:40000" # makes the replicas available on ports 50000, 50001, 50002
-      # cap_add:
-      #   - SYS_PTRACE
-      # security_opt:
-      #   - apparmor=unconfined
-    command: "-config.file=/etc/loki/loki.yaml -target=backend -legacy-read-mode=false -log.level=debug"
     networks:
       - loki
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:
The `backend` target is only present in v2.8.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I was using this docker setup to test https://github.com/grafana/loki/pull/8744 and I obviously left some things around from that. Sorry about that!

Thanks @wardbekker for noticing the issue