### PR TITLE
tsdb wal always includes labels with chunks for replay consistency

### DIFF
--- a/pkg/storage/stores/tsdb/head.go
+++ b/pkg/storage/stores/tsdb/head.go
@@ -159,10 +159,10 @@ func updateMintMaxt(mint, maxt int64, mintSrc, maxtSrc *atomic.Int64) {
 }
 
 // Note: chks must not be nil or zero-length
-func (h *Head) Append(ls labels.Labels, fprint uint64, chks index.ChunkMetas) (created bool, refID uint64) {
+func (h *Head) Append(ls labels.Labels, fprint uint64, chks index.ChunkMetas) (refID uint64) {
 	from, through := chks.Bounds()
 	var id uint64
-	created, refID = h.series.Append(ls, chks, func() *memSeries {
+	created, refID := h.series.Append(ls, chks, func() *memSeries {
 		id = h.lastSeriesID.Inc()
 		return newMemSeries(id, ls, fprint)
 	})

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -310,7 +310,7 @@ func (m *HeadManager) buildTSDBFromWALs(legacy bool) error {
 		allWALs,
 		legacy,
 	); err != nil {
-		return errors.Wrap(err, "building tsdb from WALs")
+		level.Error(m.log).Log("msg", "failed to build tsdb from WALs, continuing", "err", err.Error())
 	}
 
 	if legacy {

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -563,7 +563,6 @@ func recoverHead(name, dir string, heads *tenantHeads, wals []WALIdentifier, leg
 					return err
 				}
 
-				// labels are always written to the WAL before corresponding chunks
 				if len(rec.Series.Labels) > 0 {
 					tenant, ok := seriesMap[rec.UserID]
 					if !ok {
@@ -660,22 +659,19 @@ func (t *tenantHeads) Append(userID string, ls labels.Labels, fprint uint64, chk
 	updateMintMaxt(mint, maxt, &t.mint, &t.maxt)
 
 	head := t.getOrCreateTenantHead(userID)
-	newStream, refID := head.Append(ls, fprint, chks)
+	refID := head.Append(ls, fprint, chks)
 
 	rec := &WALRecord{
+		Fingerprint: fprint,
+		Series: record.RefSeries{
+			Ref:    chunks.HeadSeriesRef(refID),
+			Labels: ls,
+		},
 		UserID: userID,
 		Chks: ChunkMetasRecord{
 			Ref:  refID,
 			Chks: chks,
 		},
-	}
-
-	if newStream {
-		rec.Fingerprint = fprint
-		rec.Series = record.RefSeries{
-			Ref:    chunks.HeadSeriesRef(refID),
-			Labels: ls,
-		}
 	}
 
 	return rec

--- a/pkg/storage/stores/tsdb/head_wal.go
+++ b/pkg/storage/stores/tsdb/head_wal.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// Disable this to begin writing chunks and series in the same record.
-	WALWriteChunksAndSeriesSeparately = false
+	WALWriteChunksAndSeriesSeparately = true
 )
 
 type WAL interface {

--- a/pkg/storage/stores/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/tsdb/single_file_index_test.go
@@ -75,7 +75,7 @@ func TestSingleIdx(t *testing.T) {
 			fn: func() Index {
 				head := NewHead("fake", NewMetrics(nil), log.NewNopLogger())
 				for _, x := range cases {
-					_, _ = head.Append(x.Labels, x.Labels.Hash(), x.Chunks)
+					_ = head.Append(x.Labels, x.Labels.Hash(), x.Chunks)
 				}
 				reader := head.Index()
 				return NewTSDBIndex(reader)


### PR DESCRIPTION
After debugging a WAL replay corruption, we found a situation where we were trying to replay chunks written but the labels wal record was missing. I haven't found out how this is possible, so in the meantime this adds a new record format which writes the labels alongside the chunks in the same record. This will result in some data duplication but should be more reliable since chunks can't be replayed into missing series. Given that chunk flushes are orders of magnitude less common than entry pushes, this shouldn't introduce a performance bottleneck in any meaningful way.

I've added a followup commit to be reverted later which continues to write the old multi-record format while being capable of reading both new and old formats. This means we can roll out the readonly version with this commit as a rollback target before we revert the commit and begin writing the new format.