### PR TITLE
Short circuit parsing when label matchers are present

### DIFF
--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -50,7 +50,7 @@ type lineSampleExtractor struct {
 // Multiple log stages are run before converting the log line.
 func NewLineSampleExtractor(ex LineExtractor, stages []Stage, groups []string, without, noLabels bool) (SampleExtractor, error) {
 	s := ReduceStages(stages)
-	hints := NewParserHint(s.RequiredLabelNames(), groups, without, noLabels, "")
+	hints := NewParserHint(s.RequiredLabelNames(), groups, without, noLabels, "", stages)
 	return &lineSampleExtractor{
 		Stage:            s,
 		LineExtractor:    ex,
@@ -138,7 +138,7 @@ func LabelExtractorWithStages(
 		sort.Strings(groups)
 	}
 	preStage := ReduceStages(preStages)
-	hints := NewParserHint(append(preStage.RequiredLabelNames(), postFilter.RequiredLabelNames()...), groups, without, noLabels, labelName)
+	hints := NewParserHint(append(preStage.RequiredLabelNames(), postFilter.RequiredLabelNames()...), groups, without, noLabels, labelName, append(preStages, postFilter))
 	return &labelSampleExtractor{
 		preStage:         preStage,
 		conversionFn:     convFn,

--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -38,13 +38,15 @@ var (
 	errUnexpectedJSONObject = fmt.Errorf("expecting json object(%d), but it is not", jsoniter.ObjectValue)
 	errMissingCapture       = errors.New("at least one named capture must be supplied")
 	errFoundAllLabels       = errors.New("found all required labels")
+	errLabelDoesNotMatch    = errors.New("found a label with a matcher that didn't match")
 )
 
 type JSONParser struct {
 	prefixBuffer []byte // buffer used to build json keys
 	lbs          *LabelsBuilder
 
-	keys internedStringSet
+	keys        internedStringSet
+	parserHints ParserHint
 }
 
 // NewJSONParser creates a log stage that can parse a json log line and add properties as labels.
@@ -56,13 +58,15 @@ func NewJSONParser() *JSONParser {
 }
 
 func (j *JSONParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
-	if lbs.ParserLabelHints().NoLabels() {
+	parserHints := lbs.ParserLabelHints()
+	if parserHints.NoLabels() {
 		return line, true
 	}
 
 	// reset the state.
 	j.prefixBuffer = j.prefixBuffer[:0]
 	j.lbs = lbs
+	j.parserHints = parserHints
 
 	if err := jsonparser.ObjectEach(line, j.parseObject); err != nil {
 		if errors.Is(err, errFoundAllLabels) {
@@ -70,23 +74,25 @@ func (j *JSONParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, 
 			return line, true
 		}
 
-		lbs.SetErr(errJSON)
-		lbs.SetErrorDetails(err.Error())
-		if lbs.ParserLabelHints().PreserveError() {
-			lbs.Set(logqlmodel.PreserveErrorLabel, "true")
+		if errors.Is(err, errLabelDoesNotMatch) {
+			// one of the label matchers does not match. The whole line can be thrown away
+			return line, false
 		}
+
+		addErrLabel(errJSON, err, lbs)
+
 		return line, true
 	}
 	return line, true
 }
 
 func (j *JSONParser) parseObject(key, value []byte, dataType jsonparser.ValueType, offset int) error {
+	var err error
 	switch dataType {
 	case jsonparser.String, jsonparser.Number, jsonparser.Boolean:
-		j.parseLabelValue(key, value, dataType)
+		err = j.parseLabelValue(key, value, dataType)
 	case jsonparser.Object:
 		prefixLen := len(j.prefixBuffer)
-		var err error
 		if ok := j.nextKeyPrefix(key); ok {
 			err = jsonparser.ObjectEach(value, j.parseObject)
 		}
@@ -95,13 +101,13 @@ func (j *JSONParser) parseObject(key, value []byte, dataType jsonparser.ValueTyp
 		return err
 	}
 
-	if j.lbs.ParserLabelHints().AllRequiredExtracted() {
+	if j.parserHints.AllRequiredExtracted() {
 		// Not actually an error. Parsing can be short-circuited
 		// and this tells jsonparser to stop parsing
 		return errFoundAllLabels
 	}
 
-	return nil
+	return err
 }
 
 // nextKeyPrefix load the next prefix in the buffer and tells if it should be processed based on hints.
@@ -114,7 +120,7 @@ func (j *JSONParser) nextKeyPrefix(key []byte) bool {
 	return j.lbs.ParserLabelHints().ShouldExtractPrefix(unsafeGetString(j.prefixBuffer))
 }
 
-func (j *JSONParser) parseLabelValue(key, value []byte, dataType jsonparser.ValueType) {
+func (j *JSONParser) parseLabelValue(key, value []byte, dataType jsonparser.ValueType) error {
 	// the first time we use the field as label key.
 	if len(j.prefixBuffer) == 0 {
 		key, ok := j.keys.Get(key, func() (string, bool) {
@@ -128,10 +134,13 @@ func (j *JSONParser) parseLabelValue(key, value []byte, dataType jsonparser.Valu
 			return field, true
 		})
 		if !ok {
-			return
+			return nil
 		}
 		j.lbs.Set(key, readValue(value, dataType))
-		return
+		if !j.parserHints.ShouldContinueParsingLine(key, j.lbs) {
+			return errLabelDoesNotMatch
+		}
+		return nil
 
 	}
 	// otherwise we build the label key using the buffer
@@ -144,7 +153,7 @@ func (j *JSONParser) parseLabelValue(key, value []byte, dataType jsonparser.Valu
 		if j.lbs.BaseHas(string(j.prefixBuffer)) {
 			j.prefixBuffer = append(j.prefixBuffer, duplicateSuffix...)
 		}
-		if !j.lbs.ParserLabelHints().ShouldExtract(string(j.prefixBuffer)) {
+		if !j.parserHints.ShouldExtract(string(j.prefixBuffer)) {
 			return "", false
 		}
 
@@ -154,9 +163,14 @@ func (j *JSONParser) parseLabelValue(key, value []byte, dataType jsonparser.Valu
 	// reset the prefix position
 	j.prefixBuffer = j.prefixBuffer[:prefixLen]
 	if !ok {
-		return
+		return nil
 	}
+
 	j.lbs.Set(keyString, readValue(value, dataType))
+	if !j.parserHints.ShouldContinueParsingLine(keyString, j.lbs) {
+		return errLabelDoesNotMatch
+	}
+	return nil
 }
 
 func (j *JSONParser) RequiredLabelNames() []string { return []string{} }
@@ -237,6 +251,7 @@ func NewRegexpParser(re string) (*RegexpParser, error) {
 }
 
 func (r *RegexpParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
+	parserHints := lbs.ParserLabelHints()
 	for i, value := range r.regex.FindSubmatch(line) {
 		if name, ok := r.nameIndex[i]; ok {
 			key, ok := r.keys.Get(unsafeGetBytes(name), func() (string, bool) {
@@ -247,7 +262,7 @@ func (r *RegexpParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 				if lbs.BaseHas(sanitize) {
 					sanitize = fmt.Sprintf("%s%s", sanitize, duplicateSuffix)
 				}
-				if !lbs.ParserLabelHints().ShouldExtract(sanitize) {
+				if !parserHints.ShouldExtract(sanitize) {
 					return "", false
 				}
 
@@ -256,7 +271,11 @@ func (r *RegexpParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 			if !ok {
 				continue
 			}
+
 			lbs.Set(key, string(value))
+			if !parserHints.ShouldContinueParsingLine(key, lbs) {
+				return line, false
+			}
 		}
 	}
 	return line, true
@@ -279,7 +298,8 @@ func NewLogfmtParser() *LogfmtParser {
 }
 
 func (l *LogfmtParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
-	if lbs.ParserLabelHints().NoLabels() {
+	parserHints := lbs.ParserLabelHints()
+	if parserHints.NoLabels() {
 		return line, true
 	}
 
@@ -295,7 +315,7 @@ func (l *LogfmtParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 				sanitized = fmt.Sprintf("%s%s", sanitized, duplicateSuffix)
 			}
 
-			if !lbs.ParserLabelHints().ShouldExtract(sanitized) {
+			if !parserHints.ShouldExtract(sanitized) {
 				return "", false
 			}
 			return sanitized, true
@@ -308,17 +328,21 @@ func (l *LogfmtParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 		if bytes.ContainsRune(val, utf8.RuneError) {
 			val = nil
 		}
-		lbs.Set(key, string(val))
 
-		if lbs.ParserLabelHints().AllRequiredExtracted() {
+		lbs.Set(key, string(val))
+		if !parserHints.ShouldContinueParsingLine(key, lbs) {
+			return line, false
+		}
+
+		if parserHints.AllRequiredExtracted() {
 			break
 		}
 	}
 	if l.dec.Err() != nil {
-		lbs.SetErr(errLogfmt)
-		lbs.SetErrorDetails(l.dec.Err().Error())
-		if lbs.ParserLabelHints().PreserveError() {
-			lbs.Set(logqlmodel.PreserveErrorLabel, "true")
+		addErrLabel(errLogfmt, l.dec.Err(), lbs)
+
+		if !parserHints.ShouldContinueParsingLine(logqlmodel.ErrorLabel, lbs) {
+			return line, false
 		}
 		return line, true
 	}
@@ -349,7 +373,8 @@ func NewPatternParser(pn string) (*PatternParser, error) {
 }
 
 func (l *PatternParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
-	if lbs.ParserLabelHints().NoLabels() {
+	parserHints := lbs.ParserLabelHints()
+	if parserHints.NoLabels() {
 		return line, true
 	}
 	matches := l.matcher.Matches(line)
@@ -360,11 +385,14 @@ func (l *PatternParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byt
 			name = name + duplicateSuffix
 		}
 
-		if !lbs.parserKeyHints.ShouldExtract(name) {
+		if !parserHints.ShouldExtract(name) {
 			continue
 		}
 
 		lbs.Set(name, string(m))
+		if !parserHints.ShouldContinueParsingLine(name, lbs) {
+			return line, false
+		}
 	}
 	return line, true
 }
@@ -535,20 +563,14 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 	// the parser will pass an error if other
 	// parts of the line are malformed
 	if !isValidJSONStart(line) {
-		lbs.SetErr(errJSON)
-		if lbs.ParserLabelHints().PreserveError() {
-			lbs.Set(logqlmodel.PreserveErrorLabel, "true")
-		}
+		addErrLabel(errJSON, nil, lbs)
 		return line, true
 	}
 
 	var matches int
 	jsonparser.EachKey(line, func(idx int, data []byte, typ jsonparser.ValueType, err error) {
 		if err != nil {
-			lbs.SetErr(errJSON)
-			if lbs.ParserLabelHints().PreserveError() {
-				lbs.Set(logqlmodel.PreserveErrorLabel, "true")
-			}
+			addErrLabel(errJSON, err, lbs)
 			return
 		}
 
@@ -617,25 +639,38 @@ func (u *UnpackParser) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte
 		return line, true
 	}
 
+	// we only care about object and values.
+	if line[0] != '{' {
+		addErrLabel(errJSON, errUnexpectedJSONObject, lbs)
+		return line, true
+	}
+
 	u.lbsBuffer = u.lbsBuffer[:0]
 	entry, err := u.unpack(line, lbs)
 	if err != nil {
-		lbs.SetErr(errJSON)
-		lbs.SetErrorDetails(err.Error())
-		if lbs.ParserLabelHints().PreserveError() {
-			lbs.Set(logqlmodel.PreserveErrorLabel, "true")
+		if errors.Is(err, errLabelDoesNotMatch) {
+			return entry, false
 		}
+		addErrLabel(errJSON, err, lbs)
 		return line, true
 	}
+
 	return entry, true
 }
 
-func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) {
-	// we only care about object and values.
-	if entry[0] != '{' {
-		return nil, errUnexpectedJSONObject
+func addErrLabel(msg string, err error, lbs *LabelsBuilder) {
+	lbs.SetErr(msg)
+
+	if err != nil {
+		lbs.SetErrorDetails(err.Error())
 	}
 
+	if lbs.ParserLabelHints().PreserveError() {
+		lbs.Set(logqlmodel.PreserveErrorLabel, "true")
+	}
+}
+
+func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) {
 	var isPacked bool
 	err := jsonparser.ObjectEach(entry, func(key, value []byte, typ jsonparser.ValueType, _ int) error {
 		switch typ {
@@ -683,6 +718,9 @@ func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) 
 	if isPacked {
 		for i := 0; i < len(u.lbsBuffer); i = i + 2 {
 			lbs.Set(u.lbsBuffer[i], u.lbsBuffer[i+1])
+			if !lbs.ParserLabelHints().ShouldContinueParsingLine(u.lbsBuffer[i], lbs) {
+				return entry, errLabelDoesNotMatch
+			}
 		}
 	}
 	return entry, nil

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -172,8 +172,6 @@ func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, 
 
 	ph.requiredLabels = hints
 	ph.shouldPreserveError = containsError(hints)
-	ph.labelNames = labelNames
-	ph.labelFilters = labelFilters
 
 	return &Hints{requiredLabels: hints, extracted: extracted, shouldPreserveError: containsError(hints)}
 }

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -142,6 +142,8 @@ func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, 
 	for _, s := range stages {
 		switch f := s.(type) {
 		case *BinaryLabelFilter:
+			// TODO: as long as each leg of the binary filter operates on the same (and only 1) label,
+			// we should be able to add this to our filters
 			continue
 		case LabelFilterer:
 			if len(f.RequiredLabelNames()) > 1 {

--- a/pkg/logql/log/parser_hints.go
+++ b/pkg/logql/log/parser_hints.go
@@ -19,9 +19,11 @@ var noParserHints = &Hints{}
 type ParserHint interface {
 	// Tells if a label with the given key should be extracted.
 	ShouldExtract(key string) bool
+
 	// Tells if there's any hint that start with the given prefix.
 	// This allows to speed up key searching in nested structured like json.
 	ShouldExtractPrefix(prefix string) bool
+
 	// Tells if we should not extract any labels.
 	// For example in :
 	//		 sum(rate({app="foo"} | json [5m]))
@@ -31,10 +33,19 @@ type ParserHint interface {
 	// Holds state about what's already been extracted for the associated
 	// labels. This assumes that only required labels are ever extracted
 	RecordExtracted(string)
+
+	// Returns true if all the extracted labels have already been extracted
 	AllRequiredExtracted() bool
+
+	// Resets the state of extracted labels
 	Reset()
+
 	// PreserveError returns true when parsing errors were specifically requested
 	PreserveError() bool
+
+	// ShouldContinueParsingLine ShouldContinueParsing line retruns true when there is no label matcher for the
+	// provided label or the passed label and value match what's in the pipeline
+	ShouldContinueParsingLine(labelName string, lbs *LabelsBuilder) bool
 }
 
 type Hints struct {
@@ -42,6 +53,8 @@ type Hints struct {
 	requiredLabels      []string
 	shouldPreserveError bool
 	extracted           []string
+	labelFilters        []LabelFilterer
+	labelNames          []string
 }
 
 func (p *Hints) ShouldExtract(key string) bool {
@@ -101,32 +114,67 @@ func (p *Hints) Reset() {
 	p.extracted = p.extracted[:0]
 }
 
-// NewParserHint creates a new parser hint using the list of labels that are seen and required in a query.
 func (p *Hints) PreserveError() bool {
 	return p.shouldPreserveError
 }
 
+func (p *Hints) ShouldContinueParsingLine(labelName string, lbs *LabelsBuilder) bool {
+	for i := 0; i < len(p.labelNames); i++ {
+		if p.labelNames[i] == labelName {
+			_, matches := p.labelFilters[i].Process(0, nil, lbs)
+			return matches
+		}
+	}
+	return true
+}
+
 // NewParserHint creates a new parser hint using the list of labels that are seen and required in a query.
-func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, metricLabelName string) *Hints {
+func NewParserHint(requiredLabelNames, groups []string, without, noLabels bool, metricLabelName string, stages []Stage) *Hints {
 	hints := make([]string, 0, 2*(len(requiredLabelNames)+len(groups)+1))
 	hints = appendLabelHints(hints, requiredLabelNames...)
 	hints = appendLabelHints(hints, groups...)
 	hints = appendLabelHints(hints, metricLabelName)
 	hints = uniqueString(hints)
 
+	// Save the names next to the filters to avoid an alloc when f.RequiredLabelNames() is called
+	var labelNames []string
+	var labelFilters []LabelFilterer
+	for _, s := range stages {
+		switch f := s.(type) {
+		case *BinaryLabelFilter:
+			continue
+		case LabelFilterer:
+			if len(f.RequiredLabelNames()) > 1 {
+				// Hints can only operate on one label at a time
+				continue
+			}
+			labelFilters = append(labelFilters, f)
+			labelNames = append(labelNames, f.RequiredLabelNames()...)
+		}
+	}
+
 	extracted := make([]string, 0, len(hints))
 	if noLabels {
 		if len(hints) > 0 {
-			return &Hints{requiredLabels: hints, extracted: extracted, shouldPreserveError: containsError(hints)}
+			return &Hints{requiredLabels: hints, extracted: extracted, shouldPreserveError: containsError(hints), labelFilters: labelFilters, labelNames: labelNames}
 		}
 		return &Hints{noLabels: true}
 	}
+
+	ph := &Hints{labelFilters: labelFilters, labelNames: labelNames}
+
 	// we don't know what is required when a without clause is used.
 	// Same is true when there's no grouping.
 	// no hints available then.
 	if without || len(groups) == 0 {
-		return noParserHints
+		return ph
 	}
+
+	ph.requiredLabels = hints
+	ph.shouldPreserveError = containsError(hints)
+	ph.labelNames = labelNames
+	ph.labelFilters = labelFilters
+
 	return &Hints{requiredLabels: hints, extracted: extracted, shouldPreserveError: containsError(hints)}
 }
 

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -235,7 +235,7 @@ func Test_ParserHints(t *testing.T) {
 }
 
 func TestRecordingExtractedLabels(t *testing.T) {
-	p := log.NewParserHint([]string{"1", "2", "3"}, nil, false, true, "")
+	p := log.NewParserHint([]string{"1", "2", "3"}, nil, false, true, "", nil)
 	p.RecordExtracted("1")
 	p.RecordExtracted("2")
 
@@ -250,4 +250,35 @@ func TestRecordingExtractedLabels(t *testing.T) {
 	p.Reset()
 	require.False(t, p.AllRequiredExtracted())
 	require.False(t, p.NoLabels())
+}
+
+func TestLabelFiltersInParseHints(t *testing.T) {
+	t.Run("it rejects the line when label matchers don't match the label", func(t *testing.T) {
+		s := []log.Stage{log.NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "protocol", "nothing"))}
+		h := log.NewParserHint(nil, nil, true, true, "metric", s)
+
+		lb := log.NewBaseLabelsBuilder().ForLabels(labels.Labels{{Name: "protocol", Value: "HTTP/2.0"}}, 0)
+		require.False(t, h.ShouldContinueParsingLine("protocol", lb))
+	})
+
+	t.Run("it returns true when the label doesn't have a matcher", func(t *testing.T) {
+		s := []log.Stage{log.NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "protocol", "nothing"))}
+		h := log.NewParserHint(nil, nil, true, true, "metric", s)
+
+		lb := log.NewBaseLabelsBuilder().ForLabels(labels.Labels{{Name: "response", Value: "200"}}, 0)
+		require.True(t, h.ShouldContinueParsingLine("response", lb))
+	})
+
+	t.Run("it ignores BinaryMatchers", func(t *testing.T) {
+		s := []log.Stage{
+			log.ReduceAndLabelFilter([]log.LabelFilterer{
+				log.NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "protocol", "nothing")),
+				log.NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "protocol", "something")),
+			}),
+		}
+
+		h := log.NewParserHint(nil, nil, true, true, "metric", s)
+		lb := log.NewBaseLabelsBuilder().ForLabels(labels.Labels{{Name: "protocol", Value: "HTTP/2.0"}}, 0)
+		require.True(t, h.ShouldContinueParsingLine("protocol", lb))
+	})
 }

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -100,7 +100,7 @@ func Test_jsonParser_Parse(t *testing.T) {
 				{Name: "__error_details__", Value: "Value looks like object, but can't find closing '}' symbol"},
 				{Name: "__preserve_error__", Value: "true"},
 			},
-			NewParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, "", nil),
 		},
 		{
 			"duplicate extraction",
@@ -132,6 +132,41 @@ func Test_jsonParser_Parse(t *testing.T) {
 }
 
 func TestKeyShortCircuit(t *testing.T) {
+	jsonLine := []byte(`{"invalid":"a\\xc5z","proxy_protocol_addr": "","remote_addr": "3.112.221.14","remote_user": "","upstream_addr": "10.12.15.234:5000","the_real_ip": "3.112.221.14","timestamp": "2020-12-11T16:20:07+00:00","protocol": "HTTP/1.1","upstream_name": "hosted-grafana-hosted-grafana-api-80","request": {"id": "c8eacb6053552c0cd1ae443bc660e140","time": "0.001","method" : "GET","host": "hg-api-qa-us-central1.grafana.net","uri": "/","size" : "128","user_agent": "worldping-api-","referer": ""},"response": {"status": 200,"upstream_status": "200","size": "1155","size_sent": "265","latency_seconds": "0.001"}}`)
+	logfmtLine := []byte(`level=info ts=2020-12-14T21:25:20.947307459Z caller=metrics.go:83 org_id=29 traceID=c80e691e8db08e2 latency=fast query="sum by (object_name) (rate(({container=\"metrictank\", cluster=\"hm-us-east2\"} |= \"PANIC\")[5m]))" query_type=metric range_type=range length=5m0s step=15s duration=322.623724ms status=200 throughput=1.2GB total_bytes=375MB`)
+	nginxline := []byte(`10.1.0.88 - - [14/Dec/2020:22:56:24 +0000] "GET /static/img/about/bob.jpg HTTP/1.1" 200 60755 "https://grafana.com/go/observabilitycon/grafana-the-open-and-composable-observability-platform/?tech=ggl-o&pg=oss-graf&plcmt=hero-txt" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15" "123.123.123.123, 35.35.122.223" "TLSv1.3"`)
+	packedLike := []byte(`{"job":"123","pod":"someuid123","app":"foo","_entry":"10.1.0.88 - - [14/Dec/2020:22:56:24 +0000] GET /static/img/about/bob.jpg HTTP/1.1"}`)
+
+	lbs := NewBaseLabelsBuilder().ForLabels(labels.Labels{}, 0)
+	hints := newFakeParserHints()
+	hints.extractAll = true
+	hints.keepGoing = false
+
+	lbs.parserKeyHints = hints
+
+	for _, tt := range []struct {
+		name                 string
+		line                 []byte
+		p                    Stage
+		LabelFilterParseHint *labels.Matcher
+	}{
+		{"json", jsonLine, NewJSONParser(), labels.MustNewMatcher(labels.MatchEqual, "response_latency_seconds", "nope")},
+		{"unpack", packedLike, NewUnpackParser(), labels.MustNewMatcher(labels.MatchEqual, "pod", "nope")},
+		{"logfmt", logfmtLine, NewLogfmtParser(), labels.MustNewMatcher(labels.MatchEqual, "info", "nope")},
+		{"regex greedy", nginxline, mustStage(NewRegexpParser(`GET (?P<path>.*?)/\?`)), labels.MustNewMatcher(labels.MatchEqual, "path", "nope")},
+		{"pattern", nginxline, mustStage(NewPatternParser(`<_> "<method> <path> <_>"<_>`)), labels.MustNewMatcher(labels.MatchEqual, "method", "nope")},
+	} {
+		lbs.Reset()
+		t.Run(tt.name, func(t *testing.T) {
+			_, result = tt.p.Process(0, tt.line, lbs)
+
+			require.Len(t, lbs.labels(), 1)
+			require.False(t, result)
+		})
+	}
+}
+
+func TestLabelShortCircuit(t *testing.T) {
 	simpleJsn := []byte(`{
       "data": "Click Here",
       "size": 36,
@@ -145,7 +180,9 @@ func TestKeyShortCircuit(t *testing.T) {
     }`)
 	logFmt := []byte(`data="ClickHere" size=36 style=bold name=text1 name=duplicate hOffset=250 vOffset=100 alignment=center onMouseUp="sun1.opacity = (sun1.opacity / 100) * 90;"`)
 
-	hints := &fakeParseHints{label: "name"}
+	hints := newFakeParserHints()
+	hints.label = "name"
+
 	lbs := NewBaseLabelsBuilder().ForLabels(labels.Labels{}, 0)
 	lbs.parserKeyHints = hints
 
@@ -171,18 +208,26 @@ func TestKeyShortCircuit(t *testing.T) {
 	}
 }
 
+func newFakeParserHints() *fakeParseHints {
+	return &fakeParseHints{
+		keepGoing: true,
+	}
+}
+
 type fakeParseHints struct {
 	label      string
 	checkCount int
 	count      int
+	keepGoing  bool
+	extractAll bool
 }
 
 func (p *fakeParseHints) ShouldExtract(key string) bool {
 	p.checkCount++
-	return key == p.label
+	return key == p.label || p.extractAll
 }
 func (p *fakeParseHints) ShouldExtractPrefix(prefix string) bool {
-	return prefix == p.label
+	return prefix == p.label || p.extractAll
 }
 func (p *fakeParseHints) NoLabels() bool {
 	return false
@@ -191,7 +236,7 @@ func (p *fakeParseHints) RecordExtracted(_ string) {
 	p.count++
 }
 func (p *fakeParseHints) AllRequiredExtracted() bool {
-	return p.count == 1
+	return !p.extractAll && p.count == 1
 }
 func (p *fakeParseHints) Reset() {
 	p.checkCount = 0
@@ -199,6 +244,9 @@ func (p *fakeParseHints) Reset() {
 }
 func (p *fakeParseHints) PreserveError() bool {
 	return false
+}
+func (p *fakeParseHints) ShouldContinueParsingLine(_ string, _ *LabelsBuilder) bool {
+	return p.keepGoing
 }
 
 func TestJSONExpressionParser(t *testing.T) {
@@ -468,7 +516,7 @@ func TestJSONExpressionParser(t *testing.T) {
 				{Name: logqlmodel.ErrorLabel, Value: errJSON},
 				{Name: logqlmodel.PreserveErrorLabel, Value: "true"},
 			},
-			NewParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, "", nil),
 		},
 		{
 			"empty line",
@@ -560,19 +608,20 @@ func Benchmark_Parser(b *testing.B) {
 	packedLike := `{"job":"123","pod":"someuid123","app":"foo","_entry":"10.1.0.88 - - [14/Dec/2020:22:56:24 +0000] "GET /static/img/about/bob.jpg HTTP/1.1"}`
 
 	for _, tt := range []struct {
-		name            string
-		line            string
-		s               Stage
-		LabelParseHints []string //  hints to reduce label extractions.
+		name                 string
+		line                 string
+		s                    Stage
+		LabelParseHints      []string //  hints to reduce label extractions.
+		LabelFilterParseHint *labels.Matcher
 	}{
-		{"json", jsonLine, NewJSONParser(), []string{"response_latency_seconds"}},
-		{"jsonParser-not json line", nginxline, NewJSONParser(), []string{"response_latency_seconds"}},
-		{"unpack", packedLike, NewUnpackParser(), []string{"pod"}},
-		{"unpack-not json line", nginxline, NewUnpackParser(), []string{"pod"}},
-		{"logfmt", logfmtLine, NewLogfmtParser(), []string{"info", "throughput", "org_id"}},
-		{"regex greedy", nginxline, mustStage(NewRegexpParser(`GET (?P<path>.*?)/\?`)), []string{"path"}},
-		{"regex status digits", nginxline, mustStage(NewRegexpParser(`HTTP/1.1" (?P<statuscode>\d{3}) `)), []string{"statuscode"}},
-		{"pattern", nginxline, mustStage(NewPatternParser(`<_> "<method> <path> <_>"<_>`)), []string{"path"}},
+		{"json", jsonLine, NewJSONParser(), []string{"response_latency_seconds"}, labels.MustNewMatcher(labels.MatchEqual, "the_real_ip", "nope")},
+		{"jsonParser-not json line", nginxline, NewJSONParser(), []string{"response_latency_seconds"}, labels.MustNewMatcher(labels.MatchEqual, "the_real_ip", "nope")},
+		{"unpack", packedLike, NewUnpackParser(), []string{"pod"}, labels.MustNewMatcher(labels.MatchEqual, "app", "nope")},
+		{"unpack-not json line", nginxline, NewUnpackParser(), []string{"pod"}, labels.MustNewMatcher(labels.MatchEqual, "app", "nope")},
+		{"logfmt", logfmtLine, NewLogfmtParser(), []string{"info", "throughput", "org_id"}, labels.MustNewMatcher(labels.MatchEqual, "latency", "nope")},
+		{"regex greedy", nginxline, mustStage(NewRegexpParser(`GET (?P<path>.*?)/\?`)), []string{"path"}, labels.MustNewMatcher(labels.MatchEqual, "path", "nope")},
+		{"regex status digits", nginxline, mustStage(NewRegexpParser(`HTTP/1.1" (?P<statuscode>\d{3}) `)), []string{"statuscode"}, labels.MustNewMatcher(labels.MatchEqual, "status_code", "nope")},
+		{"pattern", nginxline, mustStage(NewPatternParser(`<_> "<method> <path> <_>"<_>`)), []string{"path"}, labels.MustNewMatcher(labels.MatchEqual, "method", "nope")},
 	} {
 		b.Run(tt.name, func(b *testing.B) {
 			line := []byte(tt.line)
@@ -586,7 +635,18 @@ func Benchmark_Parser(b *testing.B) {
 
 			b.Run("labels hints", func(b *testing.B) {
 				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
-				builder.parserKeyHints = NewParserHint(tt.LabelParseHints, tt.LabelParseHints, false, false, "")
+				builder.parserKeyHints = NewParserHint(tt.LabelParseHints, tt.LabelParseHints, false, false, "", nil)
+
+				for n := 0; n < b.N; n++ {
+					builder.Reset()
+					_, _ = tt.s.Process(0, line, builder)
+				}
+			})
+
+			b.Run("inline stages", func(b *testing.B) {
+				stages := []Stage{NewStringLabelFilter(tt.LabelFilterParseHint)}
+				builder := NewBaseLabelsBuilder().ForLabels(lbs, lbs.Hash())
+				builder.parserKeyHints = NewParserHint(nil, nil, false, false, ", nil", stages)
 				for n := 0; n < b.N; n++ {
 					builder.Reset()
 					_, _ = tt.s.Process(0, line, builder)
@@ -610,7 +670,7 @@ func BenchmarkKeyExtraction(b *testing.B) {
 	logFmt := []byte(`data="Click Here" size=36 style=bold name=text1 hOffset=250 vOffset=100 alignment=center onMouseUp="sun1.opacity = (sun1.opacity / 100) * 90;"`)
 
 	lbs := NewBaseLabelsBuilder().ForLabels(labels.Labels{}, 0)
-	lbs.parserKeyHints = NewParserHint([]string{"name"}, nil, false, true, "")
+	lbs.parserKeyHints = NewParserHint([]string{"name"}, nil, false, true, "", nil)
 
 	benchmarks := []struct {
 		name string
@@ -765,7 +825,7 @@ func Test_logfmtParser_Parse(t *testing.T) {
 				{Name: "__error_details__", Value: "logfmt syntax error at pos 8 : unexpected '='"},
 				{Name: "__preserve_error__", Value: "true"},
 			},
-			NewParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, "", nil),
 		},
 		{
 			"utf8 error rune",
@@ -1142,7 +1202,7 @@ func Test_unpackParser_Parse(t *testing.T) {
 				{Name: "__preserve_error__", Value: "true"},
 			},
 			[]byte(`"app":"foo","namespace":"prod","_entry":"some message","pod":{"uid":"1"}`),
-			NewParserHint([]string{"__error__"}, nil, false, true, ""),
+			NewParserHint([]string{"__error__"}, nil, false, true, "", nil),
 		},
 		{
 			"not a map",

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -126,9 +126,12 @@ func NewPipeline(stages []Stage) Pipeline {
 	if len(stages) == 0 {
 		return NewNoopPipeline()
 	}
+
+	hints := NewParserHint(nil, nil, false, false, "", stages)
+	builder := NewBaseLabelsBuilderWithGrouping(nil, hints, false, false)
 	return &pipeline{
 		stages:          stages,
-		baseBuilder:     NewBaseLabelsBuilder(),
+		baseBuilder:     builder,
 		streamPipelines: make(map[uint64]StreamPipeline),
 	}
 }


### PR DESCRIPTION
This PR makes parsers aware of any downstream label-matcher stages at parse time. As labels are parsed, if one has a matcher, the matcher is checked at parse time. If the label does not match it's matcher, parsing is halted on that log line.

**ex 1:**
consider the log:
`foo=1 bar=2 baz=3`

And the query
`{} | logfmt | bar=3`

When `bar` is parsed it is immediately checked against it's matcher. The match fails so we the parser never spends time parsing the rest of the line.

**ex 2:**
consider the log:
`foo=1 baz=3 bletch=4`

And the query
`{} | logfmt | bar=3`

`bar` is never seen in the log so the whole line is parsed.

**Benchmarks:**
```
                                                   │ parsers__old_2.txt │          parsers__new_3.txt          │
                                                   │       sec/op       │    sec/op     vs base                │
_Parser/json/inline_stages-8                              3413.5n ±  5%    766.4n ± 4%  -77.55% (p=0.000 n=10)
_Parser/jsonParser-not_json_line/inline_stages-8           101.5n ±  6%    103.1n ± 8%        ~ (p=0.645 n=10)
_Parser/unpack/inline_stages-8                             383.8n ±  4%    388.0n ± 9%        ~ (p=0.954 n=10)
_Parser/unpack-not_json_line/inline_stages-8               13.30n ±  2%    13.11n ± 1%        ~ (p=0.247 n=10)
_Parser/logfmt/inline_stages-8                            2105.5n ± 16%    727.7n ± 4%  -65.44% (p=0.000 n=10)
_Parser/regex_greedy/inline_stages-8                       4.220µ ±  4%    4.175µ ± 4%        ~ (p=0.739 n=10)
_Parser/regex_status_digits/inline_stages-8                319.8n ±  5%    326.4n ± 8%        ~ (p=0.481 n=10)
_Parser/pattern/inline_stages-8                            185.2n ±  7%    154.2n ± 3%  -16.74% (p=0.000 n=10)

                                                   │ parsers__old_2.txt │          parsers__new_3.txt          │
                                                   │        B/op        │    B/op     vs base                  │
_Parser/json/inline_stages-8                              280.00 ± 0%     64.00 ± 0%  -77.14% (p=0.000 n=10)
_Parser/jsonParser-not_json_line/inline_stages-8           16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) 
_Parser/unpack/inline_stages-8                             80.00 ± 0%     80.00 ± 0%        ~ (p=1.000 n=10) 
_Parser/unpack-not_json_line/inline_stages-8               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/logfmt/inline_stages-8                            336.00 ± 0%     74.00 ± 0%  -77.98% (p=0.000 n=10)
_Parser/regex_greedy/inline_stages-8                       193.0 ± 1%     192.0 ± 1%        ~ (p=0.656 n=10)
_Parser/regex_status_digits/inline_stages-8                51.00 ± 0%     51.00 ± 0%        ~ (p=1.000 n=10) 
_Parser/pattern/inline_stages-8                           35.000 ± 0%     3.000 ± 0%  -91.43% (p=0.000 n=10)

                                                   │ parsers__old_2.txt │          parsers__new_3.txt          │
                                                   │     allocs/op      │ allocs/op   vs base                  │

_Parser/json/inline_stages-8                              18.000 ± 0%     4.000 ± 0%  -77.78% (p=0.000 n=10)
_Parser/jsonParser-not_json_line/inline_stages-8           1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/unpack/inline_stages-8                             4.000 ± 0%     4.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/unpack-not_json_line/inline_stages-8               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/logfmt/inline_stages-8                            16.000 ± 0%     6.000 ± 0%  -62.50% (p=0.000 n=10)
_Parser/regex_greedy/inline_stages-8                       2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/regex_status_digits/inline_stages-8                2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) 
_Parser/pattern/inline_stages-8                            2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
```

