### PR TITLE
jsonnet: remove mistakenly added deep merging on stateful ingesters

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -122,7 +122,7 @@
   compactor_statefulset+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
   distributor_deployment+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
   index_gateway_statefulset+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
-  ingester_statefulset+: if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled then {} else
+  ingester_statefulset: if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled then {} else
     (super.ingester_statefulset + if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_zone_a_statefulset+:
     if $._config.multi_zone_ingester_enabled && $._config.memberlist_ring_enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

This was added in 4d55a24ed3cbed399c189dafb8c4140cbffce21d, probably to align with the multizone ingesters below, but in this case the logic is different, due to the super.ingester_statefulset in the line below. If the merging is applied this way e.g. volumes are duplicated on the statefulset.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- n/a Documentation added
- n/a Tests updated
- [?] `CHANGELOG.md` updated
- n/a Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
