### PR TITLE
Fix typo on lambda-promtail docs for keep_stream var

### DIFF
--- a/docs/sources/clients/lambda-promtail/_index.md
+++ b/docs/sources/clients/lambda-promtail/_index.md
@@ -48,7 +48,7 @@ provider "aws" {
 }
 ```
 
-To keep the log group label add `-var "keep_stream=true"`.
+To keep the log stream label add `-var "keep_stream=true"`.
 
 To add extra labels add `-var 'extra_labels="name1,value1,name2,value2"'`.
 


### PR DESCRIPTION
Change "log group" to "log stream" for `keep_stream` var.
