### PR TITLE
Remove ./tools/fetch-tags invocation from Makefile

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -780,6 +780,14 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     ],
     // Package and test the packages
     steps: [
+      {
+        name: 'fetch-tags',
+        image: 'alpine',
+        commands: [
+          'apk add --no-cache bash git',
+          'git fetch origin --tags',
+        ],
+      },
       run('write-key',
           commands=['printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE'],
           env={

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1411,6 +1411,11 @@ services:
     path: /sys/fs/cgroup
 steps:
 - commands:
+  - apk add --no-cache bash git
+  - git fetch origin --tags
+  image: alpine
+  name: fetch-tags
+- commands:
   - printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE
   environment:
     NFPM_SIGNING_KEY:
@@ -1727,6 +1732,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: ae19447e0f2e91746c5b4e6a3dc469a08a63c44045f4b995a6980d0e401e071f
+hmac: b5d3d292a9e1f7edc909dd0aa28664f1aa5794f4abe639dc1df8d9bbea5b5c13
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ BUILD_IMAGE_VERSION := 0.28.1
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-FETCH_TAGS :=$(shell ./tools/fetch-tags)
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries

--- a/tools/fetch-tags
+++ b/tools/fetch-tags
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-git fetch --tags --all


### PR DESCRIPTION
**What this PR does / why we need it**:

This invocation causes problems when make targets are executed in the build image container (`BUILD_IN_CONTAINER=true`), e.g. the `yacc` target, because git tries to fetch tags from `origin` using ssh, causing error message like these:

```
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error: Could not fetch origin
```

This is because local ssh keys are not mounted into the build container.

In order not to break CI builds
(https://github.com/grafana/loki/pull/8232) we need to manually fetch the tags as the first step in release pipelines. This is added to the Drone configuration.
