### PR TITLE
Azure: Create blob container if not found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [9184](https://github.com/grafana/loki/pull/9184) **periklis**: Bump dskit to introduce IPv6 support for memberlist
 * [9357](https://github.com/grafana/loki/pull/9357) **Indransh**: Add HTTP API to change the log level at runtime
 * [9431](https://github.com/grafana/loki/pull/9431) **dannykopping**: Add more buckets to `loki_memcache_request_duration_seconds` metric; latencies can increase if using memcached with NVMe
+* [9466](https://github.com/grafana/loki/pull/9466) **appkins**: Azure: Create blob container if not found.
 * [8684](https://github.com/grafana/loki/pull/8684) **oleksii-boiko-ua**: Helm: Add hpa templates for read, write and backend components.
 
 ##### Fixes

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -209,6 +209,17 @@ func NewBlobStorage(cfg *BlobStorageConfig, metrics BlobStorageMetrics, hedgingC
 		return nil, err
 	}
 
+	ctx := context.Background()
+	_, err = blobStorage.containerURL.GetProperties(ctx, azblob.LeaseAccessConditions{})
+	if err != nil {
+		if bloberror, ok := err.(azblob.StorageError); ok && bloberror.ServiceCode() == azblob.ServiceCodeContainerNotFound {
+			_, err = blobStorage.containerURL.Create(ctx, azblob.Metadata{}, azblob.PublicAccessNone)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create create Azure blob container '%s': %w", blobStorage.cfg.ContainerName, err)
+			}
+		}
+	}
+
 	return blobStorage, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns with the fallback behavior in Thanos object store for creating azure blob containers when they do not exist. Loki depends on the containers to function and already configures the necessary credentials for creating a container. It follows that Loki should create any required containers to prevent running in a failed state.

This behavior matches the code for Thanos here:
https://github.com/thanos-io/objstore/blob/main/providers/azure/azure.go#L167

```go
ctx := context.Background()
	_, err = containerClient.GetProperties(ctx, &container.GetPropertiesOptions{})
	if err != nil {
		if !bloberror.HasCode(err, bloberror.ContainerNotFound) {
			return nil, err
		}
		_, err := containerClient.Create(ctx, nil)
		if err != nil {
			return nil, errors.Wrapf(err, "error creating Azure blob container: %s", conf.ContainerName)
		}
		level.Info(logger).Log("msg", "Azure blob container successfully created", "address", conf.ContainerName)
	}
```

I tried to match the behavior as closely as possible while using the existing `azblob` implementation in Loki (vs the azure sdk library in Thanos object store).

**Which issue(s) this PR fixes**:
Fixes #9467

**Special notes for your reviewer**:

### Re-opened due to changing the default branch. Continuation of #9466

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
