### PR TITLE
operator: Use parallel pod management policy

### DIFF
--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -141,7 +141,7 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 			Labels: l,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			RevisionHistoryLimit: pointer.Int32(10),
 			Replicas:             pointer.Int32(opts.Stack.Template.Compactor.Replicas),
 			Selector: &metav1.LabelSelector{

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -147,7 +147,7 @@ func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 			Labels: l,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			RevisionHistoryLimit: pointer.Int32(10),
 			Replicas:             pointer.Int32(opts.Stack.Template.IndexGateway.Replicas),
 			Selector: &metav1.LabelSelector{

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -157,7 +157,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 			Labels: l,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			RevisionHistoryLimit: pointer.Int32(10),
 			Replicas:             pointer.Int32(opts.Stack.Template.Ingester.Replicas),
 			Selector: &metav1.LabelSelector{

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -653,7 +653,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 			},
 			want: &appsv1.StatefulSet{
 				Spec: appsv1.StatefulSetSpec{
-					PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+					PodManagementPolicy: appsv1.ParallelPodManagement,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"test": "test",
@@ -717,7 +717,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 			want: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
 				Spec: appsv1.StatefulSetSpec{
-					PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+					PodManagementPolicy: appsv1.ParallelPodManagement,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"test": "test",


### PR DESCRIPTION
**What this PR does / why we need it**:

The Kubernetes documentation recommends that the pod management policy should be parallel when using rolling updates.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback

**Which issue(s) this PR fixes**:

Fixes #9519

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
