### PR TITLE
Loki: Tweak how we handle X-Query-Tags header

### DIFF
--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -335,13 +335,13 @@ func tagsToKeyValues(queryTags string) []interface{} {
 		if len(val) != 2 {
 			continue
 		}
-		vals = append(vals, val...)
+		vals = append(vals, strings.ToLower(val[0]), val[1])
 	}
 
 	res := make([]interface{}, 0, len(vals))
 
 	for _, val := range vals {
-		res = append(res, strings.ToLower(val))
+		res = append(res, val)
 	}
 
 	return res

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -160,12 +160,14 @@ func Test_testToKeyValues(t *testing.T) {
 		},
 		{
 			name: "canonical-form-multiple-values",
-			in:   "Source=logvolhist,Feature=beta",
+			in:   "Source=logvolhist,Feature=beta,User=Jinx@grafana.com",
 			exp: []interface{}{
 				"source",
 				"logvolhist",
 				"feature",
 				"beta",
+				"user",
+				"Jinx@grafana.com",
 			},
 		},
 		{

--- a/pkg/util/httpreq/tags.go
+++ b/pkg/util/httpreq/tags.go
@@ -16,7 +16,7 @@ type ctxKey string
 
 var (
 	QueryTagsHTTPHeader ctxKey = "X-Query-Tags"
-	safeQueryTags              = regexp.MustCompile("[^a-zA-Z0-9-=, ]+") // only alpha-numeric, ' ', ',', '=' and `-`
+	safeQueryTags              = regexp.MustCompile("[^a-zA-Z0-9-=.@, ]+") // only alpha-numeric, ' ', ',', '=', '@', '.' and `-`
 
 	QueryQueueTimeHTTPHeader ctxKey = "X-Query-Queue-Time"
 )
@@ -26,7 +26,7 @@ func ExtractQueryTagsMiddleware() middleware.Interface {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
 			tags := req.Header.Get(string(QueryTagsHTTPHeader))
-			tags = safeQueryTags.ReplaceAllString(tags, "")
+			tags = safeQueryTags.ReplaceAllString(tags, "_")
 
 			if tags != "" {
 				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)

--- a/pkg/util/httpreq/tags_test.go
+++ b/pkg/util/httpreq/tags_test.go
@@ -30,7 +30,12 @@ func TestQueryTags(t *testing.T) {
 		{
 			desc: "remove-invalid-chars",
 			in:   `Source=log+volhi\\st,Statate=be$ta`,
-			exp:  `Source=logvolhist,Statate=beta`,
+			exp:  `Source=log_volhi_st,Statate=be_ta`,
+		},
+		{
+			desc: "test invalid char set",
+			in:   `Source=abc.def@geh.com_test-test`,
+			exp:  `Source=abc.def@geh.com_test-test`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjust the regex for X-Query-Tags to allow @ and . so that email addresses can be displayed properly. 
Also changed the ToLower to only apply to the key not the value


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
