### PR TITLE
Fix GF_INSTALL_PLUGINS syntax for k3d env GEL plugin

### DIFF
--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -217,7 +217,7 @@ local tenant = 'loki';
                       + k.core.v1.secret.metadata.withNamespace('loki'),
     grafana+: grafana.withEnterpriseLicenseText(importstr '../../secrets/grafana.jwt')
               + grafana.addPlugin(
-                'https://storage.googleapis.com/grafana-enterprise-logs/dev/grafana-enterprise-logs-app-9515528.zip'
+                'https://storage.googleapis.com/grafana-enterprise-logs/dev/grafana-enterprise-logs-app-9515528.zip;grafana-enterprise-logs-app'
               ) + {
       grafana_deployment+:
         k.apps.v1.deployment.spec.template.spec.withInitContainersMixin([


### PR DESCRIPTION
**What this PR does / why we need it**:

Not sure if this is a change to Grafana, but while the old sytnax used to work, it no longer does, and needs this `;grafana-enterprise-logs-app` suffix, which appears to fix things.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
