### PR TITLE
Reuse allocated buffer space in merge iterator.

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -138,9 +138,10 @@ func (i *mergeEntryIterator) fillBuffer() {
 				!i.buffer[0].Entry.Timestamp.Equal(entry.Timestamp)) {
 			break
 		}
+		previous := i.buffer[:len(i.buffer)-1]
 
 		var dupe bool
-		for _, t := range i.buffer[:len(i.buffer)-1] {
+		for _, t := range previous {
 			if t.Entry.Line == entry.Line {
 				i.stats.AddDuplicates(1)
 				dupe = true
@@ -148,7 +149,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 			}
 		}
 		if dupe {
-			i.buffer = i.buffer[:len(i.buffer)-1]
+			i.buffer = previous
 		}
 		if !i.tree.Next() {
 			break

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -128,7 +128,6 @@ func (i *mergeEntryIterator) fillBuffer() {
 	for {
 		next := i.tree.Winner()
 		entry := next.Entry()
-		previous := i.buffer
 		i.buffer = append(i.buffer, entryWithLabels{
 			Entry:      entry,
 			labels:     next.Labels(),
@@ -141,7 +140,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 		}
 
 		var dupe bool
-		for _, t := range previous {
+		for _, t := range i.buffer[:len(i.buffer)-1] {
 			if t.Entry.Line == entry.Line {
 				i.stats.AddDuplicates(1)
 				dupe = true
@@ -149,7 +148,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 			}
 		}
 		if dupe {
-			i.buffer = previous
+			i.buffer = i.buffer[:len(i.buffer)-1]
 		}
 		if !i.tree.Next() {
 			break

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -735,6 +735,25 @@ func BenchmarkSortIterator(b *testing.B) {
 		}
 	})
 
+	b.Run("merge sort dedupe", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			var itrs []EntryIterator
+			for i := 0; i < streamsCount; i++ {
+				itrs = append(itrs, NewStreamIterator(streams[i]))
+				itrs = append(itrs, NewStreamIterator(streams[i]))
+			}
+			b.StartTimer()
+			it := NewMergeEntryIterator(ctx, itrs, logproto.BACKWARD)
+			for it.Next() {
+				it.Entry()
+			}
+			it.Close()
+		}
+	})
+
 	b.Run("sort", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()


### PR DESCRIPTION
**What this PR does / why we need it**:
We saw a performance decrease when running the merge iterator with a very small pool of ingesters. The reason was that we would allocate a new buffer with each next call.

**Special notes for your reviewer**:
`main` is missing `merge_sort_dedupe-16` so I ran it once with a small patch to generate the data.

```goos: linux
goarch: amd64
pkg: github.com/grafana/loki/pkg/iter
cpu: AMD Ryzen 7 3700X 8-Core Processor             
                                  │ mergeiter-old.txt │         mergeiter-new.txt          │
                                  │      sec/op       │   sec/op     vs base               │
SortIterator/merge_sort-16                1.350m ± 4%   1.368m ± 4%       ~ (p=0.579 n=10)
SortIterator/merge_sort_dedupe-16         2.566m ± 4%   2.462m ± 5%       ~ (p=0.105 n=10)
SortIterator/sort-16                      1.034m ± 6%   1.029m ± 6%       ~ (p=0.684 n=10)
SortSampleIterator/merge-16               1.877m ± 2%   1.857m ± 2%       ~ (p=0.075 n=10)
SortSampleIterator/sort-16                432.7µ ± 6%   436.0µ ± 4%       ~ (p=0.579 n=10)
geomean                                   1.238m        1.229m       -0.72%

                                  │ mergeiter-old.txt │           mergeiter-new.txt           │
                                  │       B/op        │     B/op      vs base                 │
SortIterator/merge_sort-16               21.22Ki ± 0%   21.22Ki ± 0%       ~ (p=1.000 n=10)
SortIterator/merge_sort_dedupe-16        41.47Ki ± 0%   41.47Ki ± 0%       ~ (p=1.000 n=10) ¹
SortIterator/sort-16                     13.94Ki ± 0%   13.94Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                  23.06Ki        23.06Ki       +0.00%
¹ all samples are equal

                                  │ mergeiter-old.txt │          mergeiter-new.txt          │
                                  │     allocs/op     │ allocs/op   vs base                 │
SortIterator/merge_sort-16                 7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
SortIterator/merge_sort_dedupe-16          7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
SortIterator/sort-16                       5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                    6.257        6.257       +0.00%
¹ all samples are equal
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
