### PR TITLE
operator: Drop OCP 4.10 & 4.11 support in community-openshift bundle

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -24,7 +24,7 @@ LOKI_OPERATOR_NS ?= kubernetes-operators
 VERSION ?= 0.4.0
 CHANNELS ?= "alpha"
 DEFAULT_CHANNEL ?= "alpha"
-SUPPORTED_OCP_VERSIONS="v4.10"
+SUPPORTED_OCP_VERSIONS="v4.12"
 
 # REGISTRY_BASE
 # defines the container registry and organization for the bundle and operator container images.


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on #9457 we need to set the minimum required OCP version to 4.12 for the community OpenShift bundle releases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
