### PR TITLE
Add version to TSDB index builder struct

### DIFF
--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 func Test_Build(t *testing.T) {

--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -45,35 +45,6 @@ func Test_Build(t *testing.T) {
 		return reader
 	}
 
-	t.Run("ensures the directory is present", func(t *testing.T) {
-		ctx, builder, tmpDir := setup(index.LiveFormat)
-
-		_, err := builder.Build(ctx, "/path/does/not/exist", func(from, through model.Time, checksum uint32) Identifier {
-			id := SingleTenantTSDBIdentifier{
-				TS:       time.Now(),
-				From:     from,
-				Through:  through,
-				Checksum: checksum,
-			}
-			return NewPrefixedIdentifier(id, tmpDir, "")
-		})
-
-		require.Error(t, err)
-		require.ErrorContains(t, err, "permission denied")
-
-		_, err = builder.Build(ctx, filepath.Join(tmpDir, "foo"), func(from, through model.Time, checksum uint32) Identifier {
-			id := SingleTenantTSDBIdentifier{
-				TS:       time.Now(),
-				From:     from,
-				Through:  through,
-				Checksum: checksum,
-			}
-			return NewPrefixedIdentifier(id, tmpDir, "")
-		})
-
-		require.NoError(t, err)
-	})
-
 	t.Run("writes index to disk with from/through bounds of series in filename", func(t *testing.T) {
 		ctx, builder, tmpDir := setup(index.LiveFormat)
 

--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -1,0 +1,156 @@
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Build(t *testing.T) {
+	setup := func(version int) (context.Context, *Builder, string) {
+		builder := NewBuilder(version)
+		tmpDir := t.TempDir()
+
+		lbls1 := mustParseLabels(`{foo="bar", a="b"}`)
+
+		stream := stream{
+			labels: lbls1,
+			fp:     model.Fingerprint(lbls1.Hash()),
+			chunks: buildChunkMetas(1, 5),
+		}
+
+		builder.AddSeries(
+			lbls1,
+			stream.fp,
+			stream.chunks,
+		)
+
+		return context.Background(), builder, tmpDir
+	}
+
+	getReader := func(path string) *index.Reader {
+		indexPath := fakeIdentifierPathForBounds(path, 1, 6) //default step is 1
+		files, err := filepath.Glob(indexPath)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+
+		reader, err := index.NewFileReader(files[0])
+		require.NoError(t, err)
+		return reader
+	}
+
+	t.Run("ensures the directory is present", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+
+		_, err := builder.Build(ctx, "/path/does/not/exist", func(from, through model.Time, checksum uint32) Identifier {
+			id := SingleTenantTSDBIdentifier{
+				TS:       time.Now(),
+				From:     from,
+				Through:  through,
+				Checksum: checksum,
+			}
+			return NewPrefixedIdentifier(id, tmpDir, "")
+		})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "permission denied")
+
+		_, err = builder.Build(ctx, filepath.Join(tmpDir, "foo"), func(from, through model.Time, checksum uint32) Identifier {
+			id := SingleTenantTSDBIdentifier{
+				TS:       time.Now(),
+				From:     from,
+				Through:  through,
+				Checksum: checksum,
+			}
+			return NewPrefixedIdentifier(id, tmpDir, "")
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("writes index to disk with from/through bounds of series in filename", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+
+		require.NoError(t, err)
+		indexPath := fakeIdentifierPathForBounds(tmpDir, 1, 6) //default step is 1
+
+		files, err := filepath.Glob(indexPath)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+	})
+
+	t.Run("sorts symbols before writing to the index", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+		require.NoError(t, err)
+
+		reader := getReader(tmpDir)
+
+		symbols := reader.Symbols()
+		require.NoError(t, err)
+
+		symbolsList := make([]string, 0, 2)
+		for symbols.Next() {
+			symbolsList = append(symbolsList, symbols.At())
+		}
+
+		require.Equal(t, symbolsList, []string{"a", "b", "bar", "foo"})
+	})
+
+	t.Run("write index with correct version", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.FormatV2)
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+		require.NoError(t, err)
+		reader := getReader(tmpDir)
+		require.Equal(t, index.FormatV2, reader.Version())
+	})
+}
+
+type fakeIdentifier struct {
+	parentPath string
+	from       model.Time
+	through    model.Time
+	checksum   uint32
+}
+
+func (f *fakeIdentifier) Name() string {
+	return "need to implement Name() function for fakeIdentifier"
+}
+
+func (f *fakeIdentifier) Path() string {
+	path := fmt.Sprintf("%d-%d-%x.tsdb", f.from, f.through, f.checksum)
+	return filepath.Join(f.parentPath, path)
+}
+
+func fakeIdentifierPathForBounds(path string, from, through model.Time) string {
+	return filepath.Join(path, fmt.Sprintf("%d-%d-*.tsdb", from, through))
+}

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -47,7 +47,7 @@ func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableN
 		}
 	}()
 
-	builder := NewBuilder()
+	builder := NewBuilder(index.LiveFormat)
 	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).ForSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		builder.AddSeries(lbls.Copy(), fp, chks)
 	}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
@@ -193,7 +193,7 @@ func (t *tableCompactor) CompactTable() error {
 // It combines the users index from multiTenantIndexes and its existing compacted index(es)
 func setupBuilder(ctx context.Context, userID string, sourceIndexSet compactor.IndexSet, multiTenantIndexes []Index) (*Builder, error) {
 	sourceIndexes := sourceIndexSet.ListSourceFiles()
-	builder := NewBuilder()
+	builder := NewBuilder(index.LiveFormat)
 
 	// add users index from multi-tenant indexes to the builder
 	for _, idx := range multiTenantIndexes {

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -117,7 +117,7 @@ func (m *mockIndexSet) SetCompactedIndex(compactedIndex compactor.CompactedIndex
 
 func setupMultiTenantIndex(t *testing.T, userStreams map[string][]stream, destDir string, ts time.Time) string {
 	require.NoError(t, util.EnsureDirectory(destDir))
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	for userID, streams := range userStreams {
 		for _, stream := range streams {
 			lb := labels.NewBuilder(stream.labels)
@@ -155,7 +155,7 @@ func setupMultiTenantIndex(t *testing.T, userStreams map[string][]stream, destDi
 
 func setupPerTenantIndex(t *testing.T, streams []stream, destDir string, ts time.Time) string {
 	require.NoError(t, util.EnsureDirectory(destDir))
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	for _, stream := range streams {
 		b.AddSeries(
 			stream.labels,
@@ -881,7 +881,7 @@ func setupCompactedIndex(t *testing.T) *testContext {
 	userID := buildUserID(0)
 
 	buildCompactedIndex := func() *compactedIndex {
-		builder := NewBuilder()
+		builder := NewBuilder(index.LiveFormat)
 		stream := buildStream(lbls1, buildChunkMetas(shiftTableStart(0), shiftTableStart(10)), "")
 		builder.AddSeries(stream.labels, stream.fp, stream.chunks)
 

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -175,7 +175,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads, shipper indexshipper.Ind
 		for pd, matchingChks := range pds {
 			b, ok := periods[pd]
 			if !ok {
-				b = NewBuilder()
+				b = NewBuilder(index.LiveFormat)
 				periods[pd] = b
 			}
 

--- a/pkg/storage/stores/tsdb/querier_test.go
+++ b/pkg/storage/stores/tsdb/querier_test.go
@@ -24,7 +24,7 @@ func mustParseLabels(s string) labels.Labels {
 
 func TestQueryIndex(t *testing.T) {
 	dir := t.TempDir()
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	cases := []struct {
 		labels labels.Labels
 		chunks []index.ChunkMeta

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -49,7 +49,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (index
 		return nil, ErrAlreadyOnDesiredVersion
 	}
 
-	builder := NewBuilder()
+	builder := NewBuilder(desiredVer)
 	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).ForSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		builder.AddSeries(lbls.Copy(), fp, chks)
 	}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
@@ -59,7 +59,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (index
 
 	parentDir := filepath.Dir(path)
 
-	id, err := builder.BuildWithVersion(ctx, desiredVer, parentDir, func(from, through model.Time, checksum uint32) Identifier {
+	id, err := builder.Build(ctx, parentDir, func(from, through model.Time, checksum uint32) Identifier {
 		id := SingleTenantTSDBIdentifier{
 			TS:       time.Now(),
 			From:     from,

--- a/pkg/storage/stores/tsdb/util_test.go
+++ b/pkg/storage/stores/tsdb/util_test.go
@@ -18,7 +18,7 @@ type LoadableSeries struct {
 }
 
 func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 
 	for _, s := range cases {
 		b.AddSeries(s.Labels, model.Fingerprint(s.Labels.Hash()), s.Chunks)

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -60,7 +60,7 @@ func TestMigrateTables(t *testing.T) {
 
 	// setup some tables
 	for i := currTableNum - 5; i <= currTableNum; i++ {
-		b := tsdb.NewBuilder()
+		b := tsdb.NewBuilder(index.FormatV2)
 		b.AddSeries(labels.Labels{
 			{
 				Name:  "table_name",
@@ -76,7 +76,7 @@ func TestMigrateTables(t *testing.T) {
 			},
 		})
 
-		id, err := b.BuildWithVersion(context.Background(), index.FormatV2, tempDir, func(from, through model.Time, checksum uint32) tsdb.Identifier {
+		id, err := b.Build(context.Background(), tempDir, func(from, through model.Time, checksum uint32) tsdb.Identifier {
 			id := tsdb.SingleTenantTSDBIdentifier{
 				TS:       time.Now(),
 				From:     from,

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -67,7 +67,7 @@ func main() {
 		panic(err)
 	}
 
-	builder := tsdb.NewBuilder()
+	builder := tsdb.NewBuilder(index.LiveFormat)
 
 	log.Println("Loading index into memory")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds version as a property to the TSDB Index Builder, forcing users of the builder to specify a version for each builder instance. This is the first of many PRs that will add the TSDB index version to the schema version config.

**Which issue(s) this PR fixes**:

Re #9565

**Special notes for your reviewer**:

The full functionality of supporting TSDB index versions in the schema/period config is enabled via 3 PRs. Each PR can be reviewed and merged independently.

[1/3] https://github.com/grafana/loki/pull/9566
[2/3] https://github.com/grafana/loki/pull/9590
[3/3] https://github.com/grafana/loki/pull/9633

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
