### PR TITLE
Add release notes for v2.7.5 release (#8924)

### DIFF
--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -33,6 +33,10 @@ As always, please read the [upgrade guide](../../upgrading/#270) before upgradin
 
 ## Bug fixes
 
+### 2.7.5 (2023-03-28)
+
+* Flush buffered logger on exit: this makes sure logs are printed if Loki crashes on startup.
+
 ### 2.7.4 (2023-02-24)
 
 * Fixed different streams for `cri` tags ending on the same stream.


### PR DESCRIPTION
Backport https://github.com/grafana/loki/pull/8924 to the 2.7 release branch
