### PR TITLE
Rename usagestats to analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 * [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value
 * [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
 
+##### Changes
+
+* [9212](https://github.com/grafana/loki/pull/9212) **trevorwhitney**: Rename UsageReport to Analytics. This changed the `-reporting.*` command line flags to be renamed to `-analytics.*`.
+
 #### Promtail
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ##### Changes
 
-* [9212](https://github.com/grafana/loki/pull/9212) **trevorwhitney**: Rename UsageReport to Analytics. This changed the `-reporting.*` command line flags to be renamed to `-analytics.*`.
+* [9212](https://github.com/grafana/loki/pull/9212) **trevorwhitney**: Rename UsageReport to Analytics. The only external impact of this change is a change in the `-list-targets` output.
 
 #### Promtail
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -192,7 +192,7 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # Configuration for tracing.
 [tracing: <tracing>]
 
-# Configuration for usage report.
+# Configuration for analytics.
 [analytics: <analytics>]
 
 # Common configuration to be shared between multiple modules. If a more specific
@@ -2934,15 +2934,15 @@ Configuration for `tracing`.
 
 ### analytics
 
-Configuration for usage report.
+Configuration for `analytics`.
 
 ```yaml
 # Enable anonymous usage reporting.
-# CLI flag: -reporting.enabled
+# CLI flag: -analytics.enabled
 [reporting_enabled: <boolean> | default = true]
 
 # URL to which reports are sent
-# CLI flag: -reporting.usage-stats-url
+# CLI flag: -analytics.usage-stats-url
 [usage_stats_url: <string> | default = "https://stats.grafana.org/loki-usage-report"]
 ```
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2938,11 +2938,11 @@ Configuration for `analytics`.
 
 ```yaml
 # Enable anonymous usage reporting.
-# CLI flag: -analytics.enabled
+# CLI flag: -reporting.enabled
 [reporting_enabled: <boolean> | default = true]
 
 # URL to which reports are sent
-# CLI flag: -analytics.usage-stats-url
+# CLI flag: -reporting.usage-stats-url
 [usage_stats_url: <string> | default = "https://stats.grafana.org/loki-usage-report"]
 ```
 

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -42,6 +42,10 @@ If the new `ingester.shutdown_marker_path` config setting has a value that value
 If not the`common.path_prefix` config setting is used if it has a value. Otherwise a warning is shown
 in the logs on startup and the `/ingester/prepare_shutdown` endpoint will return a 500 status code.
 
+#### Rename UsageReport to Analytics
+
+The `UsageReport` module has been renamed to `Analytics` to match the config file, which was already expecting an `analytics` section. As a result the commandline flags `-reporting.*` have been renamed to `-analytics.*`.
+
 ## 2.8.0
 
 ### Loki

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -42,10 +42,6 @@ If the new `ingester.shutdown_marker_path` config setting has a value that value
 If not the`common.path_prefix` config setting is used if it has a value. Otherwise a warning is shown
 in the logs on startup and the `/ingester/prepare_shutdown` endpoint will return a 500 status code.
 
-#### Rename UsageReport to Analytics
-
-The `UsageReport` module has been renamed to `Analytics` to match the config file, which was already expecting an `analytics` section. As a result the commandline flags `-reporting.*` have been renamed to `-analytics.*`.
-
 ## 2.8.0
 
 ### Loki

--- a/pkg/analytics/reporter.go
+++ b/pkg/analytics/reporter.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"bytes"

--- a/pkg/analytics/reporter.go
+++ b/pkg/analytics/reporter.go
@@ -47,8 +47,8 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, "analytics.enabled", true, "Enable anonymous usage reporting.")
-	f.StringVar(&cfg.UsageStatsURL, "analytics.usage-stats-url", usageStatsURL, "URL to which reports are sent")
+	f.BoolVar(&cfg.Enabled, "reporting.enabled", true, "Enable anonymous usage reporting.")
+	f.StringVar(&cfg.UsageStatsURL, "reporting.usage-stats-url", usageStatsURL, "URL to which reports are sent")
 }
 
 type Reporter struct {

--- a/pkg/analytics/reporter.go
+++ b/pkg/analytics/reporter.go
@@ -47,8 +47,8 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, "reporting.enabled", true, "Enable anonymous usage reporting.")
-	f.StringVar(&cfg.UsageStatsURL, "reporting.usage-stats-url", usageStatsURL, "URL to which reports are sent")
+	f.BoolVar(&cfg.Enabled, "analytics.enabled", true, "Enable anonymous usage reporting.")
+	f.StringVar(&cfg.UsageStatsURL, "analytics.usage-stats-url", usageStatsURL, "URL to which reports are sent")
 }
 
 type Reporter struct {

--- a/pkg/analytics/reporter_test.go
+++ b/pkg/analytics/reporter_test.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"context"

--- a/pkg/analytics/seed.go
+++ b/pkg/analytics/seed.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"fmt"

--- a/pkg/analytics/seed_test.go
+++ b/pkg/analytics/seed_test.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"context"

--- a/pkg/analytics/stats.go
+++ b/pkg/analytics/stats.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"bytes"

--- a/pkg/analytics/stats_test.go
+++ b/pkg/analytics/stats_test.go
@@ -1,4 +1,4 @@
-package usagestats
+package analytics
 
 import (
 	"runtime"

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -37,7 +37,7 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/validation"
@@ -49,7 +49,7 @@ const (
 
 var (
 	maxLabelCacheSize = 100000
-	rfStats           = usagestats.NewInt("distributor_replication_factor")
+	rfStats           = analytics.NewInt("distributor_replication_factor")
 )
 
 // Config for a Distributor.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/distributor/clientpool"
 	"github.com/grafana/loki/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/pkg/ingester/client"
@@ -37,7 +38,6 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/validation"

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/ingester/index"
@@ -40,7 +41,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
 	index_stats "github.com/grafana/loki/pkg/storage/stores/index/stats"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/wal"

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -40,7 +40,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
 	index_stats "github.com/grafana/loki/pkg/storage/stores/index/stats"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/wal"
@@ -62,10 +62,10 @@ var (
 		Name: "cortex_ingester_flush_queue_length",
 		Help: "The total number of series pending in the flush queue.",
 	})
-	compressionStats   = usagestats.NewString("ingester_compression")
-	targetSizeStats    = usagestats.NewInt("ingester_target_size_bytes")
-	walStats           = usagestats.NewString("ingester_wal")
-	activeTenantsStats = usagestats.NewInt("ingester_active_tenants")
+	compressionStats   = analytics.NewString("ingester_compression")
+	targetSizeStats    = analytics.NewInt("ingester_target_size_bytes")
+	walStats           = analytics.NewString("ingester_wal")
+	activeTenantsStats = analytics.NewInt("ingester_active_tenants")
 )
 
 // Config for an ingester.

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -19,6 +19,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"go.uber.org/atomic"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/ingester/index"
 	"github.com/grafana/loki/pkg/ingester/wal"
 	"github.com/grafana/loki/pkg/iter"
@@ -30,7 +31,6 @@ import (
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/deletion"
 	util_log "github.com/grafana/loki/pkg/util/log"

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -30,7 +30,7 @@ import (
 	"github.com/grafana/loki/pkg/runtime"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/deletion"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -70,7 +70,7 @@ var (
 		Help:      "The total number of streams removed per tenant.",
 	}, []string{"tenant"})
 
-	streamsCountStats = usagestats.NewInt("ingester_streams_count")
+	streamsCountStats = analytics.NewInt("ingester_streams_count")
 )
 
 type instance struct {

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -48,17 +48,17 @@ type ingesterMetrics struct {
 	chunkEncodeTime               prometheus.Histogram
 	chunksFlushedPerReason        *prometheus.CounterVec
 	chunkLifespan                 prometheus.Histogram
-	flushedChunksStats            *usagestats.Counter
-	flushedChunksBytesStats       *usagestats.Statistics
-	flushedChunksLinesStats       *usagestats.Statistics
-	flushedChunksAgeStats         *usagestats.Statistics
-	flushedChunksLifespanStats    *usagestats.Statistics
-	flushedChunksUtilizationStats *usagestats.Statistics
+	flushedChunksStats            *analytics.Counter
+	flushedChunksBytesStats       *analytics.Statistics
+	flushedChunksLinesStats       *analytics.Statistics
+	flushedChunksAgeStats         *analytics.Statistics
+	flushedChunksLifespanStats    *analytics.Statistics
+	flushedChunksUtilizationStats *analytics.Statistics
 
 	chunksCreatedTotal prometheus.Counter
 	samplesPerChunk    prometheus.Histogram
 	blocksPerChunk     prometheus.Histogram
-	chunkCreatedStats  *usagestats.Counter
+	chunkCreatedStats  *analytics.Counter
 
 	// Shutdown marker for ingester scale down
 	shutdownMarker prometheus.Gauge
@@ -241,12 +241,12 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			// 1h -> 8hr
 			Buckets: prometheus.LinearBuckets(1, 1, 8),
 		}),
-		flushedChunksStats:            usagestats.NewCounter("ingester_flushed_chunks"),
-		flushedChunksBytesStats:       usagestats.NewStatistics("ingester_flushed_chunks_bytes"),
-		flushedChunksLinesStats:       usagestats.NewStatistics("ingester_flushed_chunks_lines"),
-		flushedChunksAgeStats:         usagestats.NewStatistics("ingester_flushed_chunks_age_seconds"),
-		flushedChunksLifespanStats:    usagestats.NewStatistics("ingester_flushed_chunks_lifespan_seconds"),
-		flushedChunksUtilizationStats: usagestats.NewStatistics("ingester_flushed_chunks_utilization"),
+		flushedChunksStats:            analytics.NewCounter("ingester_flushed_chunks"),
+		flushedChunksBytesStats:       analytics.NewStatistics("ingester_flushed_chunks_bytes"),
+		flushedChunksLinesStats:       analytics.NewStatistics("ingester_flushed_chunks_lines"),
+		flushedChunksAgeStats:         analytics.NewStatistics("ingester_flushed_chunks_age_seconds"),
+		flushedChunksLifespanStats:    analytics.NewStatistics("ingester_flushed_chunks_lifespan_seconds"),
+		flushedChunksUtilizationStats: analytics.NewStatistics("ingester_flushed_chunks_utilization"),
 		chunksCreatedTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: "loki",
 			Name:      "ingester_chunks_created_total",
@@ -269,7 +269,7 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			Buckets: prometheus.ExponentialBuckets(5, 2, 6),
 		}),
 
-		chunkCreatedStats: usagestats.NewCounter("ingester_chunk_created"),
+		chunkCreatedStats: analytics.NewCounter("ingester_chunk_created"),
 
 		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: "loki",

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -17,10 +17,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	loki_util "github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/unmarshal"
@@ -133,32 +133,4 @@ func ParseRequest(logger log.Logger, userID string, r *http.Request, tenantsRete
 		for _, e := range s.Entries {
 			totalEntries++
 			entriesSize += int64(len(e.Line))
-			bytesIngested.WithLabelValues(userID, retentionHours).Add(float64(int64(len(e.Line))))
-			bytesReceivedStats.Inc(int64(len(e.Line)))
-			if e.Timestamp.After(mostRecentEntry) {
-				mostRecentEntry = e.Timestamp
-			}
-		}
-	}
-
-	// incrementing tenant metrics if we have a tenant.
-	if totalEntries != 0 && userID != "" {
-		linesIngested.WithLabelValues(userID).Add(float64(totalEntries))
-	}
-	linesReceivedStats.Inc(totalEntries)
-
-	level.Debug(logger).Log(
-		"msg", "push request parsed",
-		"path", r.URL.Path,
-		"contentType", contentType,
-		"contentEncoding", contentEncoding,
-		"bodySize", humanize.Bytes(uint64(bodySize.Size())),
-		"streams", len(req.Streams),
-		"entries", totalEntries,
-		"streamLabelsSize", humanize.Bytes(uint64(streamLabelsSize)),
-		"entriesSize", humanize.Bytes(uint64(entriesSize)),
-		"totalSize", humanize.Bytes(uint64(entriesSize+streamLabelsSize)),
-		"mostRecentLagMs", time.Since(mostRecentEntry).Milliseconds(),
-	)
-	return &req, nil
-}
+			by

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	loki_util "github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/unmarshal"
@@ -41,8 +41,8 @@ var (
 		Help:      "The total number of lines received per tenant",
 	}, []string{"tenant"})
 
-	bytesReceivedStats = usagestats.NewCounter("distributor_bytes_received")
-	linesReceivedStats = usagestats.NewCounter("distributor_lines_received")
+	bytesReceivedStats = analytics.NewCounter("distributor_bytes_received")
+	linesReceivedStats = analytics.NewCounter("distributor_lines_received")
 )
 
 const applicationJSON = "application/json"

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -13,10 +13,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	logql_stats "github.com/grafana/loki/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	logql_stats "github.com/grafana/loki/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
@@ -72,10 +72,10 @@ var (
 		Help:      "Total count of lines sent from ingesters while executing LogQL queries.",
 	})
 
-	bytePerSecondMetricUsage = usagestats.NewStatistics("query_metric_bytes_per_second")
-	bytePerSecondLogUsage    = usagestats.NewStatistics("query_log_bytes_per_second")
-	linePerSecondMetricUsage = usagestats.NewStatistics("query_metric_lines_per_second")
-	linePerSecondLogUsage    = usagestats.NewStatistics("query_log_lines_per_second")
+	bytePerSecondMetricUsage = analytics.NewStatistics("query_metric_bytes_per_second")
+	bytePerSecondLogUsage    = analytics.NewStatistics("query_log_bytes_per_second")
+	linePerSecondMetricUsage = analytics.NewStatistics("query_metric_lines_per_second")
+	linePerSecondLogUsage    = analytics.NewStatistics("query_log_lines_per_second")
 )
 
 func RecordRangeAndInstantQueryMetrics(

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -54,7 +54,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/tracing"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/fakeauth"
 	"github.com/grafana/loki/pkg/util/limiter"
@@ -99,7 +99,7 @@ type Config struct {
 
 	RuntimeConfig runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	Tracing       tracing.Config       `yaml:"tracing"`
-	UsageReport   usagestats.Config    `yaml:"analytics"`
+	Analytics     analytics.Config    `yaml:"analytics"`
 
 	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden"`
 
@@ -165,7 +165,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Tracing.RegisterFlags(f)
 	c.CompactorConfig.RegisterFlags(f)
 	c.QueryScheduler.RegisterFlags(f)
-	c.UsageReport.RegisterFlags(f)
+	c.Analytics.RegisterFlags(f)
 }
 
 func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
@@ -365,7 +365,7 @@ type Loki struct {
 	compactor                *compactor.Compactor
 	QueryFrontEndTripperware basetripper.Tripperware
 	queryScheduler           *scheduler.Scheduler
-	usageReport              *usagestats.Reporter
+	usageReport              *analytics.Reporter
 	indexGatewayRingManager  *indexgateway.RingManager
 
 	clientMetrics       storage.ClientMetrics
@@ -383,7 +383,7 @@ func New(cfg Config) (*Loki, error) {
 		clientMetrics:       storage.NewClientMetrics(),
 		deleteClientMetrics: deletion.NewDeleteRequestClientMetrics(prometheus.DefaultRegisterer),
 	}
-	usagestats.Edition("oss")
+	analytics.Edition("oss")
 	loki.setupAuthMiddleware()
 	loki.setupGRPCRecoveryMiddleware()
 	if err := loki.setupModuleManager(); err != nil {
@@ -634,7 +634,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(IndexGateway, t.initIndexGateway)
 	mm.RegisterModule(QueryScheduler, t.initQueryScheduler)
 	mm.RegisterModule(IndexGatewayRing, t.initIndexGatewayRing, modules.UserInvisibleModule)
-	mm.RegisterModule(UsageReport, t.initUsageReport)
+	mm.RegisterModule(Analytics, t.initAnalytics)
 	mm.RegisterModule(CacheGenerationLoader, t.initCacheGenerationLoader)
 
 	mm.RegisterModule(All, nil)
@@ -645,22 +645,22 @@ func (t *Loki) setupModuleManager() error {
 	// Add dependencies
 	deps := map[string][]string{
 		Ring:                     {RuntimeConfig, Server, MemberlistKV},
-		UsageReport:              {},
+		Analytics:                {},
 		Overrides:                {RuntimeConfig},
 		OverridesExporter:        {Overrides, Server},
 		TenantConfigs:            {RuntimeConfig},
-		Distributor:              {Ring, Server, Overrides, TenantConfigs, UsageReport},
+		Distributor:              {Ring, Server, Overrides, TenantConfigs, Analytics},
 		Store:                    {Overrides, IndexGatewayRing},
-		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, UsageReport},
-		Querier:                  {Store, Ring, Server, IngesterQuerier, Overrides, UsageReport, CacheGenerationLoader},
+		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
+		Querier:                  {Store, Ring, Server, IngesterQuerier, Overrides, Analytics, CacheGenerationLoader},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},
-		QueryFrontend:            {QueryFrontendTripperware, UsageReport, CacheGenerationLoader},
-		QueryScheduler:           {Server, Overrides, MemberlistKV, UsageReport},
-		Ruler:                    {Ring, Server, RulerStorage, RuleEvaluator, Overrides, TenantConfigs, UsageReport},
-		RuleEvaluator:            {Ring, Server, Store, IngesterQuerier, Overrides, TenantConfigs, UsageReport},
-		TableManager:             {Server, UsageReport},
-		Compactor:                {Server, Overrides, MemberlistKV, UsageReport},
-		IndexGateway:             {Server, Store, Overrides, UsageReport, MemberlistKV, IndexGatewayRing},
+		QueryFrontend:            {QueryFrontendTripperware, Analytics, CacheGenerationLoader},
+		QueryScheduler:           {Server, Overrides, MemberlistKV, Analytics},
+		Ruler:                    {Ring, Server, RulerStorage, RuleEvaluator, Overrides, TenantConfigs, Analytics},
+		RuleEvaluator:            {Ring, Server, Store, IngesterQuerier, Overrides, TenantConfigs, Analytics},
+		TableManager:             {Server, Analytics},
+		Compactor:                {Server, Overrides, MemberlistKV, Analytics},
+		IndexGateway:             {Server, Store, Overrides, Analytics, MemberlistKV, IndexGatewayRing},
 		IngesterQuerier:          {Ring},
 		IndexGatewayRing:         {RuntimeConfig, Server, MemberlistKV},
 		All:                      {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler, Compactor},
@@ -755,7 +755,7 @@ func (t *Loki) setupModuleManager() error {
 	t.ModuleManager = mm
 
 	if t.isModuleActive(Ingester) {
-		if err := mm.AddDependency(UsageReport, Ring); err != nil {
+		if err := mm.AddDependency(Analytics, Ring); err != nil {
 			return err
 		}
 	}

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaveworks/common/signals"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/ingester"
 	ingester_client "github.com/grafana/loki/pkg/ingester/client"
@@ -54,7 +55,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/tracing"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/fakeauth"
 	"github.com/grafana/loki/pkg/util/limiter"
@@ -99,7 +99,7 @@ type Config struct {
 
 	RuntimeConfig runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	Tracing       tracing.Config       `yaml:"tracing"`
-	Analytics     analytics.Config    `yaml:"analytics"`
+	Analytics     analytics.Config     `yaml:"analytics"`
 
 	LegacyReadTarget bool `yaml:"legacy_read_target,omitempty" doc:"hidden"`
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -64,7 +64,7 @@ import (
 	boltdb_shipper_compactor "github.com/grafana/loki/pkg/storage/stores/shipper/index/compactor"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util/httpreq"
 	"github.com/grafana/loki/pkg/util/limiter"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -108,7 +108,7 @@ const (
 	Read                     string = "read"
 	Write                    string = "write"
 	Backend                  string = "backend"
-	UsageReport              string = "usage-report"
+	Analytics                string = "analytics"
 )
 
 func (t *Loki) initServer() (services.Service, error) {
@@ -1041,7 +1041,7 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
 	t.Cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
-		usagestats.JSONCodec,
+		analytics.JSONCodec,
 	}
 
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(
@@ -1237,16 +1237,16 @@ func (t *Loki) initQueryLimitsTripperware() (services.Service, error) {
 	return nil, nil
 }
 
-func (t *Loki) initUsageReport() (services.Service, error) {
-	if !t.Cfg.UsageReport.Enabled {
+func (t *Loki) initAnalytics() (services.Service, error) {
+	if !t.Cfg.Analytics.Enabled {
 		return nil, nil
 	}
-	t.Cfg.UsageReport.Leader = false
+	t.Cfg.Analytics.Leader = false
 	if t.isModuleActive(Ingester) {
-		t.Cfg.UsageReport.Leader = true
+		t.Cfg.Analytics.Leader = true
 	}
 
-	usagestats.Target(t.Cfg.Target.String())
+	analytics.Target(t.Cfg.Target.String())
 	period, err := t.Cfg.SchemaConfig.SchemaForTime(model.Now())
 	if err != nil {
 		return nil, err
@@ -1257,7 +1257,7 @@ func (t *Loki) initUsageReport() (services.Service, error) {
 		level.Info(util_log.Logger).Log("msg", "failed to initialize usage report", "err", err)
 		return nil, nil
 	}
-	ur, err := usagestats.NewReporter(t.Cfg.UsageReport, t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore, objectClient, util_log.Logger, prometheus.DefaultRegisterer)
+	ur, err := analytics.NewReporter(t.Cfg.Analytics, t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore, objectClient, util_log.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		level.Info(util_log.Logger).Log("msg", "failed to initialize usage report", "err", err)
 		return nil, nil

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/user"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/ingester"
 	"github.com/grafana/loki/pkg/logproto"
@@ -64,7 +65,6 @@ import (
 	boltdb_shipper_compactor "github.com/grafana/loki/pkg/storage/stores/shipper/index/compactor"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util/httpreq"
 	"github.com/grafana/loki/pkg/util/limiter"
 	util_log "github.com/grafana/loki/pkg/util/log"

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/dskit/tenant"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
@@ -32,7 +33,6 @@ import (
 	series_index "github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/deletion"
 )

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -32,15 +32,15 @@ import (
 	series_index "github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/deletion"
 )
 
 var (
-	indexTypeStats  = usagestats.NewString("store_index_type")
-	objectTypeStats = usagestats.NewString("store_object_type")
-	schemaStats     = usagestats.NewString("store_schema")
+	indexTypeStats  = analytics.NewString("store_index_type")
+	objectTypeStats = analytics.NewString("store_object_type")
+	schemaStats     = analytics.NewString("store_schema")
 
 	errWritingChunkUnsupported = errors.New("writing chunks is not supported while running store in read-only mode")
 )

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -26,7 +26,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletion"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 	shipper_storage "github.com/grafana/loki/pkg/storage/stores/indexshipper/storage"
-	"github.com/grafana/loki/pkg/usagestats"
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/filter"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -65,8 +65,8 @@ const (
 )
 
 var (
-	retentionEnabledStats = usagestats.NewString("compactor_retention_enabled")
-	defaultRetentionStats = usagestats.NewString("compactor_default_retention")
+	retentionEnabledStats = analytics.NewString("compactor_retention_enabled")
+	defaultRetentionStats = analytics.NewString("compactor_default_retention")
 )
 
 type Config struct {

--- a/pkg/storage/stores/indexshipper/compactor/compactor.go
+++ b/pkg/storage/stores/indexshipper/compactor/compactor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/storage/chunk/client"
 	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	chunk_util "github.com/grafana/loki/pkg/storage/chunk/client/util"
@@ -26,7 +27,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/deletion"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor/retention"
 	shipper_storage "github.com/grafana/loki/pkg/storage/stores/indexshipper/storage"
-	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/filter"
 	util_log "github.com/grafana/loki/pkg/util/log"

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/weaveworks/common/server"
 
+	"github.com/grafana/loki/pkg/analytics"
 	"github.com/grafana/loki/pkg/distributor"
 	"github.com/grafana/loki/pkg/ingester"
 	ingester_client "github.com/grafana/loki/pkg/ingester/client"
@@ -37,7 +38,6 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	"github.com/grafana/loki/pkg/tracing"
-	"github.com/grafana/loki/pkg/usagestats"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -144,8 +144,8 @@ var (
 		},
 		{
 			Name:       "analytics",
-			StructType: reflect.TypeOf(usagestats.Config{}),
-			Desc:       "Configuration for usage report.",
+			StructType: reflect.TypeOf(analytics.Config{}),
+			Desc:       "Configuration for analytics.",
 		},
 
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename usagestats to analytics. The config section in the yaml is already called analytics, this makes things more consistent.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
