### PR TITLE
Add query info to query.Exec span

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -217,7 +217,7 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	spLogger := spanlogger.FromContext(ctx)
 	defer spLogger.Finish()
 
-	level.Debug(spLogger).Log(
+	sp.LogKV(
 		"type", GetRangeType(q.params),
 		"query", q.params.Query(),
 		"start", q.params.Start(),


### PR DESCRIPTION
**What this PR does / why we need it**:
It's kinda difficult to see the query that is being run on a trace.

The only place where I can see the query is in the `url` attribute of the `loki_api_v1_query_range` handler, but since it’s encoded it’s kinda difficult to read. If it's elsewhere it's not quite obvious.

It’d make sense to have the query in the `query.Exec` span along with the stats of the query.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
