### PR TITLE
Only aggregate labels or series based on requested

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -641,6 +641,8 @@ func (i *instance) GetVolume(ctx context.Context, req *logproto.VolumeRequest) (
 
 	from, through := req.From.Time(), req.Through.Time()
 	volumes := make(map[string]uint64)
+	aggregateBySeries := seriesvolume.AggregateBySeries(req.AggregateBy) || req.AggregateBy == ""
+
 	if err = i.forMatchingStreams(ctx, from, matchers, nil, func(s *stream) error {
 		// Consider streams which overlap our time range
 		if shouldConsiderStream(s, from, through) {
@@ -660,12 +662,20 @@ func (i *instance) GetVolume(ctx context.Context, req *logproto.VolumeRequest) (
 				}
 			}
 
-			seriesLabels = seriesLabels[:0]
-			labelVolumes := make(map[string]uint64, len(s.labels))
-			for _, l := range s.labels {
-				if _, ok := labelsToMatch[l.Name]; matchAny || ok {
-					seriesLabels = append(seriesLabels, l)
-					labelVolumes[l.Name] += size
+			var labelVolumes map[string]uint64
+			if aggregateBySeries {
+				seriesLabels = seriesLabels[:0]
+				for _, l := range s.labels {
+					if _, ok := labelsToMatch[l.Name]; matchAny || ok {
+						seriesLabels = append(seriesLabels, l)
+					}
+				}
+			} else {
+				labelVolumes = make(map[string]uint64, len(s.labels))
+				for _, l := range s.labels {
+					if _, ok := labelsToMatch[l.Name]; matchAny || ok {
+						labelVolumes[l.Name] += size
+					}
 				}
 			}
 
@@ -676,7 +686,7 @@ func (i *instance) GetVolume(ctx context.Context, req *logproto.VolumeRequest) (
 				seriesNames[hash] = seriesLabels.String()
 			}
 
-			if seriesvolume.AggregateBySeries(req.AggregateBy) || req.AggregateBy == "" {
+			if aggregateBySeries {
 				volumes[seriesNames[hash]] += size
 			} else {
 				for k, v := range labelVolumes {

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -352,6 +352,8 @@ func (i *TSDBIndex) Volume(
 	seriesNames := make(map[uint64]string)
 	seriesLabels := labels.Labels(make([]labels.Label, 0, len(labelsToMatch)))
 
+	aggregateBySeries := seriesvolume.AggregateBySeries(aggregateBy) || aggregateBy == ""
+
 	return i.forPostings(ctx, shard, from, through, matchers, func(p index.Postings) error {
 		var ls labels.Labels
 		var filterer chunk.Filterer
@@ -375,13 +377,21 @@ func (i *TSDBIndex) Volume(
 			}
 
 			if stats.Entries > 0 {
-				seriesLabels = seriesLabels[:0]
-				labelVolumes := make(map[string]uint64, len(ls))
+				var labelVolumes map[string]uint64
 
-				for _, l := range ls {
-					if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
-						seriesLabels = append(seriesLabels, l)
-						labelVolumes[l.Name] += stats.KB << 10
+				if aggregateBySeries {
+					seriesLabels = seriesLabels[:0]
+					for _, l := range ls {
+						if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
+							seriesLabels = append(seriesLabels, l)
+						}
+					}
+				} else {
+					labelVolumes = make(map[string]uint64, len(ls))
+					for _, l := range ls {
+						if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
+							labelVolumes[l.Name] += stats.KB << 10
+						}
 					}
 				}
 
@@ -392,7 +402,7 @@ func (i *TSDBIndex) Volume(
 					seriesNames[hash] = seriesLabels.String()
 				}
 
-				if seriesvolume.AggregateBySeries(aggregateBy) || aggregateBy == "" {
+				if aggregateBySeries {
 					if err = acc.AddVolume(seriesNames[hash], stats.KB<<10); err != nil {
 						return err
 					}


### PR DESCRIPTION
This improves the logic when calculating volumes by only aggregating series or labels based on which was requested. Previously we aggregated both, and then picked the correct set for the response, causing unnecessary additional memory consumption.
