### PR TITLE
chore(dependabot): Remove enable auto-merge

### DIFF
--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -24,10 +24,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-          # According to the doc, this just "enables" auto-merge. Meaning PR will be merged **only** if all the checks are passed.
-      - name: Approve and Enable auto-merge
+      - name: Approve the dependabot PR
         run: |
-          gh pr merge --auto --squash "$PR_URL"
           gh pr review $PR_URL \
           --approve -b "Auto approve dependencies bump PR"
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
After some debugging and discussing with internal security squad, the core problem for the this permission issue with auto-merge is
```
GraphQL: ["Pull request User is not authorized for this protected branch"] (enablePullRequestAutoMerge)
```

The settings "Restrict who can push it to protected branch" rule we have `main` branch.

And currently no way to add `github-action` user to this list (there is an open discussion https://github.com/orgs/community/discussions/25305

I proposed an idea to use some "real" user's (even grafana-bot) token to do the "auto-merge". But that is still under review by security squad.

Meanwhile, to unblock merging any dependabot PR, I'm removing this step.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Related to #10126 #10141 #10144 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
