### PR TITLE
Rename per-request query limits.

### DIFF
--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/loki/integration/client"
 	"github.com/grafana/loki/integration/cluster"
+
 	"github.com/grafana/loki/pkg/util/querylimits"
 )
 

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -131,7 +131,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 	})
 
 	t.Run("per-request-limits", func(t *testing.T) {
-		queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryLength": "1m"}`}})
+		queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryTimeRange": "1m"}`}})
 		cliQueryFrontendLimited := client.New(tenantID, "", tQueryFrontend.HTTPURL(), queryLimitsPolicy)
 		cliQueryFrontendLimited.Now = now
 

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -131,7 +131,7 @@ func TestMicroServicesIngestQuery(t *testing.T) {
 	})
 
 	t.Run("per-request-limits", func(t *testing.T) {
-		queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryTimeRange": "1m"}`}})
+		queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryLength": "1m"}`}})
 		cliQueryFrontendLimited := client.New(tenantID, "", tQueryFrontend.HTTPURL(), queryLimitsPolicy)
 		cliQueryFrontendLimited.Now = now
 

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -31,7 +31,7 @@ func TestPerRequestLimits(t *testing.T) {
 
 	require.NoError(t, clu.Run())
 
-	queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryTimeRange": "1m"}`}})
+	queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryLength": "1m"}`}})
 	cliTenant := client.New("org1", "", tAll.HTTPURL(), queryLimitsPolicy)
 
 	// ingest log lines for tenant 1 and tenant 2.

--- a/integration/per_request_limits_test.go
+++ b/integration/per_request_limits_test.go
@@ -31,7 +31,7 @@ func TestPerRequestLimits(t *testing.T) {
 
 	require.NoError(t, clu.Run())
 
-	queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryLength": "1m"}`}})
+	queryLimitsPolicy := client.InjectHeadersOption(map[string][]string{querylimits.HTTPHeaderQueryLimitsKey: {`{"maxQueryTimeRange": "1m"}`}})
 	cliTenant := client.New("org1", "", tAll.HTTPURL(), queryLimitsPolicy)
 
 	// ingest log lines for tenant 1 and tenant 2.

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -22,11 +22,11 @@ const (
 // NOTE: we use custom `model.Duration` instead of standard `time.Duration` because,
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type QueryLimits struct {
-	MaxQueryLength          model.Duration   `json:"maxQueryLength,omitempty"`
+	MaxQueryLength          model.Duration   `json:"maxQueryTimeRange,omitempty"`
 	MaxQueryRange           model.Duration   `json:"maxQueryInterval,omitempty"`
 	MaxQueryLookback        model.Duration   `json:"maxQueryLookback,omitempty"`
 	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`
-	QueryTimeout            model.Duration   `json:"queryTimeout,omitempty"`
+	QueryTimeout            model.Duration   `json:"maxQueryTime,omitempty"`
 	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
 	RequiredNumberLabels    int              `json:"minimumLabelsNumber,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -22,7 +22,7 @@ const (
 // NOTE: we use custom `model.Duration` instead of standard `time.Duration` because,
 // to support user-friendly duration format (e.g: "1h30m45s") in JSON value.
 type QueryLimits struct {
-	MaxQueryLength          model.Duration   `json:"maxQueryTimeRange,omitempty"`
+	MaxQueryLength          model.Duration   `json:"maxQueryLength,omitempty"`
 	MaxQueryRange           model.Duration   `json:"maxQueryInterval,omitempty"`
 	MaxQueryLookback        model.Duration   `json:"maxQueryLookback,omitempty"`
 	MaxEntriesLimitPerQuery int              `json:"maxEntriesLimitPerQuery,omitempty"`

--- a/pkg/util/querylimits/propagation_test.go
+++ b/pkg/util/querylimits/propagation_test.go
@@ -25,7 +25,7 @@ func TestInjectAndExtractQueryLimits(t *testing.T) {
 
 func TestDeserializingQueryLimits(t *testing.T) {
 	// full limits
-	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "queryTimeout": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB"}`
+	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB"}`
 	limits, err := UnmarshalQueryLimits([]byte(payload))
 	require.NoError(t, err)
 	require.Equal(t, model.Duration(2*24*time.Hour), limits.MaxQueryLength)
@@ -34,7 +34,7 @@ func TestDeserializingQueryLimits(t *testing.T) {
 	require.Equal(t, 100, limits.MaxEntriesLimitPerQuery)
 	require.Equal(t, 1*1024*1024, limits.MaxQueryBytesRead.Val())
 	// some limits are empty
-	payload = `{"maxQueryLength":"1h"}`
+	payload = `{"maxQueryTimeRange":"1h"}`
 	limits, err = UnmarshalQueryLimits([]byte(payload))
 	require.NoError(t, err)
 	require.Equal(t, model.Duration(3600000000000), limits.MaxQueryLength)
@@ -55,7 +55,7 @@ func TestSerializingQueryLimits(t *testing.T) {
 
 	actual, err := MarshalQueryLimits(&limits)
 	require.NoError(t, err)
-	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "queryTimeout": "5s", "maxQueryBytesRead": "1MB"}`
+	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB"}`
 	require.JSONEq(t, expected, string(actual))
 
 	// some limits are empty
@@ -67,6 +67,6 @@ func TestSerializingQueryLimits(t *testing.T) {
 
 	actual, err = MarshalQueryLimits(&limits)
 	require.NoError(t, err)
-	expected = `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w"}`
+	expected = `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w"}`
 	require.JSONEq(t, expected, string(actual))
 }

--- a/pkg/util/querylimits/propagation_test.go
+++ b/pkg/util/querylimits/propagation_test.go
@@ -25,7 +25,7 @@ func TestInjectAndExtractQueryLimits(t *testing.T) {
 
 func TestDeserializingQueryLimits(t *testing.T) {
 	// full limits
-	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB"}`
+	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB"}`
 	limits, err := UnmarshalQueryLimits([]byte(payload))
 	require.NoError(t, err)
 	require.Equal(t, model.Duration(2*24*time.Hour), limits.MaxQueryLength)
@@ -34,7 +34,7 @@ func TestDeserializingQueryLimits(t *testing.T) {
 	require.Equal(t, 100, limits.MaxEntriesLimitPerQuery)
 	require.Equal(t, 1*1024*1024, limits.MaxQueryBytesRead.Val())
 	// some limits are empty
-	payload = `{"maxQueryTimeRange":"1h"}`
+	payload = `{"maxQueryLength":"1h"}`
 	limits, err = UnmarshalQueryLimits([]byte(payload))
 	require.NoError(t, err)
 	require.Equal(t, model.Duration(3600000000000), limits.MaxQueryLength)
@@ -55,7 +55,7 @@ func TestSerializingQueryLimits(t *testing.T) {
 
 	actual, err := MarshalQueryLimits(&limits)
 	require.NoError(t, err)
-	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB"}`
+	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB"}`
 	require.JSONEq(t, expected, string(actual))
 
 	// some limits are empty
@@ -67,6 +67,6 @@ func TestSerializingQueryLimits(t *testing.T) {
 
 	actual, err = MarshalQueryLimits(&limits)
 	require.NoError(t, err)
-	expected = `{"maxEntriesLimitPerQuery": 100, "maxQueryTimeRange": "2d", "maxQueryLookback": "2w"}`
+	expected = `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w"}`
 	require.JSONEq(t, expected, string(actual))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`maxQueryTime` is more in line with the other per-request limits we have.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
