### PR TITLE
expiration: do not drop index if period is a zero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
 * [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.
 * [9130](https://github.com/grafana/loki/pull/9130) **salvacorts**: Pass LogQL engine options down to the _split by range_, _sharding_, and _query size limiter_ middlewares.
+* [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value
 
 ### All Changes
 

--- a/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
+++ b/pkg/storage/stores/indexshipper/compactor/retention/expiration.go
@@ -66,6 +66,10 @@ func (e *expirationChecker) Expired(ref ChunkEntry, now model.Time) (bool, filte
 func (e *expirationChecker) DropFromIndex(ref ChunkEntry, tableEndTime model.Time, now model.Time) bool {
 	userID := unsafeGetString(ref.UserID)
 	period := e.tenantsRetention.RetentionPeriodFor(userID, ref.Labels)
+	// The 0 value should disable retention
+	if period <= 0 {
+		return false
+	}
 	return now.Sub(tableEndTime) > period
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`DropFromIndex` should be return false when `retention_period` is set to a zero value.

If we take chunks that overlap period boundary and are indexed in two tables, we drop these from the table on the left side of the period boundary even if they have not expired - https://github.com/grafana/loki/blob/ashwanth/drop-from-index-zero-value/pkg/storage/stores/indexshipper/compactor/retention/retention.go#L218

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Tests updated
- [x] `CHANGELOG.md` updated