### PR TITLE
Loki: Add debug event to ingester `GetStreamRates`

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -126,7 +126,7 @@ func (s *rateStore) updateRates(ctx context.Context, updated map[string]map[uint
 	if s.debug {
 		if sp := opentracing.SpanFromContext(ctx); sp != nil {
 			sp.LogKV("event", "started to update rates")
-			defer sp.LogKV("event", "finished to update rates", "streams", streamCnt)
+			defer sp.LogKV("event", "finished updating rates", "streams", streamCnt)
 		}
 	}
 	s.rateLock.Lock()

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -125,7 +125,7 @@ func (s *rateStore) updateRates(ctx context.Context, updated map[string]map[uint
 	streamCnt := 0
 	if s.debug {
 		if sp := opentracing.SpanFromContext(ctx); sp != nil {
-			sp.LogKV("event", "started to update rates")
+			sp.LogKV("event", "started updating rates")
 			defer sp.LogKV("event", "finished updating rates", "streams", streamCnt)
 		}
 	}

--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -122,10 +122,11 @@ type rateStats struct {
 }
 
 func (s *rateStore) updateRates(ctx context.Context, updated map[string]map[uint64]expiringRate) rateStats {
+	streamCnt := 0
 	if s.debug {
 		if sp := opentracing.SpanFromContext(ctx); sp != nil {
 			sp.LogKV("event", "started to update rates")
-			defer sp.LogKV("event", "finished to update rates")
+			defer sp.LogKV("event", "finished to update rates", "streams", streamCnt)
 		}
 	}
 	s.rateLock.Lock()
@@ -138,6 +139,7 @@ func (s *rateStore) updateRates(ctx context.Context, updated map[string]map[uint
 
 		for stream, rate := range tenant {
 			s.rates[tenantID][stream] = rate
+			streamCnt++
 		}
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -644,8 +644,8 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
 func (i *Ingester) GetStreamRates(ctx context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
-		sp.LogKV("event", "ingester started to handle get stream rates")
-		defer sp.LogKV("event", "ingester finished handling get stream rates")
+		sp.LogKV("event", "ingester started to handle GetStreamRates")
+		defer sp.LogKV("event", "ingester finished handling GetStreamRates")
 	}
 
 	allRates := i.streamRateCalculator.Rates()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tenant"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -641,7 +642,12 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 
 // GetStreamRates returns a response containing all streams and their current rate
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
-func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
+func (i *Ingester) GetStreamRates(ctx context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		sp.LogKV("event", "ingester started to handle get stream rates")
+		defer sp.LogKV("event", "ingester finished to handle get stream rates")
+	}
+
 	allRates := i.streamRateCalculator.Rates()
 
 	rates := make([]*logproto.StreamRate, 0, len(allRates))

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -645,7 +645,7 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 func (i *Ingester) GetStreamRates(ctx context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
 		sp.LogKV("event", "ingester started to handle get stream rates")
-		defer sp.LogKV("event", "ingester finished to handle get stream rates")
+		defer sp.LogKV("event", "ingester finished handling get stream rates")
 	}
 
 	allRates := i.streamRateCalculator.Rates()


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add a new span event to our ingesters `GetStreamRates` function.
- Add how many streams were updated on a `updateRates` call. This way, if we see a slow updateRates we'll be able to see if there's a correlation between the update beign slow and the amount of streams being high.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
