### PR TITLE
Loki: add an expirmental l2 chunks cache

### DIFF
--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -128,7 +128,7 @@ func testChunkFetcher(t *testing.T, c cache.Cache, keys []string, chunks []chunk
 		},
 	}
 
-	fetcher, err := fetcher.New(c, false, s, nil, 10, 100)
+	fetcher, err := fetcher.New(c, nil, false, s, nil, 10, 100, 0)
 	require.NoError(t, err)
 	defer fetcher.Stop()
 

--- a/pkg/storage/chunk/cache/mock.go
+++ b/pkg/storage/chunk/cache/mock.go
@@ -10,6 +10,7 @@ import (
 type MockCache interface {
 	Cache
 	NumKeyUpdates() int
+	GetInternal() map[string][]byte
 }
 
 type mockCache struct {
@@ -52,6 +53,10 @@ func (m *mockCache) GetCacheType() stats.CacheType {
 
 func (m *mockCache) NumKeyUpdates() int {
 	return m.numKeyUpdates
+}
+
+func (m *mockCache) GetInternal() map[string][]byte {
+	return m.cache
 }
 
 // NewMockCache makes a new MockCache.

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -1,0 +1,207 @@
+package fetcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slices"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/pkg/storage/chunk/client/testutils"
+	"github.com/grafana/loki/pkg/storage/config"
+)
+
+func Test(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name       string
+		handoff    time.Duration
+		storeStart []chunk.Chunk
+		l1Start    []chunk.Chunk
+		l2Start    []chunk.Chunk
+		fetch      []chunk.Chunk
+		l1End      []chunk.Chunk
+		l2End      []chunk.Chunk
+	}{
+		{
+			name:       "all found in L1 cache",
+			handoff:    0,
+			storeStart: []chunk.Chunk{},
+			l1Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2Start:    []chunk.Chunk{},
+			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2End:      []chunk.Chunk{},
+		},
+		{
+			name:       "all found in L2 cache",
+			handoff:    1, // Only needs to be greater than zero so that we check L2 cache
+			storeStart: []chunk.Chunk{},
+			l1Start:    []chunk.Chunk{},
+			l2Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1End:      []chunk.Chunk{},
+			l2End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+		},
+		{
+			name:       "some in L1, some in L2",
+			handoff:    1, // Only needs to be greater than zero so that we check L2 cache
+			storeStart: []chunk.Chunk{},
+			l1Start:    []chunk.Chunk{},
+			l2Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1End:      []chunk.Chunk{},
+			l2End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+		},
+		{
+			name:       "writeback l1",
+			handoff:    24 * time.Hour,
+			storeStart: makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1Start:    []chunk.Chunk{},
+			l2Start:    []chunk.Chunk{},
+			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2End:      []chunk.Chunk{},
+		},
+		{
+			name:       "writeback l2",
+			handoff:    24 * time.Hour,
+			storeStart: makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:    []chunk.Chunk{},
+			l2Start:    []chunk.Chunk{},
+			fetch:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1End:      []chunk.Chunk{},
+			l2End:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c1 := cache.NewMockCache()
+			c2 := cache.NewMockCache()
+			s := testutils.NewMockStorage()
+			// Note this is copied from the schema config used in the MockStorage
+			sc := config.SchemaConfig{
+				Configs: []config.PeriodConfig{
+					{
+						From:      config.DayTime{Time: 0},
+						Schema:    "v11",
+						RowShards: 16,
+					},
+				},
+			}
+
+			// Prepare l1 cache
+			keys := make([]string, 0, len(test.l1Start))
+			chunks := make([][]byte, 0, len(test.l1Start))
+			for _, c := range test.l1Start {
+				// Encode first to set the checksum
+				b, err := c.Encoded()
+				assert.NoError(t, err)
+
+				k := sc.ExternalKey(c.ChunkRef)
+				keys = append(keys, k)
+				chunks = append(chunks, b)
+			}
+			assert.NoError(t, c1.Store(context.Background(), keys, chunks))
+
+			// Prepare l2 cache
+			keys = make([]string, 0, len(test.l2Start))
+			chunks = make([][]byte, 0, len(test.l2Start))
+			for _, c := range test.l2Start {
+				b, err := c.Encoded()
+				assert.NoError(t, err)
+
+				k := sc.ExternalKey(c.ChunkRef)
+				keys = append(keys, k)
+				chunks = append(chunks, b)
+			}
+			assert.NoError(t, c2.Store(context.Background(), keys, chunks))
+
+			// Prepare store
+			assert.NoError(t, s.PutChunks(context.Background(), test.storeStart))
+
+			// Build fetcher
+			f, err := New(c1, c2, true, sc, s, 1, 1, test.handoff)
+			assert.NoError(t, err)
+
+			// Generate keys from chunks
+			keys = make([]string, 0, len(test.fetch))
+			for _, f := range test.fetch {
+				k := sc.ExternalKey(f.ChunkRef)
+				keys = append(keys, k)
+			}
+
+			// Run the test
+			chks, err := f.FetchChunks(context.Background(), test.fetch, keys)
+			assert.NoError(t, err)
+			assertChunks(t, test.fetch, chks)
+			l1actual, err := makeChunksFromMap(c1.GetInternal())
+			assert.NoError(t, err)
+			assertChunks(t, test.l1End, l1actual)
+			l2actual, err := makeChunksFromMap(c2.GetInternal())
+			assert.NoError(t, err)
+			assertChunks(t, test.l2End, l2actual)
+		})
+	}
+}
+
+type c struct {
+	from, through time.Duration
+}
+
+func makeChunks(now time.Time, tpls ...c) []chunk.Chunk {
+	var chks []chunk.Chunk
+	for _, chk := range tpls {
+		c := chunk.Chunk{
+			ChunkRef: logproto.ChunkRef{
+				UserID:  "fake",
+				From:    model.TimeFromUnix(now.Add(-chk.from).UTC().Unix()),
+				Through: model.TimeFromUnix(now.Add(-chk.through).UTC().Unix()),
+			},
+		}
+		c.Metric = labels.Labels{}
+		// This isn't even the write format for Loki but we dont' care for the sake of these tests
+		c.Data = chunk.New()
+		// Encode to set the checksum
+		_ = c.Encode()
+		chks = append(chks, c)
+	}
+
+	return chks
+}
+
+func makeChunksFromMap(m map[string][]byte) ([]chunk.Chunk, error) {
+	chks := make([]chunk.Chunk, 0, len(m))
+	for k := range m {
+		c, err := chunk.ParseExternalKey("fake", k)
+		if err != nil {
+			return nil, err
+		}
+		chks = append(chks, c)
+	}
+
+	return chks, nil
+}
+
+func sortChunks(chks []chunk.Chunk) {
+	slices.SortFunc[chunk.Chunk](chks, func(i, j chunk.Chunk) bool {
+		return i.From.Before(j.From)
+	})
+}
+
+func assertChunks(t *testing.T, expected, actual []chunk.Chunk) {
+	sortChunks(expected)
+	sortChunks(actual)
+	assert.Eventually(t, func() bool {
+		return len(expected) == len(actual)
+	}, 2*time.Second, time.Millisecond*100, "expected %d chunks, got %d", len(expected), len(actual))
+	for i := range expected {
+		assert.Equal(t, expected[i].ChunkRef, actual[i].ChunkRef)
+	}
+}

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -79,6 +79,16 @@ func Test(t *testing.T) {
 			l1End:      []chunk.Chunk{},
 			l2End:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
 		},
+		{
+			name:       "writeback l1 and l2",
+			handoff:    24 * time.Hour,
+			storeStart: makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:    []chunk.Chunk{},
+			l2Start:    []chunk.Chunk{},
+			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2End:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/storage/config/store.go
+++ b/pkg/storage/config/store.go
@@ -14,10 +14,10 @@ import (
 
 type ChunkStoreConfig struct {
 	ChunkCacheConfig       cache.Config `yaml:"chunk_cache_config"`
-	ChunkCacheConfigL2     cache.Config `yaml:"chunk_cache_config_l2"`
+	ChunkCacheConfigL2     cache.Config `yaml:"chunk_cache_config_l2" doc:"hidden"`
 	WriteDedupeCacheConfig cache.Config `yaml:"write_dedupe_cache_config"`
 
-	L2ChunkCacheHandoff   time.Duration  `yaml:"l2_chunk_cache_handoff"`
+	L2ChunkCacheHandoff   time.Duration  `yaml:"l2_chunk_cache_handoff" doc:"hidden"`
 	CacheLookupsOlderThan model.Duration `yaml:"cache_lookups_older_than"`
 
 	// Not visible in yaml because the setting shouldn't be common between ingesters and queriers.
@@ -41,8 +41,8 @@ func (cfg *ChunkStoreConfig) ChunkCacheStubs() bool {
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *ChunkStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.ChunkCacheConfig.RegisterFlagsWithPrefix("store.chunks-cache.", "", f)
-	cfg.ChunkCacheConfigL2.RegisterFlagsWithPrefix("store.chunks-cache-l2.", "", f)
-	f.DurationVar(&cfg.L2ChunkCacheHandoff, "store.chunks-cache-l2.handoff", 0, "Chunks will be handed off to the L2 cache after this duration. 0 to disable L2 cache.")
+	cfg.ChunkCacheConfigL2.RegisterFlagsWithPrefix("experimental.store.chunks-cache-l2.", "", f)
+	f.DurationVar(&cfg.L2ChunkCacheHandoff, "experimental.store.chunks-cache-l2.handoff", 0, "Experimental, subject to change or removal. Chunks will be handed off to the L2 cache after this duration. 0 to disable L2 cache.")
 	f.BoolVar(&cfg.chunkCacheStubs, "store.chunks-cache.cache-stubs", false, "If true, don't write the full chunk to cache, just a stub entry.")
 	cfg.WriteDedupeCacheConfig.RegisterFlagsWithPrefix("store.index-cache-write.", "", f)
 

--- a/pkg/storage/config/store.go
+++ b/pkg/storage/config/store.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -13,8 +14,10 @@ import (
 
 type ChunkStoreConfig struct {
 	ChunkCacheConfig       cache.Config `yaml:"chunk_cache_config"`
+	ChunkCacheConfigL2     cache.Config `yaml:"chunk_cache_config_l2"`
 	WriteDedupeCacheConfig cache.Config `yaml:"write_dedupe_cache_config"`
 
+	L2ChunkCacheHandoff   time.Duration  `yaml:"l2_chunk_cache_handoff"`
 	CacheLookupsOlderThan model.Duration `yaml:"cache_lookups_older_than"`
 
 	// Not visible in yaml because the setting shouldn't be common between ingesters and queriers.
@@ -38,6 +41,8 @@ func (cfg *ChunkStoreConfig) ChunkCacheStubs() bool {
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *ChunkStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.ChunkCacheConfig.RegisterFlagsWithPrefix("store.chunks-cache.", "", f)
+	cfg.ChunkCacheConfigL2.RegisterFlagsWithPrefix("store.chunks-cache-l2.", "", f)
+	f.DurationVar(&cfg.L2ChunkCacheHandoff, "store.chunks-cache-l2.handoff", 0, "Chunks will be handed off to the L2 cache after this duration. 0 to disable L2 cache.")
 	f.BoolVar(&cfg.chunkCacheStubs, "store.chunks-cache.cache-stubs", false, "If true, don't write the full chunk to cache, just a stub entry.")
 	cfg.WriteDedupeCacheConfig.RegisterFlagsWithPrefix("store.index-cache-write.", "", f)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -67,6 +67,7 @@ type store struct {
 
 	indexReadCache   cache.Cache
 	chunksCache      cache.Cache
+	chunksCacheL2    cache.Cache
 	writeDedupeCache cache.Cache
 
 	limits StoreLimits
@@ -104,10 +105,19 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 		return nil, err
 	}
 
+	chunkCacheCfgL2 := storeCfg.ChunkCacheConfigL2
+	chunkCacheCfgL2.Prefix = "chunks_l2"
+	// TODO(E.Welch) would we want to disambiguate this cache in the stats? I think not but we'd need to change stats.ChunkCache to do so.
+	chunksCacheL2, err := cache.New(chunkCacheCfgL2, registerer, logger, stats.ChunkCache)
+	if err != nil {
+		return nil, err
+	}
+
 	// Cache is shared by multiple stores, which means they will try and Stop
 	// it more than once.  Wrap in a StopOnce to prevent this.
 	indexReadCache = cache.StopOnce(indexReadCache)
 	chunksCache = cache.StopOnce(chunksCache)
+	chunksCacheL2 = cache.StopOnce(chunksCacheL2)
 	writeDedupeCache = cache.StopOnce(writeDedupeCache)
 
 	// Lets wrap all caches except chunksCache with CacheGenMiddleware to facilitate cache invalidation using cache generation numbers.
@@ -136,6 +146,7 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 
 		indexReadCache:   indexReadCache,
 		chunksCache:      chunksCache,
+		chunksCacheL2:    chunksCacheL2,
 		writeDedupeCache: writeDedupeCache,
 
 		logger: logger,
@@ -154,7 +165,7 @@ func (s *store) init() error {
 		if err != nil {
 			return err
 		}
-		f, err := fetcher.New(s.chunksCache, s.storeCfg.ChunkCacheStubs(), s.schemaCfg, chunkClient, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackConcurrency, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackBufferSize)
+		f, err := fetcher.New(s.chunksCache, s.chunksCacheL2, s.storeCfg.ChunkCacheStubs(), s.schemaCfg, chunkClient, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackConcurrency, s.storeCfg.ChunkCacheConfig.AsyncCacheWriteBackBufferSize, s.storeCfg.L2ChunkCacheHandoff)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/series_store_write_test.go
+++ b/pkg/storage/stores/series_store_write_test.go
@@ -149,7 +149,7 @@ func TestChunkWriter_PutOne(t *testing.T) {
 			idx := &mockIndexWriter{}
 			client := &mockChunksClient{}
 
-			f, err := fetcher.New(cache, false, schemaConfig, client, 1, 1)
+			f, err := fetcher.New(cache, nil, false, schemaConfig, client, 1, 1, 0)
 			require.NoError(t, err)
 
 			cw := NewChunkWriter(f, schemaConfig, idx, true)

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -248,7 +248,7 @@ func (m *mockChunkStore) GetChunkRefs(_ context.Context, _ string, _, _ model.Ti
 		panic(err)
 	}
 
-	f, err := fetcher.New(cache, false, m.schemas, m.client, 10, 100)
+	f, err := fetcher.New(cache, nil, false, m.schemas, m.client, 10, 100, 0)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

As we play around with our caching strategies, there has surfaced a potential benefit to having 2 layers of chunks cache with a `duration from now` handoff.  i.e. chunks older than _x_ days get sent to an L2 chunks cache.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
