### PR TITLE
Bump grafana and grafana-enterprise versions used for GEL Helm env

### DIFF
--- a/tools/dev/k3d/environments/helm-cluster/main.jsonnet
+++ b/tools/dev/k3d/environments/helm-cluster/main.jsonnet
@@ -133,8 +133,8 @@ local tenant = 'loki';
 
   local dashboardsPrefix = if enterprise then 'enterprise-logs' else 'loki',
   local grafanaImage = if enterprise then
-    grafana.withImage('grafana/grafana-enterprise:8.2.5') else
-    grafana.withImage('grafana/grafana:8.2.5'),
+    grafana.withImage('grafana/grafana-enterprise:9.5.1') else
+    grafana.withImage('grafana/grafana:9.5.1'),
   grafana+: grafana
             + grafana.withAnonymous()
             + grafanaImage


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the version of Grafana/Grafana-Enterprise being used to what is currently current. 


**Which issue(s) this PR fixes**:
This gets rid of a warning displayed about "The current Grafana version is not supported" in relation to the GEL plugin.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
