### PR TITLE
Skip pipelines that require secrets in forks

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -52,9 +52,10 @@ local gpg_private_key = secret('gpg_private_key', 'infra/data/ci/packages-publis
 local updater_config_template = secret('updater_config_template', 'secret/data/common/loki_ci_autodeploy', 'updater-config-template.json');
 local helm_chart_auto_update_config_template = secret('helm-chart-update-config-template', 'secret/data/common/loki-helm-chart-auto-update', 'on-loki-release-config.json');
 
-local run(name, commands, env={}) = {
+
+local run(name, commands, env={}, image='grafana/loki-build-image:%s' % build_image_version) = {
   name: name,
-  image: 'grafana/loki-build-image:%s' % build_image_version,
+  image: image,
   commands: commands,
   environment: env,
 };
@@ -66,6 +67,21 @@ local make(target, container=true, args=[]) = run(target, [
     target,
   ] + args),
 ]);
+
+// The only indication we have that we're running in a fork is the presence of a secret.
+// If a secret is blank, it means we're running in a fork.
+local skipMissingSecretPipelineStep(secretName) = run(
+  'skip pipeline if missing secret',
+  [
+    'if [ "${#TEST_SECRET}" -eq 0 ]; then',
+    '  echo "Missing a secret to run this pipeline. This branch needs to be re-pushed as a branch in main grafana/loki repository in order to run." && exit 78',
+    'fi',
+  ],
+  image='alpine',
+  env={
+    TEST_SECRET: { from_secret: secretName },
+  },
+);
 
 local docker(arch, app) = {
   name: '%s-image' % if $.settings.dry_run then 'build-' + app else 'publish-' + app,
@@ -277,10 +293,13 @@ local promtail(arch) = pipeline('promtail-' + arch) + arch_image(arch) {
 };
 
 local lambda_promtail(arch) = pipeline('lambda-promtail-' + arch) + arch_image(arch) {
+  local skipStep = skipMissingSecretPipelineStep(ecr_key.name),  // Needs ECR secrets to run
+
   steps+: [
+    skipStep,
     // dry run for everything that is not tag or main
     lambda_promtail_ecr('lambda-promtail') {
-      depends_on: ['image-tag'],
+      depends_on: ['image-tag', skipStep.name],
       when: onPRs,
       settings+: {
         dry_run: true,
@@ -785,6 +804,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
     ],
     // Package and test the packages
     steps: [
+      skipMissingSecretPipelineStep(gpg_private_key.name),  // Needs GPG keys to run
       {
         name: 'fetch-tags',
         image: 'alpine',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1419,6 +1419,16 @@ services:
     path: /sys/fs/cgroup
 steps:
 - commands:
+  - if [ "${#TEST_SECRET}" -eq 0 ]; then
+  - '  echo "Missing a secret to run this pipeline. This branch needs to be re-pushed
+    as a branch in main grafana/loki repository in order to run." && exit 78'
+  - fi
+  environment:
+    TEST_SECRET:
+      from_secret: gpg_private_key
+  image: alpine
+  name: skip pipeline if missing secret
+- commands:
   - apk add --no-cache bash git
   - git fetch origin --tags
   image: alpine
@@ -1531,8 +1541,19 @@ steps:
   - echo $(./tools/image-tag)-amd64 > .tags
   image: alpine
   name: image-tag
+- commands:
+  - if [ "${#TEST_SECRET}" -eq 0 ]; then
+  - '  echo "Missing a secret to run this pipeline. This branch needs to be re-pushed
+    as a branch in main grafana/loki repository in order to run." && exit 78'
+  - fi
+  environment:
+    TEST_SECRET:
+      from_secret: ecr_key
+  image: alpine
+  name: skip pipeline if missing secret
 - depends_on:
   - image-tag
+  - skip pipeline if missing secret
   image: cstyan/ecr
   name: build-lambda-promtail-image
   privileged: true
@@ -1589,8 +1610,19 @@ steps:
   - echo $(./tools/image-tag)-arm64 > .tags
   image: alpine
   name: image-tag
+- commands:
+  - if [ "${#TEST_SECRET}" -eq 0 ]; then
+  - '  echo "Missing a secret to run this pipeline. This branch needs to be re-pushed
+    as a branch in main grafana/loki repository in order to run." && exit 78'
+  - fi
+  environment:
+    TEST_SECRET:
+      from_secret: ecr_key
+  image: alpine
+  name: skip pipeline if missing secret
 - depends_on:
   - image-tag
+  - skip pipeline if missing secret
   image: cstyan/ecr
   name: build-lambda-promtail-image
   privileged: true
@@ -1740,6 +1772,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 3ccc42237f6cdd3de6afacf997575dafa52c9d5fee83cd3fee610e5fd365a283
+hmac: 481157ef4226aeafda64e9c66b83938482889e19e190bfe72e06613c84efbfae
 
 ...


### PR DESCRIPTION
These pipelines cannot run because secrets are not being exposed on fork builds
