### PR TITLE
[GEL jsonnet] fixed PDB creation

### DIFF
--- a/production/ksonnet/loki/common.libsonnet
+++ b/production/ksonnet/loki/common.libsonnet
@@ -51,8 +51,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     local podDisruptionBudget = $.policy.v1.podDisruptionBudget;
     local pdbName = '%s-pdb' % deploymentName;
 
-    podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName(pdbName) +
+    podDisruptionBudget.new(pdbName) +
     podDisruptionBudget.mixin.metadata.withLabels({ name: pdbName }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: deploymentName }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(maxUnavailable),

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -85,8 +85,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local podDisruptionBudget = k.policy.v1.podDisruptionBudget,
 
   ingester_pdb:
-    podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName('loki-ingester-pdb') +
+    podDisruptionBudget.new('loki-ingester-pdb') +
     podDisruptionBudget.mixin.metadata.withLabels({ name: 'loki-ingester-pdb' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: name }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),


### PR DESCRIPTION
removed redundant pdb name override because the constructor of `podDisruptionBudget` requires the name to be defined during object creation.

Re: https://github.com/grafana/loki/pull/9978/files