### PR TITLE
Promtail: Add `decompression` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ##### Enhancements
 
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
-* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Only decompress targets if they have `__infer_decompression__: true` label
+* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Add new `decompression` configuration to customize the decompressor behavior.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ##### Enhancements
 
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
+* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Only decompress targets if they have `__infer_decompression__: true` label
 
 ##### Fixes
 

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -50,6 +50,12 @@ type Config struct {
 	DockerSDConfigs        []*moby.DockerSDConfig `mapstructure:"docker_sd_configs,omitempty" yaml:"docker_sd_configs,omitempty"`
 	ServiceDiscoveryConfig ServiceDiscoveryConfig `mapstructure:",squash" yaml:",inline"`
 	Encoding               string                 `mapstructure:"encoding,omitempty" yaml:"encoding,omitempty"`
+	DecompressionCfg       *DecompressionConfig   `yaml:"decompression,omitempty"`
+}
+
+type DecompressionConfig struct {
+	Enabled      bool
+	InitialDelay time.Duration
 }
 
 type ServiceDiscoveryConfig struct {

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -56,6 +56,7 @@ type Config struct {
 type DecompressionConfig struct {
 	Enabled      bool
 	InitialDelay time.Duration `yaml:"initial_delay"`
+	Format       string
 }
 
 type ServiceDiscoveryConfig struct {

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -55,7 +55,7 @@ type Config struct {
 
 type DecompressionConfig struct {
 	Enabled      bool
-	InitialDelay time.Duration
+	InitialDelay time.Duration `yaml:"initial_delay"`
 }
 
 type ServiceDiscoveryConfig struct {

--- a/clients/pkg/promtail/targets/file/decompresser.go
+++ b/clients/pkg/promtail/targets/file/decompresser.go
@@ -114,15 +114,12 @@ func mountReader(f *os.File, logger log.Logger, format string) (reader io.Reader
 	case "gz":
 		decompressLib = "compress/gzip"
 		reader, err = gzip.NewReader(f)
-		break
 	case "z":
 		decompressLib = "compress/zlib"
 		reader, err = zlib.NewReader(f)
-		break
 	case "bz2":
 		decompressLib = "bzip2"
 		reader = bzip2.NewReader(f)
-		break
 	}
 
 	if err != nil && err != io.EOF {

--- a/clients/pkg/promtail/targets/file/decompresser_test.go
+++ b/clients/pkg/promtail/targets/file/decompresser_test.go
@@ -66,7 +66,7 @@ func BenchmarkReadlines(b *testing.B) {
 				running: atomic.NewBool(false),
 				handler: entryHandler,
 				path:    tc.file,
-				cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
+				cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "gz"},
 			}
 
 			for i := 0; i < b.N; i++ {
@@ -91,7 +91,7 @@ func TestGigantiqueGunzipFile(t *testing.T) {
 		path:    file,
 		done:    make(chan struct{}),
 		metrics: NewMetrics(prometheus.NewRegistry()),
-		cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
+		cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "gz"},
 	}
 
 	d.readLines()
@@ -120,7 +120,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
-			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "gz"},
 		}
 
 		d.readLines()
@@ -144,7 +144,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
-			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "bz2"},
 		}
 
 		d.readLines()
@@ -168,7 +168,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
-			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "gz"},
 		}
 
 		d.readLines()

--- a/clients/pkg/promtail/targets/file/decompresser_test.go
+++ b/clients/pkg/promtail/targets/file/decompresser_test.go
@@ -66,6 +66,7 @@ func BenchmarkReadlines(b *testing.B) {
 				running: atomic.NewBool(false),
 				handler: entryHandler,
 				path:    tc.file,
+				cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
 			}
 
 			for i := 0; i < b.N; i++ {
@@ -119,6 +120,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
 		}
 
 		d.readLines()
@@ -142,6 +144,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
 		}
 
 		d.readLines()
@@ -165,6 +168,7 @@ func TestOnelineFiles(t *testing.T) {
 			path:    file,
 			done:    make(chan struct{}),
 			metrics: NewMetrics(prometheus.NewRegistry()),
+			cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
 		}
 
 		d.readLines()

--- a/clients/pkg/promtail/targets/file/decompresser_test.go
+++ b/clients/pkg/promtail/targets/file/decompresser_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/client/fake"
+	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 )
 
 type noopClient struct {
@@ -89,6 +90,7 @@ func TestGigantiqueGunzipFile(t *testing.T) {
 		path:    file,
 		done:    make(chan struct{}),
 		metrics: NewMetrics(prometheus.NewRegistry()),
+		cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0},
 	}
 
 	d.readLines()

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -75,6 +75,8 @@ type FileTarget struct {
 
 	targetConfig *Config
 
+	inferDecompression bool
+
 	encoding string
 }
 
@@ -92,6 +94,7 @@ func NewFileTarget(
 	fileEventWatcher chan fsnotify.Event,
 	targetEventHandler chan fileTargetEvent,
 	encoding string,
+	inferDecompression bool,
 ) (*FileTarget, error) {
 	t := &FileTarget{
 		logger:             logger,
@@ -109,6 +112,7 @@ func NewFileTarget(
 		fileEventWatcher:   fileEventWatcher,
 		targetEventHandler: targetEventHandler,
 		encoding:           encoding,
+		inferDecompression: inferDecompression,
 	}
 
 	go t.run()
@@ -318,7 +322,7 @@ func (t *FileTarget) startTailing(ps []string) {
 		}
 
 		var reader Reader
-		if isCompressed(p) {
+		if t.inferDecompression && isCompressed(p) {
 			level.Debug(t.logger).Log("msg", "reading from compressed file", "filename", p)
 			decompressor, err := newDecompressor(t.metrics, t.logger, t.handler, t.positions, p, t.encoding)
 			if err != nil {

--- a/clients/pkg/promtail/targets/file/filetarget.go
+++ b/clients/pkg/promtail/targets/file/filetarget.go
@@ -323,7 +323,7 @@ func (t *FileTarget) startTailing(ps []string) {
 		}
 
 		var reader Reader
-		if t.decompressCfg != nil && t.decompressCfg.Enabled && isCompressed(p) {
+		if t.decompressCfg != nil && t.decompressCfg.Enabled {
 			level.Debug(t.logger).Log("msg", "reading from compressed file", "filename", p)
 			decompressor, err := newDecompressor(t.metrics, t.logger, t.handler, t.positions, p, t.encoding, t.decompressCfg)
 			if err != nil {
@@ -342,18 +342,6 @@ func (t *FileTarget) startTailing(ps []string) {
 		}
 		t.readers[p] = reader
 	}
-}
-
-func isCompressed(p string) bool {
-	ext := filepath.Ext(p)
-
-	for format := range supportedCompressedFormats() {
-		if ext == format {
-			return true
-		}
-	}
-
-	return false
 }
 
 // stopTailingAndRemovePosition will stop the tailer and remove the positions entry.

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -69,7 +69,7 @@ func TestFileTargetSync(t *testing.T) {
 	path := logDir1 + "/*.log"
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "", false)
+	}, nil, fakeHandler, "", nil)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -221,7 +221,7 @@ func TestFileTargetPathExclusion(t *testing.T) {
 	pathExclude := filepath.Join(dirName, "log3", "*.log")
 	target, err := NewFileTarget(metrics, logger, client, ps, path, pathExclude, nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "", false)
+	}, nil, fakeHandler, "", nil)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -350,7 +350,7 @@ func TestHandleFileCreationEvent(t *testing.T) {
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		// To handle file creation event from channel, set enough long time as sync period
 		SyncPeriod: 10 * time.Minute,
-	}, fakeFileHandler, fakeTargetHandler, "", false)
+	}, fakeFileHandler, fakeTargetHandler, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -69,7 +69,7 @@ func TestFileTargetSync(t *testing.T) {
 	path := logDir1 + "/*.log"
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "")
+	}, nil, fakeHandler, "", false)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -221,7 +221,7 @@ func TestFileTargetPathExclusion(t *testing.T) {
 	pathExclude := filepath.Join(dirName, "log3", "*.log")
 	target, err := NewFileTarget(metrics, logger, client, ps, path, pathExclude, nil, nil, &Config{
 		SyncPeriod: 1 * time.Minute, // assure the sync is not called by the ticker
-	}, nil, fakeHandler, "")
+	}, nil, fakeHandler, "", false)
 	assert.NoError(t, err)
 
 	// Start with nothing watched.
@@ -350,7 +350,7 @@ func TestHandleFileCreationEvent(t *testing.T) {
 	target, err := NewFileTarget(metrics, logger, client, ps, path, "", nil, nil, &Config{
 		// To handle file creation event from channel, set enough long time as sync period
 		SyncPeriod: 10 * time.Minute,
-	}, fakeFileHandler, fakeTargetHandler, "")
+	}, fakeFileHandler, fakeTargetHandler, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -30,11 +30,10 @@ import (
 )
 
 const (
-	pathLabel               = "__path__"
-	pathExcludeLabel        = "__path_exclude__"
-	hostLabel               = "__host__"
-	inferDecompressionLabel = "__infer_decompression__"
-	kubernetesPodNodeField  = "spec.nodeName"
+	pathLabel              = "__path__"
+	pathExcludeLabel       = "__path_exclude__"
+	hostLabel              = "__host__"
+	kubernetesPodNodeField = "spec.nodeName"
 )
 
 // FileTargetManager manages a set of targets.

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -41,9 +41,9 @@ drop, and the final metadata to attach to the log line. Refer to the docs for
 
 Promtail now has native support for ingesting compressed files by a mechanism
 that relies on file extensions. If a discovered target has an expected
-compression file extension and the label `__infer_decompression__: true`,
-Promtail will **lazily** decompress the compressed file and push the parsed data
-to Loki. Example of YAML configuration to decompress files:
+compression file extension and decompression is enabled, Promtail will
+**lazily** decompress the compressed file and push the parsed data to Loki.
+Example of YAML configuration to decompress files:
 
 ```yaml
 server:
@@ -55,13 +55,15 @@ clients:
   - url: http://localhost:3100/loki/api/v1/push
 scrape_configs:
 - job_name: system
+  decompression:
+    enabled: true
+    initial_sleep: 10s
   static_configs:
   - targets:
       - localhost
     labels:
       job: varlogs
       __path__: /var/log/**.gz
-      __infer_decompression__: true
 ```
 
 Important details are:

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -39,11 +39,10 @@ drop, and the final metadata to attach to the log line. Refer to the docs for
 
 ### Support for compressed files
 
-Promtail now has native support for ingesting compressed files by a mechanism
-that relies on file extensions. If a discovered target has an expected
-compression file extension and decompression is enabled, Promtail will
+Promtail now has native support for ingesting compressed files.
+If a discovered target has decompression configured, Promtail will
 **lazily** decompress the compressed file and push the parsed data to Loki.
-Example of YAML configuration to decompress files:
+The Promtail configuration below examplifies how to to set up decompression:
 
 ```yaml
 server:
@@ -58,6 +57,7 @@ scrape_configs:
   decompression:
     enabled: true
     initial_sleep: 10s
+    format: gz
   static_configs:
   - targets:
       - localhost
@@ -84,7 +84,7 @@ Important details are:
 * `.zip` extension isn't supported as of now because it doesn't support some of the interfaces
   Promtail requires. We have plans to add support for it in the near future.
 * The decompression is quite CPU intensive and a lot of allocations are expected
-  to work, especially depending on the size of the file. You can expect the number
+  to occur, especially depending on the size of the file. You can expect the number
   of garbage collection runs and the CPU usage to skyrocket, but no memory leak is
   expected.
 * Positions are supported. That means that, if you interrupt Promtail after
@@ -97,6 +97,7 @@ Important details are:
 * Log rotations **aren't supported as of now**, mostly because it requires us modifying Promtail to
   rely on file inodes instead of file names. If you'd like to see support for it, please create a new
   issue on Github asking for it and explaining your use case.
+* If you compress a file under a folder being scrapped, Promtail might try to ingest your file before you finish compressing it. To avoid it, pick a `initial_delay` that is enough to avoid it.
 * If you would like to see support for a compression protocol that isn't listed here, please
   create a new issue on Github asking for it and explaining your use case.
 

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -97,7 +97,7 @@ Important details are:
 * Log rotations **aren't supported as of now**, mostly because it requires us modifying Promtail to
   rely on file inodes instead of file names. If you'd like to see support for it, please create a new
   issue on Github asking for it and explaining your use case.
-* If you compress a file under a folder being scrapped, Promtail might try to ingest your file before you finish compressing it. To avoid it, pick a `initial_delay` that is enough to avoid it.
+* If you compress a file under a folder being scraped, Promtail might try to ingest your file before you finish compressing it. To avoid it, pick a `initial_delay` that is enough to avoid it.
 * If you would like to see support for a compression protocol that isn't listed here, please
   create a new issue on Github asking for it and explaining your use case.
 

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -335,6 +335,18 @@ job_name: <string>
 # Describes how to transform logs from targets.
 [pipeline_stages: <pipeline_stages>]
 
+# Defines decompression behavior for the given scrape target.
+decompression:
+  # Whether decompression should be tried or not.
+  [enabled: <boolean> | default = false]
+
+  # Initial delay to wait before starting the decompression.
+  # Specially useful in scenarios where compressed files are found before the compression is finished.
+  [initial_delay: <duration> | default = 0s]
+
+  # Compression format. Supported formats are: 'gz', 'bz2' and 'z.
+  [format: <string> | default = ""]
+
 # Describes how to scrape logs from the journal.
 [journal: <journal_config>]
 

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -341,7 +341,7 @@ decompression:
   [enabled: <boolean> | default = false]
 
   # Initial delay to wait before starting the decompression.
-  # Specially useful in scenarios where compressed files are found before the compression is finished.
+  # Especially useful in scenarios where compressed files are found before the compression is finished.
   [initial_delay: <duration> | default = 0s]
 
   # Compression format. Supported formats are: 'gz', 'bz2' and 'z.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new `compression` configuration to Promtail to customize decompression behavior.
As of now, two options are supported:
`enabled`: false by default but if truthy, Promtail will infer a compression algorithm to use based on the file extension
`initialDelay`: 0 by default but if higher, Decompressor will sleep for the given duration before trying to decompress. This is to avoid scenarios where the Decompressor starts to work on a file that is still being compressed/generated.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/8784

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
