### PR TITLE
docs: add memberlist section to the configuration page

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -185,6 +185,14 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # The table_manager block configures the table manager for retention.
 [table_manager: <table_manager>]
 
+# Configuration for memberlist client. Only applies if the selected kvstore is
+# memberlist.
+# 
+# When a memberlist config with atleast 1 join_members is defined, kvstore of
+# type memberlist is automatically selected for all the components that require
+# a ring unless otherwise specified in the component's configuration section.
+[memberlist: <memberlist>]
+
 # Configuration for 'runtime config' module, responsible for reloading runtime
 # configuration file.
 [runtime_config: <runtime_config>]
@@ -406,11 +414,13 @@ ring:
     # CLI flag: -distributor.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is: distributor.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is: distributor.ring
     [etcd: <etcd>]
 
@@ -563,11 +573,13 @@ scheduler_ring:
     # CLI flag: -query-scheduler.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is: query-scheduler.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is: query-scheduler.ring
     [etcd: <etcd>]
 
@@ -995,11 +1007,13 @@ ring:
     # CLI flag: -ruler.ring.prefix
     [prefix: <string> | default = "rulers/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is: ruler.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is: ruler.ring
     [etcd: <etcd>]
 
@@ -1253,10 +1267,12 @@ lifecycler:
       # CLI flag: -ring.prefix
       [prefix: <string> | default = "collectors/"]
 
-      # Configuration for a Consul client. Only applies if store is consul.
+      # Configuration for a Consul client. Only applies if the selected kvstore
+      # is consul.
       [consul: <consul>]
 
-      # Configuration for an ETCD v3 client. Only applies if store is etcd.
+      # Configuration for an ETCD v3 client. Only applies if the selected
+      # kvstore is etcd.
       [etcd: <etcd>]
 
       multi:
@@ -1529,11 +1545,13 @@ ring:
     # CLI flag: -index-gateway.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is: index-gateway.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is: index-gateway.ring
     [etcd: <etcd>]
 
@@ -2101,12 +2119,14 @@ compactor_ring:
     # CLI flag: -boltdb.shipper.compactor.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is:
     # boltdb.shipper.compactor.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is:
     # boltdb.shipper.compactor.ring
     [etcd: <etcd>]
@@ -3054,11 +3074,13 @@ ring:
     # CLI flag: -common.storage.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
-    # Configuration for a Consul client. Only applies if store is consul.
+    # Configuration for a Consul client. Only applies if the selected kvstore is
+    # consul.
     # The CLI flags prefix for this block configuration is: common.storage.ring
     [consul: <consul>]
 
-    # Configuration for an ETCD v3 client. Only applies if store is etcd.
+    # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+    # is etcd.
     # The CLI flags prefix for this block configuration is: common.storage.ring
     [etcd: <etcd>]
 
@@ -3138,7 +3160,7 @@ ring:
 
 ### consul
 
-Configuration for a Consul client. Only applies if store is `consul`. The supported CLI flags `<prefix>` used to reference this configuration block are:
+Configuration for a Consul client. Only applies if the selected kvstore is `consul`. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `boltdb.shipper.compactor.ring`
 - `common.storage.ring`
@@ -3182,7 +3204,7 @@ Configuration for a Consul client. Only applies if store is `consul`. The suppor
 
 ### etcd
 
-Configuration for an ETCD v3 client. Only applies if store is `etcd`. The supported CLI flags `<prefix>` used to reference this configuration block are:
+Configuration for an ETCD v3 client. Only applies if the selected kvstore is `etcd`. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `boltdb.shipper.compactor.ring`
 - `common.storage.ring`
@@ -3278,6 +3300,206 @@ Configuration for an ETCD v3 client. Only applies if store is `etcd`. The suppor
 # Etcd password.
 # CLI flag: -<prefix>.etcd.password
 [password: <string> | default = ""]
+```
+
+### memberlist
+
+Configuration for `memberlist` client. Only applies if the selected kvstore is memberlist.
+
+When a memberlist config with atleast 1 join_members is defined, kvstore of type memberlist is automatically selected for all the components that require a ring unless otherwise specified in the component's configuration section.
+
+```yaml
+# Name of the node in memberlist cluster. Defaults to hostname.
+# CLI flag: -memberlist.nodename
+[node_name: <string> | default = ""]
+
+# Add random suffix to the node name.
+# CLI flag: -memberlist.randomize-node-name
+[randomize_node_name: <boolean> | default = true]
+
+# The timeout for establishing a connection with a remote node, and for
+# read/write operations.
+# CLI flag: -memberlist.stream-timeout
+[stream_timeout: <duration> | default = 10s]
+
+# Multiplication factor used when sending out messages (factor * log(N+1)).
+# CLI flag: -memberlist.retransmit-factor
+[retransmit_factor: <int> | default = 4]
+
+# How often to use pull/push sync.
+# CLI flag: -memberlist.pullpush-interval
+[pull_push_interval: <duration> | default = 30s]
+
+# How often to gossip.
+# CLI flag: -memberlist.gossip-interval
+[gossip_interval: <duration> | default = 200ms]
+
+# How many nodes to gossip to.
+# CLI flag: -memberlist.gossip-nodes
+[gossip_nodes: <int> | default = 3]
+
+# How long to keep gossiping to dead nodes, to give them chance to refute their
+# death.
+# CLI flag: -memberlist.gossip-to-dead-nodes-time
+[gossip_to_dead_nodes_time: <duration> | default = 30s]
+
+# How soon can dead node's name be reclaimed with new address. 0 to disable.
+# CLI flag: -memberlist.dead-node-reclaim-time
+[dead_node_reclaim_time: <duration> | default = 0s]
+
+# Enable message compression. This can be used to reduce bandwidth usage at the
+# cost of slightly more CPU utilization.
+# CLI flag: -memberlist.compression-enabled
+[compression_enabled: <boolean> | default = true]
+
+# Gossip address to advertise to other members in the cluster. Used for NAT
+# traversal.
+# CLI flag: -memberlist.advertise-addr
+[advertise_addr: <string> | default = ""]
+
+# Gossip port to advertise to other members in the cluster. Used for NAT
+# traversal.
+# CLI flag: -memberlist.advertise-port
+[advertise_port: <int> | default = 7946]
+
+# The cluster label is an optional string to include in outbound packets and
+# gossip streams. Other members in the memberlist cluster will discard any
+# message whose label doesn't match the configured one, unless the
+# 'cluster-label-verification-disabled' configuration option is set to true.
+# CLI flag: -memberlist.cluster-label
+[cluster_label: <string> | default = ""]
+
+# When true, memberlist doesn't verify that inbound packets and gossip streams
+# have the cluster label matching the configured one. This verification should
+# be disabled while rolling out the change to the configured cluster label in a
+# live memberlist cluster.
+# CLI flag: -memberlist.cluster-label-verification-disabled
+[cluster_label_verification_disabled: <boolean> | default = false]
+
+# Other cluster members to join. Can be specified multiple times. It can be an
+# IP, hostname or an entry specified in the DNS Service Discovery format.
+# CLI flag: -memberlist.join
+[join_members: <list of strings> | default = []]
+
+# Min backoff duration to join other cluster members.
+# CLI flag: -memberlist.min-join-backoff
+[min_join_backoff: <duration> | default = 1s]
+
+# Max backoff duration to join other cluster members.
+# CLI flag: -memberlist.max-join-backoff
+[max_join_backoff: <duration> | default = 1m]
+
+# Max number of retries to join other cluster members.
+# CLI flag: -memberlist.max-join-retries
+[max_join_retries: <int> | default = 10]
+
+# If this node fails to join memberlist cluster, abort.
+# CLI flag: -memberlist.abort-if-join-fails
+[abort_if_cluster_join_fails: <boolean> | default = false]
+
+# If not 0, how often to rejoin the cluster. Occasional rejoin can help to fix
+# the cluster split issue, and is harmless otherwise. For example when using
+# only few components as a seed nodes (via -memberlist.join), then it's
+# recommended to use rejoin. If -memberlist.join points to dynamic service that
+# resolves to all gossiping nodes (eg. Kubernetes headless service), then rejoin
+# is not needed.
+# CLI flag: -memberlist.rejoin-interval
+[rejoin_interval: <duration> | default = 0s]
+
+# How long to keep LEFT ingesters in the ring.
+# CLI flag: -memberlist.left-ingesters-timeout
+[left_ingesters_timeout: <duration> | default = 5m]
+
+# Timeout for leaving memberlist cluster.
+# CLI flag: -memberlist.leave-timeout
+[leave_timeout: <duration> | default = 20s]
+
+# How much space to use for keeping received and sent messages in memory for
+# troubleshooting (two buffers). 0 to disable.
+# CLI flag: -memberlist.message-history-buffer-bytes
+[message_history_buffer_bytes: <int> | default = 0]
+
+# IP address to listen on for gossip messages. Multiple addresses may be
+# specified. Defaults to 0.0.0.0
+# CLI flag: -memberlist.bind-addr
+[bind_addr: <list of strings> | default = []]
+
+# Port to listen on for gossip messages.
+# CLI flag: -memberlist.bind-port
+[bind_port: <int> | default = 7946]
+
+# Timeout used when connecting to other nodes to send packet.
+# CLI flag: -memberlist.packet-dial-timeout
+[packet_dial_timeout: <duration> | default = 2s]
+
+# Timeout for writing 'packet' data.
+# CLI flag: -memberlist.packet-write-timeout
+[packet_write_timeout: <duration> | default = 5s]
+
+# Enable TLS on the memberlist transport layer.
+# CLI flag: -memberlist.tls-enabled
+[tls_enabled: <boolean> | default = false]
+
+# Path to the client certificate, which will be used for authenticating with the
+# server. Also requires the key path to be configured.
+# CLI flag: -memberlist.tls-cert-path
+[tls_cert_path: <string> | default = ""]
+
+# Path to the key for the client certificate. Also requires the client
+# certificate to be configured.
+# CLI flag: -memberlist.tls-key-path
+[tls_key_path: <string> | default = ""]
+
+# Path to the CA certificates to validate server certificate against. If not
+# set, the host's root CA certificates are used.
+# CLI flag: -memberlist.tls-ca-path
+[tls_ca_path: <string> | default = ""]
+
+# Override the expected name on the server certificate.
+# CLI flag: -memberlist.tls-server-name
+[tls_server_name: <string> | default = ""]
+
+# Skip validating server certificate.
+# CLI flag: -memberlist.tls-insecure-skip-verify
+[tls_insecure_skip_verify: <boolean> | default = false]
+
+# Override the default cipher suite list (separated by commas). Allowed values:
+# 
+# Secure Ciphers:
+# - TLS_RSA_WITH_AES_128_CBC_SHA
+# - TLS_RSA_WITH_AES_256_CBC_SHA
+# - TLS_RSA_WITH_AES_128_GCM_SHA256
+# - TLS_RSA_WITH_AES_256_GCM_SHA384
+# - TLS_AES_128_GCM_SHA256
+# - TLS_AES_256_GCM_SHA384
+# - TLS_CHACHA20_POLY1305_SHA256
+# - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+# - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+# - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+# - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+# - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+# - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+# - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+# - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+# - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+# - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+# 
+# Insecure Ciphers:
+# - TLS_RSA_WITH_RC4_128_SHA
+# - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+# - TLS_RSA_WITH_AES_128_CBC_SHA256
+# - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+# - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+# - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+# - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+# - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+# CLI flag: -memberlist.tls-cipher-suites
+[tls_cipher_suites: <string> | default = ""]
+
+# Override the default minimum TLS version. Allowed values: VersionTLS10,
+# VersionTLS11, VersionTLS12, VersionTLS13
+# CLI flag: -memberlist.tls-min-version
+[tls_min_version: <string> | default = ""]
 ```
 
 ### grpc_client

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -95,7 +95,7 @@ type Config struct {
 	LimitsConfig        validation.Limits           `yaml:"limits_config,omitempty"`
 	Worker              worker.Config               `yaml:"frontend_worker,omitempty"`
 	TableManager        index.TableManagerConfig    `yaml:"table_manager,omitempty"`
-	MemberlistKV        memberlist.KVConfig         `yaml:"memberlist" doc:"hidden"`
+	MemberlistKV        memberlist.KVConfig         `yaml:"memberlist"`
 
 	RuntimeConfig runtimeconfig.Config `yaml:"runtime_config,omitempty"`
 	Tracing       tracing.Config       `yaml:"tracing"`

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/kv/etcd"
+	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/weaveworks/common/server"
 
@@ -159,12 +160,19 @@ var (
 		{
 			Name:       "consul",
 			StructType: reflect.TypeOf(consul.Config{}),
-			Desc:       "Configuration for a Consul client. Only applies if store is consul.",
+			Desc:       "Configuration for a Consul client. Only applies if the selected kvstore is consul.",
 		},
 		{
 			Name:       "etcd",
 			StructType: reflect.TypeOf(etcd.Config{}),
-			Desc:       "Configuration for an ETCD v3 client. Only applies if store is etcd.",
+			Desc:       "Configuration for an ETCD v3 client. Only applies if the selected kvstore is etcd.",
+		},
+		{
+			Name:       "memberlist",
+			StructType: reflect.TypeOf(memberlist.KVConfig{}),
+			Desc: `Configuration for memberlist client. Only applies if the selected kvstore is memberlist.
+
+When a memberlist config with atleast 1 join_members is defined, kvstore of type memberlist is automatically selected for all the components that require a ring unless otherwise specified in the component's configuration section.`,
 		},
 		// GRPC client
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
`memberlist_config` section is not present in 2.8.x release, must have gotten removed by mistake when we moved to the doc generation tool. This pr adds it back.

**Which issue(s) this PR fixes**:
Fixes #9423

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
