### PR TITLE
operator: Add watch for the object storage secret

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -4,7 +4,6 @@
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
-- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub
 - [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,7 +3,6 @@
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
-- [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub
 - [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Watch the S3 Secret and reconcile
+- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub
 - [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
+- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Watch the S3 Secret and reconcile
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub
 - [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Main
 
+- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
-- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Watch the S3 Secret and reconcile
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 - [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Watch the S3 Secret and reconcile
+- [8998](https://github.com/grafana/loki/pull/8998) **periklis**: Remove static placeholder suffix for openshift bundle
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8930](https://github.com/grafana/loki/pull/8930) **periklis**: Fix makefile target operatorhub
 - [8911](https://github.com/grafana/loki/pull/8911) **aminesnow**: Update LokiStack annotaion on RulerConfig delete

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -97,7 +97,7 @@ var (
 	createUpdateOrDeletePred = builder.WithPredicates(predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld.GetGeneration() == 0 && len(e.ObjectOld.GetAnnotations()) == 0 {
-				return true
+				return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 			}
 
 			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -96,7 +96,11 @@ var (
 	})
 	createUpdateOrDeletePred = builder.WithPredicates(predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()) ||
+			if e.ObjectOld.GetGeneration() == 0 && len(e.ObjectOld.GetAnnotations()) == 0 {
+				return true
+			}
+
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
 				cmp.Diff(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations()) != ""
 		},
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
@@ -206,7 +210,8 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.Role{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.RoleBinding{}, updateOrDeleteOnlyPred).
-		Watches(&source.Kind{Type: &corev1.Service{}}, r.enqueueForAlertManagerServices(), createUpdateOrDeletePred)
+		Watches(&source.Kind{Type: &corev1.Service{}}, r.enqueueForAlertManagerServices(), createUpdateOrDeletePred).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, r.enqueueForStorageSecret(), createUpdateOrDeletePred)
 
 	if r.FeatureGates.LokiStackAlerts {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)
@@ -293,6 +298,33 @@ func (r *LokiStackReconciler) enqueueForAlertManagerServices() handler.EventHand
 			}
 
 			r.Log.Info("Enqueued requests for all LokiStacks because of UserWorkload Alertmanager Service resource change", "count", len(requests), "kind", obj.GetObjectKind())
+		}
+
+		return requests
+	})
+}
+
+func (r *LokiStackReconciler) enqueueForStorageSecret() handler.EventHandler {
+	ctx := context.TODO()
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		lokiStacks := &lokiv1.LokiStackList{}
+		if err := r.Client.List(ctx, lokiStacks); err != nil {
+			r.Log.Error(err, "Error getting LokiStack resources in event handler")
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, stack := range lokiStacks.Items {
+			if obj.GetName() == stack.Spec.Storage.Secret.Name && obj.GetNamespace() == stack.Namespace {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: stack.Namespace,
+						Name:      stack.Name,
+					},
+				})
+			}
+
+			r.Log.Info("Enqueued requests for all LokiStacks because of Storage Secret resource change", "count", len(requests), "kind", obj.GetObjectKind())
 		}
 
 		return requests

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -322,9 +322,10 @@ func (r *LokiStackReconciler) enqueueForStorageSecret() handler.EventHandler {
 						Name:      stack.Name,
 					},
 				})
-			}
+				r.Log.Info("Enqueued requests for LokiStack because of Storage Secret resource change", "LokiStack", stack.Name, "Secret", obj.GetName())
 
-			r.Log.Info("Enqueued requests for all LokiStacks because of Storage Secret resource change", "count", len(requests), "kind", obj.GetObjectKind())
+				return requests
+			}
 		}
 
 		return requests

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -203,8 +203,8 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 	table := []test{
 		{
 			src:               &source.Kind{Type: &openshiftconfigv1.APIServer{}},
-			index:             1,
-			watchesCallsCount: 2,
+			index:             2,
+			watchesCallsCount: 3,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterTLSPolicy: true,
@@ -214,8 +214,8 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 		},
 		{
 			src:               &source.Kind{Type: &openshiftconfigv1.Proxy{}},
-			index:             1,
-			watchesCallsCount: 2,
+			index:             2,
+			watchesCallsCount: 3,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterProxy: true,
@@ -226,7 +226,14 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 		{
 			src:               &source.Kind{Type: &corev1.Service{}},
 			index:             0,
-			watchesCallsCount: 1,
+			watchesCallsCount: 2,
+			featureGates:      configv1.FeatureGates{},
+			pred:              createUpdateOrDeletePred,
+		},
+		{
+			src:               &source.Kind{Type: &corev1.Secret{}},
+			index:             1,
+			watchesCallsCount: 2,
 			featureGates:      configv1.FeatureGates{},
 			pred:              createUpdateOrDeletePred,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability for the Loki Operator to watch the S3 storage `Secret` and reconcile accordingly. 

**Which issue(s) this PR fixes**:
[LOG-3818](https://issues.redhat.com/browse/LOG-3818)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
