### PR TITLE
Use Debian Bullseye

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.1',
+    local build_image_tag = '0.29.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.1
+    - 0.29.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.1
+    - 0.29.2
     username:
       from_secret: docker_username
   when:
@@ -1771,6 +1771,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: bd556134fa6d49f35ac3abb21fb7248feb0a808f86478d31ac337c6d7846f1c4
+hmac: 78893b27e5d69c80bc81138e06770965cf70ed0c1f57509cd408d2c240fd669d
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -73,7 +73,7 @@ RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.6-bookworm
+FROM golang:1.20.6-bullseye
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \


### PR DESCRIPTION
Debian Bookworm has a later version of the protobuf compiler which somehow causes the generated protobuf code to substitute `empty.Empty` with `emptypb.Empty` among others. Below is an example of the changes:

```
-	WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	WriteIndex(ctx context.Context, in *WriteIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
```

These [changes](https://protobuf.dev/reference/go/faq/#modules) will happen at some time due to new google.golang.org/protobuf library. To avoid this for now we can use Debian Bullseye instead. Note that Debian Buster is no longer available for Go 1.20.6.