### PR TITLE
allow GrafanaAgent images to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [9773](https://github.com/grafana/loki/pull/9773) **ssncferreira**: Fix instant query summary statistic's `splits` corresponding to the number of subqueries a query is split into based on `split_queries_by_interval`.
 * [9949](https://github.com/grafana/loki/pull/9949) **masslessparticle**: Fix pipelines to clear caches when tailing to avoid resource exhaustion.
 * [9936](https://github.com/grafana/loki/pull/9936) **masslessparticle**: Fix the way query stages are reordered when `unpack` is present.
+* [xxxx](https://github.com/grafana/loki/pull/xxxx) **klg71**: Add capability to specify image overrides for GrafanaAgent in Helm chart
 
 ##### Changes
 

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1994,6 +1994,24 @@ null
 </td>
 		</tr>
 		<tr>
+			<td>loki.grafanaAgentImage</td>
+			<td>string</td>
+			<td>Override image for GrafanaAgent</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>loki.grafanaAgentConfigReloaderImage</td>
+			<td>string</td>
+			<td>Override the config reloader image for GrafanaAgent</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>loki.podSecurityContext</td>
 			<td>object</td>
 			<td>The SecurityContext for Loki pods</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.12.0
+
+- [ENHANCEMENT] Added parameter to override images in GrafanaAgent
+
 ## 5.11.0
 
 - [CHANGE] Changed version of Loki to 2.8.4

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.8.4
-version: 5.11.0
+version: 5.12.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/monitoring/grafana-agent.yaml
+++ b/production/helm/loki/templates/monitoring/grafana-agent.yaml
@@ -16,6 +16,12 @@ metadata:
 spec:
   serviceAccountName: {{ include "loki.fullname" $ }}-grafana-agent
   enableConfigReadAPI: {{ .enableConfigReadAPI }}
+  {{- if .Values.loki.grafanaAgentImage }}
+  image: {{ .Values.loki.grafanaAgentImage }}
+  {{- end -}}
+  {{- if .Values.loki.grafanaAgentConfigReloaderImage  }}
+  configReloaderImage: {{ .Values.loki.grafanaAgentConfigReloaderImage }}
+  {{- end -}}
   {{- include "grafana-agent.priorityClassName" $ | nindent 2 }}
   logs:
     instanceSelector:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -58,6 +58,10 @@ loki:
   podLabels: {}
   # -- The number of old ReplicaSets to retain to allow rollback
   revisionHistoryLimit: 10
+  # -- Override the image of the GrafanaAgent
+  grafanaAgentImage: {}
+  # -- Override the configReloader image of the GrafanaAgent
+  grafanaAgentConfigReloaderImage: {}
   # -- The SecurityContext for Loki pods
   podSecurityContext:
     fsGroup: 10001


### PR DESCRIPTION
**What this PR does / why we need it**: We don't allow pulls from public docker registries and need to specify and image overrides in the GrafanaAgent resource in the helm chart.


**Special notes for your reviewer**: This is the official crd of the GrafanaAgent: https://grafana.com/docs/agent/latest/operator/api/

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
