### PR TITLE
Moves all unit tests under operator/manifests to the manifests package

### DIFF
--- a/operator/internal/manifests/compactor_test.go
+++ b/operator/internal/manifests/compactor_test.go
@@ -1,10 +1,9 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +14,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewCompactorStatefulSet(manifests.Options{
+	sts := NewCompactorStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -36,7 +35,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",

--- a/operator/internal/manifests/distributor_test.go
+++ b/operator/internal/manifests/distributor_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"math/rand"
@@ -10,11 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 )
 
 func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
-	dpl := manifests.NewDistributorDeployment(manifests.Options{
+	dpl := NewDistributorDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -34,7 +33,7 @@ func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -54,7 +53,7 @@ func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) 
 }
 
 func TestNewDistributorDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -74,7 +73,7 @@ func TestNewDistributorDeployment_HasTemplateCertRotationRequiredAtAnnotation(t 
 }
 
 func TestBuildDistributor_PodDisruptionBudget(t *testing.T) {
-	opts := manifests.Options{
+	opts := Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -88,7 +87,7 @@ func TestBuildDistributor_PodDisruptionBudget(t *testing.T) {
 			},
 		},
 	}
-	objs, err := manifests.BuildDistributor(opts)
+	objs, err := BuildDistributor(opts)
 	require.NoError(t, err)
 	require.Len(t, objs, 4)
 
@@ -98,7 +97,7 @@ func TestBuildDistributor_PodDisruptionBudget(t *testing.T) {
 	require.Equal(t, "efgh", pdb.Namespace)
 	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
 	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
-	require.EqualValues(t, manifests.ComponentLabels(manifests.LabelDistributorComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
+	require.EqualValues(t, ComponentLabels(LabelDistributorComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }
 
 func TestNewDistributorDeployment_TopologySpreadConstraints(t *testing.T) {
@@ -176,7 +175,7 @@ func TestNewDistributorDeployment_TopologySpreadConstraints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			depl := manifests.NewDistributorDeployment(manifests.Options{
+			depl := NewDistributorDeployment(Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/indexgateway_test.go
+++ b/operator/internal/manifests/indexgateway_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
@@ -9,11 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 )
 
 func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -34,7 +33,7 @@ func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T
 }
 
 func TestNewIndexGatewayStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -60,7 +59,7 @@ func TestNewIndexGatewayStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -81,7 +80,7 @@ func TestNewIndexGatewayStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestBuildIndexGateway_PodDisruptionBudget(t *testing.T) {
-	opts := manifests.Options{
+	opts := Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -92,7 +91,7 @@ func TestBuildIndexGateway_PodDisruptionBudget(t *testing.T) {
 			},
 		},
 	}
-	objs, err := manifests.BuildIndexGateway(opts)
+	objs, err := BuildIndexGateway(opts)
 
 	require.NoError(t, err)
 	require.Len(t, objs, 4)
@@ -103,12 +102,12 @@ func TestBuildIndexGateway_PodDisruptionBudget(t *testing.T) {
 	require.Equal(t, "efgh", pdb.Namespace)
 	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
 	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
-	require.EqualValues(t, manifests.ComponentLabels(manifests.LabelIndexGatewayComponent, opts.Name),
+	require.EqualValues(t, ComponentLabels(LabelIndexGatewayComponent, opts.Name),
 		pdb.Spec.Selector.MatchLabels)
 }
 
 func TestNewIndexGatewayStatefulSet_TopologySpreadConstraints(t *testing.T) {
-	depl := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	depl := NewIndexGatewayStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"math/rand"
@@ -11,12 +11,11 @@ import (
 
 	v1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/internal"
 )
 
 func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -37,7 +36,7 @@ func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewIngesterStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -63,7 +62,7 @@ func TestNewIngesterStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewIngesterStatefulSet(manifests.Options{
+	sts := NewIngesterStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -101,7 +100,7 @@ func TestBuildIngester_PodDisruptionBudget(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			opts := manifests.Options{
+			opts := Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Gates:     v1.FeatureGates{},
@@ -121,7 +120,7 @@ func TestBuildIngester_PodDisruptionBudget(t *testing.T) {
 					},
 				},
 			}
-			objs, err := manifests.BuildIngester(opts)
+			objs, err := BuildIngester(opts)
 			require.NoError(t, err)
 			require.Len(t, objs, 4)
 
@@ -131,13 +130,13 @@ func TestBuildIngester_PodDisruptionBudget(t *testing.T) {
 			require.Equal(t, "efgh", pdb.Namespace)
 			require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
 			require.Equal(t, int32(tc.ExpectedMinAvailable), pdb.Spec.MinAvailable.IntVal)
-			require.EqualValues(t, manifests.ComponentLabels(manifests.LabelIngesterComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
+			require.EqualValues(t, ComponentLabels(LabelIngesterComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 		})
 	}
 }
 
 func TestNewIngesterStatefulSet_TopologySpreadConstraints(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -1,9 +1,7 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
-
-	"github.com/grafana/loki/operator/internal/manifests"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -41,7 +39,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 	}
 
 	got := &corev1.ConfigMap{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -54,7 +52,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 func TestGetMutateFunc_ReturnErrOnNotSupportedType(t *testing.T) {
 	got := &corev1.Endpoints{}
 	want := &corev1.Endpoints{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	require.Error(t, f())
 }
@@ -70,7 +68,7 @@ func TestGetMutateFunc_MutateConfigMap(t *testing.T) {
 		BinaryData: map[string][]byte{"btest": []byte("btestss")},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -117,7 +115,7 @@ func TestGetMutateFunc_MutateServiceSpec(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -232,7 +230,7 @@ func TestGetMutateFunc_MutateServiceAccountObjectMeta(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tt.got, tt.want, nil)
+			f := MutateFuncFor(tt.got, tt.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -294,7 +292,7 @@ func TestGetMutateFunc_MutateClusterRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -359,7 +357,7 @@ func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -414,7 +412,7 @@ func TestGetMutateFunc_MutateRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -479,7 +477,7 @@ func TestGetMutateFunc_MutateRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -598,7 +596,7 @@ func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -755,7 +753,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -791,12 +789,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -818,24 +816,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -862,12 +860,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -894,24 +892,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -932,7 +930,7 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -1004,7 +1002,7 @@ func TestGetMutateFunc_MutateIngress(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -1056,7 +1054,7 @@ func TestGetMutateFunc_MutateRoute(t *testing.T) {
 			},
 		},
 	}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	err := f()
 	require.NoError(t, err)
@@ -1096,7 +1094,7 @@ func TestGetMutateFunc_MutatePodDisruptionBudget(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 
 	require.NoError(t, err)

--- a/operator/internal/manifests/querier_test.go
+++ b/operator/internal/manifests/querier_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
@@ -10,11 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 )
 
 func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -35,7 +34,7 @@ func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewQuerierDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -61,7 +60,7 @@ func TestNewQuerierDeployment_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during Deployment creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -84,12 +83,12 @@ func TestNewQuerierDeployment_SelectorMatchesLabels(t *testing.T) {
 func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 	tt := []struct {
 		name string
-		opts manifests.Options
+		opts Options
 		want policyv1.PodDisruptionBudget
 	}{
 		{
 			name: "Querier with 1 replica",
-			opts: manifests.Options{
+			opts: Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Stack: lokiv1.LokiStackSpec{
@@ -104,19 +103,19 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-querier",
 					Namespace: "efgh",
-					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 					Selector: &metav1.LabelSelector{
-						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
 					},
 				},
 			},
 		},
 		{
 			name: "Querier with 2 replicas",
-			opts: manifests.Options{
+			opts: Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Stack: lokiv1.LokiStackSpec{
@@ -131,19 +130,19 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-querier",
 					Namespace: "efgh",
-					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 					Selector: &metav1.LabelSelector{
-						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
 					},
 				},
 			},
 		},
 		{
 			name: "Querier with 3 replicas",
-			opts: manifests.Options{
+			opts: Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Stack: lokiv1.LokiStackSpec{
@@ -158,12 +157,12 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-querier",
 					Namespace: "efgh",
-					Labels:    manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
 					Selector: &metav1.LabelSelector{
-						MatchLabels: manifests.ComponentLabels(manifests.LabelQuerierComponent, "abcd"),
+						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
 					},
 				},
 			},
@@ -174,7 +173,7 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			objs, err := manifests.BuildQuerier(tc.opts)
+			objs, err := BuildQuerier(tc.opts)
 			require.NoError(t, err)
 			require.Len(t, objs, 4)
 
@@ -261,7 +260,7 @@ func TestNewQuerierDeployment_TopologySpreadConstraints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			depl := manifests.NewQuerierDeployment(manifests.Options{
+			depl := NewQuerierDeployment(Options{
 				Name:      "abcd",
 				Namespace: "efgh",
 				Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ruler_test.go
+++ b/operator/internal/manifests/ruler_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"math/rand"
@@ -9,12 +9,11 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 )
 
 func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -35,7 +34,7 @@ func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -55,7 +54,7 @@ func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *test
 }
 
 func TestBuildRuler_HasExtraObjectsForTenantMode(t *testing.T) {
-	objs, err := manifests.BuildRuler(manifests.Options{
+	objs, err := BuildRuler(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		OpenShiftOptions: openshift.Options{
@@ -90,7 +89,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewRulerStatefulSet(manifests.Options{
+	sts := NewRulerStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -111,7 +110,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T) {
-	opts := manifests.Options{
+	opts := Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -122,15 +121,15 @@ func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T
 				},
 			},
 		},
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {RuleFiles: []string{"test-rules-0___tenant-a___rule-a-alerts.yaml", "test-rules-0___tenant-a___rule-b-recs.yaml"}},
 				"tenant-b": {RuleFiles: []string{"test-rules-0___tenant-b___rule-a-alerts.yaml", "test-rules-0___tenant-b___rule-b-recs.yaml"}},
 			},
 		},
 		RulesConfigMapNames: []string{"config"},
 	}
-	sts := manifests.NewRulerStatefulSet(opts)
+	sts := NewRulerStatefulSet(opts)
 
 	vs := sts.Spec.Template.Spec.Volumes
 
@@ -145,7 +144,7 @@ func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T
 func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	// Create a large config map which will be split into 2 shards
 	opts := testOptions_withSharding()
-	rulesCMShards, err := manifests.RulesConfigMapShards(opts)
+	rulesCMShards, err := RulesConfigMapShards(opts)
 	require.NoError(t, err)
 	require.NotNil(t, rulesCMShards)
 	require.Len(t, rulesCMShards, 2)
@@ -155,7 +154,7 @@ func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	}
 
 	// Create the Ruler StatefulSet and mount the ConfigMap shards into the Ruler pod
-	sts := manifests.NewRulerStatefulSet(*opts)
+	sts := NewRulerStatefulSet(*opts)
 
 	vs := sts.Spec.Template.Spec.Volumes
 
@@ -163,7 +162,7 @@ func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	var volumeProjections []corev1.VolumeProjection
 	for _, v := range vs {
 		volumeNames = append(volumeNames, v.Name)
-		if v.Name == manifests.RulesStorageVolumeName() {
+		if v.Name == RulesStorageVolumeName() {
 			volumeProjections = append(volumeProjections, v.Projected.Sources...)
 		}
 	}
@@ -173,7 +172,7 @@ func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 }
 
 func TestBuildRuler_PodDisruptionBudget(t *testing.T) {
-	opts := manifests.Options{
+	opts := Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -185,7 +184,7 @@ func TestBuildRuler_PodDisruptionBudget(t *testing.T) {
 		},
 	}
 
-	objs, err := manifests.BuildRuler(opts)
+	objs, err := BuildRuler(opts)
 
 	require.NoError(t, err)
 	require.Len(t, objs, 4)
@@ -196,5 +195,5 @@ func TestBuildRuler_PodDisruptionBudget(t *testing.T) {
 	require.Equal(t, "efgh", pdb.Namespace)
 	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
 	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
-	require.EqualValues(t, manifests.ComponentLabels(manifests.LabelRulerComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
+	require.EqualValues(t, ComponentLabels(LabelRulerComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }

--- a/operator/internal/manifests/rules_config_test.go
+++ b/operator/internal/manifests/rules_config_test.go
@@ -1,18 +1,17 @@
-package manifests_test
+package manifests
 
 import (
 	"fmt"
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
-	cm_shards, err := manifests.RulesConfigMapShards(testOptions())
+	cm_shards, err := RulesConfigMapShards(testOptions())
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 
@@ -27,7 +26,7 @@ func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
 
 func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 	opts := testOptions()
-	cm_shards, err := manifests.RulesConfigMapShards(opts)
+	cm_shards, err := RulesConfigMapShards(opts)
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 
@@ -40,16 +39,16 @@ func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 }
 
 func TestRulesConfigMapSharding(t *testing.T) {
-	cm_shards, err := manifests.RulesConfigMapShards(testOptions_withSharding())
+	cm_shards, err := RulesConfigMapShards(testOptions_withSharding())
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 	require.Len(t, cm_shards, 2)
 }
 
-func testOptions() *manifests.Options {
-	return &manifests.Options{
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+func testOptions() *Options {
+	return &Options{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {},
 				"tenant-b": {},
 			},
@@ -133,7 +132,7 @@ func testOptions() *manifests.Options {
 	}
 }
 
-func testOptions_withSharding() *manifests.Options {
+func testOptions_withSharding() *Options {
 	// Generate a list of dummy rules to create a large amount of data
 	// that should result in sharding the rules ConfigMap
 	// In this case, each Alerting rule amounts to 598 bytes of ConfigMap data
@@ -169,7 +168,7 @@ func testOptions_withSharding() *manifests.Options {
 		})
 	}
 
-	return &manifests.Options{
+	return &Options{
 		Name:      "sharding-test",
 		Namespace: "namespace",
 		Stack: lokiv1.LokiStackSpec{
@@ -180,8 +179,8 @@ func testOptions_withSharding() *manifests.Options {
 				},
 			},
 		},
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {},
 				"tenant-b": {},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves all the unit tests under `operator/manifests` to the `manifests` package making all test files now uniform.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
