### PR TITLE
[bugfix] logq: fix Distinct operator returning too many log lines

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -946,7 +946,7 @@ func IsGlobalFilter(expr Expr) bool {
 		switch e.(type) {
 		case *DistinctFilterExpr:
 			result = true
-			break
+			return
 		}
 	})
 	return result

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/loki/pkg/util/math"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -12,8 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/httpgrpc"
-
-	"github.com/grafana/dskit/tenant"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/loki/pkg/util/math"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/util"
+	"github.com/grafana/loki/pkg/util/math"
 	"github.com/grafana/loki/pkg/util/validation"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a global filter function for distinct. Applied in 2 modules.

1: After the querier queries multiple instances and s3. Do a global filter on the final result.
2: Do a global filter on each split result after split by time.

alternative:
We can also introduce a global state map to fix this bug, but this introducing a state is a huge work.

**Which issue(s) this PR fixes**:
Fixes #9594 #8662

**Special notes for your reviewer**:
fix distinct result. only return 3 log .
![image](https://github.com/grafana/loki/assets/9583245/9d5fc3a5-cde9-4ca5-a4ea-cea0803342d6)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
