### PR TITLE
stores/series tests: use abstractions over Labels

### DIFF
--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -101,33 +101,28 @@ func newTestChunkStoreConfigWithMockStorage(t require.TestingT, schemaCfg config
 func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 	now := model.Now()
 
-	fooMetric1 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-	}
-	fooMetric2 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-	}
-	fooMetric3 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "bop"},
-		{Name: "flip", Value: "flap"},
-	}
+	fooMetric1 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+	)
+	fooMetric2 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+	)
+	fooMetric3 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "bop",
+		"flip", "flap",
+	)
 
 	// barMetric1 is a subset of barMetric2 to test over-matching bug.
-	barMetric1 := labels.Labels{
-		{Name: labels.MetricName, Value: "bar"},
-		{Name: "bar", Value: "baz"},
-	}
-	barMetric2 := labels.Labels{
-		{Name: labels.MetricName, Value: "bar"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	}
+	barMetric1 := labels.FromStrings(labels.MetricName, "bar",
+		"bar", "baz",
+	)
+	barMetric2 := labels.FromStrings(labels.MetricName, "bar",
+		"bar", "baz",
+		"toms", "code",
+	)
 
 	fooChunk1 := dummyChunkFor(now, fooMetric1)
 	fooChunk2 := dummyChunkFor(now, fooMetric2)
@@ -224,33 +219,28 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 	now := model.Now()
 
-	fooMetric1 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-	}
-	fooMetric2 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-	}
-	fooMetric3 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "bop"},
-		{Name: "flip", Value: "flap"},
-	}
+	fooMetric1 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+	)
+	fooMetric2 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+	)
+	fooMetric3 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "bop",
+		"flip", "flap",
+	)
 
 	// barMetric1 is a subset of barMetric2 to test over-matching bug.
-	barMetric1 := labels.Labels{
-		{Name: labels.MetricName, Value: "bar"},
-		{Name: "bar", Value: "baz"},
-	}
-	barMetric2 := labels.Labels{
-		{Name: labels.MetricName, Value: "bar"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	}
+	barMetric1 := labels.FromStrings(labels.MetricName, "bar",
+		"bar", "baz",
+	)
+	barMetric2 := labels.FromStrings(labels.MetricName, "bar",
+		"bar", "baz",
+		"toms", "code",
+	)
 
 	fooChunk1 := dummyChunkFor(now, fooMetric1)
 	fooChunk2 := dummyChunkFor(now, fooMetric2)
@@ -324,17 +314,15 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 // TestChunkStore_getMetricNameChunks tests if chunks are fetched correctly when we have the metric name
 func TestChunkStore_getMetricNameChunks(t *testing.T) {
 	now := model.Now()
-	chunk1 := dummyChunkFor(now, labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-	})
-	chunk2 := dummyChunkFor(now, labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-	})
+	chunk1 := dummyChunkFor(now, labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+	))
+	chunk2 := dummyChunkFor(now, labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+	))
 
 	testCases := []struct {
 		query  string
@@ -448,18 +436,16 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 
 func Test_GetSeries(t *testing.T) {
 	now := model.Now()
-	ch1lbs := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-	}
+	ch1lbs := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+	)
 	chunk1 := dummyChunkFor(now, ch1lbs)
-	ch2lbs := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-	}
+	ch2lbs := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+	)
 	chunk2 := dummyChunkFor(now, ch2lbs)
 
 	testCases := []struct {
@@ -549,18 +535,16 @@ func Test_GetSeries(t *testing.T) {
 
 func Test_GetSeriesShard(t *testing.T) {
 	now := model.Now()
-	ch1lbs := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-	}
+	ch1lbs := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+	)
 	chunk1 := dummyChunkFor(now, ch1lbs)
-	ch2lbs := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-	}
+	ch2lbs := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+	)
 	chunk2 := dummyChunkFor(now, ch2lbs)
 
 	testCases := []struct {
@@ -676,21 +660,19 @@ func TestChunkStoreError(t *testing.T) {
 func TestSeriesStore_LabelValuesForMetricName(t *testing.T) {
 	now := model.Now()
 
-	fooMetric1 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "flip", Value: "flop"},
-		{Name: "toms", Value: "code"},
-		{Name: "env", Value: "dev"},
-		{Name: "class", Value: "not-secret"},
-	}
-	fooMetric2 := labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "beep"},
-		{Name: "toms", Value: "code"},
-		{Name: "env", Value: "prod"},
-		{Name: "class", Value: "secret"},
-	}
+	fooMetric1 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "baz",
+		"flip", "flop",
+		"toms", "code",
+		"env", "dev",
+		"class", "not-secret",
+	)
+	fooMetric2 := labels.FromStrings(labels.MetricName, "foo",
+		"bar", "beep",
+		"toms", "code",
+		"env", "prod",
+		"class", "secret",
+	)
 
 	fooChunk1 := dummyChunkFor(now, fooMetric1)
 	fooChunk2 := dummyChunkFor(now, fooMetric2)
@@ -787,22 +769,21 @@ func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 }
 
 // BenchmarkLabels is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
-var BenchmarkLabels = labels.Labels{
-	{Name: model.MetricNameLabel, Value: "container_cpu_usage_seconds_total"},
-	{Name: "beta_kubernetes_io_arch", Value: "amd64"},
-	{Name: "beta_kubernetes_io_instance_type", Value: "c3.somesize"},
-	{Name: "beta_kubernetes_io_os", Value: "linux"},
-	{Name: "container_name", Value: "some-name"},
-	{Name: "cpu", Value: "cpu01"},
-	{Name: "failure_domain_beta_kubernetes_io_region", Value: "somewhere-1"},
-	{Name: "failure_domain_beta_kubernetes_io_zone", Value: "somewhere-1b"},
-	{Name: "id", Value: "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28"},
-	{Name: "image", Value: "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506"},
-	{Name: "instance", Value: "ip-111-11-1-11.ec2.internal"},
-	{Name: "job", Value: "kubernetes-cadvisor"},
-	{Name: "kubernetes_io_hostname", Value: "ip-111-11-1-11"},
-	{Name: "monitor", Value: "prod"},
-	{Name: "name", Value: "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0"},
-	{Name: "namespace", Value: "kube-system"},
-	{Name: "pod_name", Value: "some-other-name-5j8s8"},
-}
+var BenchmarkLabels = labels.FromStrings(model.MetricNameLabel, "container_cpu_usage_seconds_total",
+	"beta_kubernetes_io_arch", "amd64",
+	"beta_kubernetes_io_instance_type", "c3.somesize",
+	"beta_kubernetes_io_os", "linux",
+	"container_name", "some-name",
+	"cpu", "cpu01",
+	"failure_domain_beta_kubernetes_io_region", "somewhere-1",
+	"failure_domain_beta_kubernetes_io_zone", "somewhere-1b",
+	"id", "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28",
+	"image", "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506",
+	"instance", "ip-111-11-1-11.ec2.internal",
+	"job", "kubernetes-cadvisor",
+	"kubernetes_io_hostname", "ip-111-11-1-11",
+	"monitor", "prod",
+	"name", "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
+	"namespace", "kube-system",
+	"pod_name", "some-other-name-5j8s8",
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

Stop assuming `labels.Labels` is a slice.

**Special notes for your reviewer:**

This PR only touches tests.

Upstream Prometheus is using a different implementation of `labels.Labels`, so I plan to create a series of PRs which make Loki compatible with that. #9532 was the first.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- NA `CHANGELOG.md` updated
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- NA For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
