### PR TITLE
WriteFailures: Add metrics to increase monitoring

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -195,7 +195,7 @@ func New(
 			Name:      "stream_sharding_count",
 			Help:      "Total number of times the distributor has sharded streams",
 		}),
-		writeFailuresManager: writefailures.NewManager(util_log.Logger, cfg.WriteFailuresLogging, configs),
+		writeFailuresManager: writefailures.NewManager(util_log.Logger, registerer, cfg.WriteFailuresLogging, configs),
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/loki/pkg/ingester"
-
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
@@ -36,6 +34,7 @@ import (
 	"github.com/grafana/loki/pkg/distributor/clientpool"
 	"github.com/grafana/loki/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/pkg/distributor/writefailures"
+	"github.com/grafana/loki/pkg/ingester"
 	"github.com/grafana/loki/pkg/ingester/client"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -194,7 +194,7 @@ func New(
 			Name:      "stream_sharding_count",
 			Help:      "Total number of times the distributor has sharded streams",
 		}),
-		writeFailuresManager: writefailures.NewManager(util_log.Logger, registerer, cfg.WriteFailuresLogging, configs),
+		writeFailuresManager: writefailures.NewManager(util_log.Logger, registerer, cfg.WriteFailuresLogging, configs, "distributor"),
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -45,10 +45,10 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
-		m.m.loggedCount.WithLabelValues(tenantID)
+		m.m.loggedCount.WithLabelValues(tenantID).Inc()
 		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
 		return
 	}
 
-	m.m.discardedCount.WithLabelValues(tenantID)
+	m.m.discardedCount.WithLabelValues(tenantID).Inc()
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/limiter"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/loki/pkg/runtime"
 )
@@ -14,9 +15,10 @@ type Manager struct {
 	limiter    *limiter.RateLimiter
 	logger     log.Logger
 	tenantCfgs *runtime.TenantConfigs
+	m          *metrics
 }
 
-func NewManager(logger log.Logger, cfg Cfg, tenants *runtime.TenantConfigs) *Manager {
+func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *runtime.TenantConfigs) *Manager {
 	logger = log.With(logger, "path", "write")
 	if cfg.AddInsightsLabel {
 		logger = log.With(logger, "insight", "true")
@@ -28,6 +30,7 @@ func NewManager(logger log.Logger, cfg Cfg, tenants *runtime.TenantConfigs) *Man
 		limiter:    limiter.NewRateLimiter(strategy, time.Minute),
 		logger:     logger,
 		tenantCfgs: tenants,
+		m:          newMetrics(reg),
 	}
 }
 
@@ -42,6 +45,10 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
+		m.m.loggedCount.WithLabelValues(tenantID)
 		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
+		return
 	}
+
+	m.m.discardedCount.WithLabelValues(tenantID)
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -15,7 +15,7 @@ type Manager struct {
 	limiter    *limiter.RateLimiter
 	logger     log.Logger
 	tenantCfgs *runtime.TenantConfigs
-	m          *metrics
+	metrics    *metrics
 }
 
 func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *runtime.TenantConfigs, subsystem string) *Manager {
@@ -30,7 +30,7 @@ func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *
 		limiter:    limiter.NewRateLimiter(strategy, time.Minute),
 		logger:     logger,
 		tenantCfgs: tenants,
-		m:          newMetrics(reg, subsystem),
+		metrics:    newMetrics(reg, subsystem),
 	}
 }
 
@@ -45,10 +45,10 @@ func (m *Manager) Log(tenantID string, err error) {
 
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
-		m.m.loggedCount.WithLabelValues(tenantID).Inc()
+		m.metrics.loggedCount.WithLabelValues(tenantID).Inc()
 		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
 		return
 	}
 
-	m.m.discardedCount.WithLabelValues(tenantID).Inc()
+	m.metrics.discardedCount.WithLabelValues(tenantID).Inc()
 }

--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -18,7 +18,7 @@ type Manager struct {
 	m          *metrics
 }
 
-func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *runtime.TenantConfigs) *Manager {
+func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *runtime.TenantConfigs, subsystem string) *Manager {
 	logger = log.With(logger, "path", "write")
 	if cfg.AddInsightsLabel {
 		logger = log.With(logger, "insight", "true")
@@ -30,7 +30,7 @@ func NewManager(logger log.Logger, reg prometheus.Registerer, cfg Cfg, tenants *
 		limiter:    limiter.NewRateLimiter(strategy, time.Minute),
 		logger:     logger,
 		tenantCfgs: tenants,
-		m:          newMetrics(reg),
+		m:          newMetrics(reg, subsystem),
 	}
 }
 

--- a/pkg/distributor/writefailures/manager_test.go
+++ b/pkg/distributor/writefailures/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/runtime"
@@ -36,7 +37,7 @@ func TestWriteFailuresLogging(t *testing.T) {
 		runtimeCfg, err := runtime.NewTenantConfigs(f)
 		require.NoError(t, err)
 
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
 
 		manager.Log("bad-tenant", fmt.Errorf("bad-tenant contains invalid entry"))
 		manager.Log("good-tenant", fmt.Errorf("good-tenant contains invalid entry"))
@@ -63,7 +64,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("with zero rate limiting", func(t *testing.T) {
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(0)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(0)}, runtimeCfg)
 
 		manager.Log("known-tenant", fmt.Errorf("known-tenant entry error"))
 
@@ -72,7 +73,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("bytes exceeded on single message", func(t *testing.T) {
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
 
 		errorStr := strings.Builder{}
 		for i := 0; i < 1001; i++ {
@@ -86,7 +87,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("valid bytes", func(t *testing.T) {
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1002)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1002)}, runtimeCfg)
 
 		errorStr := strings.Builder{}
 		for i := 0; i < 1001; i++ {
@@ -101,7 +102,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("limit is reset after a second", func(t *testing.T) {
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
 
 		errorStr1 := strings.Builder{}
 		errorStr2 := strings.Builder{}
@@ -127,7 +128,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	t.Run("limit is per-tenant", func(t *testing.T) {
 		runtimeCfg, err := runtime.NewTenantConfigs(f)
 		require.NoError(t, err)
-		manager := NewManager(logger, Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
 
 		errorStr1 := strings.Builder{}
 		errorStr2 := strings.Builder{}

--- a/pkg/distributor/writefailures/manager_test.go
+++ b/pkg/distributor/writefailures/manager_test.go
@@ -37,7 +37,7 @@ func TestWriteFailuresLogging(t *testing.T) {
 		runtimeCfg, err := runtime.NewTenantConfigs(f)
 		require.NoError(t, err)
 
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg, "ingester")
 
 		manager.Log("bad-tenant", fmt.Errorf("bad-tenant contains invalid entry"))
 		manager.Log("good-tenant", fmt.Errorf("good-tenant contains invalid entry"))
@@ -64,7 +64,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("with zero rate limiting", func(t *testing.T) {
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(0)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(0)}, runtimeCfg, "distributor")
 
 		manager.Log("known-tenant", fmt.Errorf("known-tenant entry error"))
 
@@ -73,7 +73,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("bytes exceeded on single message", func(t *testing.T) {
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg, "distributor")
 
 		errorStr := strings.Builder{}
 		for i := 0; i < 1001; i++ {
@@ -87,7 +87,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("valid bytes", func(t *testing.T) {
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1002)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1002)}, runtimeCfg, "ingester")
 
 		errorStr := strings.Builder{}
 		for i := 0; i < 1001; i++ {
@@ -102,7 +102,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	})
 
 	t.Run("limit is reset after a second", func(t *testing.T) {
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg, "ingester")
 
 		errorStr1 := strings.Builder{}
 		errorStr2 := strings.Builder{}
@@ -128,7 +128,7 @@ func TestWriteFailuresRateLimiting(t *testing.T) {
 	t.Run("limit is per-tenant", func(t *testing.T) {
 		runtimeCfg, err := runtime.NewTenantConfigs(f)
 		require.NoError(t, err)
-		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg)
+		manager := NewManager(logger, prometheus.NewRegistry(), Cfg{LogRate: flagext.ByteSize(1000)}, runtimeCfg, "ingester")
 
 		errorStr1 := strings.Builder{}
 		errorStr2 := strings.Builder{}

--- a/pkg/distributor/writefailures/metrics.go
+++ b/pkg/distributor/writefailures/metrics.go
@@ -11,7 +11,6 @@ type metrics struct {
 }
 
 func newMetrics(reg prometheus.Registerer, subsystem string) *metrics {
-	// prometheus.NewCounterVec(opts prometheus.CounterOpts, labelNames []string)
 	return &metrics{
 		loggedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "loki",

--- a/pkg/distributor/writefailures/metrics.go
+++ b/pkg/distributor/writefailures/metrics.go
@@ -10,17 +10,20 @@ type metrics struct {
 	discardedCount *prometheus.CounterVec
 }
 
-func newMetrics(reg prometheus.Registerer) *metrics {
+func newMetrics(reg prometheus.Registerer, subsystem string) *metrics {
+	// prometheus.NewCounterVec(opts prometheus.CounterOpts, labelNames []string)
 	return &metrics{
 		loggedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki",
-			Name:      "write_failures_logged_total",
-			Help:      "The total number log failures were logged for a tenant.",
+			Namespace:   "loki",
+			Name:        "write_failures_logged_total",
+			Help:        "The total number log failures were logged for a tenant.",
+			ConstLabels: prometheus.Labels{"subsystem": subsystem},
 		}, []string{"tenant_id"}),
 		discardedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "loki",
-			Name:      "write_failures_discarded_total",
-			Help:      "The total number of write failures logs discarded for a tenant.",
+			Namespace:   "loki",
+			Name:        "write_failures_discarded_total",
+			Help:        "The total number of write failures logs discarded for a tenant.",
+			ConstLabels: prometheus.Labels{"subsystem": subsystem},
 		}, []string{"tenant_id"}),
 	}
 }

--- a/pkg/distributor/writefailures/metrics.go
+++ b/pkg/distributor/writefailures/metrics.go
@@ -16,7 +16,7 @@ func newMetrics(reg prometheus.Registerer, subsystem string) *metrics {
 		loggedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "loki",
 			Name:        "write_failures_logged_total",
-			Help:        "The total number log failures were logged for a tenant.",
+			Help:        "The total number of write failures logs successfully emitted for a tenant.",
 			ConstLabels: prometheus.Labels{"subsystem": subsystem},
 		}, []string{"tenant_id"}),
 		discardedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{

--- a/pkg/distributor/writefailures/metrics.go
+++ b/pkg/distributor/writefailures/metrics.go
@@ -1,0 +1,26 @@
+package writefailures
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type metrics struct {
+	loggedCount    *prometheus.CounterVec
+	discardedCount *prometheus.CounterVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	return &metrics{
+		loggedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "write_failures_logged_total",
+			Help:      "The total number log failures were logged for a tenant.",
+		}, []string{"tenant_id"}),
+		discardedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "loki",
+			Name:      "write_failures_discarded_total",
+			Help:      "The total number of write failures logs discarded for a tenant.",
+		}, []string{"tenant_id"}),
+	}
+}

--- a/pkg/distributor/writefailures/metrics.go
+++ b/pkg/distributor/writefailures/metrics.go
@@ -17,12 +17,12 @@ func newMetrics(reg prometheus.Registerer, subsystem string) *metrics {
 			Name:        "write_failures_logged_total",
 			Help:        "The total number of write failures logs successfully emitted for a tenant.",
 			ConstLabels: prometheus.Labels{"subsystem": subsystem},
-		}, []string{"tenant_id"}),
+		}, []string{"org_id"}),
 		discardedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "loki",
 			Name:        "write_failures_discarded_total",
 			Help:        "The total number of write failures logs discarded for a tenant.",
 			ConstLabels: prometheus.Labels{"subsystem": subsystem},
-		}, []string{"tenant_id"}),
+		}, []string{"org_id"}),
 	}
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -273,7 +273,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits Limits
 		flushOnShutdownSwitch: &OnceSwitch{},
 		terminateOnShutdown:   false,
 		streamRateCalculator:  NewStreamRateCalculator(),
-		writeLogManager:       writefailures.NewManager(util_log.Logger, registerer, writeFailuresCfg, configs),
+		writeLogManager:       writefailures.NewManager(util_log.Logger, registerer, writeFailuresCfg, configs, "ingester"),
 	}
 	i.replayController = newReplayController(metrics, cfg.WAL, &replayFlusher{i})
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -273,7 +273,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits Limits
 		flushOnShutdownSwitch: &OnceSwitch{},
 		terminateOnShutdown:   false,
 		streamRateCalculator:  NewStreamRateCalculator(),
-		writeLogManager:       writefailures.NewManager(util_log.Logger, writeFailuresCfg, configs),
+		writeLogManager:       writefailures.NewManager(util_log.Logger, registerer, writeFailuresCfg, configs),
 	}
 	i.replayController = newReplayController(metrics, cfg.WAL, &replayFlusher{i})
 

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -146,19 +146,19 @@ func TestMultiKVSetup(t *testing.T) {
 			require.NotNil(t, c.Ruler.Ring.KVStore.Multi.ConfigProvider)
 		},
 	} {
-		t.Run(target, func(t *testing.T) {
-			prepareGlobalMetricsRegistry(t)
+		t.Run(target, func(test *testing.T) {
+			prepareGlobalMetricsRegistry(test)
 
-			cfg := minimalWorkingConfig(t, dir, target)
+			cfg := minimalWorkingConfig(test, dir, target)
 			cfg.RuntimeConfig.LoadPath = []string{filepath.Join(dir, "config.yaml")}
 			c, err := New(cfg)
-			require.NoError(t, err)
+			require.NoError(test, err)
 
 			_, err = c.ModuleManager.InitModuleServices(cfg.Target...)
-			require.NoError(t, err)
+			require.NoError(test, err)
 			defer c.Server.Stop()
 
-			checkFn(t, c.Cfg)
+			checkFn(test, c.Cfg)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add metrics for our write failures manager. This way we can easily monitor how much logging we're doing and how much we're discarding.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
