### PR TITLE
ksonnet/loki: Add gRPC port to compactor mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 #### Jsonnet
 
 * [7923](https://github.com/grafana/loki/pull/7923) **manohar-koukuntla**: Add zone aware ingesters in jsonnet deployment
+* [8855](https://github.com/grafana/loki/pull/8855) **JoaoBraveCoding**: Add gRPC port to loki compactor mixin
 
 ##### Fixes
 

--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -49,9 +49,7 @@
     target: 'compactor',
   } else {},
 
-  compactor_ports: [
-    containerPort.new(name='http-metrics', port=$._config.http_listen_port),
-  ],
+  compactor_ports:: $.util.defaultPorts,
 
   compactor_container:: if $._config.using_boltdb_shipper then
     container.new('compactor', $._images.compactor) +


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: in https://github.com/grafana/loki/pull/7804 the possibility to use gRPC for communicating with the compactor for query time filtering of data requested for deletion was added, however, the loki mixin still generates the compactor service without a gRPC port.

Solution: make the compactor service/deployment expose both an HTTP and gRPC port.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
