### PR TITLE
[release-2.7.x] Backport 9106 to release 2.7.x

### DIFF
--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1-bullseye as build
+FROM golang:1.20.3-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.20.1-bullseye as build
+FROM golang:1.20.3-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .
-FROM golang:1.20.1-alpine as goenv
+FROM golang:1.20.3-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.1-alpine as goenv
+FROM golang:1.20.3-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:1.20.1-alpine as goenv
+FROM golang:1.20.3-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,8 +1,14 @@
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
-FROM grafana/loki-build-image:0.28.1 as build
-ARG GOARCH="amd64"
+
+FROM golang:1.20.3-alpine as goenv
+RUN go env GOARCH > /goarch && \
+    go env GOARM > /goarm && \
+    go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM --platform=linux/amd64 $BUILD_IMAGE as build
+COPY --from=goenv /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-debug

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.1-alpine as goenv
+FROM golang:1.20.3-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/bigtable v1.3.0

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.1 as helm
+FROM golang:1.20.3 as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.1 as drone
+FROM golang:1.20.3 as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,32 +47,32 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 #	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.1 as faillint
+FROM golang:1.20.3 as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
-FROM golang:1.20.1 as delve
+FROM golang:1.20.3 as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.1 as ghr
+FROM golang:1.20.3 as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.1 as nfpm
+FROM golang:1.20.3 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.1 as gotestsum
+FROM golang:1.20.3 as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.1 as jsonnet
+FROM golang:1.20.3 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.1-buster
+FROM golang:1.20.3-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM golang:1.20.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 
-FROM golang:1.19.1-alpine as goenv
+FROM golang:1.20.3-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20.3 as build
 
 # build via Makefile target helm-test-image in root
 # Makefile. Building from this directory will not be

--- a/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1
+FROM golang:1.20.3
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1-alpine AS build-image
+FROM golang:1.20.3-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/9106 as the automated one failed.