### PR TITLE
Prevent redis client from incorrectly choosing cluster mode with local address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@
 * [8972](https://github.com/grafana/loki/pull/8972) **salvacorts** Index stat requests are now cached in the results cache.
 * [9177](https://github.com/grafana/loki/pull/9177) **salvacorts** Index stat cache can be enabled or disabled with the new `cache_index_stats_results` flag. Disabled by default.
 * [9096](https://github.com/grafana/loki/pull/9096) **salvacorts**: Compute proportional TSDB index stats for chunks that doesn't fit fully in the queried time range.
+
+##### Fixes
+
+* [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
+* [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
+* [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.
+* [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
+
+### All Changes
+
+#### Promtail
+
+##### Enhancements
+
+* [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
+* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Add new `decompression` configuration to customize the decompressor behavior.
 * [8939](https://github.com/grafana/loki/pull/8939) **Suruthi-G-K**: Loki: Add support for trusted profile authentication in COS client.
 * [8852](https://github.com/grafana/loki/pull/8852) **wtchangdm**: Loki: Add `route_randomly` to Redis options.
 * [8848](https://github.com/grafana/loki/pull/8848) **dannykopping**: Ruler: add configurable rule evaluation jitter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,6 @@
 * [8972](https://github.com/grafana/loki/pull/8972) **salvacorts** Index stat requests are now cached in the results cache.
 * [9177](https://github.com/grafana/loki/pull/9177) **salvacorts** Index stat cache can be enabled or disabled with the new `cache_index_stats_results` flag. Disabled by default.
 * [9096](https://github.com/grafana/loki/pull/9096) **salvacorts**: Compute proportional TSDB index stats for chunks that doesn't fit fully in the queried time range.
-
-##### Fixes
-
-* [8971](https://github.com/grafana/loki/pull/8971) **dannykopping**: Stats: fix `Cache.Chunk.BytesSent` statistic and loki_chunk_fetcher_fetched_size_bytes metric with correct chunk size.
-* [8979](https://github.com/grafana/loki/pull/8979) **slim-bean**: Fix the case where a logs query with start time == end time was returning logs when none should be returned.
-* [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.
-* [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
-
-### All Changes
-
-#### Promtail
-
-##### Enhancements
-
-* [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
-* [8994](https://github.com/grafana/loki/pull/8994) **DylanGuedes**: Promtail: Add new `decompression` configuration to customize the decompressor behavior.
 * [8939](https://github.com/grafana/loki/pull/8939) **Suruthi-G-K**: Loki: Add support for trusted profile authentication in COS client.
 * [8852](https://github.com/grafana/loki/pull/8852) **wtchangdm**: Loki: Add `route_randomly` to Redis options.
 * [8848](https://github.com/grafana/loki/pull/8848) **dannykopping**: Ruler: add configurable rule evaluation jitter.
@@ -47,6 +31,7 @@
 * [9099](https://github.com/grafana/loki/pull/9099) **salvacorts**: Fix the estimated size of chunks when writing a new TSDB file during compaction.
 * [9130](https://github.com/grafana/loki/pull/9130) **salvacorts**: Pass LogQL engine options down to the _split by range_, _sharding_, and _query size limiter_ middlewares.
 * [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value
+* [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
 
 #### Promtail
 

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -57,24 +57,11 @@ type RedisClient struct {
 
 // NewRedisClient creates Redis client
 func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
-	endpoints := strings.Split(cfg.Endpoint, ",")
-	// Handle single configuration endpoint which resolves multiple nodes.
-	if len(endpoints) == 1 {
-		host, port, err := net.SplitHostPort(endpoints[0])
-		if err != nil {
-			return nil, err
-		}
-		addrs, err := net.LookupHost(host)
-		if err != nil {
-			return nil, err
-		}
-		if len(addrs) > 1 {
-			endpoints = nil
-			for _, addr := range addrs {
-				endpoints = append(endpoints, net.JoinHostPort(addr, port))
-			}
-		}
+	endpoints, err := deriveEndpoints(cfg.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive endpoints: %w", err)
 	}
+
 	opt := &redis.UniversalOptions{
 		Addrs:         endpoints,
 		MasterName:    cfg.MasterName,
@@ -94,6 +81,46 @@ func NewRedisClient(cfg *RedisConfig) (*RedisClient, error) {
 		timeout:    cfg.Timeout,
 		rdb:        redis.NewUniversalClient(opt),
 	}, nil
+}
+
+func deriveEndpoints(endpoint string) ([]string, error) {
+	endpoints := strings.Split(endpoint, ",")
+
+	if len(endpoints) <= 1 {
+		return endpoints, nil
+	}
+
+	// Handle single configuration endpoint which resolves multiple nodes.
+	host, port, err := net.SplitHostPort(endpoints[0])
+	if err != nil {
+		return nil, fmt.Errorf("splitting host:port failed :%w", err)
+	}
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return nil, fmt.Errorf("could not lookup host: %w", err)
+	}
+
+	// only use the resolved addresses if they are not all loopback addresses;
+	// multiple addresses invokes cluster mode
+	allLoopback := allAddrsAreLoopback(addrs)
+	if len(addrs) > 1 && !allLoopback {
+		endpoints = nil
+		for _, addr := range addrs {
+			endpoints = append(endpoints, net.JoinHostPort(addr, port))
+		}
+	}
+
+	return endpoints, nil
+}
+
+func allAddrsAreLoopback(addrs []string) bool {
+	for _, addr := range addrs {
+		if !net.ParseIP(addr).IsLoopback() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (c *RedisClient) Ping(ctx context.Context) error {

--- a/pkg/storage/chunk/cache/redis_client.go
+++ b/pkg/storage/chunk/cache/redis_client.go
@@ -89,7 +89,9 @@ func deriveEndpoints(endpoint string, lookup func(host string) ([]string, error)
 	}
 
 	endpoints := strings.Split(endpoint, ",")
-	if len(endpoints) < 1 {
+
+	// no endpoints or multiple endpoints will not need derivation
+	if len(endpoints) != 1 {
 		return endpoints, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
See referenced issue below for details

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/9149

**Special notes for your reviewer**:
This is the challenge of using magic in our code; it produces unexpected results sometimes which are hard to debug. In general we should prefer being explicit, but we cannot revert this functionality now because it may be in use. I think this (automatically deriving multiple endpoints from a single one) is a good candidate for a deprecation, and ultimately removal in v3. Thoughts?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
