### PR TITLE
Helm: Quote tenantId value in logsInstance

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -16,7 +16,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.5.4
 
 - [CHANGE] Add extraVolumeClaimTemplates for StatefulSet of the write component.
-- [CHANGE] Add clusterLabelOverride for alert label overrides.
 
 ## 5.5.3
 
@@ -25,6 +24,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.5.2
 
 - [BUGFIX] Use $.Release.Namespace consistently
+- [CHANGE] Add clusterLabelOverride for alert label overrides.
 
 ## 5.5.1
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.5.5
+
+- [BUGFIX] Quote tenantId value in logsInstance
+
 ## 5.5.4
 
 - [CHANGE] Add extraVolumeClaimTemplates for StatefulSet of the write component.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.2
-version: 5.5.4
+version: 5.5.5
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.5.4](https://img.shields.io/badge/Version-5.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 5.5.5](https://img.shields.io/badge/Version-5.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/monitoring/_helpers-monitoring.tpl
+++ b/production/helm/loki/templates/monitoring/_helpers-monitoring.tpl
@@ -21,7 +21,7 @@ Client definition for LogsInstance
       name: {{ include "enterprise-logs.selfMonitoringTenantSecret" . }}
       key: password
   {{- else if .Values.loki.auth_enabled }}
-  tenantId: {{ .Values.monitoring.selfMonitoring.tenant.name }}
+  tenantId: {{ .Values.monitoring.selfMonitoring.tenant.name | quote }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**: Quotes the value of `tenantId` for the cases where tenantId is made up of only numerical values (i.e. if tenantId is `0`)

the motivation for this is that we have long used the tenant id `0` in our loki instance for some stuff. We probably should fix that, but it's going to be easier (at least for us) to patch this than to rename this tenant or migrate to a new tenant.

**Which issue(s) this PR fixes**:
N/A - If you'd like me to file an issue to track this there as well, let me know and i'll write one up. i figured this fix was simple enough

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
