### PR TITLE
Per-tenant replication (sharding) factor for index gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ##### Enhancements
 
+* [9574](https://github.com/grafana/loki/pull/9574) **chaudum**: Add per-tenant replication factor for index gateways.
 * [8067](https://github.com/grafana/loki/pull/9497) **CCOLLOT**: Lambda-Promtail: Add support for AWS CloudTrail log ingestion.
 * [9515](https://github.com/grafana/loki/pull/9515) **MichelHollands**: Fix String() on vector aggregation LogQL expressions that contain `without ()`.
 * [8067](https://github.com/grafana/loki/pull/8067) **DylanGuedes**: Distributor: Add auto-forget unhealthy members support.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -2589,6 +2589,13 @@ shard_streams:
 
 # Minimum number of label matchers a query should contain.
 [minimum_labels_number: <int>]
+
+# Experimental. The sharding factor defines how many index gateways should be
+# used for querying. A factor of 0.0 means that replication factor amount of
+# servers are used, a factor of 1.0 means all instances of the index gateway
+# ring are used.
+# CLI flag: -index-gateway.sharding-factor
+[gateway_sharding_factor: <float> | default = 0]
 ```
 
 ### frontend_worker

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
-	github.com/grafana/dskit v0.0.0-20230518162305-3c92c534827e
+	github.com/grafana/dskit v0.0.0-20230531063521-9bd0e035aecd
 	github.com/grafana/go-gelf/v2 v2.0.1
 	github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd

--- a/go.sum
+++ b/go.sum
@@ -1089,8 +1089,8 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
-github.com/grafana/dskit v0.0.0-20230518162305-3c92c534827e h1:ODjv+9dmklDS33O2B4zPgIDKdnji18o9ofD9qWA+mAs=
-github.com/grafana/dskit v0.0.0-20230518162305-3c92c534827e/go.mod h1:M03k2fzuQ2n9TVE1xfVKTESibxsXdw0wYfWT3+9Owp4=
+github.com/grafana/dskit v0.0.0-20230531063521-9bd0e035aecd h1:lPl/cLANWA5rvlXxs1v05lkDG/aTiGRikhZqEoONaSM=
+github.com/grafana/dskit v0.0.0-20230531063521-9bd0e035aecd/go.mod h1:M03k2fzuQ2n9TVE1xfVKTESibxsXdw0wYfWT3+9Owp4=
 github.com/grafana/go-gelf/v2 v2.0.1 h1:BOChP0h/jLeD+7F9mL7tq10xVkDG15he3T1zHuQaWak=
 github.com/grafana/go-gelf/v2 v2.0.1/go.mod h1:lexHie0xzYGwCgiRGcvZ723bSNyNI8ZRD4s0CLobh90=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -664,7 +664,7 @@ func (t *Loki) setupModuleManager() error {
 		Compactor:                {Server, Overrides, MemberlistKV, Analytics},
 		IndexGateway:             {Server, Store, Overrides, Analytics, MemberlistKV, IndexGatewayRing},
 		IngesterQuerier:          {Ring},
-		IndexGatewayRing:         {RuntimeConfig, Server, MemberlistKV},
+		IndexGatewayRing:         {Overrides, Server, MemberlistKV},
 		All:                      {QueryScheduler, QueryFrontend, Querier, Ingester, Distributor, Ruler, Compactor},
 		Read:                     {QueryFrontend, Querier},
 		Write:                    {Ingester, Distributor},

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1160,7 +1160,7 @@ func (t *Loki) initIndexGateway() (services.Service, error) {
 		tableRange := period.GetIndexTableNumberRange(periodEndTime)
 
 		indexClient, err := storage.NewIndexClient(period, tableRange, t.Cfg.StorageConfig, t.Cfg.SchemaConfig, t.Overrides, t.clientMetrics, t.indexGatewayRingManager.IndexGatewayOwnsTenant,
-			prometheus.DefaultRegisterer, log.With(util_log.Logger, "index-store", fmt.Sprintf("%s-%s", period.IndexType, period.From.String())),
+			prometheus.DefaultRegisterer, t.Overrides, log.With(util_log.Logger, "index-store", fmt.Sprintf("%s-%s", period.IndexType, period.From.String())),
 		)
 		if err != nil {
 			return nil, err
@@ -1201,7 +1201,7 @@ func (t *Loki) initIndexGatewayRing() (_ services.Service, err error) {
 	if t.Cfg.isModuleEnabled(IndexGateway) || legacyReadMode || t.Cfg.isModuleEnabled(Backend) {
 		managerMode = indexgateway.ServerMode
 	}
-	rm, err := indexgateway.NewRingManager(managerMode, t.Cfg.IndexGateway, util_log.Logger, prometheus.DefaultRegisterer)
+	rm, err := indexgateway.NewRingManager(managerMode, t.Cfg.IndexGateway, util_log.Logger, prometheus.DefaultRegisterer, t.Overrides)
 
 	if err != nil {
 		return nil, gerrors.Wrap(err, "new index gateway ring manager")

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/gatewayclient"
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
@@ -61,6 +62,7 @@ func ResetBoltDBIndexClientsWithShipper() {
 type StoreLimits interface {
 	downloads.Limits
 	stores.StoreLimits
+	indexgateway.Limits
 	CardinalityLimit(string) int
 }
 
@@ -256,7 +258,7 @@ func (cfg *Config) Validate() error {
 }
 
 // NewIndexClient makes a new index client of the desired type.
-func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange, cfg Config, schemaCfg config.SchemaConfig, limits StoreLimits, cm ClientMetrics, ownsTenantFn downloads.IndexGatewayOwnsTenant, registerer prometheus.Registerer, logger log.Logger) (index.Client, error) {
+func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange, cfg Config, schemaCfg config.SchemaConfig, limits StoreLimits, cm ClientMetrics, ownsTenantFn downloads.IndexGatewayOwnsTenant, registerer prometheus.Registerer, overrides indexgateway.Limits, logger log.Logger) (index.Client, error) {
 	switch periodCfg.IndexType {
 	case config.StorageTypeInMemory:
 		store := testutils.NewMockStorage()
@@ -289,7 +291,7 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 				return indexGatewayClient, nil
 			}
 
-			gateway, err := gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, logger)
+			gateway, err := gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, overrides, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -217,7 +217,7 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 	if p.IndexType == config.TSDBType {
 		if shouldUseIndexGatewayClient(s.cfg.TSDBShipperConfig) {
 			// inject the index-gateway client into the index store
-			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, indexClientLogger)
+			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.limits, indexClientLogger)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -274,7 +274,7 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 			}, nil
 	}
 
-	idx, err := NewIndexClient(p, tableRange, s.cfg, s.schemaCfg, s.limits, s.clientMetrics, nil, indexClientReg, indexClientLogger)
+	idx, err := NewIndexClient(p, tableRange, s.cfg, s.schemaCfg, s.limits, s.clientMetrics, nil, indexClientReg, s.limits, indexClientLogger)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error creating index client")
 	}

--- a/pkg/util/limiter/combined_limits.go
+++ b/pkg/util/limiter/combined_limits.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/loki/pkg/scheduler"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper/compactor"
+	"github.com/grafana/loki/pkg/storage/stores/shipper/indexgateway"
 )
 
 type CombinedLimits interface {
@@ -20,4 +21,5 @@ type CombinedLimits interface {
 	ruler.RulesLimits
 	scheduler.Limits
 	storage.StoreLimits
+	indexgateway.Limits
 }

--- a/pkg/util/ring_test.go
+++ b/pkg/util/ring_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTokenFor(t *testing.T) {
@@ -15,23 +16,23 @@ func TestTokenFor(t *testing.T) {
 	}
 }
 
-func TestIsAssignedKey(t *testing.T) {
+func TestIsInReplicationSet(t *testing.T) {
 	for _, tc := range []struct {
 		desc   string
-		ring   ring.ReadRing
+		ring   ring.DynamicReplicationReadRing
 		userID string
 		exp    bool
 		addr   string
 	}{
 		{
-			desc:   "basic ring and tenant are assigned key",
+			desc:   "is in replication set",
 			ring:   newReadRingMock([]ring.InstanceDesc{{Addr: "127.0.0.1", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{1, 2, 3}}}),
 			userID: "1",
 			exp:    true,
 			addr:   "127.0.0.1",
 		},
 		{
-			desc:   "basic ring and tenant are not assigned key",
+			desc:   "is not in replication set",
 			ring:   newReadRingMock([]ring.InstanceDesc{{Addr: "127.0.0.2", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{1, 2, 3}}}),
 			userID: "1",
 			exp:    false,
@@ -39,9 +40,10 @@ func TestIsAssignedKey(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if res := IsAssignedKey(tc.ring, newReadLifecyclerMock(tc.addr).addr, tc.userID); res != tc.exp {
-				t.Errorf("IsAssignedKey(%v, %v) = %v, want %v", tc.ring, tc.userID, res, tc.exp)
-			}
+			token := TokenFor(tc.userID, "")
+			res, err := IsInReplicationSet(tc.ring, token, newReadLifecyclerMock(tc.addr).addr)
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, res, "IsInReplicationSet(%v, %v) = %v, want %v", tc.ring, tc.userID, res, tc.exp)
 		})
 	}
 }
@@ -66,6 +68,10 @@ func (r *readRingMock) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (r *readRingMock) Get(key uint32, op ring.Operation, buf []ring.InstanceDesc, _ []string, _ []string) (ring.ReplicationSet, error) {
+	return r.replicationSet, nil
+}
+
+func (r *readRingMock) GetWithRF(key uint32, op ring.Operation, buf []ring.InstanceDesc, _ []string, _ []string, _ int) (ring.ReplicationSet, error) {
 	return r.replicationSet, nil
 }
 
@@ -138,4 +144,44 @@ func (m *readLifecyclerMock) HealthyInstancesCount() int {
 
 func (m *readLifecyclerMock) GetInstanceAddr() string {
 	return m.addr
+}
+
+func TestDynamicReplicationFactor(t *testing.T) {
+	mockRing := newReadRingMock([]ring.InstanceDesc{
+		{Addr: "127.0.0.1", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{1, 2, 3}},
+		{Addr: "127.0.0.2", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{4, 5, 6}},
+		{Addr: "127.0.0.3", Timestamp: time.Now().UnixNano(), State: ring.ACTIVE, Tokens: []uint32{7, 8, 9}},
+	})
+
+	for _, tc := range []struct {
+		desc     string
+		factor   float64
+		expected int
+	}{
+		{
+			desc:     "factor 0.0",
+			factor:   0,
+			expected: 1, // ring.ReplicationFactor()
+		},
+		{
+			desc:     "factor 0.5",
+			factor:   0.5,
+			expected: 2, // 1 + (3 - 1) * 0.5
+		},
+		{
+			desc:     "factor 1.0",
+			factor:   1,
+			expected: 3, // num instances
+		},
+		{
+			desc:     "factor > 1.0",
+			factor:   2,
+			expected: 3, // num instances
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, DynamicReplicationFactor(mockRing, tc.factor))
+		})
+	}
 }

--- a/vendor/github.com/grafana/dskit/flagext/bytes.go
+++ b/vendor/github.com/grafana/dskit/flagext/bytes.go
@@ -8,18 +8,18 @@ import (
 	"github.com/alecthomas/units"
 )
 
-// Bytes is a data type which supports yaml serialization/deserialization
-// with units.
+// Bytes is a data type which supports use as a flag and yaml
+// serialization/deserialization with units.
 type Bytes uint64
 
-func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var value string
-	err := unmarshal(&value)
-	if err != nil {
-		return err
-	}
+// String implements flag.Value
+func (b *Bytes) String() string {
+	return units.Base2Bytes(*b).String()
+}
 
-	bytes, err := units.ParseBase2Bytes(value)
+// Set implements flag.Value
+func (b *Bytes) Set(s string) error {
+	bytes, err := units.ParseBase2Bytes(s)
 	if err != nil {
 		return err
 	}
@@ -28,6 +28,15 @@ func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (b *Bytes) MarshalYAML() (interface{}, error) {
-	return units.Base2Bytes(*b).String(), nil
+func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var value string
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+
+	return b.Set(value)
+}
+
+func (b Bytes) MarshalYAML() (interface{}, error) {
+	return b.String(), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -793,7 +793,7 @@ github.com/gorilla/websocket
 # github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2
 ## explicit; go 1.17
 github.com/grafana/cloudflare-go
-# github.com/grafana/dskit v0.0.0-20230518162305-3c92c534827e
+# github.com/grafana/dskit v0.0.0-20230531063521-9bd0e035aecd
 ## explicit; go 1.18
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/concurrency


### PR DESCRIPTION
**What this PR does / why we need it**:

_This PR introduces a per-tenant sharding (replication) factor for the index gateway._

At the moment we use a high replication factor in the index gateway ring to be able to distribute load from large tenants across a larger subset of index gateways. However, since the replication factor is a global setting in the gateway ring, also small tenants have a high replication factor, leading to a lot of data being pre-fetched at the start of the index gateways.

This PR adds a per-tenant runtime setting to specify a "sharding" factor between 0 and 1 that defines the per-tenant RF in the range of ring RF to max instances.

Example:

```
ring.RF = 3
gateway instances = 20
sharding factor = 0.75
=> 3 + (15 - 3) * 0.75 = 12
```

Using a factor instead of a fixed replication factor makes it easier to scale index gateways horizontally, because it does not require to adjust the setting when more instances are added to the ring.

**Special notes for your reviewer**:

This PR vendors https://github.com/grafana/dskit/pull/304 which has to be merged first.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
