### PR TITLE
Helm: Fix gateway proxy_pass settings

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -596,78 +596,119 @@ http {
     {{- $backendUrl = .Values.gateway.nginxConfig.customBackendUrl }}
     {{- end }}
 
+
+    # Distributor
     location = /api/prom/push {
       proxy_pass       {{ $writeUrl }}$request_uri;
     }
+    location = /loki/api/v1/push {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
+    location = /distributor/ring {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
 
+    # Ingester
+    location = /flush {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
+    location ^~ /ingester/ {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
+    location = /ingester {
+      internal;        # to suppress 301
+    }
+
+    # Ring
+    location = /ring {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
+
+    # MemberListKV
+    location = /memberlist {
+      proxy_pass       {{ $writeUrl }}$request_uri;
+    }
+
+
+    # Ruler
+    location = /ruler/ring {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /api/prom/rules {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location ^~ /api/prom/rules/ {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /loki/api/v1/rules {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location ^~ /loki/api/v1/rules/ {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /prometheus/api/v1/alerts {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /prometheus/api/v1/rules {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+
+    # Compactor
+    location = /compactor/ring {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /loki/api/v1/delete {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /loki/api/v1/cache/generation_numbers {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+
+    # IndexGateway
+    location = /indexgateway/ring {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+
+    # QueryScheduler
+    location = /scheduler/ring {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+
+    {{- if and .Values.enterprise.enabled .Values.enterprise.adminApi.enabled }}
+    # Admin API
+    location ^~ /admin/api/ {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+    location = /admin/api {
+      internal;        # to suppress 301
+    }
+    {{- end }}
+
+
+    # QueryFrontend, Querier
     location = /api/prom/tail {
       proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
-
-    location ~ /api/prom/.* {
-      proxy_pass       {{ $readUrl }}$request_uri;
-    }
-
-    location ~ /prometheus/api/v1/alerts.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-    location ~ /prometheus/api/v1/rules.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-    location ~ /ruler/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-
-    location = /loki/api/v1/push {
-      proxy_pass       {{ $writeUrl }}$request_uri;
-    }
-
     location = /loki/api/v1/tail {
       proxy_pass       {{ $readUrl }}$request_uri;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
-
-    location ~ /compactor/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-
-    location ~ /loki/api/v1/delete.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-
-    location ~ /distributor/.* {
-      proxy_pass       {{ $writeUrl }}$request_uri;
-    }
-
-    location ~ /ring {
-      proxy_pass       {{ $writeUrl }}$request_uri;
-    }
-
-    location ~ /ingester/.* {
-      proxy_pass       {{ $writeUrl }}$request_uri;
-    }
-
-    location ~ /store-gateway/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-
-    location ~ /query-scheduler/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-    location ~ /scheduler/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
-    }
-
-    location ~ /loki/api/.* {
+    location ^~ /api/prom/ {
       proxy_pass       {{ $readUrl }}$request_uri;
     }
-
-    location ~ /admin/api/.* {
-      proxy_pass       {{ $backendUrl }}$request_uri;
+    location = /api/prom {
+      internal;        # to suppress 301
     }
+    location ^~ /loki/api/v1/ {
+      proxy_pass       {{ $readUrl }}$request_uri;
+    }
+    location = /loki/api/v1 {
+      internal;        # to suppress 301
+    }
+
 
     {{- with .Values.gateway.nginxConfig.serverSnippet }}
     {{ . | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Rewrite the regular expressions for exact or prefix matches because they are matching in places where they shouldn't be (due to a missing anchor (`^`)), which is also causing inefficiency. Exact and prefix matches are also easy to understand because they are the longest matches regardless of the order in which they are listed.

2. Change the destination of the following Ruler API from `$readUrl` to `$backendUrl` because setting `LegacyReadTarget=false` cause it to stop functioning. (Fix #9214)
   - `/api/prom/rules`
   - `/api/prom/rules/*`
   - `/loki/api/v1/rules`
   - `/loki/api/v1/rules/*`

3. Add the following APIs settings.  
   - Ingester  
     - `/flush`
   - MeberListKV  
     - `/memberlist`
   - Compactor  
     - `/loki/api/v1/delete`
     - `/loki/api/v1/cache/generation_numbers`
   - IndexGateway  
     - `/indexgateway/ring`

4. Remove following APIs settings because they are unused.
   - `/store-gateway/*`
   - `/query-scheduler/*`

5. Change Admin API to be set only if enabled.

6. Re-arrange the APIs settings by component to make it easier to check.

**Which issue(s) this PR fixes**:
Fixes #9214

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
