### PR TITLE
Querier: block query by hash

### DIFF
--- a/docs/sources/operations/blocking-queries.md
+++ b/docs/sources/operations/blocking-queries.md
@@ -29,6 +29,10 @@ overrides:
       - pattern: '.*prod.*'
         regex: true
         types: filter,limited
+
+      # block any query that matches this query hash
+      - hash: 2943214005          # hash of {stream="stdout",pod="loki-canary-9w49x"}
+        types: filter,limited
 ```
 
 The available query types are:
@@ -36,6 +40,15 @@ The available query types are:
 - `metric`: a query with an aggregation, e.g. `sum(rate({env="prod"}[1m]))`
 - `filter`: a query with a log filter, e.g. `{env="prod"} |= "error"`
 - `limited`: a query without a filter or a metric aggregation
+
+The `hash` option uses a [32-bit FNV-1](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) hash of the query string, represented as a 32-bit unsigned integer.
+This can often be easier to use than query strings that are long or require lots of string escaping. A `query_hash` field
+is logged with every query request in the `query-frontend` and `querier` logs, for easy reference. Here's an example log line:
+
+```logfmt
+level=info ts=2023-03-30T09:08:15.2614555Z caller=metrics.go:152 component=frontend org_id=29 latency=fast 
+query="{stream=\"stdout\",pod=\"loki-canary-9w49x\"}" query_hash=2943214005 query_type=limited range_type=range ...
+```
 
 **Note:** the order of patterns is preserved, so the first matching pattern will be used
 

--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -27,42 +27,51 @@ func newQueryBlocker(ctx context.Context, q *query) *queryBlocker {
 }
 
 func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
-	patterns := qb.q.limits.BlockedQueries(ctx, tenant)
-	if len(patterns) <= 0 {
+	blocks := qb.q.limits.BlockedQueries(ctx, tenant)
+	if len(blocks) <= 0 {
 		return false
 	}
 
-	typ, err := QueryType(qb.q.params.Query())
+	query := qb.q.params.Query()
+	typ, err := QueryType(query)
 	if err != nil {
 		typ = "unknown"
 	}
 
 	logger := log.With(qb.logger, "user", tenant, "type", typ)
 
-	query := qb.q.params.Query()
-	for _, p := range patterns {
+	for _, b := range blocks {
+
+		if b.Hash > 0 {
+			if b.Hash == HashedQuery(query) {
+				level.Warn(logger).Log("msg", "query blocker matched with hash policy", "hash", b.Hash, "query", query)
+				return qb.block(b, typ, logger)
+			}
+
+			return false
+		}
 
 		// if no pattern is given, assume we want to match all queries
-		if p.Pattern == "" {
-			p.Pattern = ".*"
-			p.Regex = true
+		if b.Pattern == "" {
+			b.Pattern = ".*"
+			b.Regex = true
 		}
 
-		if strings.TrimSpace(p.Pattern) == strings.TrimSpace(query) {
+		if strings.TrimSpace(b.Pattern) == strings.TrimSpace(query) {
 			level.Warn(logger).Log("msg", "query blocker matched with exact match policy", "query", query)
-			return qb.block(p, typ, logger)
+			return qb.block(b, typ, logger)
 		}
 
-		if p.Regex {
-			r, err := regexp.Compile(p.Pattern)
+		if b.Regex {
+			r, err := regexp.Compile(b.Pattern)
 			if err != nil {
-				level.Error(logger).Log("msg", "query blocker regex does not compile", "pattern", p.Pattern, "err", err)
+				level.Error(logger).Log("msg", "query blocker regex does not compile", "pattern", b.Pattern, "err", err)
 				continue
 			}
 
 			if r.MatchString(query) {
-				level.Warn(logger).Log("msg", "query blocker matched with regex policy", "pattern", p.Pattern, "query", query)
-				return qb.block(p, typ, logger)
+				level.Warn(logger).Log("msg", "query blocker matched with regex policy", "pattern", b.Pattern, "query", query)
+				return qb.block(b, typ, logger)
 			}
 		}
 	}
@@ -86,7 +95,7 @@ func (qb *queryBlocker) block(q *validation.BlockedQuery, typ string, logger log
 
 	// query would be blocked, but it didn't match specified types
 	if !matched {
-		level.Debug(logger).Log("msg", "query blocker matched pattern, but not specified types", "pattern", q.Pattern, "types", q.Types.String(), "queryType", typ)
+		level.Debug(logger).Log("msg", "query blocker matched pattern, but not specified types", "pattern", q.Pattern, "regex", q.Regex, "hash", q.Hash, "types", q.Types.String(), "queryType", typ)
 		return false
 	}
 

--- a/pkg/logql/blocker_test.go
+++ b/pkg/logql/blocker_test.go
@@ -121,6 +121,22 @@ func TestEngine_ExecWithBlockedQueries(t *testing.T) {
 			}, nil,
 		},
 		{
+			"correct FNV32 hash matches",
+			defaultQuery, []*validation.BlockedQuery{
+				{
+					Hash: HashedQuery(defaultQuery),
+				},
+			}, logqlmodel.ErrBlocked,
+		},
+		{
+			"incorrect FNV32 hash does not match",
+			defaultQuery, []*validation.BlockedQuery{
+				{
+					Hash: HashedQuery(defaultQuery) + 1,
+				},
+			}, nil,
+		},
+		{
 			"no blocked queries",
 			defaultQuery, []*validation.BlockedQuery{}, nil,
 		},

--- a/pkg/util/validation/blocked_queries.go
+++ b/pkg/util/validation/blocked_queries.go
@@ -5,5 +5,6 @@ import "github.com/grafana/dskit/flagext"
 type BlockedQuery struct {
 	Pattern string                 `yaml:"pattern"`
 	Regex   bool                   `yaml:"regex"`
+	Hash    uint32                 `yaml:"hash"`
 	Types   flagext.StringSliceCSV `yaml:"types"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the [query blocker](https://grafana.com/docs/loki/next/operations/blocking-queries/) can be unergonomic since queries can be long, require escaping, or hard to copy from logs. This change enables an operator to block queries by their hash.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
We should probably provide a tool for creating uint32 representations of 32-bit FNV-1 hashes; all the online tools I found produce a hex value. It's not strictly necessary though since we have the `query_hash` in the logs, but it would be nice.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
