### PR TITLE
operator: Remove `v` prefix from openshift bundle version refs

### DIFF
--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2023-07-27T16:51:28Z"
+    createdAt: "2023-08-02T07:55:26Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2023-07-27T16:51:26Z"
+    createdAt: "2023-08-02T07:55:24Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -5,11 +5,11 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-controller-manager-metrics-service
 spec:
   ports:

--- a/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -62,9 +62,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-manager-config

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,11 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
     name: loki-operator
   name: loki-operator-metrics-monitor
 spec:

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,11 +3,11 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-prometheus
 rules:
 - apiGroups:

--- a/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/openshift/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-webhook-service
 spec:
   ports:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -149,8 +149,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-07-27T16:51:31Z"
+    containerImage: quay.io/openshift-logging/loki-operator:0.1.0
+    createdAt: "2023-08-02T07:55:28Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1601,11 +1601,11 @@ spec:
         serviceAccountName: default
       deployments:
       - label:
-          app.kubernetes.io/instance: loki-operator-v0.0.1
+          app.kubernetes.io/instance: loki-operator-0.1.0
           app.kubernetes.io/managed-by: operator-lifecycle-manager
           app.kubernetes.io/name: loki-operator
           app.kubernetes.io/part-of: cluster-logging
-          app.kubernetes.io/version: 0.0.1
+          app.kubernetes.io/version: 0.1.0
           control-plane: controller-manager
         name: loki-operator-controller-manager
         spec:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_alertingrules.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_alertingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: alertingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: lokistacks.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_recordingrules.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_recordingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: recordingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: rulerconfigs.loki.grafana.com
 spec:
   conversion:

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
+    containerImage: quay.io/openshift-logging/loki-operator:0.1.0
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -22,8 +22,8 @@ labels:
     app.kubernetes.io/managed-by: operator-lifecycle-manager
   includeSelectors: true
 - pairs:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/instance: loki-operator-0.1.0
+    app.kubernetes.io/version: "0.1.0"
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -45,4 +45,4 @@ patchesStrategicMerge:
 images:
 - name: controller
   newName: quay.io/openshift-logging/loki-operator
-  newTag: v0.0.1
+  newTag: 0.1.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the obsolete `v` prefix from any version references (e.g. labels, annotations) to simplify downstream build scripts.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
