### PR TITLE
Loki: Add route_randomly to Redis options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ##### Enhancements
 
+* [8852](https://github.com/grafana/loki/pull/8852) **wtchangdm**: Loki: Add `route_randomly` to Redis options.
 * [8848](https://github.com/grafana/loki/pull/8848) **dannykopping**: Ruler: add configurable rule evaluation jitter.
 * [8752](https://github.com/grafana/loki/pull/8752) **chaudum**: Add query fairness control across actors within a tenant to scheduler, which can be enabled by passing the `X-Loki-Actor-Path` header to the HTTP request of the query.
 * [8786](https://github.com/grafana/loki/pull/8786) **DylanGuedes**: Ingester: add new /ingester/prepare_shutdown endpoint.
@@ -57,7 +58,7 @@
 
 * [8315](https://github.com/grafana/loki/pull/8315) **thepalbi** Relicense and export `pkg/ingester` WAL code to be used in Promtail's WAL.
 * [8761](https://github.com/grafana/loki/pull/8761) **slim-bean** Remove "subqueries" from the metrics.go log line and instead provide `splits` and `shards`
- 
+
 ##### Build
 
 #### Promtail

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3533,8 +3533,9 @@ redis:
   [max_connection_age: <duration> | default = 0s]
 
   # Cache config for index entry writing.By default, the Redis client only reads
-  # from master node. Enabling this option can lower the master node's pressure
-  # by randomly routing read-only commands to master or slave nodes available.
+  # from the master node. Enabling this option can lower pressure on the master
+  # node by randomly routing read-only commands to the master and any available
+  # replicas.
   # CLI flag: -<prefix>.redis.route-randomly
   [route_randomly: <boolean> | default = false]
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3532,8 +3532,8 @@ redis:
   # CLI flag: -<prefix>.redis.max-connection-age
   [max_connection_age: <duration> | default = 0s]
 
-  # Cache config for index entry writing.Enable routing read-only commands
-  # to random master or slave nodes.
+  # Cache config for index entry writing.Enable routing read-only commands to
+  # random master or slave nodes.
   # CLI flag: -<prefix>.redis.route-randomly
   [route_randomly: <boolean> | default = false]
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3532,6 +3532,11 @@ redis:
   # CLI flag: -<prefix>.redis.max-connection-age
   [max_connection_age: <duration> | default = 0s]
 
+  # Cache config for index entry writing.Enable routing read-only commands
+  # to random master or slave nodes.
+  # CLI flag: -<prefix>.redis.route-randomly
+  [route_randomly: <boolean> | default = false]
+
 embedded_cache:
   # Whether embedded cache is enabled.
   # CLI flag: -<prefix>.embedded-cache.enabled

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3532,10 +3532,9 @@ redis:
   # CLI flag: -<prefix>.redis.max-connection-age
   [max_connection_age: <duration> | default = 0s]
 
-  # Cache config for index entry writing.By default, the Redis client only reads
-  # from the master node. Enabling this option can lower pressure on the master
-  # node by randomly routing read-only commands to the master and any available
-  # replicas.
+  # By default, the Redis client only reads from the master node. Enabling this
+  # option can lower pressure on the master node by randomly routing read-only
+  # commands to the master and any available replicas.
   # CLI flag: -<prefix>.redis.route-randomly
   [route_randomly: <boolean> | default = false]
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3532,8 +3532,9 @@ redis:
   # CLI flag: -<prefix>.redis.max-connection-age
   [max_connection_age: <duration> | default = 0s]
 
-  # Cache config for index entry writing.Enable routing read-only commands to
-  # random master or slave nodes.
+  # Cache config for index entry writing.By default, the Redis client only reads
+  # from master node. Enabling this option can lower the master node's pressure
+  # by randomly routing read-only commands to master or slave nodes available.
   # CLI flag: -<prefix>.redis.route-randomly
   [route_randomly: <boolean> | default = false]
 

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -46,7 +46,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"redis.tls-insecure-skip-verify", false, description+"Skip validating server certificate.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
 	f.DurationVar(&cfg.MaxConnAge, prefix+"redis.max-connection-age", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
-	f.BoolVar(&cfg.RouteRandomly, prefix+"redis.route-randomly", false, description+"Enable routing read-only commands to random master or slave nodes.")
+	f.BoolVar(&cfg.RouteRandomly, prefix+"redis.route-randomly", false, description+"By default, the Redis client only reads from master node. Enabling this option can lower the master node's pressure by randomly routing read-only commands to master or slave nodes available.")
 }
 
 type RedisClient struct {

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -46,7 +46,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"redis.tls-insecure-skip-verify", false, description+"Skip validating server certificate.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
 	f.DurationVar(&cfg.MaxConnAge, prefix+"redis.max-connection-age", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
-	f.BoolVar(&cfg.RouteRandomly, prefix+"redis.route-randomly", false, description+"By default, the Redis client only reads from master node. Enabling this option can lower the master node's pressure by randomly routing read-only commands to master or slave nodes available.")
+	f.BoolVar(&cfg.RouteRandomly, prefix+"redis.route-randomly", false, description+"By default, the Redis client only reads from the master node. Enabling this option can lower pressure on the master node by randomly routing read-only commands to the master and any available replicas.")
 }
 
 type RedisClient struct {

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -29,6 +29,7 @@ type RedisConfig struct {
 	InsecureSkipVerify bool           `yaml:"tls_insecure_skip_verify"`
 	IdleTimeout        time.Duration  `yaml:"idle_timeout"`
 	MaxConnAge         time.Duration  `yaml:"max_connection_age"`
+	RouteRandomly      bool           `yaml:"route_randomly"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -45,6 +46,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"redis.tls-insecure-skip-verify", false, description+"Skip validating server certificate.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
 	f.DurationVar(&cfg.MaxConnAge, prefix+"redis.max-connection-age", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
+	f.BoolVar(&cfg.RouteRandomly, prefix+"redis.route-randomly", false, description+"Enable routing read-only commands to random master or slave nodes.")
 }
 
 type RedisClient struct {
@@ -74,14 +76,15 @@ func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
 		}
 	}
 	opt := &redis.UniversalOptions{
-		Addrs:       endpoints,
-		MasterName:  cfg.MasterName,
-		Username:    cfg.Username,
-		Password:    cfg.Password.String(),
-		DB:          cfg.DB,
-		PoolSize:    cfg.PoolSize,
-		IdleTimeout: cfg.IdleTimeout,
-		MaxConnAge:  cfg.MaxConnAge,
+		Addrs:         endpoints,
+		MasterName:    cfg.MasterName,
+		Username:      cfg.Username,
+		Password:      cfg.Password.String(),
+		DB:            cfg.DB,
+		PoolSize:      cfg.PoolSize,
+		IdleTimeout:   cfg.IdleTimeout,
+		MaxConnAge:    cfg.MaxConnAge,
+		RouteRandomly: cfg.RouteRandomly,
 	}
 	if cfg.EnableTLS {
 		opt.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}


### PR DESCRIPTION
**What this PR does / why we need it**:

Current Redis client only reads from master node, which makes master node under heavy pressure.

Usually, one or more read replicas are expected on production environments.

This PR helps to increase the utilization of read replicas.

**Which issue(s) this PR fixes**:
Fixes #8811 

**Special notes for your reviewer**:

* The `route_randomly` option defaults to `false`, which matches the same behavior in previous versions, hence no breaking change.
* User needs to explicitly set `route_randomly` to `true` in order to use it.
* The purpose of this PR is to evenly distribute the read requests, so only [`RouteRandomly`][1] is used and not the following:
  * `ReadOnly` (which only reads from read replicas)
  *  `RouteByLatency` (requests probably won't be even since not all Loki components are deployed evenly separate)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`


[1]: https://pkg.go.dev/github.com/redis/go-redis/v9#UniversalOptions