### PR TITLE
Change "tenant" to "org_id"

### DIFF
--- a/pkg/distributor/writefailures/manager.go
+++ b/pkg/distributor/writefailures/manager.go
@@ -46,7 +46,7 @@ func (m *Manager) Log(tenantID string, err error) {
 	errMsg := err.Error()
 	if m.limiter.AllowN(time.Now(), tenantID, len(errMsg)) {
 		m.metrics.loggedCount.WithLabelValues(tenantID).Inc()
-		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "tenant", tenantID)
+		level.Error(m.logger).Log("msg", "write operation failed", "details", errMsg, "org_id", tenantID)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change our writefailures module to use "org_id" instead of "tenant" to be more consistent with the rest of our system.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
