### PR TITLE
WIP: Add fallback to non-strict YAML decoding.

### DIFF
--- a/pkg/util/cfg/cfg.go
+++ b/pkg/util/cfg/cfg.go
@@ -47,7 +47,7 @@ func Unmarshal(dst Cloneable, sources ...Source) error {
 func DefaultUnmarshal(dst Cloneable, args []string, fs *flag.FlagSet) error {
 	return Unmarshal(dst,
 		Defaults(fs),
-		ConfigFileLoader(args, "config.file", true),
+		ConfigFileLoader(args, "config.file", true, false),
 		Flags(args, fs),
 	)
 }

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -22,7 +22,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// Next populate the config from the config file, we do this to populate the `common`
 		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		ConfigFileLoader(args, "config.file", true),
+		ConfigFileLoader(args, "config.file", true, true),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
 		// config files so that values from a common, or shared, section can be used in
 		// the dynamic evaluation
@@ -33,7 +33,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// using strict yaml unmarshal causes an `already set in map` error with the `Clients` config,
 		// because it's a map that already has the keys we are trying to unmarshal into it.
 		// That is why we don't use strict for the second marshaling.
-		ConfigFileLoader(args, "config.file", false),
+		ConfigFileLoader(args, "config.file", false, false),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 	)

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -24,7 +24,7 @@ func (cfg *testCfg) Clone() flagext.Registerer {
 
 func TestConfigFileLoaderDoesNotMutate(t *testing.T) {
 	cfg := &testCfg{}
-	err := ConfigFileLoader(nil, "something", true)(cfg)
+	err := ConfigFileLoader(nil, "something", true, false)(cfg)
 	require.Nil(t, err)
 	require.Equal(t, 0, cfg.v)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a fallback to non-strict YAML decoding.
This way, Loki won't fail to initialize in case of a new configuration. Especially useful when rolling back to older versions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
