### PR TITLE
Fix comment and indentation in gateway config of SSD helm chart

### DIFF
--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -568,9 +568,9 @@ http {
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;
 
-  client_max_body_size 4M;
+  client_max_body_size  4M;
 
-  proxy_read_timeout    600; ## 6 minutes
+  proxy_read_timeout    600; ## 10 minutes
   proxy_send_timeout    600;
   proxy_connect_timeout 600;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The gateway config (nginx config file) incorrectly states 10 minutes (as in 600 seconds) as 6 minutes.
This small PR corrects that.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Although this indeed modifies the chart, I don't think it's worth a version bump. Please let me know if you have other ideas.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
