### PR TITLE
Helm: Increase HPA minReplicas and maxReplicas

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -74,7 +74,7 @@ false
 			<td>int</td>
 			<td>Maximum autoscaling replicas for the backend.</td>
 			<td><pre lang="json">
-3
+6
 </pre>
 </td>
 		</tr>
@@ -83,7 +83,7 @@ false
 			<td>int</td>
 			<td>Minimum autoscaling replicas for the backend.</td>
 			<td><pre lang="json">
-1
+2
 </pre>
 </td>
 		</tr>
@@ -3065,7 +3065,7 @@ false
 			<td>int</td>
 			<td>Maximum autoscaling replicas for the read</td>
 			<td><pre lang="json">
-3
+6
 </pre>
 </td>
 		</tr>
@@ -3074,7 +3074,7 @@ false
 			<td>int</td>
 			<td>Minimum autoscaling replicas for the read</td>
 			<td><pre lang="json">
-1
+2
 </pre>
 </td>
 		</tr>
@@ -4111,7 +4111,7 @@ false
 			<td>int</td>
 			<td>Maximum autoscaling replicas for the write.</td>
 			<td><pre lang="json">
-3
+6
 </pre>
 </td>
 		</tr>
@@ -4120,7 +4120,7 @@ false
 			<td>int</td>
 			<td>Minimum autoscaling replicas for the write.</td>
 			<td><pre lang="json">
-1
+2
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -12,6 +12,9 @@ Entries should be ordered as follows:
 Entries should include a reference to the pull request that introduced the change.
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
+## 5.16.1
+
+- [BUGFIX] Increase default minReplicas to 2 and maxReplicas to 6
 
 ## 5.16.0
 
@@ -64,9 +67,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.8.10
 
 - [ENHANCEMENT] Canary labelname can now be configured via monitoring.lokiCanary.labelname
-## 5.8.10
-
-- [BUGFIX] Increase default minReplicas to 2 and maxReplicas to 6
 
 ## 5.8.9
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -64,6 +64,9 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.8.10
 
 - [ENHANCEMENT] Canary labelname can now be configured via monitoring.lokiCanary.labelname
+## 5.8.10
+
+- [BUGFIX] Increase default minReplicas to 2 and maxReplicas to 6
 
 ## 5.8.9
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.4
-version: 5.16.0
+version: 5.16.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.16.0](https://img.shields.io/badge/Version-5.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
+![Version: 5.16.1](https://img.shields.io/badge/Version-5.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -692,9 +692,9 @@ write:
     # -- Enable autoscaling for the write.
     enabled: false
     # -- Minimum autoscaling replicas for the write.
-    minReplicas: 1
+    minReplicas: 2
     # -- Maximum autoscaling replicas for the write.
-    maxReplicas: 3
+    maxReplicas: 6
     # -- Target CPU utilisation percentage for the write.
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilization percentage for the write.
@@ -864,9 +864,9 @@ read:
     # -- Enable autoscaling for the read, this is only used if `queryIndex.enabled: true`
     enabled: false
     # -- Minimum autoscaling replicas for the read
-    minReplicas: 1
+    minReplicas: 2
     # -- Maximum autoscaling replicas for the read
-    maxReplicas: 3
+    maxReplicas: 6
     # -- Target CPU utilisation percentage for the read
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the read
@@ -964,9 +964,9 @@ backend:
     # -- Enable autoscaling for the backend.
     enabled: false
     # -- Minimum autoscaling replicas for the backend.
-    minReplicas: 1
+    minReplicas: 2
     # -- Maximum autoscaling replicas for the backend.
-    maxReplicas: 3
+    maxReplicas: 6
     # -- Target CPU utilization percentage for the backend.
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilization percentage for the backend.


### PR DESCRIPTION
**What this PR does / why we need it**:
The writer scaleUp configuration is missing `stabilizationWindowSeconds`, without it I cannot enable the autoscaler.

**Special notes for your reviewer**:
The autoscaling minReplicas is 1, but the default `replication_factor` is 3. If a user enables the autoscaler but does not update the minReplicas the pod will crash, should I increase the minReplicas to 2?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
