### PR TITLE
disabled indexGateway client for boltdbShipper in migration tool.

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -103,7 +103,10 @@ func main() {
 	destConfig.StorageConfig.TSDBShipperConfig.ResyncInterval = 1 * time.Minute
 
 	// Don't want to use the index gateway for this, this makes sure the index files are properly uploaded when the store is stopped.
+	sourceConfig.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 	sourceConfig.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true
+
+	destConfig.StorageConfig.BoltDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 	destConfig.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.Disabled = true
 
 	// The long nature of queries requires stretching out the cardinality limit some and removing the query length limit


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this fix, the migration tool tries to initialize the ingexGateway client, which is unreachable. 
This leads to the error:
`Failed to create source store: error creating index client: index gateway grpc dial: failed to build resolver: passthrough: received empty target in Build()`
