### PR TITLE
Configuration: Allow customization of default runtime values

### DIFF
--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -21,6 +21,9 @@ type runtimeConfigValues struct {
 	TenantLimits map[string]*validation.Limits `yaml:"overrides"`
 	TenantConfig map[string]*runtime.Config    `yaml:"configs"`
 
+	// DefaultConfig defines the default runtime configuration. Used if a tenant runtime configuration wasn't given.
+	DefaultConfig *runtime.Config `yaml:"default"`
+
 	Multi kv.MultiRuntimeConfig `yaml:"multi_kv_config"`
 }
 
@@ -91,7 +94,10 @@ func tenantConfigFromRuntimeConfig(c *runtimeconfig.Manager) runtime.TenantConfi
 		if !ok || cfg == nil {
 			return nil
 		}
-		return cfg.TenantConfig[userID]
+		if tenantCfg, ok := cfg.TenantConfig[userID]; ok {
+			return tenantCfg
+		}
+		return cfg.DefaultConfig
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new section to our runtime configuration that will allow customization of default runtime values.
For instance, our default `log_push_request` is `false`. Previously, there was no way of setting it to `true`, so you'd have to set it for every existing tenant.

For a full example, please check the added test.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
