### PR TITLE
fix integration test for multiple periods

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -551,7 +551,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
         'cd -',
       ]) { depends_on: ['clone'], when: onPRs },
       make('test', container=false) { depends_on: ['clone-target-branch', 'check-generated-files'] },
-      run('test-target-branch', commands=['cd ../loki-target-branch', 'BUILD_IN_CONTAINER=false make test']) { depends_on: ['clone-target-branch'], when: onPRs },
+      run('test-target-branch', commands=['cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test']) { depends_on: ['clone-target-branch'], when: onPRs },
       make('compare-coverage', container=false, args=[
         'old=../loki-target-branch/test_results.txt',
         'new=test_results.txt',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -124,8 +124,7 @@ steps:
   image: grafana/loki-build-image:0.29.0
   name: test
 - commands:
-  - cd ../loki-target-branch
-  - BUILD_IN_CONTAINER=false make test
+  - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
   depends_on:
   - clone-target-branch
   environment: {}
@@ -1772,6 +1771,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 9959e5fb97ebc4800659a7cb733b06279c2acd3f87c8aae3c7d745ca91cfd055
+hmac: d9c0f096978f15bd7c2c213e6afa2971ebe0d9e0b28cadf51cb47c0c34e697c4
 
 ...

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -200,8 +200,8 @@ func TestMicroServicesIngestQueryWithSchemaChange(t *testing.T) {
 	cliQueryFrontend.Now = now
 
 	t.Run("ingest-logs", func(t *testing.T) {
-		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineA", time.Now().Add(-48*time.Hour), map[string]string{"job": "fake"}))
-		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineB", time.Now().Add(-36*time.Hour), map[string]string{"job": "fake"}))
+		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineA", time.Now().Add(-72*time.Hour), map[string]string{"job": "fake"}))
+		require.NoError(t, cliDistributor.PushLogLineWithTimestamp("lineB", time.Now().Add(-48*time.Hour), map[string]string{"job": "fake"}))
 	})
 
 	t.Run("query-lookback-default", func(t *testing.T) {


### PR DESCRIPTION
The integration test is writing logs across two index periods but there's a chance that the log `lineB` is written after the beginning of the second period after it's added. This means we never get `lineB` in the results.

This change pushes back the write time of the first logs so they're always stay in the first index period.
