### PR TITLE
making clearer that TSDB is the new recommended index, and make expli…

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -30,22 +30,33 @@ For more information:
 
 The following are supported for the index:
 
-- [Single Store (boltdb-shipper) - Recommended for 2.0 and newer]({{<relref "boltdb-shipper">}}) index store which stores boltdb index files in the object store
-- [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
-- [Google Bigtable](https://cloud.google.com/bigtable)
-- [Apache Cassandra](https://cassandra.apache.org)
+- [TSDB]({{<relref "tsdb">}}) index store which stores TSDB index files in the object store. This is the recommended index store for Loki 2.8 and newer.
+- [Single Store (boltdb-shipper)]({{<relref "boltdb-shipper">}}) index store which stores boltdb index files in the object store. 
 - [BoltDB](https://github.com/boltdb/bolt) (doesn't work when clustering Loki)
 
-The following are supported for the chunks:
+The following are deprecated for the index and will be removed in a future release:
 
-- [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
-- [Google Bigtable](https://cloud.google.com/bigtable)
-- [Apache Cassandra](https://cassandra.apache.org)
+- [Amazon DynamoDB](https://aws.amazon.com/dynamodb). Support for this is deprecated and will be removed in a future release.
+- [Google Bigtable](https://cloud.google.com/bigtable). Support for this is deprecated and will be removed in a future release.
+- [Apache Cassandra](https://cassandra.apache.org). Support for this is deprecated and will be removed in a future release.
+
+The following are supported and recommended for the chunks:
+
 - [Amazon S3](https://aws.amazon.com/s3)
 - [Google Cloud Storage](https://cloud.google.com/storage/)
-- [Filesystem]({{<relref "filesystem">}}) (please read more about the filesystem to understand the pros/cons before using with production data)
 - [Baidu Object Storage](https://cloud.baidu.com/product/bos.html)
 - [IBM Cloud Object Storage](https://www.ibm.com/cloud/object-storage)
+
+The following are supported for the chunks, but not typically recommended for production use:
+
+- [Filesystem]({{<relref "filesystem">}}) (please read more about the filesystem to understand the pros/cons before using with production data)
+
+The following are deprecated for the chunks and will be removed in a future release:
+
+- [Amazon DynamoDB](https://aws.amazon.com/dynamodb). Support for this is deprecated and will be removed in a future release.
+- [Google Bigtable](https://cloud.google.com/bigtable). Support for this is deprecated and will be removed in a future release.
+- [Apache Cassandra](https://cassandra.apache.org). Support for this is deprecated and will be removed in a future release.
+
 
 ## Cloud Storage Permissions
 
@@ -63,6 +74,8 @@ Resources: `arn:aws:s3:::<bucket_name>`, `arn:aws:s3:::<bucket_name>/*`
 See the [AWS deployment section]({{<relref "../../storage/#aws-deployment-s3-single-store">}}) on the storage page for a detailed setup guide.
 
 ### DynamoDB
+
+Please note that DynamoDB support is deprecated and will be removed in a future release.
 
 When using DynamoDB for the index, the following permissions are needed:
 

--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -4,6 +4,8 @@ description: Single Store (boltdb-shipper)
 ---
 # Single Store (boltdb-shipper)
 
+Please note that this is a legacy storage option and is not recommended for new deployments. It is recommended to use the [TSDB]({{< relref "./tsdb" >}}) index instead.
+
 BoltDB Shipper lets you run Grafana Loki without any dependency on NoSQL stores for storing index.
 It locally stores the index in BoltDB files instead and keeps shipping those files to a shared object store i.e the same object store which is being used for storing chunks.
 It also keeps syncing BoltDB files from shared object store to a configured local directory for getting index entries created by other services of same Loki cluster.

--- a/docs/sources/operations/storage/table-manager/_index.md
+++ b/docs/sources/operations/storage/table-manager/_index.md
@@ -24,15 +24,16 @@ The Table Manager supports the following backends:
 
 - **Index store**
   - [Single Store (boltdb-shipper)]({{<relref "../boltdb-shipper">}})
-  - [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
-  - [Google Bigtable](https://cloud.google.com/bigtable)
-  - [Apache Cassandra](https://cassandra.apache.org)
   - [BoltDB](https://github.com/boltdb/bolt) (primarily used for local environments)
 - **Chunk store**
-  - [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
-  - [Google Bigtable](https://cloud.google.com/bigtable)
-  - [Apache Cassandra](https://cassandra.apache.org)
   - Filesystem (primarily used for local environments)
+
+
+Loki does support the following backends for both index and chunk storage, but they are deprecated and will be removed in a future release:
+
+- [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
+- [Google Bigtable](https://cloud.google.com/bigtable)
+- [Apache Cassandra](https://cassandra.apache.org)
 
 The object storages - like Amazon S3 and Google Cloud Storage - supported by Loki
 to store chunks, are not managed by the Table Manager, and a custom bucket policy

--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -6,7 +6,7 @@ weight: 1000
 
 # TSDB
 
-Starting with Loki v2.8, TSDB is the Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Owen's [blog post](https://lokidex.com/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the [boltdb-shipper]({{< relref "./boltdb-shipper" >}}) index which preceded it.
+Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Loki maintainer Owen's [blog post](https://lokidex.com/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the [boltdb-shipper]({{< relref "./boltdb-shipper" >}}) index which preceded it.
 
 ## Example Configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

making clearer that TSDB is the new recommended index, and make explicit that non TSDB and BoltDB shipper are deprecated and not recommended

**Special notes for your reviewer**:

This needs to be changed in more places, but this is a start as it concerns the main storage docs

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
