### PR TITLE
Remove recommendation for Tanak installation.

### DIFF
--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -8,8 +8,8 @@ weight: 200
 
 There are several methods of installing Loki and Promtail:
 
-- [Install using Tanka (recommended)]({{<relref "tanka">}})
-- [Install using Helm]({{<relref "helm">}})
+- [Install using Helm (recommended)]({{<relref "helm">}})
+- [Install using Tanka]({{<relref "tanka">}})
 - [Install through Docker or Docker Compose]({{<relref "docker">}})
 - [Install and run locally]({{<relref "local">}})
 - [Install from source]({{<relref "install-from-source">}})


### PR DESCRIPTION
Change the recommended installation path from Tanka to Helm in the current docs (this update has already been made in main/next).