### PR TITLE
helm: use tpl for ingress hosts

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1094,7 +1094,7 @@ false
 		<tr>
 			<td>gateway.ingress.hosts</td>
 			<td>list</td>
-			<td>Hosts configuration for the gateway ingress</td>
+			<td>Hosts configuration for the gateway ingress. Host property will be passed through `tpl`.</td>
 			<td><pre lang="json">
 [
   {
@@ -1130,7 +1130,7 @@ false
 		<tr>
 			<td>gateway.ingress.tls</td>
 			<td>list</td>
-			<td>TLS configuration for the gateway ingress</td>
+			<td>TLS configuration for the gateway ingress. Hosts property will be passed through `tpl`.</td>
 			<td><pre lang="json">
 [
   {

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1094,7 +1094,7 @@ false
 		<tr>
 			<td>gateway.ingress.hosts</td>
 			<td>list</td>
-			<td>Hosts configuration for the gateway ingress. Host property will be passed through `tpl`.</td>
+			<td>ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function</td>
 			<td><pre lang="json">
 [
   {
@@ -1130,7 +1130,7 @@ false
 		<tr>
 			<td>gateway.ingress.tls</td>
 			<td>list</td>
-			<td>TLS configuration for the gateway ingress. Hosts property will be passed through `tpl`.</td>
+			<td>ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function</td>
 			<td><pre lang="json">
 [
   {

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1094,7 +1094,7 @@ false
 		<tr>
 			<td>gateway.ingress.hosts</td>
 			<td>list</td>
-			<td>ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function</td>
+			<td>Hosts configuration for the gateway ingress, passed through the `tpl` function to allow templating</td>
 			<td><pre lang="json">
 [
   {
@@ -1130,7 +1130,7 @@ false
 		<tr>
 			<td>gateway.ingress.tls</td>
 			<td>list</td>
-			<td>ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function</td>
+			<td>TLS configuration for the gateway ingress. Hosts passed through the `tpl` function to allow templating</td>
 			<td><pre lang="json">
 [
   {
@@ -1482,11 +1482,13 @@ false
 </td>
 		</tr>
 		<tr>
-			<td>ingress.hosts[0]</td>
-			<td>string</td>
-			<td></td>
+			<td>ingress.hosts</td>
+			<td>list</td>
+			<td>Hosts configuration for the ingress, passed through the `tpl` function to allow templating</td>
 			<td><pre lang="json">
-"loki.example.com"
+[
+  "loki.example.com"
+]
 </pre>
 </td>
 		</tr>
@@ -1673,7 +1675,7 @@ false
 		<tr>
 			<td>ingress.tls</td>
 			<td>list</td>
-			<td></td>
+			<td>TLS configuration for the ingress. Hosts passed through the `tpl` function to allow templating</td>
 			<td><pre lang="json">
 []
 </pre>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -19,6 +19,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [ENHANCEMENT] Use tpl function in ingress.yaml for hosts
 - [ENHANCEMENT] Use tpl function in ingress and gateway-ingres for hosts
+- [ENHANCEMENT] Use tpl function in ingress and gateway-ingress for hosts
 
 ## 5.10.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries should include a reference to the pull request that introduced the chang
 - [CHANGE] Changed version of Loki to 2.8.4
 
 - [ENHANCEMENT] Use tpl function in ingress.yaml for hosts
+- [ENHANCEMENT] Use tpl function in ingress and gateway-ingres for hosts
 
 ## 5.10.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -17,6 +17,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [CHANGE] Changed version of Loki to 2.8.4
 
+- [ENHANCEMENT] Use tpl function in ingress.yaml for hosts
 
 ## 5.10.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -21,9 +21,6 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [CHANGE] Changed version of Loki to 2.8.4
 
-- [ENHANCEMENT] Use tpl function in ingress.yaml for hosts
-- [ENHANCEMENT] Use tpl function in ingress and gateway-ingres for hosts
-- [ENHANCEMENT] Use tpl function in ingress and gateway-ingress for hosts
 
 ## 5.10.0
 

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.12.0
+
+- [ENHANCEMENT] Use tpl function in ingress and gateway-ingress for hosts
+
 ## 5.11.0
 
 - [CHANGE] Changed version of Loki to 2.8.4

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.4
-version: 5.11.0
+version: 5.12.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.11.0](https://img.shields.io/badge/Version-5.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
+![Version: 5.12.0](https://img.shields.io/badge/Version-5.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/gateway/ingress-gateway.yaml
+++ b/production/helm/loki/templates/gateway/ingress-gateway.yaml
@@ -26,7 +26,7 @@ spec:
     {{- range .Values.gateway.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
       secretName: {{ . }}
@@ -35,7 +35,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.gateway.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/production/helm/loki/templates/ingress.yaml
+++ b/production/helm/loki/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
       secretName: {{ . }}
@@ -32,7 +32,7 @@ spec:
   {{- end }}
   rules:
     {{- range $.Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ tpl . $ | quote }}
       http:
         paths:
           {{- include "loki.ingress.servicePaths" $ | indent 10}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1288,6 +1288,7 @@ gateway:
     # -- Labels for the gateway ingress
     labels: {}
     # -- Hosts configuration for the gateway ingress. Host property will be passed through `tpl`.
+    # -- ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
     hosts:
       - host: gateway.loki.example.com
         paths:
@@ -1295,6 +1296,7 @@ gateway:
             # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
             # pathType: Prefix
     # -- TLS configuration for the gateway ingress. Hosts property will be passed through `tpl`.
+    # -- ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
     tls:
       - secretName: loki-gateway-tls
         hosts:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1152,8 +1152,10 @@ ingress:
       - /loki/api/v1/rules
       - /prometheus/api/v1/rules
       - /prometheus/api/v1/alerts
+  # -- Hosts configuration for the ingress, passed through the `tpl` function to allow templating
   hosts:
     - loki.example.com
+  # -- TLS configuration for the ingress. Hosts passed through the `tpl` function to allow templating
   tls: []
 #    - hosts:
 #       - loki.example.com
@@ -1287,16 +1289,14 @@ gateway:
     annotations: {}
     # -- Labels for the gateway ingress
     labels: {}
-    # -- Hosts configuration for the gateway ingress. Host property will be passed through `tpl`.
-    # -- ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+    # -- Hosts configuration for the gateway ingress, passed through the `tpl` function to allow templating
     hosts:
       - host: gateway.loki.example.com
         paths:
           - path: /
             # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
             # pathType: Prefix
-    # -- TLS configuration for the gateway ingress. Hosts property will be passed through `tpl`.
-    # -- ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+    # -- TLS configuration for the gateway ingress. Hosts passed through the `tpl` function to allow templating
     tls:
       - secretName: loki-gateway-tls
         hosts:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1287,14 +1287,14 @@ gateway:
     annotations: {}
     # -- Labels for the gateway ingress
     labels: {}
-    # -- Hosts configuration for the gateway ingress
+    # -- Hosts configuration for the gateway ingress. Host property will be passed through `tpl`.
     hosts:
       - host: gateway.loki.example.com
         paths:
           - path: /
             # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.) might also be required by some Ingress Controllers
             # pathType: Prefix
-    # -- TLS configuration for the gateway ingress
+    # -- TLS configuration for the gateway ingress. Hosts property will be passed through `tpl`.
     tls:
       - secretName: loki-gateway-tls
         hosts:


### PR DESCRIPTION
**What this PR does / why we need it**: Use tpl for ingress hosts. Needed for values passed from globals in umbrella charts. We´re already using this in [Grafana Helm Chart](https://github.com/grafana/helm-charts/blob/d8a64071970b5928cf990dce480925ff6b8edb56/charts/grafana/templates/ingress.yaml#L37). 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
