### PR TITLE
ksonnet: refer to tsdb_shipper_shared_store only if using_tsdb_shipper is true

### DIFF
--- a/production/ksonnet/loki/shipper.libsonnet
+++ b/production/ksonnet/loki/shipper.libsonnet
@@ -24,21 +24,23 @@
     compactor_pvc_class: 'fast',
     index_period_hours: if self.using_shipper_store then 24 else super.index_period_hours,
     loki+: if self.using_shipper_store then {
-      storage_config+: {
+      storage_config+: if $._config.using_boltdb_shipper then {
         boltdb_shipper+: {
           shared_store: $._config.boltdb_shipper_shared_store,
           active_index_directory: '/data/index',
           cache_location: '/data/boltdb-cache',
         },
+      } else {} + if $._config.using_tsdb_shipper then {
         tsdb_shipper+: {
           shared_store: $._config.tsdb_shipper_shared_store,
           active_index_directory: '/data/tsdb-index',
           cache_location: '/data/tsdb-cache',
         },
-      },
+      } else {},
       compactor+: {
         working_directory: '/data/compactor',
-        shared_store: if self.using_boltdb_shipper then self.boltdb_shipper_shared_store else self.tsdb_shipper_shared_store,
+        // prefer tsdb index over boltdb
+        shared_store: if self.using_tsdb_shipper then self.tsdb_shipper_shared_store else self.boltdb_shipper_shared_store,
       },
     } else {},
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/grafana/loki/pull/9790 introduced a new config `tsdb_shipper_shared_store`, but it's being referred to even if tsdb index is not enabled. This fixes it by accessing the value only if using_tsdb_shipper is set to true

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
