### PR TITLE
operator: Update Dockerfile to go1.20 images

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM golang:1.20.1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 
-FROM golang:1.19.1-alpine as goenv
+FROM golang:1.20.1-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Dockerfile to use golang 1.20.1 images. Continuation of #8776.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
