### PR TITLE
Update CHANGELOG and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Promtail
 
 ##### Fixes
+
 * [9095](https://github.com/grafana/loki/pull/9095) **JordanRushing** Fix journald support in amd64 binary build
 
 ## 2.8.0 (2023-04-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ##### Fixes
 
-* [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value
+* [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value.
 * [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
 * [9176](https://github.com/grafana/loki/pull/9176) **DylanGuedes**: Fix incorrect association of per-stream rate limit when sharding is enabled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,19 @@
 #### Loki
 
 ##### Fixes
+
 * [9156](https://github.com/grafana/loki/pull/9156) **ashwanthgoli**: Expiration: do not drop index if period is a zero value
 * [9185](https://github.com/grafana/loki/pull/9185) **dannykopping**: Prevent redis client from incorrectly choosing cluster mode with local address.
+* [9176](https://github.com/grafana/loki/pull/9176) **DylanGuedes**: Fix incorrect association of per-stream rate limit when sharding is enabled.
+
+##### Changes
+
+* [9106](https://github.com/grafana/loki/pull/9106) **trevorwhitney**: Update go to 1.20.3
+
+#### Promtail
+
+##### Fixes
+* [9095](https://github.com/grafana/loki/pull/9095) **JordanRushing** Fix journald support in amd64 binary build
 
 ## 2.8.0 (2023-04-04)
 

--- a/docs/sources/release-notes/v2-8.md
+++ b/docs/sources/release-notes/v2-8.md
@@ -21,3 +21,12 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) before upgrading Loki.
 
 ## Bug fixes
+
+### 2.8.1 (2023-04-21)
+
+
+* Fix bug that was dropping index if period is a zero value
+* Fix redis client to prevent it from incorrectly choosing cluster mode with local address.
+* Fix incorrect association of per-stream rate limit when sharding is enabled.
+* Update go to 1.20.3 to address security vulnerabilities if previous go version.
+* *Promtail*: Fix journald support in amd64 binary build.

--- a/docs/sources/release-notes/v2-8.md
+++ b/docs/sources/release-notes/v2-8.md
@@ -25,7 +25,7 @@ As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) bef
 ### 2.8.1 (2023-04-21)
 
 
-* Fix bug that was dropping index if period is a zero value
+* Fix bug that was dropping index if period is a zero value.
 * Fix redis client to prevent it from incorrectly choosing cluster mode with local address.
 * Fix incorrect association of per-stream rate limit when sharding is enabled.
 * Update go to 1.20.3 to address security vulnerabilities if previous go version.


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the release notes and changelog for 2.8.1
