### PR TITLE
Add note under prerequisites on architecture

### DIFF
--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -36,6 +36,10 @@ The test environment uses Docker compose to instantiate these parts, each in its
 - [Docker](https://docs.docker.com/install)
 - [Docker Compose](https://docs.docker.com/compose/install)
 
+## Note
+The instruction only cover for system running on x86_64 architecture.
+It is not designed for arm/arm64 architecture.
+
 ## Obtain the test environment
 
 1. Create a directory called `evaluate-loki` for the test environment. Make `evaluate-loki` your current working directory:

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -37,7 +37,7 @@ The test environment uses Docker compose to instantiate these parts, each in its
 - [Docker Compose](https://docs.docker.com/compose/install)
 
 ## Note
-The instruction only cover for system running on x86_64 architecture.
+These instructions are for a system running on an x86_64 architecture.
 It is not designed for arm/arm64 architecture.
 
 ## Obtain the test environment

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -38,7 +38,7 @@ The test environment uses Docker compose to instantiate these parts, each in its
 
 ## Note
 These instructions are for a system running on an x86_64 architecture.
-It is not designed for arm/arm64 architecture.
+It is not designed for an arm/arm64 architecture.
 
 ## Obtain the test environment
 


### PR DESCRIPTION
When testing on M1 Pro system, in the deployment phase, when running `docker-compose up -d` results in 
```
Error response from daemon: platform linux/arm64/v8 not supported.
```

Please add to instructions the fact this doesn't work for ARM as it is or (that would be even better) add instruction on how to use this with ARM.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
