### PR TITLE
Correctly propagates ctx used by spans

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -104,9 +104,9 @@ func (q *IngesterQuerier) forGivenIngesters(ctx context.Context, replicationSet 
 }
 
 func (q *IngesterQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) ([]iter.EntryIterator, error) {
-	resps, err := q.forAllIngesters(ctx, func(_ context.Context, client logproto.QuerierClient) (interface{}, error) {
-		stats.FromContext(ctx).AddIngesterReached(1)
-		return client.Query(ctx, params.QueryRequest)
+	resps, err := q.forAllIngesters(ctx, func(innerCtx context.Context, client logproto.QuerierClient) (interface{}, error) {
+		stats.FromContext(innerCtx).AddIngesterReached(1)
+		return client.Query(innerCtx, params.QueryRequest)
 	})
 	if err != nil {
 		return nil, err
@@ -120,9 +120,9 @@ func (q *IngesterQuerier) SelectLogs(ctx context.Context, params logql.SelectLog
 }
 
 func (q *IngesterQuerier) SelectSample(ctx context.Context, params logql.SelectSampleParams) ([]iter.SampleIterator, error) {
-	resps, err := q.forAllIngesters(ctx, func(_ context.Context, client logproto.QuerierClient) (interface{}, error) {
-		stats.FromContext(ctx).AddIngesterReached(1)
-		return client.QuerySample(ctx, params.SampleQueryRequest)
+	resps, err := q.forAllIngesters(ctx, func(innerCtx context.Context, client logproto.QuerierClient) (interface{}, error) {
+		stats.FromContext(innerCtx).AddIngesterReached(1)
+		return client.QuerySample(innerCtx, params.SampleQueryRequest)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -544,7 +544,7 @@ func (Codec) DecodeResponse(ctx context.Context, r *http.Response, req queryrang
 }
 
 func (Codec) EncodeResponse(ctx context.Context, res queryrangebase.Response) (*http.Response, error) {
-	sp, _ := opentracing.StartSpanFromContext(ctx, "codec.EncodeResponse")
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "codec.EncodeResponse")
 	defer sp.Finish()
 	var buf bytes.Buffer
 

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -42,7 +42,7 @@ func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, thro
 	if ctx.Err() != nil {
 		return nil, nil, ctx.Err()
 	}
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "GetChunkRefs")
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "storeEntry.GetChunkRefs")
 	defer sp.Finish()
 	log := spanlogger.FromContext(ctx)
 	defer log.Span.Finish()

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -85,7 +85,7 @@ func NewIndexGateway(cfg Config, log log.Logger, registerer prometheus.Registere
 }
 
 func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logproto.IndexGateway_QueryIndexServer) error {
-	log, _ := spanlogger.New(context.Background(), "IndexGateway.QueryIndex")
+	log, ctx := spanlogger.New(server.Context(), "IndexGateway.QueryIndex")
 	defer log.Finish()
 
 	var outerErr, innerErr error
@@ -127,7 +127,7 @@ func (g *Gateway) QueryIndex(request *logproto.QueryIndexRequest, server logprot
 			continue
 		}
 
-		outerErr = indexClient.QueryPages(server.Context(), queries[start:end], func(query seriesindex.Query, batch seriesindex.ReadBatchResult) bool {
+		outerErr = indexClient.QueryPages(ctx, queries[start:end], func(query seriesindex.Query, batch seriesindex.ReadBatchResult) bool {
 			innerErr = buildResponses(query, batch, func(response *logproto.QueryIndexResponse) error {
 				// do not send grpc responses concurrently. See https://github.com/grpc/grpc-go/blob/master/stream.go#L120-L123.
 				sendBatchMtx.Lock()

--- a/pkg/util/httpgrpc/carrier.go
+++ b/pkg/util/httpgrpc/carrier.go
@@ -1,6 +1,8 @@
 package httpgrpc
 
 import (
+	"errors"
+
 	"github.com/opentracing/opentracing-go"
 	weaveworks_httpgrpc "github.com/weaveworks/common/httpgrpc"
 )
@@ -33,7 +35,7 @@ func GetParentSpanForRequest(tracer opentracing.Tracer, req *weaveworks_httpgrpc
 
 	carrier := (*HeadersCarrier)(req)
 	extracted, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
-	if err == opentracing.ErrSpanContextNotFound {
+	if errors.Is(err, opentracing.ErrSpanContextNotFound) {
 		err = nil
 	}
 	return extracted, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify several places to correctly propagates ctx used internally to generate spans

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
