### PR TITLE
Sanitize label keys in the unpack parser

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -702,7 +702,7 @@ func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) 
 			}
 
 			// append to the buffer of labels
-			u.lbsBuffer = append(u.lbsBuffer, key, unescapeJSONString(value))
+			u.lbsBuffer = append(u.lbsBuffer, sanitizeLabelKey(key, true), unescapeJSONString(value))
 		default:
 			return nil
 		}

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -1260,6 +1260,20 @@ func Test_unpackParser_Parse(t *testing.T) {
 			[]byte(`I0303 17:49:45.976518    1526 kubelet_getters.go:178] "Pod status updated" pod="openshift-etcd/etcd-ip-10-0-150-50.us-east-2.compute.internal" status=Running`),
 			noParserHints,
 		},
+		{
+			"invalid key names",
+			[]byte(`{"foo.bar":"10ms","test-dash":"foo","_entry":"some message"}`),
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+			},
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+				{Name: "foo_bar", Value: "10ms"},
+				{Name: "test_dash", Value: "foo"},
+			},
+			[]byte(`some message`),
+			noParserHints,
+		},
 	}
 	for _, tt := range tests {
 		j := NewUnpackParser()


### PR DESCRIPTION
This PR makes the `unpack` parser sanitize label keys like all the other parsers. When invalid label names are included, it causes the user to get `could not write JSON response` errors when the response is serialized to send back to the user. 