### PR TITLE
Remove `t2.4xlarger` from sizing tool.

### DIFF
--- a/pkg/sizing/node.go
+++ b/pkg/sizing/node.go
@@ -48,13 +48,6 @@ var NodeTypesByProvider = map[string]map[string]NodeType{
 			readPod:  StandardRead,
 			writePod: StandardWrite,
 		},
-		"t2.4xlarge": {
-			name:     "t2.4xlarge",
-			cores:    16,
-			memoryGB: 64,
-			readPod:  StandardRead,
-			writePod: StandardWrite,
-		},
 	},
 	"GCP": {
 		"e2-standard-4": {


### PR DESCRIPTION
**What this PR does / why we need it**:
The sizing tool was listing an AWS EC2 instance that does not exsit.

**Which issue(s) this PR fixes**:
Fixes #10315

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
