### PR TITLE
Fix duplicate label values from ingester streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [9176](https://github.com/grafana/loki/pull/9176) **DylanGuedes**: Fix incorrect association of per-stream rate limit when sharding is enabled.
 * [9463](https://github.com/grafana/loki/pull/9463) **Totalus**: Fix OpenStack Swift client object listing to fetch all the objects properly.
 * [9495](https://github.com/grafana/loki/pull/9495) **thampiotr**: Promtail: Fix potential goroutine leak in file tailer.
+* [9629](https://github.com/grafana/loki/pull/9629) **periklis**: Fix duplicate label values from ingester streams.
 
 ##### Changes
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -480,15 +480,15 @@ func (i *instance) Label(ctx context.Context, req *logproto.LabelRequest, matche
 		}, nil
 	}
 
-	labels := make([]string, 0)
+	labels := util.NewUniqueStrings(0)
 	err := i.forMatchingStreams(ctx, *req.Start, matchers, nil, func(s *stream) error {
 		for _, label := range s.labels {
 			if req.Values && label.Name == req.Name {
-				labels = append(labels, label.Value)
+				labels.Add(label.Value)
 				continue
 			}
 			if !req.Values {
-				labels = append(labels, label.Name)
+				labels.Add(label.Name)
 			}
 		}
 		return nil
@@ -498,7 +498,7 @@ func (i *instance) Label(ctx context.Context, req *logproto.LabelRequest, matche
 	}
 
 	return &logproto.LabelResponse{
-		Values: labels,
+		Values: labels.Strings(),
 	}, nil
 }
 

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -288,6 +288,7 @@ func setupTestStreams(t *testing.T) (*instance, time.Time, int) {
 	testStreams := []logproto.Stream{
 		{Labels: "{app=\"test\",job=\"varlogs\"}", Entries: entries(5, currentTime)},
 		{Labels: "{app=\"test2\",job=\"varlogs\"}", Entries: entries(5, currentTime.Add(6*time.Nanosecond))},
+		{Labels: "{app=\"test\",job=\"varlogs2\"}", Entries: entries(5, currentTime.Add(12*time.Nanosecond))},
 	}
 
 	for _, testStream := range testStreams {


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the label values matchers exposed by #8824 introduces duplicate label values when the lookup goes through the ingester. This PR deduplicates label values when matching active streams and in turn aligns the behavior with the `series_index_stores.go`. Latter is used actively by the querier to lookup label values with matchers.

![screenshot-1](https://github.com/grafana/loki/assets/152312/266da83a-9b80-49f2-83dc-0c62c384f64c)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
