### PR TITLE
WIP: add endpoint for validating a query limits struct

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -404,6 +404,8 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		"/loki/api/v1/series":      querier.WrapQuerySpanAndTimeout("query.Series", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.SeriesHandler)),
 		"/loki/api/v1/index/stats": querier.WrapQuerySpanAndTimeout("query.IndexStats", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.IndexStatsHandler)),
 
+		"loki/api/v1/limits/validate": querier.WrapQuerySpanAndTimeout("query.LimitsValidation", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.LimitsValidationHandler)),
+
 		"/api/prom/query": middleware.Merge(
 			httpMiddleware,
 			querier.WrapQuerySpanAndTimeout("query.LogQuery", t.querierAPI),

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -404,7 +404,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		"/loki/api/v1/series":      querier.WrapQuerySpanAndTimeout("query.Series", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.SeriesHandler)),
 		"/loki/api/v1/index/stats": querier.WrapQuerySpanAndTimeout("query.IndexStats", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.IndexStatsHandler)),
 
-		"loki/api/v1/limits/validate": querier.WrapQuerySpanAndTimeout("query.LimitsValidation", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.LimitsValidationHandler)),
+		"/loki/api/v1/limits/validate": querier.WrapQuerySpanAndTimeout("query.LimitsValidation", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.LimitsValidationHandler)),
 
 		"/api/prom/query": middleware.Merge(
 			httpMiddleware,
@@ -855,6 +855,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	t.Server.HTTP.Path("/loki/api/v1/label/{name}/values").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/series").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/index/stats").Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path("/loki/api/v1/limits/validate").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/api/prom/query").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/api/prom/label").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/api/prom/label/{name}/values").Methods("GET", "POST").Handler(frontendHandler)

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -441,7 +441,6 @@ func (q *QuerierAPI) IndexStatsHandler(w http.ResponseWriter, r *http.Request) {
 // LimitsValidationHandler returns an error (string) if the query limits within the request are invalid
 // when compared to the tenants limits.
 func (q *QuerierAPI) LimitsValidationHandler(w http.ResponseWriter, r *http.Request) {
-	// do we maybe need to extract the header here and inject into the ctx?
 
 	// we shouldn't support multiple tenant ids for this endpoint
 	tenantIDs, err := tenant.TenantIDs(r.Context())
@@ -449,7 +448,7 @@ func (q *QuerierAPI) LimitsValidationHandler(w http.ResponseWriter, r *http.Requ
 		serverutil.WriteError(httpgrpc.Errorf(http.StatusBadRequest, "invalid # of tenant IDs passed to LimitsValidation endpoint"), w)
 		return
 	}
-	err = q.limits.ValidateQueryLimits(r.Context(), tenantIDs[0])
+	err = q.limits.ValidateQueryLimits(r, tenantIDs[0])
 
 	if err == nil {
 		return

--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -23,6 +23,7 @@ func TestTailHandler(t *testing.T) {
 	defaultLimits := defaultLimitsTestConfig()
 	limits, err := validation.NewOverrides(defaultLimits, nil)
 	require.NoError(t, err)
+	//ql := querylimits.NewLimiter(nil, limits)
 
 	api := NewQuerierAPI(mockQuerierConfig(), nil, limits, log.NewNopLogger())
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -95,6 +95,7 @@ type Limits interface {
 	MaxStreamsMatchersPerQuery(context.Context, string) int
 	MaxConcurrentTailRequests(context.Context, string) int
 	MaxEntriesLimitPerQuery(context.Context, string) int
+	ValidateQueryLimits(ctx context.Context, userID string) error
 }
 
 // SingleTenantQuerier handles single tenant queries.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -95,7 +95,7 @@ type Limits interface {
 	MaxStreamsMatchersPerQuery(context.Context, string) int
 	MaxConcurrentTailRequests(context.Context, string) int
 	MaxEntriesLimitPerQuery(context.Context, string) int
-	ValidateQueryLimits(ctx context.Context, userID string) error
+	ValidateQueryLimits(*http.Request, string) error
 }
 
 // SingleTenantQuerier handles single tenant queries.

--- a/pkg/util/explain/explain.go
+++ b/pkg/util/explain/explain.go
@@ -1,0 +1,15 @@
+package explain
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Pretty(level int, explain string) string {
+	e := new(strings.Builder)
+	for i := 0; i < level; i++ {
+		fmt.Fprintf(e, "\t")
+	}
+	fmt.Fprintf(e, "%s", explain)
+	return e.String()
+}

--- a/pkg/util/querylimits/limiter.go
+++ b/pkg/util/querylimits/limiter.go
@@ -43,31 +43,31 @@ func (l *Limiter) ValidateQueryLimits(r *http.Request, userID string) error {
 		return nil
 	}
 
-	origQueryLength := l.CombinedLimits.MaxQueryLength(nil, userID)
+	origQueryLength := l.CombinedLimits.MaxQueryLength(context.TODO(), userID)
 	if time.Duration(requestLimits.MaxQueryLength) > origQueryLength {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("MaxQueryLength of %d is greater than %d, ", requestLimits.MaxQueryLength, origQueryLength))...)
 	}
 
-	origQueryRange := l.CombinedLimits.MaxQueryRange(nil, userID)
+	origQueryRange := l.CombinedLimits.MaxQueryRange(context.TODO(), userID)
 	if time.Duration(requestLimits.MaxQueryRange) > origQueryRange {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("MaxQueryRange of %d is greater than %d, ", requestLimits.MaxQueryRange, origQueryRange))...)
 	}
 
-	origQueryLookback := l.CombinedLimits.MaxQueryLookback(nil, userID)
+	origQueryLookback := l.CombinedLimits.MaxQueryLookback(context.TODO(), userID)
 	if time.Duration(requestLimits.MaxQueryLookback) > origQueryLookback {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("MaxQueryLookback of %d is greater than %d, ", requestLimits.MaxQueryLookback, origQueryLookback))...)
 	}
 
-	origEntriesLimit := l.CombinedLimits.MaxEntriesLimitPerQuery(nil, userID)
+	origEntriesLimit := l.CombinedLimits.MaxEntriesLimitPerQuery(context.TODO(), userID)
 	if requestLimits.MaxEntriesLimitPerQuery > origEntriesLimit {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("MaxEntriesLimitPerQuery of %d is greater than %d, ", requestLimits.MaxEntriesLimitPerQuery, origEntriesLimit))...)
 	}
 
-	origQueryTimeout := l.CombinedLimits.QueryTimeout(nil, userID)
+	origQueryTimeout := l.CombinedLimits.QueryTimeout(context.TODO(), userID)
 	if time.Duration(requestLimits.QueryTimeout) > origQueryTimeout {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("QueryTimeout of %d is greater than %d, ", requestLimits.QueryTimeout, origQueryTimeout))...)
@@ -75,13 +75,13 @@ func (l *Limiter) ValidateQueryLimits(r *http.Request, userID string) error {
 
 	// don't need to check required labels, we union the two sets rather than choosing one or the other
 
-	origRequiredNumberLabels := l.CombinedLimits.RequiredNumberLabels(nil, userID)
+	origRequiredNumberLabels := l.CombinedLimits.RequiredNumberLabels(context.TODO(), userID)
 	if requestLimits.RequiredNumberLabels > origRequiredNumberLabels {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("RequiredNumberLabels of %d is greater than %d, ", requestLimits.RequiredNumberLabels, origRequiredNumberLabels))...)
 	}
 
-	origMaxQueryBytesRead := l.CombinedLimits.MaxQueryBytesRead(nil, userID)
+	origMaxQueryBytesRead := l.CombinedLimits.MaxQueryBytesRead(context.TODO(), userID)
 	if requestLimits.MaxQueryBytesRead.Val() > origMaxQueryBytesRead {
 		isErr = true
 		err = append(err, []byte(fmt.Sprintf("MaxQueryBytesRead of %d is greater than %d, ", requestLimits.MaxQueryBytesRead, origMaxQueryBytesRead))...)

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -233,6 +233,7 @@ func TestLimiter_ValidateLimits(t *testing.T) {
 		MaxQueryLookback: model.Duration(29 * time.Second),
 	}
 	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
 	ml, err := MarshalQueryLimits(&limits)
 	require.NoError(t, err)
 	require.NoError(t, l.ValidateQueryLimits(req, "fake"))
@@ -244,6 +245,7 @@ func TestLimiter_ValidateLimits(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err = http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
 	req.Header.Add(HTTPHeaderQueryLimitsKey, string(ml))
 	err = l.ValidateQueryLimits(req, "fake")
 	require.Error(t, err)
@@ -253,7 +255,9 @@ func TestLimiter_ValidateLimits(t *testing.T) {
 	limits.MaxQueryBytesRead = 100
 
 	ml, err = MarshalQueryLimits(&limits)
+	require.NoError(t, err)
 	req, err = http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
 	req.Header.Add(HTTPHeaderQueryLimitsKey, string(ml))
 	err = l.ValidateQueryLimits(req, "fake")
 	require.Error(t, err)

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -234,14 +234,12 @@ func TestLimiter_ValidateLimits(t *testing.T) {
 	}
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	require.NoError(t, err)
-	ml, err := MarshalQueryLimits(&limits)
-	require.NoError(t, err)
 	require.NoError(t, l.ValidateQueryLimits(req, "fake"))
 
 	// one limit is invalid
 	limits.MaxQueryLength = model.Duration(60 * time.Second)
 
-	ml, err = MarshalQueryLimits(&limits)
+	ml, err := MarshalQueryLimits(&limits)
 	require.NoError(t, err)
 
 	req, err = http.NewRequest("GET", "http://example.com", nil)

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -356,6 +356,10 @@ func NewOverrides(defaults Limits, tenantLimits TenantLimits) (*Overrides, error
 	}, nil
 }
 
+func (o *Overrides) ValidateQueryLimits(ctx context.Context, userID string) error {
+	return nil
+}
+
 func (o *Overrides) AllByUserID() map[string]*Limits {
 	if o.tenantLimits != nil {
 		return o.tenantLimits.AllByUserID()

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -356,7 +357,7 @@ func NewOverrides(defaults Limits, tenantLimits TenantLimits) (*Overrides, error
 	}, nil
 }
 
-func (o *Overrides) ValidateQueryLimits(ctx context.Context, userID string) error {
+func (o *Overrides) ValidateQueryLimits(r *http.Request, userID string) error {
 	return nil
 }
 


### PR DESCRIPTION
As part of the per-request query limits we've talked about having a way to validate, during creation or afterwards, whether a query limits structure is valid relative to a tenants overall limits (whether that be the default limits or their actual per tenant overrides).

I'm still trying to grok how we actually wire up our http endpoints and how I could write a test for that, I kept getting ciricular import errors in `querier/http_test.go` trying to create the query limits structure so I backed all of that out for now.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
