### PR TITLE
Fix: HPA for single binary deployment

### DIFF
--- a/docs/sources/installation/helm/reference.md
+++ b/docs/sources/installation/helm/reference.md
@@ -3278,7 +3278,7 @@ Hard node and soft zone anti-affinity
 		<tr>
 			<td>singleBinary.autoscaling.enabled</td>
 			<td>bool</td>
-			<td>Enable autoscaling, this is only used if `queryIndex.enabled: true`</td>
+			<td>Enable autoscaling</td>
 			<td><pre lang="json">
 false
 </pre>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.5.13
+
+- [BUGFIX] Fix HPA for single binary deployment
+
 ## 5.5.12
 
 - [BUGFIX] Fix checksum annotation for config in single binary

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.2
-version: 5.5.12
+version: 5.5.13
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.6.0](https://img.shields.io/badge/Version-5.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 5.6.1](https://img.shields.io/badge/Version-5.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/single-binary/hpa.yaml
+++ b/production/helm/loki/templates/single-binary/hpa.yaml
@@ -1,0 +1,50 @@
+{{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
+{{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+{{- if and $isSingleBinary ( .Values.singleBinary.autoscaling.enabled ) }}
+{{- if $autoscalingv2 }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki.singleBinaryFullname" . }}
+  labels:
+    {{- include "loki.singleBinaryLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "loki.singleBinaryFullname" . }}
+  minReplicas: {{ .Values.singleBinary.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.singleBinary.autoscaling.maxReplicas }}
+  {{- with .Values.singleBinary.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+  {{- with .Values.singleBinary.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if $autoscalingv2 }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.singleBinary.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if $autoscalingv2 }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/production/helm/loki/templates/single-binary/hpa.yaml
+++ b/production/helm/loki/templates/single-binary/hpa.yaml
@@ -1,6 +1,7 @@
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
+{{- $usingObjectStorage := eq (include "loki.isUsingObjectStorage" .) "true" }}
 {{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
-{{- if and $isSingleBinary ( .Values.singleBinary.autoscaling.enabled ) }}
+{{- if and $isSingleBinary $usingObjectStorage ( .Values.singleBinary.autoscaling.enabled ) }}
 {{- if $autoscalingv2 }}
 apiVersion: autoscaling/v2
 {{- else }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1012,7 +1012,7 @@ singleBinary:
   # -- Number of replicas for the single binary
   replicas: 0
   autoscaling:
-    # -- Enable autoscaling, this is only used if `queryIndex.enabled: true`
+    # -- Enable autoscaling
     enabled: false
     # -- Minimum autoscaling replicas for the single binary
     minReplicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Add HPA for single binary deployment. Off by default.

**Which issue(s) this PR fixes**:
Fixes #7097

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [N/A] Documentation added
- [N/A] Tests updated
- [X] `CHANGELOG.md` updated
- [N/A] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
