### PR TITLE
fix(dependabot): Combine approve and enable auto-merge into one step

### DIFF
--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -24,15 +24,12 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      # According to the doc, this just "enables" auto-merge. Meaning PR will be merged **only** if all the checks are passed.
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
+          # According to the doc, this just "enables" auto-merge. Meaning PR will be merged **only** if all the checks are passed.
+      - name: Approve and Enable auto-merge
+        run: |
+          gh pr merge --auto --squash "$PR_URL"
+          gh pr review $PR_URL \
+          --approve -b "Auto approve dependencies bump PR"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the "dependabot_reviewer" Github Action workflow.

This should fix the issues we having when trying to enable "auto-merge" for example
https://github.com/grafana/loki/actions/runs/5680113173/job/15393583446?pr=10080

I have tested this using another repository
example.
https://github.com/kavirajk/dependabot-play/pull/7

With workflow change.
https://github.com/kavirajk/dependabot-play/blob/main/.github/workflows/dependabot_reviewer.yml#L27-L35

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
