### PR TITLE
Reuse allocated buffer space in merge iterator.

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -128,7 +128,6 @@ func (i *mergeEntryIterator) fillBuffer() {
 	for {
 		next := i.tree.Winner()
 		entry := next.Entry()
-		previous := i.buffer
 		i.buffer = append(i.buffer, entryWithLabels{
 			Entry:      entry,
 			labels:     next.Labels(),
@@ -141,7 +140,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 		}
 
 		var dupe bool
-		for _, t := range previous {
+		for _, t := range i.buffer[:len(i.buffer)-1] {
 			if t.Entry.Line == entry.Line {
 				i.stats.AddDuplicates(1)
 				dupe = true
@@ -149,7 +148,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 			}
 		}
 		if dupe {
-			i.buffer = previous
+			i.buffer = i.buffer[:len(i.buffer)-1]
 		}
 		if !i.tree.Next() {
 			break


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks 7fbd41b9e25a9b37813064e420b362df8147d9ae onto `k151`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
