### PR TITLE
Add handling of timezones in unixToTime tests

### DIFF
--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -501,11 +501,11 @@ func newMustLineFormatter(tmpl string) *LineFormatter {
 func Test_labelsFormatter_Format(t *testing.T) {
 	// These variables are used to test unixToTime.
 	// They resolve to the local timezone so it works everywhere.
-	epoch_day_19503 := time.Unix(19503*86400, 0)
-	epoch_seconds_1679577215 := time.Unix(1679577215, 0)
-	epoch_milliseconds_1257894000000 := time.UnixMilli(1257894000000)
-	epoch_microseconds_1673798889902000 := time.UnixMicro(1673798889902000)
-	epoch_nanoseconds_1000000000000000000 := time.Unix(0, 1000000000000000000)
+	epochDay19503 := time.Unix(19503*86400, 0)
+	epochSeconds1679577215 := time.Unix(1679577215, 0)
+	epochMilliseconds1257894000000 := time.UnixMilli(1257894000000)
+	epochMicroseconds1673798889902000 := time.UnixMicro(1673798889902000)
+	epochNanoseconds1000000000000000000 := time.Unix(0, 1000000000000000000)
 
 	tests := []struct {
 		name  string
@@ -670,7 +670,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "19503"}},
 			labels.Labels{
 				{Name: "bar", Value: "19503"},
-				{Name: "foo", Value: epoch_day_19503.String()},
+				{Name: "foo", Value: epochDay19503.String()},
 			},
 		},
 		{
@@ -679,7 +679,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1679577215"}},
 			labels.Labels{
 				{Name: "bar", Value: "1679577215"},
-				{Name: "foo", Value: epoch_seconds_1679577215.String()},
+				{Name: "foo", Value: epochSeconds1679577215.String()},
 			},
 		},
 		{
@@ -688,7 +688,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1257894000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1257894000000"},
-				{Name: "foo", Value: epoch_milliseconds_1257894000000.String()},
+				{Name: "foo", Value: epochMilliseconds1257894000000.String()},
 			},
 		},
 		{
@@ -697,7 +697,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1673798889902000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1673798889902000"},
-				{Name: "foo", Value: epoch_microseconds_1673798889902000.String()},
+				{Name: "foo", Value: epochMicroseconds1673798889902000.String()},
 			},
 		},
 		{
@@ -706,7 +706,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1000000000000000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1000000000000000000"},
-				{Name: "foo", Value: epoch_nanoseconds_1000000000000000000.String()},
+				{Name: "foo", Value: epochNanoseconds1000000000000000000.String()},
 			},
 		},
 	}

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -657,47 +657,47 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		},
 		{
 			"unixToTime days",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" | date "2006-01-02" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "19503"}},
 			labels.Labels{
 				{Name: "bar", Value: "19503"},
-				{Name: "foo", Value: "2023-05-26"},
+				{Name: "foo", Value: "2023-05-26 00:00:00 +0000 UTC"},
 			},
 		},
 		{
 			"unixToTime seconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" | date "2006-01-02 15:04:05"}}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1679577215"}},
 			labels.Labels{
 				{Name: "bar", Value: "1679577215"},
-				{Name: "foo", Value: "2023-03-23 13:13:35"},
+				{Name: "foo", Value: "2023-03-23 13:13:35 +0000 UTC"},
 			},
 		},
 		{
 			"unixToTime milliseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" | date "2006-01-02 15:04:05"}}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1257894000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1257894000000"},
-				{Name: "foo", Value: "2009-11-10 23:00:00"},
+				{Name: "foo", Value: "2009-11-10 23:00:00 +0000 UTC"},
 			},
 		},
 		{
 			"unixToTime microseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" | date "2006-01-02"}}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1673798889902000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1673798889902000"},
-				{Name: "foo", Value: "2023-01-15"},
+				{Name: "foo", Value: "2023-01-15 16:08:09 +0000 UTC"},
 			},
 		},
 		{
 			"unixToTime nanoseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "Jan 2, 2006" | toDateInZone "Jan 2, 2006" "UTC" | date "Jan 2, 2006"}}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "Jan 2, 2006 15:04:05" | toDateInZone "Jan 2, 2006 15:04:05" "UTC" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1000000000000000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1000000000000000000"},
-				{Name: "foo", Value: "Sep 9, 2001"},
+				{Name: "foo", Value: "2001-09-09 02:46:40 +0000 UTC"},
 			},
 		},
 	}

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -498,6 +499,14 @@ func newMustLineFormatter(tmpl string) *LineFormatter {
 }
 
 func Test_labelsFormatter_Format(t *testing.T) {
+	// These variables are used to test unixToTime.
+	// They resolve to the local timezone so it works everywhere.
+	epoch_day_19503 := time.Unix(19503*86400, 0)
+	epoch_seconds_1679577215 := time.Unix(1679577215, 0)
+	epoch_milliseconds_1257894000000 := time.UnixMilli(1257894000000)
+	epoch_microseconds_1673798889902000 := time.UnixMicro(1673798889902000)
+	epoch_nanoseconds_1000000000000000000 := time.Unix(0, 1000000000000000000)
+
 	tests := []struct {
 		name  string
 		fmter *LabelsFormatter
@@ -657,47 +666,47 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		},
 		{
 			"unixToTime days",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "19503"}},
 			labels.Labels{
 				{Name: "bar", Value: "19503"},
-				{Name: "foo", Value: "2023-05-26 00:00:00 +0000 UTC"},
+				{Name: "foo", Value: epoch_day_19503.String()},
 			},
 		},
 		{
 			"unixToTime seconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1679577215"}},
 			labels.Labels{
 				{Name: "bar", Value: "1679577215"},
-				{Name: "foo", Value: "2023-03-23 13:13:35 +0000 UTC"},
+				{Name: "foo", Value: epoch_seconds_1679577215.String()},
 			},
 		},
 		{
 			"unixToTime milliseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1257894000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1257894000000"},
-				{Name: "foo", Value: "2009-11-10 23:00:00 +0000 UTC"},
+				{Name: "foo", Value: epoch_milliseconds_1257894000000.String()},
 			},
 		},
 		{
 			"unixToTime microseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1673798889902000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1673798889902000"},
-				{Name: "foo", Value: "2023-01-15 16:08:09 +0000 UTC"},
+				{Name: "foo", Value: epoch_microseconds_1673798889902000.String()},
 			},
 		},
 		{
 			"unixToTime nanoseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "Jan 2, 2006 15:04:05" | toDateInZone "Jan 2, 2006 15:04:05" "UTC" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1000000000000000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1000000000000000000"},
-				{Name: "foo", Value: "2001-09-09 02:46:40 +0000 UTC"},
+				{Name: "foo", Value: epoch_nanoseconds_1000000000000000000.String()},
 			},
 		},
 	}

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -657,7 +657,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		},
 		{
 			"unixToTime days",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" | date "2006-01-02" }}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "19503"}},
 			labels.Labels{
 				{Name: "bar", Value: "19503"},
@@ -666,25 +666,25 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		},
 		{
 			"unixToTime seconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" | date "2006-01-02 15:04:05"}}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1679577215"}},
 			labels.Labels{
 				{Name: "bar", Value: "1679577215"},
-				{Name: "foo", Value: "2023-03-23"},
+				{Name: "foo", Value: "2023-03-23 13:13:35"},
 			},
 		},
 		{
 			"unixToTime milliseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02 15:04:05" | toDateInZone "2006-01-02 15:04:05" "UTC" | date "2006-01-02 15:04:05"}}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1257894000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1257894000000"},
-				{Name: "foo", Value: "2009-11-10"},
+				{Name: "foo", Value: "2009-11-10 23:00:00"},
 			},
 		},
 		{
 			"unixToTime microseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "2006-01-02" | toDateInZone "2006-01-02" "UTC" | date "2006-01-02"}}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1673798889902000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1673798889902000"},
@@ -693,7 +693,7 @@ func Test_labelsFormatter_Format(t *testing.T) {
 		},
 		{
 			"unixToTime nanoseconds",
-			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "Jan 2, 2006" }}`)}),
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("foo", `{{ .bar | unixToTime | date "Jan 2, 2006" | toDateInZone "Jan 2, 2006" "UTC" | date "Jan 2, 2006"}}`)}),
 			labels.Labels{{Name: "foo", Value: ""}, {Name: "bar", Value: "1000000000000000000"}},
 			labels.Labels{
 				{Name: "bar", Value: "1000000000000000000"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The unit tests for unixToTime do not take the current timezone into account. 


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
