### PR TITLE
Ignore broken query limits header.

### DIFF
--- a/pkg/util/querylimits/middleware.go
+++ b/pkg/util/querylimits/middleware.go
@@ -27,11 +27,8 @@ func (l *queryLimitsMiddleware) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		limits, err := ExtractQueryLimitsHTTP(r)
 		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(err.Error())); err != nil {
-				level.Error(util_log.Logger).Log("msg", "error in queryLimitsMiddleware Wrap", "err", err)
-			}
-			return
+			level.Warn(util_log.Logger).Log("msg", "could not extract query limits from header", "err", err)
+			limits = nil
 		}
 
 		if limits != nil {

--- a/pkg/util/querylimits/middleware_test.go
+++ b/pkg/util/querylimits/middleware_test.go
@@ -23,6 +23,25 @@ func Test_MiddlewareWithoutHeader(t *testing.T) {
 	r, err := http.NewRequest("GET", "/example", nil)
 	require.NoError(t, err)
 	wrapped.ServeHTTP(rr, r)
+	response := rr.Result()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+}
+
+func Test_MiddlewareWithBrokenHeader(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limits := ExtractQueryLimitsContext(r.Context())
+		require.Nil(t, limits)
+	})
+	m := NewQueryLimitsMiddleware(log.NewNopLogger())
+	wrapped := m.Wrap(nextHandler)
+
+	rr := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/example", nil)
+	require.NoError(t, err)
+	r.Header.Add(HTTPHeaderQueryLimitsKey, "{broken}")
+	wrapped.ServeHTTP(rr, r)
+	response := rr.Result()
+	require.Equal(t, http.StatusOK, response.StatusCode)
 }
 
 func Test_MiddlewareWithHeader(t *testing.T) {
@@ -50,4 +69,6 @@ func Test_MiddlewareWithHeader(t *testing.T) {
 	err = InjectQueryLimitsHTTP(r, &limits)
 	require.NoError(t, err)
 	wrapped.ServeHTTP(rr, r)
+	response := rr.Result()
+	require.Equal(t, http.StatusOK, response.StatusCode)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A broken or invalid `X-Loki-Query-Limits` header should be ignored because it might have been injected by a proxy. That means a user cannot correct the header and would be unable to perform a query.

Note that we ignore the header when its not properly encoded and when it contains invalid entries.

**Which issue(s) this PR fixes**:
Fixes #9045

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
