### PR TITLE
Promtail: Add additional fields in cloudflare config

### DIFF
--- a/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
+++ b/clients/pkg/promtail/scrapeconfig/scrapeconfig.go
@@ -379,7 +379,10 @@ type CloudflareConfig struct {
 	// - minimal
 	// - extended
 	// - all
+	// - custom
 	FieldsType string `yaml:"fields_type"`
+	// The additional list of fields to supplement those provided via fields_type.
+	AdditionalFields []string `yaml:"additional_fields"`
 }
 
 // GcplogTargetConfig describes a scrape config to pull logs from any pubsub topic.

--- a/clients/pkg/promtail/targets/cloudflare/fields.go
+++ b/clients/pkg/promtail/targets/cloudflare/fields.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"fmt"
+
+	"golang.org/x/exp/slices"
 )
 
 type FieldsType string
@@ -11,6 +13,7 @@ const (
 	FieldsTypeMinimal  FieldsType = "minimal"
 	FieldsTypeExtended FieldsType = "extended"
 	FieldsTypeAll      FieldsType = "all"
+	FieldsTypeCustom   FieldsType = "custom"
 )
 
 var (
@@ -35,17 +38,24 @@ var (
 	}...)
 )
 
-func Fields(t FieldsType) ([]string, error) {
+// Fields returns the union of a set of fields represented by the Fieldtype and the given additional fields. The returned slice will contain no duplicates.
+func Fields(t FieldsType, additionalFields []string) ([]string, error) {
+	var fields []string
 	switch t {
 	case FieldsTypeDefault:
-		return defaultFields, nil
+		fields = append(defaultFields, additionalFields...)
 	case FieldsTypeMinimal:
-		return minimalFields, nil
+		fields = append(minimalFields, additionalFields...)
 	case FieldsTypeExtended:
-		return extendedFields, nil
+		fields = append(extendedFields, additionalFields...)
 	case FieldsTypeAll:
-		return allFields, nil
+		fields = append(allFields, additionalFields...)
+	case FieldsTypeCustom:
+		fields = append(fields, additionalFields...)
 	default:
 		return nil, fmt.Errorf("unknown fields type: %s", t)
 	}
+	// remove duplicates
+	slices.Sort(fields)
+	return slices.Compact(fields), nil
 }

--- a/clients/pkg/promtail/targets/cloudflare/fields_test.go
+++ b/clients/pkg/promtail/targets/cloudflare/fields_test.go
@@ -1,0 +1,49 @@
+package cloudflare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFields(t *testing.T) {
+	tests := []struct {
+		name             string
+		fieldsType       FieldsType
+		additionalFields []string
+		expected         []string
+	}{
+		{
+			name:             "Default fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{},
+			expected:         defaultFields,
+		},
+		{
+			name:             "Custom fields",
+			fieldsType:       FieldsTypeCustom,
+			additionalFields: []string{"ClientIP", "OriginResponseBytes"},
+			expected:         []string{"ClientIP", "OriginResponseBytes"},
+		},
+		{
+			name:             "Default fields with added custom fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{"WAFFlags", "WAFMatchedVar"},
+			expected:         append(defaultFields, "WAFFlags", "WAFMatchedVar"),
+		},
+		{
+			name:             "Default fields with duplicated custom fields",
+			fieldsType:       FieldsTypeDefault,
+			additionalFields: []string{"WAFFlags", "WAFFlags", "ClientIP"},
+			expected:         append(defaultFields, "WAFFlags"), // clientIP is already part of defaultFields
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Fields(test.fieldsType, test.additionalFields)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, result)
+		})
+	}
+}

--- a/clients/pkg/promtail/targets/cloudflare/target.go
+++ b/clients/pkg/promtail/targets/cloudflare/target.go
@@ -63,7 +63,7 @@ func NewTarget(
 	if err := validateConfig(config); err != nil {
 		return nil, err
 	}
-	fields, err := Fields(FieldsType(config.FieldsType))
+	fields, err := Fields(FieldsType(config.FieldsType), config.AdditionalFields)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (t *Target) Ready() bool {
 }
 
 func (t *Target) Details() interface{} {
-	fields, _ := Fields(FieldsType(t.config.FieldsType))
+	fields, _ := Fields(FieldsType(t.config.FieldsType), t.config.AdditionalFields)
 	var errMsg string
 	if t.err != nil {
 		errMsg = t.err.Error()

--- a/docs/sources/send-data/promtail/configuration.md
+++ b/docs/sources/send-data/promtail/configuration.md
@@ -1292,6 +1292,9 @@ zone_id: <string>
 # Supported values: default, minimal, extended, all.
 [fields_type: <string> | default = default]
 
+# The additional list of fields to supplement those provided via `fields_type`.
+[additional_fields: <string> ... ]
+
 # Label map to add to every log message.
 labels:
   [ <labelname>: <labelvalue> ... ]
@@ -1303,16 +1306,22 @@ Here are the different set of fields type available and the fields they include 
 
 - `default` includes `"ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp", "EdgeResponseBytes",
 "EdgeRequestHost", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"`
+plus any extra fields provided via `additional_fields` argument.
 
 - `minimal` includes all `default` fields and adds `"ZoneID", "ClientSSLProtocol", "ClientRequestProtocol", "ClientRequestPath", "ClientRequestUserAgent", "ClientRequestReferer",
-"EdgeColoCode", "ClientCountry", "CacheCacheStatus", "CacheResponseStatus", "EdgeResponseContentType`
+"EdgeColoCode", "ClientCountry", "CacheCacheStatus", "CacheResponseStatus", "EdgeResponseContentType"`
+plus any extra fields provided via `additional_fields` argument.
 
 - `extended` includes all `minimal`fields and adds `"ClientSSLCipher", "ClientASN", "ClientIPClass", "CacheResponseBytes", "EdgePathingOp", "EdgePathingSrc", "EdgePathingStatus", "ParentRayID",
 "WorkerCPUTime", "WorkerStatus", "WorkerSubrequest", "WorkerSubrequestCount", "OriginIP", "OriginResponseStatus", "OriginSSLProtocol",
 "OriginResponseHTTPExpires", "OriginResponseHTTPLastModified"`
+plus any extra fields provided via `additional_fields` argument.
 
 - `all` includes all `extended` fields and adds `"BotScore", "BotScoreSrc", "BotTags", "ClientRequestBytes", "ClientSrcPort", "ClientXRequestedWith", "CacheTieredFill", "EdgeResponseCompressionRatio", "EdgeServerIP", "FirewallMatchesSources",
 "FirewallMatchesActions", "FirewallMatchesRuleIDs", "OriginResponseBytes", "OriginResponseTime", "ClientDeviceType", "WAFFlags", "WAFMatchedVar", "EdgeColoID", "RequestHeaders", "ResponseHeaders", "ClientRequestSource"`
+plus any extra fields provided via `additional_fields` argument (this is still relevant in this case if new fields are made available via Cloudflare API but are not yet included in `all`).
+
+- `custom` includes only the fields defined in `additional_fields`.
 
 To learn more about each field and its value, refer to the [Cloudflare documentation](https://developers.cloudflare.com/logs/reference/log-fields/zone/http_requests).
 


### PR DESCRIPTION
**What this PR does / why we need it**: In this PR the cloudflare config is enhanced by adding a custom fields type and by having a new property "additional_types" to give the customer the ability to specify the fields that he wants. This functionality has been added in the grafana agent and therefore should also be added in promtail.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/agent/issues/4860

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
