### PR TITLE
helm: make ServiceMonitor cluster label respect clusterLabelOverride

### DIFF
--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -40,7 +40,7 @@ spec:
         - sourceLabels: [job]
           replacement: "{{ $.Release.Namespace }}/$1"
           targetLabel: job
-        - replacement: "{{ include "loki.fullname" $ }}"
+        - replacement: "{{ include "loki.clusterLabel" $ }}"
           targetLabel: cluster
         {{- with .relabelings }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

As of #9218 `clusterLabelOverride` can be used to set the `cluster` label, however the ServiceMonitor still uses `loki.fullname`. This fixes that so it will use `loki.clusterLabel` to be consistent with other components.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
