### PR TITLE
Set buckets for querier_wait_seconds histogram.

### DIFF
--- a/pkg/scheduler/queue/metrics.go
+++ b/pkg/scheduler/queue/metrics.go
@@ -37,6 +37,7 @@ func NewMetrics(subsystem string, registerer prometheus.Registerer) *Metrics {
 			Subsystem: subsystem,
 			Name:      "querier_wait_seconds",
 			Help:      "Time spend waiting for new requests.",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 240},
 		}, []string{"querier"}),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should set buckets for the `querier_wait_seconds` histogram.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
