### PR TITLE
Ingester: Reuse allocations on `GetStreamRates`

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -643,12 +643,7 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 // TODO: It might be nice for this to be human readable, eventually: Sort output and return labels, too?
 func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
 	allRates := i.streamRateCalculator.Rates()
-
-	rates := make([]*logproto.StreamRate, 0, len(allRates))
-	for idx := range allRates {
-		rates = append(rates, &allRates[idx])
-	}
-
+	rates := make([]*logproto.StreamRate, len(allRates))
 	return &logproto.StreamRatesResponse{StreamRates: rates}, nil
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -644,6 +644,9 @@ func (i *Ingester) Push(ctx context.Context, req *logproto.PushRequest) (*logpro
 func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequest) (*logproto.StreamRatesResponse, error) {
 	allRates := i.streamRateCalculator.Rates()
 	rates := make([]*logproto.StreamRate, len(allRates))
+	for idx := range allRates {
+		rates[idx] = &allRates[idx]
+	}
 	return &logproto.StreamRatesResponse{StreamRates: rates}, nil
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -646,12 +646,7 @@ func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequ
 
 	rates := make([]*logproto.StreamRate, 0, len(allRates))
 	for _, r := range allRates {
-		rates = append(rates, &logproto.StreamRate{
-			Tenant:            r.Tenant,
-			StreamHash:        r.StreamHash,
-			StreamHashNoShard: r.StreamHashNoShard,
-			Rate:              r.Rate,
-		})
+		rates = append(rates, &r)
 	}
 
 	return &logproto.StreamRatesResponse{StreamRates: rates}, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -645,8 +645,8 @@ func (i *Ingester) GetStreamRates(_ context.Context, _ *logproto.StreamRatesRequ
 	allRates := i.streamRateCalculator.Rates()
 
 	rates := make([]*logproto.StreamRate, 0, len(allRates))
-	for _, r := range allRates {
-		rates = append(rates, &r)
+	for idx := range allRates {
+		rates = append(rates, &allRates[idx])
 	}
 
 	return &logproto.StreamRatesResponse{StreamRates: rates}, nil

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -42,7 +42,6 @@ import (
 
 func BenchmarkGetStreamRatesAllocs(b *testing.B) {
 	ingesterConfig := defaultIngesterTestConfig(b)
-	ingesterConfig.UpdateInterval = time.Minute
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(b, err)
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -89,7 +89,7 @@ func BenchmarkGetStreamRatesAllocs(b *testing.B) {
 
 	b.ReportAllocs()
 	for idx := 0; idx < b.N; idx++ {
-		i.GetStreamRates(context.TODO(), nil)
+		i.GetStreamRates(context.TODO(), nil) //nolint:errcheck
 	}
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -40,6 +40,35 @@ import (
 	"github.com/grafana/loki/pkg/validation"
 )
 
+func TestIngester_GetStreamRates_Correctness(t *testing.T) {
+	ingesterConfig := defaultIngesterTestConfig(t)
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(t, err)
+
+	store := &mockStore{
+		chunks: map[string][]chunk.Chunk{},
+	}
+
+	i, err := New(ingesterConfig, client.Config{}, store, limits, runtime.DefaultTenantConfigs(), nil)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	for idx := 0; idx < 100; idx++ {
+		// push 100 different streams.
+		i.streamRateCalculator.Record("fake", uint64(idx), uint64(idx), 10)
+	}
+
+	i.streamRateCalculator.updateRates()
+
+	resp, err := i.GetStreamRates(context.TODO(), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.StreamRates, 100)
+	for idx := 0; idx < 100; idx++ {
+		resp.StreamRates[idx].StreamHash = uint64(idx)
+		resp.StreamRates[idx].Rate = 10
+	}
+}
+
 func BenchmarkGetStreamRatesAllocs(b *testing.B) {
 	ingesterConfig := defaultIngesterTestConfig(b)
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reuse rates mapping returned by the calculator to reduce the number of allocations