### PR TITLE
Replace deprecated MinIO environment variables

### DIFF
--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -66,8 +66,8 @@ services:
         mkdir -p /data/loki-ruler && \
         minio server /data
     environment:
-      - MINIO_ACCESS_KEY=loki
-      - MINIO_SECRET_KEY=supersecret
+      - MINIO_ROOT_USER=loki
+      - MINIO_ROOT_PASSWORD=supersecret
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_UPDATE=off
     ports:

--- a/operator/config/overlays/development/minio/deployment.yaml
+++ b/operator/config/overlays/development/minio/deployment.yaml
@@ -21,9 +21,9 @@ spec:
           mkdir -p /storage/loki && \
           minio server /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
         image: minio/minio
         name: minio

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -93,8 +93,8 @@ services:
         mkdir -p /data/loki-ruler &&
         minio server /data
     environment:
-      - MINIO_ACCESS_KEY=loki
-      - MINIO_SECRET_KEY=supersecret
+      - MINIO_ROOT_USER=loki
+      - MINIO_ROOT_PASSWORD=supersecret
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_UPDATE=off
     ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the [deprecated](https://min.io/docs/minio/linux/reference/minio-server/minio-server.html#envvar.MINIO_ACCESS_KEY) `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` environment variables with their new names `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`. This change has only been applied to the templates which do not have a pinned MinIO version.

**Which issue(s) this PR fixes**:
Fixes #8702 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
