### PR TITLE
Implement `RequiredNumberLabels` query limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [8474](https://github.com/grafana/loki/pull/8474) **farodin91**: Add support for short-lived S3 session tokens
 * [8774](https://github.com/grafana/loki/pull/8774) **slim-bean**: Add new logql template functions `bytes`, `duration`, `unixEpochMillis`, `unixEpochNanos`, `toDateInZone`, `b64Enc`, and `b64Dec`
 * [8670](https://github.com/grafana/loki/pull/8670) **salvacorts** Introduce two new limits to refuse log and metric queries that would read too much data.
+* [8670](https://github.com/grafana/loki/pull/8670) **salvacorts** Introduce limit to require at least a number label matchers on metric and log queries.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 * [8474](https://github.com/grafana/loki/pull/8474) **farodin91**: Add support for short-lived S3 session tokens
 * [8774](https://github.com/grafana/loki/pull/8774) **slim-bean**: Add new logql template functions `bytes`, `duration`, `unixEpochMillis`, `unixEpochNanos`, `toDateInZone`, `b64Enc`, and `b64Dec`
 * [8670](https://github.com/grafana/loki/pull/8670) **salvacorts** Introduce two new limits to refuse log and metric queries that would read too much data.
-* [8670](https://github.com/grafana/loki/pull/8670) **salvacorts** Introduce limit to require at least a number label matchers on metric and log queries.
+* [8918](https://github.com/grafana/loki/pull/8918) **salvacorts** Introduce limit to require at least a number label matchers on metric and log queries.
 
 ##### Fixes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2503,6 +2503,9 @@ shard_streams:
 
 # Define a list of required selector labels.
 [required_label_matchers: <list of strings>]
+
+# Minimum number of label matchers a query should contain.
+[required_number_label_matchers: <int>]
 ```
 
 ### frontend_worker

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -3,6 +3,7 @@ package queryrange
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -653,6 +654,118 @@ func TestTripperware_RequiredLabels(t *testing.T) {
 	}
 }
 
+func TestTripperware_RequiredNumberLabels(t *testing.T) {
+
+	const noErr = ""
+
+	for _, tc := range []struct {
+		desc                 string
+		query                string
+		requiredNumberLabels int
+		response             parser.Value
+		expectedError        string
+	}{
+		{
+			desc:                 "Log query - Limit disabled",
+			query:                `{foo="foo"}`,
+			requiredNumberLabels: 0,
+			expectedError:        noErr,
+			response:             streams,
+		},
+		{
+			desc:                 "Log query - Below limit",
+			query:                `{foo="foo"}`,
+			requiredNumberLabels: 2,
+			expectedError:        fmt.Sprintf(requiredNumberLabelsErrTmpl, "foo", 1, 2),
+			response:             nil,
+		},
+		{
+			desc:                 "Log query - On limit",
+			query:                `{foo="foo", bar="bar"}`,
+			requiredNumberLabels: 2,
+			expectedError:        noErr,
+			response:             streams,
+		},
+		{
+			desc:                 "Log query - Over limit",
+			query:                `{foo="foo", bar="bar", baz="baz"}`,
+			requiredNumberLabels: 2,
+			expectedError:        noErr,
+			response:             streams,
+		},
+		{
+			desc:                 "Metric query - Limit disabled",
+			query:                `count_over_time({foo="foo"} [1m])`,
+			requiredNumberLabels: 0,
+			expectedError:        noErr,
+			response:             vector,
+		},
+		{
+			desc:                 "Metric query - Below limit",
+			query:                `count_over_time({foo="foo"} [1m])`,
+			requiredNumberLabels: 2,
+			expectedError:        fmt.Sprintf(requiredNumberLabelsErrTmpl, "foo", 1, 2),
+			response:             nil,
+		},
+		{
+			desc:                 "Metric query - On limit",
+			query:                `count_over_time({foo="foo", bar="bar"} [1m])`,
+			requiredNumberLabels: 2,
+			expectedError:        noErr,
+			response:             vector,
+		},
+		{
+			desc:                 "Metric query - Over limit",
+			query:                `count_over_time({foo="foo", bar="bar", baz="baz"} [1m])`,
+			requiredNumberLabels: 2,
+			expectedError:        noErr,
+			response:             vector,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			limits := fakeLimits{
+				maxQueryParallelism:  1,
+				requiredNumberLabels: tc.requiredNumberLabels,
+			}
+			tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, limits, config.SchemaConfig{Configs: testSchemas}, nil, false, nil)
+			if stopper != nil {
+				defer stopper.Stop()
+			}
+			require.NoError(t, err)
+
+			rt, err := newfakeRoundTripper()
+			require.NoError(t, err)
+			defer rt.Close()
+			_, h := promqlResult(tc.response)
+			rt.setHandler(h)
+
+			lreq := &LokiRequest{
+				Query:     tc.query,
+				Limit:     1000,
+				StartTs:   testTime.Add(-6 * time.Hour),
+				EndTs:     testTime,
+				Direction: logproto.FORWARD,
+				Path:      "/loki/api/v1/query_range",
+			}
+
+			ctx := user.InjectOrgID(context.Background(), "1")
+			req, err := LokiCodec.EncodeRequest(ctx, lreq)
+			require.NoError(t, err)
+
+			req = req.WithContext(ctx)
+			err = user.InjectOrgIDIntoHTTPRequest(ctx, req)
+			require.NoError(t, err)
+
+			_, err = tpw(rt).RoundTrip(req)
+			if tc.expectedError != noErr {
+				require.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, tc.expectedError), err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_getOperation(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -735,6 +848,7 @@ type fakeLimits struct {
 	minShardingLookback     time.Duration
 	queryTimeout            time.Duration
 	requiredLabels          []string
+	requiredNumberLabels    int
 	maxQueryBytesRead       int
 	maxQuerierBytesRead     int
 }
@@ -799,6 +913,10 @@ func (f fakeLimits) BlockedQueries(context.Context, string) []*validation.Blocke
 
 func (f fakeLimits) RequiredLabels(context.Context, string) []string {
 	return f.requiredLabels
+}
+
+func (f fakeLimits) RequiredNumberLabels(ctx context.Context, s string) int {
+	return f.requiredNumberLabels
 }
 
 func counter() (*int, http.Handler) {

--- a/pkg/util/querylimits/limiter.go
+++ b/pkg/util/querylimits/limiter.go
@@ -93,6 +93,16 @@ func (l *Limiter) RequiredLabels(ctx context.Context, userID string) []string {
 	return union
 }
 
+func (l *Limiter) RequiredNumberLabels(ctx context.Context, userID string) int {
+	original := l.CombinedLimits.RequiredNumberLabels(ctx, userID)
+	requestLimits := ExtractQueryLimitsContext(ctx)
+	if requestLimits == nil || requestLimits.RequiredNumberLabels == 0 || requestLimits.RequiredNumberLabels > original {
+		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
+		return original
+	}
+	return requestLimits.RequiredNumberLabels
+}
+
 func (l *Limiter) MaxQueryBytesRead(ctx context.Context, userID string) int {
 	original := l.CombinedLimits.MaxQueryBytesRead(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)

--- a/pkg/util/querylimits/limiter.go
+++ b/pkg/util/querylimits/limiter.go
@@ -96,7 +96,7 @@ func (l *Limiter) RequiredLabels(ctx context.Context, userID string) []string {
 func (l *Limiter) RequiredNumberLabels(ctx context.Context, userID string) int {
 	original := l.CombinedLimits.RequiredNumberLabels(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
-	if requestLimits == nil || requestLimits.RequiredNumberLabels == 0 || requestLimits.RequiredNumberLabels > original {
+	if requestLimits == nil || requestLimits.RequiredNumberLabels == 0 || requestLimits.RequiredNumberLabels < original {
 		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -127,8 +127,10 @@ func TestLimiter_RejectHighLimits(t *testing.T) {
 		MaxQueryLookback:        model.Duration(30 * time.Second),
 		MaxEntriesLimitPerQuery: 10,
 		QueryTimeout:            model.Duration(30 * time.Second),
-		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
+		// In this case, the higher it is, the more restrictive.
+		// Therefore, we return the query-time limit as it's more restrictive than the original.
+		RequiredNumberLabels: 100,
 	}
 
 	ctx := InjectQueryLimitsContext(context.Background(), limits)
@@ -160,8 +162,10 @@ func TestLimiter_AcceptLowerLimits(t *testing.T) {
 		MaxQueryLookback:        model.Duration(29 * time.Second),
 		MaxEntriesLimitPerQuery: 9,
 		QueryTimeout:            model.Duration(29 * time.Second),
-		RequiredNumberLabels:    9,
 		MaxQueryBytesRead:       9,
+		// In this case, the higher it is, the more restrictive.
+		// Therefore, we return the original limit as it's more restrictive than the query-time limit.
+		RequiredNumberLabels: 10,
 	}
 
 	ctx := InjectQueryLimitsContext(context.Background(), limits)

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -39,6 +39,7 @@ func TestLimiter_Defaults(t *testing.T) {
 		MaxQueryLength:          model.Duration(30 * time.Second),
 		MaxEntriesLimitPerQuery: 10,
 		RequiredLabels:          []string{"foo", "bar"},
+		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
 		MaxQuerierBytesRead:     10,
 	}
@@ -53,6 +54,7 @@ func TestLimiter_Defaults(t *testing.T) {
 		QueryTimeout:            model.Duration(30 * time.Second),
 		MaxQueryBytesRead:       10,
 		RequiredLabels:          []string{"foo", "bar"},
+		RequiredNumberLabels:    10,
 	}
 	ctx := context.Background()
 	queryLookback := l.MaxQueryLookback(ctx, "fake")
@@ -65,6 +67,8 @@ func TestLimiter_Defaults(t *testing.T) {
 	require.Equal(t, time.Duration(expectedLimits.QueryTimeout), queryTimeout)
 	maxQueryBytesRead := l.MaxQueryBytesRead(ctx, "fake")
 	require.Equal(t, expectedLimits.MaxQueryBytesRead.Val(), maxQueryBytesRead)
+	requiredNumberLabels := l.RequiredNumberLabels(ctx, "fake")
+	require.Equal(t, expectedLimits.RequiredNumberLabels, requiredNumberLabels)
 
 	var limits QueryLimits
 
@@ -74,6 +78,7 @@ func TestLimiter_Defaults(t *testing.T) {
 		MaxEntriesLimitPerQuery: 10,
 		QueryTimeout:            model.Duration(29 * time.Second),
 		RequiredLabels:          []string{"foo", "bar"},
+		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
 	}
 	{
@@ -88,6 +93,8 @@ func TestLimiter_Defaults(t *testing.T) {
 		require.Equal(t, time.Duration(expectedLimits.QueryTimeout), queryTimeout)
 		maxQueryBytesRead := l.MaxQueryBytesRead(ctx2, "fake")
 		require.Equal(t, expectedLimits2.MaxQueryBytesRead.Val(), maxQueryBytesRead)
+		requiredNumberLabels := l.RequiredNumberLabels(ctx2, "fake")
+		require.Equal(t, expectedLimits2.RequiredNumberLabels, requiredNumberLabels)
 	}
 
 }
@@ -100,6 +107,7 @@ func TestLimiter_RejectHighLimits(t *testing.T) {
 		MaxQueryLength:          model.Duration(30 * time.Second),
 		MaxEntriesLimitPerQuery: 10,
 		QueryTimeout:            model.Duration(30 * time.Second),
+		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
 		MaxQuerierBytesRead:     10,
 	}
@@ -111,6 +119,7 @@ func TestLimiter_RejectHighLimits(t *testing.T) {
 		MaxQueryLookback:        model.Duration(14 * 24 * time.Hour),
 		MaxEntriesLimitPerQuery: 100,
 		QueryTimeout:            model.Duration(100 * time.Second),
+		RequiredNumberLabels:    100,
 		MaxQueryBytesRead:       100,
 	}
 	expectedLimits := QueryLimits{
@@ -118,6 +127,7 @@ func TestLimiter_RejectHighLimits(t *testing.T) {
 		MaxQueryLookback:        model.Duration(30 * time.Second),
 		MaxEntriesLimitPerQuery: 10,
 		QueryTimeout:            model.Duration(30 * time.Second),
+		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
 	}
 
@@ -126,6 +136,7 @@ func TestLimiter_RejectHighLimits(t *testing.T) {
 	require.Equal(t, time.Duration(expectedLimits.MaxQueryLength), l.MaxQueryLength(ctx, "fake"))
 	require.Equal(t, expectedLimits.MaxEntriesLimitPerQuery, l.MaxEntriesLimitPerQuery(ctx, "fake"))
 	require.Equal(t, time.Duration(expectedLimits.QueryTimeout), l.QueryTimeout(ctx, "fake"))
+	require.Equal(t, expectedLimits.RequiredNumberLabels, l.RequiredNumberLabels(ctx, "fake"))
 	require.Equal(t, expectedLimits.MaxQueryBytesRead.Val(), l.MaxQueryBytesRead(ctx, "fake"))
 }
 
@@ -137,6 +148,7 @@ func TestLimiter_AcceptLowerLimits(t *testing.T) {
 		MaxQueryLength:          model.Duration(30 * time.Second),
 		MaxEntriesLimitPerQuery: 10,
 		QueryTimeout:            model.Duration(30 * time.Second),
+		RequiredNumberLabels:    10,
 		MaxQueryBytesRead:       10,
 		MaxQuerierBytesRead:     10,
 	}
@@ -148,6 +160,7 @@ func TestLimiter_AcceptLowerLimits(t *testing.T) {
 		MaxQueryLookback:        model.Duration(29 * time.Second),
 		MaxEntriesLimitPerQuery: 9,
 		QueryTimeout:            model.Duration(29 * time.Second),
+		RequiredNumberLabels:    9,
 		MaxQueryBytesRead:       9,
 	}
 
@@ -157,6 +170,7 @@ func TestLimiter_AcceptLowerLimits(t *testing.T) {
 	require.Equal(t, limits.MaxEntriesLimitPerQuery, l.MaxEntriesLimitPerQuery(ctx, "fake"))
 	require.Equal(t, time.Duration(limits.QueryTimeout), l.QueryTimeout(ctx, "fake"))
 	require.Equal(t, limits.MaxQueryBytesRead.Val(), l.MaxQueryBytesRead(ctx, "fake"))
+	require.Equal(t, limits.RequiredNumberLabels, l.RequiredNumberLabels(ctx, "fake"))
 }
 
 func TestLimiter_MergeLimits(t *testing.T) {

--- a/pkg/util/querylimits/middleware_test.go
+++ b/pkg/util/querylimits/middleware_test.go
@@ -33,6 +33,7 @@ func Test_MiddlewareWithHeader(t *testing.T) {
 		model.Duration(1 * time.Second),
 		[]string{"foo", "bar"},
 		10,
+		10,
 	}
 
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -26,7 +26,7 @@ type QueryLimits struct {
 	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`
 	QueryTimeout            model.Duration   `json:"queryTimeout,omitempty"`
 	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
-	RequiredNumberLabels    int              `json:"requiredNumberLabelsMatchers,omitempty"`
+	RequiredNumberLabels    int              `json:"requiredNumberLabelMatchers,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`
 }
 

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -21,11 +21,12 @@ const (
 // NOTE: we use custom `model.Duration` instead of standard `time.Duration` because,
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type QueryLimits struct {
-	MaxQueryLength          model.Duration `json:"maxQueryLength,omitempty"`
-	MaxQueryLookback        model.Duration `json:"maxQueryLookback,omitempty"`
-	MaxEntriesLimitPerQuery int            `json:"maxEntriesLimitPerQuery,omitempty"`
-	QueryTimeout            model.Duration `json:"queryTimeout,omitempty"`
-	RequiredLabels          []string       `json:"requiredLabels,omitempty"`
+	MaxQueryLength          model.Duration   `json:"maxQueryLength,omitempty"`
+	MaxQueryLookback        model.Duration   `json:"maxQueryLookback,omitempty"`
+	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`
+	QueryTimeout            model.Duration   `json:"queryTimeout,omitempty"`
+	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
+	RequiredNumberLabels    int              `json:"requiredNumberLabels,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`
 }
 

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -26,7 +26,7 @@ type QueryLimits struct {
 	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`
 	QueryTimeout            model.Duration   `json:"queryTimeout,omitempty"`
 	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
-	RequiredNumberLabels    int              `json:"requiredNumberLabels,omitempty"`
+	RequiredNumberLabels    int              `json:"requiredNumberLabelsMatchers,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -169,7 +169,8 @@ type Limits struct {
 
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
 
-	RequiredLabels []string `yaml:"required_label_matchers,omitempty" json:"required_label_matchers,omitempty" doc:"description=Define a list of required selector labels."`
+	RequiredLabels       []string `yaml:"required_label_matchers,omitempty" json:"required_label_matchers,omitempty" doc:"description=Define a list of required selector labels."`
+	RequiredNumberLabels int      `yaml:"required_number_label_matchers,omitempty" json:"required_number_label_matchers,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
 }
 
 type StreamRetention struct {
@@ -691,6 +692,10 @@ func (o *Overrides) BlockedQueries(ctx context.Context, userID string) []*valida
 
 func (o *Overrides) RequiredLabels(ctx context.Context, userID string) []string {
 	return o.getOverridesForUser(userID).RequiredLabels
+}
+
+func (o *Overrides) RequiredNumberLabels(ctx context.Context, userID string) int {
+	return o.getOverridesForUser(userID).RequiredNumberLabels
 }
 
 func (o *Overrides) DefaultLimits() *Limits {


### PR DESCRIPTION
**What this PR does / why we need it**:
As pointed out in https://github.com/grafana/loki/pull/8851, some queries can impose a great workload on a cluster by selecting too many streams.

Similarly to the `RequiredLabels` limit introduced at https://github.com/grafana/loki/pull/8851, here we add a new limit `RequiredNumberLabels` to require queries to specify at least N label. For example, if the limit is set to 2, then the query should contain at least 2 label matchers.

This limit can be configured per tenant and at query time.

![image](https://user-images.githubusercontent.com/8354290/228271398-4b9bcc49-f539-4e94-86c1-071e519a30a9.png)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/699

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
