### PR TITLE
Helm: Ability to change loki-read and loki-write services to NodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,5 @@ If you would like to add your organization to the list, please open a PR to add 
 ## License
 
 Grafana Loki is distributed under [AGPL-3.0-only](LICENSE). For Apache-2.0 exceptions, see [LICENSING.md](LICENSING.md).
+
+# changes

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -3512,6 +3512,33 @@ null
 		<tr>
 			<td>read.service.annotations</td>
 			<td>object</td>
+			<td>Annotations for the read Service</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>read.service.clusterIP</td>
+			<td>string</td>
+			<td>ClusterIP of the read Service</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>read.service.type</td>
+			<td>string</td>
+			<td>Type of the read Service</td>
+			<td><pre lang="json">
+"ClusterIP"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>read.serviceLabels</td>
+			<td>object</td>
 			<td>Annotations for read Service</td>
 			<td><pre lang="json">
 {}
@@ -4820,6 +4847,33 @@ null
 		</tr>
 		<tr>
 			<td>write.service.annotations</td>
+			<td>object</td>
+			<td>Annotations for the write Service</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.service.clusterIP</td>
+			<td>string</td>
+			<td>ClusterIP of the write Service</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.service.type</td>
+			<td>string</td>
+			<td>Type of the write Service</td>
+			<td><pre lang="json">
+"ClusterIP"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.serviceLabels</td>
 			<td>object</td>
 			<td>Annotations for write Service</td>
 			<td><pre lang="json">

--- a/production/helm/loki/templates/read/service-read.yaml
+++ b/production/helm/loki/templates/read/service-read.yaml
@@ -21,8 +21,15 @@ metadata:
     {{- with .Values.read.service.annotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
+  {{- with .Values.read.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.read.service.type }}
+  {{- with .Values.read.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/templates/write/service-write.yaml
+++ b/production/helm/loki/templates/write/service-write.yaml
@@ -21,8 +21,15 @@ metadata:
     {{- with .Values.write.service.annotations }}
     {{- toYaml . | nindent 4}}
     {{- end }}
+  {{- with .Values.write.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.write.service.type }}
+  {{- with .Values.write.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   ports:
     - name: http-metrics
       port: 3100

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -786,7 +786,12 @@ write:
   podLabels: {}
   # -- Additional selector labels for each `write` pod
   selectorLabels: {}
+  # Write service configuration
   service:
+    # -- Type of the write Service
+    type: ClusterIP
+    # -- ClusterIP of the write Service
+    clusterIP: null
     # -- Annotations for write Service
     annotations: {}
     # -- Additional labels for write Service
@@ -973,8 +978,13 @@ read:
   podLabels: {}
   # -- Additional selector labels for each `read` pod
   selectorLabels: {}
+  # Read service configuration
   service:
-    # -- Annotations for read Service
+    # -- Type of the read Service
+    type: ClusterIP
+    # -- ClusterIP of the read Service
+    clusterIP: null
+    # -- Annotations for the read Service
     annotations: {}
     # -- Additional labels for read Service
     labels: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
When deployed to AWS EKS, services must be of type `NodePort` if `ingressClassName: alb`. By adding the ability to specify service type for the loki-read and loki-write services, EKS users can now use the chart without loki-gateway. Added ability to specify a `clusterIP` if service `type: ClusterIP`. Added ability to specify annotations for each service. 

**Which issue(s) this PR fixes**:
I never raised an issue for this. I needed it personally, so I wrote it.

**Special notes for your reviewer**:
Previous defaults were added explicitly in values.yaml to maintain backwards compatibility.
