### PR TITLE
uses lowercase standard for logging and adds total bytes to shard res…

### DIFF
--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -201,8 +201,9 @@ func (r *dynamicShardResolver) Shards(e syntax.Expr) (int, uint64, error) {
 	level.Debug(log).Log(
 		append(
 			combined.LoggingKeyValues(),
-			"msg", "Got shard factor",
+			"msg", "got shard factor",
 			"factor", factor,
+			"total_bytes", strings.Replace(humanize.Bytes(combined.Bytes), " ", "", 1),
 			"bytes_per_shard", strings.Replace(humanize.Bytes(bytesPerShard), " ", "", 1),
 		)...,
 	)


### PR DESCRIPTION
Minor logging cleanup + helpful to have total bytes on this log line to correlate without needing to derive total bytes from factor * bytes_per_shard