### PR TITLE
Querier: configurable writeback queue bytes size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [9357](https://github.com/grafana/loki/pull/9357) **Indransh**: Add HTTP API to change the log level at runtime
 * [9431](https://github.com/grafana/loki/pull/9431) **dannykopping**: Add more buckets to `loki_memcache_request_duration_seconds` metric; latencies can increase if using memcached with NVMe
 * [8684](https://github.com/grafana/loki/pull/8684) **oleksii-boiko-ua**: Helm: Add hpa templates for read, write and backend components.
+* [9604](https://github.com/grafana/loki/pull/9604) **dannykopping**: Querier: configurable writeback queue bytes size
 
 ##### Fixes
 

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3753,6 +3753,10 @@ background:
   # CLI flag: -<prefix>.background.write-back-buffer
   [writeback_buffer: <int> | default = 10000]
 
+  # Size limit of buffer for background write-back.
+  # CLI flag: -<prefix>.background.write-back-buffer-size-limit
+  [writeback_buffer_size_limit: <int> | default = 500MB]
+
 memcached:
   # How long keys stay in the memcache.
   # CLI flag: -<prefix>.memcached.expiration

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3753,9 +3753,9 @@ background:
   # CLI flag: -<prefix>.background.write-back-buffer
   [writeback_buffer: <int> | default = 10000]
 
-  # Size limit of buffer for background write-back.
-  # CLI flag: -<prefix>.background.write-back-buffer-size-limit
-  [writeback_buffer_size_limit: <int> | default = 1GB]
+  # Size limit in bytes for background write-back.
+  # CLI flag: -<prefix>.background.write-back-size-limit
+  [writeback_size_limit: <int> | default = 1GB]
 
 memcached:
   # How long keys stay in the memcache.

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -3755,7 +3755,7 @@ background:
 
   # Size limit of buffer for background write-back.
   # CLI flag: -<prefix>.background.write-back-buffer-size-limit
-  [writeback_buffer_size_limit: <int> | default = 500MB]
+  [writeback_buffer_size_limit: <int> | default = 1GB]
 
 memcached:
   # How long keys stay in the memcache.

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -11,31 +11,39 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/grafana/loki/pkg/util/flagext"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 // BackgroundConfig is config for a Background Cache.
 type BackgroundConfig struct {
-	WriteBackGoroutines int `yaml:"writeback_goroutines"`
-	WriteBackBuffer     int `yaml:"writeback_buffer"`
+	WriteBackGoroutines      int              `yaml:"writeback_goroutines"`
+	WriteBackBuffer          int              `yaml:"writeback_buffer"`
+	WriteBackBufferSizeLimit flagext.ByteSize `yaml:"writeback_buffer_size_limit"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
 func (cfg *BackgroundConfig) RegisterFlagsWithPrefix(prefix string, description string, f *flag.FlagSet) {
 	f.IntVar(&cfg.WriteBackGoroutines, prefix+"background.write-back-concurrency", 10, description+"At what concurrency to write back to cache.")
 	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 10000, description+"How many key batches to buffer for background write-back.")
+	cfg.WriteBackBufferSizeLimit.Set("500MB")
+	f.Var(&cfg.WriteBackBufferSizeLimit, prefix+"background.write-back-buffer-size-limit", description+"Size limit of buffer for background write-back.")
 }
 
 type backgroundCache struct {
 	Cache
 
-	wg       sync.WaitGroup
-	quit     chan struct{}
-	bgWrites chan backgroundWrite
-	name     string
+	wg        sync.WaitGroup
+	quit      chan struct{}
+	bgWrites  chan backgroundWrite
+	name      string
+	size      int
+	sizeLimit int
 
-	droppedWriteBack prometheus.Counter
-	queueLength      prometheus.Gauge
+	droppedWriteBack      prometheus.Counter
+	droppedWriteBackBytes prometheus.Counter
+	queueLength           prometheus.Gauge
+	queueBytes            prometheus.Gauge
 }
 
 type backgroundWrite struct {
@@ -43,17 +51,35 @@ type backgroundWrite struct {
 	bufs [][]byte
 }
 
+func (b *backgroundWrite) size() int {
+	var sz int
+
+	for _, buf := range b.bufs {
+		sz += len(buf)
+	}
+
+	return sz
+}
+
 // NewBackground returns a new Cache that does stores on background goroutines.
 func NewBackground(name string, cfg BackgroundConfig, cache Cache, reg prometheus.Registerer) Cache {
 	c := &backgroundCache{
-		Cache:    cache,
-		quit:     make(chan struct{}),
-		bgWrites: make(chan backgroundWrite, cfg.WriteBackBuffer),
-		name:     name,
+		Cache:     cache,
+		quit:      make(chan struct{}),
+		bgWrites:  make(chan backgroundWrite, cfg.WriteBackBuffer),
+		name:      name,
+		sizeLimit: cfg.WriteBackBufferSizeLimit.Val(),
+
 		droppedWriteBack: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace:   "loki",
 			Name:        "cache_dropped_background_writes_total",
 			Help:        "Total count of dropped write backs to cache.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
+		droppedWriteBackBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "loki",
+			Name:        "cache_dropped_background_writes_bytes_total",
+			Help:        "Volume of chunk data dropped in write backs to cache.",
 			ConstLabels: prometheus.Labels{"name": name},
 		}),
 
@@ -61,6 +87,13 @@ func NewBackground(name string, cfg BackgroundConfig, cache Cache, reg prometheu
 			Namespace:   "loki",
 			Name:        "cache_background_queue_length",
 			Help:        "Length of the cache background write queue.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
+
+		queueBytes: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace:   "loki",
+			Name:        "cache_background_queue_bytes",
+			Help:        "Volume of chunk bytes of the cache background write queue.",
 			ConstLabels: prometheus.Labels{"name": name},
 		}),
 	}
@@ -95,21 +128,36 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 			keys: keys[:num],
 			bufs: bufs[:num],
 		}
+
+		size := bgWrite.size()
+		newSize := c.size + size
+		if newSize > c.sizeLimit {
+			c.failStore(ctx, size, num, "queue at byte size limit")
+			return nil
+		}
+
 		select {
 		case c.bgWrites <- bgWrite:
+			c.size = newSize
+			c.queueBytes.Set(float64(c.size))
 			c.queueLength.Add(float64(num))
 		default:
-			c.droppedWriteBack.Add(float64(num))
-			sp := opentracing.SpanFromContext(ctx)
-			if sp != nil {
-				sp.LogFields(otlog.Int("dropped", num))
-			}
+			c.failStore(ctx, size, num, "queue at full capacity")
 			return nil // queue is full; give up
 		}
 		keys = keys[num:]
 		bufs = bufs[num:]
 	}
 	return nil
+}
+
+func (c *backgroundCache) failStore(ctx context.Context, size int, num int, reason string) {
+	c.droppedWriteBackBytes.Add(float64(size))
+	c.droppedWriteBack.Add(float64(num))
+	sp := opentracing.SpanFromContext(ctx)
+	if sp != nil {
+		sp.LogFields(otlog.String("reason", reason), otlog.Int("dropped", num), otlog.Int("dropped_bytes", size))
+	}
 }
 
 func (c *backgroundCache) writeBackLoop() {
@@ -121,7 +169,10 @@ func (c *backgroundCache) writeBackLoop() {
 			if !ok {
 				return
 			}
+			c.size -= bgWrite.size()
+
 			c.queueLength.Sub(float64(len(bgWrite.keys)))
+			c.queueBytes.Set(float64(c.size))
 			err := c.Cache.Store(context.Background(), bgWrite.keys, bgWrite.bufs)
 			if err != nil {
 				level.Warn(util_log.Logger).Log("msg", "backgroundCache writeBackLoop Cache.Store fail", "err", err)

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -25,7 +25,7 @@ type BackgroundConfig struct {
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
 func (cfg *BackgroundConfig) RegisterFlagsWithPrefix(prefix string, description string, f *flag.FlagSet) {
 	f.IntVar(&cfg.WriteBackGoroutines, prefix+"background.write-back-concurrency", 10, description+"At what concurrency to write back to cache.")
-	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 5000, description+"How many key batches to buffer for background write-back.")
+	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 10000, description+"How many key batches to buffer for background write-back.")
 	cfg.WriteBackBufferSizeLimit.Set("1GB")
 	f.Var(&cfg.WriteBackBufferSizeLimit, prefix+"background.write-back-buffer-size-limit", description+"Size limit of buffer for background write-back.")
 }

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -27,7 +27,7 @@ type BackgroundConfig struct {
 func (cfg *BackgroundConfig) RegisterFlagsWithPrefix(prefix string, description string, f *flag.FlagSet) {
 	f.IntVar(&cfg.WriteBackGoroutines, prefix+"background.write-back-concurrency", 10, description+"At what concurrency to write back to cache.")
 	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 10000, description+"How many key batches to buffer for background write-back.")
-	cfg.WriteBackSizeLimit.Set("1GB")
+	_ = cfg.WriteBackSizeLimit.Set("1GB")
 	f.Var(&cfg.WriteBackSizeLimit, prefix+"background.write-back-size-limit", description+"Size limit in bytes for background write-back.")
 }
 

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -25,8 +25,8 @@ type BackgroundConfig struct {
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
 func (cfg *BackgroundConfig) RegisterFlagsWithPrefix(prefix string, description string, f *flag.FlagSet) {
 	f.IntVar(&cfg.WriteBackGoroutines, prefix+"background.write-back-concurrency", 10, description+"At what concurrency to write back to cache.")
-	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 10000, description+"How many key batches to buffer for background write-back.")
-	cfg.WriteBackBufferSizeLimit.Set("500MB")
+	f.IntVar(&cfg.WriteBackBuffer, prefix+"background.write-back-buffer", 5000, description+"How many key batches to buffer for background write-back.")
+	cfg.WriteBackBufferSizeLimit.Set("1GB")
 	f.Var(&cfg.WriteBackBufferSizeLimit, prefix+"background.write-back-buffer-size-limit", description+"Size limit of buffer for background write-back.")
 }
 

--- a/pkg/storage/chunk/cache/background_test.go
+++ b/pkg/storage/chunk/cache/background_test.go
@@ -1,16 +1,27 @@
 package cache_test
 
 import (
+	"context"
+	"crypto/rand"
 	"testing"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/pkg/storage/config"
+	"github.com/grafana/loki/pkg/util/flagext"
 )
 
 func TestBackground(t *testing.T) {
+	// irrelevant in this test, set very high
+	limit, err := humanize.ParseBytes("5GB")
+	require.NoError(t, err)
+
 	c := cache.NewBackground("mock", cache.BackgroundConfig{
-		WriteBackGoroutines: 1,
-		WriteBackBuffer:     100,
+		WriteBackGoroutines:      1,
+		WriteBackBuffer:          100,
+		WriteBackBufferSizeLimit: flagext.ByteSize(limit),
 	}, cache.NewMockCache(), nil)
 
 	s := config.SchemaConfig{
@@ -29,4 +40,33 @@ func TestBackground(t *testing.T) {
 	testCacheSingle(t, c, keys, chunks)
 	testCacheMultiple(t, c, keys, chunks)
 	testCacheMiss(t, c)
+}
+
+func TestBackgroundSizeLimit(t *testing.T) {
+	limit, err := humanize.ParseBytes("15KB")
+	require.NoError(t, err)
+
+	c := cache.NewBackground("mock", cache.BackgroundConfig{
+		WriteBackGoroutines:      1,
+		WriteBackBuffer:          100,
+		WriteBackBufferSizeLimit: flagext.ByteSize(limit),
+	}, cache.NewMockCache(), nil)
+
+	ctx := context.Background()
+
+	const firstKey = "first"
+	const secondKey = "second"
+	first := make([]byte, 10e3)  // 10KB
+	second := make([]byte, 10e3) // 10KB
+	rand.Read(first)
+	rand.Read(second)
+
+	// store the first 10KB
+	require.NoError(t, c.Store(ctx, []string{firstKey}, [][]byte{first}))
+	// second key will not be stored because it will exceed the 15KB limit
+	require.NoError(t, c.Store(ctx, []string{secondKey}, [][]byte{second}))
+	cache.Flush(c)
+
+	found, _, _, _ := c.Fetch(ctx, []string{firstKey, secondKey})
+	require.Equal(t, []string{firstKey}, found)
 }

--- a/pkg/storage/chunk/cache/background_test.go
+++ b/pkg/storage/chunk/cache/background_test.go
@@ -19,9 +19,9 @@ func TestBackground(t *testing.T) {
 	require.NoError(t, err)
 
 	c := cache.NewBackground("mock", cache.BackgroundConfig{
-		WriteBackGoroutines:      1,
-		WriteBackBuffer:          100,
-		WriteBackBufferSizeLimit: flagext.ByteSize(limit),
+		WriteBackGoroutines: 1,
+		WriteBackBuffer:     100,
+		WriteBackSizeLimit:  flagext.ByteSize(limit),
 	}, cache.NewMockCache(), nil)
 
 	s := config.SchemaConfig{
@@ -47,9 +47,9 @@ func TestBackgroundSizeLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	c := cache.NewBackground("mock", cache.BackgroundConfig{
-		WriteBackGoroutines:      1,
-		WriteBackBuffer:          100,
-		WriteBackBufferSizeLimit: flagext.ByteSize(limit),
+		WriteBackGoroutines: 1,
+		WriteBackBuffer:     100,
+		WriteBackSizeLimit:  flagext.ByteSize(limit),
 	}, cache.NewMockCache(), nil)
 
 	ctx := context.Background()

--- a/pkg/storage/chunk/cache/background_test.go
+++ b/pkg/storage/chunk/cache/background_test.go
@@ -58,8 +58,8 @@ func TestBackgroundSizeLimit(t *testing.T) {
 	const secondKey = "second"
 	first := make([]byte, 10e3)  // 10KB
 	second := make([]byte, 10e3) // 10KB
-	rand.Read(first)
-	rand.Read(second)
+	_, _ = rand.Read(first)
+	_, _ = rand.Read(second)
 
 	// store the first 10KB
 	require.NoError(t, c.Store(ctx, []string{firstKey}, [][]byte{first}))


### PR DESCRIPTION
**What this PR does / why we need it**:
The background writeback process is used to write chunks that have been fetched from the store to cache. Chunks have a target size, but not all chunks will necessarily be this size, so it is tricky to find the correct value for `writeback_buffer` which specifies how many chunks will be held in the queue at any given time.

For example: setting `writeback_buffer=10000` (the default) with all chunks being the default target size (`chunk_target_size=1.5MiB`), in the worst case could result in 15GiB of memory being used for this buffer. Practically speaking, the queue never grows so deep, but if the cache Loki is writing to becomes overwhelmed this could happen.

Setting a value too low would result in many chunks not being written back to cache, which defeats the purpose.

This PR introduces a configurable _byte size_ limit to the writeback cache, which defaults to 1GB in size. With this setting `writeback_size_limit` in place, we get the best of both worlds: a deep queue which can hold many small chunks or a shallow queue which can hold a few large ones without using too much memory so as to overwhelm the querier.

If either the `writeback_buffer` or `writeback_size_limit` reaches capacity, any new chunks which are attempted to be added to the queue will be dropped.

Two new metrics are added by this PR:

- `loki_cache_background_queue_bytes`: gauge, measures the size of the queue in bytes
- `loki_cache_dropped_background_writes_bytes_total`: counter, measures the volume of bytes dropped

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
