### PR TITLE
Mark template as draft to unpublish.

### DIFF
--- a/docs/sources/lids/template.md
+++ b/docs/sources/lids/template.md
@@ -1,6 +1,7 @@
 ---
 title: "XXXX: Template"
 description: "Template"
+draft: true
 ---
 
 # XXXX: Template


### PR DESCRIPTION
**What this PR does / why we need it**:

Marks the LID template as "draft" so that the template is not published to the docs site.

**Which issue(s) this PR fixes**:
Fixes #9283


