### PR TITLE
operator: Restore minimum PVC sizes for 1x.extra-small

### DIFF
--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -30,10 +30,9 @@ type LokiStackSizeType string
 
 const (
 	// SizeOneXExtraSmall defines the size of a single Loki deployment
-	// with NO resource requirements and without HA support.
+	// with minimal resource requirements and without HA support.
 	//
-	// This is ONLY for development, testing, or demos
-	// on limited single-node clusters.
+	// This is ONLY for development, testing, or demos on limited single-node clusters.
 	// There are NO performance guarantees.
 	// LokiStack will use whatever resources are available,
 	// and WILL NOT FUNCTION CORRECTLY if there is not enough memory or CPU.

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -30,7 +30,21 @@ type ResourceRequirements struct {
 // ResourceRequirementsTable defines the default resource requests and limits for each size
 var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 	lokiv1.SizeOneXExtraSmall: {
-		// No requirements, can be deployed on any size of cluster. NOT FOR USE IN PRODUCTION.
+		Ruler: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+		},
+		Ingester: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+		},
+		Compactor: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+		},
+		IndexGateway: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+		},
+		WALStorage: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+		},
 	},
 	lokiv1.SizeOneXSmall: {
 		Querier: corev1.ResourceRequirements{


### PR DESCRIPTION
Removed by accident in:
75ec3f338 * Redefine 1x.extra-small to have 0 requirements. (#8977)