### PR TITLE
/loki/api/v1/delete is routed to backend url

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -634,6 +634,10 @@ http {
       proxy_pass       {{ $backendUrl }}$request_uri;
     }
 
+    location ~ /loki/api/v1/delete.* {
+      proxy_pass       {{ $backendUrl }}$request_uri;
+    }
+
     location ~ /distributor/.* {
       proxy_pass       {{ $writeUrl }}$request_uri;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a routing rule for `/loki/api/v1/delete` endpoint to `gateway` component.

**Which issue(s) this PR fixes**:
Fixes #9325

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
