### PR TITLE
Bumps loki.mixins dependency on grafana/jsonnet-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
 * [7923](https://github.com/grafana/loki/pull/7923) **manohar-koukuntla**: Add zone aware ingesters in jsonnet deployment
 * [8855](https://github.com/grafana/loki/pull/8855) **JoaoBraveCoding**: Add gRPC port to loki compactor mixin
 * [8880](https://github.com/grafana/loki/pull/8880) **JoaoBraveCoding**: Normalize headless service name for query-frontend/scheduler
+* [8921](https://github.com/grafana/loki/pull/8921) **JoaoBraveCoding**: Bumps loki.mixins dependency on grafana/jsonnet-lib 
+
 
 ##### Fixes
 

--- a/production/ksonnet/loki/jsonnetfile.lock.json
+++ b/production/ksonnet/loki/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "consul"
         }
       },
-      "version": "8629e32d04a0eefdce41224540f0d31de7d40deb",
-      "sum": "whodWjF2UjlDT6rDiBsxbT+71UGD2J7IKiVxJETrXCA="
+      "version": "c31b164f453738582defd06feea3a139732b6faf",
+      "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "8629e32d04a0eefdce41224540f0d31de7d40deb",
-      "sum": "DsdBoqgx5kE3zc6fMYnfiGjW2+9Mx2OXFieWm1oFHgY="
+      "version": "c31b164f453738582defd06feea3a139732b6faf",
+      "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "8629e32d04a0eefdce41224540f0d31de7d40deb",
-      "sum": "TGgjbv8oGfmMNjfvcgxi2cX9RAJKGZnYGLEhzK2wNjM="
+      "version": "c31b164f453738582defd06feea3a139732b6faf",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
       "source": {
@@ -38,8 +38,8 @@
           "subdir": "memcached"
         }
       },
-      "version": "8629e32d04a0eefdce41224540f0d31de7d40deb",
-      "sum": "AIspZ151p0qkxVc9tuoAEYNrkazV6QncWWsIsarK9GE="
+      "version": "c31b164f453738582defd06feea3a139732b6faf",
+      "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
**What this PR does / why we need it**:

As of this commit the loki.mixins have its dependency for ksonnet-util pinned on a commit from Aug 2020. Because of this, the loki mixins haven't enjoyed the many contributions done to the grafana/jsonnet-libs project. Namely without this update it's not possible to generate the loki ConfigMap if you are not using Tanka https://github.com/grafana/jsonnet-libs/pull/951


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
