### PR TITLE
drone: Fix manifest-operator pipeline waiting for deps

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -678,7 +678,15 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   )
   for arch in archs
 ] + [
-  lokioperator(arch)
+  lokioperator(arch) {
+    trigger+: {
+      ref: [
+        'refs/heads/main',
+        'refs/tags/operator/v*',
+        'refs/pull/*/head',
+      ],
+    },
+  }
   for arch in archs
 ] + [
   fluentbit(arch)

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -840,8 +840,7 @@ steps:
 trigger:
   ref:
   - refs/heads/main
-  - refs/heads/k???
-  - refs/tags/v*
+  - refs/tags/operator/v*
   - refs/pull/*/head
 ---
 depends_on:
@@ -897,8 +896,7 @@ steps:
 trigger:
   ref:
   - refs/heads/main
-  - refs/heads/k???
-  - refs/tags/v*
+  - refs/tags/operator/v*
   - refs/pull/*/head
 ---
 depends_on:
@@ -954,8 +952,7 @@ steps:
 trigger:
   ref:
   - refs/heads/main
-  - refs/heads/k???
-  - refs/tags/v*
+  - refs/tags/operator/v*
   - refs/pull/*/head
 ---
 depends_on:


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides a small fix for the drone CI pipeline `manifest-loki-operator` to wait until the corresponding docker images pipelines are built. Effectively adds the `refs/tags/operator/v*` trigger to the Loki Operator image pipelines.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
