### PR TITLE
Fix the link in the Azure Event Hubs doc

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -368,7 +368,7 @@ Targets can be configured using the `azure_event_hubs` stanza:
 ```
 
 Only `fully_qualified_namespace`, `connection_string` and `event_hubs` are required fields.
-Read the [configuration]({{< relref "../../configuration/#azure-event-hubs" >}}) section for more information.
+Read the [configuration]({{< relref "configuration/#azure-event-hubs" >}}) section for more information.
 
 ## Kafka
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the link to the configuration in the Azure Event Hubs scraping doc.

Link to the discussion https://github.com/grafana/loki/pull/8787#discussion_r1145298591

**Which issue(s) this PR fixes**:
Not available


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
