### PR TITLE
operator: Add missing replaces directives for release v0.2.0

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0 (2023-03-27)
 
+- [8912](https://github.com/grafana/loki/pull/8912) **periklis**: Add missing replaces directives for release v0.2.0
 - [8651](https://github.com/grafana/loki/pull/8651) **periklis**: Prepare Community Loki Operator release v0.2.0
 - [8881](https://github.com/grafana/loki/pull/8881) **periklis**: Provide community bundle for openshift community hub
 - [8863](https://github.com/grafana/loki/pull/8863) **periklis**: Break the API types out into their own module

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-03-27T11:29:48Z"
+    createdAt: "2023-03-27T19:02:58Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1624,6 +1624,7 @@ spec:
     name: gateway
   - image: quay.io/observatorium/opa-openshift:latest
     name: opa
+  replaces: loki-operator.v0.1.0
   version: 0.2.0
   webhookdefinitions:
   - admissionReviewVersions:

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-03-27T11:29:45Z"
+    createdAt: "2023-03-27T19:02:56Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1605,6 +1605,7 @@ spec:
     name: gateway
   - image: quay.io/observatorium/opa-openshift:latest
     name: opa
+  replaces: loki-operator.v0.1.0
   version: 0.2.0
   webhookdefinitions:
   - admissionReviewVersions:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-03-27T11:29:50Z"
+    createdAt: "2023-03-27T19:03:01Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -2061,4 +2061,5 @@ spec:
   minKubeVersion: 1.21.1
   provider:
     name: Grafana Loki SIG Operator
+  replaces: loki-operator.v0.1.0
   version: 0.0.0

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -2047,4 +2047,5 @@ spec:
   minKubeVersion: 1.21.1
   provider:
     name: Grafana Loki SIG Operator
+  replaces: loki-operator.v0.1.0
   version: 0.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up of #8651 and adds the missing `replaces` directives for easy upgrading of the Community Loki Operator from `v0.1.0` to `v0.2.0`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
To verify the replaces directives pointing to the previous CSV version:
- [k8s-operatorhub: Previous Version](https://github.com/k8s-operatorhub/community-operators/blob/bec6f9af3742764814c162c0ff384c000c7a2a69/operators/loki-operator/0.1.0/manifests/loki-operator.clusterserviceversion.yaml#L163)
- [redhat-openshift-ecocystem: Previous Version](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/6b56ca97b26059e9c9f12bc9ad62fc707b523db9/operators/loki-operator/0.1.0/manifests/loki-operator.clusterserviceversion.yaml#L163)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
