### PR TITLE
removes 20 user test from compaction; seems redundant and hits timeouts

### DIFF
--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -244,7 +244,10 @@ func TestCompactor_Compact(t *testing.T) {
 	lbls1 := mustParseLabels(`{foo="bar", a="b"}`)
 	lbls2 := mustParseLabels(`{fizz="buzz", a="b"}`)
 
-	for _, numUsers := range []int{5, 10, 20} {
+	for _, numUsers := range []int{
+		5,
+		10,
+	} {
 		t.Run(fmt.Sprintf("numUsers=%d", numUsers), func(t *testing.T) {
 			for name, tc := range map[string]struct {
 				multiTenantIndexConfigs []multiTenantIndexConfig


### PR DESCRIPTION
just a little cleanup to make tests run faster -- the 20 user test doesn't seem to test any additional surface area and takes a long time.