### PR TITLE
Fix fetched chunk from store size in metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [8953](https://github.com/grafana/loki/pull/8953) **dannykopping**: Querier: block queries by hash.
 * [8851](https://github.com/grafana/loki/pull/8851) **jeschkies**: Introduce limit to require a set of labels for selecting streams.
 
+##### Fixes
+
+* [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
+
 ### All Changes
 
 #### Promtail

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -201,9 +201,10 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk, keys []
 	// to the cache asynchronously in the background and we lose the context
 	var bytes int
 	for _, c := range fromStorage {
-		bytes += c.Size()
+		size := c.Data.Size()
+		bytes += size
 
-		chunkFetchedSize.WithLabelValues("store").Observe(float64(c.Size()))
+		chunkFetchedSize.WithLabelValues("store").Observe(float64(size))
 	}
 
 	st := stats.FromContext(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Size()` function on `chunk.Chunk` calls out to `func (ChunkRef) Size() int` in the proto, which doesn't actually include the size of the chunk data! We need to call `chunk.Data.Size()` for that.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This will fix the `Cache.Chunk.BytesSent` stat which indicates how many chunk bytes we sent to the chunk cache. This should probably be renamed for clarity at some point; it's a little confusing.

The same fix is applies to the `loki_chunk_fetcher_fetched_size_bytes{source="store"}` histogram metric.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
