### PR TITLE
fluent-plugin-grapha-loki: Add config to support tls: ciphers, min_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 
 * [8995](https://github.com/grafana/loki/pull/8995) **dannykopping**: Mixins: Fix Jsonnet `RUNTIME ERROR` that occurs when you try to use the mixins with `use_boltdb_shipper: false`.
 
+#### FluentD
+
+##### Enhancements
+* [LOG-4012](https://issues.redhat.com/browse/LOG-4012) **jcantril**: fluent-plugin-grapha-loki: Add config to support tls: ciphers, min_versio
 
 #### Jsonnet
 

--- a/clients/cmd/fluentd/.rubocop.yml
+++ b/clients/cmd/fluentd/.rubocop.yml
@@ -26,7 +26,7 @@ Style/GuardClause:
 RSpec/ExampleLength:
   Max: 100
 RSpec/MultipleExpectations:
-  Max: 10
+  Max: 12
 Style/HashEachMethods:
   Enabled: true
 Style/HashTransformKeys:

--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -52,6 +52,12 @@ module Fluent
       desc 'TLS: CA certificate file for server certificate verification'
       config_param :ca_cert, :string, default: nil
 
+      desc 'TLS: the ciphers to use for the tls connection (e.g TLS1_0, TLS1_1, TLS1_2)'
+      config_param :ciphers, :string, default: nil
+
+      desc 'TLS: The minimum version for the tls connection'
+      config_param :min_version, :string, default: nil
+
       desc 'TLS: disable server certificate verification'
       config_param :insecure_tls, :bool, default: false
 
@@ -198,6 +204,19 @@ module Fluent
             ca_file: @ca_cert
           )
         end
+
+        if @ciphers
+          opts = opts.merge(
+            ciphers: @ciphers
+          )
+        end
+
+        if @min_version
+          opts = opts.merge(
+            min_version: @min_version.to_sym
+          )
+        end
+
         opts
       end
 

--- a/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
+++ b/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Fluent::Plugin::LokiOutput do
       drop_single_key true
       remove_keys a, b
       insecure_tls true
+      ciphers abc:def
+      min_version TLS1_3
       <label>
         job
         instance instance
@@ -41,6 +43,8 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(driver.instance.remove_keys).to eq %w[a b]
     expect(driver.instance.drop_single_key).to eq true
     expect(driver.instance.insecure_tls).to eq true
+    expect(driver.instance.ciphers).to eq 'abc:def'
+    expect(driver.instance.min_version).to eq 'TLS1_3'
   end
 
   it 'converts syslog output to loki output' do


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability for the fluentd plugin to be configured with a TLS profile to define min TLS version and a cipher suite. 

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/LOG-4012

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
