### PR TITLE
Fix case insensitive label filter

### DIFF
--- a/pkg/logql/log/filter.go
+++ b/pkg/logql/log/filter.go
@@ -315,8 +315,8 @@ func containsLower(line, substr []byte) bool {
 	j := 0
 	for len(line) > 0 {
 		// ascii fast case
-		if c := line[0]; c < utf8.RuneSelf {
-			if c == substr[j] || c+'a'-'A' == substr[j] {
+		if c := line[0]; c < utf8.RuneSelf && substr[j] < utf8.RuneSelf {
+			if c == substr[j] || c+'a'-'A' == substr[j] || c == substr[j]+'a'-'A' {
 				j++
 				if j == len(substr) {
 					return true

--- a/pkg/logql/log/label_filter_test.go
+++ b/pkg/logql/log/label_filter_test.go
@@ -412,6 +412,30 @@ func TestStringLabelFilter(t *testing.T) {
 			labels:      labels.Labels{{Name: "msg", Value: "hello"}, {Name: "subqueries", Value: ""}}, // label `subqueries` exist
 			shouldMatch: true,
 		},
+		{
+			name:        `logfmt|msg=~"(?i)hello" (with label)`,
+			filter:      NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "msg", "(?i)hello")),
+			labels:      labels.Labels{{Name: "msg", Value: "HELLO"}, {Name: "subqueries", Value: ""}}, // label `msg` contains HELLO
+			shouldMatch: true,
+		},
+		{
+			name:        `logfmt|msg=~"(?i)hello" (with label)`,
+			filter:      NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "msg", "(?i)hello")),
+			labels:      labels.Labels{{Name: "msg", Value: "hello"}, {Name: "subqueries", Value: ""}}, // label `msg` contains hello
+			shouldMatch: true,
+		},
+		{
+			name:        `logfmt|msg=~"(?i)HELLO" (with label)`,
+			filter:      NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "msg", "(?i)HELLO")),
+			labels:      labels.Labels{{Name: "msg", Value: "HELLO"}, {Name: "subqueries", Value: ""}}, // label `msg` contains HELLO
+			shouldMatch: true,
+		},
+		{
+			name:        `logfmt|msg=~"(?i)HELLO" (with label)`,
+			filter:      NewStringLabelFilter(labels.MustNewMatcher(labels.MatchRegexp, "msg", "(?i)HELLO")),
+			labels:      labels.Labels{{Name: "msg", Value: "hello"}, {Name: "subqueries", Value: ""}}, // label `msg` contains hello
+			shouldMatch: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
When comparing a case insensitive regular expression to a label value, Loki was only matching values that were in upper case. This was caused by compiling a case insensitive regular expression (such as `(?i)hello`), which produced an upper case `prefix` that was then used in `containsLower` as the `substr` value - but that function was written in such a way that only allowed matches of exact case or where the `line` value was upper case and the `substr` value was lower case.

This PR added a some additional test cases to demonstrate/understand the issue, and adds two additional checks to the `containsLower` function to enable it to work correctly when either input is in either case.

**Which issue(s) this PR fixes**:
Fixes #9294

**Special notes for your reviewer**:
Given the importance of this code path, I used `BenchmarkLineLabelFilters` to validate that the performance of this code was not affected. Overall, [the differences appeared negligible](https://docs.google.com/spreadsheets/d/1BRKkCzO0i11AObC6ADguDNa7cfG93hB7JLtqYWmnfW0/edit?usp=sharing) on my device (Intel(R) Core(TM) i7-12700H).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
