### PR TITLE
[opt] querier-frontend: downstream exe fail, add detail error msg and test

### DIFF
--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -313,7 +313,7 @@ func (ev *DownstreamEvaluator) StepEvaluator(
 	default:
 		stepEvaluator, err := ev.defaultEvaluator.StepEvaluator(ctx, nextEv, e, params)
 		if err != nil {
-			return nil, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %s ,logql: %s , err: %s", reflect.TypeOf(e), e.String(), err)
+			return nil, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %T, logql: %s , err: %s", e, e, err)
 		}
 		return stepEvaluator, nil
 	}

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/grafana/loki/pkg/logqlmodel/metadata"
@@ -310,7 +311,11 @@ func (ev *DownstreamEvaluator) StepEvaluator(
 		return ConcatEvaluator(xs)
 
 	default:
-		return ev.defaultEvaluator.StepEvaluator(ctx, nextEv, e, params)
+		stepEvaluator, err := ev.defaultEvaluator.StepEvaluator(ctx, nextEv, e, params)
+		if err != nil {
+			return nil, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %s ,logql: %s , err: %s", reflect.TypeOf(e), e.String(), err)
+		}
+		return stepEvaluator, nil
 	}
 }
 

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/grafana/loki/pkg/logqlmodel/metadata"

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -312,7 +312,7 @@ func (ev *DownstreamEvaluator) StepEvaluator(
 	default:
 		stepEvaluator, err := ev.defaultEvaluator.StepEvaluator(ctx, nextEv, e, params)
 		if err != nil {
-			return nil, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %T, logql: %s , err: %s", e, e, err)
+			return nil, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %T , logql: %s , err: %s", e, e, err)
 		}
 		return stepEvaluator, nil
 	}

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -449,7 +449,7 @@ func TestDownstreamEvaluatorFailExecute(t *testing.T) {
 		query  string
 		errMsg error
 	}{
-		{logqlCase1, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %s ", reflect.TypeOf(&syntax.BinOpExpr{}))},
+		{logqlCase1, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %T ", &syntax.BinOpExpr{})},
 	} {
 		q := NewMockQuerier(
 			shards,

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"testing"
 	"time"

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -2,7 +2,10 @@ package logql
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/syntax"
 )
 
 var nilShardMetrics = NewShardMapperMetrics(nil)
@@ -416,6 +420,73 @@ func TestRangeMappingEquivalence(t *testing.T) {
 			require.Nil(t, err)
 
 			require.Equal(t, res.Data, rangeRes.Data)
+		})
+	}
+}
+
+func TestDownstreamEvaluatorFailExecute(t *testing.T) {
+	var (
+		shards   = 3
+		nStreams = 60
+		rounds   = 20
+		streams  = randomStreams(nStreams, rounds+1, shards, []string{"a", "b", "c", "d"})
+		start    = time.Unix(0, 0)
+		end      = time.Unix(0, int64(time.Second*time.Duration(rounds)))
+		step     = time.Second
+		interval = time.Duration(0)
+		limit    = 100
+	)
+
+	logqlCase1 := "sum(\n" +
+		"sum_over_time({log_type=\"service_metrics\",operation=\"InvokeFunction\",module=\"api_server\",_file=\"/service_metrics.log\",severity_text=\"INFO\"}|=`status\":200`\n|regexp `\"meteringDuration\":(?P<meteringDuration>.*?)(,|\\{|\\[|\\})`\n" + "|regexp `\"cpuCores\":(?P<cpuCores>.*?)(,|\\{|\\[|\\})`\n" + "|label_format capacity=`{{ mulf (.cpuCores | float64) (.meteringDuration|float64)}}` | unwrap capacity | __error__=\"\" [10s])" +
+		") \n" +
+		"/ \n" +
+		"sum(  " +
+		"sum_over_time({log_type=\"service_metrics\",operation=\"InvokeFunction\",_file=\"/service_metrics.log\",module=\"api_server\",severity_text=\"INFO\"}|=`status\":200`\n|regexp `\"cpuUsage\":(?P<cpuUsage>.*?)(,|\\{|\\[|\\})` | unwrap cpuUsage | __error__=\"\" [10s])\n" +
+		")"
+
+	for _, tc := range []struct {
+		query  string
+		errMsg error
+	}{
+		{logqlCase1, fmt.Errorf("downstream evaluator fail to execute default case, expr type: %s ", reflect.TypeOf(&syntax.BinOpExpr{}))},
+	} {
+		q := NewMockQuerier(
+			shards,
+			streams,
+		)
+
+		opts := EngineOpts{}
+		regular := NewEngine(opts, q, NoLimits, log.NewNopLogger())
+		sharded := NewDownstreamEngine(opts, MockDownstreamer{regular}, NoLimits, log.NewNopLogger())
+
+		t.Run(tc.query, func(t *testing.T) {
+			params := NewLiteralParams(
+				tc.query,
+				start,
+				end,
+				step,
+				interval,
+				logproto.FORWARD,
+				uint32(limit),
+				nil,
+			)
+			qry := regular.Query(params)
+			ctx := user.InjectOrgID(context.Background(), "fake")
+
+			mapper := NewShardMapper(ConstantShards(shards), nilShardMetrics)
+			_, mapped, err := mapper.Parse(tc.query)
+			require.Nil(t, err)
+
+			shardedQry := sharded.Query(ctx, params, mapped)
+
+			_, err = qry.Exec(ctx)
+			require.Nil(t, err)
+
+			_, err = shardedQry.Exec(ctx)
+			require.NotNil(t, err)
+			require.True(t, strings.Contains(err.Error(), tc.errMsg.Error()))
+
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
return detail error msg when downstream exe fail and add test.


![image](https://user-images.githubusercontent.com/9583245/226788996-56c87a43-bc45-4e9d-93c2-f7b4da450df4.png)

Currently only two types of Expr cases are supported, and some cases will cause DownStream to fail, such as the following two cases
*syntax.BinOpExpr and *syntax.VectorAggregationExpr case 

full logql：
```logql
sum(
sum_over_time({log_type="service_metrics",operation="InvokeFunction",module="api_server",_file="/service_metrics.log",severity_text="INFO"}|=`status":200`
|regexp `"meteringDuration":(?P<meteringDuration>.*?)(,|\{|\[|\})`
|regexp `"cpuCores":(?P<cpuCores>.*?)(,|\{|\[|\})`
|label_format capacity=`{{ mulf (.cpuCores | float64) (.meteringDuration|float64)}}` | unwrap capacity | __error__="" [10s])) 
/ 
sum(  sum_over_time({log_type="service_metrics",operation="InvokeFunction",_file="/service_metrics.log",module="api_server",severity_text="INFO"}|=`status":200`
|regexp `"cpuUsage":(?P<cpuUsage>.*?)(,|\{|\[|\})` | unwrap cpuUsage | __error__="" [10s])
)
```

**Which issue(s) this PR fixes**:
Fixes #8844

**Special notes for your reviewer**:
This pr does not solve the actual bug, it just returns more error messages and adds tests so that other contributors can more easily support more Expr types in the future.
![image](https://user-images.githubusercontent.com/9583245/226788711-65f4249f-bde6-465c-90de-ac825f6013d9.png)

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
