### PR TITLE
Fix promtail cluster template not finding all clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 
 #### Fixes
 
+* [9684](https://github.com/grafana/loki/pull/9684) **thampiotr**: Mixins: Fix promtail cluster template not finding all clusters.
 * [8995](https://github.com/grafana/loki/pull/8995) **dannykopping**: Mixins: Fix Jsonnet `RUNTIME ERROR` that occurs when you try to use the mixins with `use_boltdb_shipper: false`.
 
 #### FluentD

--- a/production/promtail-mixin/dashboards.libsonnet
+++ b/production/promtail-mixin/dashboards.libsonnet
@@ -4,7 +4,7 @@ local loki_mixin_utils = import 'loki-mixin/dashboards/dashboard-utils.libsonnet
 local utils = import 'mixin-utils/utils.libsonnet';
 
 {
-  grafanaDashboards+: {
+  grafanaDashboards+:: {
     local dashboard = (
       loki_mixin_utils {
         _config+:: configfile._config,
@@ -12,7 +12,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ),
     local dashboards = self,
 
-    // local labelsSelector = 'cluster=~"$cluster", namespace=~"$namespace"',
     local labelsSelector = dashboard._config.per_cluster_label + '=~"$cluster", namespace=~"$namespace"',
     local quantileLabelSelector = dashboard._config.per_cluster_label + '=~"$cluster", job=~"$namespace/promtail"',
 
@@ -20,7 +19,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                        local cfg = self,
                      } +
                      dashboard.dashboard('Loki / Promtail', uid='promtail')
-                     .addCluster()
+                     .addTemplate('cluster', 'promtail_build_info', dashboard._config.per_cluster_label)
                      .addTag()
                      .addTemplate('namespace', 'promtail_build_info{' + dashboard._config.per_cluster_label + '=~"$cluster"}', 'namespace')
                      .addRow(


### PR DESCRIPTION
**What this PR does / why we need it**:
In promtail-mixin, the dropdown template for clusters would only include clusters that run loki. So if a cluster only run promtail and not loki, it doesn't appear.

**Special notes for your reviewer**:

Tested on dashboard:
![image](https://github.com/grafana/loki/assets/17101802/f1346da7-90f6-49f0-98af-3e6fd4032402)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
