### PR TITLE
Promtail: improve behavior of partial lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
 * [8874](https://github.com/grafana/loki/pull/8874) **rfratto**: Promtail: Support expoential backoff when polling unchanged files for logs.
+* [9508](https://github.com/grafana/loki/pull/9508) **farodin91**: Promtail: improve behavior of partial lines.
 
 ##### Fixes
 

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -119,7 +119,7 @@ func New(logger log.Logger, jobName *string, stageType string,
 			return nil, err
 		}
 	case StageTypeCRI:
-		s, err = NewCRI(logger, registerer)
+		s, err = NewCRI(logger, cfg, registerer)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/sources/clients/promtail/stages/cri.md
+++ b/docs/sources/clients/promtail/stages/cri.md
@@ -9,7 +9,15 @@ The `cri` stage is a parsing stage that reads the log line using the standard CR
 ## Schema
 
 ```yaml
-cri: {}
+cri:
+  # Max buffer size to hold partial lines.
+  [max_partial_lines: <int> | default = 100]
+
+  # Max line size to hold a single partial line, if max_partial_line_size_truncate is true. Example: 262144.
+  [max_partial_line_size: <int> | default = 0]
+
+  # Allows to pretruncate partial lines before storing in partial buffer.
+  [max_partial_line_size_truncate: <bool> | default = false]
 ```
 
 Unlike most stages, the `cri` stage provides no configuration options and only


### PR DESCRIPTION
**What this PR does / why we need it**:

I started to see OOM after upgrading to a promtail version with #8497. So played around to make partial line behavior more stable. You can now truncate partial lines and configure max partial lines buffer.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
