### PR TITLE
upgrade go to 1.20 in nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661931183,
-        "narHash": "sha256-0+2KzcexiJCB3Il5t7cZAM2RXNRfm5/gMCwhcZJxLuQ=",
+        "lastModified": 1680487167,
+        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97747d3209efde533f7b1b28f1be11619f556a06",
+        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,18 +16,17 @@
           {
             buildGoModule = args:
               prev.buildGoModule (args // rec {
-                version = "1.45.2";
+                version = "1.51.2";
 
                 src = prev.fetchFromGitHub rec {
                   owner = "golangci";
                   repo = "golangci-lint";
                   rev = "v${version}";
-                  sha256 =
-                    "sha256-Mr45nJbpyzxo0ZPwx22JW2WrjyjI9FPpl+gZ7NIc6WQ=";
+                  sha256 = "F2rkVZ5ia9/wyTw1WIeizFnuaHoS2A8VzVOGDcshy64=";
                 };
 
                 vendorHash =
-                  "sha256-pcbKg1ePN8pObS9EzP3QYjtaty27L9sroKUs/qEPtJo=";
+                  "sha256-JO/mRJB3gRTtBj6pW1267/xXUtalTJo0p3q5e34vqTs=";
 
                 ldflags = [
                   "-s"

--- a/flake.nix
+++ b/flake.nix
@@ -10,67 +10,12 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      golangci-lint-overlay = final: prev: {
-        golangci-lint = prev.callPackage
-          "${prev.path}/pkgs/development/tools/golangci-lint"
-          {
-            buildGoModule = args:
-              prev.buildGoModule (args // rec {
-                version = "1.51.2";
-
-                src = prev.fetchFromGitHub rec {
-                  owner = "golangci";
-                  repo = "golangci-lint";
-                  rev = "v${version}";
-                  sha256 = "F2rkVZ5ia9/wyTw1WIeizFnuaHoS2A8VzVOGDcshy64=";
-                };
-
-                vendorHash =
-                  "sha256-JO/mRJB3gRTtBj6pW1267/xXUtalTJo0p3q5e34vqTs=";
-
-                ldflags = [
-                  "-s"
-                  "-w"
-                  "-X main.version=${version}"
-                  "-X main.commit=v${version}"
-                  "-X main.date=19700101-00:00:00"
-                ];
-              });
-          };
-      };
-
-      helm-docs-overlay = final: prev: {
-        helm-docs = prev.callPackage
-          "${prev.path}/pkgs/applications/networking/cluster/helm-docs"
-          {
-            buildGoModule = args:
-              prev.buildGoModule (args // rec {
-                version = "1.11.0";
-
-                src = prev.fetchFromGitHub {
-                  owner = "norwoodj";
-                  repo = "helm-docs";
-                  rev = "v${version}";
-                  sha256 = "sha256-476ZhjRwHlNJFkHzY8qQ7WbAUUpFNSoxXLGX9esDA/E=";
-                };
-
-                vendorSha256 = "sha256-xXwunk9rmzZEtqmSo8biuXnAjPp7fqWdQ+Kt9+Di9N8=";
-
-                ldflags = [
-                  "-w"
-                  "-s"
-                  "-X main.version=v${version}"
-                ];
-              });
-          };
-      };
-
       nix = import ./nix { inherit self; };
     in
     {
       overlays = {
-        golangci-lint = golangci-lint-overlay;
-        helm-docs = helm-docs-overlay;
+        golangci-lint = import ./nix/overlays/golangci-lint.nix;
+        helm-docs = import ./nix/overlays/helm-docs.nix;
         default = nix.overlay;
       };
     } //
@@ -80,8 +25,8 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            golangci-lint-overlay
-            helm-docs-overlay
+            (import ./nix/overlays/golangci-lint.nix)
+            (import ./nix/overlays/helm-docs.nix)
             nix.overlay
           ];
           config = { allowUnfree = true; };

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
                     "sha256-Mr45nJbpyzxo0ZPwx22JW2WrjyjI9FPpl+gZ7NIc6WQ=";
                 };
 
-                vendorSha256 =
+                vendorHash =
                   "sha256-pcbKg1ePN8pObS9EzP3QYjtaty27L9sroKUs/qEPtJo=";
 
                 ldflags = [

--- a/nix/overlays/golangci-lint.nix
+++ b/nix/overlays/golangci-lint.nix
@@ -1,0 +1,28 @@
+final: prev: {
+  golangci-lint = prev.callPackage
+    "${prev.path}/pkgs/development/tools/golangci-lint"
+    {
+      buildGoModule = args:
+        prev.buildGoModule (args // rec {
+          version = "1.51.2";
+
+          src = prev.fetchFromGitHub rec {
+            owner = "golangci";
+            repo = "golangci-lint";
+            rev = "v${version}";
+            sha256 = "F2rkVZ5ia9/wyTw1WIeizFnuaHoS2A8VzVOGDcshy64=";
+          };
+
+          vendorHash =
+            "sha256-JO/mRJB3gRTtBj6pW1267/xXUtalTJo0p3q5e34vqTs=";
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${version}"
+            "-X main.commit=v${version}"
+            "-X main.date=19700101-00:00:00"
+          ];
+        });
+    };
+}

--- a/nix/overlays/helm-docs.nix
+++ b/nix/overlays/helm-docs.nix
@@ -1,0 +1,25 @@
+final: prev: {
+  helm-docs = prev.callPackage
+    "${prev.path}/pkgs/applications/networking/cluster/helm-docs"
+    {
+      buildGoModule = args:
+        prev.buildGoModule (args // rec {
+          version = "1.11.0";
+
+          src = prev.fetchFromGitHub {
+            owner = "norwoodj";
+            repo = "helm-docs";
+            rev = "v${version}";
+            sha256 = "sha256-476ZhjRwHlNJFkHzY8qQ7WbAUUpFNSoxXLGX9esDA/E=";
+          };
+
+          vendorSha256 = "sha256-xXwunk9rmzZEtqmSo8biuXnAjPp7fqWdQ+Kt9+Di9N8=";
+
+          ldflags = [
+            "-w"
+            "-s"
+            "-X main.version=v${version}"
+          ];
+        });
+    };
+}

--- a/pkg/util/ring_test.go
+++ b/pkg/util/ring_test.go
@@ -77,11 +77,11 @@ func (r *readRingMock) ShuffleShard(identifier string, size int) ring.ReadRing {
 	}(*r)
 }
 
-func (r *readRingMock) BatchGet(keys []uint32, op ring.Operation) ([]ring.ReplicationSet, error) {
+func (r *readRingMock) BatchGet(_ []uint32, op ring.Operation) ([]ring.ReplicationSet, error) {
 	return []ring.ReplicationSet{r.replicationSet}, nil
 }
 
-func (r *readRingMock) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error) {
+func (r *readRingMock) GetAllHealthy(_ ring.Operation) (ring.ReplicationSet, error) {
 	return r.replicationSet, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `flake.lock` to grab the latest `nixpkgs-unstable` in order to upgrade go version to `1.20`.