### PR TITLE
Extract reused logic to method

### DIFF
--- a/pkg/chunkenc/testdata/testdata.go
+++ b/pkg/chunkenc/testdata/testdata.go
@@ -1,6 +1,11 @@
 package testdata
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/loki/pkg/logproto"
+)
 
 // LogString returns a test log line. Returns the same line for the same index.
 func LogString(index int64) string {
@@ -10,12 +15,26 @@ func LogString(index int64) string {
 	return Logs[index]
 }
 
+const numNonIndexedLabels = 20
+
+var NonIndexedLables []logproto.LabelAdapter
+
 var LogsBytes [][]byte
 
 func init() {
 	LogsBytes = make([][]byte, len(Logs))
 	for i, l := range Logs {
 		LogsBytes[i] = []byte(l)
+	}
+
+	NonIndexedLables = make([]logproto.LabelAdapter, numNonIndexedLabels)
+	for i, _ := range NonIndexedLables {
+		labelsName := fmt.Sprintf("foo%d", i)
+		labelsValue := fmt.Sprintf("bar%d", i)
+		NonIndexedLables[i] = logproto.LabelAdapter{
+			Name:  labelsName,
+			Value: labelsValue,
+		}
 	}
 }
 

--- a/pkg/chunkenc/util_test.go
+++ b/pkg/chunkenc/util_test.go
@@ -23,14 +23,19 @@ func logprotoEntryWithNonIndexedLabels(ts int64, line string, nonIndexedLabels [
 	}
 }
 
-func generateData(enc Encoding, chunksCount, blockSize, targetSize int) ([]Chunk, uint64) {
+func generateData(chunkFmt byte, headFmt HeadBlockFmt, enc Encoding, chunksCount, blockSize, targetSize int, withNonIndexedLabels bool) ([]Chunk, uint64) {
 	chunks := []Chunk{}
 	i := int64(0)
 	size := uint64(0)
 
 	for n := 0; n < chunksCount; n++ {
-		entry := logprotoEntry(0, testdata.LogString(0))
-		c := NewMemChunk(enc, DefaultHeadBlockFmt, blockSize, targetSize)
+		var entry *logproto.Entry
+		if withNonIndexedLabels {
+			entry = logprotoEntryWithNonIndexedLabels(0, testdata.LogString(0), testdata.NonIndexedLables)
+		} else {
+			entry = logprotoEntry(0, testdata.LogString(0))
+		}
+		c := newMemChunkWithFormat(chunkFmt, enc, headFmt, blockSize, targetSize)
 		for c.SpaceFor(entry) {
 			size += uint64(len(entry.Line))
 			_ = c.Append(entry)


### PR DESCRIPTION
**What this PR does / why we need it**:
Improved the legibility of the `moveNext` method of the entry buffered iterator by extracting some logic to separate functions for better reuse of them.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
TODO:
- Becnhmark previous implementation against new one

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
