### PR TITLE
Expose signature version property for s3 storage configs

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1,5 +1,5 @@
 ---
-title: Helm chart values
+title: Helm Chart Values
 menuTitle: Helm chart values
 description: Reference for Helm Chart values.
 weight: 200

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1,5 +1,5 @@
 ---
-title: Helm Chart Values
+title: Helm chart values
 menuTitle: Helm chart values
 description: Reference for Helm Chart values.
 weight: 200

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -1918,7 +1918,8 @@ null
     "region": null,
     "s3": null,
     "s3ForcePathStyle": false,
-    "secretAccessKey": null
+    "secretAccessKey": null,
+    "signatureVersion": null
   },
   "type": "s3"
 }

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.0
-version: 5.2.0
+version: 5.3.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 5.3.0](https://img.shields.io/badge/Version-5.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/reference.md.gotmpl
+++ b/production/helm/loki/reference.md.gotmpl
@@ -1,5 +1,5 @@
 ---
-title: Helm chart values
+title: Helm Chart Values
 menuTitle: Helm chart values
 description: Reference for Helm Chart values.
 weight: 200

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -205,6 +205,9 @@ s3:
   {{- with .accessKeyId }}
   access_key_id: {{ . }}
   {{- end }}
+  {{- with .signatureVersion }}
+  signature_version: {{ . }}
+  {{- end }}
   s3forcepathstyle: {{ .s3ForcePathStyle }}
   insecure: {{ .insecure }}
   {{- with .http_config}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -233,6 +233,7 @@ loki:
       region: null
       secretAccessKey: null
       accessKeyId: null
+      signatureVersion: null
       s3ForcePathStyle: false
       insecure: false
       http_config: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This exposed the a `signatureVersion` property in the helm chart's storage config options that can be used to set the `signature_version` for a Loki S3 storage config.