### PR TITLE
feat: build the Docker Driver for arm64

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "20aac53fcb06d378b1c1101c7e4dc989466eb4ff"
+      "version": "21f1189544e3976070cbdb6463f64c7a32dcc176"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "20aac53fcb06d378b1c1101c7e4dc989466eb4ff",
-      "sum": "bo355Fm9Gm1TU13MjlXGXgrCXo4CPr7aEeTvgNFYAl8="
+      "version": "21f1189544e3976070cbdb6463f64c7a32dcc176",
+      "sum": "IPS1oGR8k7jk6J2snciTycWFgtISCwXSPhJ3A+nEGvY="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -15,6 +15,7 @@ local imageJobs = {
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.image('promtail', 'clients/cmd/promtail'),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
+  'loki-docker-driver': build.dockerPlugin('grafana/loki-docker-driver', 'clients/cmd/docker-driver', platform=['linux/amd64', 'linux/arm64']),
 };
 
 local weeklyImageJobs = {
@@ -27,6 +28,7 @@ local weeklyImageJobs = {
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto'),
   promtail: build.weeklyImage('promtail', 'clients/cmd/promtail'),
   querytee: build.weeklyImage('loki-query-tee', 'cmd/querytee', platform=['linux/amd64']),
+  'loki-docker-driver': build.weeklyDockerPlugin('grafana/loki-docker-driver', 'clients/cmd/docker-driver', platform=['linux/amd64', 'linux/arm64']),
 };
 
 local buildImageVersion = std.extVar('BUILD_IMAGE_VERSION');

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -329,6 +329,78 @@
         "platforms": "linux/amd64,linux/arm64,linux/arm"
         "push": true
         "tags": "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ steps.weekly-version.outputs.version }}"
+  "loki-docker-driver":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_PREFIX": "grafana"
+      "RELEASE_LIB_REF": "main"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "runs-on": "ubuntu-latest"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 20
+    - "name": "Set up QEMU"
+      "uses": "docker/setup-qemu-action@v3"
+    - "name": "set up docker buildx"
+      "uses": "docker/setup-buildx-action@v3"
+    - "name": "Login to DockerHub (from vault)"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@main"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        echo "version=$(./tools/image-tag)" >> $GITHUB_OUTPUT
+        
+        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        if [[ "${platform}" == "linux/arm64" ]]; then
+          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
+        else
+          echo "plugin_arch=" >> $GITHUB_OUTPUT
+        fi
+      "working-directory": "release"
+    - "name": "Build and export"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@v6"
+      "with":
+        "build-args": "IMAGE_TAG=${{ steps.weekly-version.outputs.version }},GOARCH=${{ steps.weekly-version.outputs.platform_short }}"
+        "context": "release"
+        "file": "release/clients/cmd/docker-driver/Dockerfile"
+        "outputs": "type=docker,dest=release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        "platforms": "${{ matrix.platform }}"
+        "push": false
+        "tags": "${{ env.IMAGE_PREFIX }}/grafana/loki-docker-driver:${{ steps.weekly-version.outputs.version }}"
+    - "env":
+        "BUILD_DIR": "release/clients/cmd/docker-driver"
+        "IMAGE_TAG": "${{ steps.weekly-version.outputs.version }}"
+      "name": "Package and push as Docker plugin"
+      "run": |
+        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
+        mkdir "${{ env.BUILD_DIR }}/rootfs"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
+        docker plugin push "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}"
+      "working-directory": "release"
+    "strategy":
+      "matrix":
+        "platform":
+        - "linux/amd64"
+        - "linux/arm64"
   "promtail":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -31,6 +31,7 @@ jobs:
     - "loki"
     - "loki-canary"
     - "loki-canary-boringcrypto"
+    - "loki-docker-driver"
     - "promtail"
     - "querytee"
     runs-on: "ubuntu-latest"
@@ -598,6 +599,86 @@ jobs:
         - "linux/amd64"
         - "linux/arm64"
         - "linux/arm"
+  loki-docker-driver:
+    needs:
+    - "version"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "setup node"
+      uses: "actions/setup-node@v4"
+      with:
+        node-version: 20
+    - name: "auth gcs"
+      uses: "google-github-actions/auth@v2"
+      with:
+        credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@v3"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - id: "platform"
+      name: "parse image platform"
+      run: |
+        mkdir -p images
+        
+        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        if [[ "${platform}" == "linux/arm64" ]]; then
+          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
+        else
+          echo "plugin_arch=" >> $GITHUB_OUTPUT
+        fi
+      working-directory: "release"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Build and export"
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      uses: "docker/build-push-action@v6"
+      with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
+        context: "release"
+        file: "release/clients/cmd/docker-driver/Dockerfile"
+        outputs: "type=docker,dest=release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        platforms: "${{ matrix.platform }}"
+        push: false
+        tags: "${{ env.IMAGE_PREFIX }}/grafana/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - env:
+        BUILD_DIR: "release/clients/cmd/docker-driver"
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Package as Docker plugin"
+      run: |
+        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
+        mkdir "${{ env.BUILD_DIR }}/rootfs"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
+      working-directory: "release"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      uses: "google-github-actions/upload-cloud-storage@v2"
+      with:
+        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        path: "release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        process_gcloudignore: false
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+        - "linux/amd64"
+        - "linux/arm64"
   promtail:
     needs:
     - "version"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -31,6 +31,7 @@ jobs:
     - "loki"
     - "loki-canary"
     - "loki-canary-boringcrypto"
+    - "loki-docker-driver"
     - "promtail"
     - "querytee"
     runs-on: "ubuntu-latest"
@@ -598,6 +599,86 @@ jobs:
         - "linux/amd64"
         - "linux/arm64"
         - "linux/arm"
+  loki-docker-driver:
+    needs:
+    - "version"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "setup node"
+      uses: "actions/setup-node@v4"
+      with:
+        node-version: 20
+    - name: "auth gcs"
+      uses: "google-github-actions/auth@v2"
+      with:
+        credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@v3"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@v3"
+    - id: "platform"
+      name: "parse image platform"
+      run: |
+        mkdir -p images
+        
+        platform="$(echo "${{ matrix.platform}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.platform }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+        if [[ "${platform}" == "linux/arm64" ]]; then
+          echo "plugin_arch=-arm64" >> $GITHUB_OUTPUT
+        else
+          echo "plugin_arch=" >> $GITHUB_OUTPUT
+        fi
+      working-directory: "release"
+    - env:
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Build and export"
+      timeout-minutes: "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      uses: "docker/build-push-action@v6"
+      with:
+        build-args: "IMAGE_TAG=${{ needs.version.outputs.version }},GOARCH=${{ steps.platform.outputs.platform_short }}"
+        context: "release"
+        file: "release/clients/cmd/docker-driver/Dockerfile"
+        outputs: "type=docker,dest=release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        platforms: "${{ matrix.platform }}"
+        push: false
+        tags: "${{ env.IMAGE_PREFIX }}/grafana/loki-docker-driver:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - env:
+        BUILD_DIR: "release/clients/cmd/docker-driver"
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Package as Docker plugin"
+      run: |
+        rm -rf "${{ env.BUILD_DIR }}/rootfs" || true
+        mkdir "${{ env.BUILD_DIR }}/rootfs"
+        tar -x -C "${{ env.BUILD_DIR }}/rootfs" -f "release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        docker plugin create "${{ env.IMAGE_TAG }}${{ steps.platform.outputs.plugin_arch }}" "${{ env.BUILD_DIR }}"
+      working-directory: "release"
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      uses: "google-github-actions/upload-cloud-storage@v2"
+      with:
+        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        path: "release/images/grafana/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        process_gcloudignore: false
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+        - "linux/amd64"
+        - "linux/arm64"
   promtail:
     needs:
     - "version"

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,16 +1,29 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.34.0
+ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
-# docker build -t grafana/loki -f cmd/loki/Dockerfile .
+# docker build -t grafana/loki-docker-driver -f clients/cmd/docker-driver/Dockerfile .
 
-# TODO: add cross-platform support
 FROM $BUILD_IMAGE AS build
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && make BUILD_IN_CONTAINER=false clients/cmd/docker-driver/docker-driver
 
-FROM alpine:3.20.3
-RUN apk add --update --no-cache ca-certificates tzdata
+ARG GOARCH
+RUN make clean && make BUILD_IN_CONTAINER=false GOARCH=${GOARCH} clients/cmd/docker-driver/docker-driver
+
+FROM alpine:3.20.3 AS temp
+
+ARG GOARCH
+
+RUN apk add --update --no-cache --arch=${GOARCH} ca-certificates tzdata
+
+FROM --platform=linux/${GOARCH} alpine:3.20.3
+
+COPY --from=temp /etc/ca-certificates.conf /etc/ca-certificates.conf
+COPY --from=temp /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=temp /usr/share/zoneinfo /usr/share/zoneinfo
+
 COPY --from=build /src/loki/clients/cmd/docker-driver/docker-driver /bin/docker-driver
+
 WORKDIR /bin/
 ENTRYPOINT [ "/bin/docker-driver" ]

--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -31,6 +31,9 @@ Run the following command to install the plugin, updating the release version if
 ```bash
 docker plugin install grafana/loki-docker-driver:2.9.2 --alias loki --grant-all-permissions
 ```
+{{% admonition type="note" %}}
+Add `-arm64` to the image tag for AMR64 hosts.
+{{% /admonition %}}
 
 To check installed plugins, use the `docker plugin ls` command. 
 Plugins that have started successfully are listed as enabled:

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1213,7 +1213,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "range_query_prom",
-			path:       "/prom/query",
+			path:       "/api/prom/query",
 			expectedOp: QueryRangeOp,
 		},
 		{
@@ -1228,7 +1228,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "series_query_prom",
-			path:       "/prom/series",
+			path:       "/api/prom/series",
 			expectedOp: SeriesOp,
 		},
 		{
@@ -1238,7 +1238,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/prom/labels",
+			path:       "/api/prom/labels",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1248,7 +1248,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/prom/label",
+			path:       "/api/prom/label",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1258,7 +1258,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "label_values_query_prom",
-			path:       "/prom/label/__name__/values",
+			path:       "/api/prom/label/__name__/values",
 			expectedOp: LabelNamesOp,
 		},
 		{

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1213,7 +1213,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "range_query_prom",
-			path:       "/api/prom/query",
+			path:       "/prom/query",
 			expectedOp: QueryRangeOp,
 		},
 		{
@@ -1228,7 +1228,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "series_query_prom",
-			path:       "/api/prom/series",
+			path:       "/prom/series",
 			expectedOp: SeriesOp,
 		},
 		{
@@ -1238,7 +1238,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/api/prom/labels",
+			path:       "/prom/labels",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1248,7 +1248,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/api/prom/label",
+			path:       "/prom/label",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1258,7 +1258,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "label_values_query_prom",
-			path:       "/api/prom/label/__name__/values",
+			path:       "/prom/label/__name__/values",
 			expectedOp: LabelNamesOp,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ARM64 build and release of the Docker driver in Drone pipeline

**Which issue(s) this PR fixes**:
Fixes #5682

**Special notes for your reviewer**:
I would have loved to have a unified x64 and arm64 build but apparently Docker drivers does not support multi arch images. So instead I went with tweaking the build steps to allow cross building the image for ARM64 and added the instructions to do so in `drone.yml`.
It seems there's a drift in the images published on Docker Hub versus the one documented for use. I updated it here but this might be wrong.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [X] Tests updated (no tests for this AFAIK)
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`