### PR TITLE
POST /loki/api/v1/push should not be on query path

### DIFF
--- a/docs/sources/api/_index.md
+++ b/docs/sources/api/_index.md
@@ -34,7 +34,6 @@ These endpoints are exposed by the querier and the query frontend:
 - [`GET /loki/api/v1/series`](#list-series)
 - [`GET /loki/api/v1/index/stats`](#index-stats)
 - [`GET /loki/api/v1/tail`](#stream-log-messages)
-- [`POST /loki/api/v1/push`](#push-log-entries-to-loki)
 - [`GET /ready`](#identify-ready-loki-instance)
 - [`GET /metrics`](#return-exposed-prometheus-metrics)
 - **Deprecated** [`GET /api/prom/tail`](#get-apipromtail)


### PR DESCRIPTION
POST /loki/api/v1/push is on the write path on the distributor and should not be the query frontend (read path)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
