### PR TITLE
Fix missing ~ in the regexp match for namespace

### DIFF
--- a/docs/sources/clients/promtail/stages/tenant.md
+++ b/docs/sources/clients/promtail/stages/tenant.md
@@ -104,10 +104,18 @@ scrape_configs:
 
     pipeline_stages:
     - match:
-        selector: '{namespace=".+"}'
+        selector: '{namespace=~".+"}'
         stages:
           - tenant:
               label: "namespace"
     - output:
          source: message
 ```
+
+The pipeline would:
+
+1. Match any log where the `namespace` label matched the regexp `.+`
+1. Process the `match` stage checking if the `{namespace=~".+"}` selector matches
+   and - whenever it matches - run the sub stages. The `tenant` sub stage
+   would override the tenant with the value with the value of the `namespace` label,
+   if it was set.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix documentation which has a missing `~` for the regexp match. I was following the documentation and found it odd that this query didn't follow [LogQL](https://grafana.com/docs/loki/latest/logql/log_queries/#log-queries), but it actually does and was just a typo in the docs.

I've tested this with my own Loki 2.8 release and with the `~` this works great!

I also added a similar description block to the above example explaining the pipeline, but if this is not desired, I'm happy to remove it.

**Which issue(s) this PR fixes**:
NA, trivial issue, just a small fix in the docs.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
