### PR TITLE
sort sort log volumes by size

### DIFF
--- a/pkg/querier/queryrange/series_volume.go
+++ b/pkg/querier/queryrange/series_volume.go
@@ -215,7 +215,11 @@ func toPrometheusData(series map[string][]logproto.LegacySample, aggregateBySeri
 	}
 
 	sort.Slice(sortableResult, func(i, j int) bool {
-		return sortableResult[i].name < sortableResult[j].name
+		// Sorting by value only helps instant queries so just grab the first value
+		if sortableResult[i].samples[0].Value == sortableResult[j].samples[0].Value {
+			return sortableResult[i].name < sortableResult[j].name
+		}
+		return sortableResult[i].samples[0].Value > sortableResult[j].samples[0].Value
 	})
 
 	result := make([]queryrangebase.SampleStream, 0, len(sortableResult))

--- a/pkg/querier/queryrange/series_volume_test.go
+++ b/pkg/querier/queryrange/series_volume_test.go
@@ -67,7 +67,7 @@ func Test_toPrometheusResponse(t *testing.T) {
 	}
 
 	setupSeries := func(instant bool) chan *bucketedVolumeResponse {
-		return setup(instant, `{foo="bar", fizz="buzz"}`, `{foo="baz"}`)
+		return setup(instant, `{foo="baz"}`, `{foo="bar", fizz="buzz"}`)
 	}
 
 	setupLabels := func(instant bool) chan *bucketedVolumeResponse {
@@ -83,12 +83,8 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
-							Name:  "fizz",
-							Value: "buzz",
-						},
-						{
 							Name:  "foo",
-							Value: "bar",
+							Value: "baz",
 						},
 					},
 					Samples: []logproto.LegacySample{
@@ -105,8 +101,12 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
+							Name:  "fizz",
+							Value: "buzz",
+						},
+						{
 							Name:  "foo",
-							Value: "baz",
+							Value: "bar",
 						},
 					},
 					Samples: []logproto.LegacySample{
@@ -133,12 +133,8 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
-							Name:  "fizz",
-							Value: "buzz",
-						},
-						{
 							Name:  "foo",
-							Value: "bar",
+							Value: "baz",
 						},
 					},
 					Samples: []logproto.LegacySample{
@@ -151,8 +147,12 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
+							Name:  "fizz",
+							Value: "buzz",
+						},
+						{
 							Name:  "foo",
-							Value: "baz",
+							Value: "bar",
 						},
 					},
 					Samples: []logproto.LegacySample{
@@ -175,24 +175,6 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
-							Name:  "fizz",
-							Value: "",
-						},
-					},
-					Samples: []logproto.LegacySample{
-						{
-							Value:       50,
-							TimestampMs: t1.UnixNano() / 1e6,
-						},
-						{
-							Value:       25,
-							TimestampMs: t2.UnixNano() / 1e6,
-						},
-					},
-				},
-				{
-					Labels: []push.LabelAdapter{
-						{
 							Name:  "foo",
 							Value: "",
 						},
@@ -204,6 +186,24 @@ func Test_toPrometheusResponse(t *testing.T) {
 						},
 						{
 							Value:       50,
+							TimestampMs: t2.UnixNano() / 1e6,
+						},
+					},
+				},
+				{
+					Labels: []push.LabelAdapter{
+						{
+							Name:  "fizz",
+							Value: "",
+						},
+					},
+					Samples: []logproto.LegacySample{
+						{
+							Value:       50,
+							TimestampMs: t1.UnixNano() / 1e6,
+						},
+						{
+							Value:       25,
 							TimestampMs: t2.UnixNano() / 1e6,
 						},
 					},
@@ -221,20 +221,6 @@ func Test_toPrometheusResponse(t *testing.T) {
 				{
 					Labels: []push.LabelAdapter{
 						{
-							Name:  "fizz",
-							Value: "",
-						},
-					},
-					Samples: []logproto.LegacySample{
-						{
-							Value:       50,
-							TimestampMs: t1.UnixNano() / 1e6,
-						},
-					},
-				},
-				{
-					Labels: []push.LabelAdapter{
-						{
 							Name:  "foo",
 							Value: "",
 						},
@@ -242,6 +228,20 @@ func Test_toPrometheusResponse(t *testing.T) {
 					Samples: []logproto.LegacySample{
 						{
 							Value:       100,
+							TimestampMs: t1.UnixNano() / 1e6,
+						},
+					},
+				},
+				{
+					Labels: []push.LabelAdapter{
+						{
+							Name:  "fizz",
+							Value: "",
+						},
+					},
+					Samples: []logproto.LegacySample{
+						{
+							Value:       50,
 							TimestampMs: t1.UnixNano() / 1e6,
 						},
 					},


### PR DESCRIPTION
To save some frontend work, this PR sorts all the log volumes by volume rather than name. For range queries, only the first value is used.