### PR TITLE
Add config to avoid caching stats for recent data

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -802,6 +802,11 @@ index_stats_results_cache:
   # (disable compression).
   # CLI flag: -frontend.index-stats-results-cache.compression
   [compression: <string> | default = ""]
+
+  # Do not cache requests with an end time that falls within Now minus this
+  # duration. 0 disables this feature.
+  # CLI flag: -frontend.index-stats-results-cache.do-not-cache-request-within
+  [do_not_cache_request_within: <duration> | default = 0s]
 ```
 
 ### ruler

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -802,11 +802,6 @@ index_stats_results_cache:
   # (disable compression).
   # CLI flag: -frontend.index-stats-results-cache.compression
   [compression: <string> | default = ""]
-
-  # Do not cache requests with an end time that falls within Now minus this
-  # duration. 0 disables this feature.
-  # CLI flag: -frontend.index-stats-results-cache.do-not-cache-request-within
-  [do_not_cache_request_within: <duration> | default = 0s]
 ```
 
 ### ruler
@@ -2407,6 +2402,11 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # recent results that might still be in flux.
 # CLI flag: -frontend.max-cache-freshness
 [max_cache_freshness_per_query: <duration> | default = 1m]
+
+# Do not cache requests with an end time that falls within Now minus this
+# duration. 0 disables this feature (default).
+# CLI flag: -frontend.max-stats-cache-freshness
+[max_stats_cache_freshness: <duration> | default = 0s]
 
 # Maximum number of queriers that can handle requests for a single tenant. If
 # set to 0 or value higher than number of available queriers, *all* queriers

--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -74,6 +74,10 @@ func (cfg *IndexStatsCacheConfig) ShouldCache(req queryrangebase.Request, now mo
 	return cfg.DoNotCacheRequestWithin == 0 || model.Time(req.GetEnd()).Before(now.Add(-cfg.DoNotCacheRequestWithin))
 }
 
+// statsCacheMiddlewareNowTimeFunc is a function that returns the current time.
+// It is used to allow tests to override the current time.
+var statsCacheMiddlewareNowTimeFunc = model.Now
+
 func NewIndexStatsCacheMiddleware(
 	cfg IndexStatsCacheConfig,
 	log log.Logger,
@@ -99,7 +103,8 @@ func NewIndexStatsCacheMiddleware(
 			if shouldCache != nil && !shouldCache(r) {
 				return false
 			}
-			return cfg.ShouldCache(r, model.Now())
+			now := statsCacheMiddlewareNowTimeFunc()
+			return cfg.ShouldCache(r, now)
 		},
 		parallelismForReq,
 		retentionEnabled,

--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/util"
-	"github.com/prometheus/common/model"
 )
 
 type IndexStatsSplitter struct {

--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -9,13 +9,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/loki/pkg/util/validation"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/util/validation"
 )
 
 type IndexStatsSplitter struct {

--- a/pkg/querier/queryrange/index_stats_cache.go
+++ b/pkg/querier/queryrange/index_stats_cache.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/concurrency"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/common/model"
-	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
@@ -68,11 +66,24 @@ func (cfg *IndexStatsCacheConfig) Validate() error {
 	return cfg.ResultsCacheConfig.Validate()
 }
 
-type statsCacheMiddleware struct {
-	logger    log.Logger
-	limits    Limits
-	next      queryrangebase.Handler
-	cacheWare queryrangebase.Handler
+// statsCacheMiddlewareNowTimeFunc is a function that returns the current time.
+// It is used to allow tests to override the current time.
+var statsCacheMiddlewareNowTimeFunc = model.Now
+
+// shouldCacheStats returns true if the request should be cached.
+// It returns false if:
+// - The request end time falls within the max_stats_cache_freshness duration.
+func shouldCacheStats(ctx context.Context, req queryrangebase.Request, lim Limits) (bool, error) {
+	tenantIDs, err := tenant.TenantIDs(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	cacheFreshnessCapture := func(id string) time.Duration { return lim.MaxStatsCacheFreshness(ctx, id) }
+	maxCacheFreshness := validation.MaxDurationPerTenant(tenantIDs, cacheFreshnessCapture)
+
+	now := statsCacheMiddlewareNowTimeFunc()
+	return maxCacheFreshness == 0 || model.Time(req.GetEnd()).Before(now.Add(-maxCacheFreshness)), nil
 }
 
 func NewIndexStatsCacheMiddleware(
@@ -87,7 +98,7 @@ func NewIndexStatsCacheMiddleware(
 	transformer UserIDTransformer,
 	metrics *queryrangebase.ResultsCacheMetrics,
 ) (queryrangebase.Middleware, error) {
-	cacheWare, err := queryrangebase.NewResultsCacheMiddleware(
+	return queryrangebase.NewResultsCacheMiddleware(
 		log,
 		c,
 		IndexStatsSplitter{cacheKeyLimits{limits, transformer}},
@@ -95,76 +106,21 @@ func NewIndexStatsCacheMiddleware(
 		merger,
 		IndexStatsExtractor{},
 		cacheGenNumberLoader,
-		shouldCache,
+		func(ctx context.Context, r queryrangebase.Request) bool {
+			if shouldCache != nil && !shouldCache(ctx, r) {
+				return false
+			}
+
+			cacheStats, err := shouldCacheStats(ctx, r, limits)
+			if err != nil {
+				level.Error(log).Log("msg", "failed to determine if stats should be cached. Won't cache", "err", err)
+				return false
+			}
+
+			return cacheStats
+		},
 		parallelismForReq,
 		retentionEnabled,
 		metrics,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
-		return &statsCacheMiddleware{
-			logger:    log,
-			limits:    limits,
-			next:      next,
-			cacheWare: cacheWare.Wrap(next),
-		}
-	}), nil
-}
-
-// statsCacheMiddlewareNowTimeFunc is a function that returns the current time.
-// It is used to allow tests to override the current time.
-var statsCacheMiddlewareNowTimeFunc = model.Now
-
-// Do implements the queryrangebase.Handler interface.
-// It enforces the MaxStatsCacheFreshness limit before forwarding the request to the cache middleware.
-func (s *statsCacheMiddleware) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	tenantIDs, err := tenant.TenantIDs(ctx)
-	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
-	}
-
-	cacheFreshnessCapture := func(id string) time.Duration { return s.limits.MaxStatsCacheFreshness(ctx, id) }
-	maxCacheFreshness := validation.MaxDurationPerTenant(tenantIDs, cacheFreshnessCapture)
-
-	// If part of the request is too recent, we need to split the request into two parts:
-	// 1. A part that can be cached (before freshness). Forwarded to the cache middleware.
-	// 2. A part that cannot be cached (after freshness). Skips the cache middleware.
-	// The results of both parts are then merged and returned.
-	now := statsCacheMiddlewareNowTimeFunc()
-	if maxCacheFreshness != 0 && model.Time(r.GetEnd()).After(now.Add(-maxCacheFreshness)) {
-		cachableReq := r.WithStartEnd(r.GetStart(), int64(now.Add(-maxCacheFreshness)))
-		uncachableReq := r.WithStartEnd(int64(now.Add(-maxCacheFreshness)), r.GetEnd())
-
-		type f func() (queryrangebase.Response, error)
-		jobs := []f{
-			f(func() (queryrangebase.Response, error) {
-				return s.cacheWare.Do(ctx, cachableReq)
-			}),
-			f(func() (queryrangebase.Response, error) {
-				return s.next.Do(ctx, uncachableReq)
-			}),
-		}
-
-		results := make([]queryrangebase.Response, len(jobs))
-		if err := concurrency.ForEachJob(ctx, len(jobs), len(jobs), func(ctx context.Context, i int) error {
-			res, err := jobs[i]()
-			results[i] = res
-			return err
-		}); err != nil {
-			return nil, err
-		}
-
-		// Merge the results.
-		merged, err := LokiCodec.MergeResponse(results...)
-		if err != nil {
-			return nil, httpgrpc.Errorf(http.StatusInternalServerError, err.Error())
-		}
-
-		return merged, nil
-	}
-
-	return s.cacheWare.Do(ctx, r)
 }

--- a/pkg/querier/queryrange/index_stats_cache_test.go
+++ b/pkg/querier/queryrange/index_stats_cache_test.go
@@ -139,9 +139,12 @@ func TestIndexStatsCache_RecentData(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			statsCacheMiddlewareNowTimeFunc = func() model.Time { return model.Time(testTime.UnixMilli()) }
+			now := statsCacheMiddlewareNowTimeFunc()
+
 			statsReq := &logproto.IndexStatsRequest{
-				From:     model.Now().Add(-1 * time.Hour),
-				Through:  model.Now().Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
+				From:     now.Add(-1 * time.Hour),
+				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
 				Matchers: `{foo="bar"}`,
 			}
 

--- a/pkg/querier/queryrange/index_stats_cache_test.go
+++ b/pkg/querier/queryrange/index_stats_cache_test.go
@@ -18,15 +18,12 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
-var cfg = IndexStatsCacheConfig{
-	ResultsCacheConfig: queryrangebase.ResultsCacheConfig{
+func TestIndexStatsCache(t *testing.T) {
+	cfg := queryrangebase.ResultsCacheConfig{
 		CacheConfig: cache.Config{
 			Cache: cache.NewMockCache(),
 		},
-	},
-}
-
-func TestIndexStatsCache(t *testing.T) {
+	}
 	c, err := cache.New(cfg.CacheConfig, nil, log.NewNopLogger(), stats.ResultCache)
 	require.NoError(t, err)
 	cacheMiddleware, err := NewIndexStatsCacheMiddleware(
@@ -97,23 +94,73 @@ func TestIndexStatsCache(t *testing.T) {
 }
 
 func TestIndexStatsCache_RecentData(t *testing.T) {
+	statsCacheMiddlewareNowTimeFunc = func() model.Time { return model.Time(testTime.UnixMilli()) }
+	now := statsCacheMiddlewareNowTimeFunc()
+
+	statsResp := &IndexStatsResponse{
+		Response: &logproto.IndexStatsResponse{
+			Streams: 1,
+			Chunks:  2,
+			Bytes:   1 << 10,
+			Entries: 10,
+		},
+	}
+
 	for _, tc := range []struct {
 		name                   string
 		maxStatsCacheFreshness time.Duration
-		expectedCalls          int
+		req                    *logproto.IndexStatsRequest
+
+		expectedCallsBeforeCache int
+		expectedCallsAfterCache  int
+		expectedResp             *IndexStatsResponse
 	}{
 		{
 			name:                   "MaxStatsCacheFreshness disabled",
 			maxStatsCacheFreshness: 0,
-			expectedCalls:          0,
+			req: &logproto.IndexStatsRequest{
+				From:     now.Add(-1 * time.Hour),
+				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
+				Matchers: `{foo="bar"}`,
+			},
+
+			expectedCallsBeforeCache: 1,
+			expectedCallsAfterCache:  0,
+			expectedResp:             statsResp,
 		},
 		{
 			name:                   "MaxStatsCacheFreshness enabled",
 			maxStatsCacheFreshness: 30 * time.Minute,
-			expectedCalls:          1,
+			req: &logproto.IndexStatsRequest{
+				From:     now.Add(-1 * time.Hour),
+				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
+				Matchers: `{foo="bar"}`,
+			},
+
+			expectedCallsBeforeCache: 1,
+			expectedCallsAfterCache:  1, // The whole request is done since it wasn't cached.
+			expectedResp:             statsResp,
+		},
+		{
+			name:                   "MaxStatsCacheFreshness enabled, but request before the max freshness",
+			maxStatsCacheFreshness: 30 * time.Minute,
+			req: &logproto.IndexStatsRequest{
+				From:     now.Add(-1 * time.Hour),
+				Through:  now.Add(-45 * time.Minute),
+				Matchers: `{foo="bar"}`,
+			},
+
+			expectedCallsBeforeCache: 1,
+			expectedCallsAfterCache:  0,
+			expectedResp:             statsResp,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			cfg := queryrangebase.ResultsCacheConfig{
+				CacheConfig: cache.Config{
+					Cache: cache.NewMockCache(),
+				},
+			}
 			c, err := cache.New(cfg.CacheConfig, nil, log.NewNopLogger(), stats.ResultCache)
 			defer c.Stop()
 			require.NoError(t, err)
@@ -136,39 +183,21 @@ func TestIndexStatsCache_RecentData(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			statsCacheMiddlewareNowTimeFunc = func() model.Time { return model.Time(testTime.UnixMilli()) }
-			now := statsCacheMiddlewareNowTimeFunc()
-
-			statsReq := &logproto.IndexStatsRequest{
-				From:     now.Add(-1 * time.Hour),
-				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
-				Matchers: `{foo="bar"}`,
-			}
-
-			statsResp := &IndexStatsResponse{
-				Response: &logproto.IndexStatsResponse{
-					Streams: 1,
-					Chunks:  2,
-					Bytes:   1 << 10,
-					Entries: 10,
-				},
-			}
-
 			calls, statsHandler := indexStatsResultHandler(statsResp)
 			rc := cacheMiddleware.Wrap(statsHandler)
 
 			ctx := user.InjectOrgID(context.Background(), "fake")
-			resp, err := rc.Do(ctx, statsReq)
+			resp, err := rc.Do(ctx, tc.req)
 			require.NoError(t, err)
-			require.Equal(t, 1, *calls)
-			require.Equal(t, statsResp, resp)
+			require.Equal(t, tc.expectedCallsBeforeCache, *calls)
+			require.Equal(t, tc.expectedResp, resp)
 
 			// Doing same request again
 			*calls = 0
-			resp, err = rc.Do(ctx, statsReq)
+			resp, err = rc.Do(ctx, tc.req)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedCalls, *calls)
-			require.Equal(t, statsResp, resp)
+			require.Equal(t, tc.expectedCallsAfterCache, *calls)
+			require.Equal(t, tc.expectedResp, resp)
 		})
 	}
 }

--- a/pkg/querier/queryrange/index_stats_cache_test.go
+++ b/pkg/querier/queryrange/index_stats_cache_test.go
@@ -18,12 +18,15 @@ import (
 	"github.com/grafana/loki/pkg/util"
 )
 
-func TestIndexStatsCache(t *testing.T) {
-	cfg := queryrangebase.ResultsCacheConfig{
+var cfg = IndexStatsCacheConfig{
+	ResultsCacheConfig: queryrangebase.ResultsCacheConfig{
 		CacheConfig: cache.Config{
 			Cache: cache.NewMockCache(),
 		},
-	}
+	},
+}
+
+func TestIndexStatsCache(t *testing.T) {
 	c, err := cache.New(cfg.CacheConfig, nil, log.NewNopLogger(), stats.ResultCache)
 	require.NoError(t, err)
 	cacheMiddleware, err := NewIndexStatsCacheMiddleware(
@@ -94,81 +97,23 @@ func TestIndexStatsCache(t *testing.T) {
 }
 
 func TestIndexStatsCache_RecentData(t *testing.T) {
-	statsCacheMiddlewareNowTimeFunc = func() model.Time { return model.Time(testTime.UnixMilli()) }
-	now := statsCacheMiddlewareNowTimeFunc()
-
-	statsResp := &IndexStatsResponse{
-		Response: &logproto.IndexStatsResponse{
-			Streams: 1,
-			Chunks:  2,
-			Bytes:   1 << 10,
-			Entries: 10,
-		},
-	}
-
 	for _, tc := range []struct {
 		name                   string
 		maxStatsCacheFreshness time.Duration
-		req                    *logproto.IndexStatsRequest
-
-		expectedCallsBeforeCache int
-		expectedCallsAfterCache  int
-		expectedResp             *IndexStatsResponse
+		expectedCalls          int
 	}{
 		{
 			name:                   "MaxStatsCacheFreshness disabled",
 			maxStatsCacheFreshness: 0,
-			req: &logproto.IndexStatsRequest{
-				From:     now.Add(-1 * time.Hour),
-				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
-				Matchers: `{foo="bar"}`,
-			},
-
-			expectedCallsBeforeCache: 1,
-			expectedCallsAfterCache:  0,
-			expectedResp:             statsResp,
+			expectedCalls:          0,
 		},
 		{
 			name:                   "MaxStatsCacheFreshness enabled",
 			maxStatsCacheFreshness: 30 * time.Minute,
-			req: &logproto.IndexStatsRequest{
-				From:     now.Add(-1 * time.Hour),
-				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
-				Matchers: `{foo="bar"}`,
-			},
-
-			expectedCallsBeforeCache: 2,
-			expectedCallsAfterCache:  1, // Only the uncacheable part of the request is sent to the backend.
-			expectedResp: &IndexStatsResponse{
-				// We are hitting the stats endpoint twice, so the stats are doubled.
-				Response: &logproto.IndexStatsResponse{
-					Streams: statsResp.Response.Streams * 2,
-					Chunks:  statsResp.Response.Chunks * 2,
-					Bytes:   statsResp.Response.Bytes * 2,
-					Entries: statsResp.Response.Entries * 2,
-				},
-			},
-		},
-		{
-			name:                   "MaxStatsCacheFreshness enabled, but request before the max freshness",
-			maxStatsCacheFreshness: 30 * time.Minute,
-			req: &logproto.IndexStatsRequest{
-				From:     now.Add(-1 * time.Hour),
-				Through:  now.Add(-45 * time.Minute),
-				Matchers: `{foo="bar"}`,
-			},
-
-			expectedCallsBeforeCache: 1,
-			expectedCallsAfterCache:  0,
-			expectedResp:             statsResp,
+			expectedCalls:          1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := queryrangebase.ResultsCacheConfig{
-				CacheConfig: cache.Config{
-					Cache: cache.NewMockCache(),
-				},
-			}
 			c, err := cache.New(cfg.CacheConfig, nil, log.NewNopLogger(), stats.ResultCache)
 			defer c.Stop()
 			require.NoError(t, err)
@@ -191,21 +136,39 @@ func TestIndexStatsCache_RecentData(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			statsCacheMiddlewareNowTimeFunc = func() model.Time { return model.Time(testTime.UnixMilli()) }
+			now := statsCacheMiddlewareNowTimeFunc()
+
+			statsReq := &logproto.IndexStatsRequest{
+				From:     now.Add(-1 * time.Hour),
+				Through:  now.Add(-5 * time.Minute), // So we don't hit the max_cache_freshness_per_query limit (1m)
+				Matchers: `{foo="bar"}`,
+			}
+
+			statsResp := &IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{
+					Streams: 1,
+					Chunks:  2,
+					Bytes:   1 << 10,
+					Entries: 10,
+				},
+			}
+
 			calls, statsHandler := indexStatsResultHandler(statsResp)
 			rc := cacheMiddleware.Wrap(statsHandler)
 
 			ctx := user.InjectOrgID(context.Background(), "fake")
-			resp, err := rc.Do(ctx, tc.req)
+			resp, err := rc.Do(ctx, statsReq)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedCallsBeforeCache, *calls)
-			require.Equal(t, tc.expectedResp, resp)
+			require.Equal(t, 1, *calls)
+			require.Equal(t, statsResp, resp)
 
 			// Doing same request again
 			*calls = 0
-			resp, err = rc.Do(ctx, tc.req)
+			resp, err = rc.Do(ctx, statsReq)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedCallsAfterCache, *calls)
-			require.Equal(t, tc.expectedResp, resp)
+			require.Equal(t, tc.expectedCalls, *calls)
+			require.Equal(t, statsResp, resp)
 		})
 	}
 }

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -63,6 +63,7 @@ type Limits interface {
 	RequiredNumberLabels(context.Context, string) int
 	MaxQueryBytesRead(context.Context, string) int
 	MaxQuerierBytesRead(context.Context, string) int
+	MaxStatsCacheFreshness(context.Context, string) time.Duration
 }
 
 type limits struct {

--- a/pkg/querier/queryrange/log_result_cache.go
+++ b/pkg/querier/queryrange/log_result_cache.go
@@ -88,7 +88,7 @@ func (l *logResultCache) Do(ctx context.Context, req queryrangebase.Request) (qu
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	if l.shouldCache != nil && !l.shouldCache(req) {
+	if l.shouldCache != nil && !l.shouldCache(ctx, req) {
 		return l.next.Do(ctx, req)
 	}
 

--- a/pkg/querier/queryrange/log_result_cache.go
+++ b/pkg/querier/queryrange/log_result_cache.go
@@ -88,7 +88,7 @@ func (l *logResultCache) Do(ctx context.Context, req queryrangebase.Request) (qu
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	if l.shouldCache != nil && !l.shouldCache(ctx, req) {
+	if l.shouldCache != nil && !l.shouldCache(req) {
 		return l.next.Do(ctx, req)
 	}
 

--- a/pkg/querier/queryrange/queryrangebase/results_cache.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache.go
@@ -156,7 +156,7 @@ func (t constSplitter) GenerateCacheKey(_ context.Context, userID string, r Requ
 
 // ShouldCacheFn checks whether the current request should go to cache
 // or not. If not, just send the request to next handler.
-type ShouldCacheFn func(ctx context.Context, r Request) bool
+type ShouldCacheFn func(r Request) bool
 
 type resultsCache struct {
 	logger   log.Logger
@@ -225,7 +225,7 @@ func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	if s.shouldCache != nil && !s.shouldCache(ctx, r) {
+	if s.shouldCache != nil && !s.shouldCache(r) {
 		return s.next.Do(ctx, r)
 	}
 

--- a/pkg/querier/queryrange/queryrangebase/results_cache.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache.go
@@ -156,7 +156,7 @@ func (t constSplitter) GenerateCacheKey(_ context.Context, userID string, r Requ
 
 // ShouldCacheFn checks whether the current request should go to cache
 // or not. If not, just send the request to next handler.
-type ShouldCacheFn func(r Request) bool
+type ShouldCacheFn func(ctx context.Context, r Request) bool
 
 type resultsCache struct {
 	logger   log.Logger
@@ -225,7 +225,7 @@ func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	if s.shouldCache != nil && !s.shouldCache(r) {
+	if s.shouldCache != nil && !s.shouldCache(ctx, r) {
 		return s.next.Do(ctx, r)
 	}
 

--- a/pkg/querier/queryrange/queryrangebase/results_cache_test.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache_test.go
@@ -1005,7 +1005,7 @@ func TestResultsCacheShouldCacheFunc(t *testing.T) {
 		},
 		{
 			name: "always no cache",
-			shouldCache: func(r Request) bool {
+			shouldCache: func(_ context.Context, _ Request) bool {
 				return false
 			},
 			requests:     []Request{parsedRequest, parsedRequest},
@@ -1013,7 +1013,7 @@ func TestResultsCacheShouldCacheFunc(t *testing.T) {
 		},
 		{
 			name: "check cache based on request",
-			shouldCache: func(r Request) bool {
+			shouldCache: func(_ context.Context, r Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			requests:     []Request{noCacheRequest, noCacheRequest},

--- a/pkg/querier/queryrange/queryrangebase/results_cache_test.go
+++ b/pkg/querier/queryrange/queryrangebase/results_cache_test.go
@@ -1005,7 +1005,7 @@ func TestResultsCacheShouldCacheFunc(t *testing.T) {
 		},
 		{
 			name: "always no cache",
-			shouldCache: func(_ context.Context, _ Request) bool {
+			shouldCache: func(r Request) bool {
 				return false
 			},
 			requests:     []Request{parsedRequest, parsedRequest},
@@ -1013,7 +1013,7 @@ func TestResultsCacheShouldCacheFunc(t *testing.T) {
 		},
 		{
 			name: "check cache based on request",
-			shouldCache: func(_ context.Context, r Request) bool {
+			shouldCache: func(r Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			requests:     []Request{noCacheRequest, noCacheRequest},

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -383,7 +383,7 @@ func NewLogFilterTripperware(
 				log,
 				limits,
 				c,
-				func(r queryrangebase.Request) bool {
+				func(_ context.Context, r queryrangebase.Request) bool {
 					return !r.GetCachingOptions().Disabled
 				},
 				cfg.Transformer,
@@ -575,7 +575,7 @@ func NewMetricTripperware(
 			codec,
 			extractor,
 			cacheGenNumLoader,
-			func(r queryrangebase.Request) bool {
+			func(_ context.Context, r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {
@@ -747,7 +747,7 @@ func NewIndexStatsTripperware(
 			codec,
 			c,
 			cacheGenNumLoader,
-			func(r queryrangebase.Request) bool {
+			func(_ context.Context, r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -383,7 +383,7 @@ func NewLogFilterTripperware(
 				log,
 				limits,
 				c,
-				func(_ context.Context, r queryrangebase.Request) bool {
+				func(r queryrangebase.Request) bool {
 					return !r.GetCachingOptions().Disabled
 				},
 				cfg.Transformer,
@@ -575,7 +575,7 @@ func NewMetricTripperware(
 			codec,
 			extractor,
 			cacheGenNumLoader,
-			func(_ context.Context, r queryrangebase.Request) bool {
+			func(r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {
@@ -747,7 +747,7 @@ func NewIndexStatsTripperware(
 			codec,
 			c,
 			cacheGenNumLoader,
-			func(_ context.Context, r queryrangebase.Request) bool {
+			func(r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -742,6 +742,7 @@ func NewIndexStatsTripperware(
 	if cfg.CacheIndexStatsResults {
 		var err error
 		cacheMiddleware, err = NewIndexStatsCacheMiddleware(
+			cfg.StatsCacheConfig,
 			log,
 			limits,
 			codec,

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -383,7 +383,7 @@ func NewLogFilterTripperware(
 				log,
 				limits,
 				c,
-				func(r queryrangebase.Request) bool {
+				func(_ context.Context, r queryrangebase.Request) bool {
 					return !r.GetCachingOptions().Disabled
 				},
 				cfg.Transformer,
@@ -575,7 +575,7 @@ func NewMetricTripperware(
 			codec,
 			extractor,
 			cacheGenNumLoader,
-			func(r queryrangebase.Request) bool {
+			func(_ context.Context, r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {
@@ -742,13 +742,12 @@ func NewIndexStatsTripperware(
 	if cfg.CacheIndexStatsResults {
 		var err error
 		cacheMiddleware, err = NewIndexStatsCacheMiddleware(
-			cfg.StatsCacheConfig,
 			log,
 			limits,
 			codec,
 			c,
 			cacheGenNumLoader,
-			func(r queryrangebase.Request) bool {
+			func(_ context.Context, r queryrangebase.Request) bool {
 				return !r.GetCachingOptions().Disabled
 			},
 			func(ctx context.Context, tenantIDs []string, r queryrangebase.Request) int {

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1093,6 +1093,7 @@ type fakeLimits struct {
 	requiredNumberLabels    int
 	maxQueryBytesRead       int
 	maxQuerierBytesRead     int
+	maxStatsCacheFreshness  time.Duration
 }
 
 func (f fakeLimits) QuerySplitDuration(key string) time.Duration {
@@ -1163,6 +1164,10 @@ func (f fakeLimits) RequiredLabels(context.Context, string) []string {
 
 func (f fakeLimits) RequiredNumberLabels(ctx context.Context, s string) int {
 	return f.requiredNumberLabels
+}
+
+func (f fakeLimits) MaxStatsCacheFreshness(ctx context.Context, s string) time.Duration {
+	return f.maxStatsCacheFreshness
 }
 
 func counter() (*int, http.Handler) {

--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -150,6 +150,10 @@ func (a *AsyncStore) Stats(ctx context.Context, userID string, from, through mod
 		return nil, err
 	}
 
+	// TODO: fix inflated stats. This happens because:
+	//       - All ingesters are queried. Since we have a replication factor of 3, we get 3x the stats.
+	//       - For the same timespan, we are querying the store as well. This means we can get duplicated stats for
+	//         chunks that are already in the store but also still in the ingesters.
 	merged := stats.MergeStats(resps...)
 	return &merged, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When we query the stats for recent data, we query both the ingesters and the index gateways for the stats.
https://github.com/grafana/loki/blob/ebdb2b18007e024d56105afc5230383165ca1650/pkg/storage/async_store.go#L112-L114

https://github.com/grafana/loki/blob/ebdb2b18007e024d56105afc5230383165ca1650/pkg/storage/async_store.go#L126-L127

Then we merge all the responses, which means summing up all the stats

https://github.com/grafana/loki/blob/ebdb2b18007e024d56105afc5230383165ca1650/pkg/storage/async_store.go#L157-L158

https://github.com/grafana/loki/blob/ebdb2b18007e024d56105afc5230383165ca1650/pkg/storage/stores/index/stats/stats.go#L23-L26

Because we have a replication factor of 3, this means that we will get the stats from the ingesters repeated up to 3 times, hence inflating the stats.

In the stats cache, we store the stats for a given matcher set for the whole day, then we extract the stats from the cache by the factor of time from the request that is stored in the cache:
https://github.com/grafana/loki/blob/336283acadb34f5fda9abce4e6fcef1dca9965d8/pkg/querier/queryrange/index_stats_cache.go#L33
https://github.com/grafana/loki/blob/336283acadb34f5fda9abce4e6fcef1dca9965d8/pkg/querier/queryrange/index_stats_cache.go#L40

Inflated stats for recent data will be cached, so subsequent stats extracted from the cache will be inflated regardless of the time.

This PR adds a new per-tenant limit `max_stats_cache_freshness` to not cache requests with an end time that falls within Now minus this duration.

Here's a scenario illustrating this. The graphs below show the bytes stats queried in the sharding middleware. We are running a log filter query that won't match any log, every 5 seconds with a length of 3h.

![image](https://github.com/grafana/loki/assets/8354290/45c2e6e9-185c-4a18-b290-47da27fc3e39)

As can be seen, after enabling the stats cache and configuring`do_not_cache_request_within` to not cache stats for requests within 30m, the bytes stats used in the sharding middleware stopped increasing.

In both cases the stats cache hit ration was 100%.
![image](https://github.com/grafana/loki/assets/8354290/cd35bcb8-0c77-4693-a06b-502741fd6e23)

**Special notes for your reviewer**:
- Blocked by https://github.com/grafana/loki/pull/9535
- Note that this PR doesn't fix the root issue of inflated stats form the ingesters, but rather buys us some time to work on that.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
