### PR TITLE
operator: add initContainer to pods of zone aware components

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9795](https://github.com/grafana/loki/pull/9795) **JoaoBraveCoding**: Add initContainer to zone aware components to gatekeep them from starting without the AZ annotation
 - [9503](https://github.com/grafana/loki/pull/9503) **shwetaap**: Add Pod annotations with node topology labels to support zone aware scheduling
 - [9930](https://github.com/grafana/loki/pull/9930) **periklis**: Use PodAntiAffinity for all components
 - [9860](https://github.com/grafana/loki/pull/9860) **xperimental**: Fix update of labels and annotations of PodTemplates

--- a/operator/internal/handlers/lokistack_enable_zone_awareness_test.go
+++ b/operator/internal/handlers/lokistack_enable_zone_awareness_test.go
@@ -17,24 +17,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	defaultPod = corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "some-ns",
-			Labels: map[string]string{
-				lokiv1.LabelZoneAwarePod: "enabled",
-			},
-			Annotations: map[string]string{
-				lokiv1.AnnotationAvailabilityZoneLabels: corev1.LabelTopologyZone,
-				lokiv1.AnnotationAvailabilityZone:       "us-east-zone-2c",
-			},
+var defaultPod = corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-pod",
+		Namespace: "some-ns",
+		Labels: map[string]string{
+			lokiv1.LabelZoneAwarePod: "enabled",
 		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
+		Annotations: map[string]string{
+			lokiv1.AnnotationAvailabilityZoneLabels: corev1.LabelTopologyZone,
+			lokiv1.AnnotationAvailabilityZone:       "us-east-zone-2c",
 		},
-	}
-)
+	},
+	Spec: corev1.PodSpec{
+		NodeName: "test-node",
+	},
+}
 
 func TestAnnotatePodWithAvailabilityZone_WhenGetReturnsAnErrorOtherThanNotFound_ReturnsTheError(t *testing.T) {
 	k := &k8sfakes.FakeClient{}

--- a/operator/internal/manifests/node_placement.go
+++ b/operator/internal/manifests/node_placement.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	availabilityZoneEnvVarName = "INSTANCE_AVAILABILITY_ZONE"
-	availabilityZoneFieldPath  = "metadata.annotations['" + lokiv1.AnnotationAvailabilityZone + "']"
-	availabilityZoneInitVolumeName = "az-annotation"
+	availabilityZoneEnvVarName          = "INSTANCE_AVAILABILITY_ZONE"
+	availabilityZoneFieldPath           = "metadata.annotations['" + lokiv1.AnnotationAvailabilityZone + "']"
+	availabilityZoneInitVolumeName      = "az-annotation"
 	availabilityZoneInitVolumeMountPath = "/etc/az-annotation"
-	availabilityZoneInitVolumeFileName = "az"
+	availabilityZoneInitVolumeFileName  = "az"
 )
 
 var availabilityZoneEnvVar = corev1.EnvVar{

--- a/operator/internal/manifests/node_placement.go
+++ b/operator/internal/manifests/node_placement.go
@@ -36,7 +36,9 @@ func configureReplication(podTemplate *corev1.PodTemplateSpec, replication *loki
 			Annotations: map[string]string{},
 		},
 		Spec: corev1.PodSpec{
-			Containers: make([]corev1.Container, len(podTemplate.Spec.Containers)),
+			InitContainers: []corev1.Container{initContainerZoneAnnotationCheck(podTemplate.Spec.Containers[0].Image)},
+			Containers:     make([]corev1.Container, len(podTemplate.Spec.Containers)),
+			Volumes:        []corev1.Volume{zoneAnnotationVolumeMount()},
 		},
 	}
 

--- a/operator/internal/manifests/node_placement.go
+++ b/operator/internal/manifests/node_placement.go
@@ -18,7 +18,7 @@ const (
 	availabilityZoneVolumeName = "az-annotation"
 	// availabilityZoneVolumeMountPath path where the volume will be mounted on the init container
 	availabilityZoneVolumeMountPath = "/etc/az-annotation"
-	// availabilityZoneVolumeFileName name of the file containg the availability zone annotation
+	// availabilityZoneVolumeFileName name of the file containing the availability zone annotation
 	availabilityZoneVolumeFileName = "az"
 )
 

--- a/operator/internal/manifests/node_placement_test.go
+++ b/operator/internal/manifests/node_placement_test.go
@@ -604,7 +604,7 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 					Command: []string{
 						"sh",
 						"-c",
-						"while ! [ -s /etc/az-annotation/az ]; do echo Waiting for availability zone annotation to be set; sleep 2; done; echo availability zone annotation is set; cat /etc/az-annotation/az",
+						"while ! [ -s /etc/az-annotation/az ]; do echo Waiting for availability zone annotation to be set; sleep 2; done; echo availability zone annotation is set; cat /etc/az-annotation/az; echo",
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/operator/internal/manifests/node_placement_test.go
+++ b/operator/internal/manifests/node_placement_test.go
@@ -603,7 +603,7 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name: "az-annotation",
+							Name:      "az-annotation",
 							MountPath: "/etc/az-annotation",
 						},
 					},

--- a/operator/internal/manifests/node_placement_test.go
+++ b/operator/internal/manifests/node_placement_test.go
@@ -592,6 +592,23 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 			},
 		},
 		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:  "az-annotation-check",
+					Image: "an-image:latest",
+					Command: []string{
+						"sh",
+						"-c",
+						"while ! [ -s /etc/az-annotation/az ]; do echo Waiting for availability zone annotation to be set; sleep 2; done; echo availability zone annotation is set; cat /etc/az-annotation/az",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name: "az-annotation",
+							MountPath: "/etc/az-annotation",
+						},
+					},
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  "a-container",
@@ -636,6 +653,23 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 						MatchLabels: map[string]string{
 							kubernetesComponentLabel: "component",
 							kubernetesInstanceLabel:  "a-stack",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "az-annotation",
+					VolumeSource: corev1.VolumeSource{
+						DownwardAPI: &corev1.DownwardAPIVolumeSource{
+							Items: []corev1.DownwardAPIVolumeFile{
+								{
+									Path: "az",
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: availabilityZoneFieldPath,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/operator/internal/manifests/node_placement_test.go
+++ b/operator/internal/manifests/node_placement_test.go
@@ -561,6 +561,11 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 					},
 				},
 			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "test-volume",
+				},
+			},
 		},
 	}
 
@@ -658,6 +663,9 @@ func TestCustomTopologySpreadConstraints(t *testing.T) {
 				},
 			},
 			Volumes: []corev1.Volume{
+				{
+					Name: "test-volume",
+				},
 				{
 					Name: "az-annotation",
 					VolumeSource: corev1.VolumeSource{

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -52,14 +52,6 @@ const (
 
 	rulerContainerName = "loki-ruler"
 
-	// availabilityZoneVolumeName is the name of the volume that will contain the
-	// availability zone annotation we get from DownwardAPI
-	availabilityZoneVolumeName = "az-annotation"
-	// availabilityZoneVolumeMountPath path where the volume will be mounted on the init container
-	availabilityZoneVolumeMountPath = "/etc/az-annotation"
-	// availabilityZoneVolumeFileName name of the file containg the availability zone annotation
-	availabilityZoneVolumeFileName = "az"
-
 	// EnvRelatedImageLoki is the environment variable to fetch the Loki image pullspec.
 	EnvRelatedImageLoki = "RELATED_IMAGE_LOKI"
 	// EnvRelatedImageGateway is the environment variable to fetch the Gateway image pullspec.
@@ -576,42 +568,5 @@ func lokiReadinessProbe() *corev1.Probe {
 		TimeoutSeconds:      1,
 		SuccessThreshold:    1,
 		FailureThreshold:    3,
-	}
-}
-
-func initContainerZoneAnnotationCheck(image string) corev1.Container {
-	azPath := fmt.Sprintf("%s/%s", availabilityZoneVolumeMountPath, availabilityZoneVolumeFileName)
-	return corev1.Container{
-		Name:  "az-annotation-check",
-		Image: image,
-		Command: []string{
-			"sh",
-			"-c",
-			fmt.Sprintf("while ! [ -s %s ]; do echo Waiting for availability zone annotation to be set; sleep 2; done; echo availability zone annotation is set; cat %s", azPath, azPath),
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      availabilityZoneVolumeName,
-				MountPath: availabilityZoneVolumeMountPath,
-			},
-		},
-	}
-}
-
-func zoneAnnotationVolumeMount() corev1.Volume {
-	return corev1.Volume{
-		Name: availabilityZoneVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			DownwardAPI: &corev1.DownwardAPIVolumeSource{
-				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: availabilityZoneVolumeFileName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: availabilityZoneFieldPath,
-						},
-					},
-				},
-			},
-		},
 	}
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Issue: https://issues.redhat.com/browse/LOG-3835

Problem: when a user configures zones in spec.replication we want to
make sure that when loki pods are started that they have access to the
zone that they are scheduled in. The zone_labeling_controller is
responsible for annotating the pods of zone-aware components, once these
are scheduled an annotation containing the zone where the pod was
scheduled is added. Furthermore, the controller will also configure the container
env vars to have this annotation available as an ENV variable.
Loki for loki to operate properly this ENV var must be set when the
the container starts, otherwise, loki will not be configured properly.

**Special notes for your reviewer**:

Solution: in this PR we have added an initContainer to each pod of zone
aware components. This initContainer will validate if the annotation was
set, by mounting the annotation as a volume and validating that the file
inside that volume is not empty
So if a container starts and the controller still hasn't added the
annotation then initContainer will enter a loop waiting for the
annotation to be added. Once the annotation is added since we use a volume
mount to access tha annotation the file inside the volume will be
updated, hence breaking the loop and allowing the loki components to
start.

Validation: To validate this solution I tested the PR on a AWS cluster
and validated the if the ENV is set for the loki processes with:

`oc get pods -o json | jq --arg q "'\0' '\n'" -r ' .items[] | select( .metadata.name | test("distributor|index|ingester|querier|query")) | "echo \(.metadata.name) $(oc exec \(.metadata.name) -c \(.spec.containers[0].name) -- cat /proc/1/environ | tr \($q) | grep INSTANCE_AVAILIBILITY_ZONE)"' | bash`

<img width="1440" alt="image" src="https://github.com/grafana/loki/assets/10974558/ab4eb62f-dd75-4162-bba3-7e9b6a14a087">


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
