### PR TITLE
helm: fix resource not respect namespace

### DIFF
--- a/production/helm/loki/templates/config.yaml
+++ b/production/helm/loki/templates/config.yaml
@@ -7,6 +7,7 @@ kind: ConfigMap
 {{- end }}
 metadata:
   name: {{ tpl .Values.loki.externalConfigSecretName . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "loki.labels" . | nindent 4 }}
 {{- if eq .Values.loki.configStorageType "Secret" }}


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR make all resources have some behavior when running `helm template loki grafana/loki --name istio-system`

istio use it here: https://github.com/istio/istio/blob/master/manifests/addons/gen.sh#L89

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
