### PR TITLE
Return intersecting labels when aggregating volume by label

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -633,7 +633,8 @@ func (i *instance) GetVolume(ctx context.Context, req *logproto.VolumeRequest) (
 		return nil, err
 	}
 
-	labelsToMatch, matchers, matchAny := util.PrepareLabelsAndMatchers(req.TargetLabels, matchers)
+	targetLabels := req.TargetLabels
+	labelsToMatch, matchers, matchAny := util.PrepareLabelsAndMatchers(targetLabels, matchers)
 	matchAny = matchAny || len(matchers) == 0
 
 	seriesNames := make(map[uint64]string)
@@ -673,7 +674,11 @@ func (i *instance) GetVolume(ctx context.Context, req *logproto.VolumeRequest) (
 			} else {
 				labelVolumes = make(map[string]uint64, len(s.labels))
 				for _, l := range s.labels {
-					if _, ok := labelsToMatch[l.Name]; matchAny || ok {
+					if len(targetLabels) > 0 {
+						if _, ok := labelsToMatch[l.Name]; matchAny || ok {
+							labelVolumes[l.Name] += size
+						}
+					} else {
 						labelVolumes[l.Name] += size
 					}
 				}

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1026,7 +1026,7 @@ func TestInstance_Volume(t *testing.T) {
 				{Name: `foo`, Volume: 18},
 			}, volumes.Volumes)
 
-      require.NotContains(t, volumes.Volumes, logproto.Volume{Name: `fizz`, Volume: 11})
+			require.NotContains(t, volumes.Volumes, logproto.Volume{Name: `fizz`, Volume: 11})
 		})
 
 		t.Run("excludes streams outside of time bounds", func(t *testing.T) {

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -409,10 +409,18 @@ func (i *TSDBIndex) Volume(
 						}
 					}
 				} else {
+          // when aggregating by labels, capture sizes for target labels if provided,
+          // otherwise for all intersecting labels
 					labelVolumes = make(map[string]uint64, len(ls))
 					for _, l := range ls {
-						if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
-							labelVolumes[l.Name] += stats.KB << 10
+						if len(targetLabels) > 0 {
+							if _, ok := labelsToMatch[l.Name]; l.Name != TenantLabel && includeAll || ok {
+								labelVolumes[l.Name] += stats.KB << 10
+							}
+						} else {
+							if l.Name != TenantLabel {
+								labelVolumes[l.Name] += stats.KB << 10
+							}
 						}
 					}
 				}

--- a/pkg/storage/stores/tsdb/single_file_index.go
+++ b/pkg/storage/stores/tsdb/single_file_index.go
@@ -409,8 +409,8 @@ func (i *TSDBIndex) Volume(
 						}
 					}
 				} else {
-          // when aggregating by labels, capture sizes for target labels if provided,
-          // otherwise for all intersecting labels
+					// when aggregating by labels, capture sizes for target labels if provided,
+					// otherwise for all intersecting labels
 					labelVolumes = make(map[string]uint64, len(ls))
 					for _, l := range ls {
 						if len(targetLabels) > 0 {


### PR DESCRIPTION
This PR changes the behavior the `index/volume` endpoint to return intersecting labels when requesting volume aggregating by label. Previously it only returned labels that matched selectors in the query. The old behavior is still possible using the `targetLabels` argument.