### PR TITLE
Promtail: Clean up idle streams in UDP syslog target

### DIFF
--- a/clients/pkg/promtail/targets/syslog/transport_test.go
+++ b/clients/pkg/promtail/targets/syslog/transport_test.go
@@ -1,0 +1,33 @@
+package syslog
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleTimeoutConnPipe(t *testing.T) {
+	addrs, _ := net.InterfaceAddrs()
+	timeout := 100 * time.Millisecond
+
+	p := NewIdleTimeoutConnPipe(addrs[0], timeout)
+	// upon creation, the idle timeout is set
+	require.False(t, p.IsIdle(time.Now()))
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, p.IsIdle(time.Now()))
+
+	// When reading or writing, the deadline is extended
+	go func() {
+		buf := make([]byte, 0, 1024)
+		_, err := p.Read(buf)
+		require.NoError(t, err)
+	}()
+	_, err := p.Write([]byte{104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, p.IsIdle(time.Now()))
+	time.Sleep(80 * time.Millisecond)
+	require.True(t, p.IsIdle(time.Now()))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The UDP transport in the syslog target creates a goroutine for each remote address to handle multiple packets coming from the same address. However, these goroutines were not cleaned up.

This commit adds an idle timeout for these goroutines waiting for packets to be processed in order to prevent goroutine leaking.

**Which issue(s) this PR fixes**:
Fixes #9726 


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
