### PR TITLE
fixes bug during chunk iteration using markers

### DIFF
--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -551,6 +551,36 @@ func TestSearchWithPageMarkers(t *testing.T) {
 					{MinTime: 8, MaxTime: 9},
 				},
 			},
+			{
+				desc: "second half of chunks, out of order support",
+				chks: []ChunkMeta{
+					{MinTime: 0, MaxTime: 1},
+					{MinTime: 1, MaxTime: 2},
+
+					// when batchsize=2, the first chunk in this page
+					// has the highest maxt, so it will be the page marker's maxt.
+					// this test will error returning a different chunk than expected
+					// unless we account for this (chunks are delta encoded against the previous)
+					{MinTime: 2, MaxTime: 4},
+					{MinTime: 3, MaxTime: 3},
+
+					{MinTime: 4, MaxTime: 5},
+					{MinTime: 5, MaxTime: 6},
+
+					{MinTime: 6, MaxTime: 7},
+					{MinTime: 7, MaxTime: 8},
+
+					{MinTime: 8, MaxTime: 9},
+				},
+				mint: 6,
+				maxt: 100,
+				exp: []ChunkMeta{
+					{MinTime: 5, MaxTime: 6},
+					{MinTime: 6, MaxTime: 7},
+					{MinTime: 7, MaxTime: 8},
+					{MinTime: 8, MaxTime: 9},
+				},
+			},
 		} {
 			t.Run(fmt.Sprintf("%s-pagesize-%d", tc.desc, pageSize), func(t *testing.T) {
 				var w Writer

--- a/pkg/storage/stores/tsdb/index/chunk_test.go
+++ b/pkg/storage/stores/tsdb/index/chunk_test.go
@@ -529,6 +529,28 @@ func TestSearchWithPageMarkers(t *testing.T) {
 					{MinTime: 15, MaxTime: 30},
 				},
 			},
+			{
+				desc: "second half of chunks",
+				chks: []ChunkMeta{
+					{MinTime: 0, MaxTime: 1},
+					{MinTime: 1, MaxTime: 2},
+					{MinTime: 2, MaxTime: 3},
+					{MinTime: 3, MaxTime: 4},
+					{MinTime: 4, MaxTime: 5},
+					{MinTime: 5, MaxTime: 6},
+					{MinTime: 6, MaxTime: 7},
+					{MinTime: 7, MaxTime: 8},
+					{MinTime: 8, MaxTime: 9},
+				},
+				mint: 6,
+				maxt: 100,
+				exp: []ChunkMeta{
+					{MinTime: 5, MaxTime: 6},
+					{MinTime: 6, MaxTime: 7},
+					{MinTime: 7, MaxTime: 8},
+					{MinTime: 8, MaxTime: 9},
+				},
+			},
 		} {
 			t.Run(fmt.Sprintf("%s-pagesize-%d", tc.desc, pageSize), func(t *testing.T) {
 				var w Writer


### PR DESCRIPTION
Tricky one to find, but this does the following
* correctly subtracts remaining chunk count when skipping a page (this was previously using a zero-valued marker)
* correctly set previous maxt on pages that are skipped. This is important because chunks themselves are delta-encoded against the previous chunk.
* removes the markers pool from the chunk decoding which isn't needed.
* adds a test
* adds a bit more logging on which series resulted in a decoding error during chunk iteration