### PR TITLE
packaging: fix postinst on debian oses

### DIFF
--- a/tools/packaging/promtail-postinstall.sh
+++ b/tools/packaging/promtail-postinstall.sh
@@ -5,7 +5,7 @@
 if ! command -V systemctl >/dev/null 2>&1; then
   echo "Could not find systemd. Skipping system installation." && exit 0
 else
-    systemd_version=$(systemctl --version | head -1 | sed 's/systemd //g')
+    systemd_version=$(systemctl --version | head -1 | sed 's/systemd \([0-9]\+\).*/\1/')
 fi
 
 cleanInstall() {


### PR DESCRIPTION
Previously the systemd version extract pulled in debian string breaking the detection on debian variants



**What this PR does / why we need it**:

Fixes  postinst error on Debian variants

**Which issue(s) this PR fixes**:
Fixes #9701 #9302

**Special notes for your reviewer**:

Tests on various OS variants:

Debian/12
```
$ systemctl --version 
systemd 252 (252.6-1)
+PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified
$  systemctl --version | head -1 | sed 's/systemd \([0-9]\+\).*/\1/'
252
```
CentOS/7
```
$ systemctl --version 
systemd 219
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN
$ systemctl --version | head -1 | sed 's/systemd \([0-9]\+\).*/\1/'
219
```
Debian/11
```
$ systemctl --version 
systemd 247 (247.3-7+deb11u2)
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified
$ systemctl --version | head -1 | sed 's/systemd \([0-9]\+\).*/\1/'
247
```
Ubuntu/20.04
```
$ systemctl --version
systemd 245 (245.4-4ubuntu3.20)
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid
$ systemctl --version | head -1 | sed 's/systemd \([0-9]\+\).*/\1/'
245
```
**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
