### PR TITLE
Fail through to next middleware when querySizeLimit cannot be applied

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -353,7 +353,7 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	// Only support TSDB
 	schemaCfg, err := q.getSchemaCfg(r)
 	if err != nil {
-		level.Error(log).Log("msg", "failed to get schema config", "err", err)
+		level.Error(log).Log("msg", "failed to get schema config, not applying querySizeLimit", "err", err)
 		return q.next.Do(ctx, r)
 	}
 	if schemaCfg.IndexType != config.TSDBType {

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -353,7 +353,8 @@ func (q *querySizeLimiter) Do(ctx context.Context, r queryrangebase.Request) (qu
 	// Only support TSDB
 	schemaCfg, err := q.getSchemaCfg(r)
 	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Failed to get schema config: %s", err.Error())
+		level.Error(log).Log("msg", "failed to get schema config", "err", err)
+		return q.next.Do(ctx, r)
 	}
 	if schemaCfg.IndexType != config.TSDBType {
 		return q.next.Do(ctx, r)


### PR DESCRIPTION
**What this PR does / why we need it**:

When the query size limiter can't limit the query, fail through to the next middleware instead of erroring. This can happen, for example, when a query spans schemas, which is still a valid query case, so we want to make sure to fall back to existing behavior.