### PR TITLE
Update CODEOWNERS to include logs team for grammar file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,5 +8,9 @@
 /operator/ @grafana/loki-team @periklis @xperimental
 /.github/workflows/operator* @grafana/loki-team @periklis @xperimental
 
+# Logql grammar
+# The observability logs team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql
+/pkg/logql/syntax/expr.y @grafana/observability-logs @grafana/loki-team
+
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md


### PR DESCRIPTION
**What this PR does / why we need it**:
To keep LogQL grammar in sync with https://github.com/grafana/lezer-logql, we would like to add @grafana/observability-logs as a co-codeowner for grammar file `/pkg/logql/syntax/expr.y` to get notification when this file change. 
