### PR TITLE
Backport go 1.20.6 to 2.8

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.3',
+    local build_image_tag = '0.29.3-golangci.1.51.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.28.3',
+    local build_image_tag = '0.29.1',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.2',
+    local build_image_tag = '0.29.3',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.1',
+    local build_image_tag = '0.29.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.1
+    - 0.29.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.1
+    - 0.29.2
     username:
       from_secret: docker_username
   when:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: compare-coverage
   when:
     event:
@@ -160,7 +160,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: report-coverage
   when:
     event:
@@ -170,7 +170,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -178,7 +178,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -189,28 +189,28 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -243,7 +243,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: loki-mixin-check
   when:
     event:
@@ -268,7 +268,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1431,7 +1431,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1439,7 +1439,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1465,7 +1465,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: publish
   when:
     event:
@@ -1499,7 +1499,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.28.3
+  image: grafana/loki-build-image:0.29.3
   name: build and push
   privileged: true
   volumes:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.2
+    - 0.29.3
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.2
+    - 0.29.3
     username:
       from_secret: docker_username
   when:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3
+    - 0.29.3-golangci.1.51.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3
+    - 0.29.3-golangci.1.51.2
     username:
       from_secret: docker_username
   when:
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: compare-coverage
   when:
     event:
@@ -160,7 +160,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: report-coverage
   when:
     event:
@@ -170,7 +170,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -178,7 +178,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -189,28 +189,28 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -243,7 +243,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: loki-mixin-check
   when:
     event:
@@ -268,7 +268,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1431,7 +1431,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1439,7 +1439,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1465,7 +1465,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: publish
   when:
     event:
@@ -1499,7 +1499,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
   name: build and push
   privileged: true
   volumes:
@@ -1764,6 +1764,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: dbdae615e26ed16bc17a830bbc8fbcd043732b26a49a9869d97daca9318626da
+hmac: 50c36b419eb83a2b2216847784a107cc72c862d059ae4a84f02350e4397dce25
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.28.3
+    - 0.29.1
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.28.3
+    - 0.29.1
     username:
       from_secret: docker_username
   when:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1764,6 +1764,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: e55dd10435cadfde79f6f334a0d9ad45fc78e6568159c6d58673fcdd3e92d44e
+hmac: dbdae615e26ed16bc17a830bbc8fbcd043732b26a49a9869d97daca9318626da
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.29.3
+BUILD_IMAGE_VERSION := 0.29.3-golangci.1.51.2
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.28.3
+BUILD_IMAGE_VERSION := 0.29.3
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5@sha256:a0b51fe882f269828b63e7f69e6925f85afc548cf7cf967ecbfbcce6afe6f235 AS builder
+FROM golang:1.20.6@sha256:832f2f74baa3e2b00ace688cb2fa934dffeade39f5b4c0cc8b1cff8d3fb084a0 AS builder
 
 COPY . /src
 

--- a/clients/cmd/promtail/Dockerfile
+++ b/clients/cmd/promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-bullseye as build
+FROM golang:1.20.6-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.arm32
+++ b/clients/cmd/promtail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-bullseye as build
+FROM golang:1.20.6-bullseye as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .

--- a/clients/cmd/promtail/Dockerfile.cross
+++ b/clients/cmd/promtail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile .
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.28.3 as build
+FROM grafana/loki-build-image:0.29.3 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -2,7 +2,7 @@
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f clients/cmd/promtail/Dockerfile.debug .
 
-FROM grafana/loki-build-image:0.29.3 as build
+FROM grafana/loki-build-image:0.29.3-golangci.1.51.2 as build
 ARG GOARCH="amd64"
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -3,7 +3,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
 
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm && \
     go install github.com/go-delve/delve/cmd/dlv@latest

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 as build
+FROM golang:1.20.6 as build
 
 COPY . /src/loki
 WORKDIR /src/loki

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/promtail -f cmd/promtail/Dockerfile .

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.4 as helm
+FROM golang:1.20.6 as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.4 as drone
+FROM golang:1.20.6 as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,32 +47,32 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.4 as faillint
+FROM golang:1.20.6 as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
-FROM golang:1.20.4 as delve
+FROM golang:1.20.6 as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.4 as ghr
+FROM golang:1.20.6 as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.4 as nfpm
+FROM golang:1.20.6 as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.4 as gotestsum
+FROM golang:1.20.6 as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.4 as jsonnet
+FROM golang:1.20.6 as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.4-buster
+FROM golang:1.20.6-bookworm
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.6 as helm
+FROM golang:1.20.6-bullseye as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.6 as drone
+FROM golang:1.20.6-bullseye as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,27 +47,27 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.6 as faillint
+FROM golang:1.20.6-bullseye as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
-FROM golang:1.20.6 as delve
+FROM golang:1.20.6-bullseye as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.6 as ghr
+FROM golang:1.20.6-bullseye as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.6 as nfpm
+FROM golang:1.20.6-bullseye as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.6 as gotestsum
+FROM golang:1.20.6-bullseye as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.6 as jsonnet
+FROM golang:1.20.6-bullseye as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -72,7 +72,7 @@ RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.6-bookworm
+FROM golang:1.20.6-bullseye
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.4 as builder
+FROM golang:1.20.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
 
 FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3
+ARG BUILD_IMAGE=grafana/loki-build-image:0.29.3-golangci.1.51.2
 
 FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \

--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=grafana/loki-build-image:0.28.3
 
-FROM golang:1.20.4-alpine as goenv
+FROM golang:1.20.6-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the calculator binary
-FROM golang:1.19.1 as builder
+FROM golang:1.20.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine AS build-image
+FROM golang:1.20.6-alpine AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the 2.8 branch so it uses Go version 1.20.6. A 2.8.x release will be built from this later on.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
