### PR TITLE
Build: Remove ./tools/fetch-tags invocation from Makefile

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -52,9 +52,11 @@ local gpg_private_key = secret('gpg_private_key', 'infra/data/ci/packages-publis
 local updater_config_template = secret('updater_config_template', 'secret/data/common/loki_ci_autodeploy', 'updater-config-template.json');
 local helm_chart_auto_update_config_template = secret('helm-chart-update-config-template', 'secret/data/common/loki-helm-chart-auto-update', 'on-loki-release-config.json');
 
+local build_image_name = 'grafana/loki-build-image:%s' % build_image_version;
+
 local run(name, commands, env={}) = {
   name: name,
-  image: 'grafana/loki-build-image:%s' % build_image_version,
+  image: build_image_name,
   commands: commands,
   environment: env,
 };
@@ -69,7 +71,7 @@ local make(target, container=true, args=[]) = run(target, [
 
 local fetch_tags = {
   name: 'fetch-tags',
-  image: 'alpine',
+  image: build_image_name,
   commands: [
     'apk add --no-cache bash git',
     'git fetch origin --tags',
@@ -138,7 +140,7 @@ local arch_image(arch, tags='') = {
     {
       name: 'image-tag',
       depends_on: ['fetch-tags'],
-      image: 'alpine',
+      image: build_image_name,
       commands: [
         'echo $(./tools/image-tag)-%s > .tags' % arch,
       ] + if tags != '' then ['echo ",%s" >> .tags' % tags] else [],

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -73,7 +73,6 @@ local fetch_tags = {
   name: 'fetch-tags',
   image: build_image_name,
   commands: [
-    'apk add --no-cache bash git',
     'git fetch origin --tags',
   ],
 };

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -661,7 +661,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       fetch_tags,
       {
         name: 'prepare-updater-config',
-        image: 'alpine',
+        image: build_image_name,
         environment: {
           MAJOR_MINOR_VERSION_REGEXP: '([0-9]+\\.[0-9]+)',
           RELEASE_TAG_REGEXP: '^([0-9]+\\.[0-9]+\\.[0-9]+)$',
@@ -705,7 +705,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       fetch_tags,
       {
         name: 'check-version-is-latest',
-        image: 'alpine',
+        image: build_image_name,
         when: onTag,
         commands: [
           "latest_version=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 | sed 's/v//g')",
@@ -715,7 +715,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       },
       {
         name: 'prepare-helm-chart-update-config',
-        image: 'alpine',
+        image: build_image_name,
         depends_on: ['check-version-is-latest'],
         commands: [
           'RELEASE_TAG=$(./tools/image-tag)',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -680,7 +680,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
         settings: {
           config_template: { from_secret: updater_config_template.name },
         },
-        depends_on: ['clone'],
+        depends_on: ['fetch-tags'],
       },
       {
         name: 'trigger',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -154,7 +154,13 @@ local promtail_win() = pipeline('promtail-windows') {
     version: '1809',
   },
   steps: [
-    fetch_tags,
+    {
+      name: 'fetch-tags',
+      image: 'golang:1.19-windowsservercore-1809',
+      commands: [
+        'git fetch origin --tags',
+      ],
+    },
     {
       name: 'identify-runner',
       image: 'golang:1.19-windowsservercore-1809',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1301,7 +1301,7 @@ steps:
   environment:
     MAJOR_MINOR_VERSION_REGEXP: ([0-9]+\.[0-9]+)
     RELEASE_TAG_REGEXP: ^([0-9]+\.[0-9]+\.[0-9]+)$
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: prepare-updater-config
   settings:
     config_template:
@@ -1342,7 +1342,7 @@ steps:
   - if [ "$RELEASE_TAG" != "$latest_version" ]; then echo "Current version $RELEASE_TAG
     is not the latest version of Loki. The latest version is $latest_version" && exit
     78; fi
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: check-version-is-latest
   when:
     event:
@@ -1353,7 +1353,7 @@ steps:
   - sed -i -E "s/\{\{release\}\}/$RELEASE_TAG/g" updater-config.json
   depends_on:
   - check-version-is-latest
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: prepare-helm-chart-update-config
   settings:
     config_template:
@@ -1807,6 +1807,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 9f80fe0c29f373948797930a3f5a258086481181b9f8b76a66962960dfd4a98e
+hmac: c7de512a00ab0b3450fb14929b80be9b4a3b381279de57fe19ad1bc27228542f
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1379,7 +1379,7 @@ platform:
 steps:
 - commands:
   - git fetch origin --tags
-  image: grafana/loki-build-image:0.28.1
+  image: golang:1.19-windowsservercore-1809
   name: fetch-tags
 - commands:
   - Write-Output $env:DRONE_RUNNER_NAME
@@ -1807,6 +1807,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: a68e8d3983e37d2683f4c1752125fb7d451a8e10c18a7a6405b792e4aac54990
+hmac: 75fb0ea84d50db96cf2a3c99e19f25a27eb1e7ce190d25b8191759430cdb3451
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -291,7 +291,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -405,7 +410,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -519,7 +529,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -633,7 +648,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -685,7 +705,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -737,7 +762,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -789,7 +819,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -843,7 +878,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -897,7 +937,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -951,8 +996,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1004,8 +1054,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1057,8 +1112,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1110,8 +1170,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1233,6 +1298,9 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag) > .tag
   - export RELEASE_TAG=$(cat .tag)
   - export RELEASE_NAME=$([[ $RELEASE_TAG =~ $RELEASE_TAG_REGEXP ]] && echo $RELEASE_TAG
@@ -1279,7 +1347,10 @@ name: update-loki-helm-chart-on-loki-release
 steps:
 - commands:
   - apk add --no-cache bash git
-  - git fetch --tags
+  - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - latest_version=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 | sed
     's/v//g')
   - RELEASE_TAG=$(./tools/image-tag)
@@ -1292,8 +1363,6 @@ steps:
     event:
     - tag
 - commands:
-  - apk add --no-cache bash git
-  - git fetch origin --tags
   - RELEASE_TAG=$(./tools/image-tag)
   - echo $PLUGIN_CONFIG_TEMPLATE > updater-config.json
   - sed -i -E "s/\{\{release\}\}/$RELEASE_TAG/g" updater-config.json
@@ -1324,6 +1393,11 @@ platform:
   version: "1809"
 steps:
 - commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - Write-Output $env:DRONE_RUNNER_NAME
   image: golang:1.19-windowsservercore-1809
   name: identify-runner
@@ -1349,7 +1423,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1411,6 +1490,11 @@ services:
     path: /sys/fs/cgroup
 steps:
 - commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE
   environment:
     NFPM_SIGNING_KEY:
@@ -1444,6 +1528,8 @@ steps:
     path: /var/run/docker.sock
 - commands:
   - make BUILD_IN_CONTAINER=false publish
+  depends_on:
+  - fetch-tags
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1476,9 +1562,14 @@ kind: pipeline
 name: docker-driver
 steps:
 - commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - make docker-driver-push
   depends_on:
-  - clone
+  - fetch-tags
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -1515,7 +1606,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-amd64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1573,7 +1669,12 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - echo $(./tools/image-tag)-arm64 > .tags
+  depends_on:
+  - fetch-tags
   image: alpine
   name: image-tag
 - depends_on:
@@ -1727,6 +1828,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: ae19447e0f2e91746c5b4e6a3dc469a08a63c44045f4b995a6980d0e401e071f
+hmac: 6fdf07fbcd5077ed7cd2bfc4cb4e9d06e7caa7ff4dd95a96b3958a2882e75ba4
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1297,7 +1297,7 @@ steps:
   - sed -i "s/\"{{release}}\"/\"$RELEASE_NAME\"/g" updater-config.json
   - sed -i "s/{{version}}/$RELEASE_TAG/g" updater-config.json
   depends_on:
-  - clone
+  - fetch-tags
   environment:
     MAJOR_MINOR_VERSION_REGEXP: ([0-9]+\.[0-9]+)
     RELEASE_TAG_REGEXP: ^([0-9]+\.[0-9]+\.[0-9]+)$
@@ -1807,6 +1807,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: c7de512a00ab0b3450fb14929b80be9b4a3b381279de57fe19ad1bc27228542f
+hmac: a68e8d3983e37d2683f4c1752125fb7d451a8e10c18a7a6405b792e4aac54990
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -289,7 +289,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -408,7 +407,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -527,7 +525,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -646,7 +643,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -703,7 +699,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -760,7 +755,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -817,7 +811,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -876,7 +869,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -935,7 +927,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -994,7 +985,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1052,7 +1042,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1110,7 +1099,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1168,7 +1156,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1296,7 +1283,6 @@ kind: pipeline
 name: deploy
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1346,7 +1332,6 @@ kind: pipeline
 name: update-loki-helm-chart-on-loki-release
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1393,7 +1378,6 @@ platform:
   version: "1809"
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1421,7 +1405,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1490,7 +1473,6 @@ services:
     path: /sys/fs/cgroup
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1562,7 +1544,6 @@ kind: pipeline
 name: docker-driver
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1604,7 +1585,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1667,7 +1647,6 @@ platform:
   os: linux
 steps:
 - commands:
-  - apk add --no-cache bash git
   - git fetch origin --tags
   image: grafana/loki-build-image:0.28.1
   name: fetch-tags
@@ -1828,6 +1807,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 8563c849a51da1f128fac1a956dd0da2c4143c46107be8af11723c6e13de6d35
+hmac: 9f80fe0c29f373948797930a3f5a258086481181b9f8b76a66962960dfd4a98e
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -291,13 +291,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -410,13 +410,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -529,13 +529,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -648,13 +648,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -705,13 +705,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -762,13 +762,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -819,13 +819,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -878,13 +878,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -937,13 +937,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -996,14 +996,14 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1054,14 +1054,14 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1112,14 +1112,14 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1170,14 +1170,14 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   - echo ",main" >> .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1298,7 +1298,7 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag) > .tag
@@ -1348,7 +1348,7 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - latest_version=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 | sed
@@ -1395,7 +1395,7 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - Write-Output $env:DRONE_RUNNER_NAME
@@ -1423,13 +1423,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1492,7 +1492,7 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE
@@ -1564,7 +1564,7 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - make docker-driver-push
@@ -1606,13 +1606,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-amd64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1669,13 +1669,13 @@ steps:
 - commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: fetch-tags
 - commands:
   - echo $(./tools/image-tag)-arm64 > .tags
   depends_on:
   - fetch-tags
-  image: alpine
+  image: grafana/loki-build-image:0.28.1
   name: image-tag
 - depends_on:
   - image-tag
@@ -1828,6 +1828,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 6fdf07fbcd5077ed7cd2bfc4cb4e9d06e7caa7ff4dd95a96b3958a2882e75ba4
+hmac: 8563c849a51da1f128fac1a956dd0da2c4143c46107be8af11723c6e13de6d35
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ BUILD_IMAGE_VERSION := 0.28.1
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-FETCH_TAGS :=$(shell ./tools/fetch-tags)
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries

--- a/tools/fetch-tags
+++ b/tools/fetch-tags
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-git fetch --tags --all


### PR DESCRIPTION
**What this PR does / why we need it**:

This invocation causes problems when make targets are executed in the build image container (`BUILD_IN_CONTAINER=true`), e.g. the `yacc` target, because git tries to fetch tags from `origin` using ssh, causing error message like these:

```
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error: Could not fetch origin
```

This is because local ssh keys are not mounted into the build container.

In order not to break CI builds
(https://github.com/grafana/loki/pull/8232) we need to manually fetch the tags as the first step in release pipelines. This is added to the Drone configuration.