### PR TITLE
Add drone support for loki operator/v* tags

### DIFF
--- a/.drone/docker-manifest-operator.tmpl
+++ b/.drone/docker-manifest-operator.tmpl
@@ -1,0 +1,26 @@
+image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "operator/v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}
+tags:
+  - main
+{{#if build.tag}}
+  - latest
+{{/if}}
+{{#if build.tags}}
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "operator/v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "operator/v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  - image: grafana/{{config.target}}:{{#if build.tag}}{{trimPrefix "operator/v" build.tag}}{{else}}{{build.branch}}-{{substr 0 7 build.commit}}{{/if}}-arm
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -420,7 +420,7 @@ local manifest(apps) = pipeline('manifest') {
   ],
 };
 
-local manifest_operator(app) = pipeline('manifest') {
+local manifest_operator(app) = pipeline('manifest-operator') {
   steps: [{
     name: 'manifest-' + app,
     image: 'plugins/manifest:1.4.0',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -330,7 +330,9 @@ local lokioperator(arch) = pipeline('lokioperator-' + arch) + arch_image(arch) {
     // publish for tag or main
     docker_operator(arch, 'loki-operator') {
       depends_on: ['image-tag'],
-      when: onTagOrMain,
+      when: onTagOrMain {
+        ref: ['refs/heads/main', 'refs/tags/operator/v*'],
+      },
       settings+: {},
     },
   ],
@@ -417,6 +419,28 @@ local manifest(apps) = pipeline('manifest') {
     for arch in archs
   ],
 };
+
+local manifest_operator(app) = pipeline('manifest') {
+  steps: [{
+    name: 'manifest-' + app,
+    image: 'plugins/manifest:1.4.0',
+    settings: {
+      // the target parameter is abused for the app's name,
+      // as it is unused in spec mode. See docker-manifest-operator.tmpl
+      target: app,
+      spec: '.drone/docker-manifest-operator.tmpl',
+      ignore_missing: false,
+      username: { from_secret: docker_username_secret.name },
+      password: { from_secret: docker_password_secret.name },
+    },
+    depends_on: ['clone']
+  }],
+  depends_on: [
+    'lokioperator-%s' % arch
+    for arch in archs
+  ],
+};
+
 
 local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   steps: std.foldl(
@@ -658,8 +682,16 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   fluentd(),
   logstash(),
   querytee(),
-  manifest(['promtail', 'loki', 'loki-canary', 'loki-operator']) {
+  manifest(['promtail', 'loki', 'loki-canary']) {
     trigger+: onTagOrMain,
+  },
+  manifest_operator('loki-operator') {
+    trigger+: onTagOrMain {
+      ref: [
+        'refs/heads/main',
+        'refs/tags/operator/v*'
+      ],
+    },
   },
   pipeline('deploy') {
     local configFileName = 'updater-config.json',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -834,6 +834,9 @@ steps:
     event:
     - push
     - tag
+    ref:
+    - refs/heads/main
+    - refs/tags/operator/v*
 trigger:
   ref:
   - refs/heads/main
@@ -888,6 +891,9 @@ steps:
     event:
     - push
     - tag
+    ref:
+    - refs/heads/main
+    - refs/tags/operator/v*
 trigger:
   ref:
   - refs/heads/main
@@ -942,6 +948,9 @@ steps:
     event:
     - push
     - tag
+    ref:
+    - refs/heads/main
+    - refs/tags/operator/v*
 trigger:
   ref:
   - refs/heads/main
@@ -1209,19 +1218,6 @@ steps:
     target: loki-canary
     username:
       from_secret: docker_username
-- depends_on:
-  - clone
-  - manifest-loki-canary
-  image: plugins/manifest:1.4.0
-  name: manifest-loki-operator
-  settings:
-    ignore_missing: false
-    password:
-      from_secret: docker_password
-    spec: .drone/docker-manifest.tmpl
-    target: loki-operator
-    username:
-      from_secret: docker_username
 trigger:
   event:
   - push
@@ -1231,6 +1227,33 @@ trigger:
   - refs/heads/k???
   - refs/tags/v*
   - refs/pull/*/head
+---
+depends_on:
+- lokioperator-amd64
+- lokioperator-arm64
+- lokioperator-arm
+kind: pipeline
+name: manifest
+steps:
+- depends_on:
+  - clone
+  image: plugins/manifest:1.4.0
+  name: manifest-loki-operator
+  settings:
+    ignore_missing: false
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest-operator.tmpl
+    target: loki-operator
+    username:
+      from_secret: docker_username
+trigger:
+  event:
+  - push
+  - tag
+  ref:
+  - refs/heads/main
+  - refs/tags/operator/v*
 ---
 depends_on:
 - manifest

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1233,7 +1233,7 @@ depends_on:
 - lokioperator-arm64
 - lokioperator-arm
 kind: pipeline
-name: manifest
+name: manifest-operator
 steps:
 - depends_on:
   - clone


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to handle upcoming `operator/v*` tags for Loki Operator releases to start using tags instead of git refs. Starting with: 
- grafana/loki/pull/10050

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
