### PR TITLE
[bugfix] fix nil pointer panic: async_store.go

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -336,7 +336,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	}
 
 	store := t.Store
-	if !t.Cfg.Querier.QueryStoreOnly {
+	if !t.Cfg.Querier.QueryStoreOnly && config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
 		store = storage.NewAsyncStore(t.Cfg.StorageConfig.AsyncStoreConfig, t.Store, t.Cfg.SchemaConfig)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today I synced the latest loki code to our git branch to get the `distinct` feature, in order to fix another bug. Found the latest code When using non-TSDB index, get a NPE panic. I use cassandra index now . 

I haven't figured out the code that the shard query of `TSDB` is much higher than 16, such as how to deduplicate 3 replica log. How to ensure the correctness of the final data. So I haven't deployed the TSDB index yet. It will take several months to understand TSDB's shard query, so I still hope to fix this NPE.

for cassandra users .

![image](https://github.com/grafana/loki/assets/9583245/e3828e45-4655-470e-b6f2-f7d9e5b77077)
![image](https://github.com/grafana/loki/assets/9583245/e7ccc45f-37d0-488f-9fb5-865c9f9d360f)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
