### PR TITLE
Remove unused fallback in index gateway client store

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -226,7 +226,7 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			idx := series.NewIndexGatewayClientStore(gw)
+			idx := series.NewIndexGatewayClientStore(gw, indexClientLogger)
 
 			return failingChunkWriter{}, index.NewMonitoredReaderWriter(idx, indexClientReg), func() {
 				f.Stop()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -226,7 +226,7 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			idx := series.NewIndexGatewayClientStore(gw, nil)
+			idx := series.NewIndexGatewayClientStore(gw)
 
 			return failingChunkWriter{}, index.NewMonitoredReaderWriter(idx, indexClientReg), func() {
 				f.Stop()
@@ -295,16 +295,6 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 	indexReaderWriter := series.NewIndexReaderWriter(s.schemaCfg, schema, idx, f, s.cfg.MaxChunkBatchSize, s.writeDedupeCache)
 	indexReaderWriter = index.NewMonitoredReaderWriter(indexReaderWriter, indexClientReg)
 	chunkWriter := stores.NewChunkWriter(f, s.schemaCfg, indexReaderWriter, s.storeCfg.DisableIndexDeduplication)
-
-	// (Sandeep): Disable IndexGatewayClientStore for stores other than tsdb until we are ready to enable it again
-	/*if s.cfg.BoltDBShipperConfig != nil && shouldUseIndexGatewayClient(s.cfg.BoltDBShipperConfig) {
-		// inject the index-gateway client into the index store
-		gw, err := shipper.NewGatewayClient(s.cfg.BoltDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.logger)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		indexReaderWriter = series.NewIndexGatewayClientStore(gw, indexReaderWriter)
-	}*/
 
 	return chunkWriter,
 		indexReaderWriter,

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -29,7 +29,7 @@ func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, logger log.L
 	}
 }
 
-func (c *IndexGatewayClientStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([]logproto.ChunkRef, error) {
+func (c *IndexGatewayClientStore) GetChunkRefs(ctx context.Context, _ string, from, through model.Time, allMatchers ...*labels.Matcher) ([]logproto.ChunkRef, error) {
 	response, err := c.client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{
 		From:     from,
 		Through:  through,
@@ -47,7 +47,7 @@ func (c *IndexGatewayClientStore) GetChunkRefs(ctx context.Context, userID strin
 	return result, nil
 }
 
-func (c *IndexGatewayClientStore) GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
+func (c *IndexGatewayClientStore) GetSeries(ctx context.Context, _ string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
 	resp, err := c.client.GetSeries(ctx, &logproto.GetSeriesRequest{
 		From:     from,
 		Through:  through,
@@ -66,7 +66,7 @@ func (c *IndexGatewayClientStore) GetSeries(ctx context.Context, userID string, 
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
-func (c *IndexGatewayClientStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
+func (c *IndexGatewayClientStore) LabelNamesForMetricName(ctx context.Context, _ string, from, through model.Time, metricName string) ([]string, error) {
 	resp, err := c.client.LabelNamesForMetricName(ctx, &logproto.LabelNamesForMetricNameRequest{
 		MetricName: metricName,
 		From:       from,
@@ -78,7 +78,7 @@ func (c *IndexGatewayClientStore) LabelNamesForMetricName(ctx context.Context, u
 	return resp.Values, nil
 }
 
-func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
+func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, _ string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	resp, err := c.client.LabelValuesForMetricName(ctx, &logproto.LabelValuesForMetricNameRequest{
 		MetricName: metricName,
 		LabelName:  labelName,
@@ -92,7 +92,7 @@ func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, 
 	return resp.Values, nil
 }
 
-func (c *IndexGatewayClientStore) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
+func (c *IndexGatewayClientStore) Stats(ctx context.Context, _ string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
 	return c.client.GetStats(ctx, &logproto.IndexStatsRequest{
 		From:     from,
 		Through:  through,
@@ -100,7 +100,7 @@ func (c *IndexGatewayClientStore) Stats(ctx context.Context, userID string, from
 	})
 }
 
-func (c *IndexGatewayClientStore) SeriesVolume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
+func (c *IndexGatewayClientStore) SeriesVolume(ctx context.Context, _ string, from, through model.Time, limit int32, targetLabels []string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
 	return c.client.GetSeriesVolume(ctx, &logproto.VolumeRequest{
 		From:         from,
 		Through:      through,
@@ -110,7 +110,7 @@ func (c *IndexGatewayClientStore) SeriesVolume(ctx context.Context, userID strin
 	})
 }
 
-func (c *IndexGatewayClientStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (c *IndexGatewayClientStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
 	level.Warn(c.logger).Log("msg", "SetChunkFilterer called on index gateway client store, but it does not support it")
 }
 

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gogo/status"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
@@ -16,19 +14,14 @@ import (
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 )
 
+// IndexGatewayClientStore implements pkg/storage/stores/index.ReaderWriter
 type IndexGatewayClientStore struct {
 	client logproto.IndexGatewayClient
-	// fallbackStore is used only to keep index gateways backwards compatible.
-	// Previously index gateways would only serve index rows from boltdb-shipper files.
-	// tsdb also supports configuring index gateways but there is no concept of serving index rows so
-	// the fallbackStore could be nil and should be checked before use
-	fallbackStore index.Reader
 }
 
-func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, fallbackStore index.Reader) index.ReaderWriter {
+func NewIndexGatewayClientStore(client logproto.IndexGatewayClient) index.ReaderWriter {
 	return &IndexGatewayClientStore{
-		client:        client,
-		fallbackStore: fallbackStore,
+		client: client,
 	}
 }
 
@@ -39,12 +32,9 @@ func (c *IndexGatewayClientStore) GetChunkRefs(ctx context.Context, userID strin
 		Matchers: (&syntax.MatchersExpr{Mts: allMatchers}).String(),
 	})
 	if err != nil {
-		if isUnimplementedCallError(err) && c.fallbackStore != nil {
-			// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-			return c.fallbackStore.GetChunkRefs(ctx, userID, from, through, allMatchers...)
-		}
 		return nil, err
 	}
+
 	result := make([]logproto.ChunkRef, len(response.Refs))
 	for i, ref := range response.Refs {
 		result[i] = *ref
@@ -60,10 +50,6 @@ func (c *IndexGatewayClientStore) GetSeries(ctx context.Context, userID string, 
 		Matchers: (&syntax.MatchersExpr{Mts: matchers}).String(),
 	})
 	if err != nil {
-		if isUnimplementedCallError(err) && c.fallbackStore != nil {
-			// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-			return c.fallbackStore.GetSeries(ctx, userID, from, through, matchers...)
-		}
 		return nil, err
 	}
 
@@ -82,10 +68,6 @@ func (c *IndexGatewayClientStore) LabelNamesForMetricName(ctx context.Context, u
 		From:       from,
 		Through:    through,
 	})
-	if isUnimplementedCallError(err) && c.fallbackStore != nil {
-		// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-		return c.fallbackStore.LabelNamesForMetricName(ctx, userID, from, through, metricName)
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +82,6 @@ func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, 
 		Through:    through,
 		Matchers:   (&syntax.MatchersExpr{Mts: matchers}).String(),
 	})
-	if isUnimplementedCallError(err) && c.fallbackStore != nil {
-		// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-		return c.fallbackStore.LabelValuesForMetricName(ctx, userID, from, through, metricName, labelName, matchers...)
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -111,67 +89,26 @@ func (c *IndexGatewayClientStore) LabelValuesForMetricName(ctx context.Context, 
 }
 
 func (c *IndexGatewayClientStore) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
-	resp, err := c.client.GetStats(ctx, &logproto.IndexStatsRequest{
+	return c.client.GetStats(ctx, &logproto.IndexStatsRequest{
 		From:     from,
 		Through:  through,
 		Matchers: (&syntax.MatchersExpr{Mts: matchers}).String(),
 	})
-	if err != nil {
-		if isUnimplementedCallError(err) && c.fallbackStore != nil {
-			// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-			// Note: this is likely a noop anyway since only
-			// tsdb+ enables this and the prior index returns an
-			// empty response.
-			return c.fallbackStore.Stats(ctx, userID, from, through, matchers...)
-		}
-		return nil, err
-	}
-
-	return resp, nil
 }
 
 func (c *IndexGatewayClientStore) SeriesVolume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
-	resp, err := c.client.GetSeriesVolume(ctx, &logproto.VolumeRequest{
+	return c.client.GetSeriesVolume(ctx, &logproto.VolumeRequest{
 		From:         from,
 		Through:      through,
 		Matchers:     (&syntax.MatchersExpr{Mts: matchers}).String(),
 		Limit:        limit,
 		TargetLabels: targetLabels,
 	})
-	if err != nil {
-		if isUnimplementedCallError(err) && c.fallbackStore != nil {
-			// Handle communication with older index gateways gracefully, by falling back to the index store calls.
-			// Note: this is likely a noop anyway since only
-			// tsdb+ enables this and the prior index returns an
-			// empty response.
-			return c.fallbackStore.SeriesVolume(ctx, userID, from, through, limit, targetLabels, matchers...)
-		}
-		return nil, err
-	}
-
-	return resp, nil
 }
 
 func (c *IndexGatewayClientStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	// if there is no fallback store, we can't set the chunk filterer and index gateway would take care of filtering out data
-	if c.fallbackStore != nil {
-		c.fallbackStore.SetChunkFilterer(chunkFilter)
-	}
 }
 
 func (c *IndexGatewayClientStore) IndexChunk(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
 	return fmt.Errorf("index writes not supported on index gateway client")
-}
-
-// isUnimplementedCallError tells if the GRPC error is a gRPC error with code Unimplemented.
-func isUnimplementedCallError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	s, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	return (s.Code() == codes.Unimplemented)
 }

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -17,11 +19,13 @@ import (
 // IndexGatewayClientStore implements pkg/storage/stores/index.ReaderWriter
 type IndexGatewayClientStore struct {
 	client logproto.IndexGatewayClient
+	logger log.Logger
 }
 
-func NewIndexGatewayClientStore(client logproto.IndexGatewayClient) index.ReaderWriter {
+func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, logger log.Logger) index.ReaderWriter {
 	return &IndexGatewayClientStore{
 		client: client,
+		logger: logger,
 	}
 }
 
@@ -107,6 +111,7 @@ func (c *IndexGatewayClientStore) SeriesVolume(ctx context.Context, userID strin
 }
 
 func (c *IndexGatewayClientStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	level.Warn(c.logger).Log("msg", "SetChunkFilterer called on index gateway client store, but it does not support it")
 }
 
 func (c *IndexGatewayClientStore) IndexChunk(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {

--- a/pkg/storage/stores/series/series_index_gateway_store_test.go
+++ b/pkg/storage/stores/series/series_index_gateway_store_test.go
@@ -2,21 +2,13 @@ package series
 
 import (
 	"context"
-	"log"
-	"net"
 	"testing"
-	"time"
 
-	"github.com/grafana/dskit/grpcclient"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/storage/chunk/client/testutils"
-	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores/series/index"
 )
 
 type fakeClient struct {
@@ -34,75 +26,7 @@ func (fakeClient) GetSeries(_ context.Context, _ *logproto.GetSeriesRequest, _ .
 func Test_IndexGatewayClient(t *testing.T) {
 	idx := IndexGatewayClientStore{
 		client: fakeClient{},
-		fallbackStore: &indexReaderWriter{
-			chunkBatchSize: 1,
-		},
 	}
 	_, err := idx.GetSeries(context.Background(), "foo", model.Earliest, model.Latest)
-	require.NoError(t, err)
-}
-
-func Test_IndexGatewayClient_Fallback(t *testing.T) {
-	lis, err := net.Listen("tcp", "localhost:0")
-	require.NoError(t, err)
-	s := grpc.NewServer()
-
-	// register fake grpc service with missing methods
-	desc := grpc.ServiceDesc{
-		ServiceName: "logproto.IndexGateway",
-		HandlerType: (*logproto.IndexGatewayServer)(nil),
-		Streams: []grpc.StreamDesc{
-			{
-				StreamName:    "QueryIndex",
-				Handler:       nil,
-				ServerStreams: true,
-			},
-		},
-		Metadata: "pkg/storage/stores/shipper/indexgateway/logproto/gateway.proto",
-	}
-	s.RegisterService(&desc, nil)
-
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf("Failed to serve: %v", err)
-		}
-	}()
-	defer func() {
-		s.GracefulStop()
-	}()
-
-	cfg := grpcclient.Config{
-		MaxRecvMsgSize: 1024,
-		MaxSendMsgSize: 1024,
-	}
-
-	dialOpts, err := cfg.DialOption(nil, nil)
-	require.NoError(t, err)
-
-	conn, err := grpc.Dial(lis.Addr().String(), dialOpts...)
-	require.NoError(t, err)
-	defer conn.Close()
-	schemaCfg := config.SchemaConfig{
-		Configs: []config.PeriodConfig{
-			{From: config.DayTime{Time: model.Now().Add(-24 * time.Hour)}, Schema: "v12", RowShards: 16},
-		},
-	}
-	schema, err := index.CreateSchema(schemaCfg.Configs[0])
-	require.NoError(t, err)
-	testutils.ResetMockStorage()
-	tm, err := index.NewTableManager(index.TableManagerConfig{}, schemaCfg, 2*time.Hour, testutils.NewMockStorage(), nil, nil, nil)
-	require.NoError(t, err)
-	require.NoError(t, tm.SyncTables(context.Background()))
-	idx := NewIndexGatewayClientStore(
-		logproto.NewIndexGatewayClient(conn),
-		&indexReaderWriter{
-			chunkBatchSize: 1,
-			schema:         schema,
-			schemaCfg:      schemaCfg,
-			index:          testutils.NewMockStorage(),
-		},
-	)
-
-	_, err = idx.GetSeries(context.Background(), "foo", model.Now(), model.Now().Add(1*time.Hour), labels.MustNewMatcher(labels.MatchEqual, "__name__", "logs"))
 	require.NoError(t, err)
 }

--- a/pkg/storage/stores/series/series_index_gateway_store_test.go
+++ b/pkg/storage/stores/series/series_index_gateway_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -24,9 +25,7 @@ func (fakeClient) GetSeries(_ context.Context, _ *logproto.GetSeriesRequest, _ .
 }
 
 func Test_IndexGatewayClient(t *testing.T) {
-	idx := IndexGatewayClientStore{
-		client: fakeClient{},
-	}
+	idx := NewIndexGatewayClientStore(fakeClient{}, log.NewNopLogger())
 	_, err := idx.GetSeries(context.Background(), "foo", model.Earliest, model.Latest)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The fallback was once used by boltdb-shipper, but since boltdb-shipper changed to not use the index gateway, the fallback was also never used.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
