### PR TITLE
doc(schema): Start recommending `v12` schema instead of `v11`

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -4140,7 +4140,7 @@ The `period_config` block configures what index schemas should be used for from 
 # If omitted, defaults to the same value as store.
 [object_store: <string> | default = ""]
 
-# The schema version to use, current recommended schema is v11.
+# The schema version to use, current recommended schema is v12.
 [schema: <string> | default = ""]
 
 # Configures how the index is updated and stored.

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -159,7 +159,7 @@ type PeriodConfig struct {
 	IndexType string `yaml:"store" doc:"description=store and object_store below affect which <storage_config> key is used.\nWhich store to use for the index. Either aws, aws-dynamo, gcp, bigtable, bigtable-hashed, cassandra, boltdb or boltdb-shipper. "`
 	// type of object client to use; if omitted, defaults to store.
 	ObjectType  string              `yaml:"object_store" doc:"description=Which store to use for the chunks. Either aws, azure, gcp, bigtable, gcs, cassandra, swift, filesystem or a named_store (refer to named_stores_config). If omitted, defaults to the same value as store."`
-	Schema      string              `yaml:"schema" doc:"description=The schema version to use, current recommended schema is v11."`
+	Schema      string              `yaml:"schema" doc:"description=The schema version to use, current recommended schema is v12."`
 	IndexTables PeriodicTableConfig `yaml:"index" doc:"description=Configures how the index is updated and stored."`
 	ChunkTables PeriodicTableConfig `yaml:"chunks" doc:"description=Configured how the chunks are updated and stored."`
 	RowShards   uint32              `yaml:"row_shards" doc:"description=How many shards will be created. Only used if schema is v10 or greater."`


### PR DESCRIPTION
**What this PR does / why we need it**:
`v12` is stable schema with more efficient/stable chunks and index formats. Start recommending it instead of old `v11`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added

