### PR TITLE
operator: Fix application tenant alertmanager configuration

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9963](https://github.com/grafana/loki/pull/9963) **xperimental**: Fix application tenant alertmanager configuration
 - [9503](https://github.com/grafana/loki/pull/9503) **shwetaap**: Add Pod annotations with node topology labels to support zone aware scheduling
 - [9930](https://github.com/grafana/loki/pull/9930) **periklis**: Use PodAntiAffinity for all components
 - [9860](https://github.com/grafana/loki/pull/9860) **xperimental**: Fix update of labels and annotations of PodTemplates

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -280,7 +280,7 @@ func (r *LokiStackReconciler) enqueueForAlertManagerServices() handler.EventHand
 		var requests []reconcile.Request
 
 		if obj.GetName() == openshift.MonitoringSVCOperated &&
-			(obj.GetNamespace() == openshift.MonitoringUserwWrkloadNS ||
+			(obj.GetNamespace() == openshift.MonitoringUserWorkloadNS ||
 				obj.GetNamespace() == openshift.MonitoringNS) {
 
 			for _, stack := range lokiStacks.Items {

--- a/operator/internal/handlers/internal/openshift/alertmanager.go
+++ b/operator/internal/handlers/internal/openshift/alertmanager.go
@@ -36,7 +36,7 @@ func UserWorkloadAlertManagerSVCExists(ctx context.Context, stack lokiv1.LokiSta
 	}
 
 	var svc corev1.Service
-	key := client.ObjectKey{Name: openshift.MonitoringSVCOperated, Namespace: openshift.MonitoringUserwWrkloadNS}
+	key := client.ObjectKey{Name: openshift.MonitoringSVCOperated, Namespace: openshift.MonitoringUserWorkloadNS}
 
 	err := k.Get(ctx, key, &svc)
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -1048,6 +1048,80 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 			},
 		},
 		{
+			desc: "openshift-logging mode with application override",
+			opts: Options{
+				Stack: lokiv1.LokiStackSpec{
+					Rules: &lokiv1.RulesSpec{
+						Enabled: true,
+					},
+					Limits: &lokiv1.LimitsSpec{
+						Tenants: map[string]lokiv1.LimitsTemplateSpec{
+							"application": {
+								QueryLimits: &lokiv1.QueryLimitSpec{
+									QueryTimeout: "5m",
+								},
+							},
+						},
+					},
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.OpenshiftLogging,
+					},
+				},
+				Timeouts: testTimeoutConfig(),
+				Ruler: Ruler{
+					Spec: &lokiv1.RulerConfigSpec{
+						AlertManagerSpec: &lokiv1.AlertManagerSpec{
+							EnableV2: false,
+							DiscoverySpec: &lokiv1.AlertManagerDiscoverySpec{
+								EnableSRV:       false,
+								RefreshInterval: "2m",
+							},
+							Endpoints: []string{"http://my-alertmanager"},
+						},
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						AlertManagerEnabled:             false,
+						UserWorkloadAlertManagerEnabled: true,
+					},
+				},
+			},
+			wantOptions: &config.AlertManagerConfig{
+				EnableV2:        false,
+				EnableDiscovery: false,
+				RefreshInterval: "2m",
+				Hosts:           "http://my-alertmanager",
+			},
+			wantOverridesOptions: map[string]config.LokiOverrides{
+				"application": {
+					Limits: lokiv1.LimitsTemplateSpec{
+						QueryLimits: &lokiv1.QueryLimitSpec{
+							QueryTimeout: "5m",
+						},
+					},
+					Ruler: config.RulerOverrides{
+						AlertManager: &config.AlertManagerConfig{
+							Hosts:           "https://_web._tcp.alertmanager-operated.openshift-user-workload-monitoring.svc",
+							EnableV2:        true,
+							EnableDiscovery: true,
+							RefreshInterval: "1m",
+							Notifier: &config.NotifierConfig{
+								TLS: config.TLSConfig{
+									ServerName: pointer.String("alertmanager-user-workload.openshift-user-workload-monitoring.svc.cluster.local"),
+									CAPath:     pointer.String("/var/run/ca/alertmanager/service-ca.crt"),
+								},
+								HeaderAuth: config.HeaderAuth{
+									Type:            pointer.String("Bearer"),
+									CredentialsFile: pointer.String("/var/run/secrets/kubernetes.io/serviceaccount/token"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "openshift-network mode",
 			opts: Options{
 				Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -162,7 +162,7 @@ func ConfigureOptionsForMode(cfg *config.Options, opt Options) error {
 	case lokiv1.OpenshiftNetwork:
 		return openshift.ConfigureOptions(cfg, opt.OpenShiftOptions.BuildOpts.AlertManagerEnabled, false, "", "", "")
 	case lokiv1.OpenshiftLogging:
-		monitorServerName := fqdn(openshift.MonitoringSVCUserWorkload, openshift.MonitoringUserwWrkloadNS)
+		monitorServerName := fqdn(openshift.MonitoringSVCUserWorkload, openshift.MonitoringUserWorkloadNS)
 		return openshift.ConfigureOptions(
 			cfg,
 			opt.OpenShiftOptions.BuildOpts.AlertManagerEnabled,

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -270,7 +270,7 @@ func configureUserWorkloadAM(configOpt *config.Options, token, caPath, monitorSe
 	}
 
 	lokiOverrides.Ruler.AlertManager = &config.AlertManagerConfig{
-		Hosts:           fmt.Sprintf("https://_web._tcp.%s.%s.svc", MonitoringSVCOperated, MonitoringUserwWrkloadNS),
+		Hosts:           fmt.Sprintf("https://_web._tcp.%s.%s.svc", MonitoringSVCOperated, MonitoringUserWorkloadNS),
 		EnableV2:        true,
 		EnableDiscovery: true,
 		RefreshInterval: "1m",

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -259,23 +259,17 @@ func configureDefaultMonitoringAM(configOpt *config.Options) error {
 }
 
 func configureUserWorkloadAM(configOpt *config.Options, token, caPath, monitorServerName string) error {
-	if len(configOpt.Overrides) == 0 {
+	if configOpt.Overrides == nil {
 		configOpt.Overrides = map[string]config.LokiOverrides{}
 	}
 
-	lokiOverrides, ok := configOpt.Overrides[tenantApplication]
-	if ok {
+	lokiOverrides := configOpt.Overrides[tenantApplication]
+
+	if lokiOverrides.Ruler.AlertManager != nil {
 		return nil
 	}
 
-	lokiOverrides = config.LokiOverrides{
-		Ruler: config.RulerOverrides{
-			AlertManager: &config.AlertManagerConfig{},
-		},
-	}
-
-	configOpt.Overrides[tenantApplication] = lokiOverrides
-	amOverride := &config.AlertManagerConfig{
+	lokiOverrides.Ruler.AlertManager = &config.AlertManagerConfig{
 		Hosts:           fmt.Sprintf("https://_web._tcp.%s.%s.svc", MonitoringSVCOperated, MonitoringUserwWrkloadNS),
 		EnableV2:        true,
 		EnableDiscovery: true,
@@ -292,11 +286,6 @@ func configureUserWorkloadAM(configOpt *config.Options, token, caPath, monitorSe
 		},
 	}
 
-	if err := mergo.Merge(lokiOverrides.Ruler.AlertManager, amOverride); err != nil {
-		return kverrors.Wrap(err, "failed merging application tenant AlertManager config")
-	}
-
 	configOpt.Overrides[tenantApplication] = lokiOverrides
-
 	return nil
 }

--- a/operator/internal/manifests/openshift/var.go
+++ b/operator/internal/manifests/openshift/var.go
@@ -45,7 +45,7 @@ var (
 	MonitoringSVCOperated = "alertmanager-operated"
 
 	MonitoringSVCUserWorkload = "alertmanager-user-workload"
-	MonitoringUserwWrkloadNS  = "openshift-user-workload-monitoring"
+	MonitoringUserWorkloadNS  = "openshift-user-workload-monitoring"
 )
 
 func authorizerRbacName(componentName string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

When in `openshift-logging` tenant mode, setting any overrides on the `application` tenant currently overrides the automatic alert-manager configuration. This PR changes the behaviour, so that the automatic alert-manager configuration is only skipped when the `application` tenant is already configured with a custom alert-manager.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/LOG-4325

**Special notes for your reviewer**:

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Update tests
- [x] `CHANGELOG.md` updated

