### PR TITLE
Avoid excessive gRPC logging

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -191,6 +191,8 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 
 		fs.Var(f.Value, f.Name, f.Usage)
 	})
+
+	c.Server.DisableRequestSuccessLog = true
 }
 
 // Clone takes advantage of pass-by-value semantics to return a distinct *Config.


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the default value of `DisableRequestSuccessLog` to true. This way Loki won't log every successful gRPC call by default. The log line isn't useful either since it is redundant with existing gRPC metrics.

**Which issue(s) this PR fixes**:
N/A
