### PR TITLE
operator: Update LokiStack annotation on RulerConfig delete

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Main
 
+
+- [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
+
 ## 0.2.0 (2023-03-27)
 
-- [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotation on RulerConfig delete
 - [8651](https://github.com/grafana/loki/pull/8651) **periklis**: Prepare Community Loki Operator release v0.2.0
 - [8881](https://github.com/grafana/loki/pull/8881) **periklis**: Provide community bundle for openshift community hub
 - [8863](https://github.com/grafana/loki/pull/8863) **periklis**: Break the API types out into their own module

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0 (2023-03-27)
 
+- [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
 - [8651](https://github.com/grafana/loki/pull/8651) **periklis**: Prepare Community Loki Operator release v0.2.0
 - [8881](https://github.com/grafana/loki/pull/8881) **periklis**: Provide community bundle for openshift community hub
 - [8863](https://github.com/grafana/loki/pull/8863) **periklis**: Break the API types out into their own module

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0 (2023-03-27)
 
-- [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
+- [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotation on RulerConfig delete
 - [8651](https://github.com/grafana/loki/pull/8651) **periklis**: Prepare Community Loki Operator release v0.2.0
 - [8881](https://github.com/grafana/loki/pull/8881) **periklis**: Provide community bundle for openshift community hub
 - [8863](https://github.com/grafana/loki/pull/8863) **periklis**: Break the API types out into their own module

--- a/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
+++ b/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
@@ -19,23 +19,48 @@ const (
 // to the named Lokistack in the same namespace of the RulerConfig. If no LokiStack is found, then
 // skip reconciliation.
 func AnnotateForRulerConfig(ctx context.Context, k k8s.Client, name, namespace string) error {
-	var s lokiv1.LokiStack
 	key := client.ObjectKey{Name: name, Namespace: namespace}
-
-	if err := k.Get(ctx, key, &s); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Do nothing
-			return nil
-		}
-
-		return kverrors.Wrap(err, "failed to get lokistack", "key", key)
+	ss, err := getLokiStack(ctx, k, key)
+	if err != nil {
+		return err
 	}
 
-	ss := s.DeepCopy()
 	timeStamp := time.Now().UTC().Format(time.RFC3339)
 	if err := updateAnnotation(ctx, k, ss, annotationRulerConfigDiscoveredAt, timeStamp); err != nil {
 		return kverrors.Wrap(err, "failed to update lokistack `rulerConfigDiscoveredAt` annotation", "key", key)
 	}
 
 	return nil
+}
+
+// RemoveRulerConfigAnnotation removes the `loki.grafana.com/rulerConfigDiscoveredAt` annotation
+// from the named Lokistack in the same namespace of the RulerConfig. If no LokiStack is found, then
+// skip reconciliation.
+func RemoveRulerConfigAnnotation(ctx context.Context, k k8s.Client, name, namespace string) error {
+	key := client.ObjectKey{Name: name, Namespace: namespace}
+	ss, err := getLokiStack(ctx, k, key)
+	if err != nil {
+		return err
+	}
+
+	if err := removeAnnotation(ctx, k, ss, annotationRulerConfigDiscoveredAt); err != nil {
+		return kverrors.Wrap(err, "failed to update lokistack `rulerConfigDiscoveredAt` annotation", "key", key)
+	}
+
+	return nil
+}
+
+func getLokiStack(ctx context.Context, k k8s.Client, key client.ObjectKey) (*lokiv1.LokiStack, error) {
+	var s lokiv1.LokiStack
+
+	if err := k.Get(ctx, key, &s); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Do nothing
+			return nil, nil
+		}
+
+		return nil, kverrors.Wrap(err, "failed to get lokistack", "key", key)
+	}
+
+	return s.DeepCopy(), nil
 }

--- a/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
+++ b/operator/controllers/loki/internal/lokistack/ruler_config_discovery.go
@@ -21,7 +21,7 @@ const (
 func AnnotateForRulerConfig(ctx context.Context, k k8s.Client, name, namespace string) error {
 	key := client.ObjectKey{Name: name, Namespace: namespace}
 	ss, err := getLokiStack(ctx, k, key)
-	if err != nil {
+	if ss == nil || err != nil {
 		return err
 	}
 
@@ -39,7 +39,7 @@ func AnnotateForRulerConfig(ctx context.Context, k k8s.Client, name, namespace s
 func RemoveRulerConfigAnnotation(ctx context.Context, k k8s.Client, name, namespace string) error {
 	key := client.ObjectKey{Name: name, Namespace: namespace}
 	ss, err := getLokiStack(ctx, k, key)
-	if err != nil {
+	if ss == nil || err != nil {
 		return err
 	}
 

--- a/operator/controllers/loki/rulerconfig_controller.go
+++ b/operator/controllers/loki/rulerconfig_controller.go
@@ -32,6 +32,12 @@ func (r *RulerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	key := client.ObjectKey{Name: req.Name, Namespace: req.Namespace}
 	if err := r.Get(ctx, key, &rc); err != nil {
 		if errors.IsNotFound(err) {
+			// RulerConfig not found, remove annotation from LokiStack.
+			err = lokistack.RemoveRulerConfigAnnotation(ctx, r.Client, req.Name, req.Namespace)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{}, nil
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When `RulerConfig` is deleted, update the `LokiStack` annotations in order to update the Loki configurations.


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
