### PR TITLE
operator: Fix replication factor for 1x-extra-small size

### DIFF
--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -284,7 +284,7 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 	lokiv1.SizeOneXExtraSmall: {
 		Size: lokiv1.SizeOneXExtraSmall,
 		Replication: &lokiv1.ReplicationSpec{
-			Factor: 1,
+			Factor: 2,
 		},
 		Limits: &lokiv1.LimitsSpec{
 			Global: &lokiv1.LimitsTemplateSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the replication factor for the 1x-extra-small T-shirt size.
It should be 2 not 1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
