### PR TITLE
Re-organize store related interfaces for better composability

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -45,14 +45,11 @@ var (
 	errWritingChunkUnsupported = errors.New("writing chunks is not supported while running store in read-only mode")
 )
 
-// Store is the Loki chunk store to retrieve and save chunks.
 type Store interface {
 	stores.Store
-	SelectSamples(ctx context.Context, req logql.SelectSampleParams) (iter.SampleIterator, error)
-	SelectLogs(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error)
-	Series(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error)
+	stores.ChunkReader
+	index.Filterable
 	GetSchemaConfigs() []config.PeriodConfig
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
 }
 
 type store struct {

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -20,16 +20,9 @@ import (
 	"github.com/grafana/loki/pkg/util/validation"
 )
 
-var _ Store = &compositeStore{}
-
 type StoreLimits interface {
 	MaxChunksPerQueryFromStore(string) int
 	MaxQueryLength(context.Context, string) time.Duration
-}
-
-type ChunkWriter interface {
-	Put(ctx context.Context, chunks []chunk.Chunk) error
-	PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error
 }
 
 type compositeStoreEntry struct {

--- a/pkg/storage/stores/index/index.go
+++ b/pkg/storage/stores/index/index.go
@@ -13,16 +13,22 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 )
 
-type Reader interface {
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
+type Filterable interface {
+	// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
+	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
+}
+
+type BaseReader interface {
 	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
 	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
 	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
 	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
-	// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
-	// This is only used for GetSeries implementation.
-	// Todo we might want to pass it as a parameter to GetSeries instead.
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
+}
+
+type Reader interface {
+	BaseReader
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
+	Filterable
 }
 
 type Writer interface {

--- a/pkg/storage/stores/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/indexshipper/gatewayclient/gateway_client.go
@@ -178,6 +178,10 @@ func (s *GatewayClient) QueryPages(ctx context.Context, queries []index.Query, c
 	})
 }
 
+func (s *GatewayClient) QueryIndex(ctx context.Context, in *logproto.QueryIndexRequest, opts ...grpc.CallOption) (logproto.IndexGateway_QueryIndexClient, error) {
+	panic("not implemented")
+}
+
 func (s *GatewayClient) GetChunkRef(ctx context.Context, in *logproto.GetChunkRefRequest, opts ...grpc.CallOption) (*logproto.GetChunkRefResponse, error) {
 	if s.cfg.Mode == indexgateway.RingMode {
 		var (

--- a/pkg/storage/stores/series/index/index.go
+++ b/pkg/storage/stores/series/index/index.go
@@ -7,16 +7,22 @@ import (
 // QueryPagesCallback from an IndexQuery.
 type QueryPagesCallback func(Query, ReadBatchResult) bool
 
-// Client is a client for the storage of the index (e.g. DynamoDB or Bigtable).
-type Client interface {
-	Stop()
+// Client for the read path.
+type ReadClient interface {
+	QueryPages(ctx context.Context, queries []Query, callback QueryPagesCallback) error
+}
 
-	// For the write path.
+// Client for the write path.
+type WriteClient interface {
 	NewWriteBatch() WriteBatch
 	BatchWrite(context.Context, WriteBatch) error
+}
 
-	// For the read path.
-	QueryPages(ctx context.Context, queries []Query, callback QueryPagesCallback) error
+// Client is a client for the storage of the index (e.g. DynamoDB or Bigtable).
+type Client interface {
+	ReadClient
+	WriteClient
+	Stop()
 }
 
 // ReadBatchResult represents the results of a QueryPages.

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gogo/status"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/pkg/logproto"
@@ -18,7 +17,7 @@ import (
 )
 
 type IndexGatewayClientStore struct {
-	client IndexGatewayClient
+	client logproto.IndexGatewayClient
 	// fallbackStore is used only to keep index gateways backwards compatible.
 	// Previously index gateways would only serve index rows from boltdb-shipper files.
 	// tsdb also supports configuring index gateways but there is no concept of serving index rows so
@@ -26,15 +25,7 @@ type IndexGatewayClientStore struct {
 	fallbackStore index.Reader
 }
 
-type IndexGatewayClient interface {
-	GetChunkRef(ctx context.Context, in *logproto.GetChunkRefRequest, opts ...grpc.CallOption) (*logproto.GetChunkRefResponse, error)
-	GetSeries(ctx context.Context, in *logproto.GetSeriesRequest, opts ...grpc.CallOption) (*logproto.GetSeriesResponse, error)
-	LabelNamesForMetricName(ctx context.Context, in *logproto.LabelNamesForMetricNameRequest, opts ...grpc.CallOption) (*logproto.LabelResponse, error)
-	LabelValuesForMetricName(ctx context.Context, in *logproto.LabelValuesForMetricNameRequest, opts ...grpc.CallOption) (*logproto.LabelResponse, error)
-	GetStats(ctx context.Context, req *logproto.IndexStatsRequest, opts ...grpc.CallOption) (*logproto.IndexStatsResponse, error)
-}
-
-func NewIndexGatewayClientStore(client IndexGatewayClient, fallbackStore index.Reader) index.ReaderWriter {
+func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, fallbackStore index.Reader) index.ReaderWriter {
 	return &IndexGatewayClientStore{
 		client:        client,
 		fallbackStore: fallbackStore,

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -12,16 +12,14 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
-	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
-	"github.com/grafana/loki/pkg/storage/stores/series/index"
+	"github.com/grafana/loki/pkg/storage/stores"
+	"github.com/grafana/loki/pkg/storage/stores/index"
+	seriesindex "github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 	"github.com/grafana/loki/pkg/util/spanlogger"
 )
@@ -31,16 +29,13 @@ const (
 )
 
 type IndexQuerier interface {
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error)
-	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
-	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
-	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
-	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
+	stores.ChunkFetcher
+	index.BaseReader
 	Stop()
 }
 
 type IndexClient interface {
-	QueryPages(ctx context.Context, queries []index.Query, callback index.QueryPagesCallback) error
+	seriesindex.ReadClient
 	Stop()
 }
 
@@ -95,14 +90,14 @@ func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logprot
 
 	var outerErr, innerErr error
 
-	queries := make([]index.Query, 0, len(request.Queries))
+	queries := make([]seriesindex.Query, 0, len(request.Queries))
 	for _, query := range request.Queries {
 		if _, err := config.ExtractTableNumberFromName(query.TableName); err != nil {
 			level.Error(log).Log("msg", "skip querying table", "table", query.TableName, "err", err)
 			continue
 		}
 
-		queries = append(queries, index.Query{
+		queries = append(queries, seriesindex.Query{
 			TableName:        query.TableName,
 			HashValue:        query.HashValue,
 			RangeValuePrefix: query.RangeValuePrefix,
@@ -132,7 +127,7 @@ func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logprot
 			continue
 		}
 
-		outerErr = indexClient.QueryPages(server.Context(), queries[start:end], func(query index.Query, batch index.ReadBatchResult) bool {
+		outerErr = indexClient.QueryPages(server.Context(), queries[start:end], func(query seriesindex.Query, batch seriesindex.ReadBatchResult) bool {
 			innerErr = buildResponses(query, batch, func(response *logproto.QueryIndexResponse) error {
 				// do not send grpc responses concurrently. See https://github.com/grpc/grpc-go/blob/master/stream.go#L120-L123.
 				sendBatchMtx.Lock()
@@ -160,7 +155,7 @@ func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logprot
 	return nil
 }
 
-func buildResponses(query index.Query, batch index.ReadBatchResult, callback func(*logproto.QueryIndexResponse) error) error {
+func buildResponses(query seriesindex.Query, batch seriesindex.ReadBatchResult, callback func(*logproto.QueryIndexResponse) error) error {
 	itr := batch.Iterator()
 	var resp []*logproto.Row
 
@@ -303,7 +298,7 @@ func (g *Gateway) GetStats(ctx context.Context, req *logproto.IndexStatsRequest)
 
 type failingIndexClient struct{}
 
-func (f failingIndexClient) QueryPages(ctx context.Context, queries []index.Query, callback index.QueryPagesCallback) error {
+func (f failingIndexClient) QueryPages(ctx context.Context, queries []seriesindex.Query, callback seriesindex.QueryPagesCallback) error {
 	return errors.New("index client is not initialized likely due to boltdb-shipper not being used")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I got confused by our store related interfaces, so I split them up into smaller ones and composed them.

**Special notes for your reviewer**:

What I also noticed is that we sometimes prefix interface method with `Get`, e.g. `GetChunkRefs`, and sometimes we don't, e.g. `Series`. 

I think that re-organizing the package structure of the `pkg/storage/` package would help to better understand the individual purposes of the interfaces.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
