### PR TITLE
chore(dependabot): Change event type to `pull_request`.

### DIFF
--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
 
 name: Auto-review Dependabot PRs
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write


### PR DESCRIPTION

**What this PR does / why we need it**:
We are still facing permission error in enabling auto-merge for dependabot PRs example: https://github.com/grafana/loki/actions/runs/5737803871/job/15550129786?pr=10138

After discussing it with internal security team, they asked to try changing the event type from `pull_request_target` -> `pull_request`.

Personally, I suspect this would make any difference, given It worked with `pull_request_target` when testing it with my personal repo.
https://github.com/kavirajk/dependabot-play/blob/main/.github/workflows/dependabot_reviewer.yml#L5

Auto-merged PR.
https://github.com/kavirajk/dependabot-play/pull/15

But still wanted to test this.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
