### PR TITLE
Rename config for enforcing a minimum number of label matchers

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2502,7 +2502,7 @@ shard_streams:
 [blocked_queries: <blocked_query...>]
 
 # Define a list of required selector labels.
-[required_label_matchers: <list of strings>]
+[required_labels: <list of strings>]
 
 # Minimum number of label matchers a query should contain.
 [minimum_labels_number: <int>]

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2505,7 +2505,7 @@ shard_streams:
 [required_label_matchers: <list of strings>]
 
 # Minimum number of label matchers a query should contain.
-[required_number_label_matchers: <int>]
+[minimum_labels_number: <int>]
 ```
 
 ### frontend_worker

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -26,7 +26,7 @@ type QueryLimits struct {
 	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`
 	QueryTimeout            model.Duration   `json:"queryTimeout,omitempty"`
 	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
-	RequiredNumberLabels    int              `json:"requiredNumberLabelMatchers,omitempty"`
+	RequiredNumberLabels    int              `json:"minimumLabelsNumber,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -170,7 +170,7 @@ type Limits struct {
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
 
 	RequiredLabels       []string `yaml:"required_label_matchers,omitempty" json:"required_label_matchers,omitempty" doc:"description=Define a list of required selector labels."`
-	RequiredNumberLabels int      `yaml:"required_number_label_matchers,omitempty" json:"required_number_label_matchers,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
+	RequiredNumberLabels int      `yaml:"minimum_labels_number,omitempty" json:"required_number_label_matchers,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
 }
 
 type StreamRetention struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -170,7 +170,7 @@ type Limits struct {
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
 
 	RequiredLabels       []string `yaml:"required_label_matchers,omitempty" json:"required_label_matchers,omitempty" doc:"description=Define a list of required selector labels."`
-	RequiredNumberLabels int      `yaml:"minimum_labels_number,omitempty" json:"required_number_label_matchers,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
+	RequiredNumberLabels int      `yaml:"minimum_labels_number,omitempty" json:"minimum_labels_number,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
 }
 
 type StreamRetention struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -169,7 +169,7 @@ type Limits struct {
 
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
 
-	RequiredLabels       []string `yaml:"required_label_matchers,omitempty" json:"required_label_matchers,omitempty" doc:"description=Define a list of required selector labels."`
+	RequiredLabels       []string `yaml:"required_labels,omitempty" json:"required_labels,omitempty" doc:"description=Define a list of required selector labels."`
 	RequiredNumberLabels int      `yaml:"minimum_labels_number,omitempty" json:"minimum_labels_number,omitempty" doc:"description=Minimum number of label matchers a query should contain."`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup PR for https://github.com/grafana/loki/pull/8918 renaming config. See https://github.com/grafana/loki/pull/8918/files#r1151820792.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki-private/issues/699

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
