### PR TITLE
Distributor: Make  key configurable when logging failures

### DIFF
--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -489,6 +489,11 @@ write_failures_logging:
   # Default: 1KB.
   # CLI flag: -distributor.write-failures-logging.rate
   [rate: <int> | default = 1KB]
+
+  # Experimental and subject to change. Whether a insight=true key should be
+  # logged or not. Default: false.
+  # CLI flag: -distributor.write-failures-logging.add-insights-label
+  [add_insights_label: <boolean> | default = false]
 ```
 
 ### querier

--- a/pkg/distributor/writefailures/cfg.go
+++ b/pkg/distributor/writefailures/cfg.go
@@ -8,10 +8,14 @@ import (
 
 type Cfg struct {
 	LogRate flagext.ByteSize `yaml:"rate" category:"experimental"`
+
+	AddInsightsLabel bool `yaml:"add_insights_label" category:"experimental"`
 }
 
 // RegisterFlags registers distributor-related flags.
 func (cfg *Cfg) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
 	_ = cfg.LogRate.Set("1KB")
 	fs.Var(&cfg.LogRate, prefix+".rate", "Experimental and subject to change. Log volume allowed (per second). Default: 1KB.")
+
+	fs.BoolVar(&cfg.AddInsightsLabel, prefix+".add-insights-label", false, "Experimental and subject to change. Whether a insight=true key should be logged or not. Default: false.")
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -17,7 +17,10 @@ type Manager struct {
 }
 
 func NewManager(logger log.Logger, cfg Cfg, tenants *runtime.TenantConfigs) *Manager {
-	logger = log.With(logger, "path", "write", "insight", "true")
+	logger = log.With(logger, "path", "write")
+	if cfg.AddInsightsLabel {
+		logger = log.With(logger, "insight", "true")
+	}
 
 	strat := newStrategy(cfg.LogRate.Val(), float64(cfg.LogRate.Val()))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make appending `insight=true` key-value pair to log failures configurable.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
