### PR TITLE
Loki: Create samples based on `numChunks`

### DIFF
--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -2015,9 +2015,9 @@ type chunkSamples struct {
 	chunks []chunkSample
 }
 
-func newChunkSamples() *chunkSamples {
+func newChunkSamples(n int) *chunkSamples {
 	return &chunkSamples{
-		chunks: make([]chunkSample, 0, 30),
+		chunks: make([]chunkSample, 0, n),
 	}
 }
 
@@ -2140,7 +2140,7 @@ func (dec *Decoder) getOrCreateChunksSample(d encoding.Decbuf, seriesRef storage
 		return sample, nil
 	}
 
-	sample = newChunkSamples()
+	sample = newChunkSamples(numChunks)
 	dec.chunksSample[seriesRef] = sample
 	sample.Lock()
 	defer sample.Unlock()


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies `newChunkSamples` to create chunk samples based on `numChunks` instead of always creating a slice with n=30.

**Which issue(s) this PR fixes**:
N/A
