### PR TITLE
chunks-inspect: print chunk version (format)

### DIFF
--- a/cmd/chunks-inspect/loki.go
+++ b/cmd/chunks-inspect/loki.go
@@ -62,6 +62,7 @@ const (
 )
 
 type LokiChunk struct {
+	format   byte
 	encoding Encoding
 
 	blocks []LokiBlock
@@ -149,6 +150,7 @@ func parseLokiChunk(chunkHeader *ChunkHeader, r io.Reader) (*LokiChunk, error) {
 	metadata = metadata[n:]
 
 	lokiChunk := &LokiChunk{
+		format:                   f,
 		encoding:                 compression,
 		metadataChecksum:         metaChecksum,
 		computedMetadataChecksum: computedMetaChecksum,

--- a/cmd/chunks-inspect/main.go
+++ b/cmd/chunks-inspect/main.go
@@ -65,6 +65,7 @@ func printFile(filename string, blockDetails, printLines, storeBlocks bool) {
 		return
 	}
 
+	fmt.Println("Format (Version):", lokiChunk.format)
 	fmt.Println("Encoding:", lokiChunk.encoding)
 	fmt.Print("Blocks Metadata Checksum: ", fmt.Sprintf("%08x", lokiChunk.metadataChecksum))
 	if lokiChunk.metadataChecksum == lokiChunk.computedMetadataChecksum {


### PR DESCRIPTION
**What this PR does / why we need it**:

Get the version byte of the current inspecting Loki chunk printed.

**Which issue(s) this PR fixes**:
Fixes -

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
