### PR TITLE
Promtail: Fix examples how to build it

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ With Journal support on Ubuntu, run with the following commands:
 
 ```bash
 $ sudo apt install -y libsystemd-dev
-$ go build ./clients/cmd/promtail --tags=promtail_journal_enabled
+$ go build --tags=promtail_journal_enabled ./clients/cmd/promtail
 ```
 
 With Journal support on CentOS, run with the following commands:
 
 ```bash
 $ sudo yum install -y systemd-devel
-$ go build ./clients/cmd/promtail --tags=promtail_journal_enabled
+$ go build --tags=promtail_journal_enabled ./clients/cmd/promtail
 ```
 
 Otherwise, to build Promtail without Journal support, run `go build`

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -85,7 +85,7 @@ The go build tag `promtail_journal_enabled` should be passed to include Journal 
 If you need Journal support you will need to run go build with tag `promtail_journal_enabled`:
 
 ```shell
-go build ./clients/cmd/promtail --tags=promtail_journal_enabled
+go build --tags=promtail_journal_enabled ./clients/cmd/promtail
 ```
 Introducing this tag aims to relieve Linux/CentOS users with CGO enabled from installing libsystemd-dev/systemd-devel libraries if they don't need Journal support.
 


### PR DESCRIPTION
The build flags have to be provided before the package paths.

Otherwise the `build` command fails with this error:
> malformed import path "--tags=promtail_journal_enabled": leading dash

See `go help build`:
> usage: go build [-o output] [build flags] [packages]