### PR TITLE
Correct Loki Helm monitoring config placeholders

### DIFF
--- a/docs/sources/installation/helm/monitor-and-alert/with-grafana-cloud.md
+++ b/docs/sources/installation/helm/monitor-and-alert/with-grafana-cloud.md
@@ -74,7 +74,7 @@ Walking through this installation will create two Grafana Agent configurations, 
      selfMonitoring:
        logsInstance:
          clients:
-           - url: <CLOUD_METRICS_URL>
+           - url: <CLOUD_LOGS_URL>
              basicAuth:
                username:
                  name: grafana-cloud-logs-credentials
@@ -85,7 +85,7 @@ Walking through this installation will create two Grafana Agent configurations, 
      serviceMonitor:
        metricsInstance:
          remoteWrite:
-           - url: <CLOUD_LOGS_URL>
+           - url: <CLOUD_METRICS_URL>
              basicAuth:
                username:
                  name: grafana-cloud-metrics-credentials


### PR DESCRIPTION
**What this PR does / why we need it**:
The remote write URL placeholders for metrics and logs are in the incorrect positions in the config example.