### PR TITLE
Add image reference by digest to Loki Helm chart

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -340,6 +340,15 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>enterprise.image.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>enterprise.image.pullPolicy</td>
 			<td>string</td>
 			<td>Docker image pull policy</td>
@@ -398,6 +407,7 @@ null
   "env": [],
   "extraVolumeMounts": [],
   "image": {
+    "digest": null,
     "pullPolicy": "IfNotPresent",
     "registry": "docker.io",
     "repository": "grafana/enterprise-logs-provisioner",
@@ -467,11 +477,21 @@ true
 			<td>Provisioner image to Utilize</td>
 			<td><pre lang="json">
 {
+  "digest": null,
   "pullPolicy": "IfNotPresent",
   "registry": "docker.io",
   "repository": "grafana/enterprise-logs-provisioner",
   "tag": null
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>enterprise.provisioner.image.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>
@@ -906,6 +926,15 @@ true
 			<td>Volumes to add to the gateway pods</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>gateway.image.digest</td>
+			<td>string</td>
+			<td>Overrides the gateway image tag with an image digest</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>
@@ -1534,6 +1563,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>kubectlImage.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>kubectlImage.pullPolicy</td>
 			<td>string</td>
 			<td>Docker image pull policy</td>
@@ -1650,6 +1688,15 @@ true
 			<td>Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`</td>
 			<td><pre lang="json">
 ""
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>loki.image.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>
@@ -2142,11 +2189,21 @@ true
 			<td>Image to use for loki canary</td>
 			<td><pre lang="json">
 {
+  "digest": null,
   "pullPolicy": "IfNotPresent",
   "registry": "docker.io",
   "repository": "grafana/loki-canary",
   "tag": null
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>monitoring.lokiCanary.image.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>
@@ -3481,6 +3538,7 @@ null
   "annotations": {},
   "enabled": true,
   "image": {
+    "digest": null,
     "pullPolicy": "IfNotPresent",
     "registry": "docker.io",
     "repository": "grafana/loki-helm-test",
@@ -3508,11 +3566,21 @@ null
 			<td>Image to use for loki canary</td>
 			<td><pre lang="json">
 {
+  "digest": null,
   "pullPolicy": "IfNotPresent",
   "registry": "docker.io",
   "repository": "grafana/loki-helm-test",
   "tag": null
 }
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>test.image.digest</td>
+			<td>string</td>
+			<td>Overrides the image tag with an image digest</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,11 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+
+## 5.5.1
+
+- [FEATURE] Added ability to reference images by digest
+
 ## 5.5.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.7.2

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.2
-version: 5.5.0
+version: 5.5.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 5.5.1](https://img.shields.io/badge/Version-5.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -135,11 +135,11 @@ Base template for building docker image reference
 {{- define "loki.baseImage" }}
 {{- $registry := .global.registry | default .service.registry | default "" -}}
 {{- $repository := .service.repository | default "" -}}
-{{- $tag := .service.tag | default .defaultVersion | toString -}}
+{{- $ref := ternary (printf ":%s" (.service.tag | default .defaultVersion | toString)) (printf "@%s" .service.digest) (empty .service.digest) -}}
 {{- if and $registry $repository -}}
-  {{- printf "%s/%s:%s" $registry $repository $tag -}}
+  {{- printf "%s/%s%s" $registry $repository $ref -}}
 {{- else -}}
-  {{- printf "%s%s:%s" $registry $repository $tag -}}
+  {{- printf "%s%s%s" $registry $repository $ref -}}
 {{- end -}}
 {{- end -}}
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -23,6 +23,8 @@ kubectlImage:
   repository: bitnami/kubectl
   # -- Overrides the image tag whose default is the chart's appVersion
   tag: null
+  # -- Overrides the image tag with an image digest
+  digest: null
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 loki:
@@ -42,6 +44,8 @@ loki:
     # TODO: needed for 3rd target backend functionality
     # revert to null or latest once this behavior is relased
     tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   # -- Common annotations for all pods
@@ -340,6 +344,8 @@ enterprise:
     repository: grafana/enterprise-logs
     # -- Docker image tag
     tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   adminToken:
@@ -415,6 +421,8 @@ enterprise:
       repository: grafana/enterprise-logs-provisioner
       # -- Overrides the image tag whose default is the chart's appVersion
       tag: null
+      # -- Overrides the image tag with an image digest
+      digest: null
       # -- Docker image pull policy
       pullPolicy: IfNotPresent
     # -- Volume mounts to add to the provisioner pods
@@ -467,6 +475,8 @@ test:
     repository: grafana/loki-helm-test
     # -- Overrides the image tag whose default is the chart's appVersion
     tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 # Monitoring section determines which monitoring features to enable
@@ -606,6 +616,8 @@ monitoring:
       repository: grafana/loki-canary
       # -- Overrides the image tag whose default is the chart's appVersion
       tag: null
+      # -- Overrides the image tag with an image digest
+      digest: null
       # -- Docker image pull policy
       pullPolicy: IfNotPresent
 # Configuration for the write pod(s)
@@ -1034,6 +1046,8 @@ gateway:
     repository: nginxinc/nginx-unprivileged
     # -- The gateway image tag
     tag: 1.19-alpine
+    # -- Overrides the gateway image tag with an image digest
+    digest: null
     # -- The gateway image pull policy
     pullPolicy: IfNotPresent
   # -- The name of the PriorityClass for gateway pods


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to reference images by digest instead of tag.  Useful for images that are bundled in an OCI artifact, where the digest must be used.

**Which issue(s) this PR fixes**:
Fixes #9440 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
