### PR TITLE
Force using a buffer from the ChunkRefsPool

### DIFF
--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -743,7 +743,7 @@ func (t *tenantHeads) GetChunkRefs(ctx context.Context, userID string, from, thr
 	if !ok {
 		return nil, nil
 	}
-	return idx.GetChunkRefs(ctx, userID, from, through, nil, shard, matchers...)
+	return idx.GetChunkRefs(ctx, userID, from, through, res, shard, matchers...)
 
 }
 

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -115,8 +115,10 @@ func (c *IndexClient) GetChunkRefs(ctx context.Context, userID string, from, thr
 		return nil, err
 	}
 
-	// TODO(owen-d): use a pool to reduce allocs here
-	chks, err := c.idx.GetChunkRefs(ctx, userID, from, through, nil, shard, matchers...)
+	chks := ChunkRefsPool.Get()
+	defer ChunkRefsPool.Put(chks)
+
+	chks, err = c.idx.GetChunkRefs(ctx, userID, from, through, chks, shard, matchers...)
 	kvps = append(kvps,
 		"chunks", len(chks),
 		"indexErr", err,

--- a/pkg/storage/stores/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/tsdb/multi_file_index_test.go
@@ -67,7 +67,9 @@ func TestMultiIndex(t *testing.T) {
 	idx := NewMultiIndex(IndexSlice(indices))
 
 	t.Run("GetChunkRefs", func(t *testing.T) {
-		refs, err := idx.GetChunkRefs(context.Background(), "fake", 2, 5, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		var err error
+		refs := make([]ChunkRef, 0, 8)
+		refs, err = idx.GetChunkRefs(context.Background(), "fake", 2, 5, refs, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.Nil(t, err)
 
 		expected := []ChunkRef{

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -153,13 +153,11 @@ func (i *TSDBIndex) forPostings(
 
 func (i *TSDBIndex) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, res []ChunkRef, shard *index.ShardAnnotation, matchers ...*labels.Matcher) ([]ChunkRef, error) {
 	if res == nil {
-		res = ChunkRefsPool.Get()
+		panic("res == nil")
 	}
-	res = res[:0]
 
 	if err := i.ForSeries(ctx, shard, from, through, func(ls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		for _, chk := range chks {
-
 			res = append(res, ChunkRef{
 				User:        userID, // assumed to be the same, will be enforced by caller.
 				Fingerprint: fp,

--- a/pkg/storage/stores/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/tsdb/single_file_index_test.go
@@ -85,7 +85,9 @@ func TestSingleIdx(t *testing.T) {
 		t.Run(variant.desc, func(t *testing.T) {
 			idx := variant.fn()
 			t.Run("GetChunkRefs", func(t *testing.T) {
-				refs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+				var err error
+				refs := make([]ChunkRef, 0, 8)
+				refs, err = idx.GetChunkRefs(context.Background(), "fake", 1, 5, refs, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 				require.Nil(t, err)
 
 				expected := []ChunkRef{
@@ -126,7 +128,9 @@ func TestSingleIdx(t *testing.T) {
 					Shard: 1,
 					Of:    2,
 				}
-				shardedRefs, err := idx.GetChunkRefs(context.Background(), "fake", 1, 5, nil, &shard, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+				var err error
+				refs := make([]ChunkRef, 0, 8)
+				refs, err = idx.GetChunkRefs(context.Background(), "fake", 1, 5, refs, &shard, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 
 				require.Nil(t, err)
 
@@ -136,7 +140,7 @@ func TestSingleIdx(t *testing.T) {
 					Start:       1,
 					End:         10,
 					Checksum:    3,
-				}}, shardedRefs)
+				}}, refs)
 
 			})
 
@@ -249,10 +253,13 @@ func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
+	var err error
 	for i := 0; i < b.N; i++ {
-		chkRefs, err := tsdbIndex.GetChunkRefs(context.Background(), "fake", queryFrom, queryThrough, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		chkRefs := ChunkRefsPool.Get()
+		chkRefs, err = tsdbIndex.GetChunkRefs(context.Background(), "fake", queryFrom, queryThrough, chkRefs, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.NoError(b, err)
 		require.Len(b, chkRefs, numChunksToMatch*2)
+		ChunkRefsPool.Put(chkRefs)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-using a buffer from the `ChunkRefsPool` avoids unnecessary allocations in TSDB's GetChunkRefs call.

**Special notes for your reviewer**:

Benchmarks

```
$ gotest -v -count=1 ./pkg/storage/stores/tsdb/ -test.run="^$" -test.bench=Bench -test.benchtime=5000x
```

```console
$ benchstat tsdbbench-old.txt tsdbbench-new.txt                                                                     
name                      old time/op    new time/op    delta
TenantHeads/10-8             152µs ± 0%      53µs ± 0%   ~     (p=1.000 n=1+1)
TenantHeads/100-8           1.22ms ± 0%    0.39ms ± 0%   ~     (p=1.000 n=1+1)
TenantHeads/1000-8          16.0ms ± 0%     5.2ms ± 0%   ~     (p=1.000 n=1+1)
IndexClient_Stats-8         35.9µs ± 0%    39.3µs ± 0%   ~     (p=1.000 n=1+1)
TSDBIndex_GetChunkRefs-8    2.98ms ± 0%    1.43ms ± 0%   ~     (p=1.000 n=1+1)

name                      old alloc/op   new alloc/op   delta
IndexClient_Stats-8         2.63kB ± 0%    2.14kB ± 0%   ~     (p=1.000 n=1+1)
TSDBIndex_GetChunkRefs-8    6.40MB ± 0%    1.40MB ± 0%   ~     (p=1.000 n=1+1)

name                      old allocs/op  new allocs/op  delta
IndexClient_Stats-8           57.0 ± 0%      57.0 ± 0%   ~     (all equal)
TSDBIndex_GetChunkRefs-8      42.0 ± 0%      27.0 ± 0%   ~     (p=1.000 n=1+1)
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
