### PR TITLE
Switch on pointer `*logproto.SeriesResponse` in JSON serialization.

### DIFF
--- a/pkg/querier/http_test.go
+++ b/pkg/querier/http_test.go
@@ -337,6 +337,43 @@ func TestQueryWrapperMiddleware(t *testing.T) {
 	})
 }
 
+func TestSeriesHandler(t *testing.T) {
+	t.Run("instant queries set a step of 0", func(t *testing.T) {
+		ret := func() *logproto.SeriesResponse {
+			return &logproto.SeriesResponse{
+				Series: []logproto.SeriesIdentifier{
+					{
+						Labels: map[string]string{
+							"a": "1",
+							"b": "2",
+						},
+					},
+					{
+						Labels: map[string]string{
+							"c": "3",
+							"d": "4",
+						},
+					},
+				},
+			}
+		}
+		expected := `{"status":"success","data":[{"a":"1","b":"2"},{"c":"3","d":"4"}]}`
+
+		querier := newQuerierMock()
+		querier.On("Series", mock.Anything, mock.Anything).Return(ret, nil)
+		api := setupAPI(querier)
+
+		req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/series"+
+			"?start=0"+
+			"&end=1"+
+			"&step=42"+
+			"&query=%7Bfoo%3D%22bar%22%7D", nil)
+		res := makeRequest(t, api.SeriesHandler, req)
+
+		require.Equalf(t, 200, res.Code, "response was not HTTP OK: %s", res.Body.String())
+		require.JSONEq(t, expected, res.Body.String())
+	})
+}
 func TestSeriesVolumeHandler(t *testing.T) {
 	ret := &logproto.VolumeResponse{
 		Volumes: []logproto.Volume{

--- a/pkg/querier/queryrange/marshal.go
+++ b/pkg/querier/queryrange/marshal.go
@@ -40,9 +40,9 @@ func WriteResponseProtobuf(req *http.Request, params *logql.LiteralParams, v any
 	case *logproto.LabelResponse:
 		version := loghttp.GetVersion(req.RequestURI)
 		return WriteLabelResponseProtobuf(version, *result, w)
-	case logproto.SeriesResponse:
+	case *logproto.SeriesResponse:
 		version := loghttp.GetVersion(req.RequestURI)
-		return WriteSeriesResponseProtobuf(version, result, w)
+		return WriteSeriesResponseProtobuf(version, *result, w)
 	case *stats.Stats:
 		return WriteIndexStatsResponseProtobuf(result, w)
 	case *logproto.VolumeResponse:

--- a/pkg/util/marshal/marshal.go
+++ b/pkg/util/marshal/marshal.go
@@ -34,8 +34,8 @@ func WriteResponseJSON(r *http.Request, v any, w http.ResponseWriter) error {
 		}
 
 		return marshal_legacy.WriteLabelResponseJSON(*result, w)
-	case logproto.SeriesResponse:
-		return WriteSeriesResponseJSON(result, w)
+	case *logproto.SeriesResponse:
+		return WriteSeriesResponseJSON(*result, w)
 	case *stats.Stats:
 		return WriteIndexStatsResponseJSON(result, w)
 	case *logproto.VolumeResponse:

--- a/pkg/util/marshal/marshal_test.go
+++ b/pkg/util/marshal/marshal_test.go
@@ -675,7 +675,7 @@ func Test_WriteSeriesResponseJSON(t *testing.T) {
 			err := WriteSeriesResponseJSON(tc.input, &b)
 			require.NoError(t, err)
 
-			require.JSONEqf(t, tc.expected, b.String(), "Label Test %d failed", i)
+			require.JSONEqf(t, tc.expected, b.String(), "Series Test %d failed", i)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Commit b35bbd80d65f09eb6f1e6ba1bfe05bf4af712a97 introduced a regression in the deserialization code. It would switch on `logproto.SeriesResponse` instead of the pointer type `*logproto.SeriesResponse`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
