### PR TITLE
util/loser: Fix issue using loser tree to merge sequences that contain the maximum value

### DIFF
--- a/pkg/util/loser/tree.go
+++ b/pkg/util/loser/tree.go
@@ -107,7 +107,8 @@ func (t *Tree[E, S]) replayGames(pos int) {
 	// At the start, pos is a leaf node, and is the winner at that level.
 	n := parent(pos)
 	for n != 0 {
-		if t.less(t.nodes[n].value, t.nodes[pos].value) {
+		// Not less than == greater than or equal to
+		if !t.less(t.nodes[pos].value, t.nodes[n].value) {
 			loser := pos
 			// Record pos as the loser here, and the old loser is the new winner.
 			pos = t.nodes[n].index

--- a/pkg/util/loser/tree_test.go
+++ b/pkg/util/loser/tree_test.go
@@ -95,6 +95,21 @@ var testCases = []struct {
 		want: NewList(1, 2, 3, 4, 5),
 	},
 	{
+		name: "two lists, largest value in first list equal to maximum",
+		args: []*List{NewList(1, math.MaxUint64), NewList(2, 3)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, largest value in second list equal to maximum",
+		args: []*List{NewList(1, 3), NewList(2, math.MaxUint64)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, largest value in both lists equal to maximum",
+		args: []*List{NewList(1, math.MaxUint64), NewList(2, math.MaxUint64)},
+		want: NewList(1, 2, math.MaxUint64, math.MaxUint64),
+	},
+	{
 		name: "three lists",
 		args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
 		want: NewList(1, 2, 3, 4, 5),


### PR DESCRIPTION
**What this PR does / why we need it**:
The loser tree implementation in `util/loser` skips values equal to the tree's maximum value.

This PR adds some tests to demonstrate the problem and fixes the issue.

**Which issue(s) this PR fixes**:
(none)

**Special notes for your reviewer**:
I don't think this issue is likely to occur in the wild with Loki's current use of this package, but it might be an issue for other uses in the future. (I found this issue when using this package to merge lists of ring tokens, for example.)

I'm not sure if this change warrants a changelog entry - happy to add one if necessary.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [n/a] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [n/a] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
