### PR TITLE
logcli: fix volume routes, add targetLabels and aggregateByLabels

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -641,6 +641,8 @@ func newVolumeQuery(rangeQuery bool, cmd *kingpin.CmdClause) *index.VolumeQuery 
 	cmd.Flag("to", "Stop looking for logs at this absolute time (exclusive)").StringVar(&to)
 
 	cmd.Flag("limit", "Limit on number of series to return volumes for.").Default("30").IntVar(&q.Limit)
+	cmd.Flag("targetLabels", "List of labels to aggregate results into.").StringsVar(&q.TargetLabels)
+	cmd.Flag("aggregateByLabels", "Whether to aggregate results by label name only.").BoolVar(&q.AggregateByLabels)
 
 	if rangeQuery {
 		cmd.Flag("step", "Query resolution step width, roll up volumes into buckets cover step time each.").Default("1h").DurationVar(&q.Step)

--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/logcli/query"
 	"github.com/grafana/loki/pkg/logcli/seriesquery"
+	"github.com/grafana/loki/pkg/logcli/volume"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	_ "github.com/grafana/loki/pkg/util/build"
 )
@@ -383,9 +384,9 @@ func main() {
 		}
 
 		if cmd == volumeRangeCmd.FullCommand() {
-			volumeRangeQuery.DoVolumeRange(queryClient, out, *statistics)
+			index.GetVolumeRange(volumeRangeQuery, queryClient, out, *statistics)
 		} else {
-			volumeQuery.DoVolume(queryClient, out, *statistics)
+			index.GetVolume(volumeQuery, queryClient, out, *statistics)
 		}
 	}
 }
@@ -615,12 +616,12 @@ func newStatsQuery(cmd *kingpin.CmdClause) *index.StatsQuery {
 	return q
 }
 
-func newVolumeQuery(rangeQuery bool, cmd *kingpin.CmdClause) *index.VolumeQuery {
+func newVolumeQuery(rangeQuery bool, cmd *kingpin.CmdClause) *volume.Query {
 	// calculate query range from cli params
 	var from, to string
 	var since time.Duration
 
-	q := &index.VolumeQuery{}
+	q := &volume.Query{}
 
 	// executed after all command flags are parsed
 	cmd.Action(func(_ *kingpin.ParseContext) error {

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/dskit/backoff"
 
+	"github.com/grafana/loki/pkg/logcli/volume"
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
@@ -51,8 +52,8 @@ type Client interface {
 	LiveTailQueryConn(queryStr string, delayFor time.Duration, limit int, start time.Time, quiet bool) (*websocket.Conn, error)
 	GetOrgID() string
 	GetStats(queryStr string, start, end time.Time, quiet bool) (*logproto.IndexStatsResponse, error)
-	GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error)
-	GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error)
+	GetVolume(query *volume.Query) (*loghttp.QueryResponse, error)
+	GetVolumeRange(query *volume.Query) (*loghttp.QueryResponse, error)
 }
 
 // Tripperware can wrap a roundtripper.
@@ -185,15 +186,19 @@ func (c *DefaultClient) GetStats(queryStr string, start, end time.Time, quiet bo
 	return &statsResponse, nil
 }
 
-func (c *DefaultClient) GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
-	return c.getVolume(volumePath, queryStr, start, end, step, limit, targetLabels, aggregateByLabels, quiet)
+func (c *DefaultClient) GetVolume(query *volume.Query) (*loghttp.QueryResponse, error) {
+	return c.getVolume(volumePath, query)
 }
 
-func (c *DefaultClient) GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
-	return c.getVolume(volumeRangePath, queryStr, start, end, step, limit, targetLabels, aggregateByLabels, quiet)
+func (c *DefaultClient) GetVolumeRange(query *volume.Query) (*loghttp.QueryResponse, error) {
+	return c.getVolume(volumeRangePath, query)
 }
 
-func (c *DefaultClient) getVolume(path string, queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
+func (c *DefaultClient) getVolume(path string, query *volume.Query) (*loghttp.QueryResponse, error) {
+	queryStr, start, end, limit, step, targetLabels, aggregateByLabels, quiet :=
+		query.QueryString, query.Start, query.End, query.Limit, query.Step,
+		query.TargetLabels, query.AggregateByLabels, query.Quiet
+
 	params := util.NewQueryStringBuilder()
 	params.SetInt("start", start.UnixNano())
 	params.SetInt("end", end.UnixNano())

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/util/build"
 )
@@ -33,8 +34,8 @@ const (
 	seriesPath        = "/loki/api/v1/series"
 	tailPath          = "/loki/api/v1/tail"
 	statsPath         = "/loki/api/v1/index/stats"
-	volumePath        = "/loki/api/v1/index/series_volume"
-	volumeRangePath   = "/loki/api/v1/index/series_volume_range"
+	volumePath        = "/loki/api/v1/index/volume"
+	volumeRangePath   = "/loki/api/v1/index/volume_range"
 	defaultAuthHeader = "Authorization"
 )
 
@@ -50,8 +51,8 @@ type Client interface {
 	LiveTailQueryConn(queryStr string, delayFor time.Duration, limit int, start time.Time, quiet bool) (*websocket.Conn, error)
 	GetOrgID() string
 	GetStats(queryStr string, start, end time.Time, quiet bool) (*logproto.IndexStatsResponse, error)
-	GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, quiet bool) (*loghttp.QueryResponse, error)
-	GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, quiet bool) (*loghttp.QueryResponse, error)
+	GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error)
+	GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error)
 }
 
 // Tripperware can wrap a roundtripper.
@@ -184,15 +185,15 @@ func (c *DefaultClient) GetStats(queryStr string, start, end time.Time, quiet bo
 	return &statsResponse, nil
 }
 
-func (c *DefaultClient) GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, quiet bool) (*loghttp.QueryResponse, error) {
-	return c.getVolume(volumePath, queryStr, start, end, step, limit, quiet)
+func (c *DefaultClient) GetVolume(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
+	return c.getVolume(volumePath, queryStr, start, end, step, limit, targetLabels, aggregateByLabels, quiet)
 }
 
-func (c *DefaultClient) GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, quiet bool) (*loghttp.QueryResponse, error) {
-	return c.getVolume(volumeRangePath, queryStr, start, end, step, limit, quiet)
+func (c *DefaultClient) GetVolumeRange(queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
+	return c.getVolume(volumeRangePath, queryStr, start, end, step, limit, targetLabels, aggregateByLabels, quiet)
 }
 
-func (c *DefaultClient) getVolume(path string, queryStr string, start, end time.Time, step time.Duration, limit int, quiet bool) (*loghttp.QueryResponse, error) {
+func (c *DefaultClient) getVolume(path string, queryStr string, start, end time.Time, step time.Duration, limit int, targetLabels []string, aggregateByLabels, quiet bool) (*loghttp.QueryResponse, error) {
 	params := util.NewQueryStringBuilder()
 	params.SetInt("start", start.UnixNano())
 	params.SetInt("end", end.UnixNano())
@@ -201,6 +202,14 @@ func (c *DefaultClient) getVolume(path string, queryStr string, start, end time.
 
 	if step != 0 {
 		params.SetString("step", fmt.Sprintf("%d", int(step.Seconds())))
+	}
+
+	if len(targetLabels) > 0 {
+		params.SetString("targetLabels", strings.Join(targetLabels, ","))
+	}
+
+	if aggregateByLabels {
+		params.SetString("aggregateBy", seriesvolume.Labels)
 	}
 
 	var resp loghttp.QueryResponse

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logcli/volume"
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
@@ -187,12 +188,12 @@ func (f *FileClient) GetStats(_ string, _, _ time.Time, _ bool) (*logproto.Index
 	return nil, ErrNotSupported
 }
 
-func (f *FileClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
+func (f *FileClient) GetVolume(_ *volume.Query) (*loghttp.QueryResponse, error) {
 	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }
 
-func (f *FileClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
+func (f *FileClient) GetVolumeRange(_ *volume.Query) (*loghttp.QueryResponse, error) {
 	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }

--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -187,12 +187,12 @@ func (f *FileClient) GetStats(_ string, _, _ time.Time, _ bool) (*logproto.Index
 	return nil, ErrNotSupported
 }
 
-func (f *FileClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ bool) (*loghttp.QueryResponse, error) {
+func (f *FileClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
 	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }
 
-func (f *FileClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ bool) (*loghttp.QueryResponse, error) {
+func (f *FileClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
 	// TODO(trevorwhitney): could we teach logcli to read from an actual index file?
 	return nil, ErrNotSupported
 }

--- a/pkg/logcli/index/volume.go
+++ b/pkg/logcli/index/volume.go
@@ -11,12 +11,14 @@ import (
 )
 
 type VolumeQuery struct {
-	QueryString string
-	Start       time.Time
-	End         time.Time
-	Step        time.Duration
-	Quiet       bool
-	Limit       int
+	QueryString       string
+	Start             time.Time
+	End               time.Time
+	Step              time.Duration
+	Quiet             bool
+	Limit             int
+	TargetLabels      []string
+	AggregateByLabels bool
 }
 
 // DoVolume executes a volume query and prints the results
@@ -45,9 +47,9 @@ func (q *VolumeQuery) volume(rangeQuery bool, c client.Client) *loghttp.QueryRes
 	var err error
 
 	if rangeQuery {
-		resp, err = c.GetVolumeRange(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.Quiet)
+		resp, err = c.GetVolumeRange(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.TargetLabels, q.AggregateByLabels, q.Quiet)
 	} else {
-		resp, err = c.GetVolume(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.Quiet)
+		resp, err = c.GetVolume(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.TargetLabels, q.AggregateByLabels, q.Quiet)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)

--- a/pkg/logcli/index/volume.go
+++ b/pkg/logcli/index/volume.go
@@ -2,35 +2,27 @@ package index
 
 import (
 	"log"
-	"time"
 
 	"github.com/grafana/loki/pkg/logcli/client"
 	"github.com/grafana/loki/pkg/logcli/output"
 	"github.com/grafana/loki/pkg/logcli/print"
+	"github.com/grafana/loki/pkg/logcli/volume"
 	"github.com/grafana/loki/pkg/loghttp"
 )
 
-type VolumeQuery struct {
-	QueryString       string
-	Start             time.Time
-	End               time.Time
-	Step              time.Duration
-	Quiet             bool
-	Limit             int
-	TargetLabels      []string
-	AggregateByLabels bool
+// GetVolume executes a volume query and prints the results
+func GetVolume(q *volume.Query, c client.Client, out output.LogOutput, statistics bool) {
+	do(q, false, c, out, statistics)
 }
 
-// DoVolume executes a volume query and prints the results
-func (q *VolumeQuery) DoVolume(c client.Client, out output.LogOutput, statistics bool) {
-	q.do(false, c, out, statistics)
-}
-func (q *VolumeQuery) DoVolumeRange(c client.Client, out output.LogOutput, statistics bool) {
-	q.do(true, c, out, statistics)
+// GetVolumeRange executes a volume query over a period of time and prints the results, which will
+// be a collection of data points over time.
+func GetVolumeRange(q *volume.Query, c client.Client, out output.LogOutput, statistics bool) {
+	do(q, true, c, out, statistics)
 }
 
-func (q *VolumeQuery) do(rangeQuery bool, c client.Client, out output.LogOutput, statistics bool) {
-	resp := q.volume(rangeQuery, c)
+func do(q *volume.Query, rangeQuery bool, c client.Client, out output.LogOutput, statistics bool) {
+	resp := getVolume(q, rangeQuery, c)
 
 	resultsPrinter := print.NewQueryResultPrinter(nil, nil, q.Quiet, 0, false)
 
@@ -41,15 +33,15 @@ func (q *VolumeQuery) do(rangeQuery bool, c client.Client, out output.LogOutput,
 	_, _ = resultsPrinter.PrintResult(resp.Data.Result, out, nil)
 }
 
-// volume returns a volume result
-func (q *VolumeQuery) volume(rangeQuery bool, c client.Client) *loghttp.QueryResponse {
+// getVolume returns a volume result
+func getVolume(q *volume.Query, rangeQuery bool, c client.Client) *loghttp.QueryResponse {
 	var resp *loghttp.QueryResponse
 	var err error
 
 	if rangeQuery {
-		resp, err = c.GetVolumeRange(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.TargetLabels, q.AggregateByLabels, q.Quiet)
+		resp, err = c.GetVolumeRange(q)
 	} else {
-		resp, err = c.GetVolume(q.QueryString, q.Start, q.End, q.Step, q.Limit, q.TargetLabels, q.AggregateByLabels, q.Quiet)
+		resp, err = c.GetVolume(q)
 	}
 	if err != nil {
 		log.Fatalf("Error doing request: %+v", err)

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/grafana/loki/pkg/logcli/output"
+	"github.com/grafana/loki/pkg/logcli/volume"
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
@@ -474,11 +475,11 @@ func (t *testQueryClient) GetStats(_ string, _, _ time.Time, _ bool) (*logproto.
 	panic("not implemented")
 }
 
-func (t *testQueryClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
+func (t *testQueryClient) GetVolume(_ *volume.Query) (*loghttp.QueryResponse, error) {
 	panic("not implemented")
 }
 
-func (t *testQueryClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
+func (t *testQueryClient) GetVolumeRange(_ *volume.Query) (*loghttp.QueryResponse, error) {
 	panic("not implemented")
 }
 

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -474,11 +474,11 @@ func (t *testQueryClient) GetStats(_ string, _, _ time.Time, _ bool) (*logproto.
 	panic("not implemented")
 }
 
-func (t *testQueryClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ bool) (*loghttp.QueryResponse, error) {
+func (t *testQueryClient) GetVolume(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
 	panic("not implemented")
 }
 
-func (t *testQueryClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ bool) (*loghttp.QueryResponse, error) {
+func (t *testQueryClient) GetVolumeRange(_ string, _, _ time.Time, _ time.Duration, _ int, _ []string, _, _ bool) (*loghttp.QueryResponse, error) {
 	panic("not implemented")
 }
 

--- a/pkg/logcli/volume/volume.go
+++ b/pkg/logcli/volume/volume.go
@@ -1,0 +1,14 @@
+package volume
+
+import "time"
+
+type Query struct {
+	QueryString       string
+	Start             time.Time
+	End               time.Time
+	Step              time.Duration
+	Quiet             bool
+	Limit             int
+	TargetLabels      []string
+	AggregateByLabels bool
+}


### PR DESCRIPTION
This PR fixes `logcli` to use the new endpoints for volume, which are now `volume` and `volume_range` instead of `series_volume` and `series_volume_range`. This PR also adds support for the additional parameters `targetLabels` and `aggregateBy`.
