### PR TITLE
tsdb-manager: do not ship if TSDB index load returns error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [9130](https://github.com/grafana/loki/pull/9130) **salvacorts**: Pass LogQL engine options down to the _split by range_, _sharding_, and _query size limiter_ middlewares.
 * [9252](https://github.com/grafana/loki/pull/9252) **jeschkies**: Use un-escaped regex literal for string matching.
 * [9176](https://github.com/grafana/loki/pull/9176) **DylanGuedes**: Fix incorrect association of per-stream rate limit when sharding is enabled.
+* [9297](https://github.com/grafana/loki/pull/9297) **ashwanthgoli**: Do not ship if TSDB index load returns error
 
 #### Promtail
 

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -138,6 +138,7 @@ func (m *tsdbManager) Start() (err error) {
 					"err", err.Error(),
 				)
 				loadingErrors++
+				continue
 			}
 
 			if err := m.shipper.AddIndex(bucket, "", loaded); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
do not ship index if `NewShippableTSDBFile` returns an error.

```
 panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                 
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2130edd]                                                                                                             

goroutine 1 [running]:                                                                                                                                                                  

github.com/grafana/loki/pkg/storage/stores/tsdb.(*TSDBFile).Name(0x550000c000c48c30?)                                                                                                         <autogenerated>:1 +0x1d                                                                                                                                                             

github.com/grafana/loki/pkg/storage/stores/indexshipper/uploads.(*indexSet).Add(0xc000c6c400, {0x332f688, 0x0})
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
