### PR TITLE
Remove unnecessary build image step.

### DIFF
--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -25,9 +25,7 @@ if there were made any changes in the folder `./loki-build-image/`.
 
 1. create a branch
 2. update the `BUILD_IMAGE_VERSION` variable in the `Makefile`
-3. Repeat step 1.3, which will use the new image
-4. run `loki-build-image/version-updater.sh <new-version>` to update all the references
-
-5. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` to update the Drone config to use the new build image
-6. create a PR
+3. run `loki-build-image/version-updater.sh <new-version>` to update all the references
+4. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` to update the Drone config to use the new build image
+5. create a PR
 


### PR DESCRIPTION
**What this PR does / why we need it**:
> Repeat step 1.3, which will use the new image

is the same as calling `make drone`. So it is not required.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
