### PR TITLE
Loki: Fix wrong association of PSRL when sharding is enabled

### DIFF
--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -394,13 +394,13 @@ func (s *stream) validateEntries(entries []logproto.Entry, isReplay, rateLimitWh
 	// ingestion, the limiter should only be advanced when the whole stream can be
 	// sent
 	now := time.Now()
-	if rateLimitWholeStream && !s.limiter.AllowN(now, totalBytes) {
+	if rateLimitWholeStream && !s.limiter.AllowN(now, validBytes) {
 		// Report that the whole stream was rate limited
-		rateLimitedSamples = len(entries)
-		failedEntriesWithError = make([]entryWithError, 0, len(entries))
-		for i := 0; i < len(entries); i++ {
-			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&entries[i], &validation.ErrStreamRateLimit{RateLimit: flagext.ByteSize(limit), Labels: s.labelsString, Bytes: flagext.ByteSize(len(entries[i].Line))}})
-			rateLimitedBytes += len(entries[i].Line)
+		rateLimitedSamples = len(toStore)
+		failedEntriesWithError = make([]entryWithError, 0, len(toStore))
+		for i := 0; i < len(toStore); i++ {
+			failedEntriesWithError = append(failedEntriesWithError, entryWithError{&toStore[i], &validation.ErrStreamRateLimit{RateLimit: flagext.ByteSize(limit), Labels: s.labelsString, Bytes: flagext.ByteSize(len(toStore[i].Line))}})
+			rateLimitedBytes += len(toStore[i].Line)
 		}
 	}
 


### PR DESCRIPTION
Obs: PSRL stands for `per-stream rate limit`
**What this PR does / why we need it**:
- Fixes the scenario where all entries errors are accounted as PSRL if sharding is enabled
- Fixes invalid/rejected entries being accounted as candidates to be inserted
Scenario to illustrate:
- Let's say a push request has two entries for the same stream, one entry being invalid/super old, and another one being a valid one. Two issues will occur: 1) the two will be accounted to check if they're hitting the psrl or not; 2) the two will be rejected with PSRL error