### PR TITLE
Docs: Update Loki GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Refer to [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Loki can be run in a single host, no-dependencies mode using the following commands.
 
-You need `go`, we recommend using the version found in [our build Dockerfile](https://github.com/grafana/loki/blob/master/loki-build-image/Dockerfile)
+You need `go`, we recommend using the version found in [our build Dockerfile](https://github.com/grafana/loki/blob/main/loki-build-image/Dockerfile)
 
 ```bash
 

--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -1382,8 +1382,8 @@ $ curl -G -s  "http://localhost:3100/api/prom/label" | jq
 `/api/prom/push` is the endpoint used to send log entries to Loki. The default
 behavior is for the POST body to be a snappy-compressed protobuf message:
 
-- [Protobuf definition](https://github.com/grafana/loki/tree/master/pkg/logproto/logproto.proto)
-- [Go client library](https://github.com/grafana/loki/tree/master/pkg/promtail/client/client.go)
+- [Protobuf definition](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto)
+- [Go client library](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go)
 
 Alternatively, if the `Content-Type` header is set to `application/json`, a
 JSON post body can be sent in the following format:

--- a/docs/sources/best-practices/_index.md
+++ b/docs/sources/best-practices/_index.md
@@ -35,7 +35,7 @@ Try to keep values bounded to as small a set as possible. We don't have perfect 
 
 ## Be aware of dynamic labels applied by clients
 
-Loki has several client options: [Promtail](/grafana/loki/tree/master/docs/sources/clients/promtail) (which also supports systemd journal ingestion and TCP-based syslog ingestion), [Fluentd](https://github.com/grafana/loki/tree/main/clients/cmd/fluentd), [Fluent Bit](https://github.com/grafana/loki/tree/main/clients/cmd/fluent-bit), a [Docker plugin](/blog/2019/07/15/lokis-path-to-ga-docker-logging-driver-plugin-support-for-systemd/), and more!
+Loki has several client options: [Promtail](/grafana/loki/blob/main/docs/sources/clients/promtail) (which also supports systemd journal ingestion and TCP-based syslog ingestion), [Fluentd](https://github.com/grafana/loki/tree/main/clients/cmd/fluentd), [Fluent Bit](https://github.com/grafana/loki/tree/main/clients/cmd/fluent-bit), a [Docker plugin](/blog/2019/07/15/lokis-path-to-ga-docker-logging-driver-plugin-support-for-systemd/), and more!
 
 Each of these come with ways to configure what labels are applied to create log streams. But be aware of what dynamic labels might be applied.
 Use the Loki series API to get an idea of what your log streams look like and see if there might be ways to reduce streams and cardinality.

--- a/docs/sources/clients/aws/ec2/_index.md
+++ b/docs/sources/clients/aws/ec2/_index.md
@@ -101,7 +101,7 @@ Now we're going to download the [Promtail configuration]({{< relref "../../promt
 The file is also available as a gist at [cyriltovena/promtail-ec2.yaml][config gist].
 
 ```bash
-curl https://raw.githubusercontent.com/grafana/loki/master/docs/sources/clients/aws/ec2/promtail-ec2.yaml > ec2-promtail.yaml
+curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/ec2/promtail-ec2.yaml > ec2-promtail.yaml
 vi ec2-promtail.yaml
 ```
 
@@ -293,5 +293,5 @@ Let's head back to Grafana and verify that your Promtail logs are available in G
 [live tailing]: https://grafana.com/docs/grafana/latest/features/datasources/loki/#live-tailing
 [systemd]: ../../../installation/helm#run-promtail-with-systemd-journal-support
 [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-[final config]: https://github.com/grafana/loki/blob/master/docs/sources/clients/aws/ec2/promtail-ec2-final.yaml
+[final config]: https://github.com/grafana/loki/blob/main/docs/sources/clients/aws/ec2/promtail-ec2-final.yaml
 [relabeling]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config

--- a/docs/sources/clients/aws/ecs/_index.md
+++ b/docs/sources/clients/aws/ecs/_index.md
@@ -44,7 +44,7 @@ We will also need an [IAM Role to run containers][ecs iam] with, let's create a 
 > You might already have this `ecsTaskExecutionRole` role in your AWS account if that's the case you can skip this step.
 
 ```bash
-curl https://raw.githubusercontent.com/grafana/loki/master/docs/sources/clients/aws/ecs/ecs-role.json > ecs-role.json
+curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/ecs/ecs-role.json > ecs-role.json
 aws iam create-role --role-name ecsTaskExecutionRole  --assume-role-policy-document file://ecs-role.json
 
 {
@@ -93,7 +93,7 @@ Our [task definition][task] will be made of two containers, the [Firelens][Firel
 Let's download the task definition, we'll go through the most important parts.
 
 ```bash
-curl https://raw.githubusercontent.com/grafana/loki/master/docs/sources/clients/aws/ecs/ecs-task.json > ecs-task.json
+curl https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/ecs/ecs-task.json > ecs-task.json
 ```
 
 ```json

--- a/docs/sources/clients/aws/eks/_index.md
+++ b/docs/sources/clients/aws/eks/_index.md
@@ -216,7 +216,7 @@ helm upgrade  promtail loki/promtail -n monitoring -f values.yaml
 And deploy the `eventrouter` using:
 
 ```bash
- kubectl create -f https://raw.githubusercontent.com/grafana/loki/master/docs/sources/clients/aws/eks/eventrouter.yaml
+kubectl create -f https://raw.githubusercontent.com/grafana/loki/main/docs/sources/clients/aws/eks/eventrouter.yaml
 
 serviceaccount/eventrouter created
 clusterrole.rbac.authorization.k8s.io/eventrouter created

--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -124,7 +124,7 @@ next section for all supported options.
 While you can provide `loki-pipeline-stage-file` it can be hard to mount the configuration file to the driver root filesystem.
 This is why another option `loki-pipeline-stages` is available allowing your to pass a list of stages inlined. Pipeline stages are run at last on every lines.
 
-The example [docker-compose](https://github.com/grafana/loki/blob/master/cmd/docker-driver/docker-compose.yaml) below configures 2 stages, one to extract level values and one to set it as a label:
+The example [docker-compose](https://github.com/grafana/loki/blob/main/clients/cmd/docker-driver/docker-compose.yaml) below configures 2 stages, one to extract level values and one to set it as a label:
 
 ```yaml
 version: "3"

--- a/docs/sources/clients/fluentbit/_index.md
+++ b/docs/sources/clients/fluentbit/_index.md
@@ -195,7 +195,7 @@ To configure the Loki output plugin add this section to fluent-bit.conf
     RemoveKeys key1,key2
 ```
 
-A full [example configuration file](https://github.com/grafana/loki/blob/master/clients/cmd/fluent-bit/fluent-bit.conf) is also available in the Loki repository.
+A full [example configuration file](https://github.com/grafana/loki/blob/main/clients/cmd/fluent-bit/fluent-bit.conf) is also available in the Loki repository.
 
 ### Running multiple plugin instances
 

--- a/docs/sources/clients/lambda-promtail/_index.md
+++ b/docs/sources/clients/lambda-promtail/_index.md
@@ -5,7 +5,7 @@ weight: 20
 ---
 # Lambda Promtail
 
-Grafana Loki includes [Terraform](https://www.terraform.io/) and [CloudFormation](https://aws.amazon.com/cloudformation/) for shipping Cloudwatch and loadbalancer logs to Loki via a [lambda function](https://aws.amazon.com/lambda/). This is done via [lambda-promtail](https://github.com/grafana/loki/tree/master/tools/lambda-promtail) which processes cloudwatch events and propagates them to Loki (or a Promtail instance) via the push-api [scrape config]({{<relref "../promtail/configuration#loki_push_api">}}).
+Grafana Loki includes [Terraform](https://www.terraform.io/) and [CloudFormation](https://aws.amazon.com/cloudformation/) for shipping Cloudwatch and loadbalancer logs to Loki via a [lambda function](https://aws.amazon.com/lambda/). This is done via [lambda-promtail](https://github.com/grafana/loki/blob/main/tools/lambda-promtail) which processes cloudwatch events and propagates them to Loki (or a Promtail instance) via the push-api [scrape config]({{<relref "../promtail/configuration#loki_push_api">}}).
 
 ## Deployment
 

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -2058,7 +2058,7 @@ The `tracing` block configures tracing for Jaeger. Currently, limited to configu
 
 It's fairly difficult to tail Docker files on a standalone machine because they are in different locations for every OS.  We recommend the [Docker logging driver]({{<relref "../docker-driver/">}}) for local Docker installs or Docker Compose.
 
-If running in a Kubernetes environment, you should look at the defined configs which are in [helm](https://github.com/grafana/helm-charts/blob/main/charts/promtail/templates/configmap.yaml) and [jsonnet](https://github.com/grafana/loki/tree/master/production/ksonnet/promtail/scrape_config.libsonnet), these leverage the prometheus service discovery libraries (and give Promtail its name) for automatically finding and tailing pods.  The jsonnet config explains with comments what each section is for.
+If running in a Kubernetes environment, you should look at the defined configs which are in [helm](https://github.com/grafana/helm-charts/blob/main/charts/promtail/templates/configmap.yaml) and [jsonnet](https://github.com/grafana/loki/blob/main/production/ksonnet/promtail/scrape_config.libsonnet), these leverage the prometheus service discovery libraries (and give Promtail its name) for automatically finding and tailing pods.  The jsonnet config explains with comments what each section is for.
 
 
 ## Example Static Config

--- a/docs/sources/installation/helm/concepts.md
+++ b/docs/sources/installation/helm/concepts.md
@@ -29,7 +29,7 @@ This chart installs the [canary]({{<relref "../../operations/loki-canary">}}) an
 
 ## Gateway
 
-By default and inspired by Grafana's [Tanka setup](https://github.com/grafana/loki/tree/master/production/ksonnet/loki), the chart
+By default and inspired by Grafana's [Tanka setup](https://github.com/grafana/loki/blob/main/production/ksonnet/loki), the chart
 installs the gateway component which is an NGINX that exposes Loki's API and automatically proxies requests to the correct
 Loki components (read or write, or single instance in the case of filesystem storage).
 The gateway must be enabled if an Ingress is required, since the Ingress exposes the gateway only.

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -4,7 +4,7 @@ description: Releasing Loki Build Image
 ---
 # Releasing Loki Build Image
 
-The [`loki-build-image`](https://github.com/grafana/loki/tree/master/loki-build-image)
+The [`loki-build-image`](https://github.com/grafana/loki/blob/main/loki-build-image)
 is the Docker image used to run tests and build Grafana Loki binaries in CI.
 
 The build and publish process of the image is triggered upon a merge to `main`

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -105,7 +105,7 @@ Review your emitted metrics before scraping with Prometheus, and configure the s
 
 ## Mixins
 
-The Loki repository has a [mixin](https://github.com/grafana/loki/blob/master/production/loki-mixin) that includes a
+The Loki repository has a [mixin](https://github.com/grafana/loki/blob/main/production/loki-mixin) that includes a
 set of dashboards, recording rules, and alerts. Together, the mixin gives you a
 comprehensive package for monitoring Loki in production.
 

--- a/docs/sources/operations/scalability.md
+++ b/docs/sources/operations/scalability.md
@@ -7,7 +7,7 @@ weight: 30
 
 When scaling Loki, operators should consider running several Loki processes
 partitioned by role (ingester, distributor, querier) rather than a single Loki
-process. Grafana Labs' [production setup](https://github.com/grafana/loki/blob/master/production/ksonnet/loki)
+process. Grafana Labs' [production setup](https://github.com/grafana/loki/blob/main/production/ksonnet/loki)
 contains `.libsonnet` files that demonstrates configuring separate components
 and scaling for resource usage.
 

--- a/docs/sources/operations/storage/table-manager/_index.md
+++ b/docs/sources/operations/storage/table-manager/_index.md
@@ -210,4 +210,4 @@ When Loki runs in [microservices mode]({{<relref "../../../fundamentals/architec
 the Table Manager should be started as separate service named `table-manager`.
 
 You can check out a production grade deployment example at
-[`table-manager.libsonnet`](https://github.com/grafana/loki/tree/master/production/ksonnet/loki/table-manager.libsonnet).
+[`table-manager.libsonnet`](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/table-manager.libsonnet).

--- a/docs/sources/storage/_index.md
+++ b/docs/sources/storage/_index.md
@@ -189,7 +189,7 @@ For more information, see the [retention configuration]({{<relref "../operations
 
 ### Single machine/local development (boltdb+filesystem)
 
-[The repo contains a working example](https://github.com/grafana/loki/blob/master/cmd/loki/loki-local-config.yaml), you may want to checkout a tag of the repo to make sure you get a compatible example.
+[The repo contains a working example](https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml), you may want to checkout a tag of the repo to make sure you get a compatible example.
 
 ### GCP deployment (GCS Single Store)
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -1123,7 +1123,7 @@ exit
 docker run -d --name=loki --mount source=loki-data,target=/loki -p 3100:3100 grafana/loki:1.5.0
 ```
 
-Notice the change in the `target=/loki` for 1.5.0 to the new data directory location specified in the [included Loki config file](https://github.com/grafana/loki/tree/master/cmd/loki/loki-docker-config.yaml).
+Notice the change in the `target=/loki` for 1.5.0 to the new data directory location specified in the [included Loki config file](https://github.com/grafana/loki/blob/main/cmd/loki/loki-docker-config.yaml).
 
 The intermediate step of using an ubuntu image to change the ownership of the Loki files to the new user might not be necessary if you can easily access these files to run the `chown` command directly.
 That is if you have access to `/var/lib/docker/volumes` or if you mounted to a different local filesystem directory, you can change the ownership directly without using a container.

--- a/operator/docs/operator/hack_operator_make_run.md
+++ b/operator/docs/operator/hack_operator_make_run.md
@@ -94,7 +94,7 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
 
   This saves time by not deploying the operator again and again.
 
-* When everything works fine, for the final testing deploy everything to the cluster using this [document](https://github.com/grafana/loki/blob/master/operator/docs/hack_loki_operator.md#hacking-on-loki-operator-using-kind).
+* When everything works fine, for the final testing deploy everything to the cluster using this [document](https://github.com/grafana/loki/blob/main/operator/docs/operator/hack_loki_operator.md#hacking-on-loki-operator-using-kind).
 
 ### Cleanup
 
@@ -205,7 +205,7 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
   kubectl -n openshift-logging apply -f hack/lokistack_gateway_dev.yaml
   ```
 
-* Edit the [main file](https://github.com/grafana/loki/blob/master/operator/main.go) to set the flag values to `true` and rerun the operator using:
+* Edit the [main file](https://github.com/grafana/loki/blob/main/operator/main.go) to set the flag values to `true` and rerun the operator using:
 
   ```console
   make run
@@ -221,7 +221,7 @@ _Note:_ This is helpful when you don't want to deploy the Loki Operator image ev
 
   This saves time by not deploying the operator again and again.
 
-* When everything works fine, for the final testing deploy everything to the cluster using this [document](https://github.com/grafana/loki/blob/master/operator/docs/hack_loki_operator.md#hacking-on-loki-operator-on-openshift).
+* When everything works fine, for the final testing deploy everything to the cluster using this [document](https://github.com/grafana/loki/blob/main/operator/docs/operator/hack_loki_operator.md#hacking-on-loki-operator-on-openshift).
 
 ### Cleanup
 

--- a/operator/docs/operator/storage_size_calculator.md
+++ b/operator/docs/operator/storage_size_calculator.md
@@ -15,7 +15,7 @@ Storage Size Calculator is used to have an idea on how to properly size a Loki c
 
 ## Installation
 
-* Deploy the [Loki Operator](https://github.com/grafana/loki/blob/master/operator/docs/hack_loki_operator.md#hacking-on-loki-operator-on-openshift) to the cluster.
+* Deploy the [Loki Operator](https://github.com/grafana/loki/blob/main/operator/docs/operator/hack_loki_operator.md#hacking-on-loki-operator-on-openshift) to the cluster.
 
 * Create the `openshift-logging` namespace in the cluster:
 
@@ -63,13 +63,13 @@ This will cleanup the resources related to storage size calculator. However, the
 
 If you want to contribute to the storage size calculator, you can follow this local development and testing process.
 
-* Fork and clone the [Loki Operator](https://github.com/grafana/loki/blobs/master/operator) repo.
+* Fork and clone the [Loki Operator](https://github.com/grafana/loki/blob/main/operator) repo.
 
-* All the files related to storage size calculator exists at [`config/overlays/openshift/size-calculator`](https://github.com/grafana/loki/tree/master/operator/config/overlays/openshift/size-calculator) and the main file is at [`cmd/size-calculator`](https://github.com/grafana/loki/tree/master/operator/cmd/size-calculator).
+* All the files related to storage size calculator exists at [`config/overlays/openshift/size-calculator`](https://github.com/grafana/loki/tree/main/operator/config/overlays/openshift/size-calculator) and the main file is at [`cmd/size-calculator`](https://github.com/grafana/loki/tree/main/operator/cmd/size-calculator).
 
 * Update the code to fix a bug or add a new feature.
 
-* To test the changes made, build the image and push it to quay. Replace [here](https://github.com/grafana/loki/blob/master/operator/config/overlays/openshift/size-calculator/storage_size_calculator.yaml#L18) with your quay image to test the changes.
+* To test the changes made, build the image and push it to quay. Replace [here](https://github.com/grafana/loki/blob/v2.8.0/operator/config/overlays/openshift/size-calculator/storage_size_calculator.yaml#L18) with your quay image to test the changes.
 
   Build the image using:
 
@@ -77,7 +77,7 @@ If you want to contribute to the storage size calculator, you can follow this lo
   make oci-build-calculator
   ```
 
-  This will build the storage size calculator image using [dockerfile](https://github.com/grafana/loki/blob/master/operator/calculator.Dockerfile)
+  This will build the storage size calculator image using [dockerfile](https://github.com/grafana/loki/blob/main/operator/calculator.Dockerfile)
 
   Push the image to quay using:
 
@@ -99,7 +99,7 @@ If you want to contribute to the storage size calculator, you can follow this lo
 
 ### Permission denied on deploying prometheus secret
 
-If you get `permission denied` error while running `make deploy-size-calculator` then make [this](https://github.com/grafana/loki/blob/master/operator/hack/deploy-prometheus-secret.sh) file executable by running:
+If you get `permission denied` error while running `make deploy-size-calculator` then make [this](https://github.com/grafana/loki/blob/main/operator/hack/deploy-prometheus-secret.sh) file executable by running:
 
 ```console
 chmod +x hack/deploy-prometheus-secret.sh


### PR DESCRIPTION
* use `main` instead of `master` branch
* use a stable version in case lines are referenced
* fix outdated URLs