### PR TITLE
LogPushFailures: Log the tenant id

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -323,6 +323,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 
 			stream.Labels, stream.Hash, err = d.parseStreamLabels(validationContext, stream.Labels, &stream)
 			if err != nil {
+				d.writeFailuresManager.Log(tenantID, err)
 				validationErrors.Add(err)
 				validation.DiscardedSamples.WithLabelValues(validation.InvalidLabels, tenantID).Add(float64(len(stream.Entries)))
 				bytes := 0

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -42,6 +42,6 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
-		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg)
+		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the `writefailures.Manager` to
- Log the tenant id. Otherwise, it is hard to identify which tenant is responsible for a problematic push
- Log stream parsing failures

**Which issue(s) this PR fixes**:
N/A