### PR TITLE
Fix docs script and recreate reference

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ include docs.mk
 PODMAN := $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 BUILD_IN_CONTAINER ?= true
 
-sources/installation/helm/reference.md: ../production/helm/loki/reference.md.gotmpl
+sources/setup/install/helm/reference.md: ../production/helm/loki/reference.md.gotmpl ../production/helm/loki/values.yaml
 ifeq ($(BUILD_IN_CONTAINER),true)
 	$(PODMAN) run --rm --volume "$(realpath ..):/helm-docs" -u "$$(id -u)" "docker.io/jnorwood/helm-docs:v1.11.0" \
 		-c /helm-docs/production/helm/ \

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2,9 +2,9 @@
 title: Helm Chart Values
 menuTitle: Helm chart values
 description: Reference for Helm Chart values.
-weight: 500
 aliases:
   - ../../../installation/helm/reference/
+weight: 500
 keywords: []
 ---
 
@@ -1496,6 +1496,15 @@ false
 			<td></td>
 			<td><pre lang="json">
 ""
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingress.labels</td>
+			<td>object</td>
+			<td></td>
+			<td><pre lang="json">
+{}
 </pre>
 </td>
 		</tr>


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes to the helm docs in PR https://github.com/grafana/loki/pull/9974 missed out a corresponding change needed in `docs/Makefile`. The reference.md file was also regenerated so it's up to date now.  

**Which issue(s) this PR fixes**:
Fixes #10069

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
