### PR TITLE
Updated Scalability benefit to call out decoupled read/write paths an…

### DIFF
--- a/docs/sources/fundamentals/overview/_index.md
+++ b/docs/sources/fundamentals/overview/_index.md
@@ -56,13 +56,9 @@ and allows for efficient query execution.
 
 -  **Scalability**
 
-    Loki can be run as a single binary;
-    all the components run in one process.
-
     Loki is designed for scalability,
-    as each of Loki's components can be run as microservices.
-    Configuration permits scaling the microservices individually,
-    permitting flexible large-scale installations.
+    as each of Loki's components can be run as microservices designed to run statelessly and natively within Kubernetes.
+    Loki's read and write path are decoupled meaning that you can independently scale read or write leading to flexible large-scale installations that can quickly adapt to meet your workload at any given time.
 
 -  **Flexibility**
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated Scalability benefit to call out decoupled read/write paths and that benefit - this is a huge competitive edge over tools like Splunk and Elastic and it makes sense to explicitly call it out under our benefits