### PR TITLE
makes test pass for 0 sharding factor (equivalent to no sharding)

### DIFF
--- a/pkg/storage/stores/tsdb/index/shard.go
+++ b/pkg/storage/stores/tsdb/index/shard.go
@@ -57,6 +57,11 @@ func (shard ShardAnnotation) RequiredBits() uint64 {
 }
 
 func (shard ShardAnnotation) Validate() error {
+	if shard.Of == 0 {
+		// 0 factor is explicitly not sharding
+		return nil
+	}
+
 	if shard.Of == 1 {
 		return errDisallowedIdentityShard
 	}


### PR DESCRIPTION
Saw validation tests failing due to this on `main`; not sure how this hasn't borked our builds but this ensures we don't error on shard-factors of zero (equivalent to not sharding). This doesn't actually hit our code paths because we explicitly shortcut factor=0 in the shardmapper.