### PR TITLE
Pass engine opts down to middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
 * [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
 * [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.
+* [9130](https://github.com/grafana/loki/pull/9130) **salvacorts**: Pass LogQL engine options down to the _split by range_, _sharding_, and _query size limiter_ middlewares.
 
 ### All Changes
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -687,6 +687,7 @@ func (t *Loki) initQueryFrontendTripperware() (_ services.Service, err error) {
 
 	tripperware, stopper, err := queryrange.NewTripperware(
 		t.Cfg.QueryRange,
+		t.Cfg.Querier.Engine,
 		util_log.Logger,
 		t.Overrides,
 		t.Cfg.SchemaConfig,

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/util/math"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -23,6 +22,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/config"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/marshal"
+	"github.com/grafana/loki/pkg/util/math"
 )
 
 func TestLimits(t *testing.T) {

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -55,7 +55,7 @@ func Test_seriesLimiter(t *testing.T) {
 	cfg.CacheResults = false
 	// split in 7 with 2 in // max.
 	l := WithSplitByLimits(fakeLimits{maxSeries: 1, maxQueryParallelism: 2}, time.Hour)
-	tpw, stopper, err := NewTripperware(cfg, util_log.Logger, l, config.SchemaConfig{
+	tpw, stopper, err := NewTripperware(cfg, testEngineOpts, util_log.Logger, l, config.SchemaConfig{
 		Configs: testSchemas,
 	}, nil, false, nil)
 	if stopper != nil {
@@ -242,7 +242,7 @@ func Test_MaxQueryParallelismDisable(t *testing.T) {
 }
 
 func Test_MaxQueryLookBack(t *testing.T) {
-	tpw, stopper, err := NewTripperware(testConfig, util_log.Logger, fakeLimits{
+	tpw, stopper, err := NewTripperware(testConfig, testEngineOpts, util_log.Logger, fakeLimits{
 		maxQueryLookback:    1 * time.Hour,
 		maxQueryParallelism: 1,
 	}, config.SchemaConfig{
@@ -597,8 +597,8 @@ func Test_MaxQuerySize(t *testing.T) {
 			require.NoError(t, err)
 
 			middlewares := []queryrangebase.Middleware{
-				NewQuerySizeLimiterMiddleware(schemas, util_log.Logger, tc.limits, LokiCodec, queryStatsHandler),
-				NewQuerierSizeLimiterMiddleware(schemas, util_log.Logger, tc.limits, LokiCodec, querierStatsHandler),
+				NewQuerySizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, queryStatsHandler),
+				NewQuerierSizeLimiterMiddleware(schemas, testEngineOpts, util_log.Logger, tc.limits, querierStatsHandler),
 			}
 
 			_, err = queryrangebase.NewRoundTripper(fakeRT, LokiCodec, nil, middlewares...).RoundTrip(req)

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -796,3 +796,46 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 		})
 	}
 }
+
+func Test_ASTMapper_MaxLookBackPeriod(t *testing.T) {
+	engineOpts := testEngineOpts
+	engineOpts.MaxLookBackPeriod = 1 * time.Hour
+
+	handler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		if _, ok := req.(*logproto.IndexStatsRequest); !ok {
+			return &LokiResponse{}, nil
+		}
+
+		// This is the actual check that we're testing.
+		require.Equal(t, testTime.Add(-engineOpts.MaxLookBackPeriod).UnixMilli(), req.GetStart())
+
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{
+				Bytes: 1 << 10,
+			},
+		}, nil
+	})
+
+	mware := newASTMapperware(
+		testSchemasTSDB,
+		engineOpts,
+		handler,
+		log.NewNopLogger(),
+		nilShardingMetrics,
+		fakeLimits{maxSeries: math.MaxInt32, tsdbMaxQueryParallelism: 1, queryTimeout: time.Second},
+		0,
+	)
+
+	lokiReq := &LokiInstantRequest{
+		Query:     `{cluster="dev-us-central-0"}`,
+		Limit:     1000,
+		TimeTs:    testTime,
+		Direction: logproto.FORWARD,
+		Path:      "/loki/api/v1/query",
+	}
+
+	ctx := user.InjectOrgID(context.Background(), "foo")
+	_, err := mware.Do(ctx, lokiReq)
+	require.NoError(t, err)
+
+}

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -165,6 +165,7 @@ func Test_astMapper(t *testing.T) {
 				RowShards: 2,
 			},
 		},
+		testEngineOpts,
 		handler,
 		log.NewNopLogger(),
 		nilShardingMetrics,
@@ -296,6 +297,7 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 						IndexType: config.TSDBType,
 					},
 				},
+				testEngineOpts,
 				handler,
 				log.NewNopLogger(),
 				nilShardingMetrics,
@@ -333,6 +335,7 @@ func Test_ShardingByPass(t *testing.T) {
 				RowShards: 2,
 			},
 		},
+		testEngineOpts,
 		handler,
 		log.NewNopLogger(),
 		nilShardingMetrics,
@@ -404,7 +407,7 @@ func Test_InstantSharding(t *testing.T) {
 	cpyPeriodConf.RowShards = 3
 	sharding := NewQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
 		cpyPeriodConf,
-	}, LokiCodec, queryrangebase.NewInstrumentMiddlewareMetrics(nil),
+	}, testEngineOpts, LokiCodec, queryrangebase.NewInstrumentMiddlewareMetrics(nil),
 		nilShardingMetrics,
 		fakeLimits{
 			maxSeries:           math.MaxInt32,
@@ -689,6 +692,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 
 			mware := newASTMapperware(
 				confs,
+				testEngineOpts,
 				handler,
 				log.NewNopLogger(),
 				nilShardingMetrics,

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -72,7 +72,7 @@ func getStatsForMatchers(
 	start, end model.Time,
 	matcherGroups []syntax.MatcherRange,
 	parallelism int,
-	defaultLookback ...time.Duration,
+	defaultLookback time.Duration,
 ) ([]*stats.Stats, error) {
 	startTime := time.Now()
 
@@ -81,12 +81,12 @@ func getStatsForMatchers(
 		matchers := syntax.MatchersString(matcherGroups[i].Matchers)
 		diff := matcherGroups[i].Interval + matcherGroups[i].Offset
 		adjustedFrom := start.Add(-diff)
-		if matcherGroups[i].Interval == 0 && len(defaultLookback) > 0 {
+		if matcherGroups[i].Interval == 0 {
 			// For limited instant queries, when start == end, the queries would return
 			// zero results. Prometheus has a concept of "look back amount of time for instant queries"
 			// since metric data is sampled at some configurable scrape_interval (commonly 15s, 30s, or 1m).
 			// We copy that idea and say "find me logs from the past when start=end".
-			adjustedFrom = adjustedFrom.Add(-defaultLookback[0])
+			adjustedFrom = adjustedFrom.Add(-defaultLookback)
 		}
 
 		adjustedThrough := end.Add(-matcherGroups[i].Offset)

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -11,6 +11,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/common/model"
+
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logql/syntax"
@@ -18,8 +21,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/util/spanlogger"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 )
 
 func shardResolverForConf(

--- a/pkg/querier/queryrange/split_by_range.go
+++ b/pkg/querier/queryrange/split_by_range.go
@@ -28,13 +28,13 @@ type splitByRange struct {
 }
 
 // NewSplitByRangeMiddleware creates a new Middleware that splits log requests by the range interval.
-func NewSplitByRangeMiddleware(logger log.Logger, limits Limits, metrics *logql.MapperMetrics) queryrangebase.Middleware {
+func NewSplitByRangeMiddleware(logger log.Logger, engineOpts logql.EngineOpts, limits Limits, metrics *logql.MapperMetrics) queryrangebase.Middleware {
 	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
 		return &splitByRange{
 			logger: log.With(logger, "middleware", "InstantQuery.splitByRangeVector"),
 			next:   next,
 			limits: limits,
-			ng: logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{
+			ng: logql.NewDownstreamEngine(engineOpts, DownstreamHandler{
 				limits: limits,
 				next:   next,
 			}, limits, logger),

--- a/pkg/querier/queryrange/split_by_range_test.go
+++ b/pkg/querier/queryrange/split_by_range_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_RangeVectorSplit(t *testing.T) {
-	srm := NewSplitByRangeMiddleware(log.NewNopLogger(), fakeLimits{
+	srm := NewSplitByRangeMiddleware(log.NewNopLogger(), testEngineOpts, fakeLimits{
 		maxSeries:    10000,
 		queryTimeout: time.Second,
 		splits: map[string]time.Duration{


### PR DESCRIPTION
**What this PR does / why we need it**:

The following middlewares in the query frontend uses a downstream engine:
- `NewQuerySizeLimiterMiddleware` and `NewQuerierSizeLimiterMiddleware`
- `NewQueryShardMiddleware`
- `NewSplitByRangeMiddleware`

These were all creating the downstream engine as follows:

```go
logql.NewDownstreamEngine(logql.EngineOpts{LogExecutingQuery: false}, DownstreamHandler{next: next, limits: limits}, limits, logger),
```

As can be seen, the [engine options configured in Loki][1] were not being used at all. In the case of `NewQuerySizeLimiterMiddleware`, `NewQuerierSizeLimiterMiddleware` and `NewQueryShardMiddleware`, the downstream engine was created to get the `MaxLookBackPeriod`. When creating a new Downstream Engine as above, the `MaxLookBackPeriod` [would always be the default][2] (30 seconds).

This PR fixes this by passing down the engine config to these middlewares, so this config is used to create the new downstream engines.

**Which issue(s) this PR fixes**:
Adresses some pending tasks from https://github.com/grafana/loki/pull/8670#issuecomment-1507031976.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`

[1]: https://github.com/grafana/loki/blob/1bcf683513b5e11fb1dcc5625761b9760cfbd958/pkg/querier/querier.go#L52
[2]: https://github.com/grafana/loki/blob/edc6b0bff76714ff584c20d7ff0235461a4f4a88/pkg/logql/engine.go#L136-L140