### PR TITLE
Loki: simplify the FetchChunks method and optimize the experimental l2 cache a little more

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"sort"
 	"sync"
 	"time"
 
@@ -330,28 +329,20 @@ func (m *chunkMover) moveChunks(ctx context.Context, threadID int, syncRangeCh <
 					chunks := schemaGroups[i][j:k]
 					//log.Printf("%v Processing chunks %v-%v of %v\n", threadID, j, k, len(schemaGroups[i]))
 
-					keys := make([]string, 0, len(chunks))
 					chks := make([]chunk.Chunk, 0, len(chunks))
 
-					// FetchChunks requires chunks to be ordered by external key.
-					sort.Slice(chunks, func(x, y int) bool {
-						return m.schema.ExternalKey(chunks[x].ChunkRef) < m.schema.ExternalKey(chunks[y].ChunkRef)
-					})
 					for _, chk := range chunks {
-						key := m.schema.ExternalKey(chk.ChunkRef)
-						keys = append(keys, key)
 						chks = append(chks, chk)
 					}
-					finalChks, err := f.FetchChunks(m.ctx, chks, keys)
+					finalChks, err := f.FetchChunks(m.ctx, chks)
 					if err != nil {
 						log.Println(threadID, "Error retrieving chunks, will go through them one by one:", err)
 						finalChks = make([]chunk.Chunk, 0, len(chunks))
 						for i := range chks {
 							onechunk := []chunk.Chunk{chunks[i]}
-							onekey := []string{keys[i]}
 							var retry int
 							for retry = 4; retry >= 0; retry-- {
-								onechunk, err = f.FetchChunks(m.ctx, onechunk, onekey)
+								onechunk, err = f.FetchChunks(m.ctx, onechunk)
 								if err != nil {
 									if retry == 0 {
 										log.Println(threadID, "Final error retrieving chunks, giving up:", err)

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -331,9 +331,8 @@ func (m *chunkMover) moveChunks(ctx context.Context, threadID int, syncRangeCh <
 
 					chks := make([]chunk.Chunk, 0, len(chunks))
 
-					for _, chk := range chunks {
-						chks = append(chks, chk)
-					}
+					chks = append(chks, chunks...)
+
 					finalChks, err := f.FetchChunks(m.ctx, chks)
 					if err != nil {
 						log.Println(threadID, "Error retrieving chunks, will go through them one by one:", err)

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -705,17 +705,13 @@ func fetchLazyChunks(ctx context.Context, s config.SchemaConfig, chunks []*LazyC
 			chks := make([]chunk.Chunk, 0, len(chunks))
 			index := make(map[string]*LazyChunk, len(chunks))
 
-			// FetchChunks requires chunks to be ordered by external key.
-			sort.Slice(chunks, func(i, j int) bool {
-				return s.ExternalKey(chunks[i].Chunk.ChunkRef) < s.ExternalKey(chunks[j].Chunk.ChunkRef)
-			})
 			for _, chk := range chunks {
 				key := s.ExternalKey(chk.Chunk.ChunkRef)
 				keys = append(keys, key)
 				chks = append(chks, chk.Chunk)
 				index[key] = chk
 			}
-			chks, err := fetcher.FetchChunks(ctx, chks, keys)
+			chks, err := fetcher.FetchChunks(ctx, chks)
 			if ctx.Err() != nil {
 				errChan <- nil
 				return

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -701,13 +701,11 @@ func fetchLazyChunks(ctx context.Context, s config.SchemaConfig, chunks []*LazyC
 	errChan := make(chan error)
 	for f, chunks := range chksByFetcher {
 		go func(fetcher *fetcher.Fetcher, chunks []*LazyChunk) {
-			keys := make([]string, 0, len(chunks))
 			chks := make([]chunk.Chunk, 0, len(chunks))
 			index := make(map[string]*LazyChunk, len(chunks))
 
 			for _, chk := range chunks {
 				key := s.ExternalKey(chk.Chunk.ChunkRef)
-				keys = append(keys, key)
 				chks = append(chks, chk.Chunk)
 				index[key] = chk
 			}

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -117,7 +117,7 @@ func testCacheMultiple(t *testing.T, cache cache.Cache, keys []string, chunks []
 	require.Equal(t, chunks, result)
 }
 
-func testChunkFetcher(t *testing.T, c cache.Cache, keys []string, chunks []chunk.Chunk) {
+func testChunkFetcher(t *testing.T, c cache.Cache, chunks []chunk.Chunk) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
@@ -132,7 +132,7 @@ func testChunkFetcher(t *testing.T, c cache.Cache, keys []string, chunks []chunk
 	require.NoError(t, err)
 	defer fetcher.Stop()
 
-	found, err := fetcher.FetchChunks(context.Background(), chunks, keys)
+	found, err := fetcher.FetchChunks(context.Background(), chunks)
 	require.NoError(t, err)
 	sort.Sort(byExternalKey{found, s})
 	sort.Sort(byExternalKey{chunks, s})
@@ -181,7 +181,7 @@ func testCache(t *testing.T, cache cache.Cache) {
 		testCacheMiss(t, cache)
 	})
 	t.Run("Fetcher", func(t *testing.T) {
-		testChunkFetcher(t, cache, keys, chunks)
+		testChunkFetcher(t, cache, chunks)
 	})
 }
 

--- a/pkg/storage/chunk/cache/mock.go
+++ b/pkg/storage/chunk/cache/mock.go
@@ -11,10 +11,12 @@ type MockCache interface {
 	Cache
 	NumKeyUpdates() int
 	GetInternal() map[string][]byte
+	KeysRequested() int
 }
 
 type mockCache struct {
 	numKeyUpdates int
+	keysRequested int
 	sync.Mutex
 	cache map[string][]byte
 }
@@ -33,6 +35,7 @@ func (m *mockCache) Fetch(_ context.Context, keys []string) (found []string, buf
 	m.Lock()
 	defer m.Unlock()
 	for _, key := range keys {
+		m.keysRequested++
 		buf, ok := m.cache[key]
 		if ok {
 			found = append(found, key)
@@ -57,6 +60,10 @@ func (m *mockCache) NumKeyUpdates() int {
 
 func (m *mockCache) GetInternal() map[string][]byte {
 	return m.cache
+}
+
+func (m *mockCache) KeysRequested() int {
+	return m.keysRequested
 }
 
 // NewMockCache makes a new MockCache.

--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -219,11 +219,6 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 		chunkFetchedSize.WithLabelValues("cache").Observe(float64(len(buf)))
 	}
 
-	//fromCache, missing, err := c.processCacheResponse(ctx, chunks, cacheHits, cacheBufs)
-	//if err != nil {
-	//	level.Warn(log).Log("msg", "error process response from cache", "err", err)
-	//}
-
 	if c.l2CacheHandoff > 0 {
 		// Fetch missing from L2 chunks cache
 		missingL1Keys := make([]string, 0, len(l2OnlyChunks))
@@ -247,11 +242,6 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 
 		cacheHits = append(cacheHits, cacheHitsL2...)
 		cacheBufs = append(cacheBufs, cacheBufsL2...)
-
-		//fromCacheL2, missing, err = c.processCacheResponse(ctx, chunks, cacheHitsL2, cacheBufsL2)
-		//if err != nil {
-		//	level.Warn(log).Log("msg", "error process response from cache", "err", err)
-		//}
 	}
 
 	// processCacheResponse expects all the keys to be sorted lexographically

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -2,6 +2,7 @@ package fetcher
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -195,7 +196,7 @@ func Test(t *testing.T) {
 			assert.NoError(t, s.PutChunks(context.Background(), test.storeStart))
 
 			// Build fetcher
-			f, err := New(c1, c2, true, sc, s, 1, 1, test.handoff)
+			f, err := New(c1, c2, false, sc, s, 1, 1, test.handoff)
 			assert.NoError(t, err)
 
 			// Run the test
@@ -214,6 +215,101 @@ func Test(t *testing.T) {
 	}
 }
 
+func BenchmarkFetch(b *testing.B) {
+	now := time.Now()
+
+	numchunks := 100
+	l1Start := make([]chunk.Chunk, 0, numchunks/3)
+	for i := 0; i < numchunks/3; i++ {
+		l1Start = append(l1Start, makeChunks(now, c{time.Duration(i) * time.Hour, time.Duration(i+1) * time.Hour})...)
+	}
+	l2Start := make([]chunk.Chunk, 0, numchunks/3)
+	for i := numchunks/3 + 1000; i < (numchunks/3)+numchunks/3+1000; i++ {
+		l2Start = append(l2Start, makeChunks(now, c{time.Duration(i) * time.Hour, time.Duration(i+1) * time.Hour})...)
+	}
+	storeStart := make([]chunk.Chunk, 0, numchunks/3)
+	for i := numchunks/3 + 10000; i < (numchunks/3)+numchunks/3+10000; i++ {
+		storeStart = append(storeStart, makeChunks(now, c{time.Duration(i) * time.Hour, time.Duration(i+1) * time.Hour})...)
+	}
+	fetch := make([]chunk.Chunk, 0, numchunks)
+	fetch = append(fetch, l1Start...)
+	fetch = append(fetch, l2Start...)
+	fetch = append(fetch, storeStart...)
+
+	test := struct {
+		name            string
+		handoff         time.Duration
+		storeStart      []chunk.Chunk
+		l1Start         []chunk.Chunk
+		l2Start         []chunk.Chunk
+		fetch           []chunk.Chunk
+		l1KeysRequested int
+		l1End           []chunk.Chunk
+		l2KeysRequested int
+		l2End           []chunk.Chunk
+	}{
+		name:       "some in L1, some in L2",
+		handoff:    time.Duration(numchunks/3+100) * time.Hour,
+		storeStart: storeStart,
+		l1Start:    l1Start,
+		l2Start:    l2Start,
+		fetch:      fetch,
+	}
+
+	c1 := cache.NewMockCache()
+	c2 := cache.NewMockCache()
+	s := testutils.NewMockStorage()
+	// Note this is copied from the schema config used in the MockStorage
+	sc := config.SchemaConfig{
+		Configs: []config.PeriodConfig{
+			{
+				From:      config.DayTime{Time: 0},
+				Schema:    "v11",
+				RowShards: 16,
+			},
+		},
+	}
+
+	// Prepare l1 cache
+	keys := make([]string, 0, len(test.l1Start))
+	chunks := make([][]byte, 0, len(test.l1Start))
+	for _, c := range test.l1Start {
+		// Encode first to set the checksum
+		b, _ := c.Encoded()
+
+		k := sc.ExternalKey(c.ChunkRef)
+		keys = append(keys, k)
+		chunks = append(chunks, b)
+	}
+	_ = c1.Store(context.Background(), keys, chunks)
+
+	// Prepare l2 cache
+	keys = make([]string, 0, len(test.l2Start))
+	chunks = make([][]byte, 0, len(test.l2Start))
+	for _, c := range test.l2Start {
+		b, _ := c.Encoded()
+
+		k := sc.ExternalKey(c.ChunkRef)
+		keys = append(keys, k)
+		chunks = append(chunks, b)
+	}
+	_ = c2.Store(context.Background(), keys, chunks)
+
+	// Prepare store
+	_ = s.PutChunks(context.Background(), test.storeStart)
+
+	// Build fetcher
+	f, _ := New(c1, c2, false, sc, s, 1, 1, test.handoff)
+
+	for i := 0; i < b.N; i++ {
+		_, err := f.FetchChunks(context.Background(), test.fetch)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+}
+
 type c struct {
 	from, through time.Duration
 }
@@ -228,9 +324,18 @@ func makeChunks(now time.Time, tpls ...c) []chunk.Chunk {
 				Through: model.TimeFromUnix(now.Add(-chk.through).UTC().Unix()),
 			},
 		}
-		c.Metric = labels.Labels{}
-		// This isn't even the write format for Loki but we dont' care for the sake of these tests
+		from := int(chk.from) / int(time.Hour)
+		// This is only here because it's helpful for debugging.
+		c.Metric = labels.Labels{labels.Label{"start", strconv.Itoa(from)}}
+		// This isn't even the write format for Loki but we dont' care for the sake of these tests.
 		c.Data = chunk.New()
+		// To make sure the fetcher doesn't swap keys and buffers each chunk is built with different, but deterministic data
+		for i := 0; i < from; i++ {
+			c.Data.Add(model.SamplePair{
+				Timestamp: model.TimeFromUnix(int64(i)),
+				Value:     model.SampleValue(from),
+			})
+		}
 		// Encode to set the checksum
 		_ = c.Encode()
 		chks = append(chks, c)
@@ -259,11 +364,11 @@ func sortChunks(chks []chunk.Chunk) {
 }
 
 func assertChunks(t *testing.T, expected, actual []chunk.Chunk) {
-	sortChunks(expected)
-	sortChunks(actual)
 	assert.Eventually(t, func() bool {
 		return len(expected) == len(actual)
 	}, 2*time.Second, time.Millisecond*100, "expected %d chunks, got %d", len(expected), len(actual))
+	sortChunks(expected)
+	sortChunks(actual)
 	for i := range expected {
 		assert.Equal(t, expected[i].ChunkRef, actual[i].ChunkRef)
 	}

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -326,12 +326,12 @@ func makeChunks(now time.Time, tpls ...c) []chunk.Chunk {
 		}
 		from := int(chk.from) / int(time.Hour)
 		// This is only here because it's helpful for debugging.
-		c.Metric = labels.Labels{labels.Label{"start", strconv.Itoa(from)}}
+		c.Metric = labels.Labels{labels.Label{Name: "start", Value: strconv.Itoa(from)}}
 		// This isn't even the write format for Loki but we dont' care for the sake of these tests.
 		c.Data = chunk.New()
 		// To make sure the fetcher doesn't swap keys and buffers each chunk is built with different, but deterministic data
 		for i := 0; i < from; i++ {
-			c.Data.Add(model.SamplePair{
+			_, _ = c.Data.Add(model.SamplePair{
 				Timestamp: model.TimeFromUnix(int64(i)),
 				Value:     model.SampleValue(from),
 			})

--- a/pkg/storage/chunk/fetcher/fetcher_test.go
+++ b/pkg/storage/chunk/fetcher/fetcher_test.go
@@ -20,74 +20,132 @@ import (
 func Test(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
-		name       string
-		handoff    time.Duration
-		storeStart []chunk.Chunk
-		l1Start    []chunk.Chunk
-		l2Start    []chunk.Chunk
-		fetch      []chunk.Chunk
-		l1End      []chunk.Chunk
-		l2End      []chunk.Chunk
+		name            string
+		handoff         time.Duration
+		storeStart      []chunk.Chunk
+		l1Start         []chunk.Chunk
+		l2Start         []chunk.Chunk
+		fetch           []chunk.Chunk
+		l1KeysRequested int
+		l1End           []chunk.Chunk
+		l2KeysRequested int
+		l2End           []chunk.Chunk
 	}{
 		{
-			name:       "all found in L1 cache",
-			handoff:    0,
-			storeStart: []chunk.Chunk{},
-			l1Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l2Start:    []chunk.Chunk{},
-			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l2End:      []chunk.Chunk{},
+			name:            "all found in L1 cache",
+			handoff:         0,
+			storeStart:      []chunk.Chunk{},
+			l1Start:         makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2End:           []chunk.Chunk{},
 		},
 		{
-			name:       "all found in L2 cache",
-			handoff:    1, // Only needs to be greater than zero so that we check L2 cache
-			storeStart: []chunk.Chunk{},
-			l1Start:    []chunk.Chunk{},
-			l2Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l1End:      []chunk.Chunk{},
-			l2End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			name:            "all found in L2 cache",
+			handoff:         1, // Only needs to be greater than zero so that we check L2 cache
+			storeStart:      []chunk.Chunk{},
+			l1Start:         []chunk.Chunk{},
+			l2Start:         makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1End:           []chunk.Chunk{},
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
 		},
 		{
-			name:       "some in L1, some in L2",
-			handoff:    1, // Only needs to be greater than zero so that we check L2 cache
-			storeStart: []chunk.Chunk{},
-			l1Start:    []chunk.Chunk{},
-			l2Start:    makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l1End:      []chunk.Chunk{},
-			l2End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			name:            "some in L1, some in L2",
+			handoff:         5 * time.Hour,
+			storeStart:      []chunk.Chunk{},
+			l1Start:         makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2Start:         makeChunks(now, c{7 * time.Hour, 8 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{7 * time.Hour, 8 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{7 * time.Hour, 8 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
 		},
 		{
-			name:       "writeback l1",
-			handoff:    24 * time.Hour,
-			storeStart: makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l1Start:    []chunk.Chunk{},
-			l2Start:    []chunk.Chunk{},
-			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l2End:      []chunk.Chunk{},
+			name:            "some in L1, some in L2, some in store",
+			handoff:         5 * time.Hour,
+			storeStart:      makeChunks(now, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
+			l1Start:         makeChunks(now, c{time.Hour, 2 * time.Hour}),
+			l2Start:         makeChunks(now, c{7 * time.Hour, 8 * time.Hour}),
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{7 * time.Hour, 8 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{7 * time.Hour, 8 * time.Hour}, c{8 * time.Hour, 9 * time.Hour}, c{9 * time.Hour, 10 * time.Hour}),
 		},
 		{
-			name:       "writeback l2",
-			handoff:    24 * time.Hour,
-			storeStart: makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
-			l1Start:    []chunk.Chunk{},
-			l2Start:    []chunk.Chunk{},
-			fetch:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
-			l1End:      []chunk.Chunk{},
-			l2End:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			name:            "writeback l1",
+			handoff:         24 * time.Hour,
+			storeStart:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1Start:         []chunk.Chunk{},
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2End:           []chunk.Chunk{},
 		},
 		{
-			name:       "writeback l1 and l2",
-			handoff:    24 * time.Hour,
-			storeStart: makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
-			l1Start:    []chunk.Chunk{},
-			l2Start:    []chunk.Chunk{},
-			fetch:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
-			l1End:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
-			l2End:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			name:            "writeback l2",
+			handoff:         24 * time.Hour,
+			storeStart:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:         []chunk.Chunk{},
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1End:           []chunk.Chunk{},
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+		},
+		{
+			name:            "writeback l1 and l2",
+			handoff:         24 * time.Hour,
+			storeStart:      makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:         []chunk.Chunk{},
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+		},
+		{
+			name:            "verify l1 skip optimization",
+			handoff:         24 * time.Hour,
+			storeStart:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:         []chunk.Chunk{},
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1KeysRequested: 0,
+			l1End:           []chunk.Chunk{},
+			l2KeysRequested: 3,
+			l2End:           makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+		},
+		{
+			name:            "verify l1 skip optimization plus extended",
+			handoff:         20 * time.Hour, // 20 hours, 10% extension should be 22 hours
+			storeStart:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:         makeChunks(now, c{20 * time.Hour, 21 * time.Hour}, c{21 * time.Hour, 22 * time.Hour}, c{22 * time.Hour, 23 * time.Hour}),
+			l2Start:         makeChunks(now, c{21 * time.Hour, 22 * time.Hour}, c{22 * time.Hour, 23 * time.Hour}),
+			fetch:           makeChunks(now, c{20 * time.Hour, 21 * time.Hour}, c{21 * time.Hour, 22 * time.Hour}, c{22 * time.Hour, 23 * time.Hour}),
+			l1KeysRequested: 2,
+			l1End:           makeChunks(now, c{20 * time.Hour, 21 * time.Hour}, c{21 * time.Hour, 22 * time.Hour}, c{22 * time.Hour, 23 * time.Hour}),
+			l2KeysRequested: 1, // We won't look for the extended handoff key in L2, so only one lookup should go to L2
+			l2End:           makeChunks(now, c{21 * time.Hour, 22 * time.Hour}, c{22 * time.Hour, 23 * time.Hour}),
+		},
+		{
+			name:            "verify l2 skip optimization",
+			handoff:         24 * time.Hour,
+			storeStart:      makeChunks(now, c{31 * time.Hour, 32 * time.Hour}, c{32 * time.Hour, 33 * time.Hour}, c{33 * time.Hour, 34 * time.Hour}),
+			l1Start:         makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2Start:         []chunk.Chunk{},
+			fetch:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l1KeysRequested: 3,
+			l1End:           makeChunks(now, c{time.Hour, 2 * time.Hour}, c{2 * time.Hour, 3 * time.Hour}, c{3 * time.Hour, 4 * time.Hour}),
+			l2KeysRequested: 0,
+			l2End:           []chunk.Chunk{},
 		},
 	}
 	for _, test := range tests {
@@ -140,22 +198,17 @@ func Test(t *testing.T) {
 			f, err := New(c1, c2, true, sc, s, 1, 1, test.handoff)
 			assert.NoError(t, err)
 
-			// Generate keys from chunks
-			keys = make([]string, 0, len(test.fetch))
-			for _, f := range test.fetch {
-				k := sc.ExternalKey(f.ChunkRef)
-				keys = append(keys, k)
-			}
-
 			// Run the test
-			chks, err := f.FetchChunks(context.Background(), test.fetch, keys)
+			chks, err := f.FetchChunks(context.Background(), test.fetch)
 			assert.NoError(t, err)
 			assertChunks(t, test.fetch, chks)
 			l1actual, err := makeChunksFromMap(c1.GetInternal())
 			assert.NoError(t, err)
+			assert.Equal(t, test.l1KeysRequested, c1.KeysRequested())
 			assertChunks(t, test.l1End, l1actual)
 			l2actual, err := makeChunksFromMap(c2.GetInternal())
 			assert.NoError(t, err)
+			assert.Equal(t, test.l2KeysRequested, c2.KeysRequested())
 			assertChunks(t, test.l2End, l2actual)
 		})
 	}

--- a/pkg/storage/stores/series/series_index_store.go
+++ b/pkg/storage/stores/series/series_index_store.go
@@ -197,16 +197,17 @@ func (c *indexReaderWriter) SetChunkFilterer(f chunk.RequestChunkFilterer) {
 }
 
 type chunkGroup struct {
+	schema config.SchemaConfig
 	chunks []chunk.Chunk
-	keys   []string
 }
 
 func (c chunkGroup) Len() int { return len(c.chunks) }
 func (c chunkGroup) Swap(i, j int) {
 	c.chunks[i], c.chunks[j] = c.chunks[j], c.chunks[i]
-	c.keys[i], c.keys[j] = c.keys[j], c.keys[i]
 }
-func (c chunkGroup) Less(i, j int) bool { return c.keys[i] < c.keys[j] }
+func (c chunkGroup) Less(i, j int) bool {
+	return c.schema.ExternalKey(c.chunks[i].ChunkRef) < c.schema.ExternalKey(c.chunks[j].ChunkRef)
+}
 
 func (c *indexReaderWriter) GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
 	chks, err := c.GetChunkRefs(ctx, userID, from, through, matchers...)
@@ -220,7 +221,7 @@ func (c *indexReaderWriter) GetSeries(ctx context.Context, userID string, from, 
 func (c *indexReaderWriter) chunksToSeries(ctx context.Context, in []logproto.ChunkRef, matchers []*labels.Matcher) ([]labels.Labels, error) {
 	// download one per series and merge
 	// group chunks by series
-	chunksBySeries, keys := filterChunkRefsByUniqueFingerprint(c.schemaCfg, in)
+	chunksBySeries := filterChunkRefsByUniqueFingerprint(in)
 
 	// bound concurrency
 	groups := make([]chunkGroup, 0, len(chunksBySeries)/c.chunkBatchSize+1)
@@ -236,9 +237,8 @@ func (c *indexReaderWriter) chunksToSeries(ctx context.Context, in []logproto.Ch
 	}
 
 	for split > 0 {
-		groups = append(groups, chunkGroup{chunksBySeries[:split], keys[:split]})
+		groups = append(groups, chunkGroup{c.schemaCfg, chunksBySeries[:split]})
 		chunksBySeries = chunksBySeries[split:]
-		keys = keys[split:]
 		if len(chunksBySeries) < split {
 			split = len(chunksBySeries)
 		}
@@ -251,7 +251,7 @@ func (c *indexReaderWriter) chunksToSeries(ctx context.Context, in []logproto.Ch
 		group := g
 		jobs = append(jobs, f(func() ([]labels.Labels, error) {
 			sort.Sort(group)
-			chunks, err := c.fetcher.FetchChunks(ctx, group.chunks, group.keys)
+			chunks, err := c.fetcher.FetchChunks(ctx, group.chunks)
 			if err != nil {
 				return nil, err
 			}
@@ -683,13 +683,13 @@ func (c *indexReaderWriter) lookupLabelNamesByChunks(ctx context.Context, from, 
 
 	// Filter out chunks that are not in the selected time range and keep a single chunk per fingerprint
 	filtered := filterChunksByTime(from, through, chunks)
-	filtered, keys := filterChunksByUniqueFingerprint(c.schemaCfg, filtered)
+	filtered = filterChunksByUniqueFingerprint(filtered)
 	level.Debug(log).Log("Chunks post filtering", len(chunks))
 
 	chunksPerQuery.Observe(float64(len(filtered)))
 
 	// Now fetch the actual chunk data from Memcache / S3
-	allChunks, err := c.fetcher.FetchChunks(ctx, filtered, keys)
+	allChunks, err := c.fetcher.FetchChunks(ctx, filtered)
 	if err != nil {
 		level.Error(log).Log("msg", "FetchChunks", "err", err)
 		return nil, err

--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 	"time"
 
@@ -373,7 +372,7 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 		for _, storeCase := range stores {
 			storeCfg := storeCase.configFn()
 
-			store, schemaCfg := newTestChunkStoreConfig(t, schema, storeCfg)
+			store, _ := newTestChunkStoreConfig(t, schema, storeCfg)
 			defer store.Stop()
 
 			if err := store.Put(ctx, []chunk.Chunk{chunk1, chunk2}); err != nil {
@@ -393,15 +392,7 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 					fetchedChunk := []chunk.Chunk{}
 					for _, f := range fetchers {
 						for _, cs := range chunks {
-							keys := make([]string, 0, len(cs))
-							sort.Slice(chunks, func(i, j int) bool {
-								return schemaCfg.ExternalKey(cs[i].ChunkRef) < schemaCfg.ExternalKey(cs[j].ChunkRef)
-							})
-
-							for _, c := range cs {
-								keys = append(keys, schemaCfg.ExternalKey(c.ChunkRef))
-							}
-							cks, err := f.FetchChunks(ctx, cs, keys)
+							cks, err := f.FetchChunks(ctx, cs)
 							if err != nil {
 								t.Fatal(err)
 							}

--- a/pkg/storage/stores/series/series_store_utils.go
+++ b/pkg/storage/stores/series/series_store_utils.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/util"
 )
 
@@ -48,9 +47,8 @@ func labelNamesFromChunks(chunks []chunk.Chunk) []string {
 	return result.Strings()
 }
 
-func filterChunksByUniqueFingerprint(s config.SchemaConfig, chunks []chunk.Chunk) ([]chunk.Chunk, []string) {
+func filterChunksByUniqueFingerprint(chunks []chunk.Chunk) []chunk.Chunk {
 	filtered := make([]chunk.Chunk, 0, len(chunks))
-	keys := make([]string, 0, len(chunks))
 	uniqueFp := map[model.Fingerprint]struct{}{}
 
 	for _, chunk := range chunks {
@@ -58,15 +56,13 @@ func filterChunksByUniqueFingerprint(s config.SchemaConfig, chunks []chunk.Chunk
 			continue
 		}
 		filtered = append(filtered, chunk)
-		keys = append(keys, s.ExternalKey(chunk.ChunkRef))
 		uniqueFp[chunk.FingerprintModel()] = struct{}{}
 	}
-	return filtered, keys
+	return filtered
 }
 
-func filterChunkRefsByUniqueFingerprint(s config.SchemaConfig, chunks []logproto.ChunkRef) ([]chunk.Chunk, []string) {
+func filterChunkRefsByUniqueFingerprint(chunks []logproto.ChunkRef) []chunk.Chunk {
 	filtered := make([]chunk.Chunk, 0, len(chunks))
-	keys := make([]string, 0, len(chunks))
 	uniqueFp := map[model.Fingerprint]struct{}{}
 
 	for _, c := range chunks {
@@ -76,10 +72,9 @@ func filterChunkRefsByUniqueFingerprint(s config.SchemaConfig, chunks []logproto
 		filtered = append(filtered, chunk.Chunk{
 			ChunkRef: c,
 		})
-		keys = append(keys, s.ExternalKey(c))
 		uniqueFp[c.FingerprintModel()] = struct{}{}
 	}
-	return filtered, keys
+	return filtered
 }
 
 func uniqueStrings(cs []string) []string {

--- a/pkg/storage/stores/shipper/index/compactor/util_test.go
+++ b/pkg/storage/stores/shipper/index/compactor/util_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 	"time"
 
@@ -174,15 +173,7 @@ func (t *testStore) GetChunks(userID string, from, through model.Time, metric la
 	fetchedChunk := []chunk.Chunk{}
 	for _, f := range fetchers {
 		for _, cs := range chunks {
-			keys := make([]string, 0, len(cs))
-			sort.Slice(chunks, func(i, j int) bool {
-				return schemaCfg.ExternalKey(cs[i].ChunkRef) < schemaCfg.ExternalKey(cs[j].ChunkRef)
-			})
-
-			for _, c := range cs {
-				keys = append(keys, schemaCfg.ExternalKey(c.ChunkRef))
-			}
-			cks, err := f.FetchChunks(ctx, cs, keys)
+			cks, err := f.FetchChunks(ctx, cs)
 			if err != nil {
 				t.t.Fatal(err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This started as a simple PR to optimize the new L2 chunks cache code such that we don't look up chunks in L1 that we know won't be there, however, the complexity of the FetchChunks method taking both a slice of requested Chunks as well as a slice of requested Keys made this really challenging.

Looking at how we use this method, I saw no reason for there to be a requirement to pass both a list of chunks and keys, we only ever want the Chunks and everywhere we used this we were generating the list of keys external to this function from the list of chunks being passed in.

The second change was to the implementation of how we process the cache results to look for found vs missing keys.  The current implementation required the chunks to be sorted by external key so that it could iterate through them, I tested out a different version of this which uses a map instead of sorting and iterating.

The map performance was slightly better in terms of reduced allocations, not enough to make a meaningful difference, but I think this code is easier to understand and reason about, and it removes any requirement for sorting of the passed in Chunks by External key.

Benchmarks:

Previous:
```
100 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32           3445            334642 ns/op          478074 B/op       7536 allocs/op
BenchmarkFetch-32           2947            344439 ns/op          478534 B/op       7537 allocs/op
BenchmarkFetch-32           3489            339239 ns/op          478092 B/op       7536 allocs/op
BenchmarkFetch-32           3523            340550 ns/op          478003 B/op       7536 allocs/op
BenchmarkFetch-32           2935            346810 ns/op          478590 B/op       7537 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       23.948s

1000 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32            363           3225519 ns/op         5305481 B/op      78133 allocs/op
BenchmarkFetch-32            358           3308456 ns/op         5308299 B/op      78143 allocs/op
BenchmarkFetch-32            336           3379067 ns/op         5322534 B/op      78191 allocs/op
BenchmarkFetch-32            357           3330118 ns/op         5308854 B/op      78145 allocs/op
BenchmarkFetch-32            349           3390415 ns/op         5313813 B/op      78162 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       25.607s

10,000 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32              3         334471200 ns/op        639282104 B/op   2630192 allocs/op
BenchmarkFetch-32              2         503434741 ns/op        922833480 B/op   3412973 allocs/op
BenchmarkFetch-32              1        1064668769 ns/op        1771502096 B/op  5741173 allocs/op
BenchmarkFetch-32              1        1027755910 ns/op        1771419128 B/op  5749049 allocs/op
BenchmarkFetch-32              1        1027270578 ns/op        1774711872 B/op  5752726 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       23.251s
```

Now
```
100 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32           3856            300569 ns/op          462932 B/op       6214 allocs/op
BenchmarkFetch-32           4016            305387 ns/op          462803 B/op       6214 allocs/op
BenchmarkFetch-32           3382            303078 ns/op          463201 B/op       6215 allocs/op
BenchmarkFetch-32           3319            303367 ns/op          463308 B/op       6215 allocs/op
BenchmarkFetch-32           3289            356986 ns/op          463341 B/op       6215 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       22.879s

10,000 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32            393           2641470 ns/op         5193282 B/op      65956 allocs/op
BenchmarkFetch-32            433           2684287 ns/op         5174832 B/op      65894 allocs/op
BenchmarkFetch-32            427           2778092 ns/op         5177334 B/op      65902 allocs/op
BenchmarkFetch-32            418           2714370 ns/op         5181193 B/op      65915 allocs/op
BenchmarkFetch-32            415           2822163 ns/op         5183436 B/op      65920 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       25.053s

10,000 chunks
❯ go test -bench=Fetch -count=5
goos: linuxbench=Fetch -count=5                                                                                                                                                                                                                                                         ─╯
goarch: amd64
pkg: github.com/grafana/loki/pkg/storage/chunk/fetcher
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkFetch-32              3         362233430 ns/op        638097202 B/op   2510070 allocs/op
BenchmarkFetch-32              2         611639304 ns/op        921128060 B/op   3292828 allocs/op
BenchmarkFetch-32              1        1022180867 ns/op        1770465496 B/op  5621431 allocs/op
BenchmarkFetch-32              1        1253448115 ns/op        1771278456 B/op  5630224 allocs/op
BenchmarkFetch-32              1        1189564672 ns/op        1774053064 B/op  5628113 allocs/op
PASS
ok      github.com/grafana/loki/pkg/storage/chunk/fetcher       23.960s
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
