### PR TITLE
[logcli] fixed query command that is run against user's bucket with TSDB index enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ##### Fixes
 
+* [9597](https://github.com/grafana/loki/pull/9597) **vlad-diachenko**: Set TSDB shipper mode to ReadOnly and disabled indexGatewayClient during local query run and changed index downloading timeout from `5s` to `1m`.
 * [8566](https://github.com/grafana/loki/pull/8566) **ndrpnt**: Allow queries to start with negative filters (`!=` and `!~`) when omitting stream selector with `--stdin` flag
 
 #### Mixins

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -460,6 +460,8 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 	}
 	conf.StorageConfig.BoltDBShipperConfig.Mode = indexshipper.ModeReadOnly
 	conf.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
+	conf.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadOnly
+	conf.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 
 	querier, err := storage.NewStore(conf.StorageConfig, conf.ChunkStoreConfig, conf.SchemaConfig, limits, cm, prometheus.DefaultRegisterer, util_log.Logger)
 	if err != nil {
@@ -534,7 +536,7 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, names ...string) (*confi
 	errs := multierror.New()
 	for _, name := range names {
 		schema, err := func(name string) (*config.SchemaConfig, error) {
-			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Minute))
 			defer cancel()
 			rdr, _, err := oc.GetObject(ctx, name)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
set TSDB shipper mode to ReadOnly and disabled indexGatewayClient during local query run. Also, I increase index downloading timeout to 1m because the users run the query from local machines that not always have more than 100Mbps

**Which issue(s) this PR fixes**:
Fixes #9555 

**Special notes for your reviewer**:
Unfortunately, we do not have similar tests and test architecture to cover it with unit tests properly.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
