### PR TITLE
Updated to explicitly call our simple scalable deployment mode

### DIFF
--- a/docs/sources/installation/sizing/index.md
+++ b/docs/sources/installation/sizing/index.md
@@ -15,8 +15,8 @@ keywords: []
 <!-- vale Grafana.Quotes = YES -->
 
 This tool helps to generate a Helm Charts `values.yaml` file based on specified
- expected ingestion, retention rate and node type. It will always configure a
- [scalable]({{<relref "../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode">}}) deployment. The storage needs to be configured after generation.
+ expected ingestion, retention rate and node type. It will always configure Loki using our
+ [Simple Scalable]({{<relref "../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode">}}) deployment mode. The storage needs to be configured after generation.
 
 <div id="app">
   <label>Node Type<i class="fa fa-question" v-on:mouseover="help='node'" v-on:mouseleave="help=null"></i></label>


### PR DESCRIPTION
**What this PR does / why we need it**:
The docs prior to this change reference "A scalable deployment" which implies that some of our deployments do not scale which isn't a great message to have in high traffic docs like this page. Therefore I propose updating it to explicitly call our Loki's Simple Scalable deployment mode as we link to our deployment mode docs and all but the unsupported monolithic deployment scale very happily.