### PR TITLE
Add release notes for v2.7.5 release

### DIFF
--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -34,6 +34,22 @@ As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) bef
 
 ## Bug fixes
 
+### 2.7.5 (2023-03-28)
+
+* Flush buffered logger on exit: this makes sure logs are printed if Loki crashes on startup.
+
+### 2.7.4 (2023-02-24)
+
+* Fixed different streams for `cri` tags ending on the same stream.
+* Fixed the `userdata` field (from Windows Event Log) being scraped incorrectly.
+* Fixed `vector()` function producing wrong timestamp.
+* Fixed behavior for overlapping chunks with multiple stores.
+* Fixed logs results caching causing query-frontend to return logs outside of query window.
+* Fixed panics when:
+  * `/scheduler/ring` endpoint is requested with scheduler ring disabled.
+  * LogQL clones a specific query.
+  * Promtail deals with invalid calls to `Details()`.
+
 ### 2.7.3 (2023-02-01)
 
 * Fixed a bug in compactor that caused divide-by-zero panics when `startTime` and `endTime` of a delete request were equal.


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the release notes for v2.7.5 and v2.7.4. This last release was apparently not added last time. 

This will be backported to the release branch as well in a separate PR.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
