### PR TITLE
azure: add connection-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [10322](https://github.com/grafana/loki/pull/10322) **chaudum**: Deprecate misleading setting `-ruler.evaluation-delay-duration`.
 * [10295](https://github.com/grafana/loki/pull/10295) **changhyuni**: Storage: remove signatureversionv2 from s3.
 * [10109](https://github.com/grafana/loki/pull/10109) **vardhaman-surana**: Ruler: add limit parameter in rulegroup
+* [10187](https://github.com/grafana/loki/pull/10187) **roelarents**: Add connection-string option for Azure Blob Storage.
 * [9621](https://github.com/grafana/loki/pull/9621) **DylanGuedes**: Introduce TSDB postings cache.
 * [10010](https://github.com/grafana/loki/pull/10010) **rasta-rocket**: feat(promtail): retrieve BotTags field from cloudflare
 * [9995](https://github.com/grafana/loki/pull/9995) **chaudum**: Add jitter to the flush interval to prevent multiple ingesters to flush at the same time.

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -4382,6 +4382,13 @@ The `azure_storage_config` block configures the connection to Azure object stora
 # CLI flag: -<prefix>.azure.account-key
 [account_key: <string> | default = ""]
 
+# If `connection-string` is set, the values of `account-name` and
+# `endpoint-suffix` values will not be used. Use this method over `account-key`
+# if you need to authenticate via a SAS token. Or if you use the Azurite
+# emulator.
+# CLI flag: -<prefix>.azure.connection-string
+[connection_string: <string> | default = ""]
+
 # Name of the storage account blob container used to store chunks. This
 # container must be created before running cortex.
 # CLI flag: -<prefix>.azure.container-name

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2165,6 +2165,7 @@ null
   "azure": {
     "accountKey": null,
     "accountName": null,
+    "connectionString": null,
     "endpointSuffix": null,
     "requestTimeout": null,
     "useFederatedToken": false,

--- a/docs/sources/storage/_index.md
+++ b/docs/sources/storage/_index.md
@@ -361,6 +361,8 @@ storage_config:
     request_timeout: 0
     # Configure this if you are using private azure cloud like azure stack hub and will use this endpoint suffix to compose container and blob storage URL. Ex: https://account_name.endpoint_suffix/container_name/blob_name
     endpoint_suffix: <endpoint-suffix>
+    # If `connection_string` is set, the values of `account_name` and `endpoint_suffix` values will not be used. Use this method over `account_key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
+    connection_string: <connection-string>
   boltdb_shipper:
     active_index_directory: /data/loki/boltdb-shipper-active
     cache_location: /data/loki/boltdb-shipper-cache

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/prometheus/alertmanager v0.26.0
 	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/richardartoul/molecule v1.0.0
-	github.com/thanos-io/objstore v0.0.0-20230816175749-20395bffdf26
+	github.com/thanos-io/objstore v0.0.0-20230829152104-1b257a36f9a3
 	github.com/willf/bloom v2.0.3+incompatible
 	go4.org/netipx v0.0.0-20230125063823-8449b0a6169f
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1

--- a/go.sum
+++ b/go.sum
@@ -1682,8 +1682,8 @@ github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62/go.mod h1:qUzPVl
 github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
-github.com/thanos-io/objstore v0.0.0-20230816175749-20395bffdf26 h1:q1lin/af0lw+I3sS79ccHs2CLjFOPc190J9saeQ5qQ4=
-github.com/thanos-io/objstore v0.0.0-20230816175749-20395bffdf26/go.mod h1:oJ82xgcBDzGJrEgUsjlTj6n01+ZWUMMUR8BlZzX5xDE=
+github.com/thanos-io/objstore v0.0.0-20230829152104-1b257a36f9a3 h1:avZFY25vRM35FggTBQj2WXq45yEvIKbDLUcNDrJLfKU=
+github.com/thanos-io/objstore v0.0.0-20230829152104-1b257a36f9a3/go.mod h1:oJ82xgcBDzGJrEgUsjlTj6n01+ZWUMMUR8BlZzX5xDE=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -10,11 +10,12 @@ import (
 
 func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
 	bucketConfig := azure.Config{
-		StorageAccountName: cfg.StorageAccountName,
-		StorageAccountKey:  cfg.StorageAccountKey.String(),
-		ContainerName:      cfg.ContainerName,
-		Endpoint:           cfg.Endpoint,
-		MaxRetries:         cfg.MaxRetries,
+		StorageAccountName:      cfg.StorageAccountName,
+		StorageAccountKey:       cfg.StorageAccountKey.String(),
+		StorageConnectionString: cfg.ConnectionString.String(),
+		ContainerName:           cfg.ContainerName,
+		Endpoint:                cfg.EndpointSuffix,
+		MaxRetries:              cfg.MaxRetries,
 		HTTPConfig: azure.HTTPConfig{
 			IdleConnTimeout:       model.Duration(cfg.IdleConnTimeout),
 			ResponseHeaderTimeout: model.Duration(cfg.ResponseHeaderTimeout),

--- a/pkg/storage/bucket/azure/config.go
+++ b/pkg/storage/bucket/azure/config.go
@@ -12,8 +12,9 @@ import (
 type Config struct {
 	StorageAccountName string         `yaml:"account_name"`
 	StorageAccountKey  flagext.Secret `yaml:"account_key"`
+	ConnectionString   flagext.Secret `yaml:"connection_string"`
 	ContainerName      string         `yaml:"container_name"`
-	Endpoint           string         `yaml:"endpoint_suffix"`
+	EndpointSuffix     string         `yaml:"endpoint_suffix"`
 	MaxRetries         int            `yaml:"max_retries"`
 
 	http.Config `yaml:"http"`
@@ -28,8 +29,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name")
 	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
+	f.Var(&cfg.ConnectionString, prefix+"azure.connection-string", "If `connection-string` is set, the values of `account-name` and `endpoint-suffix` values will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "loki", "Azure storage container name")
-	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
+	f.StringVar(&cfg.EndpointSuffix, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
 	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
 	cfg.Config.RegisterFlagsWithPrefix(prefix+"azure.", f)
 }

--- a/pkg/storage/bucket/azure/config_test.go
+++ b/pkg/storage/bucket/azure/config_test.go
@@ -44,6 +44,7 @@ func TestConfig(t *testing.T) {
 			config: `
 account_name: test-account-name
 account_key: test-account-key
+connection_string: test-connection-string
 container_name: test-container-name
 endpoint_suffix: test-endpoint-suffix
 max_retries: 1
@@ -60,8 +61,9 @@ http:
 			expectedConfig: Config{
 				StorageAccountName: "test-account-name",
 				StorageAccountKey:  flagext.SecretWithValue("test-account-key"),
+				ConnectionString:   flagext.SecretWithValue("test-connection-string"),
 				ContainerName:      "test-container-name",
-				Endpoint:           "test-endpoint-suffix",
+				EndpointSuffix:     "test-endpoint-suffix",
 				MaxRetries:         1,
 				Config: http.Config{
 					IdleConnTimeout:       2 * time.Second,

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/instrument"
 	"github.com/mattn/go-ieproxy"
@@ -29,6 +30,7 @@ import (
 	client_util "github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/util"
 	loki_instrument "github.com/grafana/loki/pkg/util/instrument"
+	"github.com/grafana/loki/pkg/util/log"
 )
 
 const (
@@ -84,8 +86,9 @@ type BlobStorageConfig struct {
 	Environment         string         `yaml:"environment"`
 	StorageAccountName  string         `yaml:"account_name"`
 	StorageAccountKey   flagext.Secret `yaml:"account_key"`
+	ConnectionString    string         `yaml:"connection_string"`
 	ContainerName       string         `yaml:"container_name"`
-	Endpoint            string         `yaml:"endpoint_suffix"`
+	EndpointSuffix      string         `yaml:"endpoint_suffix"`
 	UseManagedIdentity  bool           `yaml:"use_managed_identity"`
 	UseFederatedToken   bool           `yaml:"use_federated_token"`
 	UserAssignedID      string         `yaml:"user_assigned_id"`
@@ -118,8 +121,9 @@ func (c *BlobStorageConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagS
 	f.StringVar(&c.Environment, prefix+"azure.environment", azureGlobal, fmt.Sprintf("Azure Cloud environment. Supported values are: %s.", strings.Join(supportedEnvironments, ", ")))
 	f.StringVar(&c.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name.")
 	f.Var(&c.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key.")
+	f.StringVar(&c.ConnectionString, prefix+"azure.connection-string", "", "If `connection-string` is set, the values of `account-name` and `endpoint-suffix` values will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
 	f.StringVar(&c.ContainerName, prefix+"azure.container-name", "loki", "Name of the storage account blob container used to store chunks. This container must be created before running cortex.")
-	f.StringVar(&c.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The storage account name will be prefixed to this value to create the FQDN.")
+	f.StringVar(&c.EndpointSuffix, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The storage account name will be prefixed to this value to create the FQDN.")
 	f.BoolVar(&c.UseManagedIdentity, prefix+"azure.use-managed-identity", false, "Use Managed Identity to authenticate to the Azure storage account.")
 	f.BoolVar(&c.UseFederatedToken, prefix+"azure.use-federated-token", false, "Use Federated Token to authenticate to the Azure storage account.")
 	f.StringVar(&c.UserAssignedID, prefix+"azure.user-assigned-id", "", "User assigned identity ID to authenticate to the Azure storage account.")
@@ -293,7 +297,7 @@ func (b *BlobStorage) getBlobURL(blobID string, hedging bool) (azblob.BlockBlobU
 	blobID = strings.Replace(blobID, ":", b.cfg.ChunkDelimiter, -1)
 
 	// generate url for new chunk blob
-	u, err := url.Parse(fmt.Sprintf(b.selectBlobURLFmt(), b.cfg.StorageAccountName, b.cfg.ContainerName, blobID))
+	u, err := url.Parse(b.fmtBlobURL(blobID))
 	if err != nil {
 		return azblob.BlockBlobURL{}, err
 	}
@@ -306,7 +310,7 @@ func (b *BlobStorage) getBlobURL(blobID string, hedging bool) (azblob.BlockBlobU
 }
 
 func (b *BlobStorage) buildContainerURL() (azblob.ContainerURL, error) {
-	u, err := url.Parse(fmt.Sprintf(b.selectContainerURLFmt(), b.cfg.StorageAccountName, b.cfg.ContainerName))
+	u, err := url.Parse(b.fmtContainerURL())
 	if err != nil {
 		return azblob.ContainerURL{}, err
 	}
@@ -346,6 +350,18 @@ func (b *BlobStorage) newPipeline(hedgingCfg hedging.Config, hedging bool) (pipe
 				return pipeline.NewHTTPResponse(resp), err
 			}
 		})
+	}
+
+	if b.cfg.ConnectionString != "" {
+		parsed, err := parseConnectionString(b.cfg.ConnectionString)
+		if err != nil {
+			return nil, err
+		}
+		credential, err := azblob.NewSharedKeyCredential(parsed.AccountName, parsed.AccountKey)
+		if err != nil {
+			return nil, err
+		}
+		return azblob.NewPipeline(credential, opts), nil
 	}
 
 	if !b.cfg.UseFederatedToken && !b.cfg.UseManagedIdentity && !b.cfg.UseServicePrincipal && b.cfg.UserAssignedID == "" {
@@ -401,14 +417,7 @@ func (b *BlobStorage) getOAuthToken() (azblob.TokenCredential, error) {
 }
 
 func (b *BlobStorage) getServicePrincipalToken(authFunctions authFunctions) (*adal.ServicePrincipalToken, error) {
-	var endpoint string
-	if b.cfg.Endpoint != "" {
-		endpoint = b.cfg.Endpoint
-	} else {
-		endpoint = defaultEndpoints[b.cfg.Environment]
-	}
-
-	resource := fmt.Sprintf("https://%s.%s", b.cfg.StorageAccountName, endpoint)
+	resource := b.fmtResourceURL()
 
 	if b.cfg.UseFederatedToken {
 		token, err := b.servicePrincipalTokenFromFederatedToken(resource, authFunctions.NewOAuthConfigFunc, authFunctions.NewServicePrincipalTokenFromFederatedTokenFunc)
@@ -551,18 +560,35 @@ func (c *BlobStorageConfig) Validate() error {
 	return nil
 }
 
-func (b *BlobStorage) selectBlobURLFmt() string {
-	if b.cfg.Endpoint != "" {
-		return fmt.Sprintf("https://%%s.%s/%%s/%%s", b.cfg.Endpoint)
+func (b *BlobStorage) fmtResourceURL() string {
+	if b.cfg.ConnectionString != "" {
+		return b.endpointFromConnectionString()
 	}
-	return fmt.Sprintf("https://%%s.%s/%%s/%%s", defaultEndpoints[b.cfg.Environment])
+
+	var endpoint string
+	if b.cfg.EndpointSuffix != "" {
+		endpoint = b.cfg.EndpointSuffix
+	} else {
+		endpoint = defaultEndpoints[b.cfg.Environment]
+	}
+
+	return fmt.Sprintf("https://%s.%s", b.cfg.StorageAccountName, endpoint)
 }
 
-func (b *BlobStorage) selectContainerURLFmt() string {
-	if b.cfg.Endpoint != "" {
-		return fmt.Sprintf("https://%%s.%s/%%s", b.cfg.Endpoint)
+func (b *BlobStorage) endpointFromConnectionString() string {
+	parsed, err := parseConnectionString(b.cfg.ConnectionString)
+	if err != nil || parsed.ServiceURL == "" {
+		level.Warn(log.Logger).Log("msg", "could not get resource URL from connection string", "err", err)
 	}
-	return fmt.Sprintf("https://%%s.%s/%%s", defaultEndpoints[b.cfg.Environment])
+	return parsed.ServiceURL
+}
+
+func (b *BlobStorage) fmtBlobURL(blobID string) string {
+	return fmt.Sprintf("%s/%s", b.fmtContainerURL(), blobID)
+}
+
+func (b *BlobStorage) fmtContainerURL() string {
+	return fmt.Sprintf("%s/%s", b.fmtResourceURL(), b.cfg.ContainerName)
 }
 
 // IsObjectNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
@@ -573,6 +599,80 @@ func (b *BlobStorage) IsObjectNotFoundErr(err error) bool {
 	}
 
 	return false
+}
+
+var errConnectionString = errors.New("connection string is either blank or malformed. The expected connection string " +
+	"should contain key value pairs separated by semicolons. For example 'DefaultEndpointsProtocol=https;AccountName=<accountName>;" +
+	"AccountKey=<accountKey>;EndpointSuffix=core.windows.net'")
+
+type ParsedConnectionString struct {
+	ServiceURL  string
+	AccountName string
+	AccountKey  string
+}
+
+// parseConnectionString dissects a connection string into url, account and key
+// (copied from github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared)
+func parseConnectionString(connectionString string) (ParsedConnectionString, error) {
+	const (
+		defaultScheme = "https"
+		defaultSuffix = "core.windows.net"
+	)
+
+	connStrMap := make(map[string]string)
+	connectionString = strings.TrimRight(connectionString, ";")
+
+	splitString := strings.Split(connectionString, ";")
+	if len(splitString) == 0 {
+		return ParsedConnectionString{}, errConnectionString
+	}
+	for _, stringPart := range splitString {
+		parts := strings.SplitN(stringPart, "=", 2)
+		if len(parts) != 2 {
+			return ParsedConnectionString{}, errConnectionString
+		}
+		connStrMap[parts[0]] = parts[1]
+	}
+
+	accountName, ok := connStrMap["AccountName"]
+	if !ok {
+		return ParsedConnectionString{}, errors.New("connection string missing AccountName")
+	}
+
+	accountKey, ok := connStrMap["AccountKey"]
+	if !ok {
+		sharedAccessSignature, ok := connStrMap["SharedAccessSignature"]
+		if !ok {
+			return ParsedConnectionString{}, errors.New("connection string missing AccountKey and SharedAccessSignature")
+		}
+		return ParsedConnectionString{
+			ServiceURL: fmt.Sprintf("%v://%v.blob.%v/?%v", defaultScheme, accountName, defaultSuffix, sharedAccessSignature),
+		}, nil
+	}
+
+	protocol, ok := connStrMap["DefaultEndpointsProtocol"]
+	if !ok {
+		protocol = defaultScheme
+	}
+
+	suffix, ok := connStrMap["EndpointSuffix"]
+	if !ok {
+		suffix = defaultSuffix
+	}
+
+	if blobEndpoint, ok := connStrMap["BlobEndpoint"]; ok {
+		return ParsedConnectionString{
+			ServiceURL:  blobEndpoint,
+			AccountName: accountName,
+			AccountKey:  accountKey,
+		}, nil
+	}
+
+	return ParsedConnectionString{
+		ServiceURL:  fmt.Sprintf("%v://%v.blob.%v", protocol, accountName, suffix),
+		AccountName: accountName,
+		AccountKey:  accountKey,
+	}, nil
 }
 
 // TODO(dannyk): implement for client

--- a/pkg/storage/chunk/client/azure/blob_storage_client_test.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client_test.go
@@ -167,10 +167,20 @@ func Test_EndpointSuffixWithContainer(t *testing.T) {
 		ContainerName:      "foo",
 		StorageAccountName: "bar",
 		Environment:        azureGlobal,
-		Endpoint:           "test.com",
+		EndpointSuffix:     "test.com",
 	}, metrics, hedging.Config{})
 	require.NoError(t, err)
 	expect, _ := url.Parse("https://bar.test.com/foo")
+	require.Equal(t, *expect, c.containerURL.URL())
+}
+
+func Test_ConnectionStringWithContainer(t *testing.T) {
+	c, err := NewBlobStorage(&BlobStorageConfig{
+		ContainerName:    "foo",
+		ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+	}, metrics, hedging.Config{})
+	require.NoError(t, err)
+	expect, _ := url.Parse("http://127.0.0.1:10000/devstoreaccount1/foo")
 	require.Equal(t, *expect, c.containerURL.URL())
 }
 
@@ -196,10 +206,22 @@ func Test_EndpointSuffixWithBlob(t *testing.T) {
 		ContainerName:      "foo",
 		StorageAccountName: "bar",
 		Environment:        azureGlobal,
-		Endpoint:           "test.com",
+		EndpointSuffix:     "test.com",
 	}, metrics, hedging.Config{})
 	require.NoError(t, err)
 	expect, _ := url.Parse("https://bar.test.com/foo/blob")
+	bloburl, err := c.getBlobURL("blob", false)
+	require.NoError(t, err)
+	require.Equal(t, *expect, bloburl.URL())
+}
+
+func Test_ConnectionStringWithBlob(t *testing.T) {
+	c, err := NewBlobStorage(&BlobStorageConfig{
+		ContainerName:    "foo",
+		ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+	}, metrics, hedging.Config{})
+	require.NoError(t, err)
+	expect, _ := url.Parse("http://127.0.0.1:10000/devstoreaccount1/foo/blob")
 	bloburl, err := c.getBlobURL("blob", false)
 	require.NoError(t, err)
 	require.Equal(t, *expect, bloburl.URL())

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.23.0
+
+- [ENHANCEMENT] Add loki.storage.azure.connectionString to support Azure connection string
+
 ## 5.22.2
 
 - [BUGFIX] Fix sidecar configuration for Backend
@@ -25,11 +29,9 @@ Entries should include a reference to the pull request that introduced the chang
 
 - [CHANGE] Changed version of Loki to 2.9.1
 
-
 ## 5.21.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.8.1
-
 
 ## 5.20.0
 
@@ -38,7 +40,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.19.0
 
 - [FEATURE] Add optional sidecard to load rules from ConfigMaps and Secrets.
-  
+
 ## 5.18.1
 
 - [ENHANCEMENT] #8627 Add service labels and annotations for all services.
@@ -47,7 +49,6 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.18.0
 
 - [CHANGE] Changed version of Loki to 2.9.0
-
 
 ## 5.17.0
 

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.1
-version: 5.22.2
+version: 5.23.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.22.2](https://img.shields.io/badge/Version-5.22.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 5.23.0](https://img.shields.io/badge/Version-5.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -261,6 +261,9 @@ azure:
   {{- with .accountKey }}
   account_key: {{ . }}
   {{- end }}
+  {{- with .connectionString }}
+  connection_string: {{ . }}
+  {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.chunks }}
   use_managed_identity: {{ .useManagedIdentity }}
   use_federated_token: {{ .useFederatedToken }}
@@ -330,6 +333,9 @@ azure:
   account_name: {{ .accountName }}
   {{- with .accountKey }}
   account_key: {{ . }}
+  {{- end }}
+  {{- with .connectionString }}
+  connection_string: {{ . }}
   {{- end }}
   container_name: {{ $.Values.loki.storage.bucketNames.ruler }}
   use_managed_identity: {{ .useManagedIdentity }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -285,6 +285,7 @@ loki:
     azure:
       accountName: null
       accountKey: null
+      connectionString: null
       useManagedIdentity: false
       useFederatedToken: false
       userAssignedId: null

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -28,6 +28,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
     > This also changes the behaviour of `client.NewBucket`. Now it returns, uninstrumented and untraced bucket.
     You can combine `objstore.WrapWithMetrics` and `tracing/{opentelemetry,opentracing}.WrapWithTraces` to have old behavior.
 - [#64](https://github.com/thanos-io/objstore/pull/64) OCI: OKE Workload Identity support.
+- [#73](https://github.com/thanos-io/objstore/pull/73) Аdded file path to erros from DownloadFile
+- [#51](https://github.com/thanos-io/objstore/pull/51) Azure: Support using connection string authentication.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/vendor/github.com/thanos-io/objstore/README.md
+++ b/vendor/github.com/thanos-io/objstore/README.md
@@ -419,6 +419,7 @@ type: AZURE
 config:
   storage_account: ""
   storage_account_key: ""
+  storage_connection_string: ""
   container: ""
   endpoint: ""
   user_assigned_id: ""
@@ -453,6 +454,8 @@ prefix: ""
 If `msi_resource` is used, authentication is done via system-assigned managed identity. The value for Azure should be `https://<storage-account-name>.blob.core.windows.net`.
 
 If `user_assigned_id` is used, authentication is done via user-assigned managed identity. When using `user_assigned_id` the `msi_resource` defaults to `https://<storage_account>.<endpoint>`
+
+If `storage_connection_string` is set, the values of `storage_account` and `endpoint` values will not be used. Use this method over `storage_account_key` if you need to authenticate via a SAS token.
 
 The generic `max_retries` will be used as value for the `pipeline_config`'s `max_tries` and `reader_config`'s `max_retry_requests`. For more control, `max_retries` could be ignored (0) and one could set specific retry values.
 

--- a/vendor/github.com/thanos-io/objstore/objstore.go
+++ b/vendor/github.com/thanos-io/objstore/objstore.go
@@ -315,7 +315,7 @@ func DownloadFile(ctx context.Context, logger log.Logger, bkt BucketReader, src,
 
 	f, err := os.Create(dst)
 	if err != nil {
-		return errors.Wrap(err, "create file")
+		return errors.Wrapf(err, "create file %s", dst)
 	}
 	defer func() {
 		if err != nil {
@@ -327,7 +327,7 @@ func DownloadFile(ctx context.Context, logger log.Logger, bkt BucketReader, src,
 	defer logerrcapture.Do(logger, f.Close, "close block's output file")
 
 	if _, err = io.Copy(f, rc); err != nil {
-		return errors.Wrap(err, "copy object to file")
+		return errors.Wrapf(err, "copy object to file %s", src)
 	}
 	return nil
 }

--- a/vendor/github.com/thanos-io/objstore/providers/azure/azure.go
+++ b/vendor/github.com/thanos-io/objstore/providers/azure/azure.go
@@ -44,15 +44,16 @@ var DefaultConfig = Config{
 
 // Config Azure storage configuration.
 type Config struct {
-	StorageAccountName string             `yaml:"storage_account"`
-	StorageAccountKey  string             `yaml:"storage_account_key"`
-	ContainerName      string             `yaml:"container"`
-	Endpoint           string             `yaml:"endpoint"`
-	UserAssignedID     string             `yaml:"user_assigned_id"`
-	MaxRetries         int                `yaml:"max_retries"`
-	ReaderConfig       ReaderConfig       `yaml:"reader_config"`
-	PipelineConfig     PipelineConfig     `yaml:"pipeline_config"`
-	HTTPConfig         exthttp.HTTPConfig `yaml:"http_config"`
+	StorageAccountName      string             `yaml:"storage_account"`
+	StorageAccountKey       string             `yaml:"storage_account_key"`
+	StorageConnectionString string             `yaml:"storage_connection_string"`
+	ContainerName           string             `yaml:"container"`
+	Endpoint                string             `yaml:"endpoint"`
+	UserAssignedID          string             `yaml:"user_assigned_id"`
+	MaxRetries              int                `yaml:"max_retries"`
+	ReaderConfig            ReaderConfig       `yaml:"reader_config"`
+	PipelineConfig          PipelineConfig     `yaml:"pipeline_config"`
+	HTTPConfig              exthttp.HTTPConfig `yaml:"http_config"`
 
 	// Deprecated: Is automatically set by the Azure SDK.
 	MSIResource string `yaml:"msi_resource"`
@@ -74,6 +75,14 @@ func (conf *Config) validate() error {
 	var errMsg []string
 	if conf.UserAssignedID != "" && conf.StorageAccountKey != "" {
 		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_account_key authentication")
+	}
+
+	if conf.UserAssignedID != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_connection_string authentication")
+	}
+
+	if conf.StorageAccountKey != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "storage_account_key and storage_connection_string cannot both be set")
 	}
 
 	if conf.StorageAccountName == "" {

--- a/vendor/github.com/thanos-io/objstore/providers/azure/helpers.go
+++ b/vendor/github.com/thanos-io/objstore/providers/azure/helpers.go
@@ -38,6 +38,16 @@ func getContainerClient(conf Config) (*container.Client, error) {
 			Transport: &http.Client{Transport: dt},
 		},
 	}
+
+	// Use connection string if set
+	if conf.StorageConnectionString != "" {
+		containerClient, err := container.NewClientFromConnectionString(conf.StorageConnectionString, conf.ContainerName, opt)
+		if err != nil {
+			return nil, err
+		}
+		return containerClient, nil
+	}
+
 	containerURL := fmt.Sprintf("https://%s.%s/%s", conf.StorageAccountName, conf.Endpoint, conf.ContainerName)
 
 	// Use shared keys if set

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1371,7 +1371,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
 github.com/stretchr/testify/suite
-# github.com/thanos-io/objstore v0.0.0-20230816175749-20395bffdf26
+# github.com/thanos-io/objstore v0.0.0-20230829152104-1b257a36f9a3
 ## explicit; go 1.18
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a connection-string option to the azure blob storage config. So the [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) emulator can be used in local test environments (my use case). But also to support the use of a SAS token. See the (future) addition of this option to the Thanos object storage client: https://github.com/thanos-io/objstore/pull/51

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

https://github.com/thanos-io/objstore/pull/51 isn't merged yet. But I'm already creating this PR to see what others think.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
