### PR TITLE
Failures logging: avoid logging generic errors

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -34,7 +35,7 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 				"err", err,
 			)
 		}
-		d.writeFailuresManager.Log(tenantID, err)
+		d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't parse push request: %w", err))
 
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -1,8 +1,6 @@
 package writefailures
 
 import (
-	"context"
-	"errors"
 	"time"
 
 	"github.com/go-kit/log"
@@ -42,29 +40,8 @@ func (m *Manager) Log(tenantID string, err error) {
 		return
 	}
 
-	if m.skipError(err) {
-		return
-	}
-
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
 		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg)
 	}
-}
-
-// skipError dictates if a given error should be ignored or not.
-//
-// We should ignore errors that weren't caused by an inappropriate write.
-// An inappropriate write would cause other errors instead.
-//
-// Common scenarios where we shouldn't report errors:
-// - Overloaded ingesters causing write timeouts
-// - Distributor OOMing causing cancellations
-// - Ingester OOMing causing cancellations
-func (m *Manager) skipError(err error) bool {
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return true
-	}
-
-	return false
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -1,6 +1,8 @@
 package writefailures
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kit/log"
@@ -40,8 +42,29 @@ func (m *Manager) Log(tenantID string, err error) {
 		return
 	}
 
+	if m.skipError(err) {
+		return
+	}
+
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
 		level.Error(m.logger).Log("msg", "write operation failed", "err", errMsg)
 	}
+}
+
+// skipError dictates if a given error should be ignored or not.
+//
+// We should ignore errors that weren't caused by an inappropriate write.
+// An inappropriate write would cause other errors instead.
+//
+// Common scenarios where we shouldn't report errors:
+// - Overloaded ingesters causing write timeouts
+// - Distributor OOMing causing cancellations
+// - Ingester OOMing causing cancellations
+func (m *Manager) skipError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -48,7 +48,7 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
-		level.Error(m.logger).Log("msg", "write operation failed", "err", errMsg)
+		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg)
 	}
 }
 

--- a/pkg/distributor/writefailures/manager_test.go
+++ b/pkg/distributor/writefailures/manager_test.go
@@ -2,7 +2,6 @@ package writefailures
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -49,29 +48,6 @@ func TestWriteFailuresLogging(t *testing.T) {
 		require.NotContains(t, content, "bad-tenant")
 		require.NotContains(t, content, "unknown-tenant")
 	})
-}
-
-func TestInternalErrorsAreIgnored(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-	logger := log.NewLogfmtLogger(buf)
-
-	f := func(tenantID string) *runtime.Config {
-		return &runtime.Config{LimitedLogPushErrors: true}
-	}
-
-	runtimeCfg, err := runtime.NewTenantConfigs(f)
-	require.NoError(t, err)
-	manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	cancelFunc()
-
-	err = ctx.Err()
-	require.Error(t, err)
-
-	manager.Log("fake", fmt.Errorf("internal error happened: %w", err))
-	content := buf.String()
-	require.Empty(t, content)
 }
 
 func TestWriteFailuresRateLimiting(t *testing.T) {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -316,9 +316,9 @@ func (s *stream) storeEntries(ctx context.Context, entries []logproto.Entry) (in
 
 		chunk.lastUpdated = time.Now()
 		if err := chunk.chunk.Append(&entries[i]); err != nil {
-			s.writeFailures.Log(s.tenant, err)
 			invalid = append(invalid, entryWithError{&entries[i], err})
 			if chunkenc.IsOutOfOrderErr(err) {
+				s.writeFailures.Log(s.tenant, err)
 				outOfOrderSamples++
 				outOfOrderBytes += len(entries[i].Line)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify our write path to not log generic messages with the `writefailures.Manager`. With generic messages I mean: contextCancel errors and contextDeadlineExceeded errors.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
