### PR TITLE
[Docs] - Add example of Conditional OR to IP Filter

### DIFF
--- a/docs/sources/query/ip.md
+++ b/docs/sources/query/ip.md
@@ -65,11 +65,19 @@ When specifying label filter expressions, only the  `=` and `!=` operations are 
 		| level = "error"
     ```
 
-    Filters can be chained. This example matches log lines with all IPv4 subnet values `192.168.4.5/16` except IP address `192.168.4.2`:
+    Filters can also be chained. This example matches log lines with all IPv4 subnet values `192.168.4.5/16` except IP address `192.168.4.2`:
 
     ```logql
     {job_name="myapp"}
 		| logfmt
 		| addr = ip("192.168.4.5/16")
 		| addr != ip("192.168.4.2")
+    ```
+
+    This example use the conditional `or` and matches log lines with either, all IPv4 subnet values `192.168.4.0/24` OR all IPv4 subnet values `10.10.15.0/24`:
+
+    ```logql
+    {job_name="myapp"}
+		| logfmt
+		| addr = ip("192.168.4.0/24") or addr = ip("10.10.15.0/24")
     ```


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the Docs with an example of how to use an OR conditional filter when filtering by IP addresses.

Example of this working on [Grafana Play can be found here](https://play.grafana.org/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcontainer%3D%5C%22grafana%5C%22%7D%20%7C%20logfmt%20%7C%20remote_addr%3Dip%28%6010.10.0.0%2F24%60%29%20or%20remote_addr%3Dip%28%6010.4.1.0%2F24%60%29%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%221688342400000%22,%22to%22:%221688428799000%22%7D%7D)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
