### PR TITLE
operator: Gateway pods do not need to have INSTANCE_AVAILABILITY_ZONE env set in their containers

### DIFF
--- a/operator/internal/manifests/node_placement.go
+++ b/operator/internal/manifests/node_placement.go
@@ -63,11 +63,13 @@ func configureReplication(podTemplate *corev1.PodTemplateSpec, replication *loki
 		Env: []corev1.EnvVar{availabilityZoneEnvVar},
 	}
 
-	for i, dst := range podTemplate.Spec.Containers {
-		if err := mergo.Merge(&dst, src, mergo.WithAppendSlice); err != nil {
-			return err
+	if component != LabelGatewayComponent {
+		for i, dst := range podTemplate.Spec.Containers {
+			if err := mergo.Merge(&dst, src, mergo.WithAppendSlice); err != nil {
+				return err
+			}
+			podTemplate.Spec.Containers[i] = dst
 		}
-		podTemplate.Spec.Containers[i] = dst
 	}
 
 	if err := mergo.Merge(podTemplate, template); err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
Follow up to the PR : https://github.com/grafana/loki/pull/9503

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
