### PR TITLE
fix flaky integration TestMicroServicesDeleteRequest test

### DIFF
--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -97,11 +97,11 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 			},
 			Values: [][]string{
 				{
-					strconv.FormatInt(now.Add(-46*time.Hour).UnixNano(), 10),
+					strconv.FormatInt(now.Add(-48*time.Hour).UnixNano(), 10),
 					"lineA",
 				},
 				{
-					strconv.FormatInt(now.Add(-46*time.Hour).UnixNano(), 10),
+					strconv.FormatInt(now.Add(-48*time.Hour).UnixNano(), 10),
 					"lineB",
 				},
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

`loki_compactor_deleted_lines` increments each time we find a line to delete from a chunk. If the chunk is indexed in multiple tables, we increment it for each of these tables as they get compacted.

Currently the chunk (that holds the line to be deleted) starts @`now - 46h`, so depending on when the test runs it gets indexed in 2 or 3 tables. It has been failing between hours `22:00 - 23:59` as the chunk only overlaps and gets indexed in 2 tables while the test expects it to be indexed in 3
https://drone.grafana.net/grafana/loki/23063/2/1
https://drone.grafana.net/grafana/loki/23067/2/1

Updating the chunk start time to now-48h so that it always gets indexes in 3 tables

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
