### PR TITLE
Loki microservices tanka: add some ingester replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [8732](https://github.com/grafana/loki/pull/8732) **abaguas**: azure: respect retry config before cancelling the context
 
 ##### Fixes
-
+* [9160](https://github.com/grafana/loki/pull/9160) **irizzant**: Ingester: add some replicas
 * [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
 * [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
 * [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 * [8732](https://github.com/grafana/loki/pull/8732) **abaguas**: azure: respect retry config before cancelling the context
 
 ##### Fixes
-* [9160](https://github.com/grafana/loki/pull/9160) **irizzant**: Ingester: add some replicas
 * [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
 * [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
 * [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.

--- a/production/ksonnet/loki/multi-zone.libsonnet
+++ b/production/ksonnet/loki/multi-zone.libsonnet
@@ -21,7 +21,7 @@
     multi_zone_ingester_migration_enabled: false,
     multi_zone_ingester_replication_write_path_enabled: true,
     multi_zone_ingester_replication_read_path_enabled: true,
-    multi_zone_ingester_replicas: 0,
+    multi_zone_ingester_replicas: 3,
     multi_zone_ingester_max_unavailable: std.max(1, std.floor($._config.multi_zone_ingester_replicas / 9)),
     multi_zone_default_ingester_zone: false,
     multi_zone_ingester_exclude_default: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes Ingester pods available in multi zone mode which, based on the previous defaults, were not created.

**Which issue(s) this PR fixes**:
Fixes #9139 

**Special notes for your reviewer**:

**Checklist**
- [X Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] `CHANGELOG.md` updated
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
