### PR TITLE
Update changelog and release notes for 2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 * [10188](https://github.com/grafana/loki/pull/10188) **shantanualsi**: Bump alpine version from 3.16.5 -> 3.16.7
 
+
+## 2.8.4
+
+#### Loki
+
+##### Security
+
+* [10217](https://github.com/grafana/loki/pull/10217) *ashwanthgoli*: Fix CVE-2023-1255, CVE-2023-2650, CVE-2023-2975, CVE-2023-3446, CVE-2023-3817, and bump alpine image 3.18.2
+
+
 ## 2.8.3 (2023-07-21)
 
 #### Loki
@@ -45,14 +55,6 @@
 ##### Enhancements
 
 #### Jsonnet
-
-## 2.8.3
-
-#### Loki
-
-##### Security
-
-* [10217](https://github.com/grafana/loki/pull/10217) *ashwanthgoli*: Fix CVE-2023-1255, CVE-2023-2650, CVE-2023-2975, CVE-2023-3446, CVE-2023-3817, and bump alpine image 3.18.2
 
 ## 2.8.2
 

--- a/docs/sources/release-notes/v2-8.md
+++ b/docs/sources/release-notes/v2-8.md
@@ -22,9 +22,11 @@ As always, please read the [upgrade guide]({{<relref "../upgrading/#270">}}) bef
 
 ## Bug fixes
 
-### 2.8.3 (2023-08-23)
+### 2.8.4 (2023-08-11)
 
 * Fix CVE-2023-1255, CVE-2023-2650, CVE-2023-2975, CVE-2023-3446, CVE-2023-3817, and bump alpine image 3.18.2
+
+### 2.8.3 (2023-07-21)
  
 
 ### 2.8.2 (2023-05-03)


### PR DESCRIPTION
2.8.3 was released without release notes, causing confusion in #10234, which should actually be preparing 2.8.4.