### PR TITLE
Add release notes appender action

### DIFF
--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: "trevorwhitney/grafana-github-actions"
           path: ./actions
-          ref: 01725b6aaaca42e31776a5d35d26a110346b4a15
+          ref: 0d27c31b3f0c39f6f1f4378aa11b18f9a9fa6c23
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run release notes appender

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           repository: "trevorwhitney/grafana-github-actions"
           path: ./actions

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: "trevorwhitney/grafana-github-actions"
           path: ./actions
-          ref: release-notes-action
+          ref: d2320e2d28dee87520455ed4f7ab7522e088ea11
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run release notes appender

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: "trevorwhitney/grafana-github-actions"
           path: ./actions
-          ref: 0d27c31b3f0c39f6f1f4378aa11b18f9a9fa6c23
+          ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run release notes appender

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -3,6 +3,7 @@ name: Append to Release Notes
 on:
   pull_request_target:
     types:
+      - closed
       - labeled
 
 jobs:
@@ -17,11 +18,11 @@ jobs:
           ref: release-notes-action
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Run backport
+      - name: Run release notes appender
         uses: ./actions/release-notes-appender
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
-          labelsToAdd: "backport"
+          labelsToAdd: "release-notes"
           title: "[{{base}}] {{originalTitle}}"
           releaseNotesFile: docs/sources/release-notes/v2-8.md

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -1,0 +1,27 @@
+---
+name: Append to Release Notes
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v3.3.0
+        with:
+          repository: "trevorwhitney/grafana-github-actions"
+          path: ./actions
+          ref: release-notes-action
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/release-notes-appender
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"
+          releaseNotesFile: docs/sources/release-notes/v2-8.md

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -24,4 +24,4 @@ jobs:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
           labelsToAdd: "release-notes"
-          releaseNotesFile: docs/sources/release-notes/v2-8.md
+          releaseNotesFile: docs/sources/release-notes/next.md

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@v3
         with:
-          repository: "trevorwhitney/grafana-github-actions"
+          repository: "grafana/grafana-github-actions"
           path: ./actions
           ref: main
       - name: Install Actions

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -24,5 +24,4 @@ jobs:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
           labelsToAdd: "release-notes"
-          title: "[{{base}}] {{originalTitle}}"
           releaseNotesFile: docs/sources/release-notes/v2-8.md

--- a/.github/workflows/append-release-notes.yml
+++ b/.github/workflows/append-release-notes.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: "trevorwhitney/grafana-github-actions"
           path: ./actions
-          ref: d2320e2d28dee87520455ed4f7ab7522e088ea11
+          ref: 01725b6aaaca42e31776a5d35d26a110346b4a15
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run release notes appender

--- a/docs/sources/release-notes/next.md
+++ b/docs/sources/release-notes/next.md
@@ -1,0 +1,13 @@
+---
+title: V?.?
+description: Version ?.? release notes
+weight: 100000
+---
+
+# V?.?
+Grafana Labs is excited to announce the release of Loki ?.?. Here's a summary of new enhancements and important fixes:
+
+:warning: This a placeholder for the nex release. Please clean up all features listed below
+
+## Features and enhancements
+

--- a/docs/sources/release-notes/next.md
+++ b/docs/sources/release-notes/next.md
@@ -7,7 +7,7 @@ weight: 100000
 # V?.?
 Grafana Labs is excited to announce the release of Loki ?.?. Here's a summary of new enhancements and important fixes:
 
-:warning: This a placeholder for the nex release. Please clean up all features listed below
+:warning: This a placeholder for the next release. Please clean up all features listed below
 
 ## Features and enhancements
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to remove the manual process required to create release notes during a release. It will allow contributors to add the label `add-to-release-notes` to any PR. When that PR is merged, this action will create another PR appending the original PR's # and title to the release notes for the next release. This second PR will give the author an opportunity to add a description to their addition, as well as give maintainers an opportunity to discuss it's relevance in the release notes.

If we move forward with this approach, I will follow up with an addition to the PR template to ask contributors if they think their PR is worthy of mention in the next releases' release notes, and if so to add the label.

Depends on new [github action](https://github.com/grafana/grafana-github-actions/pull/138). After both these PRs are merged I'll follow up with a PR to change the workflow to point to the version in the grafana repo.

