### PR TITLE
Logcli - Do not fail if tenant specific schema doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ##### Fixes
 
 * [8566](https://github.com/grafana/loki/pull/8566) **ndrpnt**: Allow queries to start with negative filters (`!=` and `!~`) when omitting stream selector with `--stdin` flag
+* [9191](https://github.com/grafana/loki/pull/9191) **salvacorts**: Fix loading global remote schema for backwards compatibility when tenant-specific schema is not found.
 
 #### Mixins
 

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -444,7 +444,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 		}
 		loadedSchema, err := LoadSchemaUsingObjectClient(client, objects...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load schema config: %w", err)
 		}
 
 		conf.SchemaConfig = *loadedSchema
@@ -538,7 +538,7 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, names ...string) (*confi
 			defer cancel()
 			rdr, _, err := oc.GetObject(ctx, name)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to load object '%s': %w", name, err)
 			}
 			defer rdr.Close()
 
@@ -547,7 +547,7 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, names ...string) (*confi
 			section := schemaConfigSection{}
 			err = decoder.Decode(&section)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to decode downloaded object '%s': %w", name, err)
 			}
 
 			return &section.SchemaConfig, nil

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -420,6 +420,27 @@ func (q *Query) printResult(value loghttp.ResultValue, out output.LogOutput, las
 	return length, entry
 }
 
+// loadRemoteSchema First tries to download the tenant specific schema config (tenant-schemaconfig.yaml),
+// if it doesn't exist, fallback to the global one (schemaconfig.yaml) for backwards compatibility.
+func loadRemoteSchema(client chunk.ObjectClient, tenant string) (*config.SchemaConfig, error) {
+	tenantSchemaConfigFilename := fmt.Sprintf("%s-%s.yaml", tenant, schemaConfigFilename)
+	globalSchemaConfigFilename := fmt.Sprintf("%s.yaml", schemaConfigFilename)
+	loadedSchema, err := LoadSchemaUsingObjectClient(client, tenantSchemaConfigFilename)
+	if err != nil {
+		if !strings.Contains(err.Error(), "object doesn't exist") {
+			return nil, fmt.Errorf("failed to load schema config: %w", err)
+		}
+
+		log.Printf("failed to load tenant specific schema config (%s). Falling back to load global schema", tenantSchemaConfigFilename)
+		loadedSchema, err = LoadSchemaUsingObjectClient(client, globalSchemaConfigFilename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load global schema config: %w", err)
+		}
+	}
+
+	return loadedSchema, nil
+}
+
 // DoLocalQuery executes the query against the local store using a Loki configuration file.
 func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string, useRemoteSchema bool) error {
 	var conf loki.Config
@@ -433,26 +454,14 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 
 	cm := storage.NewClientMetrics()
 	if useRemoteSchema {
-		client, err := GetObjectClient(conf, cm)
+		objectClient, err := GetObjectClient(conf, cm)
 		if err != nil {
 			return err
 		}
 
-		// First try to download the tenant specific schema config (tenant-schemaconfig.yaml),
-		// if it doesn't exist, fallback to the global one (schemaconfig.yaml) for backwards compatibility.
-		tenantSchemaConfigFilename := fmt.Sprintf("%s-%s.yaml", orgID, schemaConfigFilename)
-		globalSchemaConfigFilename := fmt.Sprintf("%s.yaml", schemaConfigFilename)
-		loadedSchema, err := LoadSchemaUsingObjectClient(client, tenantSchemaConfigFilename)
+		loadedSchema, err := loadRemoteSchema(objectClient, orgID)
 		if err != nil {
-			if !strings.Contains(err.Error(), "object doesn't exist") {
-				return fmt.Errorf("failed to load schema config: %w", err)
-			}
-
-			log.Printf("failed to load tenant specific schema config (%s). Falling back to load global schema", tenantSchemaConfigFilename)
-			loadedSchema, err = LoadSchemaUsingObjectClient(client, globalSchemaConfigFilename)
-			if err != nil {
-				return fmt.Errorf("failed to load global schema config: %w", err)
-			}
+			return err
 		}
 
 		conf.SchemaConfig = *loadedSchema

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/grafana/dskit/multierror"
 	json "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
 
-	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/loghttp"

--- a/pkg/storage/chunk/client/object_client.go
+++ b/pkg/storage/chunk/client/object_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -165,7 +166,7 @@ func (o *client) getChunk(ctx context.Context, decodeContext *chunk.DecodeContex
 
 	readCloser, size, err := o.store.GetObject(ctx, key)
 	if err != nil {
-		return chunk.Chunk{}, errors.WithStack(err)
+		return chunk.Chunk{}, errors.WithStack(fmt.Errorf("failed to load object '%s': %w", key, err))
 	}
 
 	if readCloser == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is how we currently load a remote schema from the object store:
https://github.com/grafana/loki/blob/2f8d771c6b4fe5f659535c1f62df3dc6a7746e60/pkg/logcli/query/query.go#L441-L448

`LoadSchemaUsingObjectClient` ([here](https://github.com/grafana/loki/blob/2f8d771c6b4fe5f659535c1f62df3dc6a7746e60/pkg/logcli/query/query.go#L534)) will return an error if any of the objects trying to download doesn’t exist. Therefore, if the tenant-specific schema file doesn't exist, `LoadSchemaUsingObjectClient`will return an error and we won't try to use the global schema config even if it exists. In other words, the backward compatibility won't work.

This PR fixes this by first trying to download the tenant-specific schema config and if it doesn't exist, fallback to the global one for backwards compatibility.

This PR also improves the error messaging when an object cannot be downloaded from the store by printing the name of the object along with the error.

**Which issue(s) this PR fixes**:
Internal support escalation

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
