### PR TITLE
Distributor: Reuse allocation on line truncation

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -552,8 +552,14 @@ func (d *Distributor) truncateLines(vContext validationContext, stream *logproto
 	}
 
 	var truncatedSamples, truncatedBytes int
+	maxLineSize := vContext.maxLineSize
+
+	if maxLineSize == 0 {
+		return
+	}
+
 	for i, e := range stream.Entries {
-		if maxSize := vContext.maxLineSize; maxSize != 0 && len(e.Line) > maxSize {
+		if maxSize := maxLineSize; len(e.Line) > maxSize {
 			stream.Entries[i].Line = e.Line[:maxSize]
 
 			truncatedSamples++

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -297,7 +297,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 		if sp != nil {
 			sp.LogKV("event", "start to validate request")
 			defer func() {
-				sp.LogKV("event", "finished to validate request")
+				sp.LogKV("event", "finished to validate request", "validated_lines", validatedLineCount)
 			}()
 		}
 		for _, stream := range req.Streams {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reuses allocation on calls to `truncateLines` and add a guard-clause to check if `maxLineSize==0` out of the loop.
It also adds the number of validated log lines to the existing `finished to validate request` event.

Before:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags integration,requires_docker -bench ^BenchmarkTruncateLogLines$ github.com/grafana/loki/pkg/distributor

goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/distributor
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkTruncateLogLines-24    	  139802	      8536 ns/op	      64 B/op	       2 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/distributor	1.302s
```

After:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags integration,requires_docker -bench ^BenchmarkTruncateLogLines$ github.com/grafana/loki/pkg/distributor

goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/distributor
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkTruncateLogLines-24    	  151281	      8118 ns/op	      64 B/op	       2 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/distributor	1.330s
```
