### PR TITLE
Prevent GetFactorOfTime from returning NaN

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -133,6 +133,13 @@ func GetFactorOfTime(from, through int64, minTime, maxTime int64) (factor float6
 		return 0
 	}
 
+	if minTime == maxTime {
+		// This function is most often used for chunk overlaps
+		// a chunk maxTime == minTime when it has only 1 entry
+		// return factor 1 to count that chunk's entry
+		return 1
+	}
+
 	totalTime := maxTime - minTime
 	leadingTime := utilsMath.Max64(0, from-minTime)
 	trailingTime := utilsMath.Max64(0, maxTime-through)

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -270,6 +270,12 @@ func TestGetFactorOfTime(t *testing.T) {
 			extentMin: 20, extentMax: 35,
 			exp: 0,
 		},
+		{
+			desc: "factor would be NaN",
+			from: 1685655637000000000, through: 1685656237000000000,
+			extentMin: 1685656107442496000, extentMax: 1685656107442496000,
+			exp: 1,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			factor := GetFactorOfTime(tc.from, tc.through, tc.extentMin, tc.extentMax)


### PR DESCRIPTION
`GetFactorOfTime` is used to calculate overlaps with chunk time ranges -- particularly calls to `stats`. When a chunk has only one entry, it's `start time == end time` and this `GetFactorOfTime` returns `NaN`.

The stats calculation is `uint64(total chunk bytes * factor)`. When `factor` is `NaN`:

`uint64(total chunk bytes * factor) == uint64(math.Nan()) == 9223372036854775808` 

`uint64(math.Nan()) == 9223372036854775808` is an implementation detail of golang.
