### PR TITLE
Log when returning query-time limit

### DIFF
--- a/pkg/util/querylimits/limiter.go
+++ b/pkg/util/querylimits/limiter.go
@@ -2,6 +2,7 @@ package querylimits
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -28,10 +29,9 @@ func (l *Limiter) MaxQueryLength(ctx context.Context, userID string) time.Durati
 	original := l.CombinedLimits.MaxQueryLength(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.MaxQueryLength == 0 || time.Duration(requestLimits.MaxQueryLength) > original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
-	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", requestLimits.MaxQueryLength)
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "MaxQueryLength", "tenant", userID, "query-limit", requestLimits.MaxQueryLength, "original-limit", original)
 	return time.Duration(requestLimits.MaxQueryLength)
 }
 
@@ -40,9 +40,9 @@ func (l *Limiter) MaxQueryLookback(ctx context.Context, userID string) time.Dura
 	original := l.CombinedLimits.MaxQueryLookback(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.MaxQueryLookback == 0 || time.Duration(requestLimits.MaxQueryLookback) > original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "MaxQueryLookback", "tenant", userID, "query-limit", time.Duration(requestLimits.MaxQueryLookback), "original-limit", original)
 	return time.Duration(requestLimits.MaxQueryLookback)
 }
 
@@ -51,9 +51,9 @@ func (l *Limiter) MaxEntriesLimitPerQuery(ctx context.Context, userID string) in
 	original := l.CombinedLimits.MaxEntriesLimitPerQuery(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.MaxEntriesLimitPerQuery == 0 || requestLimits.MaxEntriesLimitPerQuery > original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "MaxEntriesLimitPerQuery", "tenant", userID, "query-limit", requestLimits.MaxEntriesLimitPerQuery, "original-limit", original)
 	return requestLimits.MaxEntriesLimitPerQuery
 }
 
@@ -62,9 +62,9 @@ func (l *Limiter) QueryTimeout(ctx context.Context, userID string) time.Duration
 	// in theory this error should never happen
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.QueryTimeout == 0 || time.Duration(requestLimits.QueryTimeout) > original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "QueryTimeout", "tenant", userID, "query-limit", time.Duration(requestLimits.QueryTimeout), "original-limit", original)
 	return time.Duration(requestLimits.QueryTimeout)
 }
 
@@ -90,6 +90,7 @@ func (l *Limiter) RequiredLabels(ctx context.Context, userID string) []string {
 	for label := range unionMap {
 		union = append(union, label)
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "RequiredLabels", "tenant", userID, "query-limit", strings.Join(union, ", "), "original-limit", strings.Join(original, ", "))
 	return union
 }
 
@@ -97,9 +98,9 @@ func (l *Limiter) RequiredNumberLabels(ctx context.Context, userID string) int {
 	original := l.CombinedLimits.RequiredNumberLabels(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.RequiredNumberLabels == 0 || requestLimits.RequiredNumberLabels < original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "RequiredNumberLabels", "tenant", userID, "query-limit", requestLimits.RequiredNumberLabels, "original-limit", original)
 	return requestLimits.RequiredNumberLabels
 }
 
@@ -107,8 +108,8 @@ func (l *Limiter) MaxQueryBytesRead(ctx context.Context, userID string) int {
 	original := l.CombinedLimits.MaxQueryBytesRead(ctx, userID)
 	requestLimits := ExtractQueryLimitsContext(ctx)
 	if requestLimits == nil || requestLimits.MaxQueryBytesRead.Val() == 0 || requestLimits.MaxQueryBytesRead.Val() > original {
-		level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using original limit")
 		return original
 	}
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "MaxQueryBytesRead", "tenant", userID, "query-limit", requestLimits.MaxQueryBytesRead.Val(), "original-limit", original)
 	return requestLimits.MaxQueryBytesRead.Val()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
At https://github.com/grafana/loki/pull/8727 we introduced various limits that can now be configured at query time. We always compare the value of the limit configured at query time with the value set on the overrides for the tenant or the default if not configured (aka original); applying the most restrictive one.

If the most restrictive is the original value or the limit is not configured at query-time, we print the following debug message:
https://github.com/grafana/loki/blob/9e1846c47a1f3685fc540b7d03d285c7530da223/pkg/util/querylimits/limiter.go#L43

It will be printed many times: every time the query is not configured at query-time, as well as every time the original value is more restrictive. Moreover, this log message lacks some useful information such as the original value, the query-time value, the tenant ID and the limit name.

This PR fixes this by removing the debug message above and printing a new debug message only if we return the query-time limit. This new log also prints the tenant ID, the limit name, as well as the original and the query-time limit values. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/8932

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
