### PR TITLE
logCLI docs: Remove -q and --match from logcli series example

### DIFF
--- a/docs/sources/query/logcli.md
+++ b/docs/sources/query/logcli.md
@@ -89,7 +89,7 @@ Common labels: {job="loki-ops/consul", namespace="loki-ops"}
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169
 ...
 
-$ logcli series -q --match='{namespace="loki",container_name="loki"}'
+$ logcli series '{namespace="loki",container_name="loki"}'
 {app="loki", container_name="loki", controller_revision_hash="loki-57c9df47f4", filename="/var/log/pods/loki_loki-0_8ed03ded-bacb-4b13-a6fe-53a445a15887/loki/0.log", instance="loki-0", job="loki/loki", name="loki", namespace="loki", release="loki", statefulset_kubernetes_io_pod_name="loki-0", stream="stderr"}
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I removed -q and --match from the "logcli series" example, based on my own testing as well as reading the output of logcli series --help, which says just to pass <matcher>

The documentation as is was confusing for me as a first time user of the series function.

**Which issue(s) this PR fixes**:
no issue filed

**Special notes for your reviewer**:

**Checklist**
- [ x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ n/a] Documentation added
- [n/a ] Tests updated
- [ n/a] `CHANGELOG.md` updated
- [ n/a] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ n/a] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
