### PR TITLE
Remove ./tools/fetch-tags invocation from Makefile (#8854)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ BUILD_IMAGE_VERSION := 0.28.3
 # Docker image info
 IMAGE_PREFIX ?= grafana
 
-FETCH_TAGS :=$(shell ./tools/fetch-tags)
 IMAGE_TAG := $(shell ./tools/image-tag)
 
 # Version info for binaries

--- a/tools/fetch-tags
+++ b/tools/fetch-tags
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-git fetch --tags --all


### PR DESCRIPTION
**This is a backport of #8854**

---

**What this PR does / why we need it**:

This invocation causes problems when make targets are executed in the build image container (`BUILD_IN_CONTAINER=true`), e.g. the `yacc` target, because git tries to fetch tags from `origin` using ssh, causing error message like these:

```
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error: Could not fetch origin
```

This is because local ssh keys are not mounted into the build container.

In order not to break CI builds (https://github.com/grafana/loki/pull/8232) we need to manually fetch the tags as the first step in release pipelines. This is added to the Drone configuration.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
