### PR TITLE
operator: Add PodDisruptionBudgets to the query path

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+- [9188](https://github.com/grafana/loki/pull/9188) **aminesnow**: Add PodDisruptionBudgets to the query path
 - [9162](https://github.com/grafana/loki/pull/9162) **aminesnow**: Add a PodDisruptionBudget to lokistack-gateway
 - [9049](https://github.com/grafana/loki/pull/9049) **alanconway**: Revert 1x.extra-small changes, add 1x.demo
 - [8661](https://github.com/grafana/loki/pull/8661) **xuanyunhui**: Add a new Object Storage Type for AlibabaCloud OSS

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -8,6 +8,7 @@ import (
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
@@ -989,7 +990,7 @@ func extractAffinity(raw client.Object) (*corev1.Affinity, bool, error) {
 		return obj.Spec.Template.Spec.Affinity, false, nil
 	case *appsv1.StatefulSet:
 		return obj.Spec.Template.Spec.Affinity, false, nil
-	case *corev1.ConfigMap, *corev1.Service:
+	case *corev1.ConfigMap, *corev1.Service, *policyv1.PodDisruptionBudget:
 		return nil, true, nil
 	default:
 	}

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -55,6 +56,7 @@ func BuildIndexGateway(opts Options) ([]client.Object, error) {
 		statefulSet,
 		NewIndexGatewayGRPCService(opts),
 		NewIndexGatewayHTTPService(opts),
+		NewIndexGatewayPodDisruptionBudget(opts),
 	}, nil
 }
 
@@ -234,6 +236,30 @@ func NewIndexGatewayHTTPService(opts Options) *corev1.Service {
 				},
 			},
 			Selector: labels,
+		},
+	}
+}
+
+// NewIndexGatewayPodDisruptionBudget returns a PodDisruptionBudget for the LokiStack
+// index-gateway pods.
+func NewIndexGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
+	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)
+	ma := intstr.FromInt(1)
+	return &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodDisruptionBudget",
+			APIVersion: policyv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    l,
+			Name:      IndexGatewayName(opts.Name),
+			Namespace: opts.Namespace,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: l,
+			},
+			MinAvailable: &ma,
 		},
 	}
 }

--- a/operator/internal/manifests/indexgateway_test.go
+++ b/operator/internal/manifests/indexgateway_test.go
@@ -6,6 +6,7 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
@@ -74,4 +75,31 @@ func TestNewIndexGatewayStatefulSet_SelectorMatchesLabels(t *testing.T) {
 		require.Contains(t, l, key)
 		require.Equal(t, l[key], value)
 	}
+}
+
+func TestBuildIndexGateway_PodDisruptionBudget(t *testing.T) {
+	opts := manifests.Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				IndexGateway: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+		},
+	}
+	objs, err := manifests.BuildIndexGateway(opts)
+
+	require.NoError(t, err)
+	require.Len(t, objs, 4)
+
+	pdb := objs[3].(*policyv1.PodDisruptionBudget)
+	require.NotNil(t, pdb)
+	require.Equal(t, "abcd-index-gateway", pdb.Name)
+	require.Equal(t, "efgh", pdb.Namespace)
+	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.EqualValues(t, manifests.ComponentLabels(manifests.LabelIndexGatewayComponent, opts.Name),
+		pdb.Spec.Selector.MatchLabels)
 }

--- a/operator/internal/manifests/querier_test.go
+++ b/operator/internal/manifests/querier_test.go
@@ -6,6 +6,9 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
@@ -73,5 +76,110 @@ func TestNewQuerierDeployment_SelectorMatchesLabels(t *testing.T) {
 	for key, value := range ss.Spec.Selector.MatchLabels {
 		require.Contains(t, l, key)
 		require.Equal(t, l[key], value)
+	}
+}
+
+func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
+	tt := []struct {
+		name string
+		opts manifests.Options
+		want policyv1.PodDisruptionBudget
+	}{
+		{
+			name: "Querier with 1 replica",
+			opts: manifests.Options{
+				Name:      "abcd",
+				Namespace: "efgh",
+				Stack: lokiv1.LokiStackSpec{
+					Template: &lokiv1.LokiTemplateSpec{
+						Querier: &lokiv1.LokiComponentSpec{
+							Replicas: 1,
+						},
+					},
+				},
+			},
+			want: policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "abcd-querier",
+					Namespace: "efgh",
+					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					},
+				},
+			},
+		},
+		{
+			name: "Querier with 2 replicas",
+			opts: manifests.Options{
+				Name:      "abcd",
+				Namespace: "efgh",
+				Stack: lokiv1.LokiStackSpec{
+					Template: &lokiv1.LokiTemplateSpec{
+						Querier: &lokiv1.LokiComponentSpec{
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			want: policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "abcd-querier",
+					Namespace: "efgh",
+					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					},
+				},
+			},
+		},
+		{
+			name: "Querier with 3 replicas",
+			opts: manifests.Options{
+				Name:      "abcd",
+				Namespace: "efgh",
+				Stack: lokiv1.LokiStackSpec{
+					Template: &lokiv1.LokiTemplateSpec{
+						Querier: &lokiv1.LokiComponentSpec{
+							Replicas: 3,
+						},
+					},
+				},
+			},
+			want: policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "abcd-querier",
+					Namespace: "efgh",
+					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			objs, err := manifests.BuildQuerier(tc.opts)
+			require.NoError(t, err)
+			require.Len(t, objs, 4)
+
+			pdb := objs[3].(*policyv1.PodDisruptionBudget)
+			require.NotNil(t, pdb)
+			require.Equal(t, tc.want.ObjectMeta, pdb.ObjectMeta)
+			require.Equal(t, tc.want.Spec, pdb.Spec)
+		})
 	}
 }

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -230,7 +230,7 @@ func NewQueryFrontendHTTPService(opts Options) *corev1.Service {
 // query-frontend pods.
 func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelQueryFrontendComponent, opts.Name)
-	mu := intstr.FromInt(1)
+	ma := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -245,7 +245,7 @@ func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &mu,
+			MinAvailable: &ma,
 		},
 	}
 }

--- a/operator/internal/manifests/query-frontend_test.go
+++ b/operator/internal/manifests/query-frontend_test.go
@@ -5,6 +5,7 @@ import (
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 func TestNewQueryFrontendDeployment_SelectorMatchesLabels(t *testing.T) {
@@ -63,4 +64,30 @@ func TestNewQueryFrontendDeployment_HasTemplateCertRotationRequiredAtAnnotation(
 	annotations := ss.Spec.Template.Annotations
 	require.Contains(t, annotations, expected)
 	require.Equal(t, annotations[expected], "deadbeef")
+}
+
+func TestBuildQueryFrontend_PodDisruptionBudget(t *testing.T) {
+	opts := Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				QueryFrontend: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+		},
+	}
+	objs, err := BuildQueryFrontend(opts)
+
+	require.NoError(t, err)
+	require.Len(t, objs, 4)
+
+	pdb := objs[3].(*policyv1.PodDisruptionBudget)
+	require.NotNil(t, pdb)
+	require.Equal(t, "abcd-query-frontend", pdb.Name)
+	require.Equal(t, "efgh", pdb.Namespace)
+	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.EqualValues(t, ComponentLabels(LabelQueryFrontendComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds 3 `PodDisruptionBudget`s for the following components:
* `query-frontend` with a `MinAvailable` of 1.
* `querier` with a `MinAvailable` of 2 for `1x.medium` and 1 for `1x.small`.
* `index-gateway` with a `MinAvailable` of 1.


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
