### PR TITLE
Replacing sed with awk for determining systemd-version provides more …

### DIFF
--- a/tools/packaging/loki-postinstall.sh
+++ b/tools/packaging/loki-postinstall.sh
@@ -5,7 +5,7 @@
 if ! command -V systemctl >/dev/null 2>&1; then
   echo "Could not find systemd. Skipping system installation." && exit 0
 else
-    systemd_version=$(systemctl --version | head -1 | sed 's/systemd //g')
+    systemd_version=$(systemctl --version | awk '/systemd /{print $2}')
 fi
 
 cleanInstall() {


### PR DESCRIPTION
See https://github.com/grafana/loki/issues/9924

**What this PR does / why we need it**:
This PR addresses a parsing bug for package post install scripts.

**Which issue(s) this PR fixes**:
Fixes #9924

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
