### PR TITLE
Extend scheduler queue metrics with enqueue/dequeue counters

### DIFF
--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -6,22 +6,21 @@ import (
 )
 
 type Metrics struct {
-	QueueLength       *prometheus.GaugeVec   // Per tenant and reason.
-	DiscardedRequests *prometheus.CounterVec // Per tenant.
-	// unexported fields must only used by the RequestQueue which resides in the same package
-	enqueueCount *prometheus.CounterVec // Per tenant and level
-	dequeueCount *prometheus.CounterVec // Per tenant and querier
+	queueLength       *prometheus.GaugeVec   // Per tenant and reason.
+	discardedRequests *prometheus.CounterVec // Per tenant.
+	enqueueCount      *prometheus.CounterVec // Per tenant and level
+	dequeueCount      *prometheus.CounterVec // Per tenant and querier
 }
 
 func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 	return &Metrics{
-		QueueLength: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
+		queueLength: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "cortex",
 			Subsystem: subsystem,
 			Name:      "queue_length",
 			Help:      "Number of queries in the queue.",
 		}, []string{"user"}),
-		DiscardedRequests: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		discardedRequests: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex",
 			Subsystem: subsystem,
 			Name:      "discarded_requests_total",
@@ -43,7 +42,7 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 }
 
 func (m *Metrics) Cleanup(user string) {
-	m.QueueLength.DeleteLabelValues(user)
-	m.DiscardedRequests.DeleteLabelValues(user)
+	m.queueLength.DeleteLabelValues(user)
+	m.discardedRequests.DeleteLabelValues(user)
 	m.dequeueCount.DeletePartialMatch(prometheus.Labels{"user": user})
 }

--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -44,5 +44,6 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 func (m *Metrics) Cleanup(user string) {
 	m.queueLength.DeleteLabelValues(user)
 	m.discardedRequests.DeleteLabelValues(user)
+	m.enqueueCount.DeletePartialMatch(prometheus.Labels{"user": user})
 	m.dequeueCount.DeletePartialMatch(prometheus.Labels{"user": user})
 }

--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -27,13 +27,13 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 			Help:      "Total number of query requests discarded.",
 		}, []string{"user"}),
 		enqueueCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "cortex",
+			Namespace: "loki",
 			Subsystem: subsystem,
 			Name:      "enqueue_count",
 			Help:      "Total number of enqueued (sub-)queries.",
 		}, []string{"user", "level"}),
 		dequeueCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "cortex",
+			Namespace: "loki",
 			Subsystem: subsystem,
 			Name:      "dequeue_count",
 			Help:      "Total number of dequeued (sub-)queries.",

--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Metrics struct {
-	queueLength       *prometheus.GaugeVec   // Per tenant and reason.
-	discardedRequests *prometheus.CounterVec // Per tenant.
+	queueLength       *prometheus.GaugeVec   // Per tenant
+	discardedRequests *prometheus.CounterVec // Per tenant
 	enqueueCount      *prometheus.CounterVec // Per tenant and level
 	dequeueCount      *prometheus.CounterVec // Per tenant and querier
 }

--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -41,3 +41,9 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 		}, []string{"user", "querier"}),
 	}
 }
+
+func (m *Metrics) Cleanup(user string) {
+	m.QueueLength.DeleteLabelValues(user)
+	m.DiscardedRequests.DeleteLabelValues(user)
+	m.dequeueCount.DeletePartialMatch(prometheus.Labels{"user": user})
+}

--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -8,6 +8,9 @@ import (
 type Metrics struct {
 	QueueLength       *prometheus.GaugeVec   // Per tenant and reason.
 	DiscardedRequests *prometheus.CounterVec // Per tenant.
+	// unexported fields must only used by the RequestQueue which resides in the same package
+	enqueueCount *prometheus.CounterVec // Per tenant and level
+	dequeueCount *prometheus.CounterVec // Per tenant and querier
 }
 
 func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
@@ -24,5 +27,17 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 			Name:      "discarded_requests_total",
 			Help:      "Total number of query requests discarded.",
 		}, []string{"user"}),
+		enqueueCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Subsystem: subsystem,
+			Name:      "enqueue_count",
+			Help:      "Total number of enqueued (sub-)queries.",
+		}, []string{"user", "level"}),
+		dequeueCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Subsystem: subsystem,
+			Name:      "dequeue_count",
+			Help:      "Total number of dequeued (sub-)queries.",
+		}, []string{"user", "querier"}),
 	}
 }

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -95,7 +95,7 @@ func (q *RequestQueue) Enqueue(tenant string, path []string, req Request, maxQue
 
 	select {
 	case queue.Chan() <- req:
-		q.metrics.QueueLength.WithLabelValues(tenant).Inc()
+		q.metrics.queueLength.WithLabelValues(tenant).Inc()
 		q.metrics.enqueueCount.WithLabelValues(tenant, fmt.Sprint(len(path))).Inc()
 		q.cond.Broadcast()
 		// Call this function while holding a lock. This guarantees that no querier can fetch the request before function returns.
@@ -104,7 +104,7 @@ func (q *RequestQueue) Enqueue(tenant string, path []string, req Request, maxQue
 		}
 		return nil
 	default:
-		q.metrics.DiscardedRequests.WithLabelValues(tenant).Inc()
+		q.metrics.discardedRequests.WithLabelValues(tenant).Inc()
 		return ErrTooManyRequests
 	}
 }
@@ -147,7 +147,7 @@ FindQueue:
 				q.queues.deleteQueue(tenant)
 			}
 
-			q.metrics.QueueLength.WithLabelValues(tenant).Dec()
+			q.metrics.queueLength.WithLabelValues(tenant).Dec()
 			q.metrics.dequeueCount.WithLabelValues(tenant, querierID).Inc()
 
 			// Tell close() we've processed a request.


### PR DESCRIPTION
**What this PR does / why we need it**:

Better o11y of the scheduler.

**Special notes for your reviewer**:

This change yields new metrics with potentially high cardinality on the scheduler.

A different approach for the `enqueueCount` would be to add the `level` label to the `queueLength` metrics, however, then we would need to know the level when we dequeue an item. 

**TODO**
- [x] Clean up inactive metrics

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
