### PR TITLE
Update CONTRIBUTING.md to point to the new location of the contributi…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Loki uses GitHub to manage reviews of pull requests:
 
 Before creating a large pull request to change or add functionality, please create a _Loki Improvement Document (LID)_. We use LIDs to discuss and vet ideas submitted by maintainers or the community in an open and transparent way. As of Jan 2023, we are starting with a lightweight LID process and we may add more structure, inspired by Python's [PEP](https://peps.python.org/pep-0001/) and Kafka's [KIP](https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Improvement+Proposals) approaches.
 
-LIDs must be created as a pull request using [this template](docs/sources/lids/template.md).
+LIDs must be created as a pull request using [this template](docs/sources/community/lids/template.md).
 
 ## Pull Request Prerequisites/Checklist
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating CONTRIBUTING document to point to the location of the LID template, which has moved

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
doc change only

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
