### PR TITLE
Update contains and hasPrefix/hasSuffix with the correct examples

### DIFF
--- a/docs/sources/logql/template_functions.md
+++ b/docs/sources/logql/template_functions.md
@@ -269,7 +269,7 @@ Signature: `contains(s string, src string) bool`
 Examples:
 
 ```template
-{{ if .err contains "ErrTimeout" }} timeout {{end}}
+{{ if contains .err "ErrTimeout" }} timeout {{end}}
 {{ if contains "he" "hello" }} yes {{end}}
 ```
 
@@ -285,7 +285,7 @@ Signatures:
 Examples:
 
 ```template
-{{ if .err hasSuffix "Timeout" }} timeout {{end}}
+{{ if hasSuffix .err "Timeout" }} timeout {{end}}
 {{ if hasPrefix "he" "hello" }} yes {{end}}
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
WHAT:
- Update examples for `contains` and `hasSuffix`
- Correct order should be `functionName arg1 arg2 argN`, eg. `contains s src`

WHY:
- Current example for `contains` and `hasPrefix` / `hasSuffix` has a wrong order that will cause `TemplateFormatErr`.
- Examples I'm referring to `{{ if .err hasSuffix "Timeout" }} timeout {{end}}`

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
