### PR TITLE
Backport hedging change to k163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [7754](https://github.com/grafana/loki/pull/7754) **ashwanthgoli** index-shipper: add support for multiple stores.
 * [8662](https://github.com/grafana/loki/pull/8662) **liguozhong**: LogQL: Introduce `distinct`
 * [9813](https://github.com/grafana/loki/pull/9813) **jeschkies**: Enable Protobuf encoding via content negotiation between querier and query frontend.
+* [10281](https://github.com/grafana/loki/pull/10281) **dannykopping**: Track effectiveness of hedged requests.
 
 ##### Fixes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently have request hedging implemented in many object store clients. Right now we track how many hedged requests we make, and how many are rate-limited, but nothing actually tells us _how effective_ the hedged requests are. In other words, we don't know how many hedged requests were issued and _won_ (completed before the original).