### PR TITLE
add `trivy` to Makefile and build image

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: clone-target-branch
   when:
     event:
@@ -121,14 +121,14 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: test
 - commands:
   - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: test-target-branch
   when:
     event:
@@ -141,7 +141,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: compare-coverage
   when:
     event:
@@ -159,7 +159,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: report-coverage
   when:
     event:
@@ -169,7 +169,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -177,7 +177,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -188,21 +188,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false check-format GIT_TARGET_BRANCH="$DRONE_TARGET_BRANCH"
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-format
   when:
     event:
@@ -212,14 +212,14 @@ steps:
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -252,7 +252,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: loki-mixin-check
   when:
     event:
@@ -277,7 +277,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1670,7 +1670,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1678,7 +1678,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1704,7 +1704,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: publish
   when:
     event:
@@ -1738,7 +1738,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.29.3
+  image: grafana/loki-build-image:0.29.4
   name: build and push
   privileged: true
   volumes:

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2003,6 +2003,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 004dc2f49a59704c815e9ccd2f9b635b2114dec907477da099ffc5952695f5d1
+hmac: 596d7f8c249a11fba80c763630b228c6a0e2989ac7238d513d08642be076b15d
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2003,6 +2003,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 596d7f8c249a11fba80c763630b228c6a0e2989ac7238d513d08642be076b15d
+hmac: fb384b17b46ac77869765efc735c4d389ba33e37d5c584ec93da7b4c6b0387da
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.29.3
+BUILD_IMAGE_VERSION := 0.29.4
 
 # Docker image info
 IMAGE_PREFIX ?= grafana
@@ -825,3 +825,7 @@ dev-k3d-enterprise-logs:
 
 dev-k3d-down:
 	$(MAKE) -C $(CURDIR)/tools/dev/k3d down
+
+# Trivy is used to scan images for vulnerabilities
+trivy: loki-image
+	trivy i $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -73,6 +73,8 @@ RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
+FROM aquasec/trivy as trivy
+
 FROM golang:1.20.6-bullseye
 RUN apt-get update && \
     apt-get install -qy \
@@ -108,6 +110,7 @@ COPY --from=gotestsum /go/bin/gotestsum /usr/bin/gotestsum
 COPY --from=jsonnet /go/bin/jb /usr/bin/jb
 COPY --from=jsonnet /go/bin/mixtool /usr/bin/mixtool
 COPY --from=jsonnet /go/bin/jsonnet /usr/bin/jsonnet
+COPY --from=trivy /usr/local/bin/trivy /usr/bin/trivy
 
 # Install some necessary dependencies.
 # Forcing GO111MODULE=on is required to specify dependencies at specific versions using the go mod notation.


### PR DESCRIPTION
`trivy` is a command line utility that can scan our images for vulnerabilities. For example, this is how I checked #10217 addressed the CVEs we were hoping it would

```
❯ trivy i grafana/loki:release-2.8.x-d784431
2023-08-11T12:34:15.272-0600    INFO    Vulnerability scanning is enabled
2023-08-11T12:34:15.272-0600    INFO    Secret scanning is enabled
2023-08-11T12:34:15.272-0600    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-08-11T12:34:15.272-0600    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret/#recommendation for faster secret detection
2023-08-11T12:34:15.283-0600    INFO    Detected OS: alpine
2023-08-11T12:34:15.283-0600    INFO    Detecting Alpine vulnerabilities...
2023-08-11T12:34:15.286-0600    INFO    Number of language-specific files: 1
2023-08-11T12:34:15.286-0600    INFO    Detecting gobinary vulnerabilities...

grafana/loki:release-2.8.x-d784431 (alpine 3.18.2)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-2975 │ MEDIUM   │ 3.1.1-r1          │ 3.1.1-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│            │               │          │                   │               │ to ignore empty...                                          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3446 │          │                   │ 3.1.1-r3      │ Excessive time spent checking DH keys and parameters        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3817 │          │                   │ 3.1.2-r0      │ Excessive time spent checking DH q parameter value          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├────────────┼───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-2975 │          │                   │ 3.1.1-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│            │               │          │                   │               │ to ignore empty...                                          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3446 │          │                   │ 3.1.1-r3      │ Excessive time spent checking DH keys and parameters        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3817 │          │                   │ 3.1.2-r0      │ Excessive time spent checking DH q parameter value          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

This PR adds that command as `Makefile` target, as well as adding the `trivy` binary to our drone build image so we can add it to our pipelines in the future.