### PR TITLE
Logging improvements for volume requests

### DIFF
--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -319,20 +319,8 @@ func RecordVolumeQueryMetrics(
 		"total_entries", stats.Summary.TotalEntriesReturned,
 	)
 
-	sharded := strconv.FormatBool(false)
-	if stats.Summary.Shards > 1 {
-		sharded = strconv.FormatBool(true)
-	}
-	bytesPerSecond.WithLabelValues(status, queryType, "", latencyType, sharded).
-		Observe(float64(stats.Summary.BytesProcessedPerSecond))
 	execLatency.WithLabelValues(status, queryType, "").
 		Observe(stats.Summary.ExecTime)
-	chunkDownloadLatency.WithLabelValues(status, queryType, "").
-		Observe(stats.ChunksDownloadTime().Seconds())
-	duplicatesTotal.Add(float64(stats.TotalDuplicates()))
-	chunkDownloadedTotal.WithLabelValues(status, queryType, "").
-		Add(float64(stats.TotalChunksDownloaded()))
-	ingesterLineTotal.Add(float64(stats.Ingester.TotalLinesSent))
 }
 
 func recordUsageStats(queryType string, stats logql_stats.Result) {

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -331,7 +331,7 @@ func (r roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			"msg", "executing query",
 			"type", "volume",
 			"query", volumeQuery.Query,
-			"length", volumeQuery.Start.Sub(volumeQuery.End),
+			"length", volumeQuery.End.Sub(volumeQuery.Start),
 			"limit", volumeQuery.Limit,
 			"aggregate_by", volumeQuery.AggregateBy,
 		)

--- a/pkg/querier/queryrange/series_volume.go
+++ b/pkg/querier/queryrange/series_volume.go
@@ -90,6 +90,10 @@ func NewVolumeMiddleware() queryrangebase.Middleware {
 				}))
 			}
 
+			// Update middleware stats
+			queryStatsCtx := stats.FromContext(ctx)
+			queryStatsCtx.AddSplitQueries(int64(len(jobs)))
+
 			collector := make(chan *bucketedVolumeResponse, len(jobs))
 			err := concurrency.ForEachJob(
 				ctx,

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/grafana/loki/pkg/logproto"
 	"net"
 	"net/http"
 	"strconv"
@@ -32,6 +33,7 @@ const (
 	queryTypeMetric = "metric"
 	queryTypeSeries = "series"
 	queryTypeLabel  = "label"
+	queryTypeVolume = "volume"
 )
 
 var (
@@ -53,6 +55,8 @@ func recordQueryMetrics(data *queryData) {
 		logql.RecordLabelQueryMetrics(data.ctx, logger, data.params.Start(), data.params.End(), data.label, data.params.Query(), data.status, *data.statistics)
 	case queryTypeSeries:
 		logql.RecordSeriesQueryMetrics(data.ctx, logger, data.params.Start(), data.params.End(), data.match, data.status, *data.statistics)
+	case queryTypeVolume:
+		logql.RecordVolumeQueryMetrics(data.ctx, logger, data.params.Start(), data.params.End(), data.status, *data.statistics)
 	default:
 		level.Error(logger).Log("msg", "failed to record query metrics", "err", fmt.Errorf("expected one of the *LokiRequest, *LokiInstantRequest, *LokiSeriesRequest, *LokiLabelNamesRequest, got %s", data.queryType))
 	}
@@ -136,7 +140,11 @@ func StatsCollectorMiddleware() queryrangebase.Middleware {
 					if r.Response != nil {
 						totalEntries = len(r.Response.Data.Result)
 					}
+
 					queryType = queryTypeMetric
+					if _, ok := req.(*logproto.VolumeRequest); ok {
+						queryType = queryTypeVolume
+					}
 				case *LokiSeriesResponse:
 					responseStats = &r.Statistics // TODO: this is always nil. See codec.DecodeResponse
 					totalEntries = len(r.Data)

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/grafana/loki/pkg/logproto"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"


### PR DESCRIPTION
I noticed we were logging volume requests as metric requests in `metrics.go`. This PR logs volume requests on their own with relevant data.
