### PR TITLE
HTTP: Reuse `buffer.Bytes()` when decompressing

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -228,25 +228,26 @@ func decompressFromReader(reader io.Reader, expectedSize, maxSize int, compressi
 }
 
 func decompressFromBuffer(buffer *bytes.Buffer, maxSize int, compression CompressionType, sp opentracing.Span) ([]byte, error) {
-	if len(buffer.Bytes()) > maxSize {
-		return nil, fmt.Errorf(messageSizeLargerErrFmt, len(buffer.Bytes()), maxSize)
+	bufBytes := buffer.Bytes()
+	if len(bufBytes) > maxSize {
+		return nil, fmt.Errorf(messageSizeLargerErrFmt, len(bufBytes), maxSize)
 	}
 	switch compression {
 	case NoCompression:
-		return buffer.Bytes(), nil
+		return bufBytes, nil
 	case RawSnappy:
 		if sp != nil {
 			sp.LogFields(otlog.String("event", "util.ParseProtoRequest[decompress]"),
-				otlog.Int("size", len(buffer.Bytes())))
+				otlog.Int("size", len(bufBytes)))
 		}
-		size, err := snappy.DecodedLen(buffer.Bytes())
+		size, err := snappy.DecodedLen(bufBytes)
 		if err != nil {
 			return nil, err
 		}
 		if size > maxSize {
 			return nil, fmt.Errorf(messageSizeLargerErrFmt, size, maxSize)
 		}
-		body, err := snappy.Decode(nil, buffer.Bytes())
+		body, err := snappy.Decode(nil, bufBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/http_loki_test.go
+++ b/pkg/util/http_loki_test.go
@@ -1,0 +1,18 @@
+package util
+
+// This file is separated from `http_test.go` to differentiate from the original `http_test.go` file forked from Cortex.
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkDecompressFromBuffer(b *testing.B) {
+	buf := bytes.Buffer{}
+	buf.Grow(100)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decompressFromBuffer(&buf, 1000, RawSnappy, nil)
+	}
+}

--- a/pkg/util/http_loki_test.go
+++ b/pkg/util/http_loki_test.go
@@ -13,6 +13,6 @@ func BenchmarkDecompressFromBuffer(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		decompressFromBuffer(&buf, 1000, RawSnappy, nil)
+		decompressFromBuffer(&buf, 1000, RawSnappy, nil) //nolint:errcheck
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Modifies `decompressFromBuffer` to call `buffer.Bytes()` a single time.
- Adds a new Benchmark under `http_loki_test.go` file. I had to create this in a separated file to differentiate from the original `http_test.go` forked from Cortex and because `http_test.go` uses package `http_test` which doesn't allow us to test private functions.

Before:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags integration,requires_docker -bench ^BenchmarkDecompressFromBuffer$ github.com/grafana/loki/pkg/util

goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/util
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkBla-24    	384391501	         3.185 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/util	1.547s
```

After:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags integration,requires_docker -bench ^BenchmarkDecompressFromBuffer$ github.com/grafana/loki/pkg/util

goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/util
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkBla-24    	422789878	         2.716 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/grafana/loki/pkg/util	1.443s
```