### PR TITLE
Add release notes appender action

### DIFF
--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -1,0 +1,27 @@
+---
+name: Append to Release Notes
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v3.3.0
+        with:
+          repository: "trevorwhitney/grafana-github-actions"
+          path: ./actions
+          ref: release-notes-action
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/release-notes-appender
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"
+          releaseNotesFile: docs/sources/release-notes/v2-8.md


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to remove the manual process required to create release notes during a release. It will allow contributors to add the label `add-to-release-notes` to any PR. When that PR is merged, this action will create another PR appending the original PR's # and title to the release notes for the next release. This second PR will give the author an opportunity to add a description to their addition, as well as give maintainers an opportunity to discuss it's relevance in the release notes.

If we move forward with this approach, I will follow up with an addition to the PR template to ask contributors if they think their PR is worthy of mention in the next releases' release notes, and if so to add the label.

**Special notes for your reviewer**:

Currently in draft while I'm working out the kinks in the action, will publish when everything's working. Since it's a GitHub action that runs off of PRs, it's hard to test without first having the PR.
