### PR TITLE
Remove aliases to current location.

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -4,8 +4,6 @@ menuTitle: Alert
 description: Learn how the rule evaluates queries for alerting.
 aliases:
   - ./rules/
-  - ./alert/
-  - ./alerting/
 weight: 850
 keywords:
   - loki

--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -4,6 +4,7 @@ menuTitle: Alert
 description: Learn how the rule evaluates queries for alerting.
 aliases:
   - ./rules/
+  - ./alerting/
 weight: 850
 keywords:
   - loki

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -5,7 +5,6 @@ description: How to create and use a simple Loki cluster for testing and evaluat
 aliases:
     - ../getting-started/get-logs-into-loki/
     - ../getting-started/
-    - ../get-started/
 ---
 
 # Get started

--- a/docs/sources/get-started/architecture.md
+++ b/docs/sources/get-started/architecture.md
@@ -6,7 +6,6 @@ weight: 300
 aliases:
     - ../architecture/
     - ../fundamentals/architecture/
-    - ../get-started/architecture/
 ---
 # Loki architecture
 

--- a/docs/sources/get-started/components.md
+++ b/docs/sources/get-started/components.md
@@ -5,7 +5,6 @@ description: The components that make up Grafana Loki.
 weight: 500
 aliases:
     - ../fundamentals/architecture/components
-    - ../get-started/components/
 ---
 # Loki components
 

--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -5,7 +5,6 @@ description: Describes the different ways to deploy Loki.
 weight: 400
 aliases:
     - ../fundamentals/architecture/deployment-modes
-    - ../get-started/deployment-modes/
 ---
 # Loki deployment modes
 

--- a/docs/sources/get-started/hash-rings.md
+++ b/docs/sources/get-started/hash-rings.md
@@ -5,7 +5,6 @@ description: Describes how the Loki architecture uses consistent hash rings.
 weight: 700
 aliases:
     - ../fundamentals/architecture/rings
-    - ../get-started/hash-rings/
 ---
 # Consistent hash rings
 

--- a/docs/sources/get-started/labels.md
+++ b/docs/sources/get-started/labels.md
@@ -6,7 +6,6 @@ weight: 600
 aliases:
     - ../getting-started/labels/
     - ../fundamentals/labels/
-    - ../get-started/labels/
 ---
 # Understand labels
 

--- a/docs/sources/get-started/overview.md
+++ b/docs/sources/get-started/overview.md
@@ -6,7 +6,6 @@ weight: 200
 aliases:
     - ../overview/
     - ../fundamentals/overview/
-    - ../get-started/overview/
 ---
 # Loki overview
 

--- a/docs/sources/query/_index.md
+++ b/docs/sources/query/_index.md
@@ -4,7 +4,6 @@ menuTItle: Query
 description: LogQL, Loki's query language for logs.
 aliases: 
 - ./logql
-- ./query
 weight: 700 
 ---
 

--- a/docs/sources/query/analyzer.md
+++ b/docs/sources/query/analyzer.md
@@ -4,7 +4,6 @@ menuTitle: LoqQL Analyzer
 description: The LogQL Analyzer is an inline educational tool for experimenting with writing LogQL queries.
 aliases: 
 - ../logql/analyzer/
-- ../query/analyzer/
 weight: 60
 ---
 

--- a/docs/sources/query/ip.md
+++ b/docs/sources/query/ip.md
@@ -4,7 +4,6 @@ menuTItle:
 description: LogQL supports matching IP addresses.
 aliases: 
  - ../logql/ip/
- - ../query/ip/
 weight: 40
 ---
 

--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -4,7 +4,6 @@ menuTItle:
 description: Overview of how log queries are constructed and parsed.
 aliases: 
 - ../logql/log_queries/
-- ../query/log_queries/
 weight: 10 
 ---
 

--- a/docs/sources/query/logcli.md
+++ b/docs/sources/query/logcli.md
@@ -5,7 +5,6 @@ description: LogCLI, Grafana Loki's command-line interface
 aliases:
 - ../getting-started/logcli/
 - ../tools/logcli/
-- ../query/logcli/
 weight: 700  
 ---
 

--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -4,7 +4,6 @@ menuTItle:
 description: Metric queries extend log queries by applying a function to log query results. This powerful feature creates metrics from logs.
 aliases: 
 - ../logql/metric_queries/
-- ../query/metric_queries/
 weight: 20  
 ---
 

--- a/docs/sources/query/query_examples.md
+++ b/docs/sources/query/query_examples.md
@@ -4,7 +4,6 @@ menuTitle: Query examples
 description: LogQL query examples with explanations on what those queries accomplish.
 aliases: 
 - ../logql/query_examples/
-- ../query/query_examples/
 weight: 50 
 ---
 

--- a/docs/sources/query/template_functions.md
+++ b/docs/sources/query/template_functions.md
@@ -4,7 +4,6 @@ menuTItle:
 description: Describes functions that are supported by the text template.
 aliases: 
 - ../logql/template_functions/
-- ../query/template_functions/
 weight: 30
 ---
 

--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -2,11 +2,9 @@
 title: Visualize log data
 menuTitle: Visualize data
 description: Visualize your log data with Grafana
-
 aliases:
    - ../getting-started/grafana/
    - ../operations/grafana/
-   - ../visualize/grafana/
 weight: 825
 keywords:
    - visualize


### PR DESCRIPTION
Re: [this comment ](https://github.com/grafana/loki/pull/9890#pullrequestreview-1521562982)from @jdbaldry  on #9890 that "Relative aliases that refer to the current page location won't be effective and should be removed because they can cause confusion and might result in mistaken redirects in the future if pages are moved again."

Removing aliases that refer to the current location of the pages.
