### PR TITLE
Update retention doc tsdb support of compactor

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -8,7 +8,7 @@ Retention in Grafana Loki is achieved either through the [Table Manager](#table-
 
 By default, when `table_manager.retention_deletes_enabled` or `compactor.retention_enabled` flags are not set, then logs sent to Loki live forever.
 
-Retention through the [Table Manager]({{<relref "table-manager">}}) is achieved by relying on the object store TTL feature, and will work for both [boltdb-shipper]({{<relref "boltdb-shipper">}}) store and chunk/index store. However retention through the [Compactor]({{<relref "boltdb-shipper#compactor">}}) is supported only with the [boltdb-shipper]({{<relref "boltdb-shipper">}}) store.
+Retention through the [Table Manager]({{<relref "table-manager">}}) is achieved by relying on the object store TTL feature, and will work for both [boltdb-shipper]({{<relref "boltdb-shipper">}}) store and chunk/index store. However retention through the [Compactor]({{<relref "boltdb-shipper#compactor">}}) is supported only with the [boltdb-shipper]({{<relref "boltdb-shipper">}}) and tsdb store.
 
 The Compactor retention will become the default and have long term support. It supports more granular retention policies on per tenant and per stream use cases.
 


### PR DESCRIPTION
compactor now also supports tsdb in addition to boltdb-schipper

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
