### PR TITLE
Remove some unused code

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -50,47 +50,6 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 	return *(*labels.Labels)(unsafe.Pointer(&ls))
 }
 
-// FromLabelAdaptersToLabelsWithCopy converts []LabelAdapter to labels.Labels.
-// Do NOT use unsafe to convert between data types because this function may
-// get in input labels whose data structure is reused.
-func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
-	return CopyLabels(FromLabelAdaptersToLabels(input))
-}
-
-// Efficiently copies labels input slice. To be used in cases where input slice
-// can be reused, but long-term copy is needed.
-func CopyLabels(input []labels.Label) labels.Labels {
-	result := make(labels.Labels, len(input))
-
-	size := 0
-	for _, l := range input {
-		size += len(l.Name)
-		size += len(l.Value)
-	}
-
-	// Copy all strings into the buffer, and use 'yoloString' to convert buffer
-	// slices to strings.
-	buf := make([]byte, size)
-
-	for i, l := range input {
-		result[i].Name, buf = copyStringToBuffer(l.Name, buf)
-		result[i].Value, buf = copyStringToBuffer(l.Value, buf)
-	}
-	return result
-}
-
-// Copies string to buffer (which must be big enough), and converts buffer slice containing
-// the string copy into new string.
-func copyStringToBuffer(in string, buf []byte) (string, []byte) {
-	l := len(in)
-	c := copy(buf, in)
-	if c != l {
-		panic("not copied full string")
-	}
-
-	return yoloString(buf[0:l]), buf[l:]
-}
-
 // FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
 // It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
 // This allows us to use labels.Labels directly in protos.

--- a/pkg/logproto/compat_test.go
+++ b/pkg/logproto/compat_test.go
@@ -84,29 +84,6 @@ func TestFromLabelAdaptersToLabels(t *testing.T) {
 	assert.Equal(t, uintptr(unsafe.Pointer(&input[0].Value)), uintptr(unsafe.Pointer(&actual[0].Value)))
 }
 
-func TestFromLabelAdaptersToLabelsWithCopy(t *testing.T) {
-	input := []LabelAdapter{{Name: "hello", Value: "world"}}
-	expected := labels.Labels{labels.Label{Name: "hello", Value: "world"}}
-	actual := FromLabelAdaptersToLabelsWithCopy(input)
-
-	assert.Equal(t, expected, actual)
-
-	// All strings must be copied.
-	assert.NotEqual(t, uintptr(unsafe.Pointer(&input[0].Name)), uintptr(unsafe.Pointer(&actual[0].Name)))
-	assert.NotEqual(t, uintptr(unsafe.Pointer(&input[0].Value)), uintptr(unsafe.Pointer(&actual[0].Value)))
-}
-
-func BenchmarkFromLabelAdaptersToLabelsWithCopy(b *testing.B) {
-	input := []LabelAdapter{
-		{Name: "hello", Value: "world"},
-		{Name: "some label", Value: "and its value"},
-		{Name: "long long long long long label name", Value: "perhaps even longer label value, but who's counting anyway?"}}
-
-	for i := 0; i < b.N; i++ {
-		FromLabelAdaptersToLabelsWithCopy(input)
-	}
-}
-
 func TestLegacySampleCompatibilityMarshalling(t *testing.T) {
 	ts := int64(1232132123)
 	val := 12345.12345

--- a/pkg/querier/series/series_set.go
+++ b/pkg/querier/series/series_set.go
@@ -24,8 +24,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-
-	"github.com/grafana/loki/pkg/prom1/storage/metric"
 )
 
 // ConcreteSeriesSet implements storage.SeriesSet.
@@ -183,45 +181,6 @@ func (errIterator) AtT() (t int64) {
 
 func (e errIterator) Err() error {
 	return e.err
-}
-
-// MatrixToSeriesSet creates a storage.SeriesSet from a model.Matrix
-// Series will be sorted by labels.
-func MatrixToSeriesSet(m model.Matrix) storage.SeriesSet {
-	series := make([]storage.Series, 0, len(m))
-	for _, ss := range m {
-		series = append(series, &ConcreteSeries{
-			labels:  MetricToLabels(ss.Metric),
-			samples: ss.Values,
-		})
-	}
-	return NewConcreteSeriesSet(series)
-}
-
-// MetricsToSeriesSet creates a storage.SeriesSet from a []metric.Metric
-func MetricsToSeriesSet(ms []metric.Metric) storage.SeriesSet {
-	series := make([]storage.Series, 0, len(ms))
-	for _, m := range ms {
-		series = append(series, &ConcreteSeries{
-			labels:  MetricToLabels(m.Metric),
-			samples: nil,
-		})
-	}
-	return NewConcreteSeriesSet(series)
-}
-
-func MetricToLabels(m model.Metric) labels.Labels {
-	ls := make(labels.Labels, 0, len(m))
-	for k, v := range m {
-		ls = append(ls, labels.Label{
-			Name:  string(k),
-			Value: string(v),
-		})
-	}
-	// PromQL expects all labels to be sorted! In general, anyone constructing
-	// a labels.Labels list is responsible for sorting it during construction time.
-	sort.Sort(ls)
-	return ls
 }
 
 type byLabels []storage.Series

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -25,6 +25,8 @@ import (
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/instrument"
@@ -36,7 +38,6 @@ import (
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/logqlmodel"
-	"github.com/grafana/loki/pkg/querier/series"
 	"github.com/grafana/loki/pkg/util/build"
 	"github.com/grafana/loki/pkg/util/httpreq"
 	"github.com/grafana/loki/pkg/util/spanlogger"
@@ -299,7 +300,7 @@ func (r *RemoteEvaluator) decodeResponse(ctx context.Context, resp *httpgrpc.HTT
 
 		for _, s := range vec {
 			res = append(res, promql.Sample{
-				Metric: series.MetricToLabels(s.Metric),
+				Metric: metricToLabels(s.Metric),
 				F:      float64(s.Value),
 				T:      int64(s.Timestamp),
 			})
@@ -326,6 +327,17 @@ func (r *RemoteEvaluator) decodeResponse(ctx context.Context, resp *httpgrpc.HTT
 	default:
 		return nil, fmt.Errorf("unsupported result type: %q", decoded.Data.ResultType)
 	}
+}
+
+func metricToLabels(m model.Metric) labels.Labels {
+	b := labels.NewScratchBuilder(len(m))
+	for k, v := range m {
+		b.Add(string(k), string(v))
+	}
+	// PromQL expects all labels to be sorted! In general, anyone constructing
+	// a labels.Labels list is responsible for sorting it during construction time.
+	b.Sort()
+	return b.Labels()
 }
 
 // QueryFrontendConfig defines query-frontend transport configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove some functions I came across while making Loki compatible with different `Labels` structures.
Move `MetricToLabels` to the only place it is now used, and make it call abstractions instead of assuming `Labels` is a slice.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- NA For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
