### PR TITLE
Promtail: Prevent logging errors on normal shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@
 #### Promtail
 
 ##### Enhancements
+
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
+
+##### Fixes
+
+* [8988](https://github.com/grafana/loki/pull/8988) **darxriggs**: Promtail: Prevent logging errors on normal shutdown.
 
 ## 2.8.0 (2023-03-??)
 

--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -211,7 +211,7 @@ func journalTargetWithReader(
 					return
 				}
 
-				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
+				level.Error(t.logger).Log("msg", "received unexpected error while following the journal", "err", err.Error())
 			}
 
 			// prevent tight loop

--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -202,12 +202,16 @@ func journalTargetWithReader(
 		for {
 			err := t.r.Follow(until, io.Discard)
 			if err != nil {
-				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
+				if err == sdjournal.ErrExpired {
+					return
+				}
 
-				if err == sdjournal.ErrExpired || err == syscall.EBADMSG || err == io.EOF {
+				if err == syscall.EBADMSG || err == io.EOF {
 					level.Error(t.logger).Log("msg", "unable to follow journal", "err", err.Error())
 					return
 				}
+
+				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
 			}
 
 			// prevent tight loop


### PR DESCRIPTION
**What this PR does / why we need it**:
Since PR #4066 two messages are logged for the errors `ErrExpired` and `EOF`, whereas nothing has been logged beforehand.

As `ErrExpired` is returned by the `JournalReader` after sending a message to the `until` channel to signal a normal stop, this should not be logged as an error.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/CC @dannykopping

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
