### PR TITLE
Fix docker image tag in release template

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DRONE_TAG_NO_V=${DRONE_TAG#v}
+export DRONE_TAG_NO_V
+
 ghr \
   -t "${GITHUB_TOKEN}" \
   -u "${DRONE_REPO_OWNER}" \

--- a/tools/release-note.md
+++ b/tools/release-note.md
@@ -11,8 +11,8 @@ The components of Loki are currently distributed in plain binary form and as Doc
 * https://hub.docker.com/r/grafana/loki
 * https://hub.docker.com/r/grafana/promtail
 ```bash
-$ docker pull "grafana/loki:${DRONE_TAG}"
-$ docker pull "grafana/promtail:${DRONE_TAG}"
+$ docker pull "grafana/loki:${DRONE_TAG_NO_V}"
+$ docker pull "grafana/promtail:${DRONE_TAG_NO_V}"
 ```
 
 #### Binary


### PR DESCRIPTION
**What this PR does / why we need it**:
Releases in GitHub are published automatically from Drone. Drone calls the `tools/release` script which uses the `tools/release-note.md` template to generate the release body.

Before this PR, the template used the `$DRONE_TAG` env variable which had a `v` preffix (e. `v2.8.0`). Since we publish the docker images without the `v` preffix, the docker images referenced by the release did not exist. This affected the `v2.8.0`, `v2.8.1` and `v2.8.2` releases.

I manually fixed the `v2.8.0`, `v2.8.1` and `v2.8.2` release pages, but this PR should fix the template so we no longer run into this situation.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/9384

**Special notes for your reviewer**:

Not sure where to find the available env variables in Drone. I wonder if there is an existing env var with the version without the `v` preffix.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
