### PR TITLE
Makefile: Support debug build for `logcli`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ check-generated-files: yacc ragel fmt-proto protos clients/pkg/promtail/server/u
 ##########
 .PHONY: cmd/logcli/logcli
 logcli: cmd/logcli/logcli
+logcli-debug: cmd/logcli/logcli-debug
 
 logcli-image:
 	$(SUDO) docker build -t $(IMAGE_PREFIX)/logcli:$(IMAGE_TAG) -f cmd/logcli/Dockerfile .
@@ -138,6 +139,8 @@ logcli-image:
 cmd/logcli/logcli:
 	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./cmd/logcli
 
+cmd/logcli/logcli-debug:
+	CGO_ENABLED=0 go build $(DEBUG_GO_FLAGS) -o ./cmd/logcli/logcli-debug ./cmd/logcli
 ########
 # Loki #
 ########


### PR DESCRIPTION

**What this PR does / why we need it**:
Support debug build for `logcli` binary. This writes debug binary under `logcli-debug` name in the same `cmd/logcli` directory.

Already faced situation multiple times this is useful to debug some issues with LogQL locally.

**Which issue(s) this PR fixes**:
Fixes NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
