### PR TITLE
Bump tail dependency to address issue in retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [9155](https://github.com/grafana/loki/pull/9155) **farodin91**: Promtail: Break on iterate journal failure.
 * [8987](https://github.com/grafana/loki/pull/8987) **darxriggs**: Promtail: Fix file descriptor leak.
 * [9863](https://github.com/grafana/loki/pull/9863) **ashwanthgoli**: Promtail: Apply defaults to HTTP client config. This ensures follow_redirects is set to true.
+* [9915](https://github.com/grafana/loki/pull/9915) **frittentheke**: Promtail: Update grafana/tail to address issue in retry logic
 
 #### LogCLI
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/grafana/go-gelf/v2 v2.0.1
 	github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
-	github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd
+	github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/consul/api v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1083,8 +1083,8 @@ github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
-github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd h1:dGMa2kRARfv3+h/DuxgYS55Yt+hSsv1C5333nz7q1vE=
-github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
+github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
+github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=

--- a/vendor/github.com/grafana/tail/tail.go
+++ b/vendor/github.com/grafana/tail/tail.go
@@ -227,6 +227,7 @@ func (tail *Tail) reopen(truncated bool) error {
 	}
 
 	tail.closeFile()
+	retries := 20
 	for {
 		var err error
 		tail.fileMtx.Lock()
@@ -256,7 +257,6 @@ func (tail *Tail) reopen(truncated bool) error {
 		}
 
 		// Check to see if we are trying to reopen and tail the exact same file (and it was not truncated).
-		retries := 20
 		if !truncated && cf != nil && os.SameFile(cf, nf) {
 			retries--
 			if retries <= 0 {

--- a/vendor/github.com/grafana/tail/watch/polling.go
+++ b/vendor/github.com/grafana/tail/watch/polling.go
@@ -106,14 +106,14 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 
 			time.Sleep(bo.WaitTime())
 			deletePending, err := IsDeletePending(fw.File)
-			if err != nil {
-				util.Fatal("Failed to get file info %v: %v", fw.Filename, err)
-			}
 
 			// DeletePending is a windows state where the file has been queued
 			// for delete but won't actually get deleted until all handles are
-			// closed. It's a variation on line 87 below
-			if deletePending {
+			// closed. It's a variation on the NotifyDeleted call below.
+			//
+			// IsDeletePending may fail in cases where the file handle becomes
+			// invalid, so we treat a failed call the same as a pending delete.
+			if err != nil || deletePending {
 				fw.closeFile()
 				changes.NotifyDeleted()
 				return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -838,7 +838,7 @@ github.com/grafana/loki/pkg/push
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/tail v0.0.0-20230321215411-205c7713cbcd
+# github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0
 ## explicit; go 1.13
 github.com/grafana/tail
 github.com/grafana/tail/ratelimiter


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the grafana/tail version used, mostly to address an issue with the retry logic (https://github.com/grafana/tail/pull/16)

**Which issue(s) this PR fixes**:
Fixes #9864 #9877 #9869, maybe others

**Special notes for your reviewer**:
I did NOT add a note about this dependency bump in the changelog. Let me know if you want me to add that ... or kindly add that line yourself.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
