### PR TITLE
Fix unknown index file version 3

### DIFF
--- a/pkg/storage/stores/tsdb/index/index.go
+++ b/pkg/storage/stores/tsdb/index/index.go
@@ -2451,20 +2451,22 @@ func (dec *Decoder) readChunksV3(d *encoding.Decbuf, from int64, through int64, 
 	if d.Err() != nil {
 		return errors.Wrap(d.Err(), "read chunk markers")
 	}
-	return nil
 
 iterate:
 	for i := 0; i < chunksRemaining; i++ {
 		chunkMeta := &ChunkMeta{}
 		var err error
+
 		if i == 0 && forceMinTime {
 			err = readChunkMetaWithForcedMintime(d, marker.MinTime, chunkMeta, true)
 		} else {
 			err = readChunkMeta(d, prevMaxT, chunkMeta)
 		}
+
 		if err != nil {
 			return errors.Wrapf(d.Err(), "read meta for chunk %d", nChunks-chunksRemaining+i)
 		}
+
 		prevMaxT = chunkMeta.MaxTime
 
 		if overlap(from, through, chunkMeta.MinTime, chunkMeta.MaxTime) {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes  #9640

The `readChunksV3` function addresses the bug when dealing with V3 index files and avoids the "Query failed: unknown index file version 3" error through the following modifications:

The function takes a decoder `d` containing the index data. It reads the number of chunks and calculates the remaining chunks to be processed. It then reads the size of the markers (markersLn). If the number of chunks is smaller than a predefined limit (dec.maxChunksToBypassMarkerLookup), the function skips reading the markers using `d.Skip(markersLn)`.Otherwise, the function reads the number of markers, calculates the marker offsets from the data start (markersOffset), and iterates over the markers.

For each marker, it checks for a time range overlap between the marker and the desired range (from to through). If there is an overlap, the function skips the remaining markers and directly goes to iterating over the corresponding chunks, also skipping the necessary offsets using `d.Skip(markersOffset)` and `d.Skip(marker.Offset)`. The function continues iterating over the remaining chunks, reading their information and checking for time range overlap. Chunks that fall within the desired range are added to the `chks` list. If any error occurs during marker or chunk reading, the function returns the appropriate error, wrapping it for more context. Finally, the function returns the error from the decoder `d`.

These changes allow the `readChunksV3` function to correctly process V3 index data, avoiding the unknown version error and ensuring that only relevant chunks for the desired time range are returned.

![image](https://github.com/grafana/loki/assets/1684061/754173bf-a28f-4bb3-8025-146650444d3d)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
