### PR TITLE
Drop :z from the podman mount command to make it work on macOS

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ BUILD_IN_CONTAINER ?= true
 
 sources/installation/helm/reference.md: ../production/helm/loki/reference.md.gotmpl
 ifeq ($(BUILD_IN_CONTAINER),true)
-	$(PODMAN) run --rm --volume "$(realpath ..):/helm-docs:z" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
+	$(PODMAN) run --rm --volume "$(realpath ..):/helm-docs" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
 		-c /helm-docs/production/helm/ \
 		-t reference.md.gotmpl \
 		-o reference.md


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the `make -C docs ...` command on macOS.

**Which issue(s) this PR fixes**:
Idk, but it originates from https://github.com/grafana/loki/pull/9945#issuecomment-1645272136

**Special notes for your reviewer**:
I have tested it. Also, shouldn't break the rest of the systems (Linux).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
