### PR TITLE
Loki: Fix a merge error when getting rules from sharded rulers using the `/prometheus/api/v1/rules` endpoint

### DIFF
--- a/pkg/ruler/base/ruler.go
+++ b/pkg/ruler/base/ruler.go
@@ -942,6 +942,9 @@ func (r *Ruler) getShardedRules(ctx context.Context, userID string) ([]*GroupSta
 			name := RemoveRuleTokenFromGroupName(grp.Group.Name)
 			grp.Group.Name = name
 
+			// When merging include the namepsace in case the same group name exists in multiple namespaces
+			name = grp.Group.Namespace + "/" + name
+
 			_, found := merged[name]
 			if found {
 				merged[name].ActiveRules = append(merged[name].ActiveRules, grp.ActiveRules...)


### PR DESCRIPTION
**What this PR does / why we need it**:

The `/prometheus/api/v1/rules` api endpoint will return all the rules currently loaded and being evaluated by the ruler.

Previously when we merged the rule groups from all rulers in a sharded ruler setup, we only used the rule group name as the key in the map used for merging the results. This introduced a bug when multiple rule groups have the same name but in different namespaces, leading to some rules being reported in the incorrect namespace.

This is just a visualization bug, the rules are in the correct space and operating as defined, however Grafana uses this API in conjunction with `/loki/api/v1/rules` to track the state of a rule being added or removed. The `/loki/api/v1/rules` endpoint returns rules as they exist in storage.

When someone has multiple rule groups with the same name in different namespaces this can lead to the Grafana UI showing rules in a perpetual state of creating and deleting as it's possible for rules to be returned from `/prometheus/api/v1/rules` in the wrong group.

Adding the namespace to the key used in the map for merging rule results prevents this issue.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
