### PR TITLE
serialize empty head block as well while checkpointing to retain the head block format

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -695,14 +695,12 @@ func (c *MemChunk) SerializeForCheckpointTo(chk, head io.Writer) error {
 	// * When a write request is received with some new non-indexed labels, we update symbolizer first and then append log entry to head.
 	// * Labels stored in symbolizer are serialized with MemChunk.
 	// This means if we serialize the MemChunk before the head, we might miss writing some newly added non-indexed labels which are referenced by head.
-	if !c.head.IsEmpty() {
-		err := c.head.CheckpointTo(head)
-		if err != nil {
-			return err
-		}
+	err := c.head.CheckpointTo(head)
+	if err != nil {
+		return err
 	}
 
-	_, err := c.writeTo(chk, true)
+	_, err = c.writeTo(chk, true)
 	return err
 }
 

--- a/pkg/ingester/encoding_test.go
+++ b/pkg/ingester/encoding_test.go
@@ -82,9 +82,17 @@ func Test_EncodingChunks(t *testing.T) {
 					for _, c := range there {
 						chunks = append(chunks, c.Chunk)
 
-						// Ensure closed head chunks are empty
+						// Ensure closed head chunks only contain the head metadata but no entries
 						if close {
-							require.Equal(t, 0, len(c.Head))
+							if f < chunkenc.UnorderedHeadBlockFmt {
+								// format + #entries + size + mint + maxt
+								const orderedHeadSize = 5
+								require.Equal(t, orderedHeadSize, len(c.Head))
+							} else {
+								// format + #lines
+								const unorderedHeadSize = 2
+								require.Equal(t, unorderedHeadSize, len(c.Head))
+							}
 						} else {
 							require.Greater(t, len(c.Head), 0)
 						}


### PR DESCRIPTION
**What this PR does / why we need it**:
When the head block is empty, we do not serialize it while checkpointing. This causes a mismatch in chunk and head block format which ideally should be on the same version. The problem happens when we rollback from v4 chunk and block format to v3 and the head is empty in checkpoint which then [gets set to the default version](https://github.com/grafana/loki/blob/ce91076dd4cb6016f1f39b7a5126c2fd88a8b18e/pkg/ingester/checkpoint.go#L106) i.e v3 while the checkpointed chunk would be v4.

**Checklist**
- [x] Tests updated