### PR TITLE
Added list of supported scrapes to top of page to save reading the wh…

### DIFF
--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -7,7 +7,7 @@ description: Promtail Scraping (Service Discovery)
 Promtail currently supports scraping from the following sources:
 - {{< relref "#file-target-discovery" >}}
 - {{< relref "#kubernetes-discovery" >}}
-- Journal (Linux Only)
+-  {{< relref "#journal-scraping-linux-only" >}} 
 - GCP Logs
 - Syslog
 - Kafka

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -5,7 +5,7 @@ description: Promtail Scraping (Service Discovery)
 # Scraping
 
 Promtail currently supports scraping from the following sources:
-- Files
+- {{< relref "#file-target-discovery" >}}
 - Kubernetes Discovery
 - Journal (Linux Only)
 - GCP Logs

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -6,7 +6,7 @@ description: Promtail Scraping (Service Discovery)
 
 Promtail currently supports scraping from the following sources:
 - {{< relref "#file-target-discovery" >}}
-- Kubernetes Discovery
+- {{< relref "#kubernetes-discovery" >}}
 - Journal (Linux Only)
 - GCP Logs
 - Syslog

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -4,6 +4,17 @@ description: Promtail Scraping (Service Discovery)
 ---
 # Scraping
 
+Promtail currently supports scraping from the following sources:
+- Files
+- Kubernetes Discovery
+- Journal (Linux Only)
+- GCP Logs
+- Syslog
+- Kafka
+- GELF
+- Cloudflare
+- Heroku Drain
+
 ## File Target Discovery
 
 Promtail discovers locations of log files and extract labels from them through


### PR DESCRIPTION
**What this PR does / why we need it**:
I have added list of supported scrapes to top of page to save reading the whole thing. This provides a simple way for me to provide a link to a list of supported inputs rather than ask customers to read the whole page. Much easier for sharing information