### PR TITLE
Helm: Fix loki helm chart helper function for loki.host to explicitly include gateway port

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -21,7 +21,6 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [CHANGE] Changed version of Loki to 2.8.3
 
-
 ## 5.8.11
 
 - [BUGFIX] Fix gateway: Add `/config` proxy_pass to nginx configuration
@@ -29,9 +28,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.8.10
 
 - [ENHANCEMENT] Canary labelname can now be configured via monitoring.lokiCanary.labelname
-## 5.8.10
-
-- [BUGFIX] Fix loki helm chart helper function for loki.host to explicitly include gateway port
 
 ## 5.8.9
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -25,6 +25,9 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.8.10
 
 - [ENHANCEMENT] Canary labelname can now be configured via monitoring.lokiCanary.labelname
+## 5.8.10
+
+- [BUGFIX] Fix loki helm chart helper function for loki.host so it explicitly includes gateway port value
 
 ## 5.8.9
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -27,7 +27,7 @@ Entries should include a reference to the pull request that introduced the chang
 - [ENHANCEMENT] Canary labelname can now be configured via monitoring.lokiCanary.labelname
 ## 5.8.10
 
-- [BUGFIX] Fix loki helm chart helper function for loki.host so it explicitly includes gateway port value
+- [BUGFIX] Fix loki helm chart helper function for loki.host to explicitly include gateway port
 
 ## 5.8.9
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.9.1
+
+- [BUGFIX] Fix loki helm chart helper function for loki.host to explicitly include gateway port
+
 ## 5.9.0
 
 - [CHANGE] Changed version of Loki to 2.8.3

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.3
-version: 5.9.0
+version: 5.9.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.9.0](https://img.shields.io/badge/Version-5.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 5.9.1](https://img.shields.io/badge/Version-5.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -523,7 +523,7 @@ Create the service endpoint including port for MinIO.
 {{/* Determine the public host for the Loki cluster */}}
 {{- define "loki.host" -}}
 {{- $isSingleBinary := eq (include "loki.deployment.isSingleBinary" .) "true" -}}
-{{- $url := printf "%s.%s.svc.%s." (include "loki.gatewayFullname" .) .Release.Namespace .Values.global.clusterDomain }}
+{{- $url := printf "%s.%s.svc.%s.:%s" (include "loki.gatewayFullname" .) .Release.Namespace .Values.global.clusterDomain (.Values.gateway.service.port | toString)  }}
 {{- if and $isSingleBinary (not .Values.gateway.enabled)  }}
   {{- $url = printf "%s.%s.svc.%s.:3100" (include "loki.singleBinaryFullname" .) .Release.Namespace .Values.global.clusterDomain }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue I ran into while installing enterprise Loki in non-single binary mode via Helm. We override the port value for the gateway here `gateway.service.port` and when the provisioner launches and tries to connect to the gateway it was not aware of the overriden port and instead would try to connect over port 80 which would fail, causing the whole helm install to fail as well.

**Which issue(s) this PR fixes**:
I didn't do a comprehensive search but a quick search did not reveal an existing issue.

**Special notes for your reviewer**:
I think single binary mode is fine to assume the port as `3100` because it does not appear that can be overriden. It has been some time since I've used single binary mode though so maybe I'm missing something?

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
