### PR TITLE
Trigger `deploy` CI step only on push to main or tag of new release

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -641,7 +641,9 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   },
   pipeline('deploy') {
     local configFileName = 'updater-config.json',
-    trigger+: onTagOrMain,
+    trigger: onTagOrMain {
+      ref: ['refs/heads/main', 'refs/tags/v*'],
+    },
     depends_on: ['manifest'],
     image_pull_secrets: [pull_secret.name],
     steps: [

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1266,9 +1266,7 @@ trigger:
   - tag
   ref:
   - refs/heads/main
-  - refs/heads/k???
   - refs/tags/v*
-  - refs/pull/*/head
 ---
 depends_on:
 - manifest
@@ -1732,6 +1730,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: b5d3d292a9e1f7edc909dd0aa28664f1aa5794f4abe639dc1df8d9bbea5b5c13
+hmac: f389a87506bab15ecdd6d043f51cce6e2a7aa5dc77f2a3d2bc0389576094361f
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, backporting to a kXXX branch causes a trigger of the `deploy` pipeline, which overrides already deployed newer releases.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
