### PR TITLE
Bugfix: Fix logic of offset operator in instant query splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [9495](https://github.com/grafana/loki/pull/9495) **thampiotr**: Promtail: Fix potential goroutine leak in file tailer.
 * [9650](https://github.com/grafana/loki/pull/9650) **ashwanthgoli**: Config: ensure storage config defaults apply to named stores.
 * [9629](https://github.com/grafana/loki/pull/9629) **periklis**: Fix duplicate label values from ingester streams.
+* [9763](https://github.com/grafana/loki/pull/9763) **ssncferreira**: Fix the logic of the `offset` operator for downstream queries on instant query splitting of (range) vector aggregation expressions containing an offset.
 
 ##### Changes
 

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -370,6 +370,10 @@ func TestRangeMappingEquivalence(t *testing.T) {
 
 		// range with offset
 		{`rate({a=~".+"}[2s] offset 2s)`, time.Second},
+		{`rate({a=~".+"}[4s] offset 1s)`, 2 * time.Second},
+		{`rate({a=~".+"}[3s] offset 1s)`, 2 * time.Second},
+		{`rate({a=~".+"}[5s] offset 0s)`, 2 * time.Second},
+		{`rate({a=~".+"}[3s] offset -1s)`, 2 * time.Second},
 
 		// label_replace
 		{`label_replace(sum by (a) (count_over_time({a=~".+"}[3s])), "", "", "", "")`, time.Second},

--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -2,6 +2,7 @@ package logql
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -276,7 +277,7 @@ func appendDownstream(downstreams *ConcatSampleExpr, expr syntax.SampleExpr, int
 		case *syntax.RangeAggregationExpr:
 			concrete.Left.Interval = interval
 			if offset != 0 {
-				concrete.Left.Offset += offset
+				concrete.Left.Offset = offset
 			}
 		}
 	})
@@ -289,29 +290,61 @@ func appendDownstream(downstreams *ConcatSampleExpr, expr syntax.SampleExpr, int
 	return downstreams
 }
 
+func getOffsets(expr syntax.SampleExpr) []time.Duration {
+	// Expect to always find at most 1 offset, so preallocate it accordingly
+	offsets := make([]time.Duration, 0, 1)
+
+	expr.Walk(func(e interface{}) {
+		switch concrete := e.(type) {
+		case *syntax.RangeAggregationExpr:
+			offsets = append(offsets, concrete.Left.Offset)
+		}
+	})
+	return offsets
+}
+
+// getOriginalOffset returns the offset specified in the input expr
+// Note that the returned offset can be zero or negative
+func (m RangeMapper) getOriginalOffset(expr syntax.SampleExpr) (offset time.Duration, err error) {
+	offsets := getOffsets(expr)
+	if len(offsets) == 0 {
+		return time.Duration(0), nil
+	}
+	if len(offsets) > 1 {
+		return time.Duration(0), fmt.Errorf("found %d offsets while expecting at most 1", len(offsets))
+	}
+
+	return offsets[0], nil
+}
+
 // mapConcatSampleExpr transform expr in multiple downstream subexpressions split by offset range interval
 // rangeInterval should be greater than m.splitByInterval, otherwise the resultant expression
 // will have an unnecessary aggregation operation
 func (m RangeMapper) mapConcatSampleExpr(expr syntax.SampleExpr, rangeInterval time.Duration, recorder *downstreamRecorder) syntax.SampleExpr {
-	splitCount := int(rangeInterval / m.splitByInterval)
-
-	if splitCount == 0 {
+	splitCount := int(math.Ceil(float64(rangeInterval) / float64(m.splitByInterval)))
+	if splitCount <= 1 {
 		return expr
 	}
 
-	var split int
-	var downstreams *ConcatSampleExpr
-	for split = 0; split < splitCount; split++ {
-		downstreams = appendDownstream(downstreams, expr, m.splitByInterval, time.Duration(split)*m.splitByInterval)
+	originalOffset, err := m.getOriginalOffset(expr)
+	if err != nil {
+		return expr
 	}
-	recorder.Add(splitCount, MetricsKey)
 
-	// Add the remainder offset interval
-	if rangeInterval%m.splitByInterval != 0 {
-		offset := time.Duration(split) * m.splitByInterval
-		downstreams = appendDownstream(downstreams, expr, rangeInterval-offset, offset)
-		recorder.Add(1, MetricsKey)
+	var downstreams *ConcatSampleExpr
+	for split := 0; split < splitCount; split++ {
+		splitOffset := time.Duration(split) * m.splitByInterval
+		// The range interval of the last downstream query can be smaller than the split interval
+		splitRangeInterval := m.splitByInterval
+		if splitOffset+splitRangeInterval > rangeInterval {
+			splitRangeInterval = rangeInterval - splitOffset
+		}
+		// The offset of downstream queries is always the original offset + a multiple of the split interval
+		splitOffset += originalOffset
+		downstreams = appendDownstream(downstreams, expr, splitRangeInterval, splitOffset)
 	}
+
+	recorder.Add(splitCount, MetricsKey)
 
 	return downstreams
 }

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -32,6 +32,36 @@ func Test_SplitRangeInterval(t *testing.T) {
 				++ downstream<count_over_time({app="foo"}[2s]), shard=<nil>>
 			)`,
 		},
+		// Should support expressions with offset operator
+		{
+			`count_over_time({app="foo"}[4s] offset 1s)`,
+			`sum without () (
+				downstream<count_over_time({app="foo"}[2s] offset 3s), shard=<nil>>
+				++ downstream<count_over_time({app="foo"}[2s] offset 1s), shard=<nil>>
+			)`,
+		},
+		{
+			`sum_over_time({app="foo"} | unwrap bar [3s] offset 1s)`,
+			`sum without () (
+				downstream<sum_over_time({app="foo"} | unwrap bar [1s] offset 3s), shard=<nil>>
+				++ downstream<sum_over_time({app="foo"} | unwrap bar [2s] offset 1s), shard=<nil>>
+			)`,
+		},
+		{
+			`bytes_rate({app="foo"}[5s] offset 0s)`,
+			`sum without () (
+				downstream<bytes_rate({app="foo"}[1s] offset 4s), shard=<nil>>
+				++ downstream<bytes_rate({app="foo"}[2s] offset 2s), shard=<nil>>
+				++ downstream<bytes_rate({app="foo"}[2s]), shard=<nil>>
+			)`,
+		},
+		{
+			`count_over_time({app="foo"}[3s] offset -1s)`,
+			`sum without () (
+				downstream<count_over_time({app="foo"}[1s] offset 1s), shard=<nil>>
+				++ downstream<count_over_time({app="foo"}[2s] offset -1s), shard=<nil>>
+			)`,
+		},
 		{
 			`rate({app="foo"}[4s] offset 1m)`,
 			`(sum without () (

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -48,11 +48,11 @@ func Test_SplitRangeInterval(t *testing.T) {
 			)`,
 		},
 		{
-			`bytes_rate({app="foo"}[5s] offset 0s)`,
+			`sum_over_time({app="foo"} | unwrap bar [5s] offset 0s)`,
 			`sum without () (
-				downstream<bytes_rate({app="foo"}[1s] offset 4s), shard=<nil>>
-				++ downstream<bytes_rate({app="foo"}[2s] offset 2s), shard=<nil>>
-				++ downstream<bytes_rate({app="foo"}[2s]), shard=<nil>>
+				downstream<sum_over_time({app="foo"} | unwrap bar [1s] offset 4s), shard=<nil>>
+				++ downstream<sum_over_time({app="foo"} | unwrap bar [2s] offset 2s), shard=<nil>>
+				++ downstream<sum_over_time({app="foo"} | unwrap bar [2s]), shard=<nil>>
 			)`,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the logic of the `offset` operator for downstream queries on instant query splitting of (range) vector aggregation expressions already containing an offset.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
