### PR TITLE
Loki Promtail: Fix path exclude not honored for files created while Promtail is running

### DIFF
--- a/clients/pkg/promtail/targets/file/filetargetmanager.go
+++ b/clients/pkg/promtail/targets/file/filetargetmanager.go
@@ -438,7 +438,20 @@ func (s *targetSyncer) sendFileCreateEvent(event fsnotify.Event) {
 			level.Debug(s.log).Log("msg", "new file does not match glob", "filename", event.Name)
 			continue
 		}
-		watcher <- event
+		for _, target := range s.targets {
+			if target.path == path {
+				matchedExclude, err := doublestar.Match(target.pathExclude, event.Name)
+				if err != nil {
+					level.Error(s.log).Log("msg", "failed to exclude file", "error", err, "filename", event.Name)
+					continue
+				}
+				if matchedExclude {
+					level.Debug(s.log).Log("msg", "new file is excluded glob", "filename", event.Name)
+					continue
+				}
+				watcher <- event
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:  The PR solves a problem with __path_exclude__ not being honored for files created while Promtail is running. The code is based on changes suggested by @skeespin in #7115 . 

**Which issue(s) this PR fixes**:
Fixes #7115

**Special notes for your reviewer**:

**Checklist**
- [X ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ X] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
