### PR TITLE
Distributor: Reuse `time.Now()` for better performance

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -196,17 +196,18 @@ func (s *rateStore) aggregateByShard(ctx context.Context, streamRates map[string
 		}
 	}
 	rates := map[string]map[uint64]expiringRate{}
+	now := time.Now()
 
 	for tID, tenant := range streamRates {
-		for _, streamRate := range tenant {
-			if _, ok := rates[tID]; !ok {
-				rates[tID] = map[uint64]expiringRate{}
-			}
+		if _, ok := rates[tID]; !ok {
+			rates[tID] = map[uint64]expiringRate{}
+		}
 
+		for _, streamRate := range tenant {
 			rate := rates[tID][streamRate.StreamHashNoShard]
 			rate.rate += streamRate.Rate
 			rate.shards++
-			rate.createdAt = time.Now()
+			rate.createdAt = now
 
 			rates[tID][streamRate.StreamHashNoShard] = rate
 		}

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -212,6 +212,20 @@ func BenchmarkRateStore(b *testing.B) {
 	}
 }
 
+func BenchmarkAggregateByShard(b *testing.B) {
+	rs := &rateStore{rates: make(map[string]map[uint64]expiringRate)}
+	rates := make(map[string]map[uint64]*logproto.StreamRate)
+	rates["fake"] = make(map[uint64]*logproto.StreamRate)
+	for i := 0; i < 1000; i++ {
+		rates["fake"][uint64(i)] = &logproto.StreamRate{StreamHash: uint64(i), StreamHashNoShard: 12345}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rs.aggregateByShard(context.TODO(), rates)
+	}
+}
+
 func newFakeRing() *fakeRing {
 	return &fakeRing{}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies `AggregateByShard` to reuse `time.Now()` to improve performance.
