### PR TITLE
Do not send back non-indexed labels for each entry in query response

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1591,9 +1591,10 @@ func (e *entryBufferedIterator) Next() bool {
 
 		e.stats.AddPostFilterLines(1)
 		e.currLabels = lbs
-		e.cur.NonIndexedLabels = logproto.FromLabelsToLabelAdapters(e.currNonIndexedLabels)
 		e.cur.Timestamp = time.Unix(0, e.currTs)
 		e.cur.Line = string(newLine)
+		// There is no need to send back the non-indexed labels, as they are already part of the labels results
+		// e.cur.NonIndexedLabels = logproto.FromLabelsToLabelAdapters(e.currNonIndexedLabels)
 		return true
 	}
 	return false

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -1765,6 +1765,10 @@ func TestMemChunk_IteratorWithNonIndexedLabels(t *testing.T) {
 								e := it.Entry()
 								lines = append(lines, e.Line)
 								streams = append(streams, it.Labels())
+
+								// We don't want to send back the non-indexed labels since
+								// they are already part of the returned labels.
+								require.Empty(t, e.NonIndexedLabels)
 							}
 							assert.ElementsMatch(t, tc.expectedLines, lines)
 							assert.ElementsMatch(t, tc.expectedStreams, streams)

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -279,9 +279,10 @@ func (hb *unorderedHeadBlock) Iterator(
 			}
 
 			stream.Entries = append(stream.Entries, logproto.Entry{
-				Timestamp:        time.Unix(0, ts),
-				Line:             newLine,
-				NonIndexedLabels: logproto.FromLabelsToLabelAdapters(hb.symbolizer.Lookup(nonIndexedLabelsSymbols)),
+				Timestamp: time.Unix(0, ts),
+				Line:      newLine,
+				// There is no need to send back the non-indexed labels, as they are already part of the labels results
+				// NonIndexedLabels: logproto.FromLabelsToLabelAdapters(hb.symbolizer.Lookup(nonIndexedLabelsSymbols)),
 			})
 			return nil
 		},

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -22,10 +22,10 @@ func iterEq(t *testing.T, exp []entry, got iter.EntryIterator) {
 	var i int
 	for got.Next() {
 		require.Equal(t, logproto.Entry{
-			Timestamp:        time.Unix(0, exp[i].t),
-			Line:             exp[i].s,
-			NonIndexedLabels: logproto.FromLabelsToLabelAdapters(exp[i].nonIndexedLabels),
+			Timestamp: time.Unix(0, exp[i].t),
+			Line:      exp[i].s,
 		}, got.Entry())
+		require.Equal(t, exp[i].nonIndexedLabels.String(), got.Labels())
 		i++
 	}
 	require.Equal(t, i, len(exp))


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the non-indexed labels are part of the returned labels results, we don't need to send them also along with each returned entry. This PR will:
-  Reduce the size of the response payload
- Solve a problem in Grafana only showing the last log line

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
