### PR TITLE
Fix typo in log_queries docs

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -602,14 +602,6 @@ The renaming form `dst=src` will _drop_ the `src` label after remapping it to th
 
 **Syntax**:  `|drop name, other_name, some_name="some_value"`
 
-The `=` operator after the label name is a **label matching operator**.
-The following label matching operators are supported:
-
-- `=`: exactly equal
-- `!=`: not equal
-- `=~`: regex matches
-- `!~`: regex does not match
-
 The `| drop` expression will drop the given labels in the pipeline. For example, for the query `{job="varlogs"}|json|drop level, method="GET"`, with below log line
 
 ```
@@ -619,7 +611,7 @@ The `| drop` expression will drop the given labels in the pipeline. For example,
 the result will be
 
 ```
-{host="grafana.net", path="status="200"} {"level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
+{host="grafana.net", path="/", status="200"} {"level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
 ```
 
 Similary, this expression can be used to drop `__error__` labels as well. For example, for the query `{job="varlogs"}|json|drop __error__`, with below log line
@@ -639,13 +631,13 @@ Example with regex and multiple names
 For the query `{job="varlogs"}|json|drop level, path, app=~"some-api.*"`, with below log lines
 
 ```
-{"app": "some-api-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200}
-{"app: "other-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200}
+{"app": "some-api-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
+{"app": "other-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
 ```
 
 the result will be
 
 ```
-{host="grafana.net", job="varlogs", method="GET", status="200"} {""app": "some-api-service",", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
-{app="other-service", host="grafana.net", job="varlogs", method="GET", status="200"} {"app": "other-service",, "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
+{host="grafana.net", job="varlogs", method="GET", status="200"} {"app": "some-api-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
+{app="other-service", host="grafana.net", job="varlogs", method="GET", status="200"} {"app": "other-service", "level": "info", "method": "GET", "path": "/", "host": "grafana.net", "status": "200"}
 ```


### PR DESCRIPTION
Removed duplicated documentation and corrected typos in the Drop Labels expression section.

**What this PR does / why we need it**: fix typo for log queries documentation

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A
