### PR TITLE
helm: add setting 'useFederatedToken' for azure config

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1892,6 +1892,7 @@ null
     "accountKey": null,
     "accountName": null,
     "requestTimeout": null,
+    "useFederatedToken": false,
     "useManagedIdentity": false,
     "userAssignedId": null
   },

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -15,6 +15,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [BUGFIX] Fix dns port in network-policy
 
+## 5.1.1
+
+- [FEATURE] add setting `useFederatedToken` from Azure configuration block back.
+
 ## 4.10.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.6.3

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.0
-version: 5.1.0
+version: 5.1.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 5.1.1](https://img.shields.io/badge/Version-5.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -240,6 +240,9 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.chunks }}
   use_managed_identity: {{ .useManagedIdentity }}
+  {{- if .useFederatedToken }}
+  use_federated_token: {{ .useFederatedToken }}
+  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}
@@ -306,6 +309,9 @@ azure:
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.ruler }}
   use_managed_identity: {{ .useManagedIdentity }}
+  {{- if .useFederatedToken }}
+  use_federated_token: {{ .useFederatedToken }}
+  {{- end }}
   {{- with .userAssignedId }}
   user_assigned_id: {{ . }}
   {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -244,6 +244,7 @@ loki:
       accountName: null
       accountKey: null
       useManagedIdentity: false
+      useFederatedToken: false
       userAssignedId: null
       requestTimeout: null
     filesystem:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is adding back some changes that have been removed a while back. Some more context [here](https://github.com/grafana/loki/issues/8450)

**Which issue(s) this PR fixes**:
This adds back the possibility to use azure federated tokens when using the loki chart.

As far as the usability of the feature is, I have used the version that was using a build of loki from the main branch with the azure federated token feature and it works fine so it would be pretty beneficial to be able to use it while using the normal releases of Loki.

**Special notes for your reviewer**:
I only undid the changes that removed the flag

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
