### PR TITLE
operator: Revert 1x.extra-small changes, add 1x.tiny-test

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Main
-
+- [9049](https://github.com/grafana/loki/pull/9049) **alanconway**: Revert 1x.extra-small changes, add 1x.demo
 - [8661](https://github.com/grafana/loki/pull/8661) **xuanyunhui**: Add a new Object Storage Type for AlibabaCloud OSS
 - [9036](https://github.com/grafana/loki/pull/9036) **periklis**: Update Loki operand to v2.8.0
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -29,15 +29,20 @@ const (
 type LokiStackSizeType string
 
 const (
-	// SizeOneXExtraSmall defines the size of a single Loki deployment
-	// with minimal resource requirements and without HA support.
-	//
-	// This is ONLY for development, testing, or demos on limited single-node clusters.
-	// There are NO performance guarantees.
-	// LokiStack will use whatever resources are available,
-	// and WILL NOT FUNCTION CORRECTLY if there is not enough memory or CPU.
-	//
+	// SizeOneXDemo defines the size of a single Loki deployment
+	// with tiny resource requirements and without HA support.
+	// This size is intended to run in single-node clusters on laptops,
+	// it is only useful for very light testing, demonstrations, or prototypes.
+	// There are no ingestion/query performance guarantees.
 	// DO NOT USE THIS IN PRODUCTION!
+	SizeOneXDemo LokiStackSizeType = "1x.demo"
+
+	// SizeOneXExtraSmall defines the size of a single Loki deployment
+	// with extra small resources/limits requirements and without HA support.
+	// This size is ultimately dedicated for development and demo purposes.
+	// DO NOT USE THIS IN PRODUCTION!
+	//
+	// FIXME: Add clear description of ingestion/query performance expectations.
 	SizeOneXExtraSmall LokiStackSizeType = "1x.extra-small"
 
 	// SizeOneXSmall defines the size of a single Loki deployment

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -395,7 +395,7 @@ func CreateOrUpdateLokiStack(
 
 	// 1x.extra-small is used only for development, so the metrics will not
 	// be collected.
-	if opts.Stack.Size != lokiv1.SizeOneXExtraSmall {
+	if opts.Stack.Size != lokiv1.SizeOneXExtraSmall && opts.Stack.Size != lokiv1.SizeOneXDemo {
 		metrics.Collect(&opts.Stack, opts.Name)
 	}
 

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestApplyUserOptions_OverrideDefaults(t *testing.T) {
 	allSizes := []lokiv1.LokiStackSizeType{
+		lokiv1.SizeOneXDemo,
 		lokiv1.SizeOneXExtraSmall,
 		lokiv1.SizeOneXSmall,
 		lokiv1.SizeOneXMedium,
@@ -59,6 +60,7 @@ func TestApplyUserOptions_OverrideDefaults(t *testing.T) {
 
 func TestApplyUserOptions_AlwaysSetCompactorReplicasToOne(t *testing.T) {
 	allSizes := []lokiv1.LokiStackSizeType{
+		lokiv1.SizeOneXDemo,
 		lokiv1.SizeOneXExtraSmall,
 		lokiv1.SizeOneXSmall,
 		lokiv1.SizeOneXMedium,

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -321,6 +321,7 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 }
 
 var deleteWorkerCountMap = map[lokiv1.LokiStackSizeType]uint{
+	lokiv1.SizeOneXDemo:       10,
 	lokiv1.SizeOneXExtraSmall: 10,
 	lokiv1.SizeOneXSmall:      150,
 	lokiv1.SizeOneXMedium:     150,

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -29,7 +29,7 @@ type ResourceRequirements struct {
 
 // ResourceRequirementsTable defines the default resource requests and limits for each size
 var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
-	lokiv1.SizeOneXExtraSmall: {
+	lokiv1.SizeOneXDemo: {
 		Ruler: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 		},
@@ -44,6 +44,63 @@ var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		},
 		WALStorage: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
+		},
+	},
+	lokiv1.SizeOneXExtraSmall: {
+		Querier: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+		},
+		Ruler: ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			PVCSize: resource.MustParse("10Gi"),
+		},
+		Ingester: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		Distributor: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
+		QueryFrontend: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
+		Compactor: ResourceRequirements{
+			PVCSize: resource.MustParse("10Gi"),
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		Gateway: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		IndexGateway: ResourceRequirements{
+			PVCSize: resource.MustParse("50Gi"),
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		WALStorage: ResourceRequirements{
+			PVCSize: resource.MustParse("150Gi"),
 		},
 	},
 	lokiv1.SizeOneXSmall: {
@@ -164,6 +221,56 @@ var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 
 // StackSizeTable defines the default configurations for each size
 var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
+	lokiv1.SizeOneXDemo: {
+		Size:              lokiv1.SizeOneXDemo,
+		ReplicationFactor: 1,
+		Limits: &lokiv1.LimitsSpec{
+			Global: &lokiv1.LimitsTemplateSpec{
+				IngestionLimits: &lokiv1.IngestionLimitSpec{
+					// Defaults from Loki docs
+					IngestionRate:          4,
+					IngestionBurstSize:     6,
+					MaxLabelNameLength:     1024,
+					MaxLabelValueLength:    2048,
+					MaxLabelNamesPerSeries: 30,
+					MaxLineSize:            256000,
+				},
+				QueryLimits: &lokiv1.QueryLimitSpec{
+					// Defaults from Loki docs
+					MaxEntriesLimitPerQuery: 5000,
+					MaxChunksPerQuery:       2000000,
+					MaxQuerySeries:          500,
+					QueryTimeout:            "3m",
+				},
+			},
+		},
+		Template: &lokiv1.LokiTemplateSpec{
+			Compactor: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			Distributor: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			Ingester: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			Querier: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			QueryFrontend: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			Gateway: &lokiv1.LokiComponentSpec{
+				Replicas: 2,
+			},
+			IndexGateway: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+			Ruler: &lokiv1.LokiComponentSpec{
+				Replicas: 1,
+			},
+		},
+	},
 	lokiv1.SizeOneXExtraSmall: {
 		Size:              lokiv1.SizeOneXExtraSmall,
 		ReplicationFactor: 1,


### PR DESCRIPTION
Revert "Redefine 1x.extra-small to have 0 requirements. (#8977)"
This reverts commit 75ec3f33864ce98df1b89b0973cc67479d7486bc.
Introduce a new size 1x.tiny-test