### PR TITLE
chore: fix flaky querytee proxy test

### DIFF
--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -189,10 +189,10 @@ func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *back
 				result = comparisonFailed
 			}
 
-			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Inc()
 			if p.instrumentCompares && summary != nil {
 				p.metrics.missingMetrics.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Observe(float64(summary.missingMetrics))
 			}
+			p.metrics.responsesComparedTotal.WithLabelValues(p.backends[i].name, p.routeName, result, issuer).Inc()
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`Test_ProxyEndpoint_SummaryMetrics` does not wait for `compareResponses` call to finish which causes the test to fail as the expected metric response does not match

this pr updates the test to wait for `responses_compared_total` to be set to 1 before asserting `missingMetrics`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
