### PR TITLE
Fix CHANGELOG link

### DIFF
--- a/docs/sources/release-notes/v2-8.md
+++ b/docs/sources/release-notes/v2-8.md
@@ -14,7 +14,7 @@ Grafana Labs is excited to announce the release of Loki 2.8. Here's a summary of
 - **New `backend` target** A new, third target was added to Loki's _scalable_ configuration, which is the default configuration used in the Loki helm chart. This allows Loki to be run as 3 targets (`read`, `write`, and `backend`) and makes the `read` target stateless and therefore able to be run as a Kubernetes deployment that can be scaled automatically.
 
 
-For a full list of all changes please look at the [CHANGELOG](https://github.com/grafana/loki/blob/main/CHANGELOG.md).
+For a full list of all changes please look at the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.8.x/CHANGELOG.md).
 
 ## Upgrade Considerations
 


### PR DESCRIPTION
https://github.com/grafana/loki/pull/9048 only updated the link in the `/next` version of the docs which reflects `main`. This will update the `/latest` link which reflects the latest version (2.8).