### PR TITLE
Build gotestum, helm-docs and others on bullseye

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.2',
+    local build_image_tag = '0.29.3',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.2
+    - 0.29.3
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.2
+    - 0.29.3
     username:
       from_secret: docker_username
   when:
@@ -1771,6 +1771,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 78893b27e5d69c80bc81138e06770965cf70ed0c1f57509cd408d2c240fd669d
+hmac: 47543750eb7ac83bd3fe1c55e324942e2c742677980a59eaeedfe13d64e1f653
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.6 as helm
+FROM golang:1.20.6-bullseye as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -64,7 +64,7 @@ FROM golang:1.20.6 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.6 as gotestsum
+FROM golang:1.20.6-bullseye as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.6 as drone
+FROM golang:1.20.6-bullseye as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,20 +47,20 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.6 as faillint
+FROM golang:1.20.6-bullseye as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 RUN GO111MODULE=on go install golang.org/x/tools/cmd/goimports@v0.7.0
 
-FROM golang:1.20.6 as delve
+FROM golang:1.20.6-bullseye as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.6 as ghr
+FROM golang:1.20.6-bullseye as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.6 as nfpm
+FROM golang:1.20.6-bullseye as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
@@ -68,7 +68,7 @@ FROM golang:1.20.6-bullseye as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.6 as jsonnet
+FROM golang:1.20.6-bullseye as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0


### PR DESCRIPTION
helm-docs and gotestsum use a different libc version when built on the normal golang image so they have to be built on the bullseye image as well. Otherwise errors like these occur:

```
gotestsum: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by gotestsum)
gotestsum: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by gotestsum)

helm-docs: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by helm-docs)
helm-docs: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by helm-docs)
```

Tested by running them manually in the new build image.