### PR TITLE
chore(schema-v13): Fix series store schema creation for v13

### DIFF
--- a/pkg/storage/stores/series/index/schema_config.go
+++ b/pkg/storage/stores/series/index/schema_config.go
@@ -14,7 +14,6 @@ import (
 const (
 	secondsInDay      = int64(24 * time.Hour / time.Second)
 	millisecondsInDay = int64(24 * time.Hour / time.Millisecond)
-	v12               = "v12"
 )
 
 var (
@@ -35,14 +34,18 @@ func CreateSchema(cfg config.PeriodConfig) (SeriesStoreSchema, error) {
 		return nil, errInvalidTablePeriod
 	}
 
-	switch cfg.Schema {
-	case "v9":
+	v, err := cfg.VersionAsInt()
+	if err != nil {
+		return nil, err
+	}
+
+	if v == 9 {
 		return newSeriesStoreSchema(buckets, v9Entries{}), nil
-	case "v10", "v11", v12:
+	}
+	if v >= 10 {
 		if cfg.RowShards == 0 {
 			return nil, fmt.Errorf("must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
 		}
-
 		v10 := v10Entries{rowShards: cfg.RowShards}
 		switch cfg.Schema {
 		case "v10":

--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -34,7 +34,7 @@ const userID = "1"
 
 var (
 	ctx     = user.InjectOrgID(context.Background(), userID)
-	schemas = []string{"v9", "v10", "v11", "v12"}
+	schemas = []string{"v9", "v10", "v11", "v12", "v13"}
 	stores  = []struct {
 		name     string
 		configFn configFactory


### PR DESCRIPTION
**What this PR does / why we need it**:

The creation of a series store schema failed when using v13 schema version.


**Special notes for your reviewer**:

When adding the `v13` to the series store test cases (`pkg/storage/stores/series/series_store_test.go`) they fail. Example error:

```
=== RUN   TestSeriesStore_LabelValuesForMetricName/foo_/_toms_/_v13_/_store
    series_store_test.go:700: ========= Running labelValues with metricName foo with labelName toms with schema v13
    series_store_test.go:93: 
        	Error Trace:	/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:93
        	            				/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:77
        	            				/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:702
        	Error:      	Received unexpected error:
        	            	invalid schema version
        	Test:       	TestSeriesStore_LabelValuesForMetricName/foo_/_toms_/_v13_/_store
=== RUN   TestSeriesStore_LabelValuesForMetricName/foo_/_toms_/_v13_/_cached_store
    series_store_test.go:700: ========= Running labelValues with metricName foo with labelName toms with schema v13
    series_store_test.go:93: 
        	Error Trace:	/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:93
        	            				/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:77
        	            				/home/christian/sandbox/grafana/loki/pkg/storage/stores/series/series_store_test.go:702
        	Error:      	Received unexpected error:
        	            	invalid schema version
        	Test:       	TestSeriesStore_LabelValuesForMetricName/foo_/_toms_/_v13_/_cached_store

```