### PR TITLE
Remove dedupe cache from operations documentation.

### DIFF
--- a/docs/sources/operations/caching.md
+++ b/docs/sources/operations/caching.md
@@ -17,7 +17,7 @@ cache is configured to be in-memory by default.
 
 ## Before you begin
 
-- It is recommended to deploy four, or in the case of the Helm chart two, dedicated Memcached clusters.
+- It is recommended to deploy three, or in the case of the Helm chart two, dedicated Memcached clusters.
 - As of 2023-02-01, the `memcached:1.6.17-alpine` version of the library is recommended.
 - Consult the Loki ksonnet [memcached](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/memcached.libsonnet) deployment and the ksonnet [memcached library](https://github.com/grafana/jsonnet-libs/tree/master/memcached).
 
@@ -31,7 +31,7 @@ To enable and configure Memcached:
        ```
        --memory-limit=4096 --max-item-size=2m --conn-limit=1024
        ```
-    1. Query result, index queries and writes cache
+    1. Query result and index queries cache
        ```
        --memory-limit=1024 --max-item-size=5m --conn-limit=1024
        ```
@@ -78,14 +78,6 @@ To enable and configure Memcached:
                memcached_client:
                  host: <chunk cache memcached host>
                  service: <port name of memcached service>
-           write_dedupe_cache_config:
-             memcached:
-               batch_size: 100
-               parallelism: 100
-             memcached_client: 
-               host: <index writes memcached host>
-               service: <port name of memcached service>
-               consistent_hash: true
            ```
         1. Configure the query result cache
            ```yaml

--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -17,9 +17,6 @@
     compactor_pvc_class: 'fast',
     index_period_hours: if self.using_boltdb_shipper then 24 else super.index_period_hours,
     loki+: if self.using_boltdb_shipper then {
-      chunk_store_config+: {
-        write_dedupe_cache_config:: {},
-      },
       storage_config+: {
         boltdb_shipper+: {
           shared_store: $._config.boltdb_shipper_shared_store,

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -306,19 +306,6 @@
             consistent_hash: true,
           },
         },
-
-        write_dedupe_cache_config: {
-          memcached: {
-            batch_size: 100,
-            parallelism: 100,
-          },
-
-          memcached_client: {
-            host: 'memcached-index-writes.%s.svc.cluster.local' % $._config.namespace,
-            service: 'memcached-client',
-            consistent_hash: true,
-          },
-        },
       },
 
       // Default schema config is boltdb-shipper/gcs, this will need to be overridden for other stores

--- a/production/ksonnet/loki/memcached.libsonnet
+++ b/production/ksonnet/loki/memcached.libsonnet
@@ -15,11 +15,6 @@ memcached {
     max_item_size: '5m',
   },
 
-  // Dedicated memcached instance used to dedupe writes to the index.
-  memcached_index_writes: $.memcached {
-    name: 'memcached-index-writes',
-  },
-
   // Dedicated memcached instance used to cache query results.
   memcached_frontend: $.memcached {
     name: 'memcached-frontend',


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we are not using the write dedupe cache ourselves we should not advise other users to do so.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
