### PR TITLE
dependabot: Re-enable `auto-merge`.

### DIFF
--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -24,10 +24,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve the dependabot PR
+      - name: Approve and auto-merge the dependabot PR
         run: |
+          gh pr merge --auto --squash "$PR_URL"
           gh pr review $PR_URL \
           --approve -b "Auto approve dependencies bump PR"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}


### PR DESCRIPTION
**What this PR does / why we need it**:
I reverted back auto merge, because of permission issues with "who" can push to the repo.

After some internal discussion, we decided to use `grafanabot` for enabling auto-merge. This PR does that.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)

