### PR TITLE
New build image with old golangci

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -472,7 +472,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
 
 [
   pipeline('loki-build-image') {
-    local build_image_tag = '0.29.3',
+    local build_image_tag = '0.29.3-golangci.1.51.2',
     workspace: {
       base: '/src',
       path: 'loki',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -10,7 +10,7 @@ steps:
     dry_run: true
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3
+    - 0.29.3-golangci.1.51.2
   when:
     event:
     - pull_request
@@ -26,7 +26,7 @@ steps:
       from_secret: docker_password
     repo: grafana/loki-build-image
     tags:
-    - 0.29.3
+    - 0.29.3-golangci.1.51.2
     username:
       from_secret: docker_username
   when:
@@ -1771,6 +1771,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 0e6b14c03e7b56ab20e8bcd5e4d13a06a72d9384674d5c6fad24a2eef2139e0b
+hmac: d7648b4b008582e9d427082fbaa6bb92796e784c41c51c698751e4976e92fdb7
 
 ...

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.16.5 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.2
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
 
 FROM alpine:3.16.5 as buf
 

--- a/loki-build-image/README.md
+++ b/loki-build-image/README.md
@@ -1,0 +1,17 @@
+# Build image
+
+## Versions
+
+### 0.29.3-golangci.1.51.2
+
+- Update to Go version 1.20.6 but restore golangci-lint to v1.51.2
+
+* This release should only be used for the release branches such as 2.8.x and 2.7.x. *
+The current release of the build image uses golangci-lint to v1.53.2 which makes
+a lot of linter checks mandatory causing a huge amount of fixes 
+See https://github.com/grafana/loki/pull/9601. To avoid the integration problems this
+build image will be used in those branches.
+
+### 0.29.3
+
+- Update to Go version 1.20.6


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki build image with go 1.20.6 and previous version of golangci.

**Which issue(s) this PR fixes**:
See the Included README.md
