### PR TITLE
Azure Blob Storage is no longer experimental

### DIFF
--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -29,7 +29,6 @@ import (
 	client_util "github.com/grafana/loki/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/pkg/util"
 	loki_instrument "github.com/grafana/loki/pkg/util/instrument"
-	"github.com/grafana/loki/pkg/util/log"
 )
 
 const (
@@ -190,7 +189,6 @@ type BlobStorage struct {
 
 // NewBlobStorage creates a new instance of the BlobStorage struct.
 func NewBlobStorage(cfg *BlobStorageConfig, metrics BlobStorageMetrics, hedgingCfg hedging.Config) (*BlobStorage, error) {
-	log.WarnExperimentalUse("Azure Blob Storage", log.Logger)
 	blobStorage := &BlobStorage{
 		cfg:     cfg,
 		metrics: metrics,


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure Blob Storage is being used in production by many organisations, including Grafana Labs. It should no longer be marked experimental.

**Which issue(s) this PR fixes**:
Fixes #10298