### PR TITLE
[release-2.8.x] Update helm and jsonnet for 2.8 release (#9003)

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -369,9 +369,9 @@ null
 		<tr>
 			<td>enterprise.image.tag</td>
 			<td>string</td>
-			<td>Docker image tag TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
+			<td>Docker image tag</td>
 			<td><pre lang="json">
-"main-96f32b9f"
+null
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 2.7.3
-version: 4.8.0
+appVersion: 2.8.0
+version: 5.0.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -329,9 +329,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    # TODO: needed for 3rd target backend functionality
-    # revert to null or latest once this behavior is relased
-    tag: main-96f32b9f
+    tag: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   adminToken:

--- a/production/ksonnet/loki-canary/config.libsonnet
+++ b/production/ksonnet/loki-canary/config.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    loki_canary: 'grafana/loki-canary:2.7.3',
+    loki_canary: 'grafana/loki-canary:2.8.0',
   },
 }

--- a/production/ksonnet/loki/images.libsonnet
+++ b/production/ksonnet/loki/images.libsonnet
@@ -4,7 +4,7 @@
     memcached: 'memcached:1.5.17-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
-    loki: 'grafana/loki:2.7.3',
+    loki: 'grafana/loki:2.8.0',
 
     distributor:: self.loki,
     ingester:: self.loki,

--- a/production/ksonnet/promtail/config.libsonnet
+++ b/production/ksonnet/promtail/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    promtail: 'grafana/promtail:2.7.3',
+    promtail: 'grafana/promtail:2.8.0',
   },
 
   _config+:: {


### PR DESCRIPTION
backport #9003 to release 2.8

Prepare helm and jsonnet for 2.8 release.

(cherry picked from commit 5113906c6723234c1441838c0d5896f28d15d3e3)