### PR TITLE
marshal tests: make random quantities more obvious

### DIFF
--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -731,7 +731,8 @@ func randLabel(rand *rand.Rand) labels.Label {
 
 func randLabels(rand *rand.Rand) labels.Labels {
 	var labels labels.Labels
-	for i := 0; i < rand.Intn(100); i++ {
+	nLabels := rand.Intn(100)
+	for i := 0; i < nLabels; i++ {
 		labels = append(labels, randLabel(rand))
 	}
 
@@ -740,7 +741,8 @@ func randLabels(rand *rand.Rand) labels.Labels {
 
 func randEntries(rand *rand.Rand) []logproto.Entry {
 	var entries []logproto.Entry
-	for i := 0; i < rand.Intn(100); i++ {
+	nEntries := rand.Intn(100)
+	for i := 0; i < nEntries; i++ {
 		l, _ := quick.Value(reflect.TypeOf(""), rand)
 		entries = append(entries, logproto.Entry{Timestamp: time.Now(), Line: l.Interface().(string)})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Computing a new random number on every iteration of the loop is hard to reason about, and probably not what was meant.

This PR will mean that much more data is generated than before; I computed the expected value before as 11.2, whereas now it is 49.5.  Consider reducing the `100` if that is undesired.

**Checklist**
- NA Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- NA For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
