### PR TITLE
operator: Do not use mergo for updating existing resources

### DIFF
--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -16,14 +16,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// MutateFuncFor returns a mutate function based on the
-// existing resource's concrete type. It supports currently
-// only the following types or else panics:
-// - ConfigMap
-// - Service
-// - Deployment
-// - StatefulSet
-// - ServiceMonitor
+// MutateFuncFor returns a mutate function based on the existing resource's concrete type.
+// It currently supports the following types and will return an error for other types:
+//
+//   - ConfigMap
+//   - Secret
+//   - Service
+//   - ServiceAccount
+//   - ClusterRole
+//   - ClusterRoleBinding
+//   - Role
+//   - RoleBinding
+//   - Deployment
+//   - StatefulSet
+//   - ServiceMonitor
+//   - Ingress
+//   - Route
+//   - PrometheusRule
+//   - PodDisruptionBudget
 func MutateFuncFor(existing, desired client.Object, depAnnotations map[string]string) controllerutil.MutateFn {
 	return func() error {
 		existingAnnotations := existing.GetAnnotations()
@@ -61,7 +71,7 @@ func MutateFuncFor(existing, desired client.Object, depAnnotations map[string]st
 		case *corev1.Service:
 			svc := existing.(*corev1.Service)
 			wantSvc := desired.(*corev1.Service)
-			return mutateService(svc, wantSvc)
+			mutateService(svc, wantSvc)
 
 		case *corev1.ServiceAccount:
 			sa := existing.(*corev1.ServiceAccount)
@@ -91,12 +101,12 @@ func MutateFuncFor(existing, desired client.Object, depAnnotations map[string]st
 		case *appsv1.Deployment:
 			dpl := existing.(*appsv1.Deployment)
 			wantDpl := desired.(*appsv1.Deployment)
-			return mutateDeployment(dpl, wantDpl)
+			mutateDeployment(dpl, wantDpl)
 
 		case *appsv1.StatefulSet:
 			sts := existing.(*appsv1.StatefulSet)
 			wantSts := desired.(*appsv1.StatefulSet)
-			return mutateStatefulSet(sts, wantSts)
+			mutateStatefulSet(sts, wantSts)
 
 		case *monitoringv1.ServiceMonitor:
 			svcMonitor := existing.(*monitoringv1.ServiceMonitor)
@@ -134,14 +144,6 @@ func mergeWithOverride(dst, src interface{}) error {
 	err := mergo.Merge(dst, src, mergo.WithOverride)
 	if err != nil {
 		return kverrors.Wrap(err, "unable to mergeWithOverride", "dst", dst, "src", src)
-	}
-	return nil
-}
-
-func mergeWithOverrideEmpty(dst, src interface{}) error {
-	err := mergo.Merge(dst, src, mergo.WithOverwriteWithEmptyValue)
-	if err != nil {
-		return kverrors.Wrap(err, "unable to mergeWithOverrideEmpty", "dst", dst, "src", src)
 	}
 	return nil
 }
@@ -217,41 +219,30 @@ func mutatePrometheusRule(existing, desired *monitoringv1.PrometheusRule) {
 	existing.Spec = desired.Spec
 }
 
-func mutateService(existing, desired *corev1.Service) error {
+func mutateService(existing, desired *corev1.Service) {
 	existing.Spec.Ports = desired.Spec.Ports
-	if err := mergeWithOverride(&existing.Spec.Selector, desired.Spec.Selector); err != nil {
-		return err
-	}
-	return nil
+	existing.Spec.Selector = desired.Spec.Selector
 }
 
-func mutateDeployment(existing, desired *appsv1.Deployment) error {
+func mutateDeployment(existing, desired *appsv1.Deployment) {
 	// Deployment selector is immutable so we set this value only if
 	// a new object is going to be created
 	if existing.CreationTimestamp.IsZero() {
 		existing.Spec.Selector = desired.Spec.Selector
 	}
 	existing.Spec.Replicas = desired.Spec.Replicas
-	if err := mergeWithOverrideEmpty(&existing.Spec.Template, desired.Spec.Template); err != nil {
-		return err
-	}
-	if err := mergeWithOverride(&existing.Spec.Strategy, desired.Spec.Strategy); err != nil {
-		return err
-	}
-	return nil
+	existing.Spec.Template = desired.Spec.Template
+	existing.Spec.Strategy = desired.Spec.Strategy
 }
 
-func mutateStatefulSet(existing, desired *appsv1.StatefulSet) error {
+func mutateStatefulSet(existing, desired *appsv1.StatefulSet) {
 	// StatefulSet selector is immutable so we set this value only if
 	// a new object is going to be created
 	if existing.CreationTimestamp.IsZero() {
 		existing.Spec.Selector = desired.Spec.Selector
 	}
 	existing.Spec.Replicas = desired.Spec.Replicas
-	if err := mergeWithOverrideEmpty(&existing.Spec.Template, desired.Spec.Template); err != nil {
-		return err
-	}
-	return nil
+	existing.Spec.Template = desired.Spec.Template
 }
 
 func mutatePodDisruptionBudget(existing, desired *policyv1.PodDisruptionBudget) {

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -488,7 +488,7 @@ func TestGetMutateFunc_MutateRoleBinding(t *testing.T) {
 	require.Exactly(t, got.Subjects, want.Subjects)
 }
 
-func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
+func TestMutateFuncFor_MutateDeploymentSpec(t *testing.T) {
 	type test struct {
 		name string
 		got  *appsv1.Deployment
@@ -615,7 +615,7 @@ func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
 	}
 }
 
-func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
+func TestMutateFuncFor_MutateStatefulSetSpec(t *testing.T) {
 	type test struct {
 		name string
 		got  *appsv1.StatefulSet


### PR DESCRIPTION
**What this PR does / why we need it**:

While testing the zone-awareness PR I noticed that the labels and annotations on the pods did not disappear when I deactivated the zone-awareness again. This turned out to be an issue with how we generally update existing Deployments/StateFulSets: We merge the existing PodTemplateSpec with the desired one.

I don't think we need the merge at that point, because the operator should be the complete owner of that attribute, so we should be able to completely replace the values instead of merging with the existing one.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The situation with the annotations and labels of our resources is a bit confusing. On one hand we have `mergeWithOverride` code at the beginning of the `MutateFuncFor` function but on the other hand almost every one of the per-type `mutate*` functions contains code that overwrites existing labels/annotations. I think it should be either one or the other.

On a related note, maybe it makes sense to keep existing labels/annotations on the resources ("merging" them with the existing ones, but explicitly keep track of _our_ labels/annotations, so that we remove our annotations/labels when they are not needed anymore but don't touch "other people's annotations/labels". This would make the merge code a bit longer though.

This PR remains a draft until the question about how to proceed with labels/annotations is cleared up.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
