### PR TITLE
operator: Enable Route by default on OpenShift clusters

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [9366](https://github.com/grafana/loki/pull/9366) **periklis**: Add support for custom tenant topology in rules
 - [9315](https://github.com/grafana/loki/pull/9315) **aminesnow**: Add zone awareness spec to LokiStack
 - [9343](https://github.com/grafana/loki/pull/9343) **JoaoBraveCoding**: Add default PodAntiAffinity to Query Frontend
+- [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters
 - [9339](https://github.com/grafana/loki/pull/9339) **JoaoBraveCoding**: Add default PodAntiAffinity to Ruler
 - [9329](https://github.com/grafana/loki/pull/9329) **JoaoBraveCoding**: Add default PodAntiAffinity to Ingester
 - [9262](https://github.com/grafana/loki/pull/9262) **btaani**: Add PodDisruptionBudget to the Ruler

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -30,6 +30,7 @@ type BuiltInCertManagement struct {
 type OpenShiftFeatureGates struct {
 	// Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.
 	Enabled bool `json:"enabled,omitempty"`
+
 	// ServingCertsService enables OpenShift service-ca annotations on the lokistack-gateway service only
 	// to use the in-platform CA and generate a TLS cert/key pair per service for
 	// in-cluster data-in-transit encryption.

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -28,6 +28,8 @@ type BuiltInCertManagement struct {
 
 // OpenShiftFeatureGates is the supported set of all operator features gates on OpenShift.
 type OpenShiftFeatureGates struct {
+	// Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.
+	Enabled bool `json:"enabled,omitempty"`
 	// ServingCertsService enables OpenShift service-ca annotations on the lokistack-gateway service only
 	// to use the in-platform CA and generate a TLS cert/key pair per service for
 	// in-cluster data-in-transit encryption.

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -37,11 +37,6 @@ type OpenShiftFeatureGates struct {
 	// More details: https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html
 	ServingCertsService bool `json:"servingCertsService,omitempty"`
 
-	// GatewayRoute enables creating an OpenShift Route for the LokiStack
-	// gateway to expose the service to public internet access.
-	// More details: https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html
-	GatewayRoute bool `json:"gatewayRoute,omitempty"`
-
 	// ExtendedRuleValidation enables extended validation of AlertingRule and RecordingRule
 	// to enforce tenancy in an OpenShift context.
 	ExtendedRuleValidation bool `json:"ruleExtendedValidation,omitempty"`

--- a/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -51,6 +51,7 @@ data:
       # OpenShift feature gates
       #
       openshift:
+        enabled: true
         servingCertsService: true
         gatewayRoute: true
         ruleExtendedValidation: true

--- a/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -53,7 +53,6 @@ data:
       openshift:
         enabled: true
         servingCertsService: true
-        gatewayRoute: true
         ruleExtendedValidation: true
         clusterTLSPolicy: true
         clusterProxy: true

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-04-26T13:24:42Z"
+    createdAt: "2023-04-28T18:54:17Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-04-28T18:54:17Z"
+    createdAt: "2023-05-05T07:23:07Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1231,7 +1231,6 @@ spec:
 
     In addition it enables the following OpenShift-only related feature gates:
     * `servingCertsService`: Enables OpenShift ServiceCA annotations on the lokistack-gateway service only.
-    * `gatewayRoute`: Enables creating an OpenShift Route for the LokiStack.
     * `ruleExtendedValidation`: Enables extended validation of AlertingRule and RecordingRule to enforce tenancy in an OpenShift context.
     * `clusterTLSPolicy`: Enables usage of TLS policies set in the API Server.
     * `clusterProxy`: Enables usage of the proxy variables set in the proxy resource.

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-04-28T18:54:15Z"
+    createdAt: "2023-05-05T07:23:04Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-04-26T13:24:39Z"
+    createdAt: "2023-04-28T18:54:15Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -56,7 +56,6 @@ data:
       openshift:
         enabled: true
         servingCertsService: true
-        gatewayRoute: true
         ruleExtendedValidation: true
         clusterTLSPolicy: true
         clusterProxy: true

--- a/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -54,6 +54,7 @@ data:
       # OpenShift feature gates
       #
       openshift:
+        enabled: true
         servingCertsService: true
         gatewayRoute: true
         ruleExtendedValidation: true

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-05-02T10:32:20Z"
+    createdAt: "2023-05-05T07:23:09Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -2048,7 +2048,6 @@ spec:
 
     In addition it enables the following OpenShift-only related feature gates:
     * `servingCertsService`: Enables OpenShift ServiceCA annotations on the lokistack-gateway service only.
-    * `gatewayRoute`: Enables creating an OpenShift Route for the LokiStack.
     * `ruleExtendedValidation`: Enables extended validation of AlertingRule and RecordingRule to enforce tenancy in an OpenShift context.
     * `clusterTLSPolicy`: Enables usage of TLS policies set in the API Server.
     * `clusterProxy`: Enables usage of the proxy variables set in the proxy resource.

--- a/operator/config/overlays/community-openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/community-openshift/controller_manager_config.yaml
@@ -48,6 +48,7 @@ featureGates:
   # OpenShift feature gates
   #
   openshift:
+    enabled: true
     servingCertsService: true
     gatewayRoute: true
     ruleExtendedValidation: true

--- a/operator/config/overlays/community-openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/community-openshift/controller_manager_config.yaml
@@ -50,7 +50,6 @@ featureGates:
   openshift:
     enabled: true
     servingCertsService: true
-    gatewayRoute: true
     ruleExtendedValidation: true
     clusterTLSPolicy: true
     clusterProxy: true

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -53,7 +53,6 @@ featureGates:
   openshift:
     enabled: true
     servingCertsService: true
-    gatewayRoute: true
     ruleExtendedValidation: true
     clusterTLSPolicy: true
     clusterProxy: true

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -51,6 +51,7 @@ featureGates:
   # OpenShift feature gates
   #
   openshift:
+    enabled: true
     servingCertsService: true
     gatewayRoute: true
     ruleExtendedValidation: true

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -218,7 +218,7 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)
 	}
 
-	if r.FeatureGates.OpenShift.GatewayRoute {
+	if r.FeatureGates.OpenShift.Enabled {
 		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
 	} else {
 		bld = bld.Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred)

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -152,7 +152,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: false,
+					Enabled: false,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,
@@ -163,7 +163,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: true,
+					Enabled: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,

--- a/operator/docs/operator/feature-gates.md
+++ b/operator/docs/operator/feature-gates.md
@@ -342,6 +342,17 @@ when using HTTPEncryption or GRPCEncryption.</p>
 <tbody>
 <tr>
 <td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>servingCertsService</code><br/>
 <em>
 bool
@@ -352,19 +363,6 @@ bool
 to use the in-platform CA and generate a TLS cert/key pair per service for
 in-cluster data-in-transit encryption.
 More details: <a href="https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html">https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gatewayRoute</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>GatewayRoute enables creating an OpenShift Route for the LokiStack
-gateway to expose the service to public internet access.
-More details: <a href="https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html">https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html</a></p>
 </td>
 </tr>
 <tr>

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -153,6 +153,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -182,6 +187,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -248,6 +258,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -267,6 +282,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -43,6 +43,50 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "static mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
+					},
+				},
+			},
+		},
+		{
 			desc: "dynamic mode",
 			opts: &Options{
 				Stack: lokiv1.LokiStackSpec{
@@ -55,6 +99,50 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
+					},
+				},
+			},
+		},
+		{
+			desc: "dynamic mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
 					},
 				},
 			},

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -235,6 +235,9 @@ func TestBuildGateway_HasExtraObjectsForTenantMode(t *testing.T) {
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -265,6 +268,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_RouteSvcMatches(t *testing.T
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -337,6 +343,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ReplacesIngressWithRoute(t *
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -902,6 +911,9 @@ func TestBuildGateway_PodDisruptionBudget(t *testing.T) {
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		Stack: lokiv1.LokiStackSpec{
 			Template: &lokiv1.LokiTemplateSpec{

--- a/operator/internal/manifests/openshift/build.go
+++ b/operator/internal/manifests/openshift/build.go
@@ -10,10 +10,19 @@ func BuildGatewayObjects(opts Options) []client.Object {
 	return []client.Object{
 		BuildRoute(opts),
 		BuildGatewayCAConfigMap(opts),
-		BuildGatewayClusterRole(opts),
-		BuildGatewayClusterRoleBinding(opts),
 		BuildMonitoringRole(opts),
 		BuildMonitoringRoleBinding(opts),
+	}
+}
+
+// BuildGatewayTenantModeObjects returns a list of auxiliary openshift/k8s objects
+// for lokistack gateway deployments on OpenShift for tenant modes:
+// - openshift-logging
+// - openshift-network
+func BuildGatewayTenantModeObjects(opts Options) []client.Object {
+	return []client.Object{
+		BuildGatewayClusterRole(opts),
+		BuildGatewayClusterRoleBinding(opts),
 	}
 }
 

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 func TestBuildGatewayTenantModeObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc").
+		WithTenantsForMode(lokiv1.OpenshiftLogging, "example.com", map[string]TenantData{})
 
-	objs := BuildGatewayTenantModeObjects(opts)
+	objs := BuildGatewayTenantModeObjects(*opts)
 	cr := objs[0].(*rbacv1.ClusterRole)
 	rb := objs[1].(*rbacv1.ClusterRoleBinding)
 
@@ -22,9 +23,9 @@ func TestBuildGatewayTenantModeObjects_ClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuildGatewayObjects_MonitoringClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildGatewayObjects(opts)
+	objs := BuildGatewayObjects(*opts)
 	cr := objs[2].(*rbacv1.Role)
 	rb := objs[3].(*rbacv1.RoleBinding)
 
@@ -33,9 +34,9 @@ func TestBuildGatewayObjects_MonitoringClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuildRulerObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildRulerObjects(opts)
+	objs := BuildRulerObjects(*opts)
 	sa := objs[1].(*corev1.ServiceAccount)
 	cr := objs[2].(*rbacv1.ClusterRole)
 	rb := objs[3].(*rbacv1.ClusterRoleBinding)

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -10,12 +10,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func TestBuildGatewayObjects_ClusterRoleRefMatches(t *testing.T) {
+func TestBuildGatewayTenantModeObjects_ClusterRoleRefMatches(t *testing.T) {
 	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
 
-	objs := BuildGatewayObjects(opts)
-	cr := objs[2].(*rbacv1.ClusterRole)
-	rb := objs[3].(*rbacv1.ClusterRoleBinding)
+	objs := BuildGatewayTenantModeObjects(opts)
+	cr := objs[0].(*rbacv1.ClusterRole)
+	rb := objs[1].(*rbacv1.ClusterRoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
@@ -25,8 +25,8 @@ func TestBuildGatewayObjects_MonitoringClusterRoleRefMatches(t *testing.T) {
 	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
 
 	objs := BuildGatewayObjects(opts)
-	cr := objs[4].(*rbacv1.Role)
-	rb := objs[5].(*rbacv1.RoleBinding)
+	cr := objs[2].(*rbacv1.Role)
+	rb := objs[3].(*rbacv1.RoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -61,9 +61,11 @@ func NewOptions(
 	tenantConfigMap map[string]TenantData,
 	rulerName string,
 ) Options {
-	host := ingressHost(stackName, stackNamespace, gwBaseDomain)
-
-	var authn []AuthenticationSpec
+	var (
+		authn []AuthenticationSpec
+		authz AuthorizationSpec
+		host  string = ingressHost(stackName, stackNamespace, gwBaseDomain)
+	)
 
 	tenants := GetTenants(mode)
 	for _, name := range tenants {
@@ -81,6 +83,12 @@ func NewOptions(
 		})
 	}
 
+	if len(tenants) > 0 {
+		authz = AuthorizationSpec{
+			OPAUrl: fmt.Sprintf("http://localhost:%d/v1/data/%s/allow", GatewayOPAHTTPPort, opaDefaultPackage),
+		}
+	}
+
 	return Options{
 		BuildOpts: BuildOptions{
 			LokiStackName:        stackName,
@@ -92,9 +100,7 @@ func NewOptions(
 			RulerName:            rulerName,
 		},
 		Authentication: authn,
-		Authorization: AuthorizationSpec{
-			OPAUrl: fmt.Sprintf("http://localhost:%d/v1/data/%s/allow", GatewayOPAHTTPPort, opaDefaultPackage),
-		},
+		Authorization:  authz,
 	}
 }
 

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -76,7 +76,7 @@ func (o *Options) WithTenantsForMode(mode lokiv1.ModeType, gwBaseDomain string, 
 	var (
 		authn []AuthenticationSpec
 		authz AuthorizationSpec
-		host  string = ingressHost(o.BuildOpts.LokiStackName, o.BuildOpts.LokiStackNamespace, gwBaseDomain)
+		host  = ingressHost(o.BuildOpts.LokiStackName, o.BuildOpts.LokiStackNamespace, gwBaseDomain)
 	)
 
 	tenants := GetTenants(mode)

--- a/operator/main.go
+++ b/operator/main.go
@@ -90,7 +90,7 @@ func main() {
 	if ctrlCfg.Gates.LokiStackGateway {
 		utilruntime.Must(configv1.AddToScheme(scheme))
 
-		if ctrlCfg.Gates.OpenShift.GatewayRoute {
+		if ctrlCfg.Gates.OpenShift.Enabled {
 			utilruntime.Must(routev1.AddToScheme(scheme))
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With the availability of the `community-openshift` (See #8881) bundle we control all available hubs for OpenShift clusters. Thus we can assume that a user using either the `redhat-openshift-ecosystem/community-operators-prod` hub or the RedHat internal catalogs installs this Operator on an OpenShift clusters. Therefore we can always assume that the following facilities are available:
- OpenShift Route
- OpenShift Service Certificates Controller

This PR decouples reconciling a Route and a CABundle ConfigMap from the user selection of tenant mode. Formerly the user had to select either tenant mode `openshift-logging` or `openshift-network` to inform the operator that the hosting cluster is OpenShift. In the proposed change the cluster flavor is controlled automatically via the bundled feature gates configuration.

In addition this enables using the tenant modes `static` and `dynamic` with public OIDC providers via the route.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
