### PR TITLE
promtail: apply defaults to HTTP client config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [8988](https://github.com/grafana/loki/pull/8988) **darxriggs**: Promtail: Prevent logging errors on normal shutdown.
 * [9155](https://github.com/grafana/loki/pull/9155) **farodin91**: Promtail: Break on iterate journal failure.
 * [8987](https://github.com/grafana/loki/pull/8987) **darxriggs**: Promtail: Fix file descriptor leak.
+* [9863](https://github.com/grafana/loki/pull/9863) **ashwanthgoli**: Promtail: Apply defaults to HTTP client config. This ensures follow_redirects is set to true.
 
 #### LogCLI
 

--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -91,7 +91,15 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
+	cfg.Client = config.DefaultHTTPClientConfig
+
 	if err := unmarshal(&cfg); err != nil {
+		return err
+	}
+
+	// explicitly call Validate on HTTPClientConfig as it's UnmarshalYAML
+	// method doesn't get invoked given that it's not a pointer.
+	if err := cfg.Client.Validate(); err != nil {
 		return err
 	}
 

--- a/clients/pkg/promtail/client/config_test.go
+++ b/clients/pkg/promtail/client/config_test.go
@@ -107,7 +107,7 @@ func Test_Config(t *testing.T) {
 			require.NoError(t, err)
 
 			if !reflect.DeepEqual(tc.expectedConfig, clientConfig) {
-				t.Errorf("Configs does not match, expected: %v, received: %v", tc.expectedConfig, clientConfig)
+				t.Errorf("Configs do not match, expected: %v, got: %v", tc.expectedConfig, clientConfig)
 			}
 		}
 	}

--- a/clients/pkg/promtail/client/config_test.go
+++ b/clients/pkg/promtail/client/config_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"net/url"
 	"reflect"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/yaml.v2"
@@ -28,6 +30,15 @@ backoff_config:
 batchwait: 5s
 batchsize: 204800
 timeout: 5s
+basic_auth:
+  username: promtail
+enable_http2: false
+`
+
+var clientInvalidHTTPConfig = `
+url: http://localhost:3100/loki/api/v1/push
+bearer_token: tkn
+bearer_token_file: tkn_file
 `
 
 func Test_Config(t *testing.T) {
@@ -36,6 +47,7 @@ func Test_Config(t *testing.T) {
 	tests := []struct {
 		configValues   string
 		expectedConfig Config
+		expectedErr    error
 	}{
 		{
 			clientDefaultConfig,
@@ -51,7 +63,9 @@ func Test_Config(t *testing.T) {
 				BatchSize: BatchSize,
 				BatchWait: BatchWait,
 				Timeout:   Timeout,
+				Client:    config.DefaultHTTPClientConfig,
 			},
+			nil,
 		},
 		{
 			clientCustomConfig,
@@ -67,15 +81,34 @@ func Test_Config(t *testing.T) {
 				BatchSize: 100 * 2048,
 				BatchWait: 5 * time.Second,
 				Timeout:   5 * time.Second,
+				Client: config.HTTPClientConfig{
+					BasicAuth: &config.BasicAuth{
+						Username: "promtail",
+					},
+					FollowRedirects: true,
+				},
 			},
+			nil,
+		},
+		{
+			clientInvalidHTTPConfig,
+			Config{},
+			errors.New("at most one of bearer_token & bearer_token_file must be configured"),
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		err := yaml.Unmarshal([]byte(tc.configValues), &clientConfig)
-		require.NoError(t, err)
 
-		if !reflect.DeepEqual(tc.expectedConfig, clientConfig) {
-			t.Errorf("Configs does not match, expected: %v, received: %v", tc.expectedConfig, clientConfig)
+		if tc.expectedErr != nil {
+			require.Error(t, err)
+			require.Equal(t, tc.expectedErr, err)
+		} else {
+			require.NoError(t, err)
+
+			if !reflect.DeepEqual(tc.expectedConfig, clientConfig) {
+				t.Errorf("Configs does not match, expected: %v, received: %v", tc.expectedConfig, clientConfig)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Apply defaults to HTTPClientConfig and validate it. similar to how it's done [here](https://github.com/grafana/loki/blob/e9644d8186174654832e7b6f37a4b4ad34637b0d/vendor/github.com/prometheus/prometheus/config/config.go#L524) in prometheus.

promtail [configuration page](https://grafana.com/docs/loki/latest/clients/promtail/configuration/) incorrectly claims that `follow_redirects` is true, but it is being set to false given that the defaults are not being applied currently

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
