### PR TITLE
Promtail: Fix goroutine leak in file tailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [9252](https://github.com/grafana/loki/pull/9252) **jeschkies**: Use un-escaped regex literal for string matching.
 * [9176](https://github.com/grafana/loki/pull/9176) **DylanGuedes**: Fix incorrect association of per-stream rate limit when sharding is enabled.
 * [9463](https://github.com/grafana/loki/pull/9463) **Totalus**: Fix OpenStack Swift client object listing to fetch all the objects properly.
+* [9495](https://github.com/grafana/loki/pull/9495) **thampiotr**: Promtail: Fix potential goroutine leak in file tailer.
 
 ##### Changes
 

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -165,6 +165,64 @@ func TestFileTargetSync(t *testing.T) {
 	ps.Stop()
 }
 
+func TestFileTarget_StopsTailersCleanly(t *testing.T) {
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+
+	tempDir := t.TempDir()
+	positionsFileName := filepath.Join(tempDir, "positions.yml")
+	logFile := filepath.Join(tempDir, "test1.log")
+
+	ps, err := positions.New(logger, positions.Config{
+		SyncPeriod:    10 * time.Millisecond,
+		PositionsFile: positionsFileName,
+	})
+	require.NoError(t, err)
+
+	client := fake.New(func() {})
+	defer client.Stop()
+
+	fakeHandler := make(chan fileTargetEvent, 10)
+	pathToWatch := filepath.Join(tempDir, "*.log")
+	target, err := NewFileTarget(NewMetrics(nil), logger, client, ps, pathToWatch, "", nil, nil, &Config{
+		SyncPeriod: 10 * time.Millisecond,
+	}, DefaultWatchConig, nil, fakeHandler, "", nil)
+	assert.NoError(t, err)
+
+	_, err = os.Create(logFile)
+	assert.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(target.readers) == 1
+	}, time.Second*10, time.Millisecond*1, "expected 1 tailer to be created")
+
+	// Inject an error to tailer
+	initailTailer := target.readers[logFile].(*tailer)
+	_ = initailTailer.tail.Tomb.Killf("test: network file systems can be unreliable")
+
+	// Tailer will be replaced by a new one
+	require.Eventually(t, func() bool {
+		return len(target.readers) == 1 && target.readers[logFile].(*tailer) != initailTailer
+	}, time.Second*10, time.Millisecond*1, "expected dead tailer to be replaced by a new one")
+
+	// The old tailer should be stopped:
+	select {
+	case <-initailTailer.done:
+	case <-time.After(time.Second * 10):
+		t.Fatal("expected position timer to be stopped cleanly")
+	}
+
+	// The old tailer's position timer should be stopped
+	select {
+	case <-initailTailer.posdone:
+	case <-time.After(time.Second * 10):
+		t.Fatal("expected position timer to be stopped cleanly")
+	}
+
+	target.Stop()
+	ps.Stop()
+}
+
 func TestFileTargetPathExclusion(t *testing.T) {
 	w := log.NewSyncWriter(os.Stderr)
 	logger := log.NewLogfmtLogger(w)

--- a/clients/pkg/promtail/targets/file/tailer.go
+++ b/clients/pkg/promtail/targets/file/tailer.go
@@ -153,6 +153,8 @@ func (t *tailer) readLines() {
 		t.running.Store(false)
 		level.Info(t.logger).Log("msg", "tail routine: exited", "path", t.path)
 		close(t.done)
+		// Shut down the position marker thread
+		close(t.posquit)
 	}()
 	entries := t.handler.Chan()
 	for {
@@ -222,10 +224,6 @@ func (t *tailer) Stop() {
 	// stop can be called by two separate threads in filetarget, to avoid a panic closing channels more than once
 	// we wrap the stop in a sync.Once.
 	t.stopOnce.Do(func() {
-		// Shut down the position marker thread
-		close(t.posquit)
-		<-t.posdone
-
 		// Save the current position before shutting down tailer
 		err := t.MarkPositionAndSize()
 		if err != nil {
@@ -239,6 +237,8 @@ func (t *tailer) Stop() {
 		}
 		// Wait for readLines() to consume all the remaining messages and exit when the channel is closed
 		<-t.done
+		// Wait for the position marker thread to exit
+		<-t.posdone
 		level.Info(t.logger).Log("msg", "stopped tailing file", "path", t.path)
 		t.handler.Stop()
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a goroutine leak in promtail file tailer, which has been encountered in https://github.com/grafana/agent/issues/3885. 

The issue is the following:
- There are two goroutines that tailer manages: one for reading lines, the other for updating positions: https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/file/tailer.go#L103
- The tailer can be cleanly stopped & drained via `.Stop()` https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/file/tailer.go#L221
- But if the goroutine reading lines encounters an error from the underlying `tail`, the tailer is stopped without draining using the defer statement here: https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/file/tailer.go#L151 
- The above defer statement does not shut down the position updating goroutine and the  `.Stop()` won't be called, so we end up with a leaked goroutine.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/agent/issues/3885 

As can be seen in the [goroutine dump attached to the issue](https://gist.github.com/amseager/e37f31984facd9cbc51ce0f2153d6864), there were 933 update position goroutines, while we only had 21 files being tailed.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] `CHANGELOG.md` updated
