### PR TITLE
Jsonnet: Add `default` section to runtime jsonnet file

### DIFF
--- a/production/ksonnet/loki/overrides.libsonnet
+++ b/production/ksonnet/loki/overrides.libsonnet
@@ -25,6 +25,14 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       //   log_push_request_streams: true,
       // },
     },
+
+    defaultRuntimeConfigs: {
+      // override the default runtime configs. Useful to change a behavior globally across multiple tenants. See pkg/loki/runtime_config.go
+      //
+      // log_stream_creation: true,
+      // log_push_request: true,
+      // log_push_request_streams: true,
+    },
   },
   local configMap = k.core.v1.configMap,
 
@@ -35,6 +43,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
         {
           overrides: $._config.overrides,
           configs: $._config.runtimeConfigs,
+          default: $._config.defaultRuntimeConfigs,
         }
         + (if std.length($._config.multi_kv_config) > 0 then { multi_kv_config: $._config.multi_kv_config } else {}),
       ),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a `default` section to our runtime jsonnet file.
The `default` section was introduced by https://github.com/grafana/loki/pull/10193.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
