### PR TITLE
promtail: support configurable polling interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [8918](https://github.com/grafana/loki/pull/8918) **salvacorts** Introduce limit to require at least a number label matchers on metric and log queries.
 * [8909](https://github.com/grafana/loki/pull/8909) **salvacorts** Requests to `/loki/api/v1/index/stats` are split in 24h intervals.
 * [8732](https://github.com/grafana/loki/pull/8732) **abaguas**: azure: respect retry config before cancelling the context
+* [8874](https://github.com/grafana/loki/pull/8874) **rfratto**: Support expoential backoff when polling unchanged files for logs.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [8918](https://github.com/grafana/loki/pull/8918) **salvacorts** Introduce limit to require at least a number label matchers on metric and log queries.
 * [8909](https://github.com/grafana/loki/pull/8909) **salvacorts** Requests to `/loki/api/v1/index/stats` are split in 24h intervals.
 * [8732](https://github.com/grafana/loki/pull/8732) **abaguas**: azure: respect retry config before cancelling the context
-* [8874](https://github.com/grafana/loki/pull/8874) **rfratto**: Support expoential backoff when polling unchanged files for logs.
+* [8874](https://github.com/grafana/loki/pull/8874) **rfratto**: Promtail: Support expoential backoff when polling unchanged files for logs.
 
 ##### Fixes
 

--- a/clients/pkg/promtail/config/config.go
+++ b/clients/pkg/promtail/config/config.go
@@ -28,6 +28,7 @@ type Options struct {
 
 // Config for promtail, describing what files to watch.
 type Config struct {
+	Global       GlobalConfig  `yaml:"global,omitempty"`
 	ServerConfig server.Config `yaml:"server,omitempty"`
 	// deprecated use ClientConfigs instead
 	ClientConfig    client.Config         `yaml:"client,omitempty"`
@@ -44,6 +45,7 @@ type Config struct {
 // RegisterFlags with prefix registers flags where every name is prefixed by
 // prefix. If prefix is a non-empty string, prefix should end with a period.
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	c.Global.RegisterFlagsWithPrefix(prefix, f)
 	c.ServerConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.ClientConfig.RegisterFlagsWithPrefix(prefix, f)
 	c.PositionsConfig.RegisterFlagsWithPrefix(prefix, f)
@@ -92,4 +94,21 @@ func (c *Config) Setup(l log.Logger) {
 			c.ClientConfigs[i].ExternalLabels = flagext.LabelSet{LabelSet: c.ClientConfig.ExternalLabels.LabelSet.Merge(c.ClientConfigs[i].ExternalLabels.LabelSet)}
 		}
 	}
+}
+
+// GlobalConfig holds configuration settings which apply to all targets.
+// Individual scrape jobs can override the defaults.
+type GlobalConfig struct {
+	FileWatch file.WatchConfig `mapstructure:"file_watch_config" yaml:"file_watch_config"`
+}
+
+// RegisterFlags with prefix registers flags where every name is prefixed by
+// prefix. If prefix is a non-empty string, prefix should end with a period.
+func (cfg *GlobalConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.FileWatch.RegisterFlagsWithPrefix(prefix+"file-watch.", f)
+}
+
+// RegisterFlags register flags.
+func (cfg *GlobalConfig) RegisterFlags(flags *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", flags)
 }

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -187,7 +187,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 	entryHandlers = append(entryHandlers, p.client)
 	p.entriesFanout = utils.NewFanoutEntryHandler(timeoutUntilFanoutHardStop, entryHandlers...)
 
-	tms, err := targets.NewTargetManagers(p, p.reg, p.logger, cfg.PositionsConfig, p.entriesFanout, cfg.ScrapeConfig, &cfg.TargetConfig)
+	tms, err := targets.NewTargetManagers(p, p.reg, p.logger, cfg.PositionsConfig, p.entriesFanout, cfg.ScrapeConfig, &cfg.TargetConfig, cfg.Global.FileWatch)
 	if err != nil {
 		return err
 	}

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/tail/watch"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/positions"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
-	"github.com/grafana/tail/watch"
 )
 
 const (

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -69,7 +69,7 @@ func TestFileTargetSync(t *testing.T) {
 	path := logDir1 + "/*.log"
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "", nil)
+	}, DefaultWatchConig, nil, fakeHandler, "", nil)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -221,7 +221,7 @@ func TestFileTargetPathExclusion(t *testing.T) {
 	pathExclude := filepath.Join(dirName, "log3", "*.log")
 	target, err := NewFileTarget(metrics, logger, client, ps, path, pathExclude, nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "", nil)
+	}, DefaultWatchConig, nil, fakeHandler, "", nil)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -350,7 +350,7 @@ func TestHandleFileCreationEvent(t *testing.T) {
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		// To handle file creation event from channel, set enough long time as sync period
 		SyncPeriod: 10 * time.Minute,
-	}, fakeFileHandler, fakeTargetHandler, "", nil)
+	}, DefaultWatchConig, fakeFileHandler, fakeTargetHandler, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -58,6 +58,7 @@ func NewFileTargetManager(
 	client api.EntryHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *Config,
+	watchConfig WatchConfig,
 ) (*FileTargetManager, error) {
 	reg := metrics.reg
 	if reg == nil {
@@ -126,6 +127,7 @@ func NewFileTargetManager(
 			hostname:          hostname,
 			entryHandler:      pipeline.Wrap(client),
 			targetConfig:      targetConfig,
+			watchConfig:       watchConfig,
 			fileEventWatchers: map[string]chan fsnotify.Event{},
 			encoding:          cfg.Encoding,
 			decompressCfg:     cfg.DecompressionCfg,
@@ -279,6 +281,7 @@ type targetSyncer struct {
 
 	relabelConfig []*relabel.Config
 	targetConfig  *Config
+	watchConfig   WatchConfig
 
 	decompressCfg *scrapeconfig.DecompressionConfig
 
@@ -440,7 +443,7 @@ func (s *targetSyncer) sendFileCreateEvent(event fsnotify.Event) {
 }
 
 func (s *targetSyncer) newTarget(path, pathExclude string, labels model.LabelSet, discoveredLabels model.LabelSet, fileEventWatcher chan fsnotify.Event, targetEventHandler chan fileTargetEvent) (*FileTarget, error) {
-	return NewFileTarget(s.metrics, s.log, s.entryHandler, s.positions, path, pathExclude, labels, discoveredLabels, s.targetConfig, fileEventWatcher, targetEventHandler, s.encoding, s.decompressCfg)
+	return NewFileTarget(s.metrics, s.log, s.entryHandler, s.positions, path, pathExclude, labels, discoveredLabels, s.targetConfig, s.watchConfig, fileEventWatcher, targetEventHandler, s.encoding, s.decompressCfg)
 }
 
 func (s *targetSyncer) DroppedTargets() []target.Target {

--- a/clients/pkg/promtail/targets/file/filetargetmanager_test.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager_test.go
@@ -70,7 +70,7 @@ func newTestFileTargetManager(logger log.Logger, client api.EntryHandler, positi
 	}
 
 	metrics := NewMetrics(nil)
-	ftm, err := NewFileTargetManager(metrics, logger, positions, client, []scrapeconfig.Config{sc}, tc)
+	ftm, err := NewFileTargetManager(metrics, logger, positions, client, []scrapeconfig.Config{sc}, tc, DefaultWatchConig)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/pkg/promtail/targets/file/tailer.go
+++ b/clients/pkg/promtail/targets/file/tailer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/tail"
+	"github.com/grafana/tail/watch"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
@@ -43,7 +44,7 @@ type tailer struct {
 	decoder *encoding.Decoder
 }
 
-func newTailer(metrics *Metrics, logger log.Logger, handler api.EntryHandler, positions positions.Positions, path string, encoding string) (*tailer, error) {
+func newTailer(metrics *Metrics, logger log.Logger, handler api.EntryHandler, positions positions.Positions, pollOptions watch.PollingFileWatcherOptions, path string, encoding string) (*tailer, error) {
 	// Simple check to make sure the file we are tailing doesn't
 	// have a position already saved which is past the end of the file.
 	fi, err := os.Stat(path)
@@ -68,7 +69,8 @@ func newTailer(metrics *Metrics, logger log.Logger, handler api.EntryHandler, po
 			Offset: pos,
 			Whence: 0,
 		},
-		Logger: util.NewLogAdapter(logger),
+		Logger:      util.NewLogAdapter(logger),
+		PollOptions: pollOptions,
 	})
 	if err != nil {
 		return nil, err

--- a/clients/pkg/promtail/targets/manager.go
+++ b/clients/pkg/promtail/targets/manager.go
@@ -2,6 +2,7 @@ package targets
 
 import (
 	"fmt"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -75,6 +76,7 @@ func NewTargetManagers(
 	client api.EntryHandler,
 	scrapeConfigs []scrapeconfig.Config,
 	targetConfig *file.Config,
+	watchConfig file.WatchConfig,
 ) (*TargetManagers, error) {
 	if targetConfig.Stdin {
 		level.Debug(logger).Log("msg", "configured to read from stdin")
@@ -172,6 +174,7 @@ func NewTargetManagers(
 				client,
 				scrapeConfigs,
 				targetConfig,
+				watchConfig,
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to make file target manager")

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -82,6 +82,9 @@ be replaced with a double backslash `\\`
 ### Supported contents and default values of `config.yaml`:
 
 ```yaml
+# Configures global settings which impact all targets.
+[global: <global_config>]
+
 # Configures the server for Promtail.
 [server: <server_config>]
 
@@ -112,6 +115,33 @@ scrape_configs:
 
 # Configures tracing support
 [tracing: <tracing_config>]
+```
+
+## global
+
+The `global` block configures global settings which impact all scrape targets:
+
+```yaml
+# Configure how frequently log files from disk get polled for changes.
+[file_watch_config: <file_watch_config>]
+```
+
+## file_watch_config
+
+The `file_watch_config` block configures how often to poll log files from disk
+for changes:
+
+```yaml
+# Minimum frequency to poll for files. Any time file changes are detected, the
+# poll frequency gets reset to this duration.
+[min_poll_frequency: <duration> | default = "250ms"]
+
+# Maximum frequency to poll for files. Any time no file changes are detected,
+# the poll frequency doubles in value up to the maximum duration specified by
+# this value.
+#
+# The default is set to the same as min_poll_frequency.
+[max_poll_frequency: <duration> | default = "250ms"]
 ```
 
 ## server

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/grafana/go-gelf/v2 v2.0.1
 	github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
-	github.com/grafana/tail v0.0.0-20221214082743-3a1c242a4d7b
+	github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/consul/api v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
-github.com/grafana/tail v0.0.0-20221214082743-3a1c242a4d7b h1:lqdF6YhGFn2BJqTxbLMZM8UiDSEVF0434IDANpVblaY=
-github.com/grafana/tail v0.0.0-20221214082743-3a1c242a4d7b/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
+github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd h1:dGMa2kRARfv3+h/DuxgYS55Yt+hSsv1C5333nz7q1vE=
+github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=

--- a/vendor/github.com/grafana/tail/tail.go
+++ b/vendor/github.com/grafana/tail/tail.go
@@ -63,6 +63,7 @@ type Config struct {
 	Poll        bool      // Poll for file changes instead of using inotify
 	Pipe        bool      // Is a named pipe (mkfifo)
 	RateLimiter *ratelimiter.LeakyBucket
+	PollOptions watch.PollingFileWatcherOptions
 
 	// Generic IO
 	Follow      bool // Continue looking for new lines (tail -f)
@@ -118,7 +119,11 @@ func TailFile(filename string, config Config) (*Tail, error) {
 	}
 
 	if t.Poll {
-		t.watcher = watch.NewPollingFileWatcher(filename)
+		watcher, err := watch.NewPollingFileWatcher(filename, config.PollOptions)
+		if err != nil {
+			return nil, err
+		}
+		t.watcher = watcher
 	} else {
 		t.watcher = watch.NewInotifyFileWatcher(filename)
 	}
@@ -257,8 +262,9 @@ func (tail *Tail) reopen(truncated bool) error {
 			if retries <= 0 {
 				return errors.New("gave up trying to reopen log file with a different handle")
 			}
+
 			select {
-			case <-time.After(watch.POLL_DURATION):
+			case <-time.After(watch.DefaultPollingFileWatcherOptions.MaxPollFrequency):
 				tail.closeFile()
 				continue
 			case <-tail.Tomb.Dying():

--- a/vendor/github.com/grafana/tail/watch/polling.go
+++ b/vendor/github.com/grafana/tail/watch/polling.go
@@ -4,11 +4,13 @@
 package watch
 
 import (
-	"github.com/grafana/tail/util"
-	"gopkg.in/tomb.v1"
+	"fmt"
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/grafana/tail/util"
+	"gopkg.in/tomb.v1"
 )
 
 // PollingFileWatcher polls the file for changes.
@@ -16,16 +18,50 @@ type PollingFileWatcher struct {
 	File     *os.File
 	Filename string
 	Size     int64
+	Options  PollingFileWatcherOptions
 }
 
-func NewPollingFileWatcher(filename string) *PollingFileWatcher {
-	fw := &PollingFileWatcher{nil, filename, 0}
-	return fw
+// PollingFileWatcherOptions customizes a PollingFileWatcher.
+type PollingFileWatcherOptions struct {
+	// MinPollFrequency and MaxPollFrequency specify how frequently a
+	// PollingFileWatcher should poll the file.
+	//
+	// PollingFileWatcher starts polling at MinPollFrequency, and will
+	// exponentially increase the polling frequency up to MaxPollFrequency if no
+	// new entries are found. The polling frequency is reset to MinPollFrequency
+	// whenever a new log entry is found or if the polled file changes.
+	MinPollFrequency, MaxPollFrequency time.Duration
 }
 
-var POLL_DURATION time.Duration
+// DefaultPollingFileWatcherOptions holds default values for
+// PollingFileWatcherOptions.
+var DefaultPollingFileWatcherOptions = PollingFileWatcherOptions{
+	MinPollFrequency: 250 * time.Millisecond,
+	MaxPollFrequency: 250 * time.Millisecond,
+}
+
+func NewPollingFileWatcher(filename string, opts PollingFileWatcherOptions) (*PollingFileWatcher, error) {
+	if opts == (PollingFileWatcherOptions{}) {
+		opts = DefaultPollingFileWatcherOptions
+	}
+
+	if opts.MinPollFrequency == 0 || opts.MaxPollFrequency == 0 {
+		return nil, fmt.Errorf("MinPollFrequency and MaxPollFrequency must be greater than 0")
+	} else if opts.MaxPollFrequency < opts.MinPollFrequency {
+		return nil, fmt.Errorf("MaxPollFrequency must be larger than MinPollFrequency")
+	}
+
+	return &PollingFileWatcher{
+		File:     nil,
+		Filename: filename,
+		Size:     0,
+		Options:  opts,
+	}, nil
+}
 
 func (fw *PollingFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
+	bo := newPollBackoff(fw.Options)
+
 	for {
 		if _, err := os.Stat(fw.Filename); err == nil {
 			return nil
@@ -33,7 +69,8 @@ func (fw *PollingFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 			return err
 		}
 		select {
-		case <-time.After(POLL_DURATION):
+		case <-time.After(bo.WaitTime()):
+			bo.Backoff()
 			continue
 		case <-t.Dying():
 			return tomb.ErrDying
@@ -56,6 +93,8 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 
 	fw.Size = pos
 
+	bo := newPollBackoff(fw.Options)
+
 	go func() {
 		prevSize := fw.Size
 		for {
@@ -65,7 +104,7 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			default:
 			}
 
-			time.Sleep(POLL_DURATION)
+			time.Sleep(bo.WaitTime())
 			deletePending, err := IsDeletePending(fw.File)
 			if err != nil {
 				util.Fatal("Failed to get file info %v: %v", fw.Filename, err)
@@ -105,12 +144,14 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			if prevSize > 0 && prevSize > fw.Size {
 				changes.NotifyTruncated()
 				prevSize = fw.Size
+				bo.Reset()
 				continue
 			}
 			// File got bigger?
 			if prevSize > 0 && prevSize < fw.Size {
 				changes.NotifyModified()
 				prevSize = fw.Size
+				bo.Reset()
 				continue
 			}
 			prevSize = fw.Size
@@ -120,7 +161,12 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			if modTime != prevModTime {
 				prevModTime = modTime
 				changes.NotifyModified()
+				bo.Reset()
+				continue
 			}
+
+			// File hasn't changed; increase backoff for next sleep.
+			bo.Backoff()
 		}
 	}()
 
@@ -137,6 +183,29 @@ func (fw *PollingFileWatcher) closeFile() {
 	}
 }
 
-func init() {
-	POLL_DURATION = 250 * time.Millisecond
+type pollBackoff struct {
+	current time.Duration
+	opts    PollingFileWatcherOptions
+}
+
+func newPollBackoff(opts PollingFileWatcherOptions) *pollBackoff {
+	return &pollBackoff{
+		current: opts.MinPollFrequency,
+		opts:    opts,
+	}
+}
+
+func (pb *pollBackoff) WaitTime() time.Duration {
+	return pb.current
+}
+
+func (pb *pollBackoff) Reset() {
+	pb.current = pb.opts.MinPollFrequency
+}
+
+func (pb *pollBackoff) Backoff() {
+	pb.current = pb.current * 2
+	if pb.current > pb.opts.MaxPollFrequency {
+		pb.current = pb.opts.MaxPollFrequency
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -848,7 +848,7 @@ github.com/grafana/loki/pkg/push
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/tail v0.0.0-20221214082743-3a1c242a4d7b
+# github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd
 ## explicit; go 1.13
 github.com/grafana/tail
 github.com/grafana/tail/ratelimiter


### PR DESCRIPTION
Currently, Promtail always polls files every 250ms. This PR allows the polling period to be customized, starting at a minimum polling period and exponentially increasing the polling frequency to a bounded maximum if the file has no changes.

When file changes are detected, the polling frequency resets to the minimum.

The default behavior is the existing behavior; both the minimum and maximum polling intervals are set to 250ms.

I'm opening this in draft to get early feedback. There's a few open questions:

* Where can I add validations to ensure that the min/max polling intervals are configured properly? 
* Is this the right approach for implementation? Do I need to make any changes?
* Does this need tests? 

I'll update the CHANGELOG and Documentation after we're agreed on an approach. 
