### PR TITLE
Loki: log all trace ID's but include `sampled=true` when the trace is logged

### DIFF
--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -85,7 +85,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Regexp(t,
 		regexp.MustCompile(fmt.Sprintf(
-			`level=info org_id=foo traceID=%s latency=slow query=".*" query_hash=.* query_type=filter range_type=range length=1h0m0s .*\n`,
+			`level=info org_id=foo traceID=%s sampled=true latency=slow query=".*" query_hash=.* query_type=filter range_type=range length=1h0m0s .*\n`,
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		)),
 		buf.String())
@@ -111,7 +111,7 @@ func TestLogLabelsQuery(t *testing.T) {
 	})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s latency=slow query_type=labels length=1h0m0s duration=25.25s status=200 label=foo query= splits=0 throughput=100kB total_bytes=100kB total_entries=12\n",
+			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=labels length=1h0m0s duration=25.25s status=200 label=foo query= splits=0 throughput=100kB total_bytes=100kB total_entries=12\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())
@@ -137,7 +137,7 @@ func TestLogSeriesQuery(t *testing.T) {
 	})
 	require.Equal(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s latency=slow query_type=series length=1h0m0s duration=25.25s status=200 match=\"{container_name=~\\\"prometheus.*\\\", component=\\\"server\\\"}:{app=\\\"loki\\\"}\" splits=0 throughput=100kB total_bytes=100kB total_entries=10\n",
+			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=series length=1h0m0s duration=25.25s status=200 match=\"{container_name=~\\\"prometheus.*\\\", component=\\\"server\\\"}:{app=\\\"loki\\\"}\" splits=0 throughput=100kB total_bytes=100kB total_entries=10\n",
 			sp.Context().(jaeger.SpanContext).SpanID().String(),
 		),
 		buf.String())

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -31,10 +31,13 @@ func WithContext(ctx context.Context, l log.Logger) log.Logger {
 		l = WithUserID(userID, l)
 	}
 
-	traceID, ok := tracing.ExtractSampledTraceID(ctx)
-	if !ok {
+	traceID, sampled := tracing.ExtractSampledTraceID(ctx)
+	if sampled {
+		return log.With(l, "traceID", traceID, "sampled", "true")
+	}
+	if traceID != "" {
 		return log.With(l, "traceID", traceID)
 	}
+	return l
 
-	return log.With(l, "traceID", traceID, "sampled", "true")
 }

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -33,8 +33,8 @@ func WithContext(ctx context.Context, l log.Logger) log.Logger {
 
 	traceID, ok := tracing.ExtractSampledTraceID(ctx)
 	if !ok {
-		return log.With(l, "traceID", "NS-"+traceID)
+		return log.With(l, "traceID", traceID)
 	}
 
-	return log.With(l, "traceID", traceID)
+	return log.With(l, "traceID", traceID, "sampled", "true")
 }

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -33,7 +33,7 @@ func WithContext(ctx context.Context, l log.Logger) log.Logger {
 
 	traceID, ok := tracing.ExtractSampledTraceID(ctx)
 	if !ok {
-		return l
+		return log.With(l, "traceID", "NS-"+traceID)
 	}
 
 	return log.With(l, "traceID", traceID)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently when we log "with context" we will only add the traceID if the particular trace is being sampled. This is nice because it makes it obvious that if you go search for a trace you'll find it.

However, traceID is also useful for selecting all the log lines from a single query within Loki itself and if the trace wasn't sampled we remove this useful piece of context for querying the log lines.

In this PR, instead of dropping the traceID from the logs, we instead prefix it with `NS-`

Where NS is short for Not Sampled

Example:
```
level=debug ts=2023-04-05T15:06:24.377067817Z caller=fetcher.go:292 org_id=145265 traceID=NS-13ed6c30228e221d chunks=1 decodeRequests=1 missing=0
```

Questions: 

* should we bikeshed a little on this prefix? (I wanted something concise but if it's concise it's probably confusing to folks who've never seen it before)
* Instead of a prefix, we could change the logfmt key? `ID=13ed6c30228e221d` (this is less confusing in some ways but maybe more difficult/confusing in others?)


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
