### PR TITLE
revert count unflused chunks

### DIFF
--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -837,23 +837,6 @@ func TestStreamShardingUsage(t *testing.T) {
 	})
 }
 
-func TestGetStats(t *testing.T) {
-	instance := defaultInstance(t)
-	resp, err := instance.GetStats(context.Background(), &logproto.IndexStatsRequest{
-		From:     0,
-		Through:  11000,
-		Matchers: `{host="agent"}`,
-	})
-	require.NoError(t, err)
-
-	require.Equal(t, &logproto.IndexStatsResponse{
-		Streams: 2,
-		Chunks:  2,
-		Bytes:   160,
-		Entries: 10,
-	}, resp)
-}
-
 func defaultInstance(t *testing.T) *instance {
 	ingesterConfig := defaultIngesterTestConfig(t)
 	defaultLimits := defaultLimitsTestConfig()


### PR DESCRIPTION
revert this commit: https://github.com/grafana/loki/commit/aeba51ab0fe785ab251eaf8d7005f203ece0986f

We seem to be dramatically overcounting bytes now which is causing oversharding

This is the same query before and after:

Before: ~20 GB
![image (2)](https://github.com/grafana/loki/assets/1413241/6d0e3d4d-56ce-40aa-b57e-d2dd592eefb4)

After: ~8 EB
![image (1)](https://github.com/grafana/loki/assets/1413241/f07cca10-0e32-467f-bf96-13a83eea8ce6)

