### PR TITLE
Set unique timestamp in lambda-promtail.

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/cloudtrail_test.go
+++ b/tools/lambda-promtail/lambda-promtail/cloudtrail_test.go
@@ -13,7 +13,7 @@ func TestParseJson(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	gzipReader,err  := gzip.NewReader(file)
+	gzipReader, err := gzip.NewReader(file)
 	if err != nil {
 		t.Error(err)
 	}

--- a/tools/lambda-promtail/lambda-promtail/cw.go
+++ b/tools/lambda-promtail/lambda-promtail/cw.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 func parseCWEvent(ctx context.Context, b *batch, ev *events.CloudwatchLogsEvent) error {

--- a/tools/lambda-promtail/lambda-promtail/json_stream.go
+++ b/tools/lambda-promtail/lambda-promtail/json_stream.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-// Stream helps transmit each recordss withing a channel.
+// Stream helps transmit each recordss within a channel.
 type Stream struct {
 	records chan Record
 }

--- a/tools/lambda-promtail/lambda-promtail/kinesis.go
+++ b/tools/lambda-promtail/lambda-promtail/kinesis.go
@@ -5,8 +5,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 func parseKinesisEvent(ctx context.Context, b batchIf, ev *events.KinesisEvent) error {
@@ -15,7 +16,7 @@ func parseKinesisEvent(ctx context.Context, b batchIf, ev *events.KinesisEvent) 
 	}
 
 	for _, record := range ev.Records {
-		timestamp := time.Unix(record.Kinesis.ApproximateArrivalTimestamp.Unix(),0)
+		timestamp := time.Unix(record.Kinesis.ApproximateArrivalTimestamp.Unix(), 0)
 
 		labels := model.LabelSet{
 			model.LabelName("__aws_log_type"):                 model.LabelValue("kinesis"),

--- a/tools/lambda-promtail/lambda-promtail/kinesis_test.go
+++ b/tools/lambda-promtail/lambda-promtail/kinesis_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 type MockBatch struct {

--- a/tools/lambda-promtail/lambda-promtail/main_test.go
+++ b/tools/lambda-promtail/lambda-promtail/main_test.go
@@ -18,7 +18,7 @@ func TestLambdaPromtail_ExtraLabelsValid(t *testing.T) {
 }
 
 func TestLambdaPromtail_ExtraLabelsMissingValue(t *testing.T) {
-	extraLabels, err := parseExtraLabels("A,a,B,b,C,c,D",false)
+	extraLabels, err := parseExtraLabels("A,a,B,b,C,c,D", false)
 	require.Nil(t, extraLabels)
 	require.Errorf(t, err, invalidExtraLabelsError)
 }

--- a/tools/lambda-promtail/lambda-promtail/promtail.go
+++ b/tools/lambda-promtail/lambda-promtail/promtail.go
@@ -15,8 +15,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/backoff"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 const (

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -12,8 +12,9 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/pkg/logproto"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -97,7 +98,6 @@ func parseS3Log(ctx context.Context, b *batch, labels map[string]string, obj io.
 
 	ls = applyExtraLabels(ls)
 
-	timestamp := time.Now()
 	// extract the timestamp of the nested event and sends the rest as raw json
 	if labels["type"] == CLOUDTRAIL_LOG_TYPE {
 		records := make(chan Record)
@@ -131,11 +131,14 @@ func parseS3Log(ctx context.Context, b *batch, labels map[string]string, obj io.
 		}
 
 		match := timestampRegex.FindStringSubmatch(log_line)
+		var timestamp time.Time
 		if len(match) > 0 {
 			timestamp, err = time.Parse(time.RFC3339, match[1])
 			if err != nil {
 				return err
 			}
+		} else {
+			timestamp = time.Now()
 		}
 
 		if err := b.add(ctx, entry{ls, logproto.Entry{

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -131,14 +131,12 @@ func parseS3Log(ctx context.Context, b *batch, labels map[string]string, obj io.
 		}
 
 		match := timestampRegex.FindStringSubmatch(log_line)
-		var timestamp time.Time
+		timestamp := time.Now()
 		if len(match) > 0 {
 			timestamp, err = time.Parse(time.RFC3339, match[1])
 			if err != nil {
 				return err
 			}
-		} else {
-			timestamp = time.Now()
 		}
 
 		if err := b.add(ctx, entry{ls, logproto.Entry{

--- a/tools/lambda-promtail/lambda-promtail/s3_test.go
+++ b/tools/lambda-promtail/lambda-promtail/s3_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 func Test_getLabels(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki runs into performance issues when too many log entries have the same timestamp. Ironically our own lambda-promtail can be a cause for such data.

In this change we modify the logic a little in case lambda-promtail does not find a timestamp in the source data. Instead of adding the same for all entries it sets a new one.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
