### PR TITLE
Revert "Revert "start writing tsdb v3""

### DIFF
--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -63,7 +63,7 @@ const (
 	millisecondsInHour = int64(time.Hour / time.Millisecond)
 
 	// The format that will be written by this process
-	LiveFormat = FormatV2
+	LiveFormat = FormatV3
 )
 
 type indexWriterStage uint8


### PR DESCRIPTION
Reverts grafana/loki#9301

Should be good to start writing v3 again after https://github.com/grafana/loki/pull/9328 is merged and when we're ready to start using tsdbv3 as the default