### PR TITLE
fix json expression parser

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -586,7 +586,7 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 		case jsonparser.Null:
 			lbs.Set(key, "")
 		default:
-			lbs.Set(key, unsafeGetString(data))
+			lbs.Set(key, unescapeJSONString(data))
 		}
 
 		matches++

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -2,9 +2,10 @@ package log
 
 import (
 	"fmt"
-	"github.com/grafana/loki/pkg/logqlmodel"
 	"sort"
 	"testing"
+
+	"github.com/grafana/loki/pkg/logqlmodel"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -2,10 +2,9 @@ package log
 
 import (
 	"fmt"
+	"github.com/grafana/loki/pkg/logqlmodel"
 	"sort"
 	"testing"
-
-	"github.com/grafana/loki/pkg/logqlmodel"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -529,6 +528,19 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			labels.Labels{
 				{Name: "foo", Value: "bar"},
+			},
+			noParserHints,
+		},
+		{
+			"nested escaped object",
+			[]byte(`{"app":"{ \"key\": \"value\", \"key2\":\"value2\"}"}`),
+			[]LabelExtractionExpr{
+				NewLabelExtractionExpr("app", `app`),
+			},
+			labels.Labels{{Name: "foo", Value: "bar"}},
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+				{Name: "app", Value: `{ "key": "value", "key2":"value2"}`},
 			},
 			noParserHints,
 		},


### PR DESCRIPTION
When the value parsed by the `JsonExpressionParser` is an escaped json string, the result still contains escape character and may not be valid json. This causes subsequent json parsing steps to fail. For example:

`{app="foo"} | json message | line_format "{{.message}}" | json` fails when `message` remains escaped.

This PR unescapes the results of extracted `JsonExpressions` so they can be parsed by subsequent json parsers
