### PR TITLE
lambda-promtail: fix/refactor SQS integration in Terraform module

### DIFF
--- a/tools/lambda-promtail/moves.tf
+++ b/tools/lambda-promtail/moves.tf
@@ -17,3 +17,23 @@ moved {
   from = aws_lambda_function_event_invoke_config.lambda_promtail_invoke_config
   to   = aws_lambda_function_event_invoke_config.this
 }
+
+moved {
+  from = aws_s3_bucket_notification.push-to-sqs
+  to   = aws_s3_bucket_notification.sqs
+}
+
+moved {
+  from = aws_sqs_queue.main-queue
+  to   = aws_sqs_queue.main
+}
+
+moved {
+  from = aws_sqs_queue.dead-letter-queue
+  to   = aws_sqs_queue.dead_letter
+}
+
+moved {
+  from = aws_sqs_queue_redrive_allow_policy.from-dql-to-main
+  to   = aws_sqs_queue_redrive_allow_policy.this
+}

--- a/tools/lambda-promtail/sqs.tf
+++ b/tools/lambda-promtail/sqs.tf
@@ -63,6 +63,6 @@ data "aws_iam_policy" "lambda_sqs_execution" {
 
 resource "aws_iam_role_policy_attachment" "lambda_sqs_execution" {
   count      = var.sqs_enabled ? 1 : 0
-  role       = aws_iam_role.iam_for_lambda.name
+  role       = aws_iam_role.this.name
   policy_arn = data.aws_iam_policy.lambda_sqs_execution.arn
 }

--- a/tools/lambda-promtail/sqs.tf
+++ b/tools/lambda-promtail/sqs.tf
@@ -1,38 +1,37 @@
 locals {
-  bucket_arns       = [for name in var.bucket_names : "arn:aws:s3:::${name}"]
-  queue_name_prefix = "s3-to-lambda-promtail"
+  bucket_arns = [for name in var.bucket_names : "arn:aws:s3:::${name}"]
 }
 
-resource "aws_s3_bucket_notification" "push-to-sqs" {
+resource "aws_s3_bucket_notification" "sqs" {
   for_each = var.sqs_enabled ? var.bucket_names : []
   bucket   = each.value
   queue {
-    queue_arn     = aws_sqs_queue.main-queue[0].arn
+    queue_arn     = aws_sqs_queue.main[0].arn
     events        = ["s3:ObjectCreated:*"]
     filter_suffix = ".log.gz"
     filter_prefix = "VPC_FL/"
   }
 }
 
-resource "aws_sqs_queue" "main-queue" {
+resource "aws_sqs_queue" "main" {
   count                      = var.sqs_enabled ? 1 : 0
-  name                       = "${local.queue_name_prefix}-main-queue"
+  name                       = "${var.sqs_queue_name_prefix}-main-queue"
   sqs_managed_sse_enabled    = true
-  policy                     = data.aws_iam_policy_document.queue-policy[0].json
+  policy                     = data.aws_iam_policy_document.queue_policy[0].json
   visibility_timeout_seconds = 300
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.dead-letter-queue[0].arn
+    deadLetterTargetArn = aws_sqs_queue.dead_letter[0].arn
     maxReceiveCount     = 5
   })
 }
 
-data "aws_iam_policy_document" "queue-policy" {
+data "aws_iam_policy_document" "queue_policy" {
   count = var.sqs_enabled ? 1 : 0
   statement {
     actions = [
       "sqs:SendMessage"
     ]
-    resources = ["arn:aws:sqs:*:*:${local.queue_name_prefix}-main-queue"]
+    resources = ["arn:aws:sqs:*:*:${var.sqs_queue_name_prefix}-main-queue"]
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
@@ -41,19 +40,19 @@ data "aws_iam_policy_document" "queue-policy" {
   }
 }
 
-resource "aws_sqs_queue" "dead-letter-queue" {
+resource "aws_sqs_queue" "dead_letter" {
   count                   = var.sqs_enabled ? 1 : 0
-  name                    = "${local.queue_name_prefix}-dead-letter-queue"
+  name                    = "${var.sqs_queue_name_prefix}-dead-letter-queue"
   sqs_managed_sse_enabled = true
 }
 
-resource "aws_sqs_queue_redrive_allow_policy" "from-dql-to-main" {
+resource "aws_sqs_queue_redrive_allow_policy" "this" {
   count     = var.sqs_enabled ? 1 : 0
-  queue_url = aws_sqs_queue.dead-letter-queue[0].id
+  queue_url = aws_sqs_queue.dead_letter[0].id
 
   redrive_allow_policy = jsonencode({
     redrivePermission = "byQueue",
-    sourceQueueArns   = [aws_sqs_queue.main-queue[0].arn]
+    sourceQueueArns   = [aws_sqs_queue.main[0].arn]
   })
 }
 

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -119,3 +119,9 @@ variable "sqs_enabled" {
   description = "Enables sending S3 logs to an SQS queue which will trigger lambda-promtail, unsuccessfully processed message are sent to a dead-letter-queue"
   default     = false
 }
+
+variable "sqs_queue_name_prefix" {
+  type        = string
+  description = "Name prefix for SQS queues"
+  default     = "s3-to-lambda-promtail"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the Terraform module for lambda-promtail is not working due to a misnamed reference:

```
╷
│ Error: Reference to undeclared resource
│ 
│   on .terraform/modules/lambda_promtail/tools/lambda-promtail/sqs.tf line 66, in resource "aws_iam_role_policy_attachment" "lambda_sqs_execution":
│   66:   role       = aws_iam_role.iam_for_lambda.name
│ 
│ A managed resource "aws_iam_role" "iam_for_lambda" has not been declared in
│ module.lambda_promtail.
╵
```

It looks like this was the result of a conflict with #8231 and #8750.

While I was in there I also refactored the SQS work to be more consistent with #8750.

I also made the queue name prefix configurable with the `sqs_queue_name_prefix` variable, as it was hardcoded before which could cause issues if multiple instances of this module are initialized in the same AWS account and region.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
