### PR TITLE
fix packaging of armv7 distribution packages

### DIFF
--- a/tools/packaging/nfpm.jsonnet
+++ b/tools/packaging/nfpm.jsonnet
@@ -61,7 +61,7 @@ local arch = std.extVar('arch');
 
 {
   name: name,
-  arch: arch,
+  arch: if arch == 'arm' then 'arm7' else arch,
   platform: 'linux',
   version: '${DRONE_TAG}',
   section: 'default',


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now, the `armv7` deb/rpm packages on the GitHub release page have the wrong architecture `arm`.
This is because `nfpm` expects `arm7` instead of `arm` (see [docs](https://nfpm.goreleaser.com/configuration/)). Hence, `nfpm` cannot correctly convert the arch to its individual distribution counterpart (`armhf`/`armv7hl`/...).

**Which issue(s) this PR fixes**:
Fixes partially #7705

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
