### PR TITLE
Helm: Support of extraVolumeClaimTemplates for writer statefulset

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3731,7 +3731,7 @@ Hard node and soft zone anti-affinity
 		<tr>
 			<td>write.extraVolumeClaimTemplates</td>
 			<td>list</td>
-			<td>volumeClaimTemplates to add to statefulset</td>
+			<td>volumeClaimTemplates to add to StatefulSet</td>
 			<td><pre lang="json">
 []
 </pre>

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3684,15 +3684,6 @@ Hard node and soft zone anti-affinity
 </td>
 		</tr>
 		<tr>
-			<td>write.extraVolumeClaimTemplates</td>
-			<td>list</td>
-			<td>volumeClaimTemplates to add to stateful set</td>
-			<td><pre lang="json">
-[]
-</pre>
-</td>
-		</tr>
-		<tr>
 			<td>write.extraArgs</td>
 			<td>list</td>
 			<td>Additional CLI args for the write</td>
@@ -3714,6 +3705,15 @@ Hard node and soft zone anti-affinity
 			<td>write.extraEnvFrom</td>
 			<td>list</td>
 			<td>Environment variables from secrets or configmaps to add to the write pods</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>write.extraVolumeClaimTemplates</td>
+			<td>list</td>
+			<td>volumeClaimTemplates to add to stateful set</td>
 			<td><pre lang="json">
 []
 </pre>

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3713,7 +3713,7 @@ Hard node and soft zone anti-affinity
 		<tr>
 			<td>write.extraVolumeClaimTemplates</td>
 			<td>list</td>
-			<td>volumeClaimTemplates to add to stateful set</td>
+			<td>volumeClaimTemplates to add to statefulset</td>
 			<td><pre lang="json">
 []
 </pre>

--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3684,6 +3684,15 @@ Hard node and soft zone anti-affinity
 </td>
 		</tr>
 		<tr>
+			<td>write.extraVolumeClaimTemplates</td>
+			<td>list</td>
+			<td>volumeClaimTemplates to add to stateful set</td>
+			<td><pre lang="json">
+[]
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>write.extraArgs</td>
 			<td>list</td>
 			<td>Additional CLI args for the write</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,9 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.5.4
+
+- [CHANGE] Add extraVolumeClaimTemplates for StatefulSet of the write component.
 - [CHANGE] Add clusterLabelOverride for alert label overrides.
 
 ## 5.5.3

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.2
-version: 5.5.3
+version: 5.5.4
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.5.3](https://img.shields.io/badge/Version-5.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 5.5.4](https://img.shields.io/badge/Version-5.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -173,4 +173,7 @@ spec:
         selector:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+    {{- with .Values.write.extraVolumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -678,7 +678,7 @@ write:
   extraVolumeMounts: []
   # -- Volumes to add to the write pods
   extraVolumes: []
-  # -- volumeClaimTemplates to add to statefulset
+  # -- volumeClaimTemplates to add to StatefulSet
   extraVolumeClaimTemplates: []
   # -- Resource requests and limits for the write
   resources: {}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -664,6 +664,8 @@ write:
   extraVolumeMounts: []
   # -- Volumes to add to the write pods
   extraVolumes: []
+  # -- volumeClaimTemplates to add to stateful set
+  extraVolumeClaimTemplates: []
   # -- Resource requests and limits for the write
   resources: {}
   # -- Grace period to allow the write to shutdown before it is killed. Especially for the ingester,

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -664,7 +664,7 @@ write:
   extraVolumeMounts: []
   # -- Volumes to add to the write pods
   extraVolumes: []
-  # -- volumeClaimTemplates to add to stateful set
+  # -- volumeClaimTemplates to add to statefulset
   extraVolumeClaimTemplates: []
   # -- Resource requests and limits for the write
   resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `extraVolumeClaimTemplates` value for write loki component, it allows to have more than one volume claims for persistent statefulset configuration. For example, when it's needed to have ingester's and shipper's WAL files on different persistent volumes. 

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
