### PR TITLE
Implementing consistent rule evaluation jitter using 32-bit hash

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"hash/fnv"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -1020,7 +1020,7 @@ func (t *Loki) initRuleEvaluator() (services.Service, error) {
 		return nil, fmt.Errorf("failed to create %s rule evaluator: %w", mode, err)
 	}
 
-	t.ruleEvaluator = ruler.NewEvaluatorWithJitter(evaluator, t.Cfg.Ruler.EvaluationJitter, rand.NewSource(time.Now().UnixNano()))
+	t.ruleEvaluator = ruler.NewEvaluatorWithJitter(evaluator, t.Cfg.Ruler.Evaluation.MaxJitter, fnv.New32a())
 
 	return nil, nil
 }

--- a/pkg/ruler/base/ruler.go
+++ b/pkg/ruler/base/ruler.go
@@ -88,8 +88,6 @@ type Config struct {
 	StoreConfig RuleStoreConfig `yaml:"storage" doc:"deprecated|description=Use -ruler-storage. CLI flags and their respective YAML config options instead."`
 	// Path to store rule files for prom manager.
 	RulePath string `yaml:"rule_path"`
-	// Maximum time to sleep before each rule evaluation.
-	EvaluationJitter time.Duration `yaml:"evaluation_jitter"`
 
 	// Global alertmanager config.
 	config.AlertManagerConfig `yaml:",inline"`
@@ -163,7 +161,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes.")
-	f.DurationVar(&cfg.EvaluationJitter, "ruler.evaluation-jitter", 0, "Upper bound of random duration to wait before rule evaluation to avoid contention during concurrent execution of rules. Set 0 to disable (default).")
 
 	f.StringVar(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "", "Comma-separated list of Alertmanager URLs to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via '-ruler.alertmanager-discovery'.")
 	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover Alertmanager hosts.")

--- a/pkg/ruler/evaluator.go
+++ b/pkg/ruler/evaluator.go
@@ -17,13 +17,15 @@ type Evaluator interface {
 }
 
 type EvaluationConfig struct {
-	Mode string `yaml:"mode,omitempty"`
+	Mode      string        `yaml:"mode,omitempty"`
+	MaxJitter time.Duration `yaml:"max_jitter"`
 
 	QueryFrontend QueryFrontendConfig `yaml:"query_frontend,omitempty"`
 }
 
 func (c *EvaluationConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.Mode, "ruler.evaluation.mode", EvalModeLocal, "The evaluation mode for the ruler. Can be either 'local' or 'remote'. If set to 'local', the ruler will evaluate rules locally. If set to 'remote', the ruler will evaluate rules remotely. If unset, the ruler will evaluate rules locally.")
+	f.DurationVar(&c.MaxJitter, "ruler.evaluation.max-jitter", 0, "Upper bound of random duration to wait before rule evaluation to avoid contention during concurrent execution of rules. Jitter is calculated consistently for a given rule. Set 0 to disable (default).")
 	c.QueryFrontend.RegisterFlags(f)
 }
 

--- a/pkg/ruler/evaluator_jitter.go
+++ b/pkg/ruler/evaluator_jitter.go
@@ -2,21 +2,29 @@ package ruler
 
 import (
 	"context"
-	"math/rand"
+	"hash"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/grafana/loki/pkg/logqlmodel"
 )
 
-// EvaluatorWithJitter wraps a given Evaluator. It applies a randomly-generated jitter (sleep) before each evaluation to
-// protect against thundering-herd scenarios where multiple rules are evaluated at the same time.
+// EvaluatorWithJitter wraps a given Evaluator. It applies a consistent jitter based on a rule's query string by hashing
+// the query string to produce a 32-bit unsigned integer. From this hash, we calculate a ratio between 0 and 1 and
+// multiply it by the configured max jitter. This ratio is used to delay evaluation by a consistent amount of random time.
+//
+// Consistent jitter is important because it allows rules to be evaluated on a regular, predictable cadence
+// while also ensuring that we spread evaluations across the configured jitter window to avoid resource contention scenarios.
 type EvaluatorWithJitter struct {
+	sync.Mutex
+
 	inner     Evaluator
 	maxJitter time.Duration
-	rng       *rand.Rand
+	hasher    hash.Hash32
 }
 
-func NewEvaluatorWithJitter(inner Evaluator, maxJitter time.Duration, rngSource rand.Source) Evaluator {
+func NewEvaluatorWithJitter(inner Evaluator, maxJitter time.Duration, hasher hash.Hash32) Evaluator {
 	if maxJitter <= 0 {
 		// jitter is disabled or invalid
 		return inner
@@ -25,13 +33,28 @@ func NewEvaluatorWithJitter(inner Evaluator, maxJitter time.Duration, rngSource 
 	return &EvaluatorWithJitter{
 		inner:     inner,
 		maxJitter: maxJitter,
-		rng:       rand.New(rngSource),
+		hasher:    hasher,
 	}
 }
 
 func (e *EvaluatorWithJitter) Eval(ctx context.Context, qs string, now time.Time) (*logqlmodel.Result, error) {
-	jitter := time.Duration(e.rng.Int63n(e.maxJitter.Nanoseconds()))
-	time.Sleep(jitter)
+	time.Sleep(e.calculateJitter(qs))
 
 	return e.inner.Eval(ctx, qs, now)
+}
+
+func (e *EvaluatorWithJitter) calculateJitter(qs string) time.Duration {
+	var h uint32
+
+	// rules can be evaluated concurrently, so we protect the hasher with a mutex
+	e.Lock()
+	{
+		_, _ = e.hasher.Write([]byte(qs))
+		h = e.hasher.Sum32()
+		e.hasher.Reset()
+	}
+	e.Unlock()
+
+	ratio := float32(h) / math.MaxUint32
+	return time.Duration(ratio * float32(e.maxJitter.Nanoseconds()))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the previous random jitter with a consistent jitter. While both are random, having the random jitter be applied _consistently_ is essential for evaluating rules on a predictable cadence.

If a rule is supposed to evaluate every minute, whether it evaluates at (e.g.) `01:00` or `01:03.234` is irrelevant because the evaluation _instant_ is not adjusted, so it will produce the same result whether run at `01:00` or `01:03.234`. However, if 1000 rules are set to evaluate at `01:00`, this will create a resource contention issue.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This change is part of the wider [remote rule evaluation](https://github.com/grafana/loki/pull/8744) improvements we have been making lately.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
