### PR TITLE
Fix cacheGen for index stats reqs

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -367,15 +367,23 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	toMerge := []middleware.Interface{
 		httpreq.ExtractQueryMetricsMiddleware(),
 	}
+
+	logger := log.With(util_log.Logger, "component", "querier")
+	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, logger)
+
+	indexStatsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.IndexStats", t.querierAPI)
+
 	if t.supportIndexDeleteRequest() && t.Cfg.CompactorConfig.RetentionEnabled {
 		toMerge = append(
 			toMerge,
 			queryrangebase.CacheGenNumberHeaderSetterMiddleware(t.cacheGenerationLoader),
 		)
-	}
 
-	logger := log.With(util_log.Logger, "component", "querier")
-	t.querierAPI = querier.NewQuerierAPI(t.Cfg.Querier, t.Querier, t.Overrides, logger)
+		indexStatsHTTPMiddleware = middleware.Merge(
+			queryrangebase.CacheGenNumberHeaderSetterMiddleware(t.cacheGenerationLoader),
+			indexStatsHTTPMiddleware,
+		)
+	}
 
 	labelsHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.Label", t.querierAPI)
 
@@ -408,7 +416,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		"/loki/api/v1/label/{name}/values": labelsHTTPMiddleware.Wrap(http.HandlerFunc(t.querierAPI.LabelHandler)),
 
 		"/loki/api/v1/series":      querier.WrapQuerySpanAndTimeout("query.Series", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.SeriesHandler)),
-		"/loki/api/v1/index/stats": querier.WrapQuerySpanAndTimeout("query.IndexStats", t.querierAPI).Wrap(http.HandlerFunc(t.querierAPI.IndexStatsHandler)),
+		"/loki/api/v1/index/stats": indexStatsHTTPMiddleware.Wrap(http.HandlerFunc(t.querierAPI.IndexStatsHandler)),
 
 		"/api/prom/query": middleware.Merge(
 			httpMiddleware,


### PR DESCRIPTION
**What this PR does / why we need it**:

When deletes are enabled, we track the cache generation number to know when to invalidate the cache. The queriers add this cache generation number to the response, and in the frontend, we check if we should cache the response or not based on such generation number.

Before this PR, the queriers didn't add the cache generation number to the index stats responses, therefore, when deletes were enabled, we could see the following error message in the frontend when checking if we should store a new response in the cache:
```
we found results cache gen number %s set in store but none in headers
```

This PR fixes this by adding the middleware to add the generation number to the index stats handler in the querier.

As seen in the following screenshot, once we rolled out the fixes in this PR (at 10:12), the number of failed cache generation comparisons decreased to 0. At the same time, the number of version comparisons also decreased since we could store results in the cache and therefore the cache effectiveness improved.

([source][1])
![image](https://github.com/grafana/loki/assets/8354290/752fbc66-0005-437a-9469-bc25405198b9)


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)


[1]: https://admin-dev-us-central-0.grafana-dev.net/grafana/explore?orgId=1&left=%7B%22datasource%22:%22P09658BD21492D183%22,%22queries%22:%5B%7B%22refId%22:%22G%22,%22expr%22:%22sum%28%5Cn%20%20%20%20rate%28%5Cn%20%20%20%20%20%20%20%20loki_results_cache_version_comparisons_failed%7Bcluster%3D%5C%22dev-us-central-0%5C%22,%20namespace%3D%5C%22loki-dev-005%5C%22%7D%5Cn%20%20%20%20%20%20%20%20%5B1m%5D%5Cn%20%20%20%20%29%5Cn%29%22,%22range%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P09658BD21492D183%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22Gen%20cmp%20fail%22%7D,%7B%22refId%22:%22A%22,%22expr%22:%22sum%28%5Cn%20%20%20%20rate%28%5Cn%20%20%20%20%20%20%20%20loki_results_cache_version_comparisons_total%7Bcluster%3D%5C%22dev-us-central-0%5C%22,%20namespace%3D%5C%22loki-dev-005%5C%22%7D%5Cn%20%20%20%20%20%20%20%20%5B1m%5D%5Cn%20%20%20%20%29%5Cn%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P09658BD21492D183%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22Gen%20cpm%20total%22%7D%5D,%22range%22:%7B%22from%22:%221685094941101%22,%22to%22:%221685096865685%22%7D%7D
