### PR TITLE
Update redirects to use new alias format. (part 1 of 2)

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -2,12 +2,10 @@
 title: Alerting and recording rules
 menuTitle: Alert
 description: Learn how the rule evaluates queries for alerting.
-
 aliases:
-  - /docs/loki/latest/rules/
-  - docs/loki/latest/alert/
-  - docs/loki/latest/alerting/
-
+  - ./rules/
+  - ./alert/
+  - ./alerting/
 weight: 850
 keywords:
   - loki

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -3,9 +3,9 @@ title: Get started
 weight: 100
 description: How to create and use a simple Loki cluster for testing and evaluation purposes.
 aliases:
-    - /docs/loki/latest/getting-started/get-logs-into-loki/
-    - /docs/loki/latest/getting-started/
-    - /docs/loki/latest/get-started/
+    - ../getting-started/get-logs-into-loki/
+    - ../getting-started/
+    - ../get-started/
 ---
 
 # Get started

--- a/docs/sources/get-started/architecture.md
+++ b/docs/sources/get-started/architecture.md
@@ -4,9 +4,9 @@ title: Loki architecture
 description: Grafana Loki's architecture.
 weight: 300
 aliases:
-    - /docs/loki/latest/architecture/
-    - /docs/loki/latest/fundamentals/architecture/
-    - /docs/loki/latest/get-started/architecture/
+    - ../architecture/
+    - ../fundamentals/architecture/
+    - ../get-started/architecture/
 ---
 # Loki architecture
 

--- a/docs/sources/get-started/components.md
+++ b/docs/sources/get-started/components.md
@@ -4,8 +4,8 @@ title: Loki components
 description: The components that make up Grafana Loki.
 weight: 500
 aliases:
-    - /docs/loki/latest/fundamentals/architecture/components
-    - /docs/loki/latest/get-started/components/
+    - ../fundamentals/architecture/components
+    - ../get-started/components/
 ---
 # Loki components
 

--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -4,8 +4,8 @@ title: Loki deployment modes
 description: Describes the different ways to deploy Loki.
 weight: 400
 aliases:
-    - /docs/loki/latest/fundamentals/architecture/deployment-modes
-    - /docs/loki/latest/get-started/deployment-modes/
+    - ../fundamentals/architecture/deployment-modes
+    - ../get-started/deployment-modes/
 ---
 # Loki deployment modes
 

--- a/docs/sources/get-started/hash-rings.md
+++ b/docs/sources/get-started/hash-rings.md
@@ -4,8 +4,8 @@ title: Consistent hash rings
 description: Describes how the Loki architecture uses consistent hash rings.
 weight: 700
 aliases:
-    - /docs/loki/latest/fundamentals/architecture/rings
-    - /docs/loki/latest/get-started/hash-rings/
+    - ../fundamentals/architecture/rings
+    - ../get-started/hash-rings/
 ---
 # Consistent hash rings
 

--- a/docs/sources/get-started/labels.md
+++ b/docs/sources/get-started/labels.md
@@ -4,9 +4,9 @@ title: Understand labels
 description: Explains how to Loki uses labels to define log streams.
 weight: 600
 aliases:
-    - /docs/loki/latest/getting-started/labels/
-    - /docs/loki/latest/fundamentals/labels/
-    - /docs/loki/latest/get-started/labels/
+    - ../getting-started/labels/
+    - ../fundamentals/labels/
+    - ../get-started/labels/
 ---
 # Understand labels
 

--- a/docs/sources/get-started/overview.md
+++ b/docs/sources/get-started/overview.md
@@ -4,9 +4,9 @@ title: Loki overview
 description: Loki product overview and features.
 weight: 200
 aliases:
-    - /docs/loki/latest/overview/
-    - /docs/loki/latest/fundamentals/overview/
-    - /docs/loki/latest/get-started/overview/
+    - ../overview/
+    - ../fundamentals/overview/
+    - ../get-started/overview/
 ---
 # Loki overview
 

--- a/docs/sources/query/_index.md
+++ b/docs/sources/query/_index.md
@@ -3,8 +3,8 @@ title: "LogQL: Log query language"
 menuTItle: Query
 description: LogQL, Loki's query language for logs.
 aliases: 
-- /docs/loki/latest/logql
-- /docs/loki/latest/query
+- ./logql
+- ./query
 weight: 700 
 ---
 

--- a/docs/sources/query/analyzer.md
+++ b/docs/sources/query/analyzer.md
@@ -3,8 +3,8 @@ title: LogQL Analyzer
 menuTitle: LoqQL Analyzer 
 description: The LogQL Analyzer is an inline educational tool for experimenting with writing LogQL queries.
 aliases: 
-- /docs/loki/latest/logql
-- /docs/loki/latest/query
+- ../logql/analyzer/
+- ../query/analyzer/
 weight: 60
 ---
 

--- a/docs/sources/query/ip.md
+++ b/docs/sources/query/ip.md
@@ -3,8 +3,8 @@ title: Matching IP addresses
 menuTItle:  
 description: LogQL supports matching IP addresses.
 aliases: 
- - /docs/loki/latest/logql
- - /docs/loki/latest/query
+ - ../logql/ip/
+ - ../query/ip/
 weight: 40
 ---
 

--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -3,8 +3,8 @@ title: Log queries
 menuTItle:  
 description: Overview of how log queries are constructed and parsed.
 aliases: 
-- /docs/loki/latest/logql/log_queries/
-- /docs/loki/latest/query/log_queries/
+- ../logql/log_queries/
+- ../query/log_queries/
 weight: 10 
 ---
 

--- a/docs/sources/query/logcli.md
+++ b/docs/sources/query/logcli.md
@@ -3,9 +3,9 @@ title: LogCLI
 menuTItle:  
 description: LogCLI, Grafana Loki's command-line interface
 aliases:
-- /docs/loki/latest/getting-started/logcli/
-- /docs/loki/latest/tools/logcli/
-- /docs/loki/latest/query/logcli/
+- ../getting-started/logcli/
+- ../tools/logcli/
+- ../query/logcli/
 weight: 700  
 ---
 

--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -3,8 +3,8 @@ title: Metric queries
 menuTItle:  
 description: Metric queries extend log queries by applying a function to log query results. This powerful feature creates metrics from logs.
 aliases: 
-- /docs/loki/latest/logql
-- /docs/loki/latest/query
+- ../logql/metric_queries/
+- ../query/metric_queries/
 weight: 20  
 ---
 

--- a/docs/sources/query/query_examples.md
+++ b/docs/sources/query/query_examples.md
@@ -3,8 +3,8 @@ title: Query examples
 menuTitle: Query examples  
 description: LogQL query examples with explanations on what those queries accomplish.
 aliases: 
-- /docs/loki/latest/logql
-- /docs/loki/latest/query
+- ../logql/query_examples/
+- ../query/query_examples/
 weight: 50 
 ---
 

--- a/docs/sources/query/template_functions.md
+++ b/docs/sources/query/template_functions.md
@@ -3,8 +3,8 @@ title: Template functions
 menuTItle:  
 description: Describes functions that are supported by the text template.
 aliases: 
-- /docs/loki/latest/logql
-- /docs/loki/latest/query
+- ../logql/template_functions/
+- ../query/template_functions/
 weight: 30
 ---
 

--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -4,6 +4,7 @@ menuTitle: Visualize data
 description: Visualize your log data with Grafana
 
 aliases:
+   - ../getting-started/grafana/
    - ../operations/grafana/
    - ../visualize/grafana/
 weight: 825

--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -4,9 +4,8 @@ menuTitle: Visualize data
 description: Visualize your log data with Grafana
 
 aliases:
-   - /docs/loki/latest/operations/grafana/
-   - /docs/loki/latest/visualize/grafana/
-   - /docs/loki/latest/getting-started/grafana/
+   - ../operations/grafana/
+   - ../visualize/grafana/
 weight: 825
 keywords:
    - visualize


### PR DESCRIPTION
**Special notes for your reviewer**:
@jdbaldry commented on #9717 that the alias format had changed, but we [agreed](https://github.com/grafana/loki/pull/9717#issuecomment-1594960563) that I could update it in a follow up PR. This is that follow up.  Also updating previously merged file moves that used the old alias format.

Breaking the alias updates into two PRs to make for smaller reviews.

