### PR TITLE
Enforce per tenant queue size

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -93,7 +93,9 @@ func (q *RequestQueue) Enqueue(tenant string, path []string, req Request, maxQue
 		return errors.New("no queue found")
 	}
 
-	// Optimistically increase queue counter for tenant.
+	// Optimistically increase queue counter for tenant instead of doing separate
+	// get and set operations, because _most_ of the time the increased value is
+	// smaller than the max queue length.
 	// We need to keep track of queue length separately because the size of the
 	// buffered channel is the same across all sub-queues which would allow
 	// enqueuing more items than there are allowed at tenant level.


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to the changes in https://github.com/grafana/loki/pull/8752 the max queue size per tenant was enforced by the size of the buffered channel to which a request was enqueued.
However, since we have hierarchical queues, every subqueue has the same channel capacity as the root (tenant) queue. Therefore the total queue size per tenant needs to be tracked separately, so requests can be rejected when the max queue size is reached.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [n/a] Documentation added
- [x] Tests updated
- [n/a] `CHANGELOG.md` updated
- [n/a] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
