### PR TITLE
use tsdb version from period config in compactor

### DIFF
--- a/pkg/storage/stores/tsdb/compactor.go
+++ b/pkg/storage/stores/tsdb/compactor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -54,13 +53,11 @@ func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableN
 	}
 
 	if version != periodConfig.TSDBIndexVersion {
-		return nil, errors.New(
-			fmt.Sprintf(
-				"opened TSDB Index file with version %d that does not match the TSDBIndexVersion %d of the period config from %s",
-				version,
-				periodConfig.TSDBIndexVersion,
-				periodConfig.From,
-			),
+		return nil, fmt.Errorf(
+			"opened TSDB Index file with version %d that does not match the TSDBIndexVersion %d of the period config from %s",
+			version,
+			periodConfig.TSDBIndexVersion,
+			periodConfig.From,
 		)
 	}
 

--- a/pkg/storage/stores/tsdb/compactor_test.go
+++ b/pkg/storage/stores/tsdb/compactor_test.go
@@ -573,7 +573,9 @@ func TestCompactor_Compact(t *testing.T) {
 						defer initializedIndexSetsMtx.Unlock()
 						initializedIndexSets[userID] = idxSet
 						return idxSet, nil
-					}, config.PeriodConfig{})
+					}, config.PeriodConfig{
+						TSDBIndexVersion: index.FormatV3,
+					})
 
 					require.NoError(t, tCompactor.CompactTable())
 

--- a/pkg/storage/stores/tsdb/index_client_test.go
+++ b/pkg/storage/stores/tsdb/index_client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/config"
 	index_shipper "github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
+	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 type mockIndexShipperIndexIterator struct {
@@ -55,7 +56,7 @@ func BenchmarkIndexClient_Stats(b *testing.B) {
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartToday), int64(indexStartToday+99)),
 				},
-			}),
+			}, index.FormatV3),
 		},
 
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartYesterday): {
@@ -64,7 +65,7 @@ func BenchmarkIndexClient_Stats(b *testing.B) {
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartYesterday), int64(indexStartYesterday+99)),
 				},
-			}),
+			}, index.FormatV3),
 		},
 	}
 
@@ -113,7 +114,7 @@ func TestIndexClient_Stats(t *testing.T) {
 					Labels: mustParseLabels(`{fizz="buzz"}`),
 					Chunks: buildChunkMetas(int64(indexStartToday), int64(indexStartToday+99), 10),
 				},
-			}),
+			}, index.FormatV3),
 		},
 
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartYesterday): {
@@ -130,7 +131,7 @@ func TestIndexClient_Stats(t *testing.T) {
 					Labels: mustParseLabels(`{ping="pong"}`),
 					Chunks: buildChunkMetas(int64(indexStartYesterday), int64(indexStartYesterday+99), 10),
 				},
-			}),
+			}, index.FormatV3),
 		},
 	}
 

--- a/pkg/storage/stores/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/tsdb/multi_file_index_test.go
@@ -61,7 +61,7 @@ func TestMultiIndex(t *testing.T) {
 	var indices []Index
 	dir := t.TempDir()
 	for i := 0; i < n; i++ {
-		indices = append(indices, BuildIndex(t, dir, cases))
+		indices = append(indices, BuildIndex(t, dir, cases, index.FormatV3))
 	}
 
 	idx := NewMultiIndex(IndexSlice(indices))

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -109,6 +109,27 @@ func (f *TSDBFile) Reader() (io.ReadSeeker, error) {
 	return f.getRawFileReader()
 }
 
+func (f *TSDBFile) Version() (int, error) {
+	r, err := f.getRawFileReader()
+	if err != nil {
+		return 0, err
+	}
+
+  // index.MagicIndex is 4 bytes, version is after that
+	_, err = r.Seek(4, io.SeekStart)
+	if err != nil {
+		return 0, err
+	}
+
+	version := make([]byte, 1)
+	_, err = r.Read(version)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(version[0]), nil
+}
+
 // nolint
 // TSDBIndex is backed by an IndexReader
 // and translates the IndexReader to an Index implementation

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -115,7 +115,7 @@ func (f *TSDBFile) Version() (int, error) {
 		return 0, err
 	}
 
-  // index.MagicIndex is 4 bytes, version is after that
+	// index.MagicIndex is 4 bytes, version is after that
 	_, err = r.Seek(4, io.SeekStart)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/stores/tsdb/util_test.go
+++ b/pkg/storage/stores/tsdb/util_test.go
@@ -17,8 +17,8 @@ type LoadableSeries struct {
 	Chunks index.ChunkMetas
 }
 
-func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
-	b := NewBuilder(index.LiveFormat)
+func BuildIndex(t testing.TB, dir string, cases []LoadableSeries, version int) *TSDBFile {
+	b := NewBuilder(version)
 
 	for _, s := range cases {
 		b.AddSeries(s.Labels, model.Fingerprint(s.Labels.Hash()), s.Chunks)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is PR 3/3 to move TSDB index versions into schema config. This PR makes the compactor respect the TSDB index version from the period config when compacting indexes for that period

**Which issue(s) this PR fixes**:
Fixes #9565 

**Special notes for your reviewer**:

The full functionality of supporting TSDB index versions in the schema/period config is enabled via 3 PRs. Each PR can be reviewed and merged independently.

[1/3] https://github.com/grafana/loki/pull/9566
[2/3] https://github.com/grafana/loki/pull/9590
[3/3] https://github.com/grafana/loki/pull/9633

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
