### PR TITLE
Redefine 1x.extra-small to have 0 requirements.

### DIFF
--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -30,11 +30,15 @@ type LokiStackSizeType string
 
 const (
 	// SizeOneXExtraSmall defines the size of a single Loki deployment
-	// with extra small resources/limits requirements and without HA support.
-	// This size is ultimately dedicated for development and demo purposes.
-	// DO NOT USE THIS IN PRODUCTION!
+	// with NO resource requirements and without HA support.
 	//
-	// FIXME: Add clear description of ingestion/query performance expectations.
+	// This is ONLY for development, testing, or demos
+	// on limited single-node clusters.
+	// There are NO performance guarantees.
+	// LokiStack will use whatever resources are available,
+	// and WILL NOT FUNCTION CORRECTLY if there is not enough memory or CPU.
+	//
+	// DO NOT USE THIS IN PRODUCTION!
 	SizeOneXExtraSmall LokiStackSizeType = "1x.extra-small"
 
 	// SizeOneXSmall defines the size of a single Loki deployment

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -30,61 +30,7 @@ type ResourceRequirements struct {
 // ResourceRequirementsTable defines the default resource requests and limits for each size
 var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 	lokiv1.SizeOneXExtraSmall: {
-		Querier: corev1.ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("3Gi"),
-			},
-		},
-		Ruler: ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-			PVCSize: resource.MustParse("10Gi"),
-		},
-		Ingester: ResourceRequirements{
-			PVCSize: resource.MustParse("10Gi"),
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-			},
-		},
-		Distributor: corev1.ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
-			},
-		},
-		QueryFrontend: corev1.ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("200m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
-			},
-		},
-		Compactor: ResourceRequirements{
-			PVCSize: resource.MustParse("10Gi"),
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-			},
-		},
-		Gateway: corev1.ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("256Mi"),
-			},
-		},
-		IndexGateway: ResourceRequirements{
-			PVCSize: resource.MustParse("50Gi"),
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-			},
-		},
-		WALStorage: ResourceRequirements{
-			PVCSize: resource.MustParse("150Gi"),
-		},
+		// No requirements, can be deployed on any size of cluster. NOT FOR USE IN PRODUCTION.
 	},
 	lokiv1.SizeOneXSmall: {
 		Querier: corev1.ResourceRequirements{


### PR DESCRIPTION
Remove resource requirements so lokistack can run on laptop-sized SNO or CRC clusters.
Originally I thought to add an even smaller size, but I see that
1x.extra-small is already documented as not-for-production, so it seems appropriate.

Doc comment:

// SizeOneXExtraSmall defines the size of a single Loki deployment
// with NO resource requirements and without HA support.
//
// This is ONLY for development, testing, or demos
// on limited single-node clusters.
// There are NO performance guarantees.
// LokiStack will use whatever resources are available,
// and WILL NOT FUNCTION CORRECTLY if there is not enough memory or CPU.
//
// DO NOT USE THIS IN PRODUCTION!