### PR TITLE
Update doc-validator to v3.0.0

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -16,7 +16,6 @@ jobs:
       - name: "Run doc-validator tool"
         run: >
           doc-validator
-          --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
          '--skip-checks=^image'
           ./docs/sources
           /docs/loki/latest

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -11,9 +11,12 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
       - name: "Run doc-validator"
         run: |
           doc-validator \
+            "--include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")" \
             '--skip-checks=^image' \
             docs/sources \
             /docs/loki/latest \

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
         with:
-          fetch-depth: 0
+          fetch-depth: "0"
       - name: "Run doc-validator tool"
         run: >
           doc-validator

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -11,20 +11,17 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
-        with:
-          fetch-depth: "0"
-      - name: "Run doc-validator tool"
-        run: >
-          doc-validator
-          --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
-         '--skip-checks=^image'
-          ./docs/sources
-          /docs/loki/latest
-          | reviewdog
-          -f=rdjsonl
-          --fail-on-error
-          --filter-mode=nofilter
-          --name=doc-validator
-          --reporter=github-pr-review
+      - name: "Run doc-validator"
+        run: |
+          doc-validator \
+            '--skip-checks=^image' \
+            docs/sources \
+            /docs/loki/latest \
+            | reviewdog \
+              -f=rdjsonl \
+              --fail-on-error \
+              --filter-mode=nofilter \
+              --name=doc-validator \
+              --reporter=github-pr-review
         env:
           REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v1.9.0"
+      image: "grafana/doc-validator:v3.0.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
@@ -17,6 +17,14 @@ jobs:
         run: >
           doc-validator
           --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
-          --skip-image-validation
+         '--skip-checks=^image'
           ./docs/sources
           /docs/loki/latest
+          | reviewdog
+          -f=rdjsonl
+          --fail-on-error
+          --filter-mode=nofilter
+          --name=doc-validator
+          --reporter=github-pr-review
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -16,6 +16,7 @@ jobs:
       - name: "Run doc-validator tool"
         run: >
           doc-validator
+          --include=$(git config --global --add safe.directory $(realpath .); printf '^docs/sources/(%s)$' "$(git --no-pager diff --name-only --diff-filter=ACMRT origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} -- docs/sources | sed 's/^docs\/sources\///' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "|"$0}}')")
          '--skip-checks=^image'
           ./docs/sources
           /docs/loki/latest

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -1,3 +1,5 @@
+# The source of this file is https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk.
+# 3.0.0 (2023-05-18)
 include variables.mk
 -include variables.mk.local
 
@@ -52,6 +54,11 @@ ifeq ($(origin DOC_VALIDATOR_IMAGE), undefined)
 export DOC_VALIDATOR_IMAGE := grafana/doc-validator:latest
 endif
 
+# Container image used for vale linting.
+ifeq ($(origin VALE_IMAGE), undefined)
+export VALE_IMAGE := grafana/vale:latest
+endif
+
 # PATH-like list of directories within which to find projects.
 # If all projects are checked out into the same directory, ~/repos/ for example, then the default should work.
 ifeq ($(origin REPOS_PATH), undefined)
@@ -91,10 +98,10 @@ docs-no-pull: make-docs
 .PHONY: docs-debug
 docs-debug: ## Run Hugo web server with debugging enabled. TODO: support all SERVER_FLAGS defined in website Makefile.
 docs-debug: make-docs
-	WEBSITE_EXEC='hugo server --debug' $(PWD)/make-docs $(PROJECTS)
+	WEBSITE_EXEC='hugo server --bind 0.0.0.0 --port 3002 --debug' $(PWD)/make-docs $(PROJECTS)
 
 .PHONY: doc-validator
-doc-validator: ## Run docs-validator on the entire docs folder.
+doc-validator: ## Run doc-validator on the entire docs folder.
 doc-validator: make-docs
 	DOCS_IMAGE=$(DOC_VALIDATOR_IMAGE) $(PWD)/make-docs $(PROJECTS)
 
@@ -102,6 +109,11 @@ doc-validator: make-docs
 doc-validator/%: ## Run doc-validator on a specific path. To lint the path /docs/sources/administration, run 'make doc-validator/administration'.
 doc-validator/%: make-docs
 	DOCS_IMAGE=$(DOC_VALIDATOR_IMAGE) DOC_VALIDATOR_INCLUDE=$(subst doc-validator/,,$@) $(PWD)/make-docs $(PROJECTS)
+
+.PHONY: vale
+vale: ## Run vale on the entire docs folder.
+vale: make-docs
+	DOCS_IMAGE=$(VALE_IMAGE) $(PWD)/make-docs $(PROJECTS)
 
 .PHONY: update
 update: ## Fetch the latest version of this Makefile and the `make-docs` script from Writers' Toolkit.

--- a/docs/make-docs
+++ b/docs/make-docs
@@ -1,5 +1,6 @@
 #!/bin/sh
 # The source of this file is https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs.
+# 3.0.0 (2023-05-18)
 
 set -ef
 
@@ -8,9 +9,11 @@ readonly DOCS_HOST_PORT="${DOCS_HOST_PORT:-3002}"
 readonly DOCS_IMAGE="${DOCS_IMAGE:-grafana/docs-base:latest}"
 
 readonly DOC_VALIDATOR_INCLUDE="${DOC_VALIDATOR_INCLUDE:-.+\.md$}"
+readonly DOC_VALIDATOR_SKIP_CHECKS="${DOC_VALIDATOR_SKIP_CHECKS:-^image-}"
 
 readonly HUGO_REFLINKSERRORLEVEL="${HUGO_REFLINKSERRORLEVEL:-WARNING}"
-readonly WEBSITE_EXEC="${WEBSITE_EXEC:-make server}"
+readonly VALE_MINALERTLEVEL="${VALE_MINALERTLEVEL:-error}"
+readonly WEBSITE_EXEC="${WEBSITE_EXEC:-make server-docs}"
 # If set, the docs-base image will run a prebuild script that sets up Hugo mounts.
 readonly WEBSITE_MOUNTS="${WEBSITE_MOUNTS:-}"
 
@@ -59,8 +62,11 @@ fi
 SOURCES_as_code='as-code-docs'
 SOURCES_enterprise_metrics='backend-enterprise'
 SOURCES_enterprise_metrics_='backend-enterprise'
-SOURCES_grafana_cloud='cloud-docs'
+SOURCES_grafana_cloud='website'
 SOURCES_grafana_cloud_k6='k6-docs'
+SOURCES_grafana_cloud_data_configuration_integrations='cloud-onboarding'
+SOURCES_grafana_cloud_frontend_observability_faro_web_sdk='faro-web-sdk'
+SOURCES_grafana_cloud_machine_learning='machine-learning'
 SOURCES_helm_charts_mimir_distributed='mimir'
 SOURCES_helm_charts_tempo_distributed='tempo'
 SOURCES_opentelemetry='opentelemetry-docs'
@@ -68,14 +74,20 @@ SOURCES_opentelemetry='opentelemetry-docs'
 VERSIONS_as_code='UNVERSIONED'
 VERSIONS_grafana_cloud='UNVERSIONED'
 VERSIONS_grafana_cloud_k6='UNVERSIONED'
+VERSIONS_grafana_cloud_data_configuration_integrations='UNVERSIONED'
+VERSIONS_grafana_cloud_frontend_observability_faro_web_sdk='UNVERSIONED'
+VERSIONS_grafana_cloud_machine_learning='UNVERSIONED'
 VERSIONS_opentelemetry='UNVERSIONED'
 VERSIONS_technical_documentation='UNVERSIONED'
+VERSIONS_website='UNVERSIONED'
 VERSIONS_writers_toolkit='UNVERSIONED'
 
+PATHS_grafana_cloud='content/docs/grafana-cloud'
 PATHS_helm_charts_mimir_distributed='docs/sources/helm-charts/mimir-distributed'
 PATHS_helm_charts_tempo_distributed='docs/sources/helm-charts/tempo-distributed'
 PATHS_mimir='docs/sources/mimir'
 PATHS_tempo='docs/sources/tempo'
+PATHS_website='content/docs'
 
 # identifier STR
 # Replace characters that are not valid in an identifier with underscores.
@@ -138,6 +150,13 @@ proj_url() {
 $1
 POSIX_HERESTRING
 
+  if [ "${_project}" = 'website' ]; then
+    echo "http://localhost:${DOCS_HOST_PORT}/docs/"
+
+    unset _project _version
+    return
+  fi
+
   if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
     echo "http://localhost:${DOCS_HOST_PORT}/docs/${_project}/"
   else
@@ -165,12 +184,41 @@ proj_dst() {
 $1
 POSIX_HERESTRING
 
+  if [ "${_project}" = 'website' ]; then
+    echo '/hugo/content/docs'
+
+    unset _project _version
+    return
+  fi
+
   if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
     echo "/hugo/content/docs/${_project}"
   else
     echo "/hugo/content/docs/${_project}/${_version}"
   fi
+
   unset _project _version
+}
+
+# repo_path returns the host path to the project repository.
+# It looks for the provided repository name in each of the paths specified in the REPOS_PATH environment variable.
+repo_path() {
+  _repo="$1"
+  IFS=:
+  for lookup in ${REPOS_PATH}; do
+    if [ -d "${lookup}/${_repo}" ]; then
+      echo "${lookup}/${_repo}"
+      unset _path _repo
+      return
+    fi
+  done
+  unset IFS
+
+  echo "ERRR: could not find project '${_repo}' in any of the paths in REPOS_PATH '${REPOS_PATH}'." >&2
+  echo "NOTE: you must have a checkout of the project '${_repo}' at '${REPOS_PATH##:*}/${_repo}'." >&2
+  echo "NOTE: if you have cloned the repository into a directory with a different name, consider changing it to ${_repo}." >&2
+  unset _repo
+  exit 1
 }
 
 # proj_src returns the host path to content source for a project.
@@ -181,21 +229,10 @@ proj_src() {
 $1
 POSIX_HERESTRING
 
-  IFS=:
-  for lookup in ${REPOS_PATH}; do
-    if [ -d "${lookup}/${_repo}" ]; then
-      echo "${lookup}/${_repo}/${_path}"
-      unset _path _repo
-      return
-    fi
-  done
-  unset IFS
+  _repo="$(repo_path "${_repo}")"
+  echo "${_repo}/${_path}"
 
-  echo "ERRR: could not find project '${_repo}' in any of the paths in REPOS_PATH '${REPOS_PATH}'." >&2
-  echo "NOTE: you must have a checkout of the project '${_repo}' at '${REPOS_PATH##:*}/${_repo}'." >&2
-  echo "NOTE: if you have cloned the repository into a directory with a different name, consider changing it to ${_repo}." >&2
   unset _path _repo
-  exit 1
 }
 
 # proj_canonical returns the canonical absolute path partial URI for a project.
@@ -205,11 +242,19 @@ proj_canonical() {
 $1
 POSIX_HERESTRING
 
+  if [ "${_project}" = 'website' ]; then
+    echo '/docs'
+
+    unset _project _version
+    return
+  fi
+
   if [ -z "${_version}" ] || [ "${_version}" = 'UNVERSIONED' ]; then
     echo "/docs/${_project}"
   else
     echo "/docs/${_project}/${_version}"
   fi
+
   unset _project _version
 }
 
@@ -262,6 +307,17 @@ url_src_dst_vers="$(url_src_dst_vers "$@")"
 volumes=""
 redirects=""
 
+for arg in "$@"; do
+  IFS=: read -r _project _ _repo _ <<POSIX_HERESTRING
+${arg}
+POSIX_HERESTRING
+  if [ "${_project}" = website ]; then
+    _repo="$(repo_path website)"
+    volumes="--volume=${_repo}/config:/hugo/config"
+  fi
+  unset _project _repo
+done
+
 for x in ${url_src_dst_vers}; do
   IFS='^' read -r _url _src _dst _ver <<POSIX_HERESTRING
 $x
@@ -296,30 +352,57 @@ IFS=':' read -r image _ <<POSIX_HERESTRING
 ${DOCS_IMAGE}
 POSIX_HERESTRING
 
-if [ "${image}" = "grafana/doc-validator" ]; then
-  echo
-  "${PODMAN}" run \
-    --init \
-    --interactive \
-    --name "${DOCS_CONTAINER}" \
-    --platform linux/amd64 \
-    --rm \
-    --tty \
-    ${volumes} \
-    "${DOCS_IMAGE}" \
-    --skip-image-validation \
-    --include="${DOC_VALIDATOR_INCLUDE}" \
-    /hugo/content/docs \
-    "$(proj_canonical "$(new_proj "$1")")"
-else
-
-  tempfile="$(mktemp -t make-docs.XXX)"
-  cat <<EOF >"${tempfile}"
+case "${image}" in
+  'grafana/doc-validator')
+    proj="$(new_proj "$1")"
+    echo
+    "${PODMAN}" run \
+      --init \
+      --interactive \
+      --name "${DOCS_CONTAINER}" \
+      --platform linux/amd64 \
+      --rm \
+      --tty \
+      ${volumes} \
+      "${DOCS_IMAGE}" \
+      --include="${DOC_VALIDATOR_INCLUDE}" \
+      --skip-checks="${DOC_VALIDATOR_SKIP_CHECKS}" \
+      /hugo/content/docs \
+      "$(proj_canonical "${proj}")" | sed "s#$(proj_dst "${proj}")#sources#"
+    ;;
+  'grafana/vale')
+    proj="$(new_proj "$1")"
+    echo
+    "${PODMAN}" run \
+      --init \
+      --interactive \
+      --name "${DOCS_CONTAINER}" \
+      --platform linux/amd64 \
+      --rm \
+      --tty \
+      ${volumes} \
+      "${DOCS_IMAGE}" \
+      --minAlertLevel="${VALE_MINALERTLEVEL}" \
+      --config=/etc/vale/.vale.ini \
+      --output=line \
+      /hugo/content/docs | sed "s#$(proj_dst "${proj}")#sources#"
+    ;;
+  *)
+    tempfile="$(mktemp -t make-docs.XXX)"
+    cat <<EOF >"${tempfile}"
 #!/usr/bin/env bash
 for redirect in ${redirects}; do
   IFS='^' read -r path ver <<<"\${redirect}"
   echo -e "---\\nredirectURL: \"\${path/\/hugo\/content/}\"\\ntype: redirect\\n---\\n" > "\${path/\${ver}/_index.md}"
+done
 
+for x in "${url_src_dst_vers}"; do
+  IFS='^' read -r _ _ dst _ <<<"\${x}"
+
+  while [[ -n "\${dst}" ]]; do
+    touch "\${dst}/_index.md"
+    dst="\${dst%/*}"
+  done
 done
 
 if [[ -n "${WEBSITE_MOUNTS}" ]]; then
@@ -328,34 +411,37 @@ fi
 
 ${WEBSITE_EXEC}
 EOF
-  chmod +x "${tempfile}"
-  volumes="${volumes} --volume=$(realpath "${tempfile}"):/entrypoint"
-  readonly volumes
+    chmod +x "${tempfile}"
+    volumes="${volumes} --volume=$(realpath "${tempfile}"):/entrypoint"
+    readonly volumes
 
-  echo
-  echo "Documentation will be served at the following URLs:"
-  for x in ${url_src_dst_vers}; do
-    IFS='^' read -r url _ _ <<POSIX_HERESTRING
+    echo
+    echo "Documentation will be served at the following URLs:"
+    for x in ${url_src_dst_vers}; do
+      IFS='^' read -r url _ _ <<POSIX_HERESTRING
 $x
 POSIX_HERESTRING
 
-    if [ -n "${url}" ]; then
-      echo "  ${url}"
-    fi
-  done
+      if [ -n "${url}" ]; then
+        if [ "${_url}" != "arbitrary" ]; then
+          echo "  ${url}"
+        fi
+      fi
+    done
 
-  echo
-  "${PODMAN}" run \
-    --env "HUGO_REFLINKSERRORLEVEL=${HUGO_REFLINKSERRORLEVEL}" \
-    --init \
-    --interactive \
-    --name "${DOCS_CONTAINER}" \
-    --platform linux/amd64 \
-    --publish "${DOCS_HOST_PORT}:3002" \
-    --publish "3003:3003" \
-    --rm \
-    --tty \
-    ${volumes} \
-    "${DOCS_IMAGE}" \
-    /entrypoint
-fi
+    echo
+    "${PODMAN}" run \
+      --env "HUGO_REFLINKSERRORLEVEL=${HUGO_REFLINKSERRORLEVEL}" \
+      --init \
+      --interactive \
+      --name "${DOCS_CONTAINER}" \
+      --platform linux/amd64 \
+      --publish "${DOCS_HOST_PORT}:3002" \
+      --publish "3003:3003" \
+      --rm \
+      --tty \
+      ${volumes} \
+      "${DOCS_IMAGE}" \
+      /entrypoint
+    ;;
+esac

--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -133,11 +133,11 @@ ruler:
       url: http://localhost:9090/api/v1/write
 ```
 
-Further configuration options can be found under [ruler]({{<relref "../configuration#ruler">}}).
+Further configuration options can be found under [ruler]({{< relref "../configuration#ruler" >}}).
 
 ### Operations
 
-Please refer to the [Recording Rules]({{<relref "../operations/recording-rules">}}) page.
+Please refer to the [Recording Rules]({{< relref "../operations/recording-rules" >}}) page.
 
 ## Use cases
 
@@ -241,7 +241,7 @@ jobs:
 
 One option to scale the Ruler is by scaling it horizontally. However, with multiple Ruler instances running they will need to coordinate to determine which instance will evaluate which rule. Similar to the ingesters, the Rulers establish a hash ring to divide up the responsibilities of evaluating rules.
 
-The possible configurations are listed fully in the [configuration documentation]({{<relref "../configuration">}}), but in order to shard rules across multiple Rulers, the rules API must be enabled via flag (`-ruler.enable-api`) or config file parameter. Secondly, the Ruler requires its own ring to be configured. From there the Rulers will shard and handle the division of rules automatically. Unlike ingesters, Rulers do not hand over responsibility: all rules are re-sharded randomly every time a Ruler is added to or removed from the ring.
+The possible configurations are listed fully in the [configuration documentation]({{< relref "../configuration" >}}), but in order to shard rules across multiple Rulers, the rules API must be enabled via flag (`-ruler.enable-api`) or config file parameter. Secondly, the Ruler requires its own ring to be configured. From there the Rulers will shard and handle the division of rules automatically. Unlike ingesters, Rulers do not hand over responsibility: all rules are re-sharded randomly every time a Ruler is added to or removed from the ring.
 
 A full sharding-enabled Ruler example is:
 
@@ -266,7 +266,7 @@ ruler:
 
 The Ruler supports the following types of storage: `azure`, `gcs`, `s3`, `swift`, `cos` and `local`. Most kinds of storage work with the sharded Ruler configuration in an obvious way, that is, configure all Rulers to use the same backend.
 
-The local implementation reads the rule files off of the local filesystem. This is a read-only backend that does not support the creation and deletion of rules through the [Ruler API]({{<relref "../reference/api/#ruler">}}). Despite the fact that it reads the local filesystem this method can still be used in a sharded Ruler configuration if the operator takes care to load the same rules to every Ruler. For instance, this could be accomplished by mounting a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) onto every Ruler pod.
+The local implementation reads the rule files off of the local filesystem. This is a read-only backend that does not support the creation and deletion of rules through the [Ruler API]({{< relref "../reference/api#ruler" >}}). Despite the fact that it reads the local filesystem this method can still be used in a sharded Ruler configuration if the operator takes care to load the same rules to every Ruler. For instance, this could be accomplished by mounting a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) onto every Ruler pod.
 
 A typical local configuration might look something like:
 ```

--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -87,7 +87,7 @@ We support [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/
 
 > Querying the precomputed result will then often be much faster than executing the original expression every time it is needed. This is especially useful for dashboards, which need to query the same expression repeatedly every time they refresh.
 
-Loki allows you to run [metric queries]({{< relref "../query/metric_queries" >}}) over your logs, which means
+Loki allows you to run [metric queries]({{<relref "../query/metric_queries">}}) over your logs, which means
 that you can derive a numeric aggregation from your logs, like calculating the number of requests over time from your NGINX access log.
 
 ### Example

--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -87,7 +87,7 @@ We support [Prometheus-compatible](https://prometheus.io/docs/prometheus/latest/
 
 > Querying the precomputed result will then often be much faster than executing the original expression every time it is needed. This is especially useful for dashboards, which need to query the same expression repeatedly every time they refresh.
 
-Loki allows you to run [metric queries]({{<relref "../query/metric_queries">}}) over your logs, which means
+Loki allows you to run [metric queries]({{< relref "../query/metric_queries" >}}) over your logs, which means
 that you can derive a numeric aggregation from your logs, like calculating the number of requests over time from your NGINX access log.
 
 ### Example

--- a/docs/sources/best-practices/_index.md
+++ b/docs/sources/best-practices/_index.md
@@ -70,7 +70,7 @@ Loki can cache data at many levels, which can drastically improve performance. D
 
 ## Time ordering of logs
 
-Loki [accepts out-of-order writes]({{< relref "../configuration/#accept-out-of-order-writes" >}}) _by default_.
+Loki [accepts out-of-order writes]({{< relref "../configuration#accept-out-of-order-writes" >}}) _by default_.
 This section identifies best practices when Loki is _not_ configured to accept out-of-order writes.
 
 One issue many people have with Loki is their client receiving errors for out of order log entries.  This happens because of this hard and fast rule within Loki:

--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -7,16 +7,16 @@ weight: 600
 
 Grafana Loki supports the following official clients for sending logs:
 
-- [Promtail]({{<relref "promtail">}})
-- [Docker Driver]({{<relref "docker-driver">}})
-- [Fluentd]({{<relref "fluentd">}})
-- [Fluent Bit]({{<relref "fluentbit">}})
-- [Logstash]({{<relref "logstash">}})
-- [Lambda Promtail]({{<relref "lambda-promtail">}})
+- [Promtail]({{< relref "./promtail" >}})
+- [Docker Driver]({{< relref "./docker-driver" >}})
+- [Fluentd]({{< relref "./fluentd" >}})
+- [Fluent Bit]({{< relref "./fluentbit" >}})
+- [Logstash]({{< relref "./logstash" >}})
+- [Lambda Promtail]({{< relref "./lambda-promtail" >}})
 
 There are also a number of third-party clients, see [Unofficial clients](#unofficial-clients).
 
-The [xk6-loki extension](https://github.com/grafana/xk6-loki) permits [load testing Loki]({{<relref "k6">}}).
+The [xk6-loki extension](https://github.com/grafana/xk6-loki) permits [load testing Loki]({{< relref "./k6" >}}).
 
 ## Picking a client
 
@@ -59,7 +59,7 @@ By adding our output plugin you can quickly try Loki without doing big configura
 
 ### Lambda Promtail
 
-This is a workflow combining the Promtail push-api [scrape config]({{<relref "promtail/configuration#loki_push_api">}}) and the [lambda-promtail]({{<relref "lambda-promtail">}}) AWS Lambda function which pipes logs from Cloudwatch to Loki.
+This is a workflow combining the Promtail push-api [scrape config]({{< relref "./promtail/configuration#loki_push_api" >}}) and the [lambda-promtail]({{< relref "./lambda-promtail" >}}) AWS Lambda function which pipes logs from Cloudwatch to Loki.
 
 This is a good choice if you're looking to try out Loki in a low-footprint way or if you wish to monitor AWS lambda logs in Loki.
 

--- a/docs/sources/clients/aws/_index.md
+++ b/docs/sources/clients/aws/_index.md
@@ -6,6 +6,6 @@ weight: 30
 
 Sending logs from AWS services to Grafana Loki is a little different depending on what AWS service you are using:
 
-* [Elastic Compute Cloud (EC2)]({{<relref "./ec2/_index.md">}})
-* [Elastic Container Service (ECS)]({{<relref "./ecs/_index.md">}})
-* [Elastic Kubernetes Service (EKS)]({{<relref "./eks/_index.md">}})
+* [Elastic Compute Cloud (EC2)]({{< relref "./ec2" >}})
+* [Elastic Container Service (ECS)]({{< relref "./ecs" >}})
+* [Elastic Kubernetes Service (EKS)]({{< relref "./eks" >}})

--- a/docs/sources/clients/aws/ec2/_index.md
+++ b/docs/sources/clients/aws/ec2/_index.md
@@ -4,7 +4,7 @@ description: Running Promtail on AWS EC2
 ---
 # EC2
 
-In this tutorial we're going to setup [Promtail]({{< relref "../../promtail/" >}}) on an AWS EC2 instance and configure it to sends all its logs to a Grafana Loki instance.
+In this tutorial we're going to setup [Promtail]({{< relref "../../promtail" >}}) on an AWS EC2 instance and configure it to sends all its logs to a Grafana Loki instance.
 
 <!-- TOC -->
 
@@ -48,7 +48,7 @@ aws ec2 create-security-group --group-name promtail-ec2  --description "promtail
 }
 ```
 
-Now let's authorize inbound access for SSH and [Promtail]({{< relref "../../promtail/" >}}) server:
+Now let's authorize inbound access for SSH and [Promtail]({{< relref "../../promtail" >}}) server:
 
 ```bash
 aws ec2 authorize-security-group-ingress --group-id sg-02c489bbdeffdca1d --protocol tcp --port 22 --cidr 0.0.0.0/0
@@ -88,7 +88,7 @@ ssh ec2-user@ec2-13-59-62-37.us-east-2.compute.amazonaws.com
 ## Setting up Promtail
 
 First let's make sure we're running as root by using `sudo -s`.
-Next we'll download, install and give executable right to [Promtail]({{< relref "../../promtail/" >}}).
+Next we'll download, install and give executable right to [Promtail]({{< relref "../../promtail" >}}).
 
 ```bash
 mkdir /opt/promtail && cd /opt/promtail
@@ -97,7 +97,7 @@ unzip "promtail-linux-amd64.zip"
 chmod a+x "promtail-linux-amd64"
 ```
 
-Now we're going to download the [Promtail configuration]({{< relref "../../promtail/" >}}) file below and edit it, don't worry we will explain what those means.
+Now we're going to download the [Promtail configuration]({{< relref "../../promtail" >}}) file below and edit it, don't worry we will explain what those means.
 The file is also available as a gist at [cyriltovena/promtail-ec2.yaml][config gist].
 
 ```bash
@@ -144,7 +144,7 @@ The **server** section indicates Promtail to bind his http server to 3100. Promt
 
 The **clients** section allow you to target your loki instance, if you're using GrafanaCloud simply replace `<user id>` and `<api secret>` with your credentials. Otherwise just replace the whole URL with your custom Loki instance.(e.g `http://my-loki-instance.my-org.com/loki/api/v1/push`)
 
-[Promtail]({{< relref "../../promtail/" >}}) uses the same [Prometheus **scrape_configs**][prometheus scrape config]. This means if you already own a Prometheus instance the config will be very similar and easy to grasp.
+[Promtail]({{< relref "../../promtail" >}}) uses the same [Prometheus **scrape_configs**][prometheus scrape config]. This means if you already own a Prometheus instance the config will be very similar and easy to grasp.
 
 Since we're running on AWS EC2 we want to uses EC2 service discovery, this will allows us to scrape metadata about the current instance (and even your custom tags) and attach those to our logs. This way managing and querying on logs will be much easier.
 
@@ -236,7 +236,7 @@ Jul 08 15:48:57 ip-172-31-45-69.us-east-2.compute.internal promtail-linux-amd64[
 Jul 08 15:48:57 ip-172-31-45-69.us-east-2.compute.internal promtail-linux-amd64[2732]: level=info ts=2020-07-08T15:48:57.56029474Z caller=main.go:67 msg="Starting Promtail" version="(version=1.6.0, branch=HEAD, revision=12c7eab8)"
 ```
 
-You can now verify in Grafana that Loki has correctly received your instance logs by using the [LogQL]({{< relref "../../../query/" >}}) query `{zone="us-east-2"}`.
+You can now verify in Grafana that Loki has correctly received your instance logs by using the [LogQL]({{< relref "../../../query" >}}) query `{zone="us-east-2"}`.
 
 ![Grafana Loki logs][ec2 logs]
 
@@ -265,7 +265,7 @@ Note that you can use [relabeling][relabeling] to convert systemd labels to matc
 
 That's it, save the config and you can `reboot` the machine (or simply restart the service `systemctl restart promtail.service`).
 
-Let's head back to Grafana and verify that your Promtail logs are available in Grafana by using the [LogQL]({{< relref "../../../query/" >}}) query `{unit="promtail.service"}` in Explore. Finally make sure to checkout [live tailing][live tailing] to see logs appearing as they are ingested in Loki.
+Let's head back to Grafana and verify that your Promtail logs are available in Grafana by using the [LogQL]({{< relref "../../../query" >}}) query `{unit="promtail.service"}` in Explore. Finally make sure to checkout [live tailing][live tailing] to see logs appearing as they are ingested in Loki.
 
 [promtail]: ../../promtail/README
 [aws cli]: https://aws.amazon.com/cli/

--- a/docs/sources/clients/aws/eks/_index.md
+++ b/docs/sources/clients/aws/eks/_index.md
@@ -52,7 +52,7 @@ Server Version: version.Info{Major:"1", Minor:"16+", GitVersion:"v1.16.8-eks-fd1
 
 ## Adding Promtail DaemonSet
 
-To ship all your pods logs we're going to set up [Promtail]({{< relref "../../promtail/" >}}) as a DaemonSet in our cluster. This means it will run on each nodes of the cluster, we will then configure it to find the logs of your containers on the host.
+To ship all your pods logs we're going to set up [Promtail]({{< relref "../../promtail" >}}) as a DaemonSet in our cluster. This means it will run on each nodes of the cluster, we will then configure it to find the logs of your containers on the host.
 
 What's nice about Promtail is that it uses the same [service discovery as Prometheus][prometheus conf], you should make sure the `scrape_configs` of Promtail matches the Prometheus one. Not only this is simpler to configure, but this also means Metrics and Logs will have the same metadata (labels) attached by the Prometheus service discovery. When querying Grafana you will be able to correlate metrics and logs very quickly, you can read more about this on our [blogpost][correlate].
 

--- a/docs/sources/clients/docker-driver/_index.md
+++ b/docs/sources/clients/docker-driver/_index.md
@@ -13,7 +13,7 @@ to a private Loki instance or [Grafana Cloud](/oss/loki).
 > [Docker Engine managed plugin system](https://docs.docker.com/engine/extend) documentation for more information.
 
 Documentation on configuring the Loki Docker Driver can be found on the
-[configuration page]({{<relref "configuration.md">}}).
+[configuration page]({{< relref "./configuration" >}}).
 
 If you have any questions or issues using the Docker plugin feel free to open an issue in this [repository](https://github.com/grafana/loki/issues).
 
@@ -37,7 +37,7 @@ ID                  NAME         DESCRIPTION           ENABLED
 ac720b8fcfdb        loki         Loki Logging Driver   true
 ```
 
-Once the plugin is installed it can be [configured]({{<relref "configuration.md">}}).
+Once the plugin is installed it can be [configured]({{< relref "./configuration" >}}).
 
 ## Upgrading
 
@@ -64,4 +64,4 @@ docker plugin rm loki
 
 The driver keeps all logs in memory and will drop log entries if Loki is not reachable and if the quantity of `max_retries` has been exceeded. To avoid the dropping of log entries, setting `max_retries` to zero allows unlimited retries; the drive will continue trying forever until Loki is again reachable. Trying forever may have undesired consequences, because the Docker daemon will wait for the Loki driver to process all logs of a container, until the container is removed. Thus, the Docker daemon might wait forever if the container is stuck.
 
-Use Promtail's [Docker target]({{<relref "../promtail/configuration/#docker">}}) or [Docker service discovery]({{<relref "../promtail/configuration/#docker_sd_config">}}) to avoid this issue.
+Use Promtail's [Docker target]({{< relref "../promtail/configuration#docker" >}}) or [Docker service discovery]({{< relref "../promtail/configuration#docker_sd_config" >}}) to avoid this issue.

--- a/docs/sources/clients/docker-driver/configuration.md
+++ b/docs/sources/clients/docker-driver/configuration.md
@@ -9,7 +9,7 @@ each container will use the default driver unless configured otherwise.
 
 ## Installation
 
-Before configuring the plugin, [install or upgrade the Grafana Loki Docker Driver Client]({{<relref "_index.md">}})
+Before configuring the plugin, [install or upgrade the Grafana Loki Docker Driver Client]({{< relref "../docker-driver" >}})
 
 ## Change the logging driver for a container
 
@@ -104,7 +104,7 @@ Once deployed, the Grafana service will send its logs to Loki.
 
 ## Labels
 
-Loki can received a set of labels along with log line. These labels are used to index log entries and query back logs using [LogQL stream selector]({{<relref "../../query/log_queries/#log-stream-selector">}}).
+Loki can received a set of labels along with log line. These labels are used to index log entries and query back logs using [LogQL stream selector]({{< relref "../../query/log_queries#log-stream-selector" >}}).
 
 By default, the Docker driver will add the following labels to each log line:
 
@@ -207,8 +207,8 @@ To specify additional logging driver options, you can use the --log-opt NAME=VAL
 | `loki-min-backoff`              |    No     |          `500ms`           | The minimum amount of time to wait before retrying a batch. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".                                                                                                                                                             |
 | `loki-max-backoff`              |    No     |            `5m`            | The maximum amount of time to wait before retrying a batch. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".                                                                                                                                                             |
 | `loki-retries`                  |    No     |            `10`            | The maximum amount of retries for a log batch. Setting it to `0` will retry indefinitely.                                                                                                                                                                                               |
-| `loki-pipeline-stage-file`      |    No     |                            | The location of a pipeline stage configuration file ([example](/grafana/loki/blob/main/clients/cmd/docker-driver/pipeline-example.yaml)). Pipeline stages allows to parse log lines to extract more labels, [see associated documentation]({{<relref "../promtail/stages/_index.md">}}). |
-| `loki-pipeline-stages`          |    No     |                            | The pipeline stage configuration provided as a string [see pipeline stages](#pipeline-stages) and [associated documentation]({{<relref "../promtail/stages/_index.md">}}).                                                                                                              |
+| `loki-pipeline-stage-file`      |    No     |                            | The location of a pipeline stage configuration file ([example](https://github.com/grafana/loki/blob/main/clients/cmd/docker-driver/pipeline-example.yaml)). Pipeline stages allows to parse log lines to extract more labels, [see associated documentation]({{< relref "../promtail/stages" >}}). |
+| `loki-pipeline-stages`          |    No     |                            | The pipeline stage configuration provided as a string [see pipeline stages](#pipeline-stages) and [associated documentation]({{< relref "../promtail/stages" >}}).                                                                                                              |
 | `loki-relabel-config`           |    No     |                            | A [Prometheus relabeling configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) allowing you to rename labels [see relabeling](#relabeling).                                                                                          |
 | `loki-tenant-id`                |    No     |                            | Set the tenant id (http header`X-Scope-OrgID`) when sending logs to Loki. It can be overridden by a pipeline stage.                                                                                                                                                                     |
 | `loki-tls-ca-file`              |    No     |                            | Set the path to a custom certificate authority.                                                                                                                                                                                                                                         |

--- a/docs/sources/clients/fluentbit/_index.md
+++ b/docs/sources/clients/fluentbit/_index.md
@@ -44,7 +44,7 @@ helm upgrade --install loki-stack grafana/loki-stack \
 ### AWS Elastic Container Service (ECS)
 
 You can use fluent-bit Loki Docker image as a Firelens log router in AWS ECS.
-For more information about this see our [AWS documentation]({{<relref "../aws/ecs">}})
+For more information about this see our [AWS documentation]({{< relref "../aws/ecs" >}})
 
 ### Local
 
@@ -92,7 +92,7 @@ You can also adapt your plugins.conf, removing the need to change the command li
 
 ### Labels
 
-Labels are used to [query logs]({{<relref "../../query">}}) `{container_name="nginx", cluster="us-west1"}`, they are usually metadata about the workload producing the log stream (`instance`, `container_name`, `region`, `cluster`, `level`).  In Loki labels are indexed consequently you should be cautious when choosing them (high cardinality label values can have performance drastic impact).
+Labels are used to [query logs]({{< relref "../../query" >}}) `{container_name="nginx", cluster="us-west1"}`, they are usually metadata about the workload producing the log stream (`instance`, `container_name`, `region`, `cluster`, `level`).  In Loki labels are indexed consequently you should be cautious when choosing them (high cardinality label values can have performance drastic impact).
 
 You can use `Labels`, `RemoveKeys` , `LabelKeys` and `LabelMapPath` to how the output plugin will perform labels extraction.
 
@@ -151,7 +151,7 @@ Buffering refers to the ability to store the records somewhere, and while they a
 
 The blocking state with some of the input plugins is not acceptable, because it can have an undesirable side effect on the part that generates the logs. Fluent Bit implements a buffering mechanism that is based on parallel processing. Therefore, it cannot send logs in order. There are two ways of handling the out-of-order logs: 
 
-- Configure Loki to [accept out-of-order writes]({{<relref "../../configuration/#accept-out-of-order-writes">}}).
+- Configure Loki to [accept out-of-order writes]({{< relref "../../configuration#accept-out-of-order-writes" >}}).
 
 - Configure the Loki output plugin to use the buffering mechanism based on [`dque`](https://github.com/joncrlsn/dque), which is compatible with the Loki server strict time ordering:
 

--- a/docs/sources/clients/fluentd/_index.md
+++ b/docs/sources/clients/fluentd/_index.md
@@ -27,7 +27,7 @@ The Docker image `grafana/fluent-plugin-loki:master` contains [default configura
 
 This image also uses `LOKI_URL`, `LOKI_USERNAME`, and `LOKI_PASSWORD` environment variables to specify the Loki's endpoint, user, and password (you can leave the USERNAME and PASSWORD blank if they're not used).
 
-This image starts an instance of Fluentd that forwards incoming logs to the specified Loki URL. As an alternate, containerized applications can also use [docker driver plugin]({{<relref "../docker-driver/">}}) to ship logs without needing Fluentd.
+This image starts an instance of Fluentd that forwards incoming logs to the specified Loki URL. As an alternate, containerized applications can also use [docker driver plugin]({{< relref "../docker-driver" >}}) to ship logs without needing Fluentd.
 
 ### Example
 
@@ -147,7 +147,7 @@ Use with the `remove_keys kubernetes` option to eliminate metadata from the log.
 
 ### Multi-worker usage
 
-Loki enables out-of-order inserts by default; refer to [accept out-of-order writes]({{<relref "../../configuration/#accept-out-of-order-writes">}}).
+Loki enables out-of-order inserts by default; refer to [accept out-of-order writes]({{< relref "../../configuration#accept-out-of-order-writes" >}}).
 If out-of-order inserts are _disabled_, attempting to insert a log entry with an earlier timestamp after a log entry with identical labels but a later timestamp, the insert will fail with `HTTP status code: 500, message: rpc error: code = Unknown desc = Entry out of order`. Therefore, in order to use this plugin in a multi worker Fluentd setup, you'll need to include the worker ID in the labels or otherwise [ensure log streams are always sent to the same worker](https://docs.fluentd.org/deployment/multi-process-workers#less-than-worker-n-greater-than-directive).
 
 For example, using [fluent-plugin-record-modifier](https://github.com/repeatedly/fluent-plugin-record-modifier):

--- a/docs/sources/clients/k6/_index.md
+++ b/docs/sources/clients/k6/_index.md
@@ -81,12 +81,12 @@ The `Client` class exposes the following instance methods:
 | method | description |
 | ------ | ----------- |
 | `push()` | shortcut for `pushParameterized(5, 800*1024, 1024*1024)` |
-| `pushParameterized(streams, minSize, maxSize)` | execute push request ([POST /loki/api/v1/push]({{< relref "../../reference/api/#push-log-entries-to-loki" >}})) |
-| `instantQuery(query, limit)` | execute instant query  ([GET /loki/api/v1/query]({{< relref "../../reference/api/#query-loki" >}})) |
-| `client.rangeQuery(query, duration, limit)` | execute range query  ([GET /loki/api/v1/query_range]({{< relref "../../reference/api/#query-loki-over-a-range-of-time" >}})) |
-| `client.labelsQuery(duration)` | execute labels query  ([GET /loki/api/v1/labels]({{< relref "../../reference/api/#list-labels-within-a-range-of-time" >}})) |
-| `client.labelValuesQuery(label, duration)` | execute label values query  ([GET /loki/api/v1/label/\<name\>/values]({{< relref "../../reference/api/#list-label-values-within-a-range-of-time" >}})) |
-| `client.seriesQuery(matchers, duration)` | execute series query  ([GET /loki/api/v1/series]({{< relref "../../reference/api/#list-series" >}})) |
+| `pushParameterized(streams, minSize, maxSize)` | execute push request ([POST /loki/api/v1/push]({{< relref "../../reference/api#push-log-entries-to-loki" >}})) |
+| `instantQuery(query, limit)` | execute instant query  ([GET /loki/api/v1/query]({{< relref "../../reference/api#query-loki" >}})) |
+| `client.rangeQuery(query, duration, limit)` | execute range query  ([GET /loki/api/v1/query_range]({{< relref "../../reference/api#query-loki-over-a-range-of-time" >}})) |
+| `client.labelsQuery(duration)` | execute labels query  ([GET /loki/api/v1/labels]({{< relref "../../reference/api#list-labels-within-a-range-of-time" >}})) |
+| `client.labelValuesQuery(label, duration)` | execute label values query  ([GET /loki/api/v1/label/\<name\>/values]({{< relref "../../reference/api#list-label-values-within-a-range-of-time" >}})) |
+| `client.seriesQuery(matchers, duration)` | execute series query  ([GET /loki/api/v1/series]({{< relref "../../reference/api#list-series" >}})) |
 
 **Javascript load test example:**
 

--- a/docs/sources/clients/lambda-promtail/_index.md
+++ b/docs/sources/clients/lambda-promtail/_index.md
@@ -5,7 +5,7 @@ weight: 20
 ---
 # Lambda Promtail
 
-Grafana Loki includes [Terraform](https://www.terraform.io/) and [CloudFormation](https://aws.amazon.com/cloudformation/) for shipping Cloudwatch, Cloudtrail, VPC Flow Logs and loadbalancer logs to Loki via a [lambda function](https://aws.amazon.com/lambda/). This is done via [lambda-promtail](https://github.com/grafana/loki/blob/main/tools/lambda-promtail) which processes cloudwatch events and propagates them to Loki (or a Promtail instance) via the push-api [scrape config]({{<relref "../promtail/configuration#loki_push_api">}}).
+Grafana Loki includes [Terraform](https://www.terraform.io/) and [CloudFormation](https://aws.amazon.com/cloudformation/) for shipping Cloudwatch, Cloudtrail, VPC Flow Logs and loadbalancer logs to Loki via a [lambda function](https://aws.amazon.com/lambda/). This is done via [lambda-promtail](https://github.com/grafana/loki/blob/main/tools/lambda-promtail) which processes cloudwatch events and propagates them to Loki (or a Promtail instance) via the push-api [scrape config]({{< relref "../promtail/configuration#loki_push_api" >}}).
 
 ## Deployment
 
@@ -85,7 +85,7 @@ To modify an existing CloudFormation stack, use [update-stack](https://docs.aws.
 
 ### Ephemeral Jobs
 
-This workflow is intended to be an effective approach for monitoring ephemeral jobs such as those run on AWS Lambda which are otherwise hard/impossible to monitor via one of the other Loki [clients]({{<relref "../">}}).
+This workflow is intended to be an effective approach for monitoring ephemeral jobs such as those run on AWS Lambda which are otherwise hard/impossible to monitor via one of the other Loki [clients]({{< relref ".." >}}).
 
 Ephemeral jobs can quite easily run afoul of cardinality best practices. During high request load, an AWS lambda function might balloon in concurrency, creating many log streams in Cloudwatch. For this reason lambda-promtail defaults to **not** keeping the log stream value as a label when propagating the logs to Loki. This is only possible because new versions of Loki no longer have an ingestion ordering constraint on logs within a single stream.
 
@@ -121,7 +121,7 @@ Triggering lambda-promtail through SQS allows handling on-failure recovery of th
 
 ## Propagated Labels
 
-Incoming logs can have seven special labels assigned to them which can be used in [relabeling]({{<relref "../promtail/configuration#relabel_configs">}}) or later stages in a Promtail [pipeline]({{<relref "../promtail/pipelines/">}}):
+Incoming logs can have seven special labels assigned to them which can be used in [relabeling]({{< relref "../promtail/configuration#relabel_configs" >}}) or later stages in a Promtail [pipeline]({{< relref "../promtail/pipelines" >}}):
 
 - `__aws_log_type`: Where this log came from (Cloudwatch, Kinesis or S3).
 - `__aws_cloudwatch_log_group`: The associated Cloudwatch Log Group for this log.
@@ -207,4 +207,4 @@ Instead we can pipeline Cloudwatch logs to a set of Promtails, which can mitigat
 1) Using Promtail's push api along with the `use_incoming_timestamp: false` config, we let Promtail determine the timestamp based on when it ingests the logs, not the timestamp assigned by cloudwatch. Obviously, this means that we lose the origin timestamp because Promtail now assigns it, but this is a relatively small difference in a real time ingestion system like this.
 2) In conjunction with (1), Promtail can coalesce logs across  Cloudwatch log streams because it's no longer susceptible to out-of-order errors when combining multiple sources (lambda invocations).
 
-One important aspect to keep in mind when running with a set of Promtails behind a load balancer is that we're effectively moving the cardinality problems from the  number of log streams -> number of Promtails. If you have not configured Loki to [accept out-of-order writes]({{<relref "../../configuration#accept-out-of-order-writes">}}), you'll need to assign a Promtail-specific label on each Promtail so that you don't run into out-of-order errors when the Promtails send data for the same log groups to Loki. This can easily be done via a configuration like `--client.external-labels=promtail=${HOSTNAME}` passed to Promtail.
+One important aspect to keep in mind when running with a set of Promtails behind a load balancer is that we're effectively moving the cardinality problems from the  number of log streams -> number of Promtails. If you have not configured Loki to [accept out-of-order writes]({{< relref "../../configuration#accept-out-of-order-writes" >}}), you'll need to assign a Promtail-specific label on each Promtail so that you don't run into out-of-order errors when the Promtails send data for the same log groups to Loki. This can easily be done via a configuration like `--client.external-labels=promtail=${HOSTNAME}` passed to Promtail.

--- a/docs/sources/clients/promtail/_index.md
+++ b/docs/sources/clients/promtail/_index.md
@@ -35,7 +35,7 @@ Kubernetes API server while `static` usually covers all other use cases.
 Just like Prometheus, `promtail` is configured using a `scrape_configs` stanza.
 `relabel_configs` allows for fine-grained control of what to ingest, what to
 drop, and the final metadata to attach to the log line. Refer to the docs for
-[configuring Promtail]({{<relref "configuration.md">}}) for more details.
+[configuring Promtail]({{< relref "./configuration" >}}) for more details.
 
 ### Support for compressed files
 
@@ -104,7 +104,7 @@ Important details are:
 
 ## Loki Push API
 
-Promtail can also be configured to receive logs from another Promtail or any Loki client by exposing the [Loki Push API]({{<relref "../../reference/api#push-log-entries-to-loki">}}) with the [loki_push_api]({{<relref "configuration#loki_push_api">}}) scrape config.
+Promtail can also be configured to receive logs from another Promtail or any Loki client by exposing the [Loki Push API]({{< relref "../../reference/api#push-log-entries-to-loki" >}}) with the [loki_push_api]({{< relref "./configuration#loki_push_api" >}}) scrape config.
 
 There are a few instances where this might be helpful:
 
@@ -114,12 +114,12 @@ There are a few instances where this might be helpful:
 
 ## Receiving logs From Syslog
 
-When the [Syslog Target]({{<relref "configuration#syslog">}}) is being used, logs
+When the [Syslog Target]({{< relref "./configuration#syslog" >}}) is being used, logs
 can be written with the syslog protocol to the configured port.
 
 ## AWS
 
-If you need to run Promtail on Amazon Web Services EC2 instances, you can use our [detailed tutorial]({{<relref "../aws/ec2/">}}).
+If you need to run Promtail on Amazon Web Services EC2 instances, you can use our [detailed tutorial]({{< relref "../aws/ec2" >}}).
 
 ## Labeling and parsing
 
@@ -132,7 +132,7 @@ To allow more sophisticated filtering afterwards, Promtail allows to set labels
 not only from service discovery, but also based on the contents of each log
 line. The `pipeline_stages` can be used to add or update labels, correct the
 timestamp, or re-write log lines entirely. Refer to the documentation for
-[pipelines]({{<relref "pipelines">}}) for more details.
+[pipelines]({{< relref "./pipelines" >}}) for more details.
 
 ## Shipping
 
@@ -158,7 +158,7 @@ This endpoint returns 200 when Promtail is up and running, and there's at least 
 ### `GET /metrics`
 
 This endpoint returns Promtail metrics for Prometheus. Refer to
-[Observing Grafana Loki]({{<relref "../../operations/observability/">}}) for the list
+[Observing Grafana Loki]({{< relref "../../operations/observability" >}}) for the list
 of exported metrics.
 
 ### Promtail web server config

--- a/docs/sources/clients/promtail/configuration.md
+++ b/docs/sources/clients/promtail/configuration.md
@@ -35,8 +35,8 @@ defined by the schema below. Brackets indicate that a parameter is optional. For
 non-list parameters the value is set to the specified default.
 
 For more detailed information on configuring how to discover and scrape logs from
-targets, see [Scraping]({{<relref "scraping">}}). For more information on transforming logs
-from scraped targets, see [Pipelines]({{<relref "pipelines">}}).
+targets, see [Scraping]({{< relref "./scraping" >}}). For more information on transforming logs
+from scraped targets, see [Pipelines]({{< relref "./pipelines" >}}).
 
 ### Use environment variables in the configuration
 
@@ -446,7 +446,7 @@ docker_sd_configs:
 
 ### pipeline_stages
 
-[Pipeline]({{<relref "pipelines">}}) stages are used to transform log entries and their labels. The pipeline is executed after the discovery process finishes. The `pipeline_stages` object consists of a list of stages which correspond to the items listed below.
+[Pipeline]({{< relref "./pipelines" >}}) stages are used to transform log entries and their labels. The pipeline is executed after the discovery process finishes. The `pipeline_stages` object consists of a list of stages which correspond to the items listed below.
 
 In most cases, you extract data from logs with `regex` or `json` stages. The extracted data is transformed into a temporary map object. The data can then be used by Promtail e.g. as values for `labels` or as an `output`. Additionally any other stage aside from `docker` and `cri` can access the extracted data.
 
@@ -592,7 +592,7 @@ template:
 #### match
 
 The match stage conditionally executes a set of stages when a log entry matches
-a configurable [LogQL]({{<relref "../../query/">}}) stream selector.
+a configurable [LogQL]({{< relref "../../query" >}}) stream selector.
 
 ```yaml
 match:
@@ -862,8 +862,8 @@ Promtail needs to wait for the next message to catch multi-line messages,
 therefore delays between messages can occur.
 
 See recommended output configurations for
-[syslog-ng]({{<relref "scraping#syslog-ng-output-configuration">}}) and
-[rsyslog]({{<relref "scraping#rsyslog-output-configuration">}}). Both configurations enable
+[syslog-ng]({{< relref "./scraping#syslog-ng-output-configuration" >}}) and
+[rsyslog]({{< relref "./scraping#rsyslog-output-configuration" >}}). Both configurations enable
 IETF Syslog with octet-counting.
 
 You may need to increase the open files limit for the Promtail process
@@ -917,7 +917,7 @@ max_message_length: <int>
 
 ### loki_push_api
 
-The `loki_push_api` block configures Promtail to expose a [Loki push API]({{<relref "../../reference/api#push-log-entries-to-loki">}}) server.
+The `loki_push_api` block configures Promtail to expose a [Loki push API]({{< relref "../../reference/api#push-log-entries-to-loki" >}}) server.
 
 Each job configured with a `loki_push_api` will expose this API and will require a separate port.
 
@@ -1235,7 +1235,7 @@ Each GELF message received will be encoded in JSON as the log line. For example:
 {"version":"1.1","host":"example.org","short_message":"A short message","timestamp":1231231123,"level":5,"_some_extra":"extra"}
 ```
 
-You can leverage [pipeline stages]({{<relref "./stages">}}) with the GELF target,
+You can leverage [pipeline stages]({{< relref "./stages" >}}) with the GELF target,
 if for example, you want to parse the log line and extract more labels or change the log line format.
 
 ```yaml
@@ -1391,7 +1391,7 @@ All Cloudflare logs are in JSON. Here is an example:
 }
 ```
 
-You can leverage [pipeline stages]({{<relref "./stages">}}) if, for example, you want to parse the JSON log line and extract more labels or change the log line format.
+You can leverage [pipeline stages]({{< relref "./stages" >}}) if, for example, you want to parse the JSON log line and extract more labels or change the log line format.
 
 ### heroku_drain
 
@@ -2096,7 +2096,7 @@ The `tracing` block configures tracing for Jaeger. Currently, limited to configu
 
 ## Example Docker Config
 
-It's fairly difficult to tail Docker files on a standalone machine because they are in different locations for every OS.  We recommend the [Docker logging driver]({{<relref "../docker-driver/">}}) for local Docker installs or Docker Compose.
+It's fairly difficult to tail Docker files on a standalone machine because they are in different locations for every OS.  We recommend the [Docker logging driver]({{< relref "../docker-driver" >}}) for local Docker installs or Docker Compose.
 
 If running in a Kubernetes environment, you should look at the defined configs which are in [helm](https://github.com/grafana/helm-charts/blob/main/charts/promtail/templates/configmap.yaml) and [jsonnet](https://github.com/grafana/loki/blob/main/production/ksonnet/promtail/scrape_config.libsonnet), these leverage the prometheus service discovery libraries (and give Promtail its name) for automatically finding and tailing pods.  The jsonnet config explains with comments what each section is for.
 

--- a/docs/sources/clients/promtail/gcplog-cloud.md
+++ b/docs/sources/clients/promtail/gcplog-cloud.md
@@ -231,7 +231,7 @@ We need a service account with the following permissions:
 
 This enables Promtail to read log entries from the pubsub subscription created before.
 
-You can find an example for Promtail scrape config for `gcplog` [here]({{<relref "scraping/#gcp-log-scraping">}})
+You can find an example for Promtail scrape config for `gcplog` [here]({{< relref "./scraping#gcp-log-scraping" >}})
 
 If you are scraping logs from multiple GCP projects, then this serviceaccount should have above permissions in all the projects you are tyring to scrape.
 

--- a/docs/sources/clients/promtail/logrotation/_index.md
+++ b/docs/sources/clients/promtail/logrotation/_index.md
@@ -82,7 +82,7 @@ Here, the `create` mode works as explained in (2) above. The `create` mode is op
 
 ### Kubernetes
 
-[Kubernetes Service Discovery in Promtail]({{<relref "../scraping#kubernetes-discovery">}}) also uses file-based scraping. Meaning, logs from your pods are stored on the nodes and Promtail scrapes the pod logs from the node files.
+[Kubernetes Service Discovery in Promtail]({{< relref "../scraping#kubernetes-discovery" >}}) also uses file-based scraping. Meaning, logs from your pods are stored on the nodes and Promtail scrapes the pod logs from the node files.
 
 You can [configure](https://kubernetes.io/docs/concepts/cluster-administration/logging/#log-rotation) the `kubelet` process running on each node to manage log rotation via two configuration settings.
 
@@ -139,4 +139,4 @@ If neither `kubelet` nor `CRI` is configured for rotating logs, then the `logrot
 
 Promtail uses `polling` to watch for file changes. A `polling` mechanism combined with a [copy and truncate](#copy-and-truncate) log rotation may result in losing some logs. As explained earlier in this topic, this happens when the file is truncated before Promtail reads all the log lines from such a file.
 
-Therefore, for a long-term solution, we strongly recommend changing the log rotation strategy to [rename and create](#rename-and-create). Alternatively, as a workaround in the short term, you can tweak the promtail client's `batchsize` [config]({{<relref "../configuration#clients">}}) to set higher values (like 5M or 8M). This gives Promtail more room to read loglines without frequently waiting for push responses from the Loki server.
+Therefore, for a long-term solution, we strongly recommend changing the log rotation strategy to [rename and create](#rename-and-create). Alternatively, as a workaround in the short term, you can tweak the promtail client's `batchsize` [config]({{< relref "../configuration#clients" >}}) to set higher values (like 5M or 8M). This gives Promtail more room to read loglines without frequently waiting for push responses from the Loki server.

--- a/docs/sources/clients/promtail/pipelines.md
+++ b/docs/sources/clients/promtail/pipelines.md
@@ -26,13 +26,13 @@ stages:
    condition.
 
 Typical pipelines will start with a parsing stage (such as a
-[regex]({{<relref "stages/regex/">}}) or [json]({{<relref "stages/json/">}}) stage) to extract data
+[regex]({{< relref "./stages/regex" >}}) or [json]({{< relref "./stages/json" >}}) stage) to extract data
 from the log line. Then, a series of action stages will be present to do
 something with that extracted data. The most common action stage will be a
-[labels]({{<relref "stages/labels/">}}) stage to turn extracted data into a label.
+[labels]({{< relref "./stages/labels" >}}) stage to turn extracted data into a label.
 
-A common stage will also be the [match]({{<relref "stages/match/">}}) stage to selectively
-apply stages or drop entries based on a [LogQL stream selector and filter expressions]({{<relref "../../query/">}}).
+A common stage will also be the [match]({{< relref "./stages/match" >}}) stage to selectively
+apply stages or drop entries based on a [LogQL stream selector and filter expressions]({{< relref "../../query" >}}).
 
 Note that pipelines can not currently be used to deduplicate logs; Grafana Loki will
 receive the same log line multiple times if, for example:
@@ -200,27 +200,27 @@ given log entry.
 
 Parsing stages:
 
-  - [docker]({{<relref "stages/docker/">}}): Extract data by parsing the log line using the standard Docker format.
-  - [cri]({{<relref "stages/cri/">}}): Extract data by parsing the log line using the standard CRI format.
-  - [regex]({{<relref "stages/regex/">}}): Extract data using a regular expression.
-  - [json]({{<relref "stages/json/">}}): Extract data by parsing the log line as JSON.
-  - [eventlogmessage]({{<relref "stages/eventlogmessage/">}}): Extract data by parsing the Message field from the Windows Event Log.
+  - [docker]({{< relref "./stages/docker" >}}): Extract data by parsing the log line using the standard Docker format.
+  - [cri]({{< relref "./stages/cri" >}}): Extract data by parsing the log line using the standard CRI format.
+  - [regex]({{< relref "./stages/regex" >}}): Extract data using a regular expression.
+  - [json]({{< relref "./stages/json" >}}): Extract data by parsing the log line as JSON.
+  - [eventlogmessage]({{< relref "./stages/eventlogmessage" >}}): Extract data by parsing the Message field from the Windows Event Log.
 
 Transform stages:
 
-  - [multiline]({{<relref "stages/multiline/">}}): Merges multiple lines, e.g. stack traces, into multiline blocks.
-  - [template]({{<relref "stages/template/">}}): Use Go templates to modify extracted data.
+  - [multiline]({{< relref "./stages/multiline" >}}): Merges multiple lines, e.g. stack traces, into multiline blocks.
+  - [template]({{< relref "./stages/template" >}}): Use Go templates to modify extracted data.
 
 Action stages:
 
-  - [timestamp]({{<relref "stages/timestamp/">}}): Set the timestamp value for the log entry.
-  - [output]({{<relref "stages/output/">}}): Set the log line text.
-  - [labels]({{<relref "stages/labels/">}}): Update the label set for the log entry.
-  - [metrics]({{<relref "stages/metrics/">}}): Calculate metrics based on extracted data.
-  - [tenant]({{<relref "stages/tenant/">}}): Set the tenant ID value to use for the log entry.
+  - [timestamp]({{< relref "./stages/timestamp" >}}): Set the timestamp value for the log entry.
+  - [output]({{< relref "./stages/output" >}}): Set the log line text.
+  - [labels]({{< relref "./stages/labels" >}}): Update the label set for the log entry.
+  - [metrics]({{< relref "./stages/metrics" >}}): Calculate metrics based on extracted data.
+  - [tenant]({{< relref "./stages/tenant" >}}): Set the tenant ID value to use for the log entry.
 
 Filtering stages:
 
-  - [match]({{<relref "stages/match/">}}): Conditionally run stages based on the label set.
-  - [drop]({{<relref "stages/drop/">}}): Conditionally drop log lines based on several options.
-  - [limit]({{<relref "stages/limit/">}}): Conditionally rate limit log lines based on several options.
+  - [match]({{< relref "./stages/match" >}}): Conditionally run stages based on the label set.
+  - [drop]({{< relref "./stages/drop" >}}): Conditionally drop log lines based on several options.
+  - [limit]({{< relref "./stages/limit" >}}): Conditionally rate limit log lines based on several options.

--- a/docs/sources/clients/promtail/scraping.md
+++ b/docs/sources/clients/promtail/scraping.md
@@ -83,7 +83,7 @@ relabel_configs:
     target_label: '__host__'
 ```
 
-See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery configuration]({{< relref "configuration#kubernetes_sd_config" >}}).
+See [Relabeling](#relabeling) for more information. For more information on how to configure the service discovery see the [Kubernetes Service Discovery configuration]({{< relref "./configuration#kubernetes_sd_config" >}}).
 
 ## Journal Scraping (Linux Only)
 
@@ -192,9 +192,9 @@ You can relabel default labels via [Relabeling](#relabeling) if required.
 Providing a path to a bookmark is mandatory, it will be used to persist the last event processed and allow
 resuming the target without skipping logs.
 
-Read the [configuration]({{< relref "configuration#windows_events" >}}) section for more information.
+Read the [configuration]({{< relref "./configuration#windows_events" >}}) section for more information.
 
-See the [eventlogmessage]({{<relref "stages/eventlogmessage/">}}) stage for extracting
+See the [eventlogmessage]({{< relref "./stages/eventlogmessage" >}}) stage for extracting
 data from the `message`.
 
 ## GCP Log scraping
@@ -227,7 +227,7 @@ Here `project_id` and `subscription` are the only required fields.
 - `project_id` is the GCP project id.
 - `subscription` is the GCP pubsub subscription where Promtail can consume log entries from.
 
-Before using `gcplog` target, GCP should be [configured]({{<relref "gcplog-cloud">}}) with pubsub subscription to receive logs from.
+Before using `gcplog` target, GCP should be [configured]({{< relref "./gcplog-cloud" >}}) with pubsub subscription to receive logs from.
 
 It also supports `relabeling` and `pipeline` stages just like other targets.
 
@@ -263,7 +263,7 @@ section. This server exposes the single endpoint `POST /gcp/api/v1/push`, respon
 
 For Google's PubSub to be able to send logs, **Promtail server must be publicly accessible, and support HTTPS**. For that, Promtail can be deployed
 as part of a larger orchestration service like Kubernetes, which can handle HTTPS traffic through an ingress, or it can be hosted behind
-a proxy/gateway, offloading the HTTPS to that component and routing the request to Promtail. Once that's solved, GCP can be [configured]({{<relref "gcplog-cloud">}})
+a proxy/gateway, offloading the HTTPS to that component and routing the request to Promtail. Once that's solved, GCP can be [configured]({{< relref "./gcplog-cloud" >}})
 to send logs to Promtail.
 
 It also supports `relabeling` and `pipeline` stages.
@@ -373,7 +373,7 @@ Targets can be configured using the `azure_event_hubs` stanza:
 ```
 
 Only `fully_qualified_namespace`, `connection_string` and `event_hubs` are required fields.
-Read the [configuration]({{< relref "configuration/#azure-event-hubs" >}}) section for more information.
+Read the [configuration]({{< relref "./configuration#azure-event-hubs" >}}) section for more information.
 
 ## Kafka
 
@@ -412,7 +412,7 @@ scrape_configs:
 ```
 
 Only the `brokers` and `topics` are required.
-Read the [configuration]({{< relref "configuration/#kafka" >}}) section for more information.
+Read the [configuration]({{< relref "./configuration#kafka" >}}) section for more information.
 
 
 ## GELF
@@ -462,7 +462,7 @@ scrape_configs:
 ```
 
 Only `api_token` and `zone_id` are required.
-Refer to the [Cloudfare]({{< relref "configuration#cloudflare" >}}) configuration section for details.
+Refer to the [Cloudfare]({{< relref "./configuration#cloudflare" >}}) configuration section for details.
 
 ## Heroku Drain
 Promtail supports receiving logs from a Heroku application by using a [Heroku HTTPS Drain](https://devcenter.heroku.com/articles/log-drains#https-drains).
@@ -489,7 +489,7 @@ Configuration is specified in a`heroku_drain` block within the Promtail `scrape_
 ```
 Within the `scrape_configs` configuration for a Heroku Drain target, the `job_name` must be a Prometheus-compatible [metric name](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
-The [server]({{< relref "configuration#server" >}}) section configures the HTTP server created for receiving logs.
+The [server]({{< relref "./configuration#server" >}}) section configures the HTTP server created for receiving logs.
 `labels` defines a static set of label values added to each received log entry. `use_incoming_timestamp` can be used to pass
 the timestamp received from Heroku.
 
@@ -593,5 +593,5 @@ clients:
   - [ <client_option> ]
 ```
 
-Refer to [`client_config`]({{< relref "configuration#clients" >}}) from the Promtail
+Refer to [`client_config`]({{< relref "./configuration#clients" >}}) from the Promtail
 Configuration reference for all available options.

--- a/docs/sources/clients/promtail/stages/_index.md
+++ b/docs/sources/clients/promtail/stages/_index.md
@@ -5,39 +5,39 @@ description: Stages
 # Stages
 
 This section is a collection of all stages Promtail supports in a
-[Pipeline]({{<relref "../pipelines/">}}).
+[Pipeline]({{< relref "../pipelines" >}}).
 
 Parsing stages:
 
-  - [docker]({{<relref "docker">}}): Extract data by parsing the log line using the standard Docker format.
-  - [cri]({{<relref "cri">}}): Extract data by parsing the log line using the standard CRI format.
-  - [regex]({{<relref "regex">}}): Extract data using a regular expression.
-  - [json]({{<relref "json">}}): Extract data by parsing the log line as JSON.
-  - [logfmt]({{<relref "logfmt">}}): Extract data by parsing the log line as logfmt.
-  - [replace]({{<relref "replace">}}): Replace data using a regular expression.
-  - [multiline]({{<relref "multiline">}}): Merge multiple lines into a multiline block.
-  - [geoip]({{<relref "geoip">}}): Extract geoip data from extracted labels.
+  - [docker]({{< relref "./docker" >}}): Extract data by parsing the log line using the standard Docker format.
+  - [cri]({{< relref "./cri" >}}): Extract data by parsing the log line using the standard CRI format.
+  - [regex]({{< relref "./regex" >}}): Extract data using a regular expression.
+  - [json]({{< relref "./json" >}}): Extract data by parsing the log line as JSON.
+  - [logfmt]({{< relref "./logfmt" >}}): Extract data by parsing the log line as logfmt.
+  - [replace]({{< relref "./replace" >}}): Replace data using a regular expression.
+  - [multiline]({{< relref "./multiline" >}}): Merge multiple lines into a multiline block.
+  - [geoip]({{< relref "./geoip" >}}): Extract geoip data from extracted labels.
 
 Transform stages:
 
-  - [template]({{<relref "template">}}): Use Go templates to modify extracted data.
-  - [pack]({{<relref "pack">}}): Packs a log line in a JSON object allowing extracted values and labels to be placed inside the log line.
-  - [decolorize]({{<relref "decolorize">}}): Strips ANSI color sequences from the log line.
+  - [template]({{< relref "./template" >}}): Use Go templates to modify extracted data.
+  - [pack]({{< relref "./pack" >}}): Packs a log line in a JSON object allowing extracted values and labels to be placed inside the log line.
+  - [decolorize]({{< relref "./decolorize" >}}): Strips ANSI color sequences from the log line.
 
 Action stages:
 
-  - [timestamp]({{<relref "timestamp">}}): Set the timestamp value for the log entry.
-  - [output]({{<relref "output">}}): Set the log line text.
-  - [labeldrop]({{<relref "labeldrop">}}): Drop label set for the log entry.
-  - [labelallow]({{<relref "labelallow">}}): Allow label set for the log entry.
-  - [labels]({{<relref "labels">}}): Update the label set for the log entry.
-  - [limit]({{<relref "limit">}}): Limit the rate lines will be sent to Loki.
-  - [sampling]({{<relref "sampling">}}): Sampling the lines will be sent to Loki.
-  - [static_labels]({{<relref "static_labels">}}): Add static-labels to the log entry. 
-  - [metrics]({{<relref "metrics">}}): Calculate metrics based on extracted data.
-  - [tenant]({{<relref "tenant">}}): Set the tenant ID value to use for the log entry.
+  - [timestamp]({{< relref "./timestamp" >}}): Set the timestamp value for the log entry.
+  - [output]({{< relref "./output" >}}): Set the log line text.
+  - [labeldrop]({{< relref "./labeldrop" >}}): Drop label set for the log entry.
+  - [labelallow]({{< relref "./labelallow" >}}): Allow label set for the log entry.
+  - [labels]({{< relref "./labels" >}}): Update the label set for the log entry.
+  - [limit]({{< relref "./limit" >}}): Limit the rate lines will be sent to Loki.
+  - [sampling]({{< relref "./sampling" >}}): Sampling the lines will be sent to Loki.
+  - [static_labels]({{< relref "./static_labels" >}}): Add static-labels to the log entry. 
+  - [metrics]({{< relref "./metrics" >}}): Calculate metrics based on extracted data.
+  - [tenant]({{< relref "./tenant" >}}): Set the tenant ID value to use for the log entry.
 
 Filtering stages:
 
-  - [match]({{<relref "match">}}): Conditionally run stages based on the label set.
-  - [drop]({{<relref "drop">}}): Conditionally drop log lines based on several options.
+  - [match]({{< relref "./match" >}}): Conditionally run stages based on the label set.
+  - [drop]({{< relref "./drop" >}}): Conditionally drop log lines based on several options.

--- a/docs/sources/clients/promtail/stages/drop.md
+++ b/docs/sources/clients/promtail/stages/drop.md
@@ -121,7 +121,7 @@ Would drop this log line:
 
 #### Drop old log lines
 
-**NOTE** For `older_than` to work, you must be using the [timestamp]({{<relref "timestamp">}}) stage to set the timestamp from the ingested log line _before_ applying the `drop` stage.
+**NOTE** For `older_than` to work, you must be using the [timestamp]({{< relref "./timestamp" >}}) stage to set the timestamp from the ingested log line _before_ applying the `drop` stage.
 
 Given the pipeline:
 

--- a/docs/sources/clients/promtail/stages/eventlogmessage.md
+++ b/docs/sources/clients/promtail/stages/eventlogmessage.md
@@ -31,7 +31,7 @@ eventlogmessage:
 The extracted data can hold non-string values and this stage does not do any
 type conversions; downstream stages will need to perform correct type
 conversion of these values as necessary. Please refer to the
-[the `template` stage]({{<relref "template">}}) for how to do this.
+[the `template` stage]({{< relref "./template" >}}) for how to do this.
 
 ## Example combined with json
 

--- a/docs/sources/clients/promtail/stages/json.md
+++ b/docs/sources/clients/promtail/stages/json.md
@@ -33,7 +33,7 @@ This stage uses the Go JSON unmarshaler, which means non-string types like
 numbers or booleans will be unmarshaled into those types. The extracted data
 can hold non-string values and this stage does not do any type conversions;
 downstream stages will need to perform correct type conversion of these values
-as necessary. Please refer to the [the `template` stage]({{<relref "template">}}) for how
+as necessary. Please refer to the [the `template` stage]({{< relref "./template" >}}) for how
 to do this.
 
 If the value extracted is a complex type, such as an array or a JSON object, it

--- a/docs/sources/clients/promtail/stages/limit.md
+++ b/docs/sources/clients/promtail/stages/limit.md
@@ -9,7 +9,7 @@ The `limit` stage is a rate-limiting stage that throttles logs based on several 
 ## Limit stage schema
 
 This pipeline stage places limits on the rate or burst quantity of log lines that Promtail pushes to Loki.
-The concept of having distinct burst and rate limits mirrors the approach to limits that can be set for Loki's distributor component:  `ingestion_rate_mb` and `ingestion_burst_size_mb`, as defined in [limits_config]({{<relref "../../../configuration/#limits_config">}}).
+The concept of having distinct burst and rate limits mirrors the approach to limits that can be set for Loki's distributor component:  `ingestion_rate_mb` and `ingestion_burst_size_mb`, as defined in [limits_config]({{< relref "../../../configuration#limits_config" >}}).
 
 ```yaml
 limit:

--- a/docs/sources/clients/promtail/stages/logfmt.md
+++ b/docs/sources/clients/promtail/stages/logfmt.md
@@ -25,7 +25,7 @@ This stage uses the [go-logfmt](https://github.com/go-logfmt/logfmt) unmarshaler
 numbers or booleans will be unmarshaled into those types. The extracted data
 can hold non-string values, and this stage does not do any type conversions;
 downstream stages will need to perform correct type conversion of these values
-as necessary. Please refer to the [`template` stage]({{<relref "template">}}) for how
+as necessary. Please refer to the [`template` stage]({{< relref "./template" >}}) for how
 to do this.
 
 If the value extracted is a complex type, its value is extracted as a string.

--- a/docs/sources/clients/promtail/stages/match.md
+++ b/docs/sources/clients/promtail/stages/match.md
@@ -5,7 +5,7 @@ description: match stage
 # match
 
 The match stage is a filtering stage that conditionally applies a set of stages
-or drop entries when a log entry matches a configurable [LogQL]({{<relref "../../../query">}})
+or drop entries when a log entry matches a configurable [LogQL]({{< relref "../../../query" >}})
 stream selector and filter expressions.
 
 ## Schema
@@ -48,7 +48,7 @@ match:
       ]
 ```
 
-Refer to the [Promtail Configuration Reference]({{<relref "../configuration">}}) for the
+Refer to the [Promtail Configuration Reference]({{< relref "../configuration" >}}) for the
 schema on the various other stages referenced here.
 
 ### Example

--- a/docs/sources/clients/promtail/stages/pack.md
+++ b/docs/sources/clients/promtail/stages/pack.md
@@ -58,7 +58,7 @@ This would create a log line
 }
 ```
 
-**Loki 2.2 also includes a new [`unpack` parser]({{< relref "../../../query/log_queries/#unpack" >}}) to work with the pack stage.**
+**Loki 2.2 also includes a new [`unpack` parser]({{< relref "../../../query/log_queries#unpack" >}}) to work with the pack stage.**
 
 For example:
 

--- a/docs/sources/clients/promtail/stages/tenant.md
+++ b/docs/sources/clients/promtail/stages/tenant.md
@@ -6,7 +6,7 @@ description: tenant stage
 
 The tenant stage is an action stage that sets the tenant ID for the log entry
 picking it from a field in the extracted data map. If the field is missing, the
-default promtail client [`tenant_id`]({{<relref "../configuration#clients">}}) will
+default promtail client [`tenant_id`]({{< relref "../configuration#clients" >}}) will
 be used.
 
 

--- a/docs/sources/clients/promtail/troubleshooting/_index.md
+++ b/docs/sources/clients/promtail/troubleshooting/_index.md
@@ -12,7 +12,7 @@ adopted trade-offs.
 Promtail can be configured to print log stream entries instead of sending them to Loki.
 This can be used in combination with [piping data](#pipe-data-to-promtail) to debug or troubleshoot Promtail log parsing.
 
-In dry run mode, Promtail still support reading from a [positions]({{<relref "../configuration#positions">}}) file however no update will be made to the targeted file, this is to ensure you can easily retry the same set of lines.
+In dry run mode, Promtail still support reading from a [positions]({{< relref "../configuration#positions" >}}) file however no update will be made to the targeted file, this is to ensure you can easily retry the same set of lines.
 
 To start Promtail in dry run mode use the flag `--dry-run` as shown in the example below:
 
@@ -75,9 +75,9 @@ This will add labels `k1` and `k2` with respective values `v1` and `v2`.
 In pipe mode Promtail also support file configuration using `--config.file`, however do note that positions config is not used and
 only **the first scrape config is used**.
 
-[`static_configs:`]({{<relref "../configuration">}}) can be used to provide static labels, although the targets property is ignored.
+[`static_configs:`]({{< relref "../configuration" >}}) can be used to provide static labels, although the targets property is ignored.
 
-If you don't provide any [`scrape_config:`]({{<relref "../configuration#scrape_configs">}}) a default one is used which will automatically adds the following default labels: `{job="stdin",hostname="<detected_hostname>"}`.
+If you don't provide any [`scrape_config:`]({{< relref "../configuration#scrape_configs" >}}) a default one is used which will automatically adds the following default labels: `{job="stdin",hostname="<detected_hostname>"}`.
 
 For example you could use this config below to parse and add the label `level` on all your piped logs:
 
@@ -197,7 +197,7 @@ from there. This means that if new log entries have been read and pushed to the
 ingester between the last sync period and the crash, these log entries will be
 sent again to the ingester on Promtail restart.
 
-If Loki is not configured to [accept out-of-order writes]({{<relref "../../../configuration/#accept-out-of-order-writes">}}), Loki will reject all log lines received in
+If Loki is not configured to [accept out-of-order writes]({{< relref "../../../configuration#accept-out-of-order-writes" >}}), Loki will reject all log lines received in
 what it perceives is out of
 order. If Promtail happens to
 crash, it may re-send log lines that were sent prior to the crash. The default

--- a/docs/sources/community/_index.md
+++ b/docs/sources/community/_index.md
@@ -5,9 +5,9 @@ weight: 1100
 ---
 # Community
 
-1. [Governance]({{<relref "governance">}})
-1. [Getting in Touch]({{<relref "getting-in-touch">}})
-1. [Contributing]({{<relref "contributing">}})
-1. [Maintaining Loki]({{<relref "maintaining/_index.md">}})
-1. [Loki Improvement Documents]({{<relref "lids/_index.md">}})
-1. [Design documents]({{<relref "design-documents/_index.md">}})
+1. [Governance]({{< relref "./governance" >}})
+1. [Getting in Touch]({{< relref "./getting-in-touch" >}})
+1. [Contributing]({{< relref "./contributing" >}})
+1. [Maintaining Loki]({{< relref "./maintaining" >}})
+1. [Loki Improvement Documents]({{< relref "./lids" >}})
+1. [Design documents]({{< relref "./design-documents" >}})

--- a/docs/sources/community/design-documents/_index.md
+++ b/docs/sources/community/design-documents/_index.md
@@ -8,7 +8,7 @@ weight: 1300
 ---
 # Design documents
 
-- [Labels from Logs]({{<relref "labels">}})
-- [Promtail Push API]({{<relref "2020-02-Promtail-Push-API">}})
-- [Write-Ahead Logs]({{<relref "2020-09-Write-Ahead-Log">}})
-- [Ordering Constraint Removal]({{<relref "2021-01-Ordering-Constraint-Removal">}})
+- [Labels from Logs]({{< relref "./labels" >}})
+- [Promtail Push API]({{< relref "./2020-02-Promtail-Push-API" >}})
+- [Write-Ahead Logs]({{< relref "./2020-09-Write-Ahead-Log" >}})
+- [Ordering Constraint Removal]({{< relref "./2021-01-Ordering-Constraint-Removal" >}})

--- a/docs/sources/community/lids/0001-Introduction.md
+++ b/docs/sources/community/lids/0001-Introduction.md
@@ -54,4 +54,4 @@ Inspired by Python's [PEP](https://peps.python.org/pep-0001/) and Kafka's [KIP](
 
 Google Docs were considered for this, but they are less useful because:
 - they would need to be owned by the Grafana Labs organisation, so that they remain viewable even if the author closes their account
-- we already have previous [design documents]({{<relref "../design-documents">}}) in our documentation and, in a recent ([5th Jan 2023](https://docs.google.com/document/d/1MNjiHQxwFukm2J4NJRWyRgRIiK7VpokYyATzJ5ce-O8/edit#heading=h.78vexgrrtw5a)) community call, the community expressed a preference for this type of approach
+- we already have previous [design documents]({{< relref "../design-documents" >}}) in our documentation and, in a recent ([5th Jan 2023](https://docs.google.com/document/d/1MNjiHQxwFukm2J4NJRWyRgRIiK7VpokYyATzJ5ce-O8/edit#heading=h.78vexgrrtw5a)) community call, the community expressed a preference for this type of approach

--- a/docs/sources/configuration/_index.md
+++ b/docs/sources/configuration/_index.md
@@ -13,7 +13,7 @@ Grafana Loki is configured in a YAML file (usually referred to as `loki.yaml` )
 which contains information on the Loki server and its individual components,
 depending on which mode Loki is launched in.
 
-Configuration examples can be found in the [Configuration Examples]({{< relref "./examples/" >}}) document.
+Configuration examples can be found in the [Configuration Examples]({{< relref "./examples" >}}) document.
 
 ## Printing Loki config at runtime
 

--- a/docs/sources/configuration/index.template
+++ b/docs/sources/configuration/index.template
@@ -13,7 +13,7 @@ Grafana Loki is configured in a YAML file (usually referred to as `loki.yaml` )
 which contains information on the Loki server and its individual components,
 depending on which mode Loki is launched in.
 
-Configuration examples can be found in the [Configuration Examples]({{ `{{< relref "./examples/" >}}` }}) document.
+Configuration examples can be found in the [Configuration Examples]({{ `{{< relref "./examples" >}}` }}) document.
 
 ## Printing Loki config at runtime
 

--- a/docs/sources/fundamentals/architecture/_index.md
+++ b/docs/sources/fundamentals/architecture/_index.md
@@ -75,7 +75,7 @@ bytes of the log entry.
 
 ### Single Store
 
-Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`boltdb_shipper`]({{<relref "../../operations/storage/boltdb-shipper">}}) to store the `index` in object storage (the same way we store `chunks`).
+Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`boltdb_shipper`]({{< relref "../../operations/storage/boltdb-shipper" >}}) to store the `index` in object storage (the same way we store `chunks`).
 
 ###  Deprecated: Multi-store
 
@@ -96,7 +96,7 @@ maintenance tasks. It consists of:
 
 > Unlike the other core components of Loki, the chunk store is not a separate
 > service, job, or process, but rather a library embedded in the two services
-> that need to access Loki data: the [ingester]({{<relref "components#ingester">}}) and [querier]({{<relref "components#querier">}}).
+> that need to access Loki data: the [ingester]({{< relref "./components#ingester" >}}) and [querier]({{< relref "./components#querier" >}}).
 
 The chunk store relies on a unified interface to the
 "[NoSQL](https://en.wikipedia.org/wiki/NoSQL)" stores (DynamoDB, Bigtable, and

--- a/docs/sources/fundamentals/architecture/components/_index.md
+++ b/docs/sources/fundamentals/architecture/components/_index.md
@@ -32,7 +32,7 @@ Currently the only way the distributor mutates incoming data is by normalizing l
 
 The distributor can also rate limit incoming logs based on the maximum per-tenant bitrate. It does this by checking a per tenant limit and dividing it by the current number of distributors. This allows the rate limit to be specified per tenant at the cluster level and enables us to scale the distributors up or down and have the per-distributor limit adjust accordingly. For instance, say we have 10 distributors and tenant A has a 10MB rate limit. Each distributor will allow up to 1MB/second before limiting. Now, say another large tenant joins the cluster and we need to spin up 10 more distributors. The now 20 distributors will adjust their rate limits for tenant A to `(10MB / 20 distributors) = 500KB/s`! This is how global limits allow much simpler and safer operation of the Loki cluster.
 
-**Note: The distributor uses the `ring` component under the hood to register itself amongst its peers and get the total number of active distributors. This is a different "key" than the ingesters use in the ring and comes from the distributor's own [ring configuration]({{<relref "../../../configuration#distributor">}}).**
+**Note: The distributor uses the `ring` component under the hood to register itself amongst its peers and get the total number of active distributors. This is a different "key" than the ingesters use in the ring and comes from the distributor's own [ring configuration]({{< relref "../../../configuration#distributor" >}}).**
 
 ### Forwarding
 
@@ -139,7 +139,7 @@ deduplicated.
 
 ### Timestamp Ordering
 
-Loki can be configured to [accept out-of-order writes]({{<relref "../../../configuration/#accept-out-of-order-writes">}}).
+Loki can be configured to [accept out-of-order writes]({{< relref "../../../configuration#accept-out-of-order-writes" >}}).
 
 When not configured to accept out-of-order writes, the ingester validates that ingested log lines are in order. When an
 ingester receives a log line that doesn't follow the expected order, the line
@@ -154,7 +154,7 @@ Logs from each unique set of labels are built up into "chunks" in memory and
 then flushed to the backing storage backend.
 
 If an ingester process crashes or exits abruptly, all the data that has not yet
-been flushed could be lost. Loki is usually configured with a [Write Ahead Log]({{<relref "../../../operations/storage/wal">}}) which can be _replayed_ on restart as well as with a `replication_factor` (usually 3) of each log to mitigate this risk.
+been flushed could be lost. Loki is usually configured with a [Write Ahead Log]({{< relref "../../../operations/storage/wal" >}}) which can be _replayed_ on restart as well as with a `replication_factor` (usually 3) of each log to mitigate this risk.
 
 When not configured to accept out-of-order writes,
 all lines pushed to Loki for a given stream (unique combination of
@@ -170,7 +170,7 @@ nanosecond timestamps:
    different content, the log line is accepted. This means it is possible to
    have two different log lines for the same timestamp.
 
-### Handoff - Deprecated in favor of the [WAL]({{<relref "../../../operations/storage/wal">}})
+### Handoff - Deprecated in favor of the [WAL]({{< relref "../../../operations/storage/wal" >}})
 
 By default, when an ingester is shutting down and tries to leave the hash ring,
 it will wait to see if a new ingester tries to enter before flushing and will
@@ -224,7 +224,7 @@ Caching log (filter, regexp) queries are under active development.
 
 ## Querier
 
-The **querier** service handles queries using the [LogQL]({{<relref "../../../query/">}}) query
+The **querier** service handles queries using the [LogQL]({{< relref "../../../query" >}}) query
 language, fetching logs both from the ingesters and from long-term storage.
 
 Queriers query all ingesters for in-memory data before falling back to

--- a/docs/sources/fundamentals/architecture/deployment-modes/_index.md
+++ b/docs/sources/fundamentals/architecture/deployment-modes/_index.md
@@ -36,7 +36,7 @@ as well as for small read/write volumes of up to approximately 100GB per day.
 
 Horizontally scale up a monolithic mode deployment to more instances
 by using a shared object store, and by configuring the
-[`ring` section]({{<relref "../../../configuration#common">}})
+[`ring` section]({{< relref "../../../configuration#common" >}})
 to share state between all instances.
 
 High availability can be configured by running two Loki instances
@@ -59,7 +59,7 @@ Consider the microservices mode approach for very large Loki installations.
 
 In this mode the component microservices of Loki are bundled into two targets:
 `-target=read` and `-target=write`.
-The BoltDB [compactor]({{<relref "../../../operations/storage/boltdb-shipper#compactor">}}) 
+The BoltDB [compactor]({{< relref "../../../operations/storage/boltdb-shipper#compactor" >}}) 
 service will run as part of the read target.
 
 There are advantages to separating the read and write paths:

--- a/docs/sources/fundamentals/architecture/rings/_index.md
+++ b/docs/sources/fundamentals/architecture/rings/_index.md
@@ -50,7 +50,7 @@ For each node, the key-value store holds:
 
 ## Configuring rings
 
-Define [ring configuration]({{<relref "../../../configuration/#common">}}) within the `common.ring_config` block.
+Define [ring configuration]({{< relref "../../../configuration#common" >}}) within the `common.ring_config` block.
 
 Use the default `memberlist` key-value store type unless there is
 a compelling reason to use a different key-value store type.

--- a/docs/sources/fundamentals/labels.md
+++ b/docs/sources/fundamentals/labels.md
@@ -146,7 +146,7 @@ The two previous examples use statically defined labels with a single value; how
       __path__: /var/log/apache.log
 ```
 
-This regex matches every component of the log line and extracts the value of each component into a capture group. Inside the pipeline code, this data is placed in a temporary data structure that allows using it for several purposes during the processing of that log line (at which point that temp data is discarded). Much more detail about this can be found in the [Promtail pipelines]({{<relref "../clients/promtail/pipelines">}}) documentation.
+This regex matches every component of the log line and extracts the value of each component into a capture group. Inside the pipeline code, this data is placed in a temporary data structure that allows using it for several purposes during the processing of that log line (at which point that temp data is discarded). Much more detail about this can be found in the [Promtail pipelines]({{< relref "../clients/promtail/pipelines" >}}) documentation.
 
 From that regex, we will be using two of the capture groups to dynamically set two labels based on content from the log line itself:
 
@@ -202,7 +202,7 @@ Now let's talk about Loki, where the index is typically an order of magnitude sm
 
 Loki will effectively keep your static costs as low as possible (index size and memory requirements as well as static log storage) and make the query performance something you can control at runtime with horizontal scaling.
 
-To see how this works, let's look back at our example of querying your access log data for a specific IP address. We don't want to use a label to store the IP address. Instead we use a [filter expression]({{<relref "../query/log_queries#line-filter-expression">}}) to query for it:
+To see how this works, let's look back at our example of querying your access log data for a specific IP address. We don't want to use a label to store the IP address. Instead we use a [filter expression]({{< relref "../query/log_queries#line-filter-expression" >}}) to query for it:
 
 ```
 {job="apache"} |= "11.11.11.11"

--- a/docs/sources/fundamentals/overview/_index.md
+++ b/docs/sources/fundamentals/overview/_index.md
@@ -22,7 +22,7 @@ An agent (also called a client) acquires logs,
 turns the logs into streams,
 and pushes the streams to Loki through an HTTP API.
 The Promtail agent is designed for Loki installations,
-but many other [Agents]({{<relref "../../clients">}}) seamlessly integrate with Loki.
+but many other [Agents]({{< relref "../../clients" >}}) seamlessly integrate with Loki.
 
 ![Loki agent interaction](loki-overview-2.png)
 
@@ -31,7 +31,7 @@ Each stream identifies a set of logs associated with a unique set of labels.
 A quality set of labels is key to the creation of an index that is both compact
 and allows for efficient query execution.
 
-[LogQL]({{<relref "../../query">}}) is the query language for Loki.
+[LogQL]({{< relref "../../query" >}}) is the query language for Loki.
 
 ## Loki features
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -22,7 +22,7 @@ Grafana provides a way to pose queries against the logs stored in Loki and visua
 
 The test environment uses Docker compose to instantiate these parts, each in its own container: 
 
-- One [single scalable deployment]({{<relref "../fundamentals/architecture/deployment-modes">}}) mode **Loki** instance has:
+- One [single scalable deployment]({{< relref "../fundamentals/architecture/deployment-modes" >}}) mode **Loki** instance has:
     - One Loki read component
     - One Loki write component
     - **Minio** is Loki's storage back end in the test environment.
@@ -97,7 +97,7 @@ To see every log line other than those that contain the value 401:
 {container="evaluate-loki-flog-1"} != "401"
 ```
 
-Refer to [query examples]({{<relref "../query/query_examples">}}) for more examples.
+Refer to [query examples]({{< relref "../query/query_examples" >}}) for more examples.
 
 ## Stop and clean up the test environment
 

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -8,13 +8,13 @@ weight: 200
 
 There are several methods of installing Loki and Promtail:
 
-- [Install using Helm (recommended)]({{<relref "helm">}})
-- [Install using Tanka]({{<relref "tanka">}})
-- [Install through Docker or Docker Compose]({{<relref "docker">}})
-- [Install and run locally]({{<relref "local">}})
-- [Install from source]({{<relref "install-from-source">}})
+- [Install using Helm (recommended)]({{< relref "./helm" >}})
+- [Install using Tanka]({{< relref "./tanka" >}})
+- [Install through Docker or Docker Compose]({{< relref "./docker" >}})
+- [Install and run locally]({{< relref "./local" >}})
+- [Install from source]({{< relref "./install-from-source" >}})
 
-The [Sizing Tool]({{<relref "sizing">}}) can be used to determine the proper cluster sizing
+The [Sizing Tool]({{< relref "./sizing" >}}) can be used to determine the proper cluster sizing
 given an expected ingestion rate and query performance.  It targets the Helm
 installation on Kubernetes.
 

--- a/docs/sources/installation/helm/_index.md
+++ b/docs/sources/installation/helm/_index.md
@@ -22,4 +22,4 @@ This guide references the Loki Helm chart version 3.0 or greater and contains th
 
 ## Reference
 
-[Values reference]({{<relref "reference">}})
+[Values reference]({{< relref "./reference" >}})

--- a/docs/sources/installation/helm/concepts.md
+++ b/docs/sources/installation/helm/concepts.md
@@ -25,7 +25,7 @@ This chart includes dashboards for monitoring Loki. These require the scrape con
 
 ## Canary
 
-This chart installs the [canary]({{<relref "../../operations/loki-canary">}}) and its alerts by default. This is another tool to verify the Loki deployment is in a healthy state. It can be disabled with `monitoring.lokiCanary.enabled=false`.
+This chart installs the [canary]({{< relref "../../operations/loki-canary" >}}) and its alerts by default. This is another tool to verify the Loki deployment is in a healthy state. It can be disabled with `monitoring.lokiCanary.enabled=false`.
 
 ## Gateway
 

--- a/docs/sources/installation/helm/configure-storage/index.md
+++ b/docs/sources/installation/helm/configure-storage/index.md
@@ -13,7 +13,7 @@ keywords:
 
 # Configure storage
 
-The [scalable]({{<relref "../install-scalable">}}) installation requires a managed object store such as AWS S3 or Google Cloud Storage or a self-hosted store such as Minio. The [single binary]({{<relref "../install-monolithic">}}) installation can only use the filesystem for storage.
+The [scalable]({{< relref "../install-scalable" >}}) installation requires a managed object store such as AWS S3 or Google Cloud Storage or a self-hosted store such as Minio. The [single binary]({{< relref "../install-monolithic" >}}) installation can only use the filesystem for storage.
 
 This guide assumes Loki will be installed in one of the modes above and that a `values.yaml ` has been created.
 
@@ -37,7 +37,7 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 
 **To grant access to S3 via an IAM role without providing credentials:**
 
-1. Provision an IAM role, policy and S3 bucket as described in [Storage]({{<relref "../../../storage/#aws-deployment-s3-single-store">}}).
+1. Provision an IAM role, policy and S3 bucket as described in [Storage]({{< relref "../../../storage#aws-deployment-s3-single-store" >}}).
    - If the Terraform module was used note the annotation emitted by `terraform output -raw annotation`.
 
 2. Add the IAM role annotation to the service account in `values.yaml`:

--- a/docs/sources/installation/helm/install-monolithic/index.md
+++ b/docs/sources/installation/helm/install-monolithic/index.md
@@ -12,7 +12,7 @@ keywords:
 
 This Helm Chart installation runs the Grafana Loki *single binary* within a Kubernetes cluster.
 
-If you set the `singleBinary.replicas` value to 1, this chart configures Loki to run the `all` target in a [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode">}}), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
+If you set the `singleBinary.replicas` value to 1, this chart configures Loki to run the `all` target in a [monolithic mode]({{< relref "../../../fundamentals/architecture/deployment-modes#monolithic-mode" >}}), designed to work with a filesystem storage. It will also configure meta-monitoring of metrics and logs.
 If you set the `singleBinary.replicas` value to 2 or more, this chart configures Loki to run a *single binary* in a replicated, highly available mode.  When running replicas of a single binary, you must configure object storage.
 
 **Before you begin: Software Requirements**

--- a/docs/sources/installation/helm/install-scalable/index.md
+++ b/docs/sources/installation/helm/install-scalable/index.md
@@ -14,7 +14,7 @@ keywords:
 
 This Helm Chart installation runs the Grafana Loki cluster within a Kubernetes cluster.
 
-If object storge is configured, this chart configures Loki to run `read` and `write` targets in a [scalable mode]({{<relref "../../../fundamentals/architecture/deployment-modes/#simple-scalable-deployment-mode">}}), highly available architecture (3 replicas of each) designed to work with AWS S3 object storage. It will also configure meta-monitoring of metrics and logs.
+If object storge is configured, this chart configures Loki to run `read` and `write` targets in a [scalable mode]({{< relref "../../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode" >}}), highly available architecture (3 replicas of each) designed to work with AWS S3 object storage. It will also configure meta-monitoring of metrics and logs.
 
 It is not possible to run the scalable mode with the `filesystem` storage.
 
@@ -23,7 +23,7 @@ It is not possible to run the scalable mode with the `filesystem` storage.
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
 - A running Kubernetes cluster.
 - A Prometheus operator installation in case meta-monitoring should be used.
-- Optionally a Memcached deployment for better performance. Consult the [caching section]({{<relref "../../../operations/caching">}}) on how to configure Memcached.
+- Optionally a Memcached deployment for better performance. Consult the [caching section]({{< relref "../../../operations/caching" >}}) on how to configure Memcached.
 
 **To deploy Loki in scalable mode:**
 
@@ -60,7 +60,7 @@ It is not possible to run the scalable mode with the `filesystem` storage.
             insecure: false
       ```
 
-      Consult the [Reference]({{<relref "../reference">}}) for configuring other storage providers.
+      Consult the [Reference]({{< relref "../reference" >}}) for configuring other storage providers.
 
     - If you're just trying things, you can use the following configuration instead, that sets MinIO as storage:
       ```yaml

--- a/docs/sources/installation/helm/monitor-and-alert/_index.md
+++ b/docs/sources/installation/helm/monitor-and-alert/_index.md
@@ -15,5 +15,5 @@ keywords:
 
 There are two common ways to monitor Loki:
 
-- [Monitor using Grafana Cloud (recommended)]({{<relref "with-grafana-cloud">}})
-- [Monitor using Local Monitoring]({{<relref "with-local-monitoring">}})
+- [Monitor using Grafana Cloud (recommended)]({{< relref "./with-grafana-cloud" >}})
+- [Monitor using Local Monitoring]({{< relref "./with-local-monitoring" >}})

--- a/docs/sources/installation/local.md
+++ b/docs/sources/installation/local.md
@@ -31,7 +31,7 @@ The configuration specifies running Loki as a single binary.
 1. Navigate to the [release page](https://github.com/grafana/loki/releases/).
 2. Scroll down to the Assets section under the version that you want to install.
 3. Download the Loki and Promtail .zip files that correspond to your system.
-   **Note:** Do not download LogCLI or Loki Canary at this time. `LogCLI` allows you to run Loki queries in a command line interface. [Loki Canary]({{<relref "../operations/loki-canary">}}) is a tool to audit Loki performance.
+   **Note:** Do not download LogCLI or Loki Canary at this time. `LogCLI` allows you to run Loki queries in a command line interface. [Loki Canary]({{< relref "../operations/loki-canary" >}}) is a tool to audit Loki performance.
 4. Unzip the package contents into the same directory. This is where the two programs will run.
 5. In the command line, change directory (`cd` on most systems) to the directory with Loki and Promtail. Copy and paste the commands below into your command line to download generic configuration files.
    **Note:** Use the corresponding Git refs that match your downloaded Loki version to get the correct configuration file. For example, if you are using Loki version 2.6.1, you need to use the `https://raw.githubusercontent.com/grafana/loki/v2.6.1/cmd/loki/loki-local-config.yaml` URL to download the configuration file that corresponds to the Loki version you aim to run.
@@ -56,7 +56,7 @@ The configuration specifies running Loki as a single binary.
 Loki runs and displays Loki logs in your command line and on http://localhost:3100/metrics.
 
 The next step will be running an agent to send logs to Loki.
-To do so with Promtail, refer to the [Promtal configuration]({{<relref "../clients/promtail">}}).
+To do so with Promtail, refer to the [Promtal configuration]({{< relref "../clients/promtail" >}}).
 
 ## Release binaries - openSUSE Linux only
 

--- a/docs/sources/installation/sizing/index.md
+++ b/docs/sources/installation/sizing/index.md
@@ -16,7 +16,7 @@ keywords: []
 
 This tool helps to generate a Helm Charts `values.yaml` file based on specified
  expected ingestion, retention rate and node type. It will always configure a
- [scalable]({{<relref "../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode">}}) deployment. The storage needs to be configured after generation.
+ [scalable]({{< relref "../../fundamentals/architecture/deployment-modes#simple-scalable-deployment-mode" >}}) deployment. The storage needs to be configured after generation.
 
 <div id="app">
   <label>Node Type<i class="fa fa-question" v-on:mouseover="help='node'" v-on:mouseleave="help=null"></i></label>

--- a/docs/sources/operations/authentication.md
+++ b/docs/sources/operations/authentication.md
@@ -12,7 +12,7 @@ as NGINX using basic auth or an OAuth2 proxy.
 Note that when using Loki in multi-tenant mode, Loki requires the HTTP header
 `X-Scope-OrgID` to be set to a string identifying the tenant; the responsibility
 of populating this value should be handled by the authenticating reverse proxy.
-Read the [multi-tenancy]({{<relref "multi-tenancy">}}) documentation for more information.
+Read the [multi-tenancy]({{< relref "./multi-tenancy" >}}) documentation for more information.
 
 For information on authenticating Promtail, please see the docs for [how to
-configure Promtail]({{<relref "../clients/promtail/configuration">}}).
+configure Promtail]({{< relref "../clients/promtail/configuration" >}}).

--- a/docs/sources/operations/automatic-stream-sharding.md
+++ b/docs/sources/operations/automatic-stream-sharding.md
@@ -12,7 +12,7 @@ existing streams. When properly tuned, this should eliminate issues where log pr
 per-stream rate limit.
 
 **To enable automatic stream sharding:**
-1. Edit the global [limits_config]({{<relref "../configuration#limits_config">}}) of the Loki configuration file:
+1. Edit the global [limits_config]({{< relref "../configuration#limits_config" >}}) of the Loki configuration file:
    ```yaml
    limits_config:
      shard_streams:

--- a/docs/sources/operations/blocking-queries.md
+++ b/docs/sources/operations/blocking-queries.md
@@ -9,7 +9,7 @@ In certain situations, you may not be able to control the queries being sent to 
 may be intentionally or unintentionally expensive to run, and they may affect the overall stability or cost of running
 your service.
 
-You can block queries using [per-tenant overrides]({{<relref "../configuration/#runtime-configuration-file">}}), like so:
+You can block queries using [per-tenant overrides]({{< relref "../configuration#runtime-configuration-file" >}}), like so:
 
 ```yaml
 overrides:
@@ -35,7 +35,7 @@ overrides:
         types: filter,limited
 ```
 
-NOTE: changes to these configurations **do not require a restart**; they are defined in the [runtime configuration file]({{<relref "../configuration/#runtime-configuration-file">}}).
+NOTE: changes to these configurations **do not require a restart**; they are defined in the [runtime configuration file]({{< relref "../configuration#runtime-configuration-file" >}}).
 
 The available query types are:
 
@@ -60,4 +60,4 @@ Blocked queries are logged, as well as counted in the `loki_blocked_queries` met
 
 ## Scope
 
-Queries received via the API and executed as [alerting/recording rules]({{<relref "../alert">}}) will be blocked.
+Queries received via the API and executed as [alerting/recording rules]({{< relref "../alert" >}}) will be blocked.

--- a/docs/sources/operations/observability.md
+++ b/docs/sources/operations/observability.md
@@ -91,7 +91,7 @@ Most of these metrics are counters and should continuously increase during norma
 
 If Promtail uses any pipelines with metrics stages, those metrics will also be
 exposed by Promtail at its `/metrics` endpoint. See Promtail's documentation on
-[Pipelines]({{<relref "../clients/promtail/pipelines">}}) for more information.
+[Pipelines]({{< relref "../clients/promtail/pipelines" >}}) for more information.
 
 An example Grafana dashboard was built by the community and is available as
 dashboard [10004](/dashboards/10004).

--- a/docs/sources/operations/query-fairness/_index.md
+++ b/docs/sources/operations/query-fairness/_index.md
@@ -7,7 +7,7 @@ weight: 101
 
 # Query fairness within tenants
 
-Loki uses [shuffle sharding]({{<relref "../shuffle-sharding/_index.md">}})
+Loki uses [shuffle sharding]({{< relref "../shuffle-sharding/_index.md" >}})
 to minimize impact across tenants in case of querier failures or misbehaving
 neighboring tenants.
 
@@ -20,7 +20,7 @@ In that case, as an operator, you would also want to ensure some sort of query
 fairness across these actors within the tenants. An actor could be a Grafana user,
 a CLI user, or an application accessing the API. To achieve that, Loki
 introduces hierarchical scheduler queues in version 2.9 based on
-[LID 0003: Query fairness across users within tenants]({{<relref "../../community/lids/0003-QueryFairnessInScheduler.md">}})
+[LID 0003: Query fairness across users within tenants]({{< relref "../../community/lids/0003-QueryFairnessInScheduler.md" >}})
 and they are enabled by default.
 
 ## What are hierarchical queues and how do they work

--- a/docs/sources/operations/recording-rules.md
+++ b/docs/sources/operations/recording-rules.md
@@ -7,7 +7,7 @@ description: Working with recording rules.
 
 Recording rules are evaluated by the `ruler` component. Each `ruler` acts as its own `querier`, in the sense that it
 executes queries against the store without using the `query-frontend` or `querier` components. It will respect all query
-[limits]({{< relref "../configuration/#limits_config" >}}) put in place for the `querier`.
+[limits]({{< relref "../configuration#limits_config" >}}) put in place for the `querier`.
 
 Loki's implementation of recording rules largely reuses Prometheus' code.
 
@@ -70,8 +70,8 @@ so a `Persistent Volume` should be utilised.
 ### Per-Tenant Limits
 
 Remote-write can be configured at a global level in the base configuration, and certain parameters tuned specifically on
-a per-tenant basis. Most of the configuration options [defined here]({{<relref "../configuration/#ruler">}})
-have [override options]({{<relref "../configuration/#limits_config">}}) (which can be also applied at runtime!).
+a per-tenant basis. Most of the configuration options [defined here]({{< relref "../configuration#ruler" >}})
+have [override options]({{< relref "../configuration#limits_config" >}}) (which can be also applied at runtime!).
 
 ### Tuning
 

--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -17,20 +17,20 @@ format](#chunk-format) for how chunks are stored internally.
 The **index** stores each stream's label set and links them to the individual
 chunks.
 
-Refer to Loki's [configuration]({{<relref "../../configuration/">}}) for details on
+Refer to Loki's [configuration]({{< relref "../../configuration" >}}) for details on
 how to configure the storage and the index.
 
 For more information:
 
-1. [Table Manager]({{<relref "table-manager">}})
-1. [Retention]({{<relref "retention">}})
-1. [Logs Deletion]({{<relref "logs-deletion">}})
+1. [Table Manager]({{< relref "./table-manager" >}})
+1. [Retention]({{< relref "./retention" >}})
+1. [Logs Deletion]({{< relref "./logs-deletion" >}})
 
 ## Supported Stores
 
 The following are supported for the index:
 
-- [Single Store (boltdb-shipper) - Recommended for 2.0 and newer]({{<relref "boltdb-shipper">}}) index store which stores boltdb index files in the object store
+- [Single Store (boltdb-shipper) - Recommended for 2.0 and newer]({{< relref "./boltdb-shipper" >}}) index store which stores boltdb index files in the object store
 - [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
 - [Google Bigtable](https://cloud.google.com/bigtable)
 - [Apache Cassandra](https://cassandra.apache.org)
@@ -43,7 +43,7 @@ The following are supported for the chunks:
 - [Apache Cassandra](https://cassandra.apache.org)
 - [Amazon S3](https://aws.amazon.com/s3)
 - [Google Cloud Storage](https://cloud.google.com/storage/)
-- [Filesystem]({{<relref "filesystem">}}) (please read more about the filesystem to understand the pros/cons before using with production data)
+- [Filesystem]({{< relref "./filesystem" >}}) (please read more about the filesystem to understand the pros/cons before using with production data)
 - [Baidu Object Storage](https://cloud.baidu.com/product/bos.html)
 - [IBM Cloud Object Storage](https://www.ibm.com/cloud/object-storage)
 
@@ -60,7 +60,7 @@ When using S3 as object storage, the following permissions are needed:
 
 Resources: `arn:aws:s3:::<bucket_name>`, `arn:aws:s3:::<bucket_name>/*`
 
-See the [AWS deployment section]({{<relref "../../storage/#aws-deployment-s3-single-store">}}) on the storage page for a detailed setup guide.
+See the [AWS deployment section]({{< relref "../../storage#aws-deployment-s3-single-store" >}}) on the storage page for a detailed setup guide.
 
 ### DynamoDB
 
@@ -114,7 +114,7 @@ Resources: `arn:aws:iam::<aws_account_id>:role/<role_name>`
 
 When using IBM Cloud Object Storage (COS) as object storage, IAM `Writer` role is needed.
 
-See the [IBM Cloud Object Storage section]({{<relref "../../storage/#ibm-cloud-object-storage">}}) on the storage page for a detailed setup guide.
+See the [IBM Cloud Object Storage section]({{< relref "../../storage#ibm-cloud-object-storage" >}}) on the storage page for a detailed setup guide.
 
 ## Chunk Format
 

--- a/docs/sources/operations/storage/boltdb-shipper.md
+++ b/docs/sources/operations/storage/boltdb-shipper.md
@@ -105,14 +105,14 @@ Within Kubernetes, if you are not using an Index Gateway, we recommend running Q
 An Index Gateway downloads and synchronizes the BoltDB index from the Object Storage in order to serve index queries to the Queriers and Rulers over gRPC.
 This avoids running Queriers and Rulers with a disk for persistence. Disks can become costly in a big cluster.
 
-To run an Index Gateway, configure [StorageConfig]({{<relref "../../configuration/#storage_config">}}) and set the `-target` CLI flag to `index-gateway`.
-To connect Queriers and Rulers to the Index Gateway, set the address (with gRPC port) of the Index Gateway with the `-boltdb.shipper.index-gateway-client.server-address` CLI flag or its equivalent YAML value under [StorageConfig]({{<relref "../../configuration/#storage_config">}}).
+To run an Index Gateway, configure [StorageConfig]({{< relref "../../configuration#storage_config" >}}) and set the `-target` CLI flag to `index-gateway`.
+To connect Queriers and Rulers to the Index Gateway, set the address (with gRPC port) of the Index Gateway with the `-boltdb.shipper.index-gateway-client.server-address` CLI flag or its equivalent YAML value under [StorageConfig]({{< relref "../../configuration#storage_config" >}}).
 
 When using the Index Gateway within Kubernetes, we recommend using a StatefulSet with persistent storage for downloading and querying index files. This can obtain better read performance, avoids [noisy neighbor problems](https://en.wikipedia.org/wiki/Cloud_computing_issues#Performance_interference_and_noisy_neighbors) by not using the node disk, and avoids the time consuming index downloading step on startup after rescheduling to a new node.
 
 ### Write Deduplication disabled
 
-Loki does write deduplication of chunks and index using Chunks and WriteDedupe cache respectively, configured with [ChunkStoreConfig]({{<relref "../../configuration/#chunk_store_config">}}).
+Loki does write deduplication of chunks and index using Chunks and WriteDedupe cache respectively, configured with [ChunkStoreConfig]({{< relref "../../configuration#chunk_store_config" >}}).
 The problem with write deduplication when using `boltdb-shipper` though is ingesters only keep uploading boltdb files periodically to make them available to all the other services which means there would be a brief period where some of the services would not have received updated index yet.
 The problem due to that is if an ingester which first wrote the chunks and index goes down and all the other ingesters which were part of replication scheme skipped writing those chunks and index due to deduplication, we would end up missing those logs from query responses since only the ingester which had the index went down.
 This problem would be faced even during rollouts which is quite common.

--- a/docs/sources/operations/storage/filesystem.md
+++ b/docs/sources/operations/storage/filesystem.md
@@ -18,7 +18,7 @@ A folder is created for every tenant all the chunks for one tenant are stored in
 
 If Loki is run in single-tenant mode, all the chunks are put in a folder named `fake` which is the synthesized tenant name used for single tenant mode.
 
-See [multi-tenancy]({{<relref "../multi-tenancy">}}) for more information.
+See [multi-tenancy]({{< relref "../multi-tenancy" >}}) for more information.
 
 ## Pros
 

--- a/docs/sources/operations/storage/logs-deletion.md
+++ b/docs/sources/operations/storage/logs-deletion.md
@@ -11,11 +11,11 @@ Log entries that fall within a specified time window and match an optional line 
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
-The compactor component exposes REST [endpoints]({{<relref "../../reference/api/#compactor">}}) that process delete requests.
+The compactor component exposes REST [endpoints]({{< relref "../../reference/api#compactor" >}}) that process delete requests.
 Hitting the endpoint specifies the streams and the time window.
 The deletion of the log entries takes place after a configurable cancellation time period expires.
 
-Log entry deletion relies on configuration of the custom logs retention workflow as defined for the [compactor]({{<relref "retention#compactor">}}). The compactor looks at unprocessed requests which are past their cancellation period to decide whether a chunk is to be deleted or not.
+Log entry deletion relies on configuration of the custom logs retention workflow as defined for the [compactor]({{< relref "./retention#compactor" >}}). The compactor looks at unprocessed requests which are past their cancellation period to decide whether a chunk is to be deleted or not.
 
 ## Configuration
 

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -8,13 +8,13 @@ Retention in Grafana Loki is achieved either through the [Table Manager](#table-
 
 By default, when `table_manager.retention_deletes_enabled` or `compactor.retention_enabled` flags are not set, then logs sent to Loki live forever.
 
-Retention through the [Table Manager]({{<relref "table-manager">}}) is achieved by relying on the object store TTL feature, and will work for both [boltdb-shipper]({{<relref "boltdb-shipper">}}) store and chunk/index store. However retention through the [Compactor]({{<relref "boltdb-shipper#compactor">}}) is supported only with the [boltdb-shipper]({{<relref "boltdb-shipper">}}) and tsdb store.
+Retention through the [Table Manager]({{< relref "./table-manager" >}}) is achieved by relying on the object store TTL feature, and will work for both [boltdb-shipper]({{< relref "./boltdb-shipper" >}}) store and chunk/index store. However retention through the [Compactor]({{< relref "./boltdb-shipper#compactor" >}}) is supported only with the [boltdb-shipper]({{< relref "./boltdb-shipper" >}}) and tsdb store.
 
 The Compactor retention will become the default and have long term support. It supports more granular retention policies on per tenant and per stream use cases.
 
 ## Compactor
 
-The [Compactor]({{<relref "boltdb-shipper#compactor">}}) can deduplicate index entries. It can also apply granular retention. When applying retention with the Compactor, the [Table Manager]({{<relref "table-manager">}}) is unnecessary.
+The [Compactor]({{< relref "./boltdb-shipper#compactor" >}}) can deduplicate index entries. It can also apply granular retention. When applying retention with the Compactor, the [Table Manager]({{< relref "./table-manager" >}}) is unnecessary.
 
 > Run the Compactor as a singleton (a single instance).
 
@@ -88,7 +88,7 @@ The index period must be 24h.
 
 #### Configuring the retention period
 
-Retention period is configured within the [`limits_config`]({{<relref "../../configuration/#limits_config">}}) configuration section.
+Retention period is configured within the [`limits_config`]({{< relref "../../configuration#limits_config" >}}) configuration section.
 
 There are two ways of setting retention policies:
 
@@ -164,7 +164,7 @@ The example configurations will set these rules:
 
 In order to enable the retention support, the Table Manager needs to be
 configured to enable deletions and a retention period. Please refer to the
-[`table_manager`]({{<relref "../../configuration#table_manager">}})
+[`table_manager`]({{< relref "../../configuration#table_manager" >}})
 section of the Loki configuration reference for all available options.
 Alternatively, the `table-manager.retention-period` and
 `table-manager.retention-deletes-enabled` command line flags can be used. The
@@ -172,12 +172,12 @@ provided retention period needs to be a duration represented as a string that
 can be parsed using the Prometheus common model [ParseDuration](https://pkg.go.dev/github.com/prometheus/common/model#ParseDuration). Examples: `7d`, `1w`, `168h`.
 
 > **WARNING**: The retention period must be a multiple of the index and chunks table
-`period`, configured in the [`period_config`]({{<relref "../../configuration#period_config">}})
-block. See the [Table Manager]({{<relref "table-manager#retention">}}) documentation for
+`period`, configured in the [`period_config`]({{< relref "../../configuration#period_config" >}})
+block. See the [Table Manager]({{< relref "./table-manager#retention" >}}) documentation for
 more information.
 
 > **NOTE**: To avoid querying of data beyond the retention period,
-`max_look_back_period` config in [`chunk_store_config`]({{<relref "../../configuration#chunk_store_config">}}) must be set to a value less than or equal to
+`max_look_back_period` config in [`chunk_store_config`]({{< relref "../../configuration#chunk_store_config" >}}) must be set to a value less than or equal to
 what is set in `table_manager.retention_period`.
 
 When using S3 or GCS, the bucket storing the chunks needs to have the expiry
@@ -197,7 +197,7 @@ intact; you will still be able to see related labels but will be unable to
 retrieve the deleted log content.
 
 For further details on the Table Manager internals, refer to the
-[Table Manager]({{<relref "table-manager">}}) documentation.
+[Table Manager]({{< relref "./table-manager" >}}) documentation.
 
 
 ## Example Configuration

--- a/docs/sources/operations/storage/table-manager/_index.md
+++ b/docs/sources/operations/storage/table-manager/_index.md
@@ -23,7 +23,7 @@ time range exceeds the retention period.
 The Table Manager supports the following backends:
 
 - **Index store**
-  - [Single Store (boltdb-shipper)]({{<relref "../boltdb-shipper">}})
+  - [Single Store (boltdb-shipper)]({{< relref "../boltdb-shipper" >}})
   - [Amazon DynamoDB](https://aws.amazon.com/dynamodb)
   - [Google Bigtable](https://cloud.google.com/bigtable)
   - [Apache Cassandra](https://cassandra.apache.org)
@@ -39,7 +39,7 @@ to store chunks, are not managed by the Table Manager, and a custom bucket polic
 should be set to delete old data.
 
 For detailed information on configuring the Table Manager, refer to the
-[`table_manager`]({{<relref "../../../configuration#table_manager">}})
+[`table_manager`]({{< relref "../../../configuration#table_manager" >}})
 section in the Loki configuration document.
 
 
@@ -48,10 +48,10 @@ section in the Loki configuration document.
 A periodic table stores the index or chunk data relative to a specific period
 of time. The duration of the time range of the data stored in a single table and
 its storage type is configured in the
-[`schema_config`]({{<relref "../../../configuration#schema_config">}}) configuration
+[`schema_config`]({{< relref "../../../configuration#schema_config" >}}) configuration
 block.
 
-The [`schema_config`]({{<relref "../../../configuration#schema_config">}}) can contain
+The [`schema_config`]({{< relref "../../../configuration#schema_config" >}}) can contain
 one or more `configs`. Each config, defines the storage used between the day
 set in `from` (in the format `yyyy-mm-dd`) and the next config, or "now"
 in the case of the last schema config entry.
@@ -105,7 +105,7 @@ order to make sure that the new table is ready once the current table end
 period is reached.
 
 The `creation_grace_period` property - in the
-[`table_manager`]({{<relref "../../../configuration#table_manager">}})
+[`table_manager`]({{< relref "../../../configuration#table_manager" >}})
 configuration block - defines how long before a table should be created.
 
 
@@ -140,7 +140,7 @@ It's important to note that - due to the internal implementation - the table
 the expected behavior.
 
 For detailed information on configuring the retention, refer to the
-[Loki Storage Retention]({{<relref "../retention">}})
+[Loki Storage Retention]({{< relref "../retention" >}})
 documentation.
 
 
@@ -149,7 +149,7 @@ documentation.
 A table can be active or inactive.
 
 A table is considered **active** if the current time is within the range:
-- Table start period - [`creation_grace_period`]({{<relref "../../../configuration#table_manager">}})
+- Table start period - [`creation_grace_period`]({{< relref "../../../configuration#table_manager" >}})
 - Table end period + max chunk age (hardcoded to `12h`)
 
 ![active_vs_inactive_tables](./table-manager-active-vs-inactive-tables.png)
@@ -200,13 +200,13 @@ The Table Manager can be executed in two ways:
 
 ### Monolithic mode
 
-When Loki runs in [monolithic mode]({{<relref "../../../fundamentals/architecture/deployment-modes">}}),
+When Loki runs in [monolithic mode]({{< relref "../../../fundamentals/architecture/deployment-modes" >}}),
 the Table Manager is also started as component of the entire stack.
 
 
 ### Microservices mode
 
-When Loki runs in [microservices mode]({{<relref "../../../fundamentals/architecture/deployment-modes">}}),
+When Loki runs in [microservices mode]({{< relref "../../../fundamentals/architecture/deployment-modes" >}}),
 the Table Manager should be started as separate service named `table-manager`.
 
 You can check out a production grade deployment example at

--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -75,7 +75,7 @@ We've added a user per-tenant limit called `tsdb_max_query_parallelism` in the `
 
 ### Dynamic Query Sharding
 
-Previously we would statically shard queries based on the index row shards configured [here]({{< relref "../../configuration/#period_config" >}}).
+Previously we would statically shard queries based on the index row shards configured [here]({{< relref "../../configuration#period_config" >}}).
 TSDB does Dynamic Query Sharding based on how much data a query is going to be processing.
 We additionally store size(KB) and number of lines for each chunk in the TSDB index which is then used by the [Query Frontend]({{< relref "../../fundamentals/architecture/components#query-frontend" >}}) for planning the query.
 Based on our experience from operating many Loki clusters, we have configured TSDB to aim for processing 300-600 MBs of data per query shard.
@@ -83,4 +83,4 @@ This means with TSDB we will be running more, smaller queries.
 
 ### Index Caching not required
 
-TSDB is a compact and optimized format. Loki does not currently use an index cache for TSDB. If you are already using Loki with other index types, it is recommended to keep the index caching until all of your existing data falls out of [retention]({{< relref "./retention" >}}) or your configured `max_query_lookback` under [limits_config]({{< relref "../../configuration/#limits_config" >}}). After that, we suggest running without an index cache (it isn't used in TSDB).
+TSDB is a compact and optimized format. Loki does not currently use an index cache for TSDB. If you are already using Loki with other index types, it is recommended to keep the index caching until all of your existing data falls out of [retention]({{< relref "./retention" >}}) or your configured `max_query_lookback` under [limits_config]({{< relref "../../configuration#limits_config" >}}). After that, we suggest running without an index cache (it isn't used in TSDB).

--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -83,7 +83,7 @@ When scaling down, we must ensure existing data on the leaving ingesters are flu
 
 Consider you have 4 ingesters `ingester-0 ingester-1 ingester-2 ingester-3` and you want to scale down to 2 ingesters, the ingesters which will be shutdown according to statefulset rules are `ingester-3` and then `ingester-2`.
 
-Hence before actually scaling down in Kubernetes, port forward those ingesters and hit the [`/ingester/flush_shutdown`]({{<relref "../../reference/api#post-ingesterflush_shutdown">}}) endpoint. This will flush the chunks and remove itself from the ring, after which it will register as unready and may be deleted.
+Hence before actually scaling down in Kubernetes, port forward those ingesters and hit the [`/ingester/flush_shutdown`]({{< relref "../../reference/api#post-ingesterflush_shutdown" >}}) endpoint. This will flush the chunks and remove itself from the ring, after which it will register as unready and may be deleted.
 
 After hitting the endpoint for `ingester-2 ingester-3`, scale down the ingesters to 2.
 

--- a/docs/sources/operations/troubleshooting.md
+++ b/docs/sources/operations/troubleshooting.md
@@ -61,7 +61,7 @@ can have many possible causes.
 If you have a reverse proxy in front of Loki, that is, between Loki and Grafana, then check any configured timeouts, such as an NGINX proxy read timeout.
 
 - Other causes.  To determine if the issue is related to Loki itself or another system such as Grafana or a client-side error,
-attempt to run a [LogCLI]({{<relref "../query/logcli">}}) query in as direct a manner as you can. For example, if running on virtual machines, run the query on the local machine. If running in a Kubernetes cluster, then port forward the Loki HTTP port, and attempt to run the query there. If you do not get a timeout, then consider these causes:
+attempt to run a [LogCLI]({{< relref "../query/logcli" >}}) query in as direct a manner as you can. For example, if running on virtual machines, run the query on the local machine. If running in a Kubernetes cluster, then port forward the Loki HTTP port, and attempt to run the query there. If you do not get a timeout, then consider these causes:
 
     - Adjust the [Grafana dataproxy timeout](/docs/grafana/latest/administration/configuration/#dataproxy). Configure Grafana with a large enough dataproxy timeout.
     - Check timeouts for reverse proxies or load balancers between your client and Grafana. Queries to Grafana are made from the your local browser with Grafana serving as a proxy (a dataproxy). Therefore, connections from your client to Grafana must have their timeout configured as well.

--- a/docs/sources/query/_index.md
+++ b/docs/sources/query/_index.md
@@ -16,8 +16,8 @@ LogQL uses labels and operators for filtering.
 
 There are two types of LogQL queries:
 
-- [Log queries]({{<relref "log_queries">}}) return the contents of log lines.
-- [Metric queries]({{<relref "metric_queries">}}) extend log queries to calculate values
+- [Log queries]({{< relref "./log_queries" >}}) return the contents of log lines.
+- [Metric queries]({{< relref "./metric_queries" >}}) extend log queries to calculate values
 based on query results.
 
 ## Binary operators

--- a/docs/sources/query/analyzer.md
+++ b/docs/sources/query/analyzer.md
@@ -21,7 +21,7 @@ A set of example log lines are included for each format.
 Use the provided example log lines, or copy and paste your own log lines into the example log lines box.
 
 Use the provided example query, or enter your own query.
-The [log stream selector]({{<relref "./log_queries/#log-stream-selector">}}) remains fixed for all possible example queries.
+The [log stream selector]({{< relref "./log_queries#log-stream-selector" >}}) remains fixed for all possible example queries.
 Modify the remainder of the log line and click on the **Run query** button
 to run the entered query against the example log lines. 
 

--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -200,7 +200,7 @@ will always run faster than
 Line filter expressions are the fastest way to filter logs once the
 log stream selectors have been applied.
 
-Line filter expressions have support matching IP addresses. See [Matching IP addresses]({{<relref "../ip">}}) for details.
+Line filter expressions have support matching IP addresses. See [Matching IP addresses]({{< relref "../ip" >}}) for details.
 
 
 ### Removing color codes
@@ -240,7 +240,7 @@ Using Duration, Number and Bytes will convert the label value prior to comparisi
 
 For instance, `logfmt | duration > 1m and bytes_consumed > 20MB`
 
-If the conversion of the label value fails, the log line is not filtered and an `__error__` label is added. To filters those errors see the [pipeline errors]({{<relref "../#pipeline-errors">}}) section.
+If the conversion of the label value fails, the log line is not filtered and an `__error__` label is added. To filters those errors see the [pipeline errors]({{< relref "..#pipeline-errors" >}}) section.
 
 You can chain multiple predicates using `and` and `or` which respectively express the `and` and `or` binary operations. `and` can be equivalently expressed by a comma, a space or another pipe. Label filters can be place anywhere in a log pipeline.
 
@@ -271,7 +271,7 @@ To evaluate the logical `and` first, use parenthesis, as in this example:
 
 > Label filter expressions are the only expression allowed after the unwrap expression. This is mainly to allow filtering errors from the metric extraction.
 
-Label filter expressions have support matching IP addresses. See [Matching IP addresses]({{<relref "../ip">}}) for details.
+Label filter expressions have support matching IP addresses. See [Matching IP addresses]({{< relref "../ip" >}}) for details.
 
 ### Distinct filter expression
 
@@ -291,7 +291,7 @@ The expression `{app="order"} | json | distinct id` will return the distinct occ
 ```
 ### Parser expression
 
-Parser expression can parse and extract labels from the log content. Those extracted labels can then be used for filtering using [label filter expressions](#label-filter-expression) or for [metric aggregations]({{<relref "../metric_queries">}}).
+Parser expression can parse and extract labels from the log content. Those extracted labels can then be used for filtering using [label filter expressions](#label-filter-expression) or for [metric aggregations]({{< relref "../metric_queries" >}}).
 
 Extracted label keys are automatically sanitized by all parsers, to follow Prometheus metric name convention.(They can only contain ASCII letters and digits, as well as underscores and colons. They cannot start with a digit.)
 
@@ -311,7 +311,7 @@ If an extracted label key name already exists in the original log stream, the ex
 Loki supports  [JSON](#json), [logfmt](#logfmt), [pattern](#pattern), [regexp](#regular-expression) and [unpack](#unpack) parsers.
 
 It's easier to use the predefined parsers `json` and `logfmt` when you can. If you can't, the `pattern` and `regexp` parsers can be used for log lines with an unusual structure. The `pattern` parser is easier and faster to write; it also outperforms the `regexp` parser.
-Multiple parsers can be used by a single log pipeline. This is useful for parsing complex logs. There are examples in [Multiple parsers]({{<relref "../query_examples#examples-that-use-multiple-parsers">}}).
+Multiple parsers can be used by a single log pipeline. This is useful for parsing complex logs. There are examples in [Multiple parsers]({{< relref "../query_examples#examples-that-use-multiple-parsers" >}}).
 
 #### JSON
 
@@ -582,7 +582,7 @@ If we have the following labels `ip=1.1.1.1`, `status=200` and `duration=3000`(m
 
 The above query will give us the `line` as `1.1.1.1 200 3`
 
-See [template functions]({{<relref "../template_functions/">}}) to learn about available functions in the template format.
+See [template functions]({{< relref "../template_functions" >}}) to learn about available functions in the template format.
 
 ### Labels format expression
 

--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -60,7 +60,7 @@ Examples:
 
 ### Unwrapped range aggregations
 
-Unwrapped ranges uses extracted labels as sample values instead of log lines. However to select which label will be used within the aggregation, the log query must end with an unwrap expression and optionally a label filter expression to discard [errors]({{<relref "./#pipeline-errors">}}).
+Unwrapped ranges uses extracted labels as sample values instead of log lines. However to select which label will be used within the aggregation, the log query must end with an unwrap expression and optionally a label filter expression to discard [errors]({{< relref ".#pipeline-errors" >}}).
 
 The unwrap expression is noted `| unwrap label_identifier` where the label identifier is the label name to use for extracting sample values.
 
@@ -96,7 +96,7 @@ Which can be used to aggregate over distinct labels dimensions by including a `w
 
 `without` removes the listed labels from the result vector, while all other labels are preserved the output. `by` does the opposite and drops labels that are not listed in the `by` clause, even if their label values are identical between all elements of the vector.
 
-See [Unwrap examples]({{<relref "query_examples/#unwrap-examples">}}) for query examples that use the unwrap expression.
+See [Unwrap examples]({{< relref "./query_examples#unwrap-examples" >}}) for query examples that use the unwrap expression.
 
 ## Built-in aggregation operators
 
@@ -127,7 +127,7 @@ The aggregation operators can either be used to aggregate over all label values 
 The `without` clause removes the listed labels from the resulting vector, keeping all others.
 The `by` clause does the opposite, dropping labels that are not listed in the clause, even if their label values are identical between all elements of the vector.
 
-See [vector aggregation examples]({{<relref "query_examples/#vector-aggregation-examples">}}) for query examples that use vector aggregation expressions.
+See [vector aggregation examples]({{< relref "./query_examples#vector-aggregation-examples" >}}) for query examples that use vector aggregation expressions.
 
 ## Functions
 

--- a/docs/sources/reference/_index.md
+++ b/docs/sources/reference/_index.md
@@ -9,4 +9,4 @@ weight: 1100
 
 This section provides reference material for Loki.
 
-1. [Loki HTTP API]({{<relref "api.md">}})
+1. [Loki HTTP API]({{< relref "./api" >}})

--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -117,7 +117,7 @@ GET /loki/api/v1/query
 `/loki/api/v1/query` allows for doing queries against a single point in time. The URL
 query parameters support the following values:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) query to perform
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
 - `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
 - `time`: The evaluation time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward`.
@@ -226,7 +226,7 @@ gave this response:
 ```
 
 If your cluster has
-[Grafana Loki Multi-Tenancy]({{< relref "../operations/multi-tenancy/" >}}) enabled,
+[Grafana Loki Multi-Tenancy]({{< relref "../operations/multi-tenancy" >}}) enabled,
 set the `X-Scope-OrgID` header to identify the tenant you want to query.
 Here is the same example query for the single tenant called `Tenant1`:
 
@@ -269,7 +269,7 @@ GET /loki/api/v1/query_range
 `/loki/api/v1/query_range` is used to do a query over a range of time and
 accepts the following query parameters in the URL:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) query to perform
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
 - `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
 - `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to one hour ago. Loki returns results with timestamp greater or equal to this value.
 - `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now. Loki returns results with timestamp lower than this value.
@@ -524,7 +524,7 @@ GET /loki/api/v1/tail
 `/loki/api/v1/tail` is a WebSocket endpoint that will stream log messages based on
 a query. It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) query to perform
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
   loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return. It defaults to `100`.
@@ -699,7 +699,7 @@ GET /metrics
 ```
 
 `/metrics` returns exposed Prometheus metrics. See
-[Observing Loki]({{< relref "../operations/observability/" >}})
+[Observing Loki]({{< relref "../operations/observability" >}})
 for a list of exported metrics.
 
 In microservices mode, the `/metrics` endpoint is exposed by all components.
@@ -843,7 +843,7 @@ The `/loki/api/v1/index/stats` endpoint can be used to query the index for the n
 
 URL query parameters:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) matchers to check (i.e. `{job="foo", env!="dev"}`)
+- `query`: The [LogQL]({{< relref "../query" >}}) matchers to check (i.e. `{job="foo", env!="dev"}`)
 - `start=<nanosecond Unix epoch>`: Start timestamp.
 - `end=<nanosecond Unix epoch>`: End timestamp.
 
@@ -1089,7 +1089,7 @@ PUT /loki/api/v1/delete
 ```
 
 Create a new delete request for the authenticated tenant.
-The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion" >}}) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
@@ -1129,7 +1129,7 @@ GET /loki/api/v1/delete
 ```
 
 List the existing delete requests for the authenticated tenant.
-The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion" >}}) documentation has configuration details.
 
 Log entry deletion is supported _only_ when the BoltDB Shipper is configured for the index store.
 
@@ -1166,7 +1166,7 @@ DELETE /loki/api/v1/delete
 ```
 
 Remove a delete request for the authenticated tenant.
-The [log entry deletion]({{< relref "../operations/storage/logs-deletion/" >}}) documentation has configuration details.
+The [log entry deletion]({{< relref "../operations/storage/logs-deletion" >}}) documentation has configuration details.
 
 Loki allows cancellation of delete requests until the requests are picked up for processing. It is controlled by the `delete_request_cancel_period` YAML configuration or the equivalent command line option when invoking Loki. To cancel a delete request that has been picked up for processing or is partially complete, pass the `force=true` query parameter to the API.
 
@@ -1213,7 +1213,7 @@ curl -u "Tenant1:$API_TOKEN" \
 `/api/prom/tail` is a WebSocket endpoint that will stream log messages based on
 a query. It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) query to perform
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
 - `delay_for`: The number of seconds to delay retrieving logs to let slow
   loggers catch up. Defaults to 0 and cannot be larger than 5.
 - `limit`: The max number of entries to return
@@ -1262,7 +1262,7 @@ will be sent over the WebSocket multiple times.
 `/api/prom/query` supports doing general queries. The URL query parameters
 support the following values:
 
-- `query`: The [LogQL]({{< relref "../query/" >}}) query to perform
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
 - `limit`: The max number of entries to return
 - `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
 - `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,11 +8,11 @@ weight: 100
 Release notes for Loki are in the CHANGELOG for the release and
 listed here by version number.
 
-- [V2.8 release notes]({{<relref "v2-8">}})
-- [V2.7 release notes]({{<relref "v2-7">}})
-- [V2.6 release notes]({{<relref "v2-6">}})
-- [V2.5 release notes]({{<relref "v2-5">}})
-- [V2.4 release notes]({{<relref "v2-4">}})
-- [V2.3 release notes]({{<relref "v2-3">}})
+- [V2.8 release notes]({{< relref "./v2-8" >}})
+- [V2.7 release notes]({{< relref "./v2-7" >}})
+- [V2.6 release notes]({{< relref "./v2-6" >}})
+- [V2.5 release notes]({{< relref "./v2-5" >}})
+- [V2.4 release notes]({{< relref "./v2-4" >}})
+- [V2.3 release notes]({{< relref "./v2-3" >}})
 
-The details about our release cadence are documented [here]({{<relref "cadence">}}).
+The details about our release cadence are documented [here]({{< relref "./cadence" >}}).

--- a/docs/sources/release-notes/v2-3.md
+++ b/docs/sources/release-notes/v2-3.md
@@ -16,15 +16,15 @@ Some parts of the Loki repo will remain Apache-2.0 licensed (mainly clients and 
 
 ## Features and enhancements
 
-* Loki now has the ability to apply [custom retention]({{<relref "../operations/storage/retention">}}) based on stream selectors! This will allow much finer control over log retention all of which is now handled by Loki, no longer requiring the use of object store configs for retention.
-* Coming along hand in hand with storing logs for longer durations is the ability to [delete log streams]({{<relref "../operations/storage/logs-deletion">}}). The initial implementation lets you submit delete request jobs which will be processed after 24 hours.
-* A very exciting new LogQL parser has been introduced: the [pattern parser]({{<relref "../query/log_queries#parser-expression">}}). Much simpler and faster than regexp for log lines that have a little bit of structure to them such as the [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format). This is now Loki's fastest parser so try it out on any of your log lines!
-* Extending on the work of Alerting Rules, Loki now accepts [recording rules]({{<relref "../alert/#recording-rules">}}). This lets you turn your logs into metrics and push them to Prometheus or any Prometheus compatible remote_write endpoint.
-* LogQL can understand [IP addresses]({{<relref "../query/ip">}})! This enables filtering on IP addresses and subnet ranges.
+* Loki now has the ability to apply [custom retention]({{< relref "../operations/storage/retention" >}}) based on stream selectors! This will allow much finer control over log retention all of which is now handled by Loki, no longer requiring the use of object store configs for retention.
+* Coming along hand in hand with storing logs for longer durations is the ability to [delete log streams]({{< relref "../operations/storage/logs-deletion" >}}). The initial implementation lets you submit delete request jobs which will be processed after 24 hours.
+* A very exciting new LogQL parser has been introduced: the [pattern parser]({{< relref "../query/log_queries#parser-expression" >}}). Much simpler and faster than regexp for log lines that have a little bit of structure to them such as the [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format). This is now Loki's fastest parser so try it out on any of your log lines!
+* Extending on the work of Alerting Rules, Loki now accepts [recording rules]({{< relref "../alert#recording-rules" >}}). This lets you turn your logs into metrics and push them to Prometheus or any Prometheus compatible remote_write endpoint.
+* LogQL can understand [IP addresses]({{< relref "../query/ip" >}})! This enables filtering on IP addresses and subnet ranges.
 
 For those of you running Loki as microservices, the following features will improve performance operations significantly for many operations.
 
-* We created an [index gateway]({{<relref "../operations/storage/boltdb-shipper/#index-gateway">}}) which takes on the task of downloading the boltdb-shipper index files allowing you to run your queriers without any local disk requirements, this is really helpful in Kubernetes environments where you can return your queriers from Statefulsets back to Deployments and save a lot of PVC costs and operational headaches.
+* We created an [index gateway]({{< relref "../operations/storage/boltdb-shipper#index-gateway" >}}) which takes on the task of downloading the boltdb-shipper index files allowing you to run your queriers without any local disk requirements, this is really helpful in Kubernetes environments where you can return your queriers from Statefulsets back to Deployments and save a lot of PVC costs and operational headaches.
 * Ingester queriers [are now shardable](https://github.com/grafana/loki/pull/3852), this is a significant performance boost for high volume log streams when querying recent data. 
 * Instant queries can now be [split and sharded](https://github.com/grafana/loki/pull/3984) making them just as fast as range queries.
 

--- a/docs/sources/release-notes/v2-4.md
+++ b/docs/sources/release-notes/v2-4.md
@@ -13,13 +13,13 @@ Loki 2.4 focuses on two items:
 
 ## Features and enhancements
 
-* [**Loki no longer requires logs to be sent in perfect chronological order.**]({{<relref "../configuration/#accept-out-of-order-writes">}}) Support for out of order logs is one of the most highly requested features for Loki. The strict ordering constraint has been removed.
-* Scaling Loki is now easier with a hybrid deployment mode that falls between our single binary and our microservices. The [Simple scalable deployment]({{<relref "../fundamentals/architecture/deployment-modes">}}) scales Loki with new `read` and `write` targets. Where previously you would have needed Kubernetes and the microservices approach to start tapping into Loki’s potential, it’s now possible to do this in a simpler way.
-* The new [`common` section]({{<relref "../configuration/#common">}}) results in a 70% smaller Loki configuration. Pair that with updated defaults and Loki comes out of the box with more appropriate defaults and limits. Check out the [example local configuration](https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml) as the new reference for running Loki.
-* [**Recording rules**]({{<relref "../alert/#recording-rules">}}) are no longer an experimental feature. We've given them a more resilient implementation which leverages the existing write ahead log code in Prometheus.
-* The new [**Promtail Kafka Consumer**]({{<relref "../clients/promtail/scraping/#kafka">}}) can easily get your logs out of Kafka and into Loki.
-* There are **nice LogQL enhancements**, thanks to the amazing Loki community. LogQL now has [group_left and group_right]({{<relref "../query/#many-to-one-and-one-to-many-vector-matches">}}). And, the `label_format` and `line_format` functions now support [working with dates and times]({{<relref "../query/template_functions/#now">}}).
-* Another great community contribution allows Promtail to [**accept ndjson and plaintext log files over HTTP**]({{<relref "../clients/promtail/configuration/#loki_push_api">}}).
+* [**Loki no longer requires logs to be sent in perfect chronological order.**]({{< relref "../configuration#accept-out-of-order-writes" >}}) Support for out of order logs is one of the most highly requested features for Loki. The strict ordering constraint has been removed.
+* Scaling Loki is now easier with a hybrid deployment mode that falls between our single binary and our microservices. The [Simple scalable deployment]({{< relref "../fundamentals/architecture/deployment-modes" >}}) scales Loki with new `read` and `write` targets. Where previously you would have needed Kubernetes and the microservices approach to start tapping into Loki’s potential, it’s now possible to do this in a simpler way.
+* The new [`common` section]({{< relref "../configuration#common" >}}) results in a 70% smaller Loki configuration. Pair that with updated defaults and Loki comes out of the box with more appropriate defaults and limits. Check out the [example local configuration](https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml) as the new reference for running Loki.
+* [**Recording rules**]({{< relref "../alert#recording-rules" >}}) are no longer an experimental feature. We've given them a more resilient implementation which leverages the existing write ahead log code in Prometheus.
+* The new [**Promtail Kafka Consumer**]({{< relref "../clients/promtail/scraping#kafka" >}}) can easily get your logs out of Kafka and into Loki.
+* There are **nice LogQL enhancements**, thanks to the amazing Loki community. LogQL now has [group_left and group_right]({{< relref "../query#many-to-one-and-one-to-many-vector-matches" >}}). And, the `label_format` and `line_format` functions now support [working with dates and times]({{< relref "../query/template_functions#now" >}}).
+* Another great community contribution allows Promtail to [**accept ndjson and plaintext log files over HTTP**]({{< relref "../clients/promtail/configuration#loki_push_api" >}}).
 
 All in all, about 260 PR’s went into Loki 2.4, and we thank everyone for helping us make the best Loki yet.
 
@@ -27,7 +27,7 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 
 ## Upgrade Considerations
 
-Please read the [upgrade guide]({{<relref "../upgrading/#240">}}) before updating Loki.
+Please read the [upgrade guide]({{< relref "../upgrading#240" >}}) before updating Loki.
 
 We made a lot of changes to Loki’s configuration as part of this release.
 We have tried our best to make sure changes are compatible with existing configurations, however some changes to default limits may impact users who didn't have values explicitly set for these limits in their configuration files.

--- a/docs/sources/release-notes/v2-5.md
+++ b/docs/sources/release-notes/v2-5.md
@@ -14,7 +14,7 @@ It has been nearly 6 months since Loki 2.4 was released, and we’ve been busy m
 - **[Binary operations are now significantly faster](https://github.com/grafana/loki/pull/5317)**, taking full advantage of Loki's parallelism.
 - **[A new schema is available](https://github.com/grafana/loki/pull/5054)**, which uses more path prefixes to avoid rate limits on S3.
 - That same schema change **[was also added to the filesystem store](https://github.com/grafana/loki/pull/5291)**, which avoids using one directory to store every chunk.
-- A new capability for **[hedging requests to storage](https://github.com/grafana/loki/pull/4826)** improves performance on highly parallelized queries. Refer to the [hedging configuration]({{<relref "../configuration/#storage_config">}}) under the `storage_config` block for more information.
+- A new capability for **[hedging requests to storage](https://github.com/grafana/loki/pull/4826)** improves performance on highly parallelized queries. Refer to the [hedging configuration]({{< relref "../configuration#storage_config" >}}) under the `storage_config` block for more information.
 - Promtail has several new ways to ingest logs:
     - The **[ability to do service discovery and tailing directly from the Docker daemon](https://github.com/grafana/loki/pull/4911)**.
     - **[Fetching logs directly from Cloudflare](https://github.com/grafana/loki/pull/4813)**.
@@ -25,7 +25,7 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 
 ## Upgrade Considerations
 
-As always, please read the [upgrade guide]({{<relref "../upgrading/#250">}}) before upgrading Loki.
+As always, please read the [upgrade guide]({{< relref "../upgrading#250" >}}) before upgrading Loki.
 
 ### Changes to the config `split_queries_by_interval`
 The most likely impact many people will see is Loki failing to start because of a change in the YAML configuration for `split_queries_by_interval`. It was previously possible to define this value in two places.

--- a/docs/sources/release-notes/v2-6.md
+++ b/docs/sources/release-notes/v2-6.md
@@ -19,7 +19,7 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 
 ## Upgrade Considerations
 
-As always, please read the [upgrade guide]({{<relref "../upgrading/#260">}}) before upgrading Loki.
+As always, please read the [upgrade guide]({{< relref "../upgrading#260" >}}) before upgrading Loki.
 
 ## Bug fixes
 

--- a/docs/sources/release-notes/v2-7.md
+++ b/docs/sources/release-notes/v2-7.md
@@ -14,7 +14,7 @@ Grafana Labs is excited to announce the release of Loki 2.7. Here's a summary of
 - **Better Support for Azure Blob Storage** thanks to the ability to use Azure's Service Principal Credentials.
 - **Logs can now be pushed from the Loki canary** so you don't have to rely on a scraping service to use the canary.
 - **Additional `label_format` fields** `__timestamp__` and `__line__`.
-- **`fifocache` has been renamed** The in-memory `fifocache` has been renamed to `embedded-cache`. Check [upgrade guide]({{<relref "../upgrading/#270">}}) for more details
+- **`fifocache` has been renamed** The in-memory `fifocache` has been renamed to `embedded-cache`. Check [upgrade guide]({{< relref "../upgrading#270" >}}) for more details
 - **New HTTP endpoint for Ingester shutdown** that will also delete the ring token.
 - **Faster label queries** thanks to new parallization.
 - **Introducing Stream Sharding** an experimental new feature to help deal with very large streams.
@@ -30,7 +30,7 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 
 ## Upgrade Considerations
 
-As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) before upgrading Loki.
+As always, please read the [upgrade guide]({{< relref "../upgrading#270" >}}) before upgrading Loki.
 
 ## Bug fixes
 

--- a/docs/sources/release-notes/v2-8.md
+++ b/docs/sources/release-notes/v2-8.md
@@ -18,7 +18,7 @@ For a full list of all changes please look at the [CHANGELOG](https://github.com
 
 ## Upgrade Considerations
 
-As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) before upgrading Loki.
+As always, please read the [upgrade guide]({{< relref "../upgrading#270" >}}) before upgrading Loki.
 
 ## Bug fixes
 

--- a/docs/sources/storage/_index.md
+++ b/docs/sources/storage/_index.md
@@ -67,7 +67,7 @@ Performance is comparable to a dedicated index type while providing a much less 
 
 ### Cassandra
 
-Cassandra can also be utilized for the index store and aside from the [boltdb-shipper]({{<relref "../operations/storage/boltdb-shipper">}}), it's the only non-cloud offering that can be used for the index that's horizontally scalable and has configurable replication. It's a good candidate when you already run Cassandra, are running on-prem, or do not wish to use a managed cloud offering.
+Cassandra can also be utilized for the index store and aside from the [boltdb-shipper]({{< relref "../operations/storage/boltdb-shipper" >}}), it's the only non-cloud offering that can be used for the index that's horizontally scalable and has configurable replication. It's a good candidate when you already run Cassandra, are running on-prem, or do not wish to use a managed cloud offering.
 
 ### BigTable
 
@@ -83,7 +83,7 @@ DynamoDB is susceptible to rate limiting, particularly due to overconsuming what
 
 ### BoltDB
 
-BoltDB is an embedded database on disk. It is not replicated and thus cannot be used for high availability or clustered Loki deployments, but is commonly paired with a `filesystem` chunk store for proof of concept deployments, trying out Loki, and development. The [boltdb-shipper]({{<relref "../operations/storage/boltdb-shipper">}}) aims to support clustered deployments using `boltdb` as an index.
+BoltDB is an embedded database on disk. It is not replicated and thus cannot be used for high availability or clustered Loki deployments, but is commonly paired with a `filesystem` chunk store for proof of concept deployments, trying out Loki, and development. The [boltdb-shipper]({{< relref "../operations/storage/boltdb-shipper" >}}) aims to support clustered deployments using `boltdb` as an index.
 
 ### Azure Storage Account
 
@@ -127,7 +127,7 @@ table_manager:
   retention_period: 2520h
 ```
 
-For more information, see the [table manager]({{<relref "../operations/storage/table-manager">}}) documentation.
+For more information, see the [table manager]({{< relref "../operations/storage/table-manager" >}}) documentation.
 
 ### Provisioning
 
@@ -146,13 +146,13 @@ table_manager:
     inactive_read_throughput: <int> | Default = 300
 ```
 
-Note, there are a few other DynamoDB provisioning options including DynamoDB autoscaling and on-demand capacity. See the [provisioning configuration]({{<relref "../configuration/#table_manager">}}) in the `table_manager` block documentation for more information.
+Note, there are a few other DynamoDB provisioning options including DynamoDB autoscaling and on-demand capacity. See the [provisioning configuration]({{< relref "../configuration#table_manager" >}}) in the `table_manager` block documentation for more information.
 
 ## Upgrading Schemas
 
 When a new schema is released and you want to gain the advantages it provides, you can! Loki can transparently query & merge data from across schema boundaries so there is no disruption of service and upgrading is easy.
 
-First, you'll want to create a new [period_config]({{<relref "../configuration#period_config">}}) entry in your [schema_config]({{<relref "../configuration#schema_config">}}). The important thing to remember here is to set this at some point in the _future_ and then roll out the config file changes to Loki. This allows the table manager to create the required table in advance of writes and ensures that existing data isn't queried as if it adheres to the new schema.
+First, you'll want to create a new [period_config]({{< relref "../configuration#period_config" >}}) entry in your [schema_config]({{< relref "../configuration#schema_config" >}}). The important thing to remember here is to set this at some point in the _future_ and then roll out the config file changes to Loki. This allows the table manager to create the required table in advance of writes and ensures that existing data isn't queried as if it adheres to the new schema.
 
 As an example, let's say it's 2020-07-14 and we want to start using the `v11` schema on the 20th:
 ```yaml
@@ -182,7 +182,7 @@ With the exception of the `filesystem` chunk store, Loki will not delete old chu
 
 We're interested in adding targeted deletion in future Loki releases (think tenant or stream level granularity) and may include other strategies as well.
 
-For more information, see the [retention configuration]({{<relref "../operations/storage/retention">}}) documentation.
+For more information, see the [retention configuration]({{< relref "../operations/storage/retention" >}}) documentation.
 
 
 ## Examples

--- a/docs/sources/upgrading/_index.md
+++ b/docs/sources/upgrading/_index.md
@@ -424,7 +424,7 @@ limits_config:
   retention_period: [30d]
 ```
 
-See the [retention docs]({{<relref "../operations/storage/retention">}}) for more info.
+See the [retention docs]({{< relref "../operations/storage/retention" >}}) for more info.
 
 #### Log messages on startup: proto: duplicate proto type registered:
 
@@ -886,7 +886,7 @@ If you happen to have `results_cache.max_freshness` set please use `limits_confi
 
 ### Promtail config removed
 
-The long deprecated `entry_parser` config in Promtail has been removed, use [pipeline_stages]({{< relref "../clients/promtail/configuration/#pipeline_stages" >}}) instead.
+The long deprecated `entry_parser` config in Promtail has been removed, use [pipeline_stages]({{< relref "../clients/promtail/configuration#pipeline_stages" >}}) instead.
 
 ### Upgrading schema to use boltdb-shipper and/or v11 schema
 

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,2 +1,5 @@
 # List of projects to provide to the make-docs script.
-PROJECTS = loki
+PROJECTS := loki
+
+# Use alternative image until make-docs 3.0.0 is rolled out.
+export DOCS_IMAGE := grafana/docs-base:dbd975af06

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -3,3 +3,6 @@ PROJECTS := loki
 
 # Use alternative image until make-docs 3.0.0 is rolled out.
 export DOCS_IMAGE := grafana/docs-base:dbd975af06
+
+# Set the DOC_VALIDATOR_IMAGE to match the one defined in CI.
+export DOC_VALIDATOR_IMAGE := $(shell sed -En 's, *image: "(grafana/doc-validator.*)",\1,p' "$(shell git rev-parse --show-toplevel)/.github/workflows/doc-validator.yml")


### PR DESCRIPTION
## 3.0.0

### Added

- Structured output for use with [`reviewdog`](https://github.com/reviewdog/reviewdog).
  You can achieve the original error output by piping the output to the following `jq` expression: `jq -r '"ERROR: \(.location.path):\(.location.range.start.line):\(.location.range.start.column): \(.message)"'`.
- Suggestions for simple link fixes. In GitHub, [`reviewdog`](https://github.com/reviewdog/reviewdog) comments these suggestions for convenient replacement.
- Support for anchors referring to repeated headings.
  In the case that a page has multiple headings that share the same text, the renderer appends a zero indexed, numbered suffix to the identifier.
  For example, when there are two headings that are both "Heading text", the first anchor identifier is `heading-text` and the second is `heading-text-1`.
- Error when running `doc-validator` on no files.

**Notes for reviewer:**

This also updates the `make-docs` procedure. Please ensure you can run `make docs` from the `docs/` directory before approving and merging this PR.


