### PR TITLE
Always merge VolumeRequests in split by interval middleware

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -92,6 +92,11 @@ func NewDisableableTicker(interval time.Duration) (func(), <-chan time.Time) {
 // except for the start time of first split and end time of last split which would be kept same as original start/end
 // When endTimeInclusive is true, it would keep a gap of 1ms between the splits.
 func ForInterval(interval time.Duration, start, end time.Time, endTimeInclusive bool, callback func(start, end time.Time)) {
+	if interval <= 0 {
+		callback(start, end)
+		return
+	}
+
 	ogStart := start
 	startNs := start.UnixNano()
 	start = time.Unix(0, startNs-startNs%interval.Nanoseconds())

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -228,6 +228,27 @@ func TestForInterval(t *testing.T) {
 	}
 }
 
+func TestForInterval_OfZero(t *testing.T) {
+	var actualIntervals []timeInterval
+
+	from := time.Unix(5, 0)
+	through := time.Unix(8, 0)
+	endTimeInclusive := true
+	ForInterval(0, from, through, endTimeInclusive, func(start, end time.Time) {
+		actualIntervals = append(actualIntervals, timeInterval{
+			from:    start,
+			through: end,
+		})
+	})
+
+	require.Equal(t, []timeInterval{
+		{
+			from:    time.Unix(5, 0),
+			through: time.Unix(8, 0),
+		},
+	}, actualIntervals)
+}
+
 func TestGetFactorOfTime(t *testing.T) {
 	for _, tc := range []struct {
 		desc                                string


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we're relying on the `MergeRequests` logic to turn `VolumeResponses` into `LokiPromResponses`, we need to make sure we're always utilizing the `merger` in the split by interval middleware for `VolumeRequests`.

This is a smell and is tech debt we are aware of. This will be addressed during the work to enable range queries. I'm comfortable shipping this "hack" for now though so the frontend team can develop against the instant query functionality in dev.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
