### PR TITLE
Loki ECS Client: Update Name in Options config

### DIFF
--- a/docs/sources/clients/aws/ecs/_index.md
+++ b/docs/sources/clients/aws/ecs/_index.md
@@ -135,7 +135,7 @@ The `log_router` container image is the [Fluent bit Loki docker image][fluentbit
     "logConfiguration": {
         "logDriver": "awsfirelens",
         "options": {
-            "Name": "grafana-loki",
+            "Name": "loki",
             "Url": "https://<userid>:<grafancloud apikey>@<grafanacloud host>/loki/api/v1/push",
             "Labels": "{job=\"firelens\"}",
             "RemoveKeys": "container_id,ecs_task_arn",


### PR DESCRIPTION
Configuration options show  "Name": "grafana-loki", however, fluentbit specifies this should just be "loki"

A few users have reported receiving an error when using the documented "Name" option, but it works as expected when using the Name specified in the fluentbit docs:

Reference: https://docs.fluentbit.io/manual/pipeline/outputs/loki#fluent-bit-+-grafana-cloud