### PR TITLE
Tsdb/v3

### DIFF
--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -39,8 +39,8 @@ func (m *IndexStatsResponse) AddStream(_ model.Fingerprint) {
 // Safe for concurrent use
 func (m *IndexStatsResponse) AddChunkStats(s index.ChunkStats) {
 	atomic.AddUint64(&m.Chunks, s.Chunks)
-	atomic.AddUint64(&m.Bytes, uint64(s.KB<<10))
-	atomic.AddUint64(&m.Entries, uint64(s.Entries))
+	atomic.AddUint64(&m.Bytes, s.KB<<10)
+	atomic.AddUint64(&m.Entries, s.Entries)
 }
 
 func (m *IndexStatsResponse) Stats() IndexStatsResponse {

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -37,10 +37,10 @@ func (m *IndexStatsResponse) AddStream(_ model.Fingerprint) {
 }
 
 // Safe for concurrent use
-func (m *IndexStatsResponse) AddChunk(_ model.Fingerprint, chk index.ChunkMeta) {
-	atomic.AddUint64(&m.Chunks, 1)
-	atomic.AddUint64(&m.Bytes, uint64(chk.KB<<10))
-	atomic.AddUint64(&m.Entries, uint64(chk.Entries))
+func (m *IndexStatsResponse) AddChunkStats(s index.ChunkStats) {
+	atomic.AddUint64(&m.Chunks, s.Chunks)
+	atomic.AddUint64(&m.Bytes, uint64(s.KB<<10))
+	atomic.AddUint64(&m.Entries, uint64(s.Entries))
 }
 
 func (m *IndexStatsResponse) Stats() IndexStatsResponse {

--- a/pkg/storage/stores/index/stats/stats.go
+++ b/pkg/storage/stores/index/stats/stats.go
@@ -96,8 +96,8 @@ func (b *Blooms) AddStream(fp model.Fingerprint) {
 	})
 }
 
-func (b *Blooms) AddChunk(fp model.Fingerprint, chk index.ChunkMeta) {
-	b.stats.AddChunk(fp, chk)
+func (b *Blooms) AddChunkStats(s index.ChunkStats) {
+	b.stats.AddChunkStats(s)
 }
 
 func (b *Blooms) add(filter *bloom.BloomFilter, key []byte, update func()) {

--- a/pkg/storage/stores/tsdb/head_read.go
+++ b/pkg/storage/stores/tsdb/head_read.go
@@ -146,6 +146,30 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int6
 	return s.fp, nil
 }
 
+func (h *headIndexReader) ChunkStats(ref storage.SeriesRef, from, through int64, lbls *labels.Labels) (uint64, index.ChunkStats, error) {
+	s := h.head.series.getByID(uint64(ref))
+
+	if s == nil {
+		h.head.metrics.seriesNotFound.Inc()
+		return 0, index.ChunkStats{}, storage.ErrNotFound
+	}
+	*lbls = append((*lbls)[:0], s.ls...)
+
+	queryBounds := newBounds(model.Time(from), model.Time(through))
+
+	var res index.ChunkStats
+	s.Lock()
+	for _, chk := range s.chks {
+		if !Overlap(chk, queryBounds) {
+			continue
+		}
+		res.AddChunk(&chk, from, through)
+	}
+	s.Unlock()
+
+	return s.fp, res, nil
+}
+
 // LabelValueFor returns label value for the given label name in the series referred to by ID.
 func (h *headIndexReader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
 	memSeries := h.head.series.getByID(uint64(id))

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -3,6 +3,7 @@ package index
 import (
 	"sort"
 
+	"github.com/grafana/loki/pkg/util/encoding"
 	"github.com/prometheus/common/model"
 )
 
@@ -182,6 +183,20 @@ func (m *chunkPageMarker) combine(c ChunkMeta) {
 	if c.MaxTime > m.MaxTime {
 		m.MaxTime = c.MaxTime
 	}
+}
+
+func (m *chunkPageMarker) put(e *encoding.Encbuf, offset int) {
+	// put chunks, kb, entries, offset, mintime, maxtime
+	e.PutBE32(m.Chunks)
+	e.PutBE32(m.KB)
+	e.PutBE32(m.Entries)
+	e.PutUvarint(offset)
+	e.PutVarint64(m.MinTime)
+	e.PutVarint64(m.MaxTime - m.MinTime) // delta-encoded
+}
+
+func (m *chunkPageMarker) clear() {
+	*m = chunkPageMarker{}
 }
 
 // How many bytes must be allocated to encode this in TSDB.

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -217,7 +217,7 @@ func (m *chunkPageMarker) decode(d *encoding.Decbuf) {
 // Chunks per page. This is encoded into the binary
 // format and can thus be changed without needing a
 // new schema version
-const ChunkPageSize = 512
+const ChunkPageSize = 128
 
 type chunkPageMarkers []chunkPageMarker
 

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -178,6 +178,11 @@ type chunkPageMarker struct {
 
 	// bounds associated with this page
 	MinTime, MaxTime int64
+
+	// internal field to test if MinTime has been set since the zero
+	// value is valid and I don't want to use a pointer. This is only
+	// used during encoding.
+	minTimeSet bool
 }
 
 func (m *chunkPageMarker) subsetOf(from, through int64) bool {
@@ -187,8 +192,9 @@ func (m *chunkPageMarker) subsetOf(from, through int64) bool {
 func (m *chunkPageMarker) combine(c ChunkMeta) {
 	m.KB += c.KB
 	m.Entries += c.Entries
-	if c.MinTime < m.MinTime {
+	if !m.minTimeSet || c.MinTime < m.MinTime {
 		m.MinTime = c.MinTime
+		m.minTimeSet = true
 	}
 	if c.MaxTime > m.MaxTime {
 		m.MaxTime = c.MaxTime

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -3,8 +3,9 @@ package index
 import (
 	"sort"
 
-	"github.com/grafana/loki/pkg/util/encoding"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/util/encoding"
 )
 
 // Meta holds information about a chunk of data.

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -261,8 +261,8 @@ func (cs *ChunkStats) AddChunk(chk *ChunkMeta, from, through int64) {
 	// to use it as a factor to get the amount of bytes and entries
 	// factor = C = (T - (A + B)) / T = (chunkTime - (leadingTime + trailingTime)) / chunkTime
 	chunkTime := chk.MaxTime - chk.MinTime
-	leadingTime := math.Max64(0, int64(from)-chk.MinTime)
-	trailingTime := math.Max64(0, chk.MaxTime-int64(through))
+	leadingTime := math.Max64(0, from-chk.MinTime)
+	trailingTime := math.Max64(0, chk.MaxTime-through)
 	factor := float32(chunkTime-(leadingTime+trailingTime)) / float32(chunkTime)
 
 	kb := uint32(float32(chk.KB) * factor)

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -230,7 +230,7 @@ const ChunkPageSize = 16
 
 // Minimum number of chunks present to use page based lookup
 // instead of linear scan which performs better at lower n-values.
-const MaxChunksToBypassMarkerLookup = 64
+const DefaultMaxChunksToBypassMarkerLookup = 64
 
 type chunkPageMarkers []chunkPageMarker
 

--- a/pkg/storage/stores/tsdb/index/chunk.go
+++ b/pkg/storage/stores/tsdb/index/chunk.go
@@ -224,10 +224,15 @@ func (m *chunkPageMarker) decode(d *encoding.Decbuf) {
 	m.MaxTime = m.MinTime + d.Varint64()
 }
 
-// Chunks per page. This is encoded into the binary
-// format and can thus be changed without needing a
-// new schema version
-const ChunkPageSize = 128
+// Chunks per page. This can be inferred in the data format
+// via the ChunksRemaining field
+// and can thus be changed without needing a
+// new tsdb version
+const ChunkPageSize = 16
+
+// Minimum number of chunks present to use page based lookup
+// instead of linear scan which performs better at lower n-values.
+const MaxChunksToBypassMarkerLookup = 64
 
 type chunkPageMarkers []chunkPageMarker
 

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/prometheus/prometheus/storage"
 	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
 
@@ -441,9 +440,7 @@ func TestChunkEncodingRoundTrip(t *testing.T) {
 					w.addChunks(chks, &primary, &scratch, pageSize)
 
 					decbuf := encoding.DecWrap(tsdb_enc.Decbuf{B: primary.Get()})
-					dec := &Decoder{
-						chunksSample: map[storage.SeriesRef]*chunkSamples{},
-					}
+					dec := newDecoder(nil, 0)
 
 					dst := []ChunkMeta{}
 					require.Nil(t, dec.readChunks(version, &decbuf, 0, 0, math.MaxInt64, &dst))
@@ -541,9 +538,7 @@ func TestSearchWithPageMarkers(t *testing.T) {
 				w.addChunks(tc.chks, &primary, &scratch, pageSize)
 
 				decbuf := encoding.DecWrap(tsdb_enc.Decbuf{B: primary.Get()})
-				dec := &Decoder{
-					chunksSample: map[storage.SeriesRef]*chunkSamples{},
-				}
+				dec := newDecoder(nil, 0)
 				dst := []ChunkMeta{}
 				require.Nil(t, dec.readChunksV3(&decbuf, tc.mint, tc.maxt, &dst))
 				require.Equal(t, tc.exp, dst)
@@ -657,9 +652,7 @@ func TestDecoderChunkStats(t *testing.T) {
 					w.addChunks(tc.chks, &primary, &scratch, pageSize)
 
 					decbuf := encoding.DecWrap(tsdb_enc.Decbuf{B: primary.Get()})
-					dec := &Decoder{
-						chunksSample: map[storage.SeriesRef]*chunkSamples{},
-					}
+					dec := newDecoder(nil, 0)
 
 					stats, err := dec.readChunkStats(version, &decbuf, 1, tc.from, tc.through)
 					require.Nil(t, err)
@@ -683,9 +676,7 @@ func BenchmarkChunkStats(b *testing.B) {
 				scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 				w.addChunks(chks, &primary, &scratch, ChunkPageSize)
 
-				dec := &Decoder{
-					chunksSample: map[storage.SeriesRef]*chunkSamples{},
-				}
+				dec := newDecoder(nil, DefaultMaxChunksToBypassMarkerLookup)
 				for i := 0; i < b.N; i++ {
 					decbuf := encoding.DecWrap(tsdb_enc.Decbuf{B: primary.Get()})
 
@@ -710,9 +701,7 @@ func BenchmarkReadChunks(b *testing.B) {
 				scratch := encoding.EncWrap(tsdb_enc.Encbuf{B: make([]byte, 0)})
 				w.addChunks(chks, &primary, &scratch, ChunkPageSize)
 
-				dec := &Decoder{
-					chunksSample: map[storage.SeriesRef]*chunkSamples{},
-				}
+				dec := newDecoder(nil, DefaultMaxChunksToBypassMarkerLookup)
 				for i := 0; i < b.N; i++ {
 					decbuf := encoding.DecWrap(tsdb_enc.Decbuf{B: primary.Get()})
 

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -586,12 +586,15 @@ func TestDecoderChunkStats(t *testing.T) {
 						{MinTime: 1, MaxTime: 2, KB: 1, Entries: 1},
 						{MinTime: 2, MaxTime: 3, KB: 1, Entries: 1},
 						{MinTime: 3, MaxTime: 4, KB: 1, Entries: 1},
-						{MinTime: 4, MaxTime: 5, KB: 1, Entries: 1},
+						{MinTime: 5, MaxTime: 6, KB: 1, Entries: 1},
 					},
 					from:    2,
-					through: 3,
+					through: 4,
 					exp: ChunkStats{
-						Chunks:  2,
+						// technically the 2nd chunk overlaps, but we don't add
+						// any of it's stats as its only 1 nanosecond in the range
+						// and thus gets integer-divisioned to 0
+						Chunks:  3,
 						KB:      2,
 						Entries: 2,
 					},
@@ -618,9 +621,11 @@ func TestDecoderChunkStats(t *testing.T) {
 					from:    4,
 					through: 9,
 					exp: ChunkStats{
+						// same deal with previous case, 1ns overlap isn't enough
+						// to include its data
 						Chunks:  6,
-						KB:      6,
-						Entries: 6,
+						KB:      5,
+						Entries: 5,
 					},
 				},
 			} {
@@ -643,7 +648,6 @@ func TestDecoderChunkStats(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func BenchmarkChunkStats(b *testing.B) {

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -5,10 +5,11 @@ import (
 	"math"
 	"testing"
 
-	"github.com/grafana/loki/pkg/util/encoding"
 	"github.com/prometheus/prometheus/storage"
 	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/util/encoding"
 )
 
 // Test all sort variants

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -377,12 +377,12 @@ func TestChunkMetas_Drop(t *testing.T) {
 func TestChunkPageMarkerEncodeDecode(t *testing.T) {
 	// Create a chunk page marker.
 	marker := chunkPageMarker{
-		ChunksRemaining: 1,
-		KB:              2,
-		Entries:         3,
-		Offset:          4,
-		MinTime:         5,
-		MaxTime:         6,
+		ChunksInPage: 1,
+		KB:           2,
+		Entries:      3,
+		Offset:       4,
+		MinTime:      5,
+		MaxTime:      6,
 	}
 
 	// Encode the chunk page marker.

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -461,7 +461,10 @@ func TestChunkEncodingRoundTrip(t *testing.T) {
 }
 
 func TestSearchWithPageMarkers(t *testing.T) {
-	for _, pageSize := range []int{2, 10} {
+	for _, pageSize := range []int{
+		2,
+		10,
+	} {
 		for _, tc := range []struct {
 			desc       string
 			chks, exp  []ChunkMeta
@@ -510,6 +513,23 @@ func TestSearchWithPageMarkers(t *testing.T) {
 					{MinTime: 1, MaxTime: 2},
 					{MinTime: 2, MaxTime: 3},
 					{MinTime: 3, MaxTime: 4},
+				},
+			},
+			{
+				desc: "semi ordered chunks",
+				chks: []ChunkMeta{
+					{MinTime: 5, MaxTime: 50},
+					{MinTime: 10, MaxTime: 20},
+					{MinTime: 11, MaxTime: 20},
+					{MinTime: 12, MaxTime: 20},
+					{MinTime: 13, MaxTime: 20},
+					{MinTime: 15, MaxTime: 30},
+				},
+				mint: 25,
+				maxt: 30,
+				exp: []ChunkMeta{
+					{MinTime: 5, MaxTime: 50},
+					{MinTime: 15, MaxTime: 30},
 				},
 			},
 		} {

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -2343,8 +2343,8 @@ func (dec *Decoder) readChunkStatsV3(d *encoding.Decbuf, from, through int64) (r
 
 func (dec *Decoder) accumulateChunkStats(d *encoding.Decbuf, nChunks int, from, through int64) (res ChunkStats, err error) {
 	var prevMaxT int64
+	chunkMeta := &ChunkMeta{}
 	for i := 0; i < nChunks; i++ {
-		chunkMeta := &ChunkMeta{}
 		if err := readChunkMeta(d, prevMaxT, chunkMeta); err != nil {
 			return res, errors.Wrap(d.Err(), "read meta for chunk")
 		}

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -63,7 +63,7 @@ const (
 	millisecondsInHour = int64(time.Hour / time.Millisecond)
 
 	// The format that will be written by this process
-	LiveFormat = FormatV3
+	LiveFormat = FormatV2
 )
 
 type indexWriterStage uint8

--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -215,8 +215,7 @@ func NewTOCFromByteSlice(bs ByteSlice) (*TOC, error) {
 	}, nil
 }
 
-// NewWriter returns a new Writer to the given filename. It serializes data in format version 2.
-func NewWriter(ctx context.Context, fn string) (*Writer, error) {
+func NewWriterWithVersion(ctx context.Context, version int, fn string) (*Writer, error) {
 	dir := filepath.Dir(fn)
 
 	df, err := fileutil.OpenDir(dir)
@@ -249,7 +248,7 @@ func NewWriter(ctx context.Context, fn string) (*Writer, error) {
 	}
 
 	iw := &Writer{
-		Version: LiveFormat,
+		Version: version,
 		ctx:     ctx,
 		f:       f,
 		fP:      fP,
@@ -268,6 +267,11 @@ func NewWriter(ctx context.Context, fn string) (*Writer, error) {
 		return nil, err
 	}
 	return iw, nil
+}
+
+// NewWriter returns a new Writer to the given filename. It serializes data according to the `LiveFormat` version
+func NewWriter(ctx context.Context, fn string) (*Writer, error) {
+	return NewWriterWithVersion(ctx, LiveFormat, fn)
 }
 
 func (w *Writer) write(bufs ...[]byte) error {

--- a/pkg/storage/stores/tsdb/index/index_test.go
+++ b/pkg/storage/stores/tsdb/index/index_test.go
@@ -29,12 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/grafana/loki/pkg/util/encoding"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/util/testutil"
+
+	"github.com/grafana/loki/pkg/util/encoding"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/storage/stores/tsdb/index/index_test.go
+++ b/pkg/storage/stores/tsdb/index/index_test.go
@@ -720,7 +720,7 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			iw, err := NewWriter(context.Background(), filepath.Join(dir, name))
+			iw, err := NewWriterWithVersion(context.Background(), FormatV2, filepath.Join(dir, name))
 			require.NoError(t, err)
 
 			syms := []string{}

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -42,7 +42,7 @@ func DefaultIndexClientOptions() IndexClientOptions {
 
 type IndexStatsAccumulator interface {
 	AddStream(fp model.Fingerprint)
-	AddChunk(fp model.Fingerprint, chk index.ChunkMeta)
+	AddChunkStats(s index.ChunkStats)
 	Stats() stats.Stats
 }
 

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -186,7 +186,9 @@ func TestIndexClient_Stats(t *testing.T) {
 				Start: indexStartToday + 50,
 				End:   indexStartToday + 60,
 			},
-			expectedNumChunks:  1, // end time not inclusive
+			// end time is inclusive because chunks are indexed by their start and end, although the chunk's stats contributions get reduced to zero
+			// in integer division due to 1 nanosecond overlap
+			expectedNumChunks:  2,
 			expectedNumEntries: 10,
 			expectedNumStreams: 1,
 			expectedNumBytes:   10 * 1024,

--- a/pkg/storage/stores/tsdb/querier.go
+++ b/pkg/storage/stores/tsdb/querier.go
@@ -68,6 +68,9 @@ type IndexReader interface {
 	// Returns storage.ErrNotFound if the ref does not resolve to a known series.
 	Series(ref storage.SeriesRef, from int64, through int64, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
 
+	// ChunkStats returns the stats for the chunks in the given series.
+	ChunkStats(ref storage.SeriesRef, from, through int64, lset *labels.Labels) (uint64, index.ChunkStats, error)
+
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)
 

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -103,6 +103,7 @@ func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
 // fn must NOT capture it's arguments. They're reused across series iterations and returned to
 // a pool after completion.
 func (i *TSDBIndex) forSeries(ctx context.Context, shard *index.ShardAnnotation, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta), matchers ...*labels.Matcher) error {
+	// TODO(owen-d): use pool
 	var ls labels.Labels
 	chks := ChunkMetasPool.Get()
 	defer ChunkMetasPool.Put(chks)
@@ -225,6 +226,7 @@ func (i *TSDBIndex) Identifier(string) SingleTenantTSDBIdentifier {
 
 func (i *TSDBIndex) Stats(ctx context.Context, userID string, from, through model.Time, acc IndexStatsAccumulator, shard *index.ShardAnnotation, shouldIncludeChunk shouldIncludeChunk, matchers ...*labels.Matcher) error {
 	return i.forPostings(ctx, shard, from, through, matchers, func(p index.Postings) error {
+		// TODO(owen-d): use pool
 		var ls labels.Labels
 		var filterer chunk.Filterer
 		if i.chunkFilter != nil {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -16,6 +16,10 @@ type Encbuf struct {
 
 func (e *Encbuf) PutString(s string) { e.B = append(e.B, s...) }
 
+func (e *Encbuf) Skip(i int) {
+	e.B = e.B[:len(e.B)+i]
+}
+
 func DecWith(b []byte) (res Decbuf) {
 	res.B = b
 	return res


### PR DESCRIPTION
brief: adds page support for chunks within a series. This lets us do a few optimizations, most notably skipping chunk ranges that don't overlap with our query bounds. It also allows us to use aggregated stats for pages when computing `Stats` calls that completely overlap all chunks in a page.

teaser:
```
pkg: github.com/grafana/loki/pkg/storage/stores/tsdb/index
BenchmarkChunkStats/version_2/2_chunks-10         	10121240	       109.4 ns/op	      24 B/op	       1 allocs/op
BenchmarkChunkStats/version_3/2_chunks-10         	27591069	        43.51 ns/op	       0 B/op	       0 allocs/op
BenchmarkChunkStats/version_2/4_chunks-10         	 9410245	       128.7 ns/op	      24 B/op	       1 allocs/op
BenchmarkChunkStats/version_3/4_chunks-10         	21808070	        54.44 ns/op	       0 B/op	       0 allocs/op
BenchmarkChunkStats/version_2/10_chunks-10        	 6048235	       201.3 ns/op	      24 B/op	       1 allocs/op
BenchmarkChunkStats/version_3/10_chunks-10        	 9517605	       125.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkChunkStats/version_2/100_chunks-10       	 1000000	      1081 ns/op	      24 B/op	       1 allocs/op
BenchmarkChunkStats/version_3/100_chunks-10       	 1669972	       715.4 ns/op	     528 B/op	       3 allocs/op
BenchmarkChunkStats/version_2/1000_chunks-10      	  118125	     10165 ns/op	      24 B/op	       1 allocs/op
BenchmarkChunkStats/version_3/1000_chunks-10      	  570576	      2125 ns/op	    4816 B/op	       6 allocs/op
BenchmarkChunkStats/version_2/10000_chunks-10     	   10000	    117447 ns/op	  123014 B/op	       3 allocs/op
BenchmarkChunkStats/version_3/10000_chunks-10     	   74524	     16225 ns/op	   48601 B/op	       9 allocs/op
BenchmarkChunkStats/version_2/100000_chunks-10    	     842	   1240380 ns/op	 3211679 B/op	      13 allocs/op
BenchmarkChunkStats/version_3/100000_chunks-10    	    8494	    141169 ns/op	  516530 B/op	      13 allocs/op

```

```
pkg: github.com/grafana/loki/pkg/storage/stores/tsdb/index
BenchmarkReadChunks/version_2/2_chunks-10         	13673050	        80.52 ns/op	     172 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/2_chunks-10         	25713412	        64.06 ns/op	     201 B/op	       0 allocs/op
BenchmarkReadChunks/version_2/4_chunks-10         	12302040	        96.56 ns/op	     373 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/4_chunks-10         	20512030	        84.93 ns/op	     346 B/op	       0 allocs/op
BenchmarkReadChunks/version_2/10_chunks-10        	 6974947	       168.7 ns/op	     490 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/10_chunks-10        	 7436360	       161.0 ns/op	     632 B/op	       0 allocs/op
BenchmarkReadChunks/version_2/50_chunks-10        	 2038724	       599.3 ns/op	    2034 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/50_chunks-10        	 2251822	       619.8 ns/op	    1926 B/op	       0 allocs/op
BenchmarkReadChunks/version_2/100_chunks-10       	  946430	      1092 ns/op	    4132 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/100_chunks-10       	 1467297	      1000 ns/op	    3308 B/op	       1 allocs/op
BenchmarkReadChunks/version_2/150_chunks-10       	  674575	      1721 ns/op	    5767 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/150_chunks-10       	 1000000	      1373 ns/op	    6171 B/op	       1 allocs/op
BenchmarkReadChunks/version_2/1000_chunks-10      	  109153	     10554 ns/op	   33063 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/1000_chunks-10      	  158086	      6963 ns/op	   32829 B/op	       1 allocs/op
BenchmarkReadChunks/version_2/10000_chunks-10     	    9043	    114121 ns/op	  345258 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/10000_chunks-10     	   22083	     79896 ns/op	  435493 B/op	       1 allocs/op
BenchmarkReadChunks/version_2/100000_chunks-10    	    1039	   1103621 ns/op	 3479873 B/op	       0 allocs/op
BenchmarkReadChunks/version_3/100000_chunks-10    	    2101	   1155419 ns/op	 4680266 B/op	       1 allocs/op
```
