### PR TITLE
helm: Use parallel pod management policy

### DIFF
--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -12,7 +12,7 @@ spec:
 {{- if not .Values.write.autoscaling.enabled }}
   replicas: {{ .Values.write.replicas }}
 {{- end }}
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   updateStrategy:
     rollingUpdate:
       partition: 0


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent [PR](https://github.com/grafana/loki/pull/8684) changed the pod management policy from parallel to ordered ready without reason. The Kubernetes documentation recommends that the pod management policy should be parallel when using rolling updates.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback

**Which issue(s) this PR fixes**:

Fixes #9519

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
