### PR TITLE
Distributor: Modify `createShard` to create slice with more precise size

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -479,6 +479,11 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 		streamCount = streamCount(totalShards, stream)
 	)
 
+	if totalShards <= 0 {
+		level.Error(util_log.Logger).Log("msg", "attempt to create shard with zeroed total shards")
+		return derivedKeys, derivedStreams
+	}
+
 	startShard := d.shardTracker.LastShardNum(tenantID, stream.Hash)
 	for i := 0; i < streamCount; i++ {
 		shardNum := (startShard + i) % totalShards

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -480,7 +480,7 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 	)
 
 	if totalShards <= 0 {
-		level.Error(util_log.Logger).Log("msg", "attempt to create shard with zeroed total shards")
+		level.Error(util_log.Logger).Log("msg", "attempt to create shard with zeroed total shards", "org_id", tenantID, "stream", stream.Labels, "entries_len", len(stream.Entries))
 		return derivedKeys, derivedStreams
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -482,7 +482,7 @@ func (d *Distributor) createShards(stream logproto.Stream, totalShards int, tena
 	startShard := d.shardTracker.LastShardNum(tenantID, stream.Hash)
 	for i := 0; i < streamCount; i++ {
 		shardNum := (startShard + i) % totalShards
-		shard := d.createShard(streamLabels, streamPattern, shardNum)
+		shard := d.createShard(streamLabels, streamPattern, shardNum, len(stream.Entries)/totalShards)
 
 		derivedKeys = append(derivedKeys, util.TokenFor(tenantID, shard.Labels))
 		derivedStreams = append(derivedStreams, streamTracker{stream: shard})
@@ -521,7 +521,7 @@ func labelTemplate(lbls string) labels.Labels {
 	return streamLabels
 }
 
-func (d *Distributor) createShard(lbls labels.Labels, streamPattern string, shardNumber int) logproto.Stream {
+func (d *Distributor) createShard(lbls labels.Labels, streamPattern string, shardNumber, numOfEntries int) logproto.Stream {
 	shardLabel := strconv.Itoa(shardNumber)
 	for i := 0; i < len(lbls); i++ {
 		if lbls[i].Name == ingester.ShardLbName {
@@ -533,7 +533,7 @@ func (d *Distributor) createShard(lbls labels.Labels, streamPattern string, shar
 	return logproto.Stream{
 		Labels:  strings.Replace(streamPattern, ingester.ShardLbPlaceholder, shardLabel, 1),
 		Hash:    lbls.Hash(),
-		Entries: make([]logproto.Entry, 0, 1024),
+		Entries: make([]logproto.Entry, 0, numOfEntries),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the `createShard` method to create the entries slice with the number of entries divided by the total number of shards instead of always creating it with len=1024. 
