### PR TITLE
Loki: Fix span event logging on rate store

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -194,8 +194,8 @@ func (s *rateStore) anyShardingEnabled() bool {
 func (s *rateStore) aggregateByShard(ctx context.Context, streamRates map[string]map[uint64]*logproto.StreamRate) map[string]map[uint64]expiringRate {
 	if s.debug {
 		if sp := opentracing.SpanFromContext(ctx); sp != nil {
-			sp.LogKV("started to aggregate by shard")
-			defer sp.LogKV("finished to aggregate by shard")
+			sp.LogKV("event", "started to aggregate by shard")
+			defer sp.LogKV("event", "finished to aggregate by shard")
 		}
 	}
 	rates := map[string]map[uint64]expiringRate{}

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -10,12 +10,12 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/loki/pkg/util"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/instrument"
 
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -6,22 +6,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/loki/pkg/util"
-	"github.com/opentracing/opentracing-go"
-
-	"github.com/weaveworks/common/instrument"
-
-	"github.com/grafana/dskit/services"
-
 	"github.com/go-kit/log/level"
-
-	util_log "github.com/grafana/loki/pkg/util/log"
-
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/loki/pkg/util"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/instrument"
 
 	"github.com/grafana/loki/pkg/logproto"
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 type poolClientFactory interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix an event logging on rate store that is missing the `event` key. `LogKV` expects a key-value pair always.  