### PR TITLE
Loki Promtail: Don't Create home directory for `promtail` user in promtail-postinstall.sh

### DIFF
--- a/tools/packaging/promtail-postinstall.sh
+++ b/tools/packaging/promtail-postinstall.sh
@@ -13,7 +13,7 @@ cleanInstall() {
 
     # Create the user
     if ! id promtail > /dev/null 2>&1 ; then
-        adduser --system --shell /bin/false "promtail"
+        adduser --no-create-home --system --shell /bin/false "promtail"
     fi
 
     # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root


### PR DESCRIPTION
**What this PR does / why we need it**:

When the `promtail-postinstall` script creates a `promtail` user, I do not believe that user requires a home directory to function correctly, and there are cases where the directory cannot be created causing the installation to fail.

**Which issue(s) this PR fixes**:
n/a - trivial fix

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)