### PR TITLE
Sharding optimizations

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -205,8 +205,11 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 	}
 
 	switch expr.Operation {
-	case syntax.OpTypeSum:
+
+	case syntax.OpTypeSum, syntax.OpTypeMin, syntax.OpTypeMax:
 		// sum(x) -> sum(sum(x, shard=1) ++ sum(x, shard=2)...)
+		// max(x) -> max(max(x, shard=1) ++ max(x, shard=2)...)
+		// min(x) -> min(min(x, shard=1) ++ min(x, shard=2)...)
 		sharded, bytesPerShard, err := m.mapSampleExpr(expr, r)
 		if err != nil {
 			return nil, 0, err

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -354,7 +354,7 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		// so we explicitly set the wrapping vector aggregation to this
 		// for parity when it's not explicitly set
 		grouping := expr.Grouping
-		if grouping == nil || grouping.IsZero() {
+		if grouping == nil {
 			grouping = &syntax.Grouping{Without: true}
 		}
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -320,6 +320,14 @@ func TestMappingStrings(t *testing.T) {
 			)`,
 		},
 		{
+			in: `max_over_time({foo="ugh"} | unwrap baz [1m]) by ()`,
+			out: `max(
+				downstream<max_over_time({foo="ugh"}|unwrapbaz[1m])by(),shard=0_of_2>
+				++
+				downstream<max_over_time({foo="ugh"}|unwrapbaz[1m])by(),shard=1_of_2>
+			)`,
+		},
+		{
 			in:  `avg(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]))`,
 			out: `avg(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]))`,
 		},

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -197,6 +197,12 @@ func TestMappingStrings(t *testing.T) {
 			out: `count(rate({foo="bar"} | json | label_format foo=bar [5m]))`,
 		},
 		{
+			in: `sum without () (rate({job="foo"}[5m]))`,
+			out: `sumwithout()(
+				downstream<sumwithout()(rate({job="foo"}[5m])),shard=0_of_2>++downstream<sumwithout()(rate({job="foo"}[5m])),shard=1_of_2>
+			)`,
+		},
+		{
 			in: `{foo="bar"} |= "id=123"`,
 			out: `downstream<{foo="bar"}|="id=123", shard=0_of_2>
 					++ downstream<{foo="bar"}|="id=123", shard=1_of_2>`,

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1237,7 +1237,7 @@ type Grouping struct {
 func (g Grouping) String() string {
 	var sb strings.Builder
 
-	if g.Groups == nil {
+	if len(g.Groups) == 0 && !g.Without {
 		return ""
 	}
 

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -705,13 +705,13 @@ func TestGroupingString(t *testing.T) {
 		Groups:  []string{},
 		Without: false,
 	}
-	require.Equal(t, "", g.String())
+	require.Equal(t, " by ()", g.String())
 
 	g = Grouping{
 		Groups:  nil,
 		Without: false,
 	}
-	require.Equal(t, "", g.String())
+	require.Equal(t, " by ()", g.String())
 
 	g = Grouping{
 		Groups:  []string{"a", "b"},

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -705,7 +705,7 @@ func TestGroupingString(t *testing.T) {
 		Groups:  []string{},
 		Without: false,
 	}
-	require.Equal(t, " by ()", g.String())
+	require.Equal(t, "", g.String())
 
 	g = Grouping{
 		Groups:  nil,
@@ -729,5 +729,5 @@ func TestGroupingString(t *testing.T) {
 		Groups:  nil,
 		Without: true,
 	}
-	require.Equal(t, "", g.String())
+	require.Equal(t, " without ()", g.String())
 }

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -208,7 +208,7 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 		},
 		{
 			desc:                     "Non shardable query too big",
-			query:                    `sum_over_time({app="foo"} |= "foo" | unwrap foo [1h])`,
+			query:                    `avg_over_time({job="foo"} | json busy="utilization" | unwrap busy [5m])`,
 			maxQuerierBytesSize:      10,
 			err:                      fmt.Sprintf(limErrQuerierTooManyBytesUnshardableTmpl, "100 B", "10 B"),
 			expectedStatsHandlerHits: 1,


### PR DESCRIPTION
A few bugfixes and more sharding optimizations
* fix bug on `<aggr> by|without ()` groupings which removed the grouping while downstreaming
* shardable implementations for `max+min`, operation specific merge strategies which enable many more types of sharded requests, even when label-reduction is performed at edge.