### PR TITLE
Put unescaped regexes in a raw string literal

### DIFF
--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -368,6 +368,16 @@ type lineFilterLabelFilter struct {
 	filter Filterer
 }
 
+// overrides the matcher.String() function in case there is a regexpFilter
+func (s *lineFilterLabelFilter) String() string {
+	if unwrappedFilter, ok := s.filter.(regexpFilter); ok {
+		rStr := unwrappedFilter.String()
+		str := fmt.Sprintf("%s%s`%s`", s.Matcher.Name, s.Matcher.Type, rStr)
+		return str
+	}
+	return s.Matcher.String()
+}
+
 func (s *lineFilterLabelFilter) Process(_ int64, line []byte, lbs *LabelsBuilder) ([]byte, bool) {
 	v := labelValue(s.Name, lbs)
 	return line, s.filter.Filter(unsafeGetBytes(v))

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -3465,3 +3465,22 @@ func TestNoOpLabelToString(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stages, 0)
 }
+
+func TestParseSampleExpr_String(t *testing.T) {
+	t.Run("it doesn't add escape characters when after getting parsed", func(t *testing.T) {
+		query := `sum(rate({cluster="beep", namespace="boop"} | msg=~` + "`" + `.*?(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) /loki/api/(?i)(\d+[a-z]|[a-z]+\d)\w*/query_range` + "`" + `[1d]))`
+		expr, err := ParseSampleExpr(query)
+		require.NoError(t, err)
+
+		require.Equal(t, query, expr.String())
+	})
+
+	t.Run("it removes escape characters after being parsed", func(t *testing.T) {
+		query := `{cluster="beep", namespace="boop"} | msg=~"\\w.*"`
+		expr, err := ParseExpr(query)
+		require.NoError(t, err)
+
+		// escaping is hard: the result is {cluster="beep", namespace="boop"} | msg=~`\w.*` which is equivalent to the original
+		require.Equal(t, "{cluster=\"beep\", namespace=\"boop\"} | msg=~`\\w.*`", expr.String())
+	})
+}


### PR DESCRIPTION
[This PR](https://github.com/grafana/loki/pull/10277) fixed an issue where regexes were being escaped multiple times and causing otherwise valid queries to fail our length check. It put the resulting regexes in double quotes which meant that any regexes that _needed_ escaping were now invalid. 

This PR make is so the unescaped regex is put in a raw string literal so any extra escaping in unnecessary.