### PR TITLE
operator: Expose per_stream_rate_limit & burst

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9630](https://github.com/grafana/loki/pull/9630) **jpinsonneau**: Expose per_stream_rate_limit & burst
 - [9457](https://github.com/grafana/loki/pull/9457) **Red-GV**: Set seccomp profile to runtime default
 - [9448](https://github.com/grafana/loki/pull/9448) **btaani**: Include runtime-config in compiling the SHA1 checksum
 - [9511](https://github.com/grafana/loki/pull/9511) **xperimental**: Do not update status after setting degraded condition

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -622,6 +622,20 @@ type IngestionLimitSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Max Line Size"
 	MaxLineSize int32 `json:"maxLineSize,omitempty"`
+
+	// PerStreamRateLimit defines the maximum byte rate per second per stream. Units MB.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Maximum byte rate per second per stream (in MB)"
+	PerStreamRateLimit int32 `json:"perStreamRateLimit,omitempty"`
+
+	// PerStreamRateLimitBurst defines the maximum burst bytes per stream. Units MB.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Maximum burst bytes per stream (in MB)"
+	PerStreamRateLimitBurst int32 `json:"perStreamRateLimitBurst,omitempty"`
 }
 
 // RetentionStreamSpec defines a log stream with separate retention time.

--- a/operator/apis/loki/v1beta1/lokistack_types_test.go
+++ b/operator/apis/loki/v1beta1/lokistack_types_test.go
@@ -379,6 +379,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -396,6 +398,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -412,6 +416,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -704,6 +710,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -721,6 +729,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -737,6 +747,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -1001,6 +1013,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1beta1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -1018,6 +1032,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1beta1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -1034,6 +1050,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1beta1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-05-24T15:10:18Z"
+    createdAt: "2023-06-05T12:57:30Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -329,6 +329,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -394,6 +406,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -240,6 +250,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-ac1c1fd
-    createdAt: "2023-05-24T15:10:16Z"
+    createdAt: "2023-06-05T12:57:28Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -329,6 +329,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -394,6 +406,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -240,6 +250,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-05-24T15:10:20Z"
+    createdAt: "2023-06-05T12:57:32Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -342,6 +342,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -407,6 +419,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -240,6 +250,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -113,6 +113,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -223,6 +233,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -242,6 +242,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -307,6 +319,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -242,6 +242,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -307,6 +319,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -254,6 +254,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can
           be fetched by a single query.
         displayName: Max Chunk per Query
@@ -319,6 +331,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: MaxChunksPerQuery defines the maximum number of chunks that can

--- a/operator/docs/lokistack/sop.md
+++ b/operator/docs/lokistack/sop.md
@@ -202,7 +202,7 @@ A service(s) is rate limiting at least 10% of all incoming requests.
 | `label_value_too_long` | `maxLabelValueLength` |
 | `line_too_long` | `maxLineSize` |
 | `max_label_names_per_series` | `maxLabelNamesPerSeries` |
-| `Per stream rate limit exceeded` | `perStreamRateLimit`, `perStreamRateLimitBurst` |
+| `per_stream_rate_limit` | `perStreamRateLimit`, `perStreamRateLimitBurst` |
 
 
 ## Loki Storage Slow Write

--- a/operator/docs/lokistack/sop.md
+++ b/operator/docs/lokistack/sop.md
@@ -202,6 +202,8 @@ A service(s) is rate limiting at least 10% of all incoming requests.
 | `label_value_too_long` | `maxLabelValueLength` |
 | `line_too_long` | `maxLineSize` |
 | `max_label_names_per_series` | `maxLabelNamesPerSeries` |
+| `Per stream rate limit exceeded` | `perStreamRateLimit`, `perStreamRateLimitBurst` |
+
 
 ## Loki Storage Slow Write
 

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -1112,6 +1112,30 @@ int32
 <p>MaxLineSize defines the maximum line size on ingestion path. Units in Bytes.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>perStreamRateLimit</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PerStreamRateLimit defines the maximum byte rate per second per stream. Units MB.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>perStreamRateLimitBurst</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PerStreamRateLimitBurst defines the maximum burst bytes per stream. Units MB.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -75,6 +75,8 @@ func randomConfigOptions() Options {
 						MaxLabelNamesPerSeries:    rand.Int31(),
 						MaxGlobalStreamsPerTenant: rand.Int31(),
 						MaxLineSize:               rand.Int31(),
+						PerStreamRateLimit:        rand.Int31(),
+						PerStreamRateLimitBurst:   rand.Int31(),
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: rand.Int31(),
@@ -92,6 +94,8 @@ func randomConfigOptions() Options {
 							MaxLabelNamesPerSeries:    rand.Int31(),
 							MaxGlobalStreamsPerTenant: rand.Int31(),
 							MaxLineSize:               rand.Int31(),
+							PerStreamRateLimit:        rand.Int31(),
+							PerStreamRateLimitBurst:   rand.Int31(),
 						},
 						QueryLimits: &lokiv1.QueryLimitSpec{
 							MaxEntriesLimitPerQuery: rand.Int31(),

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -190,6 +190,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -444,6 +446,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -556,6 +560,8 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					// making it nil so that the template is not generated and error is returned
 					QueryLimits: nil,
@@ -849,6 +855,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1199,6 +1207,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1563,6 +1573,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1895,6 +1907,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -2283,6 +2297,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -2672,6 +2688,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -3060,6 +3078,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -3442,6 +3462,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -177,8 +177,8 @@ limits_config:
 {{- end }}
 {{- end }}{{- end }}
   max_cache_freshness_per_query: 10m
-  per_stream_rate_limit: 3MB
-  per_stream_rate_limit_burst: 15MB
+  per_stream_rate_limit: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimit }}MB
+  per_stream_rate_limit_burst: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimitBurst }}MB
   split_queries_by_interval: 30m
 {{- with .GossipRing }}
 memberlist:

--- a/operator/internal/manifests/internal/config/loki-runtime-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-runtime-config.yaml
@@ -26,6 +26,12 @@ overrides:
     {{- if $l.MaxGlobalStreamsPerTenant }}
     max_global_streams_per_user: {{ $l.MaxGlobalStreamsPerTenant }}
     {{- end }}
+    {{- if $l.PerStreamRateLimit }}
+    per_stream_rate_limit: {{ $l.PerStreamRateLimit }}MB
+    {{- end }}
+    {{- if $l.PerStreamRateLimitBurst }}
+    per_stream_rate_limit_burst: {{ $l.PerStreamRateLimitBurst }}MB
+    {{- end }}
   {{- end -}}
   {{- if $l := $spec.QueryLimits -}}
     {{- if $l.MaxEntriesLimitPerQuery }}

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -235,12 +235,14 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 			Global: &lokiv1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1.IngestionLimitSpec{
 					// Defaults from Loki docs
-					IngestionRate:          4,
-					IngestionBurstSize:     6,
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					IngestionRate:           4,
+					IngestionBurstSize:      6,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs
@@ -287,12 +289,14 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 			Global: &lokiv1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1.IngestionLimitSpec{
 					// Defaults from Loki docs
-					IngestionRate:          4,
-					IngestionBurstSize:     6,
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					IngestionRate:           4,
+					IngestionBurstSize:      6,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs
@@ -344,10 +348,12 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 					IngestionBurstSize:        20,
 					MaxGlobalStreamsPerTenant: 10000,
 					// Defaults from Loki docs
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs
@@ -399,10 +405,12 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 					IngestionBurstSize:        20,
 					MaxGlobalStreamsPerTenant: 25000,
 					// Defaults from Loki docs
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes allow users to configure `PerStreamRateLimit` and `PerStreamRateLimitBurst` in `IngestionLimitSpec`.
This is needed for [Netobserv](https://github.com/netobserv) to increase the default values in some large clusters scenarios.

**Which issue(s) this PR fixes**:
None 

**Special notes for your reviewer**:
I have forced using `MB` unit for consistency with `ingestion_rate_mb`. 
Please let me know if you prefer to keep it flexible to any human readable forms (1MB, 256KB, etc).

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [X] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
