### PR TITLE
operator: Fix calculator dockerfile

### DIFF
--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.19.1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
+COPY apis/ apis/
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up of #8863 to fix image building on `main`. Currently it fails with:
```
#12 [builder 5/8] RUN go mod download
#12 1.822 go: github.com/grafana/loki/operator/apis/loki@v0.0.0-00010101000000-000000000000 (replaced by ./apis/loki): reading apis/loki/go.mod: open /workspace/apis/loki/go.mod: no such file or directory
#12 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
------
 > [builder 5/8] RUN go mod download:
#12 1.822 go: github.com/grafana/loki/operator/apis/loki@v0.0.0-00010101000000-000000000000 (replaced by ./apis/loki): reading apis/loki/go.mod: open /workspace/apis/loki/go.mod: no such file or directory
------
calculator.Dockerfile:10
--------------------
   8 |     # cache deps before building and copying source so that we don't need to re-download as much
   9 |     # and so that source changes don't invalidate our downloaded layer
  10 | >>> RUN go mod download
  11 |     
  12 |     # Copy the go source
--------------------
ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
