### PR TITLE
correctly handle unpack when reordering stages

### DIFF
--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -120,6 +120,21 @@ func (m MultiStageExpr) reorderStages() []StageExpr {
 
 			filters = filters[:0]
 			rest = rest[:0]
+		case *LabelParserExpr:
+			rest = append(rest, f)
+
+			// unpack modifies the contents of the line so any line filter
+			// originally after an unpack must still be after the same
+			// line_format.
+			if f.Op == OpParserTypeUnpack {
+				if len(filters) > 0 {
+					result = append(result, combineFilters(filters))
+				}
+				result = append(result, rest...)
+
+				filters = filters[:0]
+				rest = rest[:0]
+			}
 		default:
 			rest = append(rest, f)
 		}

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -652,6 +652,16 @@ func TestFilterReodering(t *testing.T) {
 		require.Len(t, stages, 5)
 		require.Equal(t, `|= "foo" |= "next" |= "bar" |= "baz" | logfmt | line_format "{{.foo}}" |= "1" |= "2" |= "3" | logfmt`, MultiStageExpr(stages).String())
 	})
+
+	t.Run("unpack test", func(t *testing.T) {
+		logExpr := `{container_name="app"} |= "06497595" | unpack != "message" | json | line_format "new log: {{.foo}}"`
+		l, err := ParseExpr(logExpr)
+		require.NoError(t, err)
+
+		stages := l.(*PipelineExpr).MultiStages.reorderStages()
+		require.Len(t, stages, 5)
+		require.Equal(t, `|= "06497595" | unpack != "message" | json | line_format "new log: {{.foo}}"`, MultiStageExpr(stages).String())
+	})
 }
 
 var result bool


### PR DESCRIPTION
The optimization to reorder stages doesn't take into account the `unpack` stage. When line filters come after unpack stages, they shouldn't be moved.