### PR TITLE
Backports the fix for unescaped json strings to k148

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -586,7 +586,7 @@ func (j *JSONExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilder)
 		case jsonparser.Null:
 			lbs.Set(key, "")
 		default:
-			lbs.Set(key, unsafeGetString(data))
+			lbs.Set(key, unescapeJSONString(data))
 		}
 
 		matches++

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -532,6 +532,19 @@ func TestJSONExpressionParser(t *testing.T) {
 			},
 			noParserHints,
 		},
+		{
+			"nested escaped object",
+			[]byte(`{"app":"{ \"key\": \"value\", \"key2\":\"value2\"}"}`),
+			[]LabelExtractionExpr{
+				NewLabelExtractionExpr("app", `app`),
+			},
+			labels.Labels{{Name: "foo", Value: "bar"}},
+			labels.Labels{
+				{Name: "foo", Value: "bar"},
+				{Name: "app", Value: `{ "key": "value", "key2":"value2"}`},
+			},
+			noParserHints,
+		},
 	}
 	for _, tt := range tests {
 		j, err := NewJSONExpressionParser(tt.expressions)


### PR DESCRIPTION
https://github.com/grafana/loki/pull/9410