### PR TITLE
Loki microservices Tanka: remove unintended override

### DIFF
--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -122,7 +122,7 @@
   compactor_statefulset+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
   distributor_deployment+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
   index_gateway_statefulset+: if !$._config.memberlist_ring_enabled then {} else gossipLabel,
-  ingester_statefulset+: if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled then {} else
+  ingester_statefulset: if $._config.multi_zone_ingester_enabled && !$._config.multi_zone_ingester_migration_enabled then {} else
     (super.ingester_statefulset + if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_zone_a_statefulset+:
     if $._config.multi_zone_ingester_enabled && $._config.memberlist_ring_enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a duplicated ConfigMap volume definition in Ingester StatefulSet when:
` multi_zone_ingester_enabled: false,`

See generated json:
```

"ingester_statefulset": {
...
"terminationGracePeriodSeconds": 4800,
          "volumes": [
            {
              "configMap": {
                "name": "loki"
              },
              "name": "loki"
            },
            {
              "configMap": {
                "name": "overrides"
              },
              "name": "overrides"
            },
            {
              "configMap": {
                "name": "loki"
              },
              "name": "loki"
            },
            {
              "configMap": {
                "name": "overrides"
              },
              "name": "overrides"
            }
          ]
        }
      },

```

**Which issue(s) this PR fixes**:
Fixes #9344

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] `CHANGELOG.md` updated
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
