### PR TITLE
Create new `http.TargetServer` shared across all HTTP Promtail Targets

### DIFF
--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -416,8 +416,8 @@ type GcplogTargetConfig struct {
 
 // HerokuDrainTargetConfig describes a scrape config to listen and consume heroku logs, in the HTTPS drain manner.
 type HerokuDrainTargetConfig struct {
-	// Server is the weaveworks server config for listening connections
-	Server server.Config `yaml:"server"`
+	// Server is used to configure the HTTP server the target exposes.
+	Server phttp.Config `yaml:",inline"`
 
 	// Labels optionally holds labels to associate with each record received on the push api.
 	Labels model.LabelSet `yaml:"labels"`

--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/logentry/stages"
 	"github.com/grafana/loki/clients/pkg/promtail/discovery/consulagent"
+	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 )
 
 // Config describes a job to scrape.
@@ -405,8 +406,8 @@ type GcplogTargetConfig struct {
 	// PushTimeout is used to set a maximum processing time for each incoming GCP Logs entry. Used just for `push` subscription type.
 	PushTimeout time.Duration `yaml:"push_timeout"`
 
-	// Server is the weaveworks server config for listening connections. Used just for `push` subscription type.
-	Server server.Config `yaml:"server"`
+	// Server is used to configure the HTTP server the target exposes. Used just for `push` subscription type.
+	Server phttp.Config `yaml:",inline"`
 
 	// UseFullLine force Promtail to send the full line from Cloud Logging even if `textPayload` is available.
 	// By default, if `textPayload` is present in the line, then it's used as log line.

--- a/clients/pkg/promtail/targets/gcplog/push_target.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/serverutils"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 
@@ -23,6 +24,7 @@ import (
 )
 
 type pushTarget struct {
+	ts             *phttp.TargetServer
 	config         *scrapeconfig.GcplogTargetConfig
 	entries        chan<- api.Entry
 	handler        api.EntryHandler

--- a/clients/pkg/promtail/targets/gcplog/push_target.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"io"
 	"net/http"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/relabel"
 )
 
 type pushTarget struct {

--- a/clients/pkg/promtail/targets/gcplog/push_target_test.go
+++ b/clients/pkg/promtail/targets/gcplog/push_target_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/client/fake"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/gcplog"
+	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 )
 
 const localhost = "127.0.0.1"
@@ -443,7 +444,7 @@ func waitForMessages(eh *fake.Client) {
 	}
 }
 
-func getServerConfigWithAvailablePort() (cfg server.Config, port int, err error) {
+func getServerConfigWithAvailablePort() (cfg phttp.Config, port int, err error) {
 	// Get a randomly available port by open and closing a TCP socket
 	addr, err := net.ResolveTCPAddr("tcp", localhost+":0")
 	if err != nil {
@@ -460,11 +461,13 @@ func getServerConfigWithAvailablePort() (cfg server.Config, port int, err error)
 	}
 
 	// Adjust some of the defaults
-	cfg.RegisterFlags(flag.NewFlagSet("empty", flag.ContinueOnError))
-	cfg.HTTPListenAddress = localhost
-	cfg.HTTPListenPort = port
-	cfg.GRPCListenAddress = localhost
-	cfg.GRPCListenPort = 0 // Not testing GRPC, a random port will be assigned
+	c := server.Config{}
+	c.RegisterFlags(flag.NewFlagSet("empty", flag.ContinueOnError))
+	c.HTTPListenAddress = localhost
+	c.HTTPListenPort = port
+	c.GRPCListenAddress = localhost
+	c.GRPCListenPort = 0 // Not testing GRPC, a random port will be assigned
+	cfg.Server = c
 
 	return
 }

--- a/clients/pkg/promtail/targets/heroku/target.go
+++ b/clients/pkg/promtail/targets/heroku/target.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
+	herokuEncoding "github.com/heroku/x/logplex/encoding"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -18,7 +19,6 @@ import (
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
-	herokuEncoding "github.com/heroku/x/logplex/encoding"
 
 	"github.com/grafana/loki/pkg/logproto"
 )

--- a/clients/pkg/promtail/targets/heroku/target.go
+++ b/clients/pkg/promtail/targets/heroku/target.go
@@ -2,22 +2,23 @@ package heroku
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	lokiClient "github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
 	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 	"github.com/grafana/loki/clients/pkg/promtail/targets/target"
 	herokuEncoding "github.com/heroku/x/logplex/encoding"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/relabel"
 
 	"github.com/grafana/loki/pkg/logproto"
 )

--- a/clients/pkg/promtail/targets/heroku/target_test.go
+++ b/clients/pkg/promtail/targets/heroku/target_test.go
@@ -22,6 +22,7 @@ import (
 	lokiClient "github.com/grafana/loki/clients/pkg/promtail/client"
 	"github.com/grafana/loki/clients/pkg/promtail/client/fake"
 	"github.com/grafana/loki/clients/pkg/promtail/scrapeconfig"
+	phttp "github.com/grafana/loki/clients/pkg/promtail/targets/http"
 )
 
 const localhost = "127.0.0.1"
@@ -274,7 +275,7 @@ func TestHerokuDrainTarget(t *testing.T) {
 			serverConfig, port, err := getServerConfigWithAvailablePort()
 			require.NoError(t, err, "error generating server config or finding open port")
 			config := &scrapeconfig.HerokuDrainTargetConfig{
-				Server:               serverConfig,
+				Server:               phttp.Config{Server: serverConfig},
 				Labels:               tc.args.Labels,
 				UseIncomingTimestamp: false,
 			}
@@ -335,7 +336,7 @@ func TestHerokuDrainTarget_UseIncomingTimestamp(t *testing.T) {
 	serverConfig, port, err := getServerConfigWithAvailablePort()
 	require.NoError(t, err, "error generating server config or finding open port")
 	config := &scrapeconfig.HerokuDrainTargetConfig{
-		Server:               serverConfig,
+		Server:               phttp.Config{Server: serverConfig},
 		Labels:               nil,
 		UseIncomingTimestamp: true,
 	}
@@ -378,7 +379,7 @@ func TestHerokuDrainTarget_ErrorOnNotPrometheusCompatibleJobName(t *testing.T) {
 	serverConfig, _, err := getServerConfigWithAvailablePort()
 	require.NoError(t, err, "error generating server config or finding open port")
 	config := &scrapeconfig.HerokuDrainTargetConfig{
-		Server:               serverConfig,
+		Server:               phttp.Config{Server: serverConfig},
 		Labels:               nil,
 		UseIncomingTimestamp: true,
 	}
@@ -404,7 +405,7 @@ func TestHerokuDrainTarget_UseTenantIDHeaderIfPresent(t *testing.T) {
 	serverConfig, port, err := getServerConfigWithAvailablePort()
 	require.NoError(t, err, "error generating server config or finding open port")
 	config := &scrapeconfig.HerokuDrainTargetConfig{
-		Server:               serverConfig,
+		Server:               phttp.Config{Server: serverConfig},
 		Labels:               nil,
 		UseIncomingTimestamp: true,
 	}

--- a/clients/pkg/promtail/targets/http/config.go
+++ b/clients/pkg/promtail/targets/http/config.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/common/server"
+)
+
+type Config struct {
+	// Server is the weaveworks server config for listening connections
+	Server server.Config `yaml:"server"`
+
+	// Labels optionally holds labels to associate with each record received on the push api.
+	Labels model.LabelSet `yaml:"labels"`
+
+	// UseIncomingTimestamp uses the timestamp in the received log entry. If false,
+	// Promtail will assign the current timestamp to the log entry when it was processed.
+	UseIncomingTimestamp bool `yaml:"use_incoming_timestamp"`
+}

--- a/clients/pkg/promtail/targets/http/config.go
+++ b/clients/pkg/promtail/targets/http/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/weaveworks/common/server"
 )
 
+// Config wraps the server.Config object.
 type Config struct {
 	// Server is the weaveworks server config for listening connections
 	Server server.Config `yaml:"server"`

--- a/clients/pkg/promtail/targets/http/config.go
+++ b/clients/pkg/promtail/targets/http/config.go
@@ -1,18 +1,10 @@
 package http
 
 import (
-	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/server"
 )
 
 type Config struct {
 	// Server is the weaveworks server config for listening connections
 	Server server.Config `yaml:"server"`
-
-	// Labels optionally holds labels to associate with each record received on the push api.
-	Labels model.LabelSet `yaml:"labels"`
-
-	// UseIncomingTimestamp uses the timestamp in the received log entry. If false,
-	// Promtail will assign the current timestamp to the log entry when it was processed.
-	UseIncomingTimestamp bool `yaml:"use_incoming_timestamp"`
 }

--- a/clients/pkg/promtail/targets/http/server.go
+++ b/clients/pkg/promtail/targets/http/server.go
@@ -2,14 +2,17 @@ package http
 
 import (
 	"fmt"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
-	"github.com/grafana/loki/clients/pkg/promtail/targets/serverutils"
-	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/server"
+
+	"github.com/grafana/loki/clients/pkg/promtail/targets/serverutils"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 // TargetServer is wrapper around WeaveWorks Server that handled some common configuration used in all Promtail targets

--- a/clients/pkg/promtail/targets/http/targettemplate.go
+++ b/clients/pkg/promtail/targets/http/targettemplate.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"fmt"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/grafana/loki/clients/pkg/promtail/api"
+	"github.com/grafana/loki/clients/pkg/promtail/targets/serverutils"
+	util_log "github.com/grafana/loki/pkg/util/log"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/server"
+)
+
+type TargetServer struct {
+	logger         log.Logger
+	handler        api.EntryHandler
+	config         *Config
+	componentName  string
+	jobName        string
+	server         *server.Server
+	relabelConfigs []*relabel.Config
+}
+
+func NewTargetServer(
+	mountRoute func(router *mux.Router),
+	logger log.Logger,
+	handler api.EntryHandler,
+	jobName, componentName string,
+	config *Config,
+	relabel []*relabel.Config,
+) (*TargetServer, error) {
+	wrappedLogger := log.With(logger, "component", componentName)
+
+	t := &TargetServer{
+		logger:         wrappedLogger,
+		handler:        handler,
+		jobName:        jobName,
+		config:         config,
+		relabelConfigs: relabel,
+	}
+
+	mergedServerConfigs, err := serverutils.MergeWithDefaults(config.Server)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse configs and override defaults when configuring target: %w", err)
+	}
+	// Set the config to the new combined config.
+	config.Server = mergedServerConfigs
+
+	return t, nil
+}
+
+func (ts *TargetServer) MountAndRun(mountRoute func(router *mux.Router)) error {
+	level.Info(ts.logger).Log("msg", fmt.Sprintf("starting %s target", ts.componentName), "job", ts.jobName)
+
+	// To prevent metric collisions because all metrics are going to be registered in the global Prometheus registry.
+
+	tentativeServerMetricNamespace := fmt.Sprintf("promtail_%s_target_", ts.componentName) + ts.jobName
+	if !model.IsValidMetricName(model.LabelValue(tentativeServerMetricNamespace)) {
+		return fmt.Errorf("invalid prometheus-compatible job name: %s", ts.jobName)
+	}
+	ts.config.Server.MetricsNamespace = tentativeServerMetricNamespace
+
+	// We don't want the /debug and /metrics endpoints running, since this is not the main promtail HTTP server.
+	// We want this target to expose the least surface area possible, hence disabling WeaveWorks HTTP server metrics
+	// and debugging functionality.
+	ts.config.Server.RegisterInstrumentation = false
+
+	// Wrapping util logger with component-specific key vals, and the expected GoKit logging interface
+	ts.config.Server.Log = logging.GoKit(log.With(util_log.Logger, "component", ts.componentName))
+
+	srv, err := server.New(ts.config.Server)
+	if err != nil {
+		return err
+	}
+
+	ts.server = srv
+	mountRoute(ts.server.HTTP)
+
+	go func() {
+		err := srv.Run()
+		if err != nil {
+			level.Error(ts.logger).Log("msg", fmt.Sprintf("%s target shutdown with error", ts.componentName), "err", err)
+		}
+	}()
+
+	return nil
+}
+
+func (ts *TargetServer) Stop() {
+	ts.server.Stop()
+	ts.server.Shutdown()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR creates a wrapper around WeaveWorks HTTP server, to be able to re-use some common configuration all Promtail targets that expose and HTTP server do.

From all the targets: gcp logs push, heroku and lokipush expose and HTTP server, based on WeaveWorks. They all have some repeated logic that:
- applies some defaults to the config
- configures a metrics namespace
- toggles instrumentation and some other stuff

By extracting a common `TargetServer`, we can share all that configuration procedure, delegating to each target itself configuring just the HTTP handlers..

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
[lokipush](https://github.com/grafana/loki/tree/main/clients/pkg/promtail/targets/lokipush) was not pulled in the new wrapped sever, since it handles some configurations differently. Leaving as a follow up.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
