### PR TITLE
chore(CODEOWNERS): Add dependabot as codeowners for dependencies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,8 @@
 
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md
+
+# Make dependabot as codeowners for specific files to auto-merge dependencies PRs
+go.mod @dependabot @grafana/loki-team
+go.sum @dependabot @grafana/loki-team
+/vendor @dependabot @grafana/loki-team


### PR DESCRIPTION
**What this PR does / why we need it**:
Add dependabot as codeowner for dependencies related files (`go.mod`, `go.sum` and `/vendor`)

This is needed because, we have branch protection rule (for `main` branch) with "Required review of code owners" as one of the checks
**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:
Follow up to #10126 

NOTE: Github linter may show "@dependabot is unknown and may not have write permission for the repo" But that's fine. I tested it on my personal repository.

example: Before having it as CODEOWNERS.
https://github.com/kavirajk/dependabot-play/pull/10 (GH action waited for another user from CODOWNER to review before merging)

example: After adding it to CODEOWNERS
https://github.com/kavirajk/dependabot-play/pull/13 (GH action merged the PR because approve from dependabot is good enough as it's code owner for `go.mod`related files)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
