### PR TITLE
[helm] Bump GEL version, default to 3 scalable targets

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -706,7 +706,7 @@ false
 			<td>string</td>
 			<td></td>
 			<td><pre lang="json">
-"v1.6.3"
+"v1.7.0"
 </pre>
 </td>
 		</tr>
@@ -1686,6 +1686,17 @@ true
 			<td>Overrides the image tag whose default is the chart's appVersion TODO: needed for 3rd target backend functionality revert to null or latest once this behavior is relased</td>
 			<td><pre lang="json">
 null
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>loki.index_gateway</td>
+			<td>object</td>
+			<td>Optional index gateway configuration</td>
+			<td><pre lang="json">
+{
+  "mode": "ring"
+}
 </pre>
 </td>
 		</tr>
@@ -2798,7 +2809,7 @@ null
 			<td>bool</td>
 			<td>Whether or not to use the 2 target type simple scalable mode (read, write) or the 3 target type (read, write, backend). Legacy refers to the 2 target type, so true will run two targets, false will run 3 targets.</td>
 			<td><pre lang="json">
-true
+false
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.0
-version: 5.0.0
+version: 5.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -657,7 +657,7 @@ http {
     }
 
     location ~ /admin/api/.* {
-      proxy_pass       {{ $writeUrl }}$request_uri;
+      proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
     {{- with .Values.gateway.nginxConfig.serverSnippet }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -193,6 +193,11 @@ loki:
     querier:
       {{- tpl (. | toYaml) $ | nindent 4 }}
     {{- end }}
+
+    {{- with .Values.loki.index_gateway }}
+    index_gateway:
+      {{- tpl (. | toYaml) $ | nindent 4 }}
+    {{- end }}
   # Should authentication be enabled
   auth_enabled: true
   # -- Tenants list to be created on nginx htpasswd file, with name and password keys
@@ -281,11 +286,14 @@ loki:
   querier: {}
   # --  Optional ingester configuration
   ingester: {}
+  # --  Optional index gateway configuration
+  index_gateway:
+    mode: ring
 enterprise:
   # Enable enterprise features, license must be provided
   enabled: false
   # Default verion of GEL to deploy
-  version: v1.6.3
+  version: v1.7.0
   # -- Optional name of the GEL cluster, otherwise will use .Release.Name
   # The cluster name must match what is in your GEL license
   cluster_name: null
@@ -761,7 +769,7 @@ read:
   # -- Whether or not to use the 2 target type simple scalable mode (read, write) or the
   # 3 target type (read, write, backend). Legacy refers to the 2 target type, so true will
   # run two targets, false will run 3 targets.
-  legacyReadTarget: true
+  legacyReadTarget: false
   # -- Additional CLI args for the read
   extraArgs: []
   # -- Environment variables to add to the read pods

--- a/tools/dev/k3d/environments/helm-cluster/spec.json
+++ b/tools/dev/k3d/environments/helm-cluster/spec.json
@@ -6,7 +6,7 @@
     "namespace": "environments/helm-cluster/main.jsonnet"
   },
   "spec": {
-    "apiServer": "https://0.0.0.0:33931",
+    "apiServer": "https://0.0.0.0:45123",
     "namespace": "k3d-helm-cluster",
     "resourceDefaults": {},
     "expectVersions": {}

--- a/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
+++ b/tools/dev/k3d/environments/helm-cluster/values/enterprise-logs.yaml
@@ -2,7 +2,6 @@
 loki:
   querier:
     multi_tenant_queries_enabled: true
-
 enterprise:
   enabled: true
   adminToken:
@@ -30,5 +29,7 @@ monitoring:
     namespace: k3d-helm-cluster
     labels:
       release: "prometheus"
+read:
+  legacyReadTarget: false
 minio:
   enabled: true

--- a/tools/dev/k3d/jsonnetfile.lock.json
+++ b/tools/dev/k3d/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "consul"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "Po3c1Ic96ngrJCtOazic/7OsLkoILOKZWXWyZWl+od8="
     },
     {
@@ -18,7 +18,7 @@
           "subdir": "enterprise-metrics"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "hi2ZpHKl7qWXmSZ46sAycjWEQK6oGsoECuDKQT1dA+k="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "etcd-operator"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "duHm6wmUju5KHQurOe6dnXoKgl5gTUsfGplgbmAOsHw="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "Y5nheroSOIwmE+djEVPq4OvvTxKenzdHhpEwaR3Ebjs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "jaeger-agent-mixin"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "nsukyr2SS8h97I2mxvBazXZp2fxu1i6eg+rKq3/NRwY="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
-      "sum": "/pkNOLhRqvQoPA0yYdUuJvpPHqhkCLauAUMD2ZHMIkE="
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
       "source": {
@@ -78,7 +78,7 @@
           "subdir": "memcached"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "SWywAq4U0MRPMbASU0Ez8O9ArRNeoZzb75sEuReueow="
     },
     {
@@ -88,7 +88,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "e87aa70c8857d09235fa658a6780e7646a625ce6",
+      "version": "af3ca2c3fae4096002b0c0c921f18ca7da8d361f",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -108,8 +108,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "01f689fb4a2d93f0fa4415491e95ea3ca641d6d8",
-      "sum": "yRBlDzGmyJ4eTdfftx51XrRW1fcBrtym+/yJENZywyE="
+      "version": "2eae33a828320269c42acf38e808479a33e416db",
+      "sum": "lppHbNARpG3YTpuSv94X9TyIE9TfV3CyTVceIHSRxpc="
     },
     {
       "source": {
@@ -118,8 +118,8 @@
           "subdir": "1.20"
         }
       },
-      "version": "85543e49238903ac14b486321bd3d60fef09d9ef",
-      "sum": "K8hAiyQ4ELAsln24tcwTf/++hKM/3YvLXsOYN0zD8eM="
+      "version": "9e5b48eee32913938d3cac30f183b49ecd9fe13a",
+      "sum": "KXx5RVXiqTJQo2GVfrD8DIvlm292s0TxfTKT8I591+c="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the GEL version to match the Loki version that was added in version 5 of the helm chart. With these new versions we can now default to 3 targets in scalable mode `read`, `write`, and `backend`.

This PR also fixes 2 bugs when running in scalable mode:

* the gateway should forward requests to the admin api to the `backend` target when running 3 targets
* the index gateway should default to using `ring` mode, which will allow the queriers in the new `read` target to find the index gateway address for their index gateway clients via the ring.jj

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
