### PR TITLE
Support tsdb version from schema config in head manager

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3964,6 +3964,9 @@ chunks:
 
 # How many shards will be created. Only used if schema is v10 or greater.
 [row_shards: <int>]
+
+# The version of the TSDB index to use. Only used with the TSDB index type.
+[tsdb_index_version: <int>]
 ```
 
 ### aws_storage_config

--- a/operator/website/node_modules
+++ b/operator/website/node_modules
@@ -1,1 +1,0 @@
-./themes/doks/node_modules

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -390,9 +390,9 @@ func (cfg PeriodConfig) validate() error {
 		return errTSDBNon24HoursIndexPeriod
 	}
 
-  if cfg.IndexType != TSDBType && cfg.TSDBIndexVersion != 0 {
-    return errInvalidNonTSDBSchemaType
-  }
+	if cfg.IndexType != TSDBType && cfg.TSDBIndexVersion != 0 {
+		return errInvalidNonTSDBSchemaType
+	}
 
 	// Ensure the tables period is a multiple of the bucket period
 	if cfg.IndexTables.Period > 0 && cfg.IndexTables.Period%(24*time.Hour) != 0 {

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -162,6 +162,8 @@ type PeriodConfig struct {
 	ChunkTables PeriodicTableConfig `yaml:"chunks" doc:"description=Configured how the chunks are updated and stored."`
 	RowShards   uint32              `yaml:"row_shards" doc:"description=How many shards will be created. Only used if schema is v10 or greater."`
 
+	TSDBIndexVersion int `yaml:"tsdb_index_version" doc:"description=The version of the TSDB index to use. Only used with the TSDB index type."`
+
 	// Integer representation of schema used for hot path calculation. Populated on unmarshaling.
 	schemaInt *int `yaml:"-"`
 }

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 func TestChunkTableFor(t *testing.T) {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1043,11 +1043,11 @@ func TestStore_MultiPeriod(t *testing.T) {
 						},
 					},
 					{
-						From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
-						IndexType:  indexes[1],
-						ObjectType: "named-store",
-						Schema:     "v11",
-            TSDBIndexVersion: index.FormatV3,
+						From:             config.DayTime{Time: timeToModelTime(secondStoreDate)},
+						IndexType:        indexes[1],
+						ObjectType:       "named-store",
+						Schema:           "v11",
+						TSDBIndexVersion: index.FormatV3,
 						IndexTables: config.PeriodicTableConfig{
 							Prefix: "index_",
 							Period: time.Hour * 24,
@@ -1352,11 +1352,11 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 				RowShards: 2,
 			},
 			{
-				From:       config.DayTime{Time: timeToModelTime(tsdbStartDate)},
-				IndexType:  "tsdb",
-				ObjectType: config.StorageTypeFileSystem,
-				Schema:     "v12",
-        TSDBIndexVersion: index.FormatV3,
+				From:             config.DayTime{Time: timeToModelTime(tsdbStartDate)},
+				IndexType:        "tsdb",
+				ObjectType:       config.StorageTypeFileSystem,
+				Schema:           "v12",
+				TSDBIndexVersion: index.FormatV3,
 				IndexTables: config.PeriodicTableConfig{
 					Prefix: "index_",
 					Period: time.Hour * 24,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper"
 	"github.com/grafana/loki/pkg/storage/stores/shipper"
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/marshal"
 	"github.com/grafana/loki/pkg/validation"
@@ -1046,6 +1047,7 @@ func TestStore_MultiPeriod(t *testing.T) {
 						IndexType:  indexes[1],
 						ObjectType: "named-store",
 						Schema:     "v11",
+            TSDBIndexVersion: index.FormatV3,
 						IndexTables: config.PeriodicTableConfig{
 							Prefix: "index_",
 							Period: time.Hour * 24,
@@ -1354,6 +1356,7 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 				IndexType:  "tsdb",
 				ObjectType: config.StorageTypeFileSystem,
 				Schema:     "v12",
+        TSDBIndexVersion: index.FormatV3,
 				IndexTables: config.PeriodicTableConfig{
 					Prefix: "index_",
 					Period: time.Hour * 24,

--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 func Test_Build(t *testing.T) {

--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -45,35 +45,6 @@ func Test_Build(t *testing.T) {
 		return reader
 	}
 
-	t.Run("ensures the directory is present", func(t *testing.T) {
-		ctx, builder, tmpDir := setup(index.LiveFormat)
-
-		_, err := builder.Build(ctx, "/path/does/not/exist", func(from, through model.Time, checksum uint32) Identifier {
-			id := SingleTenantTSDBIdentifier{
-				TS:       time.Now(),
-				From:     from,
-				Through:  through,
-				Checksum: checksum,
-			}
-			return NewPrefixedIdentifier(id, tmpDir, "")
-		})
-
-		require.Error(t, err)
-		require.ErrorContains(t, err, "permission denied")
-
-		_, err = builder.Build(ctx, filepath.Join(tmpDir, "foo"), func(from, through model.Time, checksum uint32) Identifier {
-			id := SingleTenantTSDBIdentifier{
-				TS:       time.Now(),
-				From:     from,
-				Through:  through,
-				Checksum: checksum,
-			}
-			return NewPrefixedIdentifier(id, tmpDir, "")
-		})
-
-		require.NoError(t, err)
-	})
-
 	t.Run("writes index to disk with from/through bounds of series in filename", func(t *testing.T) {
 		ctx, builder, tmpDir := setup(index.LiveFormat)
 

--- a/pkg/storage/stores/tsdb/builder_test.go
+++ b/pkg/storage/stores/tsdb/builder_test.go
@@ -1,0 +1,156 @@
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Build(t *testing.T) {
+	setup := func(version int) (context.Context, *Builder, string) {
+		builder := NewBuilder(version)
+		tmpDir := t.TempDir()
+
+		lbls1 := mustParseLabels(`{foo="bar", a="b"}`)
+
+		stream := stream{
+			labels: lbls1,
+			fp:     model.Fingerprint(lbls1.Hash()),
+			chunks: buildChunkMetas(1, 5),
+		}
+
+		builder.AddSeries(
+			lbls1,
+			stream.fp,
+			stream.chunks,
+		)
+
+		return context.Background(), builder, tmpDir
+	}
+
+	getReader := func(path string) *index.Reader {
+		indexPath := fakeIdentifierPathForBounds(path, 1, 6) //default step is 1
+		files, err := filepath.Glob(indexPath)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+
+		reader, err := index.NewFileReader(files[0])
+		require.NoError(t, err)
+		return reader
+	}
+
+	t.Run("ensures the directory is present", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+
+		_, err := builder.Build(ctx, "/path/does/not/exist", func(from, through model.Time, checksum uint32) Identifier {
+			id := SingleTenantTSDBIdentifier{
+				TS:       time.Now(),
+				From:     from,
+				Through:  through,
+				Checksum: checksum,
+			}
+			return NewPrefixedIdentifier(id, tmpDir, "")
+		})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "permission denied")
+
+		_, err = builder.Build(ctx, filepath.Join(tmpDir, "foo"), func(from, through model.Time, checksum uint32) Identifier {
+			id := SingleTenantTSDBIdentifier{
+				TS:       time.Now(),
+				From:     from,
+				Through:  through,
+				Checksum: checksum,
+			}
+			return NewPrefixedIdentifier(id, tmpDir, "")
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("writes index to disk with from/through bounds of series in filename", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+
+		require.NoError(t, err)
+		indexPath := fakeIdentifierPathForBounds(tmpDir, 1, 6) //default step is 1
+
+		files, err := filepath.Glob(indexPath)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+	})
+
+	t.Run("sorts symbols before writing to the index", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.LiveFormat)
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+		require.NoError(t, err)
+
+		reader := getReader(tmpDir)
+
+		symbols := reader.Symbols()
+		require.NoError(t, err)
+
+		symbolsList := make([]string, 0, 2)
+		for symbols.Next() {
+			symbolsList = append(symbolsList, symbols.At())
+		}
+
+		require.Equal(t, symbolsList, []string{"a", "b", "bar", "foo"})
+	})
+
+	t.Run("write index with correct version", func(t *testing.T) {
+		ctx, builder, tmpDir := setup(index.FormatV2)
+		_, err := builder.Build(ctx, tmpDir, func(from, through model.Time, checksum uint32) Identifier {
+			return &fakeIdentifier{
+				parentPath: tmpDir,
+				from:       from,
+				through:    through,
+				checksum:   checksum,
+			}
+		})
+		require.NoError(t, err)
+		reader := getReader(tmpDir)
+		require.Equal(t, index.FormatV2, reader.Version())
+	})
+}
+
+type fakeIdentifier struct {
+	parentPath string
+	from       model.Time
+	through    model.Time
+	checksum   uint32
+}
+
+func (f *fakeIdentifier) Name() string {
+	return "need to implement Name() function for fakeIdentifier"
+}
+
+func (f *fakeIdentifier) Path() string {
+	path := fmt.Sprintf("%d-%d-%x.tsdb", f.from, f.through, f.checksum)
+	return filepath.Join(f.parentPath, path)
+}
+
+func fakeIdentifierPathForBounds(path string, from, through model.Time) string {
+	return filepath.Join(path, fmt.Sprintf("%d-%d-*.tsdb", from, through))
+}

--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -47,7 +47,7 @@ func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableN
 		}
 	}()
 
-	builder := NewBuilder()
+	builder := NewBuilder(index.LiveFormat)
 	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).ForSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		builder.AddSeries(lbls.Copy(), fp, chks)
 	}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
@@ -193,7 +193,7 @@ func (t *tableCompactor) CompactTable() error {
 // It combines the users index from multiTenantIndexes and its existing compacted index(es)
 func setupBuilder(ctx context.Context, userID string, sourceIndexSet compactor.IndexSet, multiTenantIndexes []Index) (*Builder, error) {
 	sourceIndexes := sourceIndexSet.ListSourceFiles()
-	builder := NewBuilder()
+	builder := NewBuilder(index.LiveFormat)
 
 	// add users index from multi-tenant indexes to the builder
 	for _, idx := range multiTenantIndexes {

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -117,7 +117,7 @@ func (m *mockIndexSet) SetCompactedIndex(compactedIndex compactor.CompactedIndex
 
 func setupMultiTenantIndex(t *testing.T, userStreams map[string][]stream, destDir string, ts time.Time) string {
 	require.NoError(t, util.EnsureDirectory(destDir))
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	for userID, streams := range userStreams {
 		for _, stream := range streams {
 			lb := labels.NewBuilder(stream.labels)
@@ -155,7 +155,7 @@ func setupMultiTenantIndex(t *testing.T, userStreams map[string][]stream, destDi
 
 func setupPerTenantIndex(t *testing.T, streams []stream, destDir string, ts time.Time) string {
 	require.NoError(t, util.EnsureDirectory(destDir))
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	for _, stream := range streams {
 		b.AddSeries(
 			stream.labels,
@@ -881,7 +881,7 @@ func setupCompactedIndex(t *testing.T) *testContext {
 	userID := buildUserID(0)
 
 	buildCompactedIndex := func() *compactedIndex {
-		builder := NewBuilder()
+		builder := NewBuilder(index.LiveFormat)
 		stream := buildStream(lbls1, buildChunkMetas(shiftTableStart(0), shiftTableStart(10)), "")
 		builder.AddSeries(stream.labels, stream.fp, stream.chunks)
 

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -861,8 +861,9 @@ func setupCompactedIndex(t *testing.T) *testContext {
 
 	now := model.Now()
 	periodConfig := config.PeriodConfig{
-		IndexTables: config.PeriodicTableConfig{Period: config.ObjectStorageIndexRequiredPeriod},
-		Schema:      "v12",
+		IndexTables:      config.PeriodicTableConfig{Period: config.ObjectStorageIndexRequiredPeriod},
+		Schema:           "v12",
+		TSDBIndexVersion: index.FormatV3,
 	}
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{periodConfig},

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -214,7 +214,7 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 		},
 	}
 
-	storeName := "store_2010-10-10"
+	const storeName = "store_2010-10-10"
 	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
 	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 	// so ensure our dirs exist

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -400,6 +400,7 @@ func TestBuildLegacyWALs(t *testing.T) {
 					Prefix: "index_",
 					Period: time.Hour * 24,
 				},
+				TSDBIndexVersion: index.LiveFormat,
 			},
 			{
 				From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
@@ -409,6 +410,7 @@ func TestBuildLegacyWALs(t *testing.T) {
 					Prefix: "index_",
 					Period: time.Hour * 24,
 				},
+				TSDBIndexVersion: index.LiveFormat,
 			},
 		},
 	}

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -42,7 +42,7 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 		// Ensure we query both per tenant and multitenant TSDBs
 		idxBuckets := indexBuckets(from, through, []config.TableRange{i.tableRange})
 		for _, bkt := range idxBuckets {
-			if err := i.shipper.ForEachConcurrent(ctx, bkt, user, func(multitenant bool, idx shipper_index.Index) error {
+			if err := i.shipper.ForEachConcurrent(ctx, bkt.tableName, user, func(multitenant bool, idx shipper_index.Index) error {
 				impl, ok := idx.(Index)
 				if !ok {
 					return fmt.Errorf("unexpected shipper index type: %T", idx)

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -151,11 +151,6 @@ func (m *tsdbManager) Start() (err error) {
 	return nil
 }
 
-type idxTblNameWithVersion struct {
-	tableName string
-	version   int
-}
-
 func (m *tsdbManager) buildFromHead(heads *tenantHeads, shipper indexshipper.IndexShipper, tableRanges []config.TableRange) (err error) {
 	periods := make(map[string]*Builder)
 
@@ -293,6 +288,11 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier, legacy boo
 	}
 
 	return nil
+}
+
+type idxTblNameWithVersion struct {
+	tableName string
+	version   int
 }
 
 func indexBuckets(from, through model.Time, tableRanges config.TableRanges) (res []idxTblNameWithVersion) {

--- a/pkg/storage/stores/tsdb/manager.go
+++ b/pkg/storage/stores/tsdb/manager.go
@@ -175,7 +175,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads, shipper indexshipper.Ind
 		for pd, matchingChks := range pds {
 			b, ok := periods[pd]
 			if !ok {
-				b = NewBuilder()
+				b = NewBuilder(index.LiveFormat)
 				periods[pd] = b
 			}
 

--- a/pkg/storage/stores/tsdb/manager_test.go
+++ b/pkg/storage/stores/tsdb/manager_test.go
@@ -1,0 +1,283 @@
+package tsdb
+
+import (
+	"context"
+	"io"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/loki/pkg/storage/chunk/client/util"
+	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	tsdbIndex "github.com/grafana/loki/pkg/storage/stores/tsdb/index"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_BuildFromHead_HasCorrectIndexVersion(t *testing.T) {
+	secondStoreDate := parseDate("2023-01-02")
+	schemaCfg := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				IndexType:  config.TSDBType,
+				ObjectType: config.StorageTypeFileSystem,
+				IndexTables: config.PeriodicTableConfig{
+					Prefix: "index_",
+					Period: time.Hour * 24,
+				},
+				TSDBIndexVersion: tsdbIndex.FormatV2,
+			},
+			{
+				From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
+				IndexType:  config.TSDBType,
+				ObjectType: config.StorageTypeFileSystem,
+				IndexTables: config.PeriodicTableConfig{
+					Prefix: "index_",
+					Period: time.Hour * 24,
+				},
+				TSDBIndexVersion: tsdbIndex.FormatV3,
+			},
+		},
+	}
+
+	ls := mustParseLabels(`{foo="bar"}`)
+	fakeShipper := &fakeShipper{}
+	dir := t.TempDir()
+
+	tt := []struct {
+		tableRange config.TableRange
+		version    int
+		chunks     []tsdbIndex.ChunkMeta
+	}{
+		{
+
+			tableRange: schemaCfg.Configs[0].GetIndexTableNumberRange(config.DayTime{Time: timeToModelTime(secondStoreDate.Add(-time.Millisecond))}),
+			version:    tsdbIndex.FormatV2,
+			chunks: []tsdbIndex.ChunkMeta{
+				{
+					Checksum: 0,
+					MinTime:  1,
+					MaxTime:  10,
+					KB:       2,
+					Entries:  30,
+				},
+			},
+		},
+		{
+
+			tableRange: schemaCfg.Configs[1].GetIndexTableNumberRange(config.DayTime{Time: math.MaxInt64}),
+			version:    tsdbIndex.FormatV3,
+			chunks: []tsdbIndex.ChunkMeta{
+				{
+					Checksum: 0,
+					MinTime:  secondStoreDate.Add(time.Millisecond).UnixMilli(),
+					MaxTime:  secondStoreDate.Add(time.Minute).UnixMilli(),
+					KB:       2,
+					Entries:  30,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tenantHeads := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger())
+		tsdbManager := NewTSDBManager(
+			"foo",
+			"uploader",
+			filepath.Join(dir, "active"),
+			fakeShipper,
+			tc.tableRange,
+			schemaCfg,
+			log.NewNopLogger(),
+			NewMetrics(nil),
+		)
+
+		_ = tenantHeads.Append("fake", ls, ls.Hash(), tc.chunks)
+
+		err := tsdbManager.BuildFromHead(tenantHeads)
+		require.NoError(t, err)
+
+		index := fakeShipper.index
+
+		r, err := index.Reader()
+		require.NoError(t, err)
+
+		_, err = r.Seek(4, io.SeekStart)
+		require.NoError(t, err)
+
+		version := make([]byte, 1)
+		_, err = r.Read(version)
+		require.NoError(t, err)
+
+		require.Equal(t, tc.version, int(version[0]))
+	}
+}
+
+func Test_BuildFromWAL_HasCorrectIndexVersion(t *testing.T) {
+	secondStoreDate := parseDate("2023-01-02")
+	walTime := secondStoreDate.Add(-time.Minute)
+	schemaCfg := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				IndexType:  config.TSDBType,
+				ObjectType: config.StorageTypeFileSystem,
+				IndexTables: config.PeriodicTableConfig{
+					Prefix: "index_",
+					Period: time.Hour * 24,
+				},
+				TSDBIndexVersion: tsdbIndex.FormatV2,
+			},
+			{
+				From:       config.DayTime{Time: timeToModelTime(secondStoreDate)},
+				IndexType:  config.TSDBType,
+				ObjectType: config.StorageTypeFileSystem,
+				IndexTables: config.PeriodicTableConfig{
+					Prefix: "index_",
+					Period: time.Hour * 24,
+				},
+				TSDBIndexVersion: tsdbIndex.FormatV3,
+			},
+		},
+	}
+
+	fakeShipper := &fakeShipper{}
+	dir := t.TempDir()
+
+	storeName := "store_2010-10-10"
+
+	for _, d := range managerRequiredDirs(storeName, dir) {
+		require.Nil(t, util.EnsureDirectory(d))
+	}
+
+	now := time.Now()
+	w, err := newHeadWAL(log.NewNopLogger(), walPath(storeName, dir, walTime), now)
+	require.Nil(t, err)
+
+	cases := []struct {
+		Labels      labels.Labels
+		Fingerprint uint64
+		Chunks      []tsdbIndex.ChunkMeta
+		User        string
+	}{
+		{
+			User:        "tenant1",
+			Labels:      mustParseLabels(`{foo="bar", bazz="buzz"}`),
+			Fingerprint: mustParseLabels(`{foo="bar", bazz="buzz"}`).Hash(),
+			Chunks: []tsdbIndex.ChunkMeta{
+				{
+					Checksum: 0,
+					MinTime:  secondStoreDate.Add(-time.Minute).UnixMilli(),
+					MaxTime:  secondStoreDate.Add(-time.Millisecond).UnixMilli(),
+					KB:       2,
+					Entries:  30,
+				},
+			},
+		},
+		{
+			User:        "tenant2",
+			Labels:      mustParseLabels(`{foo="bard", bazz="bozz", bonk="borb"}`),
+			Fingerprint: 1, // Different fingerprint should be preserved
+			Chunks: []tsdbIndex.ChunkMeta{
+				{
+					Checksum: 0,
+					MinTime:  secondStoreDate.Add(time.Millisecond).UnixMilli(),
+					MaxTime:  secondStoreDate.Add(time.Minute).UnixMilli(),
+					KB:       2,
+					Entries:  30,
+				},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		require.Nil(t, w.Log(&WALRecord{
+			UserID:      c.User,
+			Fingerprint: c.Fingerprint,
+			Series: record.RefSeries{
+				Ref:    chunks.HeadSeriesRef(i),
+				Labels: c.Labels,
+			},
+			Chks: ChunkMetasRecord{
+				Chks: c.Chunks,
+				Ref:  uint64(i),
+			},
+		}))
+	}
+
+	tt := []struct {
+		tableRange config.TableRange
+		version    int
+	}{
+		{
+			tableRange: schemaCfg.Configs[0].GetIndexTableNumberRange(config.DayTime{Time: timeToModelTime(secondStoreDate.Add(-time.Millisecond))}),
+			version:    tsdbIndex.FormatV2,
+		},
+		{
+
+			tableRange: schemaCfg.Configs[1].GetIndexTableNumberRange(config.DayTime{Time: math.MaxInt64}),
+			version:    tsdbIndex.FormatV3,
+		},
+	}
+
+	for _, tc := range tt {
+		tsdbManager := NewTSDBManager(
+			storeName,
+			"uploader",
+			dir,
+			fakeShipper,
+			tc.tableRange,
+			schemaCfg,
+			log.NewNopLogger(),
+			NewMetrics(nil),
+		)
+
+		err := tsdbManager.BuildFromWALs(now, []WALIdentifier{{
+			ts: walTime,
+		}}, false)
+		require.NoError(t, err)
+
+		index := fakeShipper.index
+
+		r, err := index.Reader()
+		require.NoError(t, err)
+
+		_, err = r.Seek(4, io.SeekStart)
+		require.NoError(t, err)
+
+		version := make([]byte, 1)
+		_, err = r.Read(version)
+		require.NoError(t, err)
+
+		require.Equal(t, tc.version, int(version[0]))
+	}
+}
+
+type fakeShipper struct {
+	index index.Index
+}
+
+// AddIndex adds an immutable index to a logical table which would eventually get uploaded to the object store.
+func (f *fakeShipper) AddIndex(tableName string, userID string, index index.Index) error {
+	f.index = index
+	return nil
+}
+
+// ForEach lets us iterates through each index file in a table for a specific user.
+// On the write path, it would iterate on the files given to the shipper for uploading, until they eventually get dropped from local disk.
+// On the read path, it would iterate through the files if already downloaded else it would download and iterate through them.
+func (f *fakeShipper) ForEach(ctx context.Context, tableName string, userID string, callback index.ForEachIndexCallback) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (f *fakeShipper) ForEachConcurrent(ctx context.Context, tableName string, userID string, callback index.ForEachIndexCallback) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (f *fakeShipper) Stop() {
+	panic("not implemented") // TODO: Implement
+}

--- a/pkg/storage/stores/tsdb/manager_test.go
+++ b/pkg/storage/stores/tsdb/manager_test.go
@@ -9,14 +9,15 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/loki/pkg/storage/chunk/client/util"
-	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
-	tsdbIndex "github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/storage/chunk/client/util"
+	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	tsdbIndex "github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 func Test_BuildFromHead_HasCorrectIndexVersion(t *testing.T) {

--- a/pkg/storage/stores/tsdb/querier_test.go
+++ b/pkg/storage/stores/tsdb/querier_test.go
@@ -24,7 +24,7 @@ func mustParseLabels(s string) labels.Labels {
 
 func TestQueryIndex(t *testing.T) {
 	dir := t.TempDir()
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 	cases := []struct {
 		labels labels.Labels
 		chunks []index.ChunkMeta

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -49,7 +49,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (index
 		return nil, ErrAlreadyOnDesiredVersion
 	}
 
-	builder := NewBuilder()
+	builder := NewBuilder(desiredVer)
 	err = indexFile.(*TSDBFile).Index.(*TSDBIndex).ForSeries(ctx, nil, 0, math.MaxInt64, func(lbls labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) {
 		builder.AddSeries(lbls.Copy(), fp, chks)
 	}, labels.MustNewMatcher(labels.MatchEqual, "", ""))
@@ -59,7 +59,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (index
 
 	parentDir := filepath.Dir(path)
 
-	id, err := builder.BuildWithVersion(ctx, desiredVer, parentDir, func(from, through model.Time, checksum uint32) Identifier {
+	id, err := builder.Build(ctx, parentDir, func(from, through model.Time, checksum uint32) Identifier {
 		id := SingleTenantTSDBIdentifier{
 			TS:       time.Now(),
 			From:     from,

--- a/pkg/storage/stores/tsdb/util_test.go
+++ b/pkg/storage/stores/tsdb/util_test.go
@@ -18,7 +18,7 @@ type LoadableSeries struct {
 }
 
 func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
-	b := NewBuilder()
+	b := NewBuilder(index.LiveFormat)
 
 	for _, s := range cases {
 		b.AddSeries(s.Labels, model.Fingerprint(s.Labels.Hash()), s.Chunks)

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -60,7 +60,7 @@ func TestMigrateTables(t *testing.T) {
 
 	// setup some tables
 	for i := currTableNum - 5; i <= currTableNum; i++ {
-		b := tsdb.NewBuilder()
+		b := tsdb.NewBuilder(index.FormatV2)
 		b.AddSeries(labels.Labels{
 			{
 				Name:  "table_name",
@@ -76,7 +76,7 @@ func TestMigrateTables(t *testing.T) {
 			},
 		})
 
-		id, err := b.BuildWithVersion(context.Background(), index.FormatV2, tempDir, func(from, through model.Time, checksum uint32) tsdb.Identifier {
+		id, err := b.Build(context.Background(), tempDir, func(from, through model.Time, checksum uint32) tsdb.Identifier {
 			id := tsdb.SingleTenantTSDBIdentifier{
 				TS:       time.Now(),
 				From:     from,

--- a/tools/tsdb/tsdb-map/main.go
+++ b/tools/tsdb/tsdb-map/main.go
@@ -67,7 +67,7 @@ func main() {
 		panic(err)
 	}
 
-	builder := tsdb.NewBuilder()
+	builder := tsdb.NewBuilder(index.LiveFormat)
 
 	log.Println("Loading index into memory")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is PR 2/3 to move the TSDB schema version to the period config. This PR sets the correct version in the index file when cutting the index from the head manager (aka ingesters). Future work will be to also respect this versioning in the compactor.

**Which issue(s) this PR fixes**:
Re #9565

**Special notes for your reviewer**:

The full functionality of supporting TSDB index versions in the schema/period config is enabled via 3 PRs. Each PR can be reviewed and merged independently.

[1/3] https://github.com/grafana/loki/pull/9566
[2/3] https://github.com/grafana/loki/pull/9590
[3/3] https://github.com/grafana/loki/pull/9633

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
