### PR TITLE
Distributor: add detail to stream rates failure

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -229,7 +229,7 @@ func (s *rateStore) getRatesFromIngesters(ctx context.Context, clients chan inge
 
 		resp, err := c.client.GetStreamRates(ctx, &logproto.StreamRatesRequest{})
 		if err != nil {
-			level.Error(util_log.Logger).Log("msg", "unable to get stream rates", "err", err)
+			level.Error(util_log.Logger).Log("msg", "unable to get stream rates from ingester", "ingester", c.addr, "err", err)
 			s.metrics.rateRefreshFailures.WithLabelValues(c.addr).Inc()
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we can see if a single ingester is the source of the `unable to get stream rates` failures. This change adds the client address to the log entry.