### PR TITLE
operator: Pin go version used in netlify env

### DIFF
--- a/operator/netlify.toml
+++ b/operator/netlify.toml
@@ -6,6 +6,7 @@
   # HUGO_VERSION = "..." is set by bingo which allows reproducible local environment.
   NODE_VERSION = "15.5.1"
   NPM_VERSION = "7.3.0"
+  GO_VERSION = "1.20.1"
 
 [context.production]
   command = "(env && make web) || (sleep 30; false)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin go version to the operator version to get `gen-crd-api-reference-docs` work always with the linked k8s/go version deps. FWIW for the last 2 weeks we didn't have docs deploys because the default netlify image was using go1.17 and a k8s deps could not be parsed properly:

```
9:14:06 PM: (re)installing /opt/buildhome/.gimme_cache/gopath/bin/gen-crd-api-reference-docs-v0.0.3
9:14:07 PM: /opt/buildhome/.gimme_cache/gopath/bin/gen-crd-api-reference-docs-v0.0.3 -api-dir "github.com/grafana/loki/operator/apis/loki/" -config "/opt/build/repo/operator/config/docs/config.json" -template-dir "/opt/build/repo/operator/config/docs/templates" -out-file "/opt/build/repo/operator/docs/operator/api.md"
9:14:07 PM: I0321 20:14:07.293426    2144 main.go:155] parsing go packages in directory github.com/grafana/loki/operator/apis/loki/
9:15:06 PM: F0321 20:15:06.853738    2144 main.go:158] failed to parse pkgs and types: findTypesIn(k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json): package is not known
9:15:06 PM: make: *** [Makefile:305: docs/operator/api.md] Error 255
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
