### PR TITLE
Uniformize "Available Labels" headers in Promtail config reference doc

### DIFF
--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -1050,7 +1050,7 @@ labels:
   [ <labelname>: <labelvalue> ... ]
 ```
 
-### Available Labels
+#### Available Labels
 
 When Promtail receives GCP logs, various internal labels are made available for [relabeling](#relabel_configs). This depends on the subscription type chosen.
 
@@ -1108,11 +1108,9 @@ connection_string: <string> | default = "range"
   [ <labelname>: <labelvalue> ... ]
 ```
 
-### Available Labels
+#### Available Labels
 
 When Promtail receives Azure Event Hubs messages, various internal labels are made available for [relabeling](#relabel_configs).
-
-**Available Labels:**
 
 - `__azure_event_hubs_category`: The log category of the message when a message is an application log.
 
@@ -1211,7 +1209,7 @@ labels:
 [use_incoming_timestamp: <bool> | default = false]
 ```
 
-**Available Labels:**
+#### Available Labels
 
 The list of labels below are discovered when consuming kafka:
 
@@ -1255,7 +1253,7 @@ use_incoming_timestamp: <bool>
 
 ```
 
-**Available Labels:**
+#### Available Labels
 
 - `__gelf_message_level`: The GELF level as string.
 - `__gelf_message_host`: The host sending the GELF message.


### PR DESCRIPTION
**What this PR does / why we need it**:

There were various formats for the "Available Labels" headings. This PR makes them all the same heading level and spelling.