### PR TITLE
Automatically Reorder Pipeline Filters

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -106,6 +106,10 @@ func (m MultiStageExpr) reorderStages() []StageExpr {
 		case *LineFilterExpr:
 			filters = append(filters, f)
 		case *LineFmtExpr:
+			// line_format modifies the contents of the line so any line filter
+			// originally after a line_format must still be after the same
+			// line_format.
+
 			rest = append(rest, f)
 
 			if len(filters) > 0 {

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -107,7 +107,10 @@ func (m MultiStageExpr) reorderStages() []StageExpr {
 			filters = append(filters, f)
 		case *LineFmtExpr:
 			rest = append(rest, f)
-			result = append(result, combineFilters(filters))
+
+			if len(filters) > 0 {
+				result = append(result, combineFilters(filters))
+			}
 			result = append(result, rest...)
 
 			filters = filters[:0]
@@ -117,7 +120,9 @@ func (m MultiStageExpr) reorderStages() []StageExpr {
 		}
 	}
 
-	result = append(result, combineFilters(filters))
+	if len(filters) > 0 {
+		result = append(result, combineFilters(filters))
+	}
 	return append(result, rest...)
 }
 

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -622,3 +622,35 @@ func Test_MergeBinOpVectors_Filter(t *testing.T) {
 		Point: promql.Point{V: 2},
 	}, res)
 }
+
+func TestFilterReodering(t *testing.T) {
+	t.Run("it makes sure line filters are as early in the pipeline stages as possible", func(t *testing.T) {
+		logExpr := `{container_name="app"} |= "foo" |= "next" | logfmt |="bar" |="baz" | line_format "{{.foo}}" |="1" |="2" | logfmt |="3"`
+		l, err := ParseExpr(logExpr)
+		require.NoError(t, err)
+
+		stages := l.(*PipelineExpr).MultiStages.reorderStages()
+		require.Len(t, stages, 5)
+		require.Equal(t, `|= "foo" |= "next" |= "bar" |= "baz" | logfmt | line_format "{{.foo}}" |= "1" |= "2" |= "3" | logfmt`, MultiStageExpr(stages).String())
+	})
+}
+
+var result bool
+
+func BenchmarkReorderedPipeline(b *testing.B) {
+	logfmtLine := []byte(`level=info ts=2020-12-14T21:25:20.947307459Z caller=metrics.go:83 org_id=29 traceID=c80e691e8db08e2 latency=fast query="sum by (object_name) (rate(({container=\"metrictank\", cluster=\"hm-us-east2\"} |= \"PANIC\")[5m]))" query_type=metric range_type=range length=5m0s step=15s duration=322.623724ms status=200 throughput=1.2GB total_bytes=375MB`)
+
+	logExpr := `{container_name="app"} | logfmt |= "slow"`
+	l, err := ParseLogSelector(logExpr, true)
+	require.NoError(b, err)
+
+	p, err := l.Pipeline()
+	require.NoError(b, err)
+
+	sp := p.ForStream(labels.Labels{})
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _, result = sp.Process(0, logfmtLine)
+	}
+}


### PR DESCRIPTION
This PR moves Line Filters to be as early in a log pipeline as possible. 

For example:
`{app="foo"} | logfmt |="some stuff"` becomes `{app="foo"} |="some stuff" | logfmt`

Any LineFilter after a `LineFormat` stage will be moved to directly after the nearest `LineFormat` stage

benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/logql/syntax
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                    │ reorder_old.txt │           reorder_new.txt           │
                    │     sec/op      │   sec/op     vs base                │
ReorderedPipeline-8      2104.5n ± 3%   173.9n ± 2%  -91.74% (p=0.000 n=10)

                    │ reorder_old.txt │          reorder_new.txt          │
                    │      B/op       │   B/op    vs base                 │
ReorderedPipeline-8        336.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=10)

                    │ reorder_old.txt │          reorder_new.txt           │
                    │    allocs/op    │ allocs/op  vs base                 │
ReorderedPipeline-8        16.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
```