### PR TITLE
Clarify that label filter expressions are not supported in promtail.

### DIFF
--- a/clients/pkg/logentry/stages/match_test.go
+++ b/clients/pkg/logentry/stages/match_test.go
@@ -126,6 +126,7 @@ func TestMatcher(t *testing.T) {
 		{`{foo="bar",bar!~"te.*"}`, map[string]string{"foo": "bar", "bar": "test"}, MatchActionDrop, false, false, false},
 
 		{`{foo=""}`, map[string]string{}, MatchActionKeep, false, true, false},
+		{`{foo="bar"} |= "foo" | status >= 200`, map[string]string{"foo": "bar"}, MatchActionKeep, false, false, true},
 	}
 
 	for _, tt := range tests {

--- a/docs/sources/clients/promtail/stages/match.md
+++ b/docs/sources/clients/promtail/stages/match.md
@@ -5,14 +5,18 @@ description: match stage
 # match
 
 The match stage is a filtering stage that conditionally applies a set of stages
-or drop entries when a log entry matches a configurable [LogQL]({{< relref "../../../query" >}})
-stream selector and filter expressions.
+or drop entries when a log entry matches a configurable LogQL
+[stream selector]({{< relref "../../../query/log_queries#log-stream-selector" >}}) and
+[filter expressions]({{< relref "../../../query/log_queries#line-filter-expression" >}}).
+
+Please note that the filters do not include label filter expressions such as `|
+label == "foobar"`.
 
 ## Schema
 
 ```yaml
 match:
-  # LogQL stream selector and filter expressions.
+  # LogQL stream selector and line filter expressions.
   selector: <string>
 
   # Names the pipeline. When defined, creates an additional label in

--- a/docs/sources/clients/promtail/stages/match.md
+++ b/docs/sources/clients/promtail/stages/match.md
@@ -9,8 +9,9 @@ or drop entries when a log entry matches a configurable LogQL
 [stream selector]({{< relref "../../../query/log_queries#log-stream-selector" >}}) and
 [filter expressions]({{< relref "../../../query/log_queries#line-filter-expression" >}}).
 
-Please note that the filters do not include label filter expressions such as `|
-label == "foobar"`.
+{{% admonition type="note" %}}
+The filters do not include label filter expressions such as `| label == "foobar"`.
+{{% /admonition %}}
 
 ## Schema
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some users of Promtail seem to be confused that certain types of filter expressions are not supported in Promtail's `match` stage.

This change clarifies what kind of filter expressions are supported.

**Which issue(s) this PR fixes**:
Fixes #5209

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
