### PR TITLE
Ruler: compare header with `strings.EqualFold`

### DIFF
--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -202,7 +202,7 @@ func (r *walRegistry) getTenantConfig(tenant string) (instance.Config, error) {
 
 			// ensure that no variation of the X-Scope-OrgId header can be added, which might trick authentication
 			for k := range clt.Headers {
-				if strings.ToLower(user.OrgIDHeaderName) == strings.ToLower(strings.TrimSpace(k)) {
+				if strings.EqualFold(user.OrgIDHeaderName, strings.TrimSpace(k)) {
 					delete(clt.Headers, k)
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Resubmit of PR https://github.com/grafana/loki/pull/10098 (https://github.com/grafana/loki/pull/10098#issuecomment-1657051336)

/cc @dannykopping 

> provided the PR comes with a test to ensure no regression

The existing tests in `pkg/ruler/registry_test.go` already cover this change. However, if they are insufficient, I am more than willing to add additional tests.

https://github.com/grafana/loki/blob/77b04b796350616c7c22994a1b6950774b5621c3/pkg/ruler/registry_test.go#L171-L179

https://github.com/grafana/loki/blob/77b04b796350616c7c22994a1b6950774b5621c3/pkg/ruler/registry_test.go#L599-L652

Original PR description:

> Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.
> 
> Sample benchmark:
> 
> ```go
> func BenchmarkToLower(b *testing.B) {
> 	for i := 0; i < b.N; i++ {
> 		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
> 			b.Fail()
> 		}
> 	}
> }
> 
> func BenchmarkEqualFold(b *testing.B) {
> 	for i := 0; i < b.N; i++ {
> 		if !strings.EqualFold("FOOBAR", "foobar") {
> 			b.Fail()
> 		}
> 	}
> }
> ```
> 
> Result:
> 
> ```
> goos: linux
> goarch: amd64
> pkg: github.com/grafana/loki/pkg/ruler
> cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
> BenchmarkToLower-16      	20712434	        90.97 ns/op	       8 B/op	       1 allocs/op
> BenchmarkEqualFold-16    	142683400	         7.857 ns/op	       0 B/op	       0 allocs/op
> PASS
> ok  	github.com/grafana/loki/pkg/ruler	3.612s
> ```

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
