### PR TITLE
Loki: Remove global singleton of the tsdb.Store and keep it scoped to the storage.Store

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -76,6 +76,10 @@ type store struct {
 	logger log.Logger
 
 	chunkFilterer chunk.RequestChunkFilterer
+
+	// Keep a reference to the tsdb index store as we use one store for multiple schema period configs.
+	tsdbStore         index.ReaderWriter
+	tsdbStoreStopFunc func()
 }
 
 // NewStore creates a new Loki Store using configuration supplied.
@@ -246,20 +250,25 @@ func (s *store) storeForPeriod(p config.PeriodConfig, chunkClient client.Client,
 			}
 		}
 
-		indexReaderWriter, stopTSDBStoreFunc, err := tsdb.NewStore(s.cfg.TSDBShipperConfig, p, f, objectClient, s.limits,
-			getIndexStoreTableRanges(config.TSDBType, s.schemaCfg.Configs), backupIndexWriter, indexClientReg)
-		if err != nil {
-			return nil, nil, nil, err
+		// We should only create one tsdb.Store per storage.Store and reuse it over all TSDB schema periods.
+		if s.tsdbStore == nil {
+			indexReaderWriter, stopTSDBStoreFunc, err := tsdb.NewStore(s.cfg.TSDBShipperConfig, p, f, objectClient, s.limits,
+				getIndexStoreTableRanges(config.TSDBType, s.schemaCfg.Configs), backupIndexWriter, indexClientReg)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.tsdbStore = indexReaderWriter
+			s.tsdbStoreStopFunc = stopTSDBStoreFunc
 		}
 
-		indexReaderWriter = index.NewMonitoredReaderWriter(indexReaderWriter, indexClientReg)
-		chunkWriter := stores.NewChunkWriter(f, s.schemaCfg, indexReaderWriter, s.storeCfg.DisableIndexDeduplication)
+		indexReaderWriter := index.NewMonitoredReaderWriter(s.tsdbStore, indexClientReg)
+		chunkWriter := stores.NewChunkWriter(f, s.schemaCfg, s.tsdbStore, s.storeCfg.DisableIndexDeduplication)
 
 		return chunkWriter, indexReaderWriter,
 			func() {
 				f.Stop()
 				chunkClient.Stop()
-				stopTSDBStoreFunc()
+				s.tsdbStoreStopFunc()
 				objectClient.Stop()
 				backupStoreStop()
 			}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

I made this change to fix an issue with the cmd/migrate tool which I'm also sneaking a few fixes on in this PR too.

We had a global singleton of the tsdb.Store which was leading to the migrate tool reading and writing from the `source` storage.Store because it created the singleton with an object store client only pointing to the source store.

This PR changes the scoping of that singleton to not be global but instead local to each instance of storage.Store

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
