### PR TITLE
operator: Replace deprecated MinIO environment variables

### DIFF
--- a/operator/config/overlays/development/minio/deployment.yaml
+++ b/operator/config/overlays/development/minio/deployment.yaml
@@ -21,9 +21,9 @@ spec:
           mkdir -p /storage/loki && \
           minio server /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
         image: minio/minio
         name: minio


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the deprecated MINIO_ACCESS_KEY and MINIO_SECRET_KEY environment variables in the operator template with their new names MINIO_ROOT_USER and MINIO_ROOT_PASSWORD.

**Which issue(s) this PR fixes**:
Fixes #8702 

**Special notes for your reviewer**:
This splits the previous PR #9150 in order to have separate PRs for Loki and Operator.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
