### PR TITLE
[release-2.8.x] Change loki version in docs for 2.8 release (#8985)

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -22,10 +22,10 @@ The configuration acquired with these installation instructions run Loki as a si
 Copy and paste the commands below into your command line.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.7.3/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.6.1 -config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.7.3/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.1 -config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.8.0 -config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.0 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -40,10 +40,10 @@ Copy and paste the commands below into your terminal. Note that you will need to
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v2.7.3/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.6.1 --config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.7.3/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.6.1 --config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.8.0 --config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.8.0 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -55,6 +55,6 @@ Navigate to http://localhost:3100/metrics to view the output.
 Run the following commands in your command line. They work for Windows or Linux systems.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.7.3/production/docker-compose.yaml -O docker-compose.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.8.0/production/docker-compose.yaml -O docker-compose.yaml
 docker-compose -f docker-compose.yaml up
 ```

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -33,6 +33,8 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+## 2.8.0
+
 ### Loki
 
 #### Default retention_period has changed

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   read:
-    image: grafana/loki:2.7.1
+    image: grafana/loki:2.8.0
     command: "-config.file=/etc/loki/config.yaml -target=read"
     ports:
       - 3101:3100
@@ -27,7 +27,7 @@ services:
           - loki
 
   write:
-    image: grafana/loki:2.7.1
+    image: grafana/loki:2.8.0
     command: "-config.file=/etc/loki/config.yaml -target=write"
     ports:
       - 3102:3100
@@ -46,7 +46,7 @@ services:
       <<: *loki-dns
 
   promtail:
-    image: grafana/promtail:2.7.1
+    image: grafana/promtail:2.8.0
     volumes:
       - ./promtail-local-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/production/docker-compose.yaml
+++ b/production/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.7.3
+    image: grafana/loki:2.8.0
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,7 +13,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.7.3
+    image: grafana/promtail:2.8.0
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: grafana/loki:2.7.3
+    image: grafana/loki:2.8.0
     user: root
     entrypoint:
       - "chown"
@@ -72,7 +72,7 @@ services:
       - ./loki/:/var/log/
 
   promtail:
-    image: grafana/promtail:2.7.3
+    image: grafana/promtail:2.8.0
     volumes:
       - ./loki/:/var/log/
       - ./config:/etc/promtail/
@@ -114,7 +114,7 @@ services:
       - loki
 
   loki-read:
-    image: grafana/loki:2.7.3
+    image: grafana/loki:2.8.0
     volumes:
       - ./config:/etc/loki/
     ports:
@@ -136,7 +136,7 @@ services:
     # only needed for interactive debugging with dlv
 
   loki-write:
-    image: grafana/loki:2.7.3
+    image: grafana/loki:2.8.0
     volumes:
       - ./config:/etc/loki/
     ports:

--- a/tools/diff-metrics.sh
+++ b/tools/diff-metrics.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# To use this script
+# * run the script, it will spin up 2 loki instances and print the local port 3100 is bound to
+# * in another terminal, curl the two instances /metrics endpoints, and save to a file
+# * diff the files
+# * press enter to kill the servers
+
+set -eo pipefail
+
+current_dir="$(cd "$(dirname "${0}")" && pwd)"
+loki_dir="$(cd "${current_dir}/../cmd/loki" && pwd)"
+root_dir="$(cd "${current_dir}/.." && pwd)"
+
+export OLD_LOKI=${OLD_VERSION:-2.7.5}
+export NEW_LOKI=${NEW_VERSION:-$("${current_dir}/image-tag")}
+
+export CONFIG_FILE="loki-local-config.yaml"
+
+function start_loki() {
+	local version=${1}
+
+	docker run --rm -t -d -v "${loki_dir}:/config" \
+    -p 3100 \
+    "grafana/loki:${version}" \
+		-config.file="/config/${CONFIG_FILE}"
+}
+
+
+make -C "${root_dir}" loki-image
+
+loki1="$(start_loki "${OLD_LOKI}")"
+loki2="$(start_loki "${NEW_LOKI}")"
+
+echo "Loki 1: ${loki1}"
+echo "Loki 2: ${loki2}"
+
+docker port "${loki1}"
+docker port "${loki2}"
+
+echo "Curl instances on ports above to get metrics."
+read -r -n 1 -p "Press enter to kill loki instances..."
+
+docker kill "${loki1}" "${loki2}"
+


### PR DESCRIPTION
Automatic backport failed: https://github.com/grafana/loki/pull/8985#issuecomment-1494977977
