### PR TITLE
unpack: fix panic on processing empty line

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -579,7 +579,7 @@ func NewUnpackParser() *UnpackParser {
 func (UnpackParser) RequiredLabelNames() []string { return []string{} }
 
 func (u *UnpackParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
-	if lbs.ParserLabelHints().NoLabels() {
+	if len(line) == 0 || lbs.ParserLabelHints().NoLabels() {
 		return line, true
 	}
 

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -1018,6 +1018,14 @@ func Test_unpackParser_Parse(t *testing.T) {
 			noParserHints,
 		},
 		{
+			"empty line",
+			[]byte(``),
+			labels.Labels{{Name: "cluster", Value: "us-central1"}},
+			labels.Labels{{Name: "cluster", Value: "us-central1"}},
+			[]byte(``),
+			noParserHints,
+		},
+		{
 			"wrong json with hints",
 			[]byte(`"app":"foo","namespace":"prod","_entry":"some message","pod":{"uid":"1"}`),
 			labels.Labels{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes panic in unpack parser when processing empty lines

```
    /src/enterprise-logs/vendor/github.com/grafana/loki/pkg/logql/log/parser.go:583
github.com/grafana/loki/pkg/logql/log.(*UnpackParser).unpack(...)
panic: runtime error: index out of range [0] with length 0
```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
