### PR TITLE
Revert high cardinality metric in scheduler

### DIFF
--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -9,7 +9,6 @@ type Metrics struct {
 	queueLength       *prometheus.GaugeVec   // Per tenant
 	discardedRequests *prometheus.CounterVec // Per tenant
 	enqueueCount      *prometheus.CounterVec // Per tenant and level
-	dequeueCount      *prometheus.CounterVec // Per tenant and querier
 }
 
 func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
@@ -32,12 +31,6 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 			Name:      "enqueue_count",
 			Help:      "Total number of enqueued (sub-)queries.",
 		}, []string{"user", "level"}),
-		dequeueCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki",
-			Subsystem: subsystem,
-			Name:      "dequeue_count",
-			Help:      "Total number of dequeued (sub-)queries.",
-		}, []string{"user", "querier"}),
 	}
 }
 
@@ -45,5 +38,4 @@ func (m *Metrics) Cleanup(user string) {
 	m.queueLength.DeleteLabelValues(user)
 	m.discardedRequests.DeleteLabelValues(user)
 	m.enqueueCount.DeletePartialMatch(prometheus.Labels{"user": user})
-	m.dequeueCount.DeletePartialMatch(prometheus.Labels{"user": user})
 }

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -148,7 +148,6 @@ FindQueue:
 			}
 
 			q.metrics.queueLength.WithLabelValues(tenant).Dec()
-			q.metrics.dequeueCount.WithLabelValues(tenant, querierID).Inc()
 
 			// Tell close() we've processed a request.
 			q.cond.Broadcast()


### PR DESCRIPTION
**What this PR does / why we need it**:

The metrics was useful for initial testing of the new scheduler queue implementation but yields high cardinality metrics, which is not desired. Also, the metric does not add additional value beyond the initial testing phase.

**Special notes for your reviewer**:

The metric was introduced with commit cba31024d4d0cc5c45612dd051c032f248817729

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
