### PR TITLE
Revert "start writing tsdb v3"

### DIFF
--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -63,7 +63,7 @@ const (
 	millisecondsInHour = int64(time.Hour / time.Millisecond)
 
 	// The format that will be written by this process
-	LiveFormat = FormatV3
+	LiveFormat = FormatV2
 )
 
 type indexWriterStage uint8


### PR DESCRIPTION
Reverts grafana/loki#9276

Update main to prevent writing v3 by default while I find a bug in it.