### PR TITLE
k147: Upgrade toGo security release 1.20.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "grafana/loki-build-image:0.28.2",
+  "image": "grafana/loki-build-image:0.28.3",
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.28.2',
+    local build_image_tag = '0.28.3',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.28.2
+    - 0.28.3
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.28.2
+    - 0.28.3
     username:
       from_secret: docker_username
   when:
@@ -1772,6 +1772,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 59c2b7df0660f1b6855eac6b71b4cf8ad62727d6b10314baf48a2ab85bf27463
+hmac: febb8cc3011da973120e5c72954ad4d5ba34619e0e1267c56df40dff73cc17e1
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: compare-coverage
   when:
     event:
@@ -160,7 +160,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: report-coverage
   when:
     event:
@@ -170,7 +170,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -178,7 +178,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -189,21 +189,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false check-format GIT_TARGET_BRANCH="$DRONE_TARGET_BRANCH"
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-format
   when:
     event:
@@ -213,14 +213,14 @@ steps:
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -253,7 +253,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: loki-mixin-check
   when:
     event:
@@ -278,7 +278,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1439,7 +1439,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1447,7 +1447,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1473,7 +1473,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: publish
   when:
     event:
@@ -1507,7 +1507,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.28.2
+  image: grafana/loki-build-image:0.28.3
   name: build and push
   privileged: true
   volumes:
@@ -1772,6 +1772,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: febb8cc3011da973120e5c72954ad4d5ba34619e0e1267c56df40dff73cc17e1
+hmac: e2f1f4d9480deb7fda22f0550d45d68820a89dbf391fb2f2b1f6416275294d02
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.28.2
+BUILD_IMAGE_VERSION := 0.28.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-bullseye as build
+FROM golang:1.20.4-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-bullseye as build
+FROM golang:1.20.4-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.28.1 as build
+FROM grafana/loki-build-image:0.28.3 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -3,7 +3,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
 
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm && \
     go install github.com/go-delve/delve/cmd/dlv@latest

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -17,6 +17,7 @@ if there were made any changes in the folder `./loki-build-image/`.
 1. create a branch with the desired changes to the Dockerfile
 2. update the version tag of the `loki-build-image` pipeline defined in `.drone/drone.jsonnet` (search for `pipeline('loki-build-image')`) to a new version number (try follow semver)
 3. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` and commit the changes to the same branch
+   1. the `<token>` is your personal drone token, which can be found by navigating to https://drone.grafana.net/account.
 4. create a PR
 5. once approved and merged to `main`, the image with the new version is built and published
    - **hint:** keep an eye on https://drone.grafana.net/grafana/loki for the build after merging ([example](https://drone.grafana.net/grafana/loki/17760/1/2))

--- a/docs/sources/maintaining/release-loki-build-image.md
+++ b/docs/sources/maintaining/release-loki-build-image.md
@@ -28,5 +28,5 @@ if there were made any changes in the folder `./loki-build-image/`.
 2. update the `BUILD_IMAGE_VERSION` variable in the `Makefile`
 3. run `loki-build-image/version-updater.sh <new-version>` to update all the references
 4. run `DRONE_SERVER=https://drone.grafana.net/ DRONE_TOKEN=<token> make drone` to update the Drone config to use the new build image
-5. create a PR
+5. create a new PR
 

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.3 as helm
+FROM golang:1.20.4 as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.3 as drone
+FROM golang:1.20.4 as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,33 +47,33 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.3 as faillint
+FROM golang:1.20.4 as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 RUN GO111MODULE=on go install golang.org/x/tools/cmd/goimports@v0.7.0
 
-FROM golang:1.20.3 as delve
+FROM golang:1.20.4 as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.3 as ghr
+FROM golang:1.20.4 as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.3 as nfpm
+FROM golang:1.20.4 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.3 as gotestsum
+FROM golang:1.20.4 as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.3 as jsonnet
+FROM golang:1.20.4 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.3-buster
+FROM golang:1.20.4-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.3 as builder
+FROM golang:1.20.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
+ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 
 FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.28.1
 
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.4-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.4 as build
 
 # build via Makefile target helm-test-image in root
 # Makefile. Building from this directory will not be

--- a/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3
+FROM golang:1.20.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-alpine AS build-image
+FROM golang:1.20.4-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:
https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU