### PR TITLE
chore(format_query): Change response type to `application/json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [8953](https://github.com/grafana/loki/pull/8953) **dannykopping**: Querier: block queries by hash.
 * [8851](https://github.com/grafana/loki/pull/8851) **jeschkies**: Introduce limit to require a set of labels for selecting streams.
+* [9016](https://github.com/grafana/loki/pull/9016) **kavirajk**: Change response type of `format_query` handler to `application/json`
 
 ##### Fixes
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -729,6 +729,15 @@ Params:
 
 The `/loki/api/v1/format_query` endpoint allows to format LogQL queries. It returns an error if the passed LogQL is invalid. It is exposed by all Loki components and helps to improve readability and the debugging experience of LogQL queries.
 
+The following example formats the expression LogQL `{foo=   "bar"}` into
+
+```json
+{
+   "status" : "success",
+   "data" : "{foo=\"bar\"}"
+}
+```
+
 ## List series
 
 The Series API is available under the following:

--- a/pkg/loki/format_query_handler.go
+++ b/pkg/loki/format_query_handler.go
@@ -28,11 +28,7 @@ func formatQueryHandler() http.HandlerFunc {
 			formatted = syntax.Prettify(expr)
 		}
 
-		resp := struct {
-			Status string `json:"status"`
-			Data   string `json:"data,omitempty"`
-			Err    string `json:"error,omitempty"`
-		}{
+		resp := FormatQueryResponse{
 			Status: status,
 			Data:   formatted,
 			Err:    errStr,
@@ -46,4 +42,10 @@ func formatQueryHandler() http.HandlerFunc {
 		}
 
 	}
+}
+
+type FormatQueryResponse struct {
+	Status string `json:"status"`
+	Data   string `json:"data,omitempty"`
+	Err    string `json:"error,omitempty"`
 }

--- a/pkg/loki/format_query_handler.go
+++ b/pkg/loki/format_query_handler.go
@@ -1,24 +1,49 @@
 package loki
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
-	serverutil "github.com/grafana/loki/pkg/util/server"
+	"github.com/grafana/loki/pkg/util/server"
 )
 
 func formatQueryHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			statusCode = http.StatusOK
+			status     = "success"
+			formatted  string
+			errStr     string
+		)
+
 		expr, err := syntax.ParseExpr(r.FormValue("query"))
 		if err != nil {
-			serverutil.WriteError(err, w)
-			return
+			statusCode = http.StatusBadRequest
+			status = "invalid-query"
+			errStr = err.Error()
 		}
 
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
+		if err == nil {
+			formatted = syntax.Prettify(expr)
+		}
 
-		fmt.Fprintf(w, "%s", syntax.Prettify(expr))
+		resp := struct {
+			Status string `json:"status"`
+			Data   string `json:"data,omitempty"`
+			Err    string `json:"error,omitempty"`
+		}{
+			Status: status,
+			Data:   formatted,
+			Err:    errStr,
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(statusCode)
+
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			server.WriteError(err, w)
+		}
+
 	}
 }

--- a/pkg/loki/format_query_handler_test.go
+++ b/pkg/loki/format_query_handler_test.go
@@ -1,0 +1,55 @@
+package loki
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_formatQueryHandlerResponse(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		expected FormatQueryResponse
+	}{
+		{
+			name:  "happy-path",
+			query: `{foo="bar"}`,
+			expected: FormatQueryResponse{
+				Status: "success",
+				Data:   `{foo="bar"}`,
+			},
+		},
+		{
+			name:  "invalid-query",
+			query: `{foo="bar}`,
+			expected: FormatQueryResponse{
+				Status: "invalid-query",
+				Err:    "parse error at line 1, col 6: literal not terminated",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:808?query=%s", tc.query), nil)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+
+			formatQueryHandler()(w, req)
+
+			var got FormatQueryResponse
+
+			err = json.NewDecoder(w.Body).Decode(&got)
+			require.NoError(t, err)
+
+			assert.Equal(t, got, tc.expected)
+		})
+	}
+}

--- a/pkg/loki/format_query_handler_test.go
+++ b/pkg/loki/format_query_handler_test.go
@@ -49,7 +49,7 @@ func Test_formatQueryHandlerResponse(t *testing.T) {
 			err = json.NewDecoder(w.Body).Decode(&got)
 			require.NoError(t, err)
 
-			assert.Equal(t, got, tc.expected)
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Change is to be in consistent with other endpoints and also to the prometheus `format_query` format. https://prometheus.io/docs/prometheus/latest/querying/api/#formatting-query-expressions

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:
requested by @gwdawson.

Related: https://github.com/grafana/grafana/pull/64337

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
