### PR TITLE
Add 3rd backend target to docker-compose stack

### DIFF
--- a/production/docker/config/loki.yaml
+++ b/production/docker/config/loki.yaml
@@ -1,7 +1,5 @@
 auth_enabled: true
 
-http_prefix:
-
 server:
   http_listen_address: 0.0.0.0
   grpc_listen_address: 0.0.0.0
@@ -10,6 +8,7 @@ server:
   log_level: info
 
 common:
+  path_prefix: /loki
   storage:
     s3:
       endpoint: minio:9000
@@ -52,12 +51,12 @@ ingester:
 ruler:
   enable_api: true
   wal:
-    dir: /tmp/ruler-wal
+    dir: /loki/ruler-wal
   storage:
     type: local
     local:
       directory: /loki/rules
-  rule_path: /tmp/prom-rules
+  rule_path: /loki/prom-rules
   remote_write:
     enabled: true
     clients:
@@ -71,18 +70,12 @@ ruler:
 schema_config:
   configs:
   - from: 2020-08-01
-    store: boltdb-shipper
+    store: tsdb
     object_store: s3
-    schema: v11
+    schema: v12
     index:
       prefix: index_
       period: 24h
-
-storage_config:
-  boltdb_shipper:
-    shared_store: s3
-    active_index_directory: /tmp/index
-    cache_location: /tmp/boltdb-cache
 
 
 limits_config:
@@ -94,6 +87,7 @@ limits_config:
   ingestion_burst_size_mb: 20
   # parallelize queries in 15min intervals
   split_queries_by_interval: 15m
+  volume_enabled: true
 
 chunk_store_config:
   max_look_back_period: 336h

--- a/production/docker/docker-compose.yaml
+++ b/production/docker/docker-compose.yaml
@@ -3,20 +3,18 @@ version: "3.8"
 networks:
   loki:
 
-
 volumes:
   prometheus:
   grafana:
   alertmanager-data:
-
+  loki:
 
 services:
-
   # Since the Loki containers are running as user 10001 and the mounted data volume is owned by root,
   # Loki would not have permissions to create the directories.
   # Therefore the init container changes permissions of the mounted directory.
   init:
-    image: grafana/loki:2.8.2
+    image: &lokiImage grafana/loki:2.8.2
     user: root
     entrypoint:
       - "chown"
@@ -115,7 +113,7 @@ services:
       - loki
 
   loki-read:
-    image: grafana/loki:2.8.2
+    image: *lokiImage
     volumes:
       - ./config:/etc/loki/
       - ./rules:/loki/rules:ro
@@ -123,11 +121,11 @@ services:
       - "3100"
       - "7946"
       # uncomment to use interactive debugging
-      # - "40000-40002:40000" # # makes the replicas available on ports 40000, 40001, 40002
-      #cap_add:
-      #  - SYS_PTRACE
-      #security_opt:
-      #  - apparmor=unconfined
+      # - "40000-40002:40000" # makes the replicas available on ports 40000, 40001, 40002
+    # cap_add:
+    # - SYS_PTRACE
+    # security_opt:
+    # - apparmor=unconfined
     command: "-config.file=/etc/loki/loki.yaml -target=read"
     networks:
       - loki
@@ -138,19 +136,40 @@ services:
     # only needed for interactive debugging with dlv
 
   loki-write:
-    image: grafana/loki:2.8.2
+    image: *lokiImage
     volumes:
       - ./config:/etc/loki/
     ports:
       - "3100"
       - "7946"
       # uncomment to use interactive debugging
-      # - "50000-50002:40000" # makes the replicas available on ports 50000, 50001, 50002
-      # cap_add:
-      #   - SYS_PTRACE
-      # security_opt:
-      #   - apparmor=unconfined
+      # - "50000-50002:40000" #  makes the replicas available on ports 50000, 50001, 50002
+    # cap_add:
+    # - SYS_PTRACE
+    # security_opt:
+    # - apparmor=unconfined
     command: "-config.file=/etc/loki/loki.yaml -target=write"
+    networks:
+      - loki
+    restart: always
+    deploy:
+      mode: replicated
+      replicas: 3
+
+  loki-backend:
+    image: *lokiImage
+    volumes:
+      - ./config:/etc/loki/
+    ports:
+      - "3100"
+      - "7946"
+      # uncomment to use interactive debugging
+      # - "60000-60002:40000" #  makes the replicas available on ports 60000, 60001, 60002
+    # cap_add:
+    # - SYS_PTRACE
+    # security_opt:
+    # - apparmor=unconfined
+    command: "-config.file=/etc/loki/loki.yaml -target=backend"
     networks:
       - loki
     restart: always


### PR DESCRIPTION
* Adds 3rd backend target to `production/docker` stack
* Uses a anchor for the image to make local overrides easier
* Updates the config to use TSDB

@dannykopping you seem to be the SME here, mind taking a look?