### PR TITLE
Canary: Add `-actor` CLI flag to be able to set the `X-Loki-Actor-Path` HTTP header for query requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,23 +21,6 @@
 * [8972](https://github.com/grafana/loki/pull/8972) **salvacorts** Index stat requests are now cached in the results cache.
 * [9177](https://github.com/grafana/loki/pull/9177) **salvacorts** Index stat cache can be enabled or disabled with the new `cache_index_stats_results` flag. Disabled by default.
 * [9096](https://github.com/grafana/loki/pull/9096) **salvacorts**: Compute proportional TSDB index stats for chunks that doesn't fit fully in the queried time range.
-
-##### Fixes
-
-* [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
-* [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
-
-#### Loki Canary
-
-* [8889](https://github.com/grafana/loki/pull/8889) **chaudum**: Add `-actor` CLI argument to Canary binary to allow for setting the `X-Loki-Actor-Path` header for queries.
-
-
-#### Promtail
-
-##### Enhancements
-
-* [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
-* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Add new `decompression` configuration to customize the decompressor behavior.
 * [8939](https://github.com/grafana/loki/pull/8939) **Suruthi-G-K**: Loki: Add support for trusted profile authentication in COS client.
 * [8852](https://github.com/grafana/loki/pull/8852) **wtchangdm**: Loki: Add `route_randomly` to Redis options.
 * [8848](https://github.com/grafana/loki/pull/8848) **dannykopping**: Ruler: add configurable rule evaluation jitter.
@@ -85,6 +68,10 @@
 
 * [9857](https://github.com/grafana/loki/pull/9857) **DylanGuedes**: Stop emitting spans for every `AWS.S3` or `Azure.Blob` call.
 * [9212](https://github.com/grafana/loki/pull/9212) **trevorwhitney**: Rename UsageReport to Analytics. The only external impact of this change is a change in the `-list-targets` output.
+
+#### Loki Canary
+
+* [8889](https://github.com/grafana/loki/pull/8889) **chaudum**: Add `-actor` CLI argument to Canary binary to allow for setting the `X-Loki-Actor-Path` header for queries.
 
 #### Promtail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@
 * [8972](https://github.com/grafana/loki/pull/8972) **salvacorts** Index stat requests are now cached in the results cache.
 * [9177](https://github.com/grafana/loki/pull/9177) **salvacorts** Index stat cache can be enabled or disabled with the new `cache_index_stats_results` flag. Disabled by default.
 * [9096](https://github.com/grafana/loki/pull/9096) **salvacorts**: Compute proportional TSDB index stats for chunks that doesn't fit fully in the queried time range.
+
+##### Fixes
+
+* [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
+* [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
+
+#### Loki Canary
+
+* [8889](https://github.com/grafana/loki/pull/8889) **chaudum**: Add `-actor` CLI argument to Canary binary to allow for setting the `X-Loki-Actor-Path` header for queries.
+
+
+#### Promtail
+
+##### Enhancements
+
+* [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
+* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Add new `decompression` configuration to customize the decompressor behavior.
 * [8939](https://github.com/grafana/loki/pull/8939) **Suruthi-G-K**: Loki: Add support for trusted profile authentication in COS client.
 * [8852](https://github.com/grafana/loki/pull/8852) **wtchangdm**: Loki: Add `route_randomly` to Redis options.
 * [8848](https://github.com/grafana/loki/pull/8848) **dannykopping**: Ruler: add configurable rule evaluation jitter.

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -55,6 +55,7 @@ func main() {
 	user := flag.String("user", "", "Loki username.")
 	pass := flag.String("pass", "", "Loki password. This credential should have both read and write permissions to Loki endpoints")
 	tenantID := flag.String("tenant-id", "", "Tenant ID to be set in X-Scope-OrgID header.")
+	actor := flag.String("actor", "", "Actor to be set in X-Loki-Actor-Path header.")
 	writeTimeout := flag.Duration("write-timeout", 10*time.Second, "How long to wait write response from Loki")
 	writeMinBackoff := flag.Duration("write-min-backoff", defaultMinBackoff, "Initial backoff time before first retry ")
 	writeMaxBackoff := flag.Duration("write-max-backoff", defaultMaxBackoff, "Maximum backoff time between retries ")
@@ -184,7 +185,7 @@ func main() {
 
 		c.writer = writer.NewWriter(entryWriter, sentChan, *interval, *outOfOrderMin, *outOfOrderMax, *outOfOrderPercentage, *size, logger)
 		var err error
-		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend)
+		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *actor, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Unable to create reader for Loki querier, check config: %s", err)
 			os.Exit(1)

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -57,6 +57,7 @@ type Reader struct {
 	user            string
 	pass            string
 	tenantID        string
+	actor           string
 	httpClient      *http.Client
 	queryTimeout    time.Duration
 	sName           string
@@ -85,6 +86,7 @@ func NewReader(writer io.Writer,
 	user string,
 	pass string,
 	tenantID string,
+	actor string,
 	queryTimeout time.Duration,
 	labelName string,
 	labelVal string,
@@ -116,6 +118,9 @@ func NewReader(writer io.Writer,
 	if tenantID != "" {
 		h.Set("X-Scope-OrgID", tenantID)
 	}
+	if actor != "" {
+		h.Set("X-Loki-Actor-Path", actor)
+	}
 
 	next := time.Now()
 	bkcfg := backoff.Config{
@@ -134,6 +139,7 @@ func NewReader(writer io.Writer,
 		user:            user,
 		pass:            pass,
 		tenantID:        tenantID,
+		actor:           actor,
 		queryTimeout:    queryTimeout,
 		httpClient:      httpClient,
 		sName:           streamName,
@@ -214,6 +220,9 @@ func (r *Reader) QueryCountOverTime(queryRange string) (float64, error) {
 	}
 	if r.tenantID != "" {
 		req.Header.Set("X-Scope-OrgID", r.tenantID)
+	}
+	if r.actor != "" {
+		req.Header.Set("X-Loki-Actor-Path", r.actor)
 	}
 	req.Header.Set("User-Agent", userAgent)
 
@@ -305,6 +314,9 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	}
 	if r.tenantID != "" {
 		req.Header.Set("X-Scope-OrgID", r.tenantID)
+	}
+	if r.actor != "" {
+		req.Header.Set("X-Loki-Actor-Path", r.actor)
 	}
 	req.Header.Set("User-Agent", userAgent)
 

--- a/pkg/canary/reader/reader_test.go
+++ b/pkg/canary/reader/reader_test.go
@@ -1,0 +1,52 @@
+package reader
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyHeaders(t *testing.T) {
+	reader := &Reader{
+		user:     "user",
+		pass:     "pass",
+		tenantID: "tenant",
+		actor:    "actor",
+	}
+
+	t.Run("apply headers to existing request", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		header := reader.ApplyHeaders(req)
+		require.Equal(t, "tenant", req.Header.Get("X-Scope-OrgID"))
+		require.Equal(t, "actor", req.Header.Get("X-Loki-Actor-Path"))
+		require.Equal(t, "loki-canary/", req.Header.Get("User-Agent"))
+
+		auth := reader.user + ":" + reader.pass
+		require.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)), req.Header.Get("Authorization"))
+
+		require.Equal(t, req.Header, header)
+	})
+
+	t.Run("apply headers to nil request", func(t *testing.T) {
+		header := reader.ApplyHeaders(nil)
+		require.Equal(t, "tenant", header.Get("X-Scope-OrgID"))
+		require.Equal(t, "actor", header.Get("X-Loki-Actor-Path"))
+		require.Equal(t, "loki-canary/", header.Get("User-Agent"))
+
+		auth := reader.user + ":" + reader.pass
+		require.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)), header.Get("Authorization"))
+	})
+
+	t.Run("only apply headers for existing fields", func(t *testing.T) {
+		reader := &Reader{}
+		header := reader.ApplyHeaders(nil)
+		keys := []string{}
+		for k := range header {
+			keys = append(keys, k)
+		}
+		require.Equal(t, []string{"User-Agent"}, keys)
+	})
+
+}


### PR DESCRIPTION
The CLI argument allows to set the `X-Loki-Actor-Path` HTTP header for requests of the reader.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
