### PR TITLE
Get basic statistics from series volume requests

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -947,6 +947,16 @@ func paramsFromRequest(req queryrangebase.Request) (logql.Params, error) {
 		return &paramsRangeWrapper{
 			LokiRequest: r,
 		}, nil
+	case *logproto.VolumeRequest:
+		return &paramsRangeWrapper{
+			LokiRequest: &LokiRequest{
+				Query:   r.GetQuery(),
+				Limit:   uint32(r.GetLimit()),
+				Step:    r.GetStep(),
+				StartTs: time.UnixMilli(r.GetStart()),
+				EndTs:   time.UnixMilli(r.GetEnd()),
+			},
+		}, nil
 	case *LokiInstantRequest:
 		return &paramsInstantWrapper{
 			LokiInstantRequest: r,

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -802,6 +802,7 @@ func volumeRangeTripperware(codec queryrangebase.Codec, nextTW queryrangebase.Tr
 			}
 
 			seriesVolumeMiddlewares := []queryrangebase.Middleware{
+				StatsCollectorMiddleware(),
 				NewSeriesVolumeMiddleware(),
 			}
 


### PR DESCRIPTION
The `series_volume` endpoint returns stats about the call. This PR wires things up such that basic stats are returned:
- Execution time
- Number of responses