### PR TITLE
Logcli - Better logging when object cannot get loaded from object store

### DIFF
--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/fatih/color"
 	json "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
@@ -531,14 +531,14 @@ type schemaConfigSection struct {
 
 // LoadSchemaUsingObjectClient returns the loaded schema from the first found object
 func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, names ...string) (*config.SchemaConfig, error) {
-	errors := multierror.New()
+	errs := multierror.New()
 	for _, name := range names {
 		schema, err := func(name string) (*config.SchemaConfig, error) {
 			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
 			defer cancel()
 			rdr, _, err := oc.GetObject(ctx, name)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "failed to load schema object '%s'", name)
 			}
 			defer rdr.Close()
 
@@ -554,12 +554,12 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, names ...string) (*confi
 		}(name)
 
 		if err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 			continue
 		}
 		return schema, nil
 	}
-	return nil, errors.Err()
+	return nil, errs.Err()
 }
 
 // SetInstant makes the Query an instant type

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -14,13 +14,13 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/grafana/dskit/multierror"
 	json "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
 
-	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/loghttp"

--- a/pkg/storage/chunk/client/object_client.go
+++ b/pkg/storage/chunk/client/object_client.go
@@ -165,7 +165,7 @@ func (o *client) getChunk(ctx context.Context, decodeContext *chunk.DecodeContex
 
 	readCloser, size, err := o.store.GetObject(ctx, key)
 	if err != nil {
-		return chunk.Chunk{}, errors.WithStack(err)
+		return chunk.Chunk{}, errors.WithStack(errors.Wrapf(err, "failed to load chunk '%s'", key))
 	}
 
 	if readCloser == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the error messaging for Logcli when an object cannot be downloaded from the store by printing the name of the object along with the error.

**Which issue(s) this PR fixes**:
Internal support escalation

**Special notes for your reviewer**:
There are other places where GetObject is called:
- `indexStorageClient.GetFile`
- `indexStorageClient.GetUserFile`

Looks like both of them are used only by the compactor and the table manager. IIUC, these functions are not used by LogCLI.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
