### PR TITLE
Docs: Replace mimir example config path with a loki one

### DIFF
--- a/docs/sources/operations/scalability.md
+++ b/docs/sources/operations/scalability.md
@@ -20,7 +20,7 @@ To run with the Query Scheduler, the frontend needs to be passed the scheduler's
 
 It is not valid to start the querier with both a configured frontend and a scheduler address.
 
-The query scheduler process itself can be started via the `-target=query-scheduler` option of the Loki Docker image. For instance, `docker run grafana/loki:latest -config.file=/mimir/config/mimir.yaml -target=query-scheduler -server.http-listen-port=8009 -server.grpc-listen-port=9009` starts the query scheduler listening on ports `8009` and `9009`.
+The query scheduler process itself can be started via the `-target=query-scheduler` option of the Loki Docker image. For instance, `docker run grafana/loki:latest -config.file=/etc/loki/config.yaml -target=query-scheduler -server.http-listen-port=8009 -server.grpc-listen-port=9009` starts the query scheduler listening on ports `8009` and `9009`.
 
 ## Memory ballast
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The example config path on Loki's query scheduler is using `-config.file=/mimir/config/mimir.yaml`, which looks a little bit confusing on Loki's document, even though there are multiple references to Mimir.

https://github.com/grafana/loki/blob/7bec727c6dff8e6268f9a8f9b64fee725d4195f8/docs/sources/operations/scalability.md?plain=1#L23

This PR replaces the Mimir config path with the one found in query-frontend's document.

https://github.com/grafana/loki/blob/7bec727c6dff8e6268f9a8f9b64fee725d4195f8/docs/sources/configuration/query-frontend.md?plain=1#L115

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I noticed this when checking configuration of 2.6, but this is still the case in the [latest version](https://grafana.com/docs/loki/v2.8.x/operations/scalability/).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
