### PR TITLE
chore(CODEOWNERS): Remove dependabot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,8 +6,3 @@
 
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md
-
-# Make dependabot as codeowners for specific files to auto-merge dependencies PRs
-go.mod @dependabot @grafana/loki-team
-go.sum @dependabot @grafana/loki-team
-/vendor @dependabot @grafana/loki-team


### PR DESCRIPTION
**What this PR does / why we need it**:
This is not needed as
(1) Adding it on codeowners have no impact for dependabot 
(2) CODEOWNER linter errors complanining about dependabot not existing and don't have write access to the repo

<img width="619" alt="Screenshot 2023-08-04 at 10 00 44" src="https://github.com/grafana/loki/assets/3735252/ad6b190d-27cf-4fd9-b05e-d076b0e4c62f">


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
