### PR TITLE
Call FetchChunks in parallel from series index store

### DIFF
--- a/pkg/storage/stores/series/series_index_store.go
+++ b/pkg/storage/stores/series/series_index_store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/dskit/concurrency"
+
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/querier/astmapper"
 	"github.com/grafana/loki/pkg/storage/chunk"


### PR DESCRIPTION
This PR changes the invocation of `FetchChunks` in the series index store to happen in parallel. It seems like this was the original intention due to the `// bound concurrency` comment when allocating the `groups` slice. This came out of an investigation of some slow queries, and the traces showed many serial calls to `FetchChunks`.

![image (1)](https://github.com/grafana/loki/assets/469592/d15301c2-0241-45fa-97d4-f2b1da1af8a3)

