### PR TITLE
tsdb: use unique uploader name while building tsdb index filename, same as boltdb-shipper

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1496,7 +1496,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 	tsdbFiles, err := os.ReadDir(filepath.Join(cfg.FSConfig.Directory, "index", indexTables[1].Name()))
 	require.NoError(t, err)
 	require.Len(t, tsdbFiles, 1)
-	require.Regexp(t, regexp.MustCompile(fmt.Sprintf(`\d{10}-%s\.tsdb\.gz`, ingesterName)), tsdbFiles[0].Name())
+	require.Regexp(t, regexp.MustCompile(fmt.Sprintf(`\d{10}-%s-\d{19}\.tsdb\.gz`, ingesterName)), tsdbFiles[0].Name())
 
 	store, err = NewStore(cfg, config.ChunkStoreConfig{}, schemaConfig, limits, cm, nil, util_log.Logger)
 	require.NoError(t, err)

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -99,6 +99,8 @@ func (cfg *Config) Validate() error {
 	return storage.ValidateSharedStoreKeyPrefix(cfg.SharedStoreKeyPrefix)
 }
 
+// GetUniqueUploaderName builds a unique uploader name using IngesterName + `-` + <nanosecond-timestamp>.
+// The name is persisted in the configured ActiveIndexDirectory and reused when already exists.
 func (cfg *Config) GetUniqueUploaderName() (string, error) {
 	uploader := fmt.Sprintf("%s-%d", cfg.IngesterName, time.Now().UnixNano())
 

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/pkg/storage/chunk/client"
+	"github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/downloads"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/gatewayclient"
@@ -94,6 +97,33 @@ func (cfg *Config) Validate() error {
 		cfg.Mode = ModeReadWrite
 	}
 	return storage.ValidateSharedStoreKeyPrefix(cfg.SharedStoreKeyPrefix)
+}
+
+func (cfg *Config) GetUniqueUploaderName() (string, error) {
+	uploader := fmt.Sprintf("%s-%d", cfg.IngesterName, time.Now().UnixNano())
+
+	uploaderFilePath := path.Join(cfg.ActiveIndexDirectory, "uploader", "name")
+	if err := util.EnsureDirectory(path.Dir(uploaderFilePath)); err != nil {
+		return "", err
+	}
+
+	_, err := os.Stat(uploaderFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		if err := os.WriteFile(uploaderFilePath, []byte(uploader), 0o666); err != nil {
+			return "", err
+		}
+	} else {
+		ub, err := os.ReadFile(uploaderFilePath)
+		if err != nil {
+			return "", err
+		}
+		uploader = string(ub)
+	}
+
+	return uploader, nil
 }
 
 type indexShipper struct {

--- a/pkg/storage/stores/tsdb/identifier.go
+++ b/pkg/storage/stores/tsdb/identifier.go
@@ -67,6 +67,7 @@ type SingleTenantTSDBIdentifier struct {
 	Checksum      uint32
 }
 
+// str builds filename with format <file-creation-ts> + `-` + `compactor` + `-` + <oldest-chunk-start-ts> + `-` + <latest-chunk-end-ts> `-` + <index-checksum>
 func (i SingleTenantTSDBIdentifier) str() string {
 	return fmt.Sprintf(
 		"%d-%s-%d-%d-%x.tsdb",
@@ -138,6 +139,7 @@ type MultitenantTSDBIdentifier struct {
 	ts       time.Time
 }
 
+// Name builds filename with format <file-creation-ts> + `-` + `<nodeName>
 func (id MultitenantTSDBIdentifier) Name() string {
 	return fmt.Sprintf("%d-%s.tsdb", id.ts.Unix(), id.nodeName)
 }

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -133,11 +133,11 @@ func (s *store) init(indexShipperCfg indexshipper.Config, objectClient client.Ob
 	}
 
 	if indexShipperCfg.Mode != indexshipper.ModeReadOnly {
-
-		var (
-			nodeName = indexShipperCfg.IngesterName
-			dir      = indexShipperCfg.ActiveIndexDirectory
-		)
+		dir := indexShipperCfg.ActiveIndexDirectory
+		nodeName, err := indexShipperCfg.GetUniqueUploaderName()
+		if err != nil {
+			return err
+		}
 
 		tsdbMetrics := NewMetrics(reg)
 		tsdbManager := NewTSDBManager(


### PR DESCRIPTION
**What this PR does / why we need it**:
While building file names from `boltdb-shipper` and `tsdb`, we add the name of the uploader to it.
To avoid collisions in filenames when running multiple ingesters with the same name, we also add a nanosecond precise timestamp to the ingester name, which is persistent as the uploader name in the active index directory.

This is not being done for the tsdb index built from ingesters which can cause collisions in filenames when running multiple ingesters with the same name. I have moved the code to manage the uploader name to the index shipper config and used the same to share it with tsdb.
