### PR TITLE
loser tree: allow sequences to contain maxVal

### DIFF
--- a/pkg/util/loser/tree_test.go
+++ b/pkg/util/loser/tree_test.go
@@ -95,6 +95,31 @@ var testCases = []struct {
 		want: NewList(1, 2, 3, 4, 5),
 	},
 	{
+		name: "two lists, largest value in first list equal to maximum",
+		args: []*List{NewList(1, math.MaxUint64), NewList(2, 3)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, first straddles second and has maxval",
+		args: []*List{NewList(1, 3, math.MaxUint64), NewList(2)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, largest value in second list equal to maximum",
+		args: []*List{NewList(1, 3), NewList(2, math.MaxUint64)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, second straddles first and has maxval",
+		args: []*List{NewList(2), NewList(1, 3, math.MaxUint64)},
+		want: NewList(1, 2, 3, math.MaxUint64),
+	},
+	{
+		name: "two lists, largest value in both lists equal to maximum",
+		args: []*List{NewList(1, math.MaxUint64), NewList(2, math.MaxUint64)},
+		want: NewList(1, 2, math.MaxUint64, math.MaxUint64),
+	},
+	{
 		name: "three lists",
 		args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
 		want: NewList(1, 2, 3, 4, 5),


### PR DESCRIPTION
**What this PR does / why we need it**:

The tree stores the loser in each node, or maxVal if the sequence has ended. If sequences can contain maxVal, we need to take care not to let an ended sequence overtake an active one.

Some test cases from Charles who pointed out the issue in #9053.

Note this situation cannot happen for real in Loki, since we don't expect log lines with a timestamp that far into the future,
but this is supposed to be a re-usable library.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
