### PR TITLE
Helm chart: add parameter for extra memberlist config

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.0
-version: 5.0.0
+version: 5.0.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -82,6 +82,9 @@ loki:
     {{- end}}
 
     memberlist:
+    {{- if .Values.loki.extraMemberlistConfig}}
+    {{- toYaml .Values.loki.extraMemberlistConfig | nindent 2}}
+    {{- end }}
       join_members:
         - {{ include "loki.memberlist" . }}
         {{- with .Values.migrate.fromDistributed }}
@@ -195,6 +198,8 @@ loki:
     {{- end }}
   # Should authentication be enabled
   auth_enabled: true
+  #  Extra memberlist configuraiton
+  extraMemberlistConfig: {}
   # -- Tenants list to be created on nginx htpasswd file, with name and password keys
   tenants: []
   # -- Check https://grafana.com/docs/loki/latest/configuration/#server for more info on the server configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a helm parameter to allow for adding extra`memberlist` configuration for  the `config.yaml` ConfigMap.

This will allow users to use the workaround described in https://github.com/grafana/loki/issues/6370#issuecomment-1176502466 without having to fork the helm chart as some (@Dunge) have said they've already done so in that issue's discussion. The workaround is not possible with the current helm chart.

**Which issue(s) this PR fixes**:
This provides a workaround for https://github.com/grafana/loki/issues/8634 for the helm chart but does not fix the root cause of the issue, which appears to be caused by some pod deployments not being on expected CIDR ranges.

**Special notes for your reviewer**:
People having trouble with https://github.com/grafana/loki/issues/8634 could set the following override with these changes to achieve [the workaround](https://github.com/grafana/loki/issues/6370#issuecomment-1176502466) without having to fork the chart:
```
loki:
  extraMemberlistConfig:
    bind_addr:
    - ${MY_POD_IP}
singleBinary: # or read/write/backend etc
  extraArgs:
    - -config.expand-env=true
   extraEnv:
     - name: MY_POD_IP
        valueFrom:       
           fieldRef:
             fieldPath: status.podIP
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated 
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
