### PR TITLE
Fix link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Loki differs from Prometheus by focusing on logs instead of metrics, and deliver
 
 Commonly used sections:
 
-- [API documentation](https://grafana.com/docs/loki/latest/reference/api/) for getting logs into Loki.
+- [API documentation](https://grafana.com/docs/loki/latest/api/) for getting logs into Loki.
 - [Labels](https://grafana.com/docs/loki/latest/getting-started/labels/)
 - [Operations](https://grafana.com/docs/loki/latest/operations/)
 - [Promtail](https://grafana.com/docs/loki/latest/clients/promtail/) is an agent which tails log files and pushes them to Loki.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the link to the API docs. 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
