### PR TITLE
Batch log enqueue and dequeue operations

### DIFF
--- a/pkg/lokifrontend/frontend/v1/frontend.go
+++ b/pkg/lokifrontend/frontend/v1/frontend.go
@@ -195,7 +195,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	lastIndex := queue.StartIndex
 
 	for {
-		reqWrapper, idx, err := f.requestQueue.Dequeue(server.Context(), lastIndex, querierID)
+		reqWrapper, idx, _, err := f.requestQueue.Dequeue(server.Context(), lastIndex, querierID)
 		if err != nil {
 			return err
 		}

--- a/pkg/scheduler/queue/dequeue_qos_test.go
+++ b/pkg/scheduler/queue/dequeue_qos_test.go
@@ -80,7 +80,7 @@ func BenchmarkQueryFairness(t *testing.B) {
 					defer requestQueue.UnregisterQuerierConnection(id)
 					idx := StartIndex
 					for ctx.Err() == nil {
-						r, newIdx, err := requestQueue.Dequeue(ctx, idx, id)
+						r, newIdx, _, err := requestQueue.Dequeue(ctx, idx, id)
 						if err != nil {
 							if err != context.Canceled {
 								t.Log("Dequeue() returned error:", err)
@@ -156,7 +156,7 @@ func TestQueryFairnessAcrossSameLevel(t *testing.T) {
 
 	idx := StartIndexWithLocalQueue
 	for ctx.Err() == nil {
-		r, newIdx, err := requestQueue.Dequeue(ctx, idx, "querier")
+		r, newIdx, _, err := requestQueue.Dequeue(ctx, idx, "querier")
 		if err != nil {
 			if err != context.Canceled {
 				t.Log("Dequeue() returned error:", err)

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -76,7 +76,7 @@ func BenchmarkGetNextRequest(b *testing.B) {
 				for j := 0; j < queriers; j++ {
 					idx := StartIndexWithLocalQueue
 					for x := 0; x < maxOutstandingPerTenant*numTenants/queriers; x++ {
-						r, nidx, err := queues[i].Dequeue(ctx, idx, querierNames[j])
+						r, nidx, _, err := queues[i].Dequeue(ctx, idx, querierNames[j])
 						if r == nil {
 							break
 						}
@@ -151,7 +151,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 	querier2wg.Add(1)
 	go func() {
 		defer querier2wg.Done()
-		_, _, err := queue.Dequeue(ctx, StartIndex, "querier-2")
+		_, _, _, err := queue.Dequeue(ctx, StartIndex, "querier-2")
 		require.NoError(t, err)
 	}()
 
@@ -318,9 +318,9 @@ func TestMaxQueueSize(t *testing.T) {
 		assert.Equal(t, err, ErrTooManyRequests)
 
 		// dequeue and enqueue some items
-		_, _, err = queue.Dequeue(context.Background(), StartIndexWithLocalQueue, "querier")
+		_, _, _, err = queue.Dequeue(context.Background(), StartIndexWithLocalQueue, "querier")
 		assert.NoError(t, err)
-		_, _, err = queue.Dequeue(context.Background(), StartIndexWithLocalQueue, "querier")
+		_, _, _, err = queue.Dequeue(context.Background(), StartIndexWithLocalQueue, "querier")
 		assert.NoError(t, err)
 
 		assert.NoError(t, queue.Enqueue("tenant", []string{"user-a"}, 4, 0, nil))

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -10,33 +10,9 @@ import (
 	"sort"
 	"time"
 
+	schedulerutil "github.com/grafana/loki/pkg/scheduler/util"
 	"github.com/grafana/loki/pkg/util"
 )
-
-type intPointerMap map[string]*int
-
-func (tqs intPointerMap) Inc(key string) int {
-	ptr, ok := tqs[key]
-	if !ok {
-		size := 1
-		tqs[key] = &size
-		return size
-	}
-	(*ptr)++
-	return *ptr
-}
-
-func (tqs intPointerMap) Dec(key string) int {
-	ptr, ok := tqs[key]
-	if !ok {
-		return 0
-	}
-	(*ptr)--
-	if *ptr == 0 {
-		delete(tqs, key)
-	}
-	return *ptr
-}
 
 // querier holds information about a querier registered in the queue.
 type querier struct {
@@ -56,7 +32,7 @@ type tenantQueues struct {
 	mapping *Mapping[*tenantQueue]
 
 	maxUserQueueSize int
-	perUserQueueLen  intPointerMap
+	perUserQueueLen  schedulerutil.IntPointerMap
 
 	// How long to wait before removing a querier which has got disconnected
 	// but hasn't notified about a graceful shutdown.
@@ -102,7 +78,7 @@ func newTenantQueues(maxUserQueueSize int, forgetDelay time.Duration) *tenantQue
 	return &tenantQueues{
 		mapping:          mm,
 		maxUserQueueSize: maxUserQueueSize,
-		perUserQueueLen:  make(intPointerMap),
+		perUserQueueLen:  make(schedulerutil.IntPointerMap),
 		forgetDelay:      forgetDelay,
 		queriers:         map[string]*querier{},
 		sortedQueriers:   nil,

--- a/pkg/scheduler/util/batchlogger.go
+++ b/pkg/scheduler/util/batchlogger.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 )
 

--- a/pkg/scheduler/util/batchlogger.go
+++ b/pkg/scheduler/util/batchlogger.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/grafana/dskit/services"
+)
+
+type BatchLogger struct {
+	services.Service
+	logger log.Logger
+	msg    string
+	mtx    sync.Mutex
+	m      IntPointerMap
+}
+
+func NewBatchLogger(logger log.Logger, interval time.Duration, msg string) *BatchLogger {
+	bl := &BatchLogger{
+		logger: logger,
+		msg:    msg,
+	}
+	bl.Service = services.NewTimerService(interval, nil, bl.log, nil).WithName("batch logger")
+	return bl
+}
+
+func (bl *BatchLogger) log(ctx context.Context) error {
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+	for k, v := range bl.m {
+		bl.logger.Log("msg", bl.msg, "key", k, "count", *v)
+		delete(bl.m, k)
+	}
+	return nil
+}
+
+func (bl *BatchLogger) Inc(key string) {
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+	bl.m.Inc(key)
+}

--- a/pkg/scheduler/util/batchlogger.go
+++ b/pkg/scheduler/util/batchlogger.go
@@ -21,6 +21,7 @@ func NewBatchLogger(logger log.Logger, interval time.Duration, msg string) *Batc
 	bl := &BatchLogger{
 		logger: logger,
 		msg:    msg,
+		m:      make(IntPointerMap),
 	}
 	bl.Service = services.NewTimerService(interval, nil, bl.log, nil).WithName("batch logger")
 	return bl

--- a/pkg/scheduler/util/util.go
+++ b/pkg/scheduler/util/util.go
@@ -1,0 +1,26 @@
+package util
+
+type IntPointerMap map[string]*int
+
+func (m IntPointerMap) Inc(key string) int {
+	ptr, ok := m[key]
+	if !ok {
+		size := 1
+		m[key] = &size
+		return size
+	}
+	(*ptr)++
+	return *ptr
+}
+
+func (m IntPointerMap) Dec(key string) int {
+	ptr, ok := m[key]
+	if !ok {
+		return 0
+	}
+	(*ptr)--
+	if *ptr == 0 {
+		delete(m, key)
+	}
+	return *ptr
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

To have better observability of the scheduler and the hierarchical queues, this PR adds logging for otherwise high cardinality metrics.

* Enqueue operations per tenant and actor path
* Dequeue operations per tenant and querier


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
