### PR TITLE
Queriers: Stop emitting spans for every objectstorage call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 ##### Changes
 
+* [9857](https://github.com/grafana/loki/pull/9857) **DylanGuedes**: Stop emitting spans for every `AWS.S3` or `Azure.Blob` call.
 * [9212](https://github.com/grafana/loki/pull/9212) **trevorwhitney**: Rename UsageReport to Analytics. The only external impact of this change is a change in the `-list-targets` output.
 
 #### Promtail

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -381,7 +381,7 @@ func (a *S3ObjectClient) GetObject(ctx context.Context, objectKey string) (io.Re
 			return nil, 0, errors.Wrap(ctx.Err(), "ctx related error during s3 getObject")
 		}
 
-		lastErr = loki_instrument.ObserveRequest(ctx, "S3.GetObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		lastErr = loki_instrument.TimeRequest(ctx, "S3.GetObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			var requestErr error
 			resp, requestErr = a.hedgedS3.GetObjectWithContext(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(bucket),
@@ -405,7 +405,7 @@ func (a *S3ObjectClient) GetObject(ctx context.Context, objectKey string) (io.Re
 
 // PutObject into the store
 func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
-	return loki_instrument.ObserveRequest(ctx, "S3.PutObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	return loki_instrument.TimeRequest(ctx, "S3.PutObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		putObjectInput := &s3.PutObjectInput{
 			Body:         object,
 			Bucket:       aws.String(a.bucketFromKey(objectKey)),
@@ -430,7 +430,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 	var commonPrefixes []client.StorageCommonPrefix
 
 	for i := range a.bucketNames {
-		err := loki_instrument.ObserveRequest(ctx, "S3.List", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		err := loki_instrument.TimeRequest(ctx, "S3.List", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 			input := s3.ListObjectsV2Input{
 				Bucket:    aws.String(a.bucketNames[i]),
 				Prefix:    aws.String(prefix),

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/client/hedging"
 	client_util "github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/util"
+	loki_instrument "github.com/grafana/loki/pkg/util/instrument"
 	"github.com/grafana/loki/pkg/util/log"
 )
 
@@ -226,7 +227,7 @@ func (b *BlobStorage) GetObject(ctx context.Context, objectKey string) (io.ReadC
 		size int64
 		rc   io.ReadCloser
 	)
-	err := instrument.CollectedRequest(ctx, "azure.GetObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	err := loki_instrument.ObserveRequest(ctx, "azure.GetObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		var err error
 		rc, size, err = b.getObject(ctx, objectKey)
 		return err
@@ -257,7 +258,7 @@ func (b *BlobStorage) getObject(ctx context.Context, objectKey string) (rc io.Re
 }
 
 func (b *BlobStorage) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
-	return instrument.CollectedRequest(ctx, "azure.PutObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	return loki_instrument.ObserveRequest(ctx, "azure.PutObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		blockBlobURL, err := b.getBlobURL(objectKey, false)
 		if err != nil {
 			return err
@@ -471,7 +472,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]cli
 			return nil, nil, ctx.Err()
 		}
 
-		err := instrument.CollectedRequest(ctx, "azure.List", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+		err := loki_instrument.ObserveRequest(ctx, "azure.List", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 			listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
 			if err != nil {
 				return err
@@ -504,7 +505,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]cli
 }
 
 func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
-	return instrument.CollectedRequest(ctx, "azure.DeleteObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	return loki_instrument.ObserveRequest(ctx, "azure.DeleteObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		blockBlobURL, err := b.getBlobURL(blobID, false)
 		if err != nil {
 			return err

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -227,7 +227,7 @@ func (b *BlobStorage) GetObject(ctx context.Context, objectKey string) (io.ReadC
 		size int64
 		rc   io.ReadCloser
 	)
-	err := loki_instrument.ObserveRequest(ctx, "azure.GetObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	err := loki_instrument.TimeRequest(ctx, "azure.GetObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		var err error
 		rc, size, err = b.getObject(ctx, objectKey)
 		return err
@@ -258,7 +258,7 @@ func (b *BlobStorage) getObject(ctx context.Context, objectKey string) (rc io.Re
 }
 
 func (b *BlobStorage) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
-	return loki_instrument.ObserveRequest(ctx, "azure.PutObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	return loki_instrument.TimeRequest(ctx, "azure.PutObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		blockBlobURL, err := b.getBlobURL(objectKey, false)
 		if err != nil {
 			return err
@@ -472,7 +472,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]cli
 			return nil, nil, ctx.Err()
 		}
 
-		err := loki_instrument.ObserveRequest(ctx, "azure.List", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+		err := loki_instrument.TimeRequest(ctx, "azure.List", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 			listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
 			if err != nil {
 				return err
@@ -505,7 +505,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]cli
 }
 
 func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
-	return loki_instrument.ObserveRequest(ctx, "azure.DeleteObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
+	return loki_instrument.TimeRequest(ctx, "azure.DeleteObject", instrument.NewHistogramCollector(b.metrics.requestDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		blockBlobURL, err := b.getBlobURL(blobID, false)
 		if err != nil {
 			return err

--- a/pkg/util/instrument/instrument.go
+++ b/pkg/util/instrument/instrument.go
@@ -7,7 +7,7 @@ import (
 	"github.com/weaveworks/common/instrument"
 )
 
-// ObserveRequest reports how much time was spent on the given f.
+// ObserveRequest reports how much time was spent on the given function  `f`.
 //
 // It is a thinner version of weaveworks/common/instrument.CollectedRequest that doesn't emit spans.
 func ObserveRequest(ctx context.Context, method string, col instrument.Collector, toStatusCode func(error) string, f func(context.Context) error) error {

--- a/pkg/util/instrument/instrument.go
+++ b/pkg/util/instrument/instrument.go
@@ -7,10 +7,10 @@ import (
 	"github.com/weaveworks/common/instrument"
 )
 
-// ObserveRequest reports how much time was spent on the given function  `f`.
+// TimeRequest reports how much time was spent on the given function  `f`.
 //
 // It is a thinner version of weaveworks/common/instrument.CollectedRequest that doesn't emit spans.
-func ObserveRequest(ctx context.Context, method string, col instrument.Collector, toStatusCode func(error) string, f func(context.Context) error) error {
+func TimeRequest(ctx context.Context, method string, col instrument.Collector, toStatusCode func(error) string, f func(context.Context) error) error {
 	if toStatusCode == nil {
 		toStatusCode = instrument.ErrorCode
 	}

--- a/pkg/util/instrument/instrument.go
+++ b/pkg/util/instrument/instrument.go
@@ -1,0 +1,24 @@
+package instrument
+
+import (
+	"context"
+	"time"
+
+	"github.com/weaveworks/common/instrument"
+)
+
+// ObserveRequest reports how much time was spent on the given f.
+//
+// It is a thinner version of weaveworks/common/instrument.CollectedRequest that doesn't emit spans.
+func ObserveRequest(ctx context.Context, method string, col instrument.Collector, toStatusCode func(error) string, f func(context.Context) error) error {
+	if toStatusCode == nil {
+		toStatusCode = instrument.ErrorCode
+	}
+
+	start := time.Now()
+	col.Before(ctx, method, start)
+	err := f(ctx)
+	col.After(ctx, method, toStatusCode(err), start)
+
+	return err
+}

--- a/pkg/util/instrument/instrument_test.go
+++ b/pkg/util/instrument/instrument_test.go
@@ -1,0 +1,69 @@
+package instrument
+
+// Source: https://github.com/weaveworks/common/blob/master/instrument/instrument_test.go
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/instrument"
+)
+
+func TestNewHistogramCollector(t *testing.T) {
+	m := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "test",
+		Subsystem: "instrumentation",
+		Name:      "foo",
+		Help:      "",
+		Buckets:   prometheus.DefBuckets,
+	}, instrument.HistogramCollectorBuckets)
+	c := instrument.NewHistogramCollector(m)
+	assert.NotNil(t, c)
+}
+
+type spyCollector struct {
+	before    bool
+	after     bool
+	afterCode string
+}
+
+func (c *spyCollector) Register() {
+}
+
+// Before collects for the upcoming request.
+func (c *spyCollector) Before(ctx context.Context, method string, start time.Time) {
+	c.before = true
+}
+
+// After collects when the request is done.
+func (c *spyCollector) After(ctx context.Context, method, statusCode string, start time.Time) {
+	c.after = true
+	c.afterCode = statusCode
+}
+
+func TestCollectedRequest(t *testing.T) {
+	c := &spyCollector{}
+	fcalled := false
+	instrument.CollectedRequest(context.Background(), "test", c, nil, func(_ context.Context) error {
+		fcalled = true
+		return nil
+	})
+	assert.True(t, fcalled)
+	assert.True(t, c.before)
+	assert.True(t, c.after)
+	assert.Equal(t, "200", c.afterCode)
+}
+
+func TestCollectedRequest_Error(t *testing.T) {
+	c := &spyCollector{}
+	instrument.CollectedRequest(context.Background(), "test", c, nil, func(_ context.Context) error {
+		return errors.New("boom")
+	})
+	assert.True(t, c.before)
+	assert.True(t, c.after)
+	assert.Equal(t, "500", c.afterCode)
+}

--- a/pkg/util/instrument/instrument_test.go
+++ b/pkg/util/instrument/instrument_test.go
@@ -36,12 +36,12 @@ func (c *spyCollector) Register() {
 }
 
 // Before collects for the upcoming request.
-func (c *spyCollector) Before(_ context.Context, method string, start time.Time) {
+func (c *spyCollector) Before(_ context.Context, _ string, _ time.Time) {
 	c.before = true
 }
 
 // After collects when the request is done.
-func (c *spyCollector) After(_ context.Context, method, statusCode string, start time.Time) {
+func (c *spyCollector) After(_ context.Context, _, statusCode string, _ time.Time) {
 	c.after = true
 	c.afterCode = statusCode
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Stop emitting spans for every call to our object storages (like S3 or Azure); we don't emit them for GCP already. It causes every chunk fetching to emit a span, which can end with a huge amount of unnecessary spans. It will still report request metrics just fine.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
