### PR TITLE
LogPushErrors: Log error categories

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/weaveworks/common/httpgrpc"
 
+	"github.com/grafana/loki/pkg/distributor/writefailures"
 	"github.com/grafana/loki/pkg/util"
 
 	"github.com/grafana/dskit/tenant"
@@ -35,7 +36,7 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 				"err", err,
 			)
 		}
-		d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't parse push request: %w", err))
+		d.writeFailuresManager.Log(tenantID, fmt.Errorf("couldn't parse push request: %w", err), writefailures.InvalidRequestErr)
 
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -10,6 +10,15 @@ import (
 	"github.com/grafana/loki/pkg/runtime"
 )
 
+type ErrCategory string
+
+const (
+	InvalidEntryErr   ErrCategory = "invalid-entry"
+	InvalidLabelErr               = "invalid-label"
+	InvalidRequestErr             = "invalid-request"
+	RateLimitErr                  = "rate-limit"
+)
+
 type Manager struct {
 	limiter    *limiter.RateLimiter
 	logger     log.Logger
@@ -31,7 +40,7 @@ func NewManager(logger log.Logger, cfg Cfg, tenants *runtime.TenantConfigs) *Man
 	}
 }
 
-func (m *Manager) Log(tenantID string, err error) {
+func (m *Manager) Log(tenantID string, err error, category ErrCategory) {
 	if m == nil {
 		return
 	}
@@ -42,6 +51,6 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
-		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
+		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID, "category", category)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Expect an error category for a push error and logs it. This will be useful in the future to rate-limit based on categories and to create category-based dashboards

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
