### PR TITLE
Mixins: check that `memcached_index_writes` exists before using it in `boltdb_shipper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
 
 * [8988](https://github.com/grafana/loki/pull/8988) **darxriggs**: Promtail: Prevent logging errors on normal shutdown.
 
+#### Mixins
+
+#### Enhancements
+
+#### Fixes
+
+* [8995](https://github.com/grafana/loki/pull/8995) **dannykopping**: Mixins: check that `memcached_index_writes` exists before using it in `boltdb_shipper`
+
 ## 2.8.0 (2023-03-??)
 
 #### Loki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@
 #### Promtail
 
 ##### Enhancements
+
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
+
+##### Fixes
+
+* [8988](https://github.com/grafana/loki/pull/8988) **darxriggs**: Promtail: Prevent logging errors on normal shutdown.
 
 ## 2.8.0 (2023-03-??)
 

--- a/clients/pkg/promtail/targets/journal/journaltarget.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget.go
@@ -202,12 +202,16 @@ func journalTargetWithReader(
 		for {
 			err := t.r.Follow(until, io.Discard)
 			if err != nil {
-				level.Error(t.logger).Log("msg", "received error during sdjournal follow", "err", err.Error())
+				if err == sdjournal.ErrExpired {
+					return
+				}
 
-				if err == sdjournal.ErrExpired || err == syscall.EBADMSG || err == io.EOF {
+				if err == syscall.EBADMSG || err == io.EOF {
 					level.Error(t.logger).Log("msg", "unable to follow journal", "err", err.Error())
 					return
 				}
+
+				level.Error(t.logger).Log("msg", "received unexpected error while following the journal", "err", err.Error())
 			}
 
 			// prevent tight loop

--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -33,7 +33,7 @@
 
   // we don't dedupe index writes when using boltdb-shipper so don't deploy a cache for it.
   memcached_index_writes: if $._config.using_boltdb_shipper then {} else
-  if 'memcached_index_writes' in super then super.memcached_index_writes else {},
+    if 'memcached_index_writes' in super then super.memcached_index_writes else {},
 
   // Use PVC for compactor instead of node disk.
   compactor_data_pvc:: if $._config.using_boltdb_shipper then

--- a/production/ksonnet/loki/boltdb_shipper.libsonnet
+++ b/production/ksonnet/loki/boltdb_shipper.libsonnet
@@ -32,7 +32,8 @@
   },
 
   // we don't dedupe index writes when using boltdb-shipper so don't deploy a cache for it.
-  memcached_index_writes: if $._config.using_boltdb_shipper then {} else super.memcached_index_writes,
+  memcached_index_writes: if $._config.using_boltdb_shipper then {} else
+  if 'memcached_index_writes' in super then super.memcached_index_writes else {},
 
   // Use PVC for compactor instead of node disk.
   compactor_data_pvc:: if $._config.using_boltdb_shipper then


### PR DESCRIPTION
**What this PR does / why we need it**:
This key is missing when not using boltdb_shipper, but this lib is included by default