### PR TITLE
Only modify identical timestamps when increment-duplicate-timestamps enabled

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -338,8 +338,8 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 					// Traditional logic for Loki is that 2 lines with the same timestamp and
 					// exact same content will be de-duplicated, (i.e. only one will be stored, others dropped)
 					// To maintain this behavior, only increment the timestamp if the log content is different
-					if stream.Entries[n-1].Line != entry.Line {
-						stream.Entries[n].Timestamp = maxT(entry.Timestamp, stream.Entries[n-1].Timestamp.Add(1*time.Nanosecond))
+					if stream.Entries[n-1].Line != entry.Line && entry.Timestamp == stream.Entries[n-1].Timestamp {
+						stream.Entries[n].Timestamp = entry.Timestamp.Add(1 * time.Nanosecond)
 					}
 				}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -323,6 +323,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 
 			n := 0
 			pushSize := 0
+			prevTs := stream.Entries[0].Timestamp
 			for _, entry := range stream.Entries {
 				if err := d.validator.ValidateEntry(validationContext, stream.Labels, entry); err != nil {
 					validationErr = err
@@ -334,12 +335,15 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 				// If configured for this tenant, increment duplicate timestamps. Note, this is imperfect
 				// since Loki will accept out of order writes it doesn't account for separate
 				// pushes with overlapping time ranges having entries with duplicate timestamps
+
 				if validationContext.incrementDuplicateTimestamps && n != 0 {
 					// Traditional logic for Loki is that 2 lines with the same timestamp and
 					// exact same content will be de-duplicated, (i.e. only one will be stored, others dropped)
 					// To maintain this behavior, only increment the timestamp if the log content is different
-					if stream.Entries[n-1].Line != entry.Line && entry.Timestamp == stream.Entries[n-1].Timestamp {
-						stream.Entries[n].Timestamp = entry.Timestamp.Add(1 * time.Nanosecond)
+					if stream.Entries[n-1].Line != entry.Line && (entry.Timestamp == prevTs || entry.Timestamp == stream.Entries[n-1].Timestamp) {
+						stream.Entries[n].Timestamp = stream.Entries[n-1].Timestamp.Add(1 * time.Nanosecond)
+					} else {
+						prevTs = entry.Timestamp
 					}
 				}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -327,6 +327,34 @@ func Test_IncrementTimestamp(t *testing.T) {
 				},
 			},
 		},
+		"incrementing enabled, no dupes, out of order": {
+			limits: incrementingEnabled,
+			push: &logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels: "{job=\"foo\"}",
+						Entries: []logproto.Entry{
+							{Timestamp: time.Unix(123456, 0), Line: "hey1"},
+							{Timestamp: time.Unix(123458, 0), Line: "hey3"},
+							{Timestamp: time.Unix(123457, 0), Line: "hey2"},
+						},
+					},
+				},
+			},
+			expectedPush: &logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels: "{job=\"foo\"}",
+						Hash:   0x8eeb87f5eb220480,
+						Entries: []logproto.Entry{
+							{Timestamp: time.Unix(123456, 0), Line: "hey1"},
+							{Timestamp: time.Unix(123458, 0), Line: "hey3"},
+							{Timestamp: time.Unix(123457, 0), Line: "hey2"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
When `-validation.increment-duplicate-timestamps` is enabled out of order log entries within the same push request can have their timestamps  incorrectly mutated.

The code is currently just looking for 2 consecutive entries where the timestamp is not increasing.
It should only affect entries where the timestamp is a *duplicate*

Test push request payload:

```json
{
  "streams": [
    {
      "stream": {
        "increment_duplicate_timestamp": "fixed|true|false"
      },
      "values": [
        [
          "1683665111628000000",
          "1a: 1683665111628000000"
        ],
        [
          "1683665111628000000",
          "1b: 1683665111628000000"
        ],
        [
          "1683665111628000003",
          "3: 1683665111628000003"
        ],
        [
          "1683665111628000002",
          "2: 1683665111628000002"
        ]
      ]
    }
  ]
}
````

As only the first 2 of these timestamps are the same I would expect all but `1b` to have the timestamps recorded as-is and the logs returned by a query in the order: 1a,1b,2,3.

Actual Results:

```
> logcli query --forward --limit 100 -z UTC -q --no-labels  --since 60m -o jsonl  '{increment_duplicate_timestamp="fixed"}' | jq
{
  "line": "1a: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628Z"
}
{
  "line": "1b: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628000001Z"
}
{
  "line": "2: 1683665111628000002",
  "timestamp": "2023-05-09T20:45:11.628000002Z"
}
{
  "line": "3: 1683665111628000003",
  "timestamp": "2023-05-09T20:45:11.628000003Z"
}

> logcli query --forward --limit 100 -z UTC -q --no-labels  --since 60m -o jsonl  '{increment_duplicate_timestamp="true"}' | jq
{
  "line": "1a: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628Z"
}
{
  "line": "1b: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628000001Z"
}
{
  "line": "3: 1683665111628000003",
  "timestamp": "2023-05-09T20:45:11.628000003Z"
}
{
  "line": "2: 1683665111628000002",
  "timestamp": "2023-05-09T20:45:11.628000004Z"
}

> logcli query --forward --limit 100 -z UTC -q --no-labels  --since 60m -o jsonl  '{increment_duplicate_timestamp="false"}' | jq
{
  "line": "1a: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628Z"
}
{
  "line": "1b: 1683665111628000000",
  "timestamp": "2023-05-09T20:45:11.628Z"
}
{
  "line": "2: 1683665111628000002",
  "timestamp": "2023-05-09T20:45:11.628000002Z"
}
{
  "line": "3: 1683665111628000003",
  "timestamp": "2023-05-09T20:45:11.628000003Z"
}
```

`true` and `false` were written to Loki 2.8.2 with the `-validation.increment-duplicate-timestamps` enabled or disabled
`fixed` with this patch applied and the flag enabled

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
