### PR TITLE
revert(9476): Bringback async store like before for the queriers (#9715)

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -654,14 +654,14 @@ func (t *Loki) setupModuleManager() error {
 		OverridesExporter:        {Overrides, Server},
 		TenantConfigs:            {RuntimeConfig},
 		Distributor:              {Ring, Server, Overrides, TenantConfigs, Analytics},
-		Store:                    {Overrides, IndexGatewayRing, IngesterQuerier},
+		Store:                    {Overrides, IndexGatewayRing},
 		Ingester:                 {Store, Server, MemberlistKV, TenantConfigs, Analytics},
-		Querier:                  {Store, Ring, Server, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
+		Querier:                  {Store, Ring, Server, IngesterQuerier, Overrides, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryFrontendTripperware: {Server, Overrides, TenantConfigs},
 		QueryFrontend:            {QueryFrontendTripperware, Analytics, CacheGenerationLoader, QuerySchedulerRing},
 		QueryScheduler:           {Server, Overrides, MemberlistKV, Analytics, QuerySchedulerRing},
 		Ruler:                    {Ring, Server, RulerStorage, RuleEvaluator, Overrides, TenantConfigs, Analytics},
-		RuleEvaluator:            {Ring, Server, Store, Overrides, TenantConfigs, Analytics},
+		RuleEvaluator:            {Ring, Server, Store, IngesterQuerier, Overrides, TenantConfigs, Analytics},
 		TableManager:             {Server, Analytics},
 		Compactor:                {Server, Overrides, MemberlistKV, Analytics},
 		IndexGateway:             {Server, Store, Overrides, Analytics, MemberlistKV, IndexGatewayRing},
@@ -706,6 +706,11 @@ func (t *Loki) setupModuleManager() error {
 		if err := mm.AddDependency(Server, QueryLimitsInterceptors); err != nil {
 			return err
 		}
+	}
+
+	// Add IngesterQuerier as a dependency for store when target is either querier, ruler, read, or backend.
+	if t.Cfg.isModuleEnabled(Querier) || t.Cfg.isModuleEnabled(Ruler) || t.Cfg.isModuleEnabled(Read) || t.Cfg.isModuleEnabled(Backend) {
+		deps[Store] = append(deps[Store], IngesterQuerier)
 	}
 
 	// If the query scheduler and querier are running together, make sure the scheduler goes

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -336,12 +336,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		return nil, err
 	}
 
-	store := t.Store
-	if !t.Cfg.Querier.QueryStoreOnly {
-		store = storage.NewAsyncStore(t.Cfg.StorageConfig.AsyncStoreConfig, t.Store, t.Cfg.SchemaConfig)
-	}
-
-	q, err := querier.New(t.Cfg.Querier, store, t.ingesterQuerier, t.Overrides, deleteStore, prometheus.DefaultRegisterer)
+	q, err := querier.New(t.Cfg.Querier, t.Store, t.ingesterQuerier, t.Overrides, deleteStore, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}
@@ -606,6 +601,8 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 	}
 
 	if config.UsingObjectStorageIndex(t.Cfg.SchemaConfig.Configs) {
+		var asyncStore bool
+
 		shipperConfigIdx := config.ActivePeriodConfig(t.Cfg.SchemaConfig.Configs)
 		iTy := t.Cfg.SchemaConfig.Configs[shipperConfigIdx].IndexType
 		if iTy != config.BoltDBShipperType && iTy != config.TSDBType {
@@ -636,6 +633,10 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 				break
 			}
 
+			// Use AsyncStore to query both ingesters local store and chunk store for store queries.
+			// Only queriers should use the AsyncStore, it should never be used in ingesters.
+			asyncStore = true
+
 			// The legacy Read target includes the index gateway, so disable the index-gateway client in that configuration.
 			if t.Cfg.LegacyReadTarget && t.Cfg.isModuleEnabled(Read) {
 				t.Cfg.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
@@ -663,12 +664,14 @@ func (t *Loki) initStore() (_ services.Service, err error) {
 			t.Cfg.Ingester.QueryStoreMaxLookBackPeriod = mlb
 		}
 
-		t.Cfg.StorageConfig.AsyncStoreConfig = storage.AsyncStoreCfg{
-			IngesterQuerier: t.ingesterQuerier,
-			QueryIngestersWithin: calculateAsyncStoreQueryIngestersWithin(
-				t.Cfg.Querier.QueryIngestersWithin,
-				minIngesterQueryStoreDuration,
-			),
+		if asyncStore {
+			t.Cfg.StorageConfig.AsyncStoreConfig = storage.AsyncStoreCfg{
+				IngesterQuerier: t.ingesterQuerier,
+				QueryIngestersWithin: calculateAsyncStoreQueryIngestersWithin(
+					t.Cfg.Querier.QueryIngestersWithin,
+					minIngesterQueryStoreDuration,
+				),
+			}
 		}
 	}
 
@@ -1360,12 +1363,7 @@ func (t *Loki) createRulerQueryEngine(logger log.Logger) (eng *logql.Engine, err
 		return nil, fmt.Errorf("could not create delete requests store: %w", err)
 	}
 
-	store := t.Store
-	if !t.Cfg.Querier.QueryStoreOnly {
-		store = storage.NewAsyncStore(t.Cfg.StorageConfig.AsyncStoreConfig, t.Store, t.Cfg.SchemaConfig)
-	}
-
-	q, err := querier.New(t.Cfg.Querier, store, t.ingesterQuerier, t.Overrides, deleteStore, nil)
+	q, err := querier.New(t.Cfg.Querier, t.Store, t.ingesterQuerier, t.Overrides, deleteStore, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create querier: %w", err)
 	}

--- a/pkg/storage/async_store.go
+++ b/pkg/storage/async_store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/loki/pkg/storage/stores"
+
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/prometheus/common/model"
@@ -35,13 +37,13 @@ type AsyncStoreCfg struct {
 // AsyncStore is meant to be used only in queriers or any other service other than ingesters.
 // It should never be used in ingesters otherwise it would start spiraling around doing queries over and over again to other ingesters.
 type AsyncStore struct {
-	Store
+	stores.Store
 	scfg                 config.SchemaConfig
 	ingesterQuerier      IngesterQuerier
 	queryIngestersWithin time.Duration
 }
 
-func NewAsyncStore(cfg AsyncStoreCfg, store Store, scfg config.SchemaConfig) *AsyncStore {
+func NewAsyncStore(cfg AsyncStoreCfg, store stores.Store, scfg config.SchemaConfig) *AsyncStore {
 	return &AsyncStore{
 		Store:                store,
 		scfg:                 scfg,

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -287,6 +287,7 @@ type Config struct {
 
 	// Config for using AsyncStore when using async index stores like `boltdb-shipper`.
 	// It is required for getting chunk ids of recently flushed chunks from the ingesters.
+	EnableAsyncStore bool          `yaml:"-"`
 	AsyncStoreConfig AsyncStoreCfg `yaml:"-"`
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -170,6 +170,10 @@ func (s *store) init() error {
 		s.composite.AddStore(p.From.Time, f, idx, w, stop)
 	}
 
+	if s.cfg.EnableAsyncStore {
+		s.Store = NewAsyncStore(s.cfg.AsyncStoreConfig, s.Store, s.schemaCfg)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This seems to cause some issue with `querier`, not getting chunks from ingesters correctly via `async_store`.

I narrowed down to this PR. But hard `revert` seems not possible anymore. So created this manually.

https://github.com/grafana/loki/pull/9476

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
