### PR TITLE
Add PrepDownScalePath setting and use in ingester

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -1476,6 +1476,11 @@ wal:
 # Maximum number of dropped streams to keep in memory during tailing.
 # CLI flag: -ingester.tailer.max-dropped-streams
 [max_dropped_streams: <int> | default = 10]
+
+# If this file exists the /ingester/prepare-shutdown endpoint will be called on
+# startup
+# CLI flag: -prep-downscale.path
+[prep_downscale_path: <string> | default = "/etc/annotations/prep-downscale"]
 ```
 
 ### index_gateway

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -104,6 +104,8 @@ type Config struct {
 	IndexShards int `yaml:"index_shards"`
 
 	MaxDroppedStreams int `yaml:"max_dropped_streams"`
+
+	PrepDownScalePath string `yaml:"prep_downscale_path"`
 }
 
 // RegisterFlags registers the flags.
@@ -128,6 +130,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.AutoForgetUnhealthy, "ingester.autoforget-unhealthy", false, "Forget about ingesters having heartbeat timestamps older than `ring.kvstore.heartbeat_timeout`. This is equivalent to clicking on the `/ring` `forget` button in the UI: the ingester is removed from the ring. This is a useful setting when you are sure that an unhealthy node won't return. An example is when not using stateful sets or the equivalent. Use `memberlist.rejoin_interval` > 0 to handle network partition cases when using a memberlist.")
 	f.IntVar(&cfg.IndexShards, "ingester.index-shards", index.DefaultIndexShards, "Shard factor used in the ingesters for the in process reverse index. This MUST be evenly divisible by ALL schema shard factors or Loki will not start.")
 	f.IntVar(&cfg.MaxDroppedStreams, "ingester.tailer.max-dropped-streams", 10, "Maximum number of dropped streams to keep in memory during tailing.")
+	f.StringVar(&cfg.PrepDownScalePath, "prep-downscale.path", "/etc/annotations/prep-downscale", "If this file exists the /ingester/prepare-shutdown endpoint will be called on startup")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"os"
@@ -479,6 +480,16 @@ func (t *Loki) initIngester() (_ services.Service, err error) {
 	t.Server.HTTP.Methods("POST").Path("/ingester/shutdown").Handler(
 		httpMiddleware.Wrap(http.HandlerFunc(t.Ingester.ShutdownHandler)),
 	)
+
+	if len(t.Cfg.Ingester.PrepDownScalePath) != 0 {
+		_, err := os.Stat(t.Cfg.Ingester.PrepDownScalePath)
+		if err == nil {
+			rec := httptest.NewRecorder()
+			req := http.Request{}
+			t.Ingester.PrepareShutdown(rec, &req)
+		}
+	}
+
 	return t.Ingester, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a new config setting for the ingester that points to a file containing the prep-downscale annotations. This file will be created using the k8s downwards API. These sections will be added to the pods.

```
        volumeMounts:
        - mountPath: /etc/annotations
          name: annotations
 
  volumes:
    - name: annotations
      downwardAPI:
        items:
          - path: "annotations"
            fieldRef:
              fieldPath: metadata.annotations['grafana.com/last-prepared-for-downscale']
```

This was manually tested by adding the instructions to create the file in the config setting to the Dockerfile. On startup it then showed the log lines of the prepare shutdown function.

**Special notes for your reviewer**:

This forms part of the ingester auto-scaling work.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
