### PR TITLE
Support non-indexed labels in WAL

### DIFF
--- a/pkg/ingester/wal/encoding.go
+++ b/pkg/ingester/wal/encoding.go
@@ -25,10 +25,13 @@ const (
 	// WALRecordEntriesV2 is the type for the WAL record for samples with an
 	// additional counter value for use in replaying without the ordering constraint.
 	WALRecordEntriesV2
+	// WALRecordEntriesV3 is the type for the WAL record for samples with non-indexed labels.
+	WALRecordEntriesV3
 )
 
 // The current type of Entries that this distribution writes.
 // Loki can read in a backwards compatible manner, but will write the newest variant.
+// TODO: Change to WALRecordEntriesV3?
 const CurrentEntriesRec = WALRecordEntriesV2
 
 // Record is a struct combining the series and samples record.
@@ -128,6 +131,17 @@ outer:
 			buf.PutVarint64(s.Timestamp.UnixNano() - first)
 			buf.PutUvarint(len(s.Line))
 			buf.PutString(s.Line)
+
+			if version >= WALRecordEntriesV3 {
+				// non-indexed labels
+				buf.PutUvarint(len(s.NonIndexedLabels))
+				for _, l := range s.NonIndexedLabels {
+					buf.PutUvarint(len(l.Name))
+					buf.PutString(l.Name)
+					buf.PutUvarint(len(l.Value))
+					buf.PutString(l.Value)
+				}
+			}
 		}
 	}
 	return buf.Get()
@@ -158,9 +172,28 @@ func DecodeEntries(b []byte, version RecordType, rec *Record) error {
 			lineLength := dec.Uvarint()
 			line := dec.Bytes(lineLength)
 
+			var nonIndexedLabels []logproto.LabelAdapter
+			if version >= WALRecordEntriesV3 {
+				nNonIndexedLabels := dec.Uvarint()
+				if nNonIndexedLabels > 0 {
+					nonIndexedLabels = make([]logproto.LabelAdapter, 0, nNonIndexedLabels)
+					for i := 0; dec.Err() == nil && i < nNonIndexedLabels; i++ {
+						nameLength := dec.Uvarint()
+						name := dec.Bytes(nameLength)
+						valueLength := dec.Uvarint()
+						value := dec.Bytes(valueLength)
+						nonIndexedLabels = append(nonIndexedLabels, logproto.LabelAdapter{
+							Name:  string(name),
+							Value: string(value),
+						})
+					}
+				}
+			}
+
 			refEntries.Entries = append(refEntries.Entries, logproto.Entry{
-				Timestamp: time.Unix(0, baseTime+timeOffset),
-				Line:      string(line),
+				Timestamp:        time.Unix(0, baseTime+timeOffset),
+				Line:             string(line),
+				NonIndexedLabels: nonIndexedLabels,
 			})
 		}
 
@@ -195,7 +228,7 @@ func DecodeRecord(b []byte, walRec *Record) (err error) {
 	case WALRecordSeries:
 		userID = decbuf.UvarintStr()
 		rSeries, err = dec.Series(decbuf.B, walRec.Series)
-	case WALRecordEntriesV1, WALRecordEntriesV2:
+	case WALRecordEntriesV1, WALRecordEntriesV2, WALRecordEntriesV3:
 		userID = decbuf.UvarintStr()
 		err = DecodeEntries(decbuf.B, t, walRec)
 	default:


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/loki/pull/9700, we support encoding and decoding non-indexed labels for each entry into the chunks. This PR adds support for writing/reading the non-indexed labels to/from the WAL.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
