### PR TITLE
Remove deprecated s3 sse toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [10308](https://github.com/grafana/loki/pull/10308) **bboreham** Tracing: elide small traces for Stats call.
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
+* [10376](https://github.com/grafana/loki/pull/10376) **shantanualsi** Remove deprecated `s3.sse-encryption`
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
 * [10373](https://github.com/grafana/loki/pull/10373) **jeschkies**  Loki: Shard `avg_over_time` range aggregations.
-* [10377](https://github.com/grafana/loki/pull/10377) **shantanualsi** Remove deprecated `s3.sse-encryption`
+* [10377](https://github.com/grafana/loki/pull/10377) **shantanualsi** Remove deprecated config `-s3.sse-encryption` in favor or `-s3.sse.*` settings.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [10308](https://github.com/grafana/loki/pull/10308) **bboreham** Tracing: elide small traces for Stats call.
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
-* [10376](https://github.com/grafana/loki/pull/10376) **shantanualsi** Remove deprecated `s3.sse-encryption`
+* [10377](https://github.com/grafana/loki/pull/10377) **shantanualsi** Remove deprecated `s3.sse-encryption`
 
 ##### Fixes
 

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -4288,11 +4288,6 @@ dynamodb:
 # CLI flag: -s3.insecure
 [insecure: <boolean> | default = false]
 
-# Enable AWS Server Side Encryption [Deprecated: Use .sse instead. if
-# s3.sse-encryption is enabled, it assumes .sse.type SSE-S3]
-# CLI flag: -s3.sse-encryption
-[sse_encryption: <boolean> | default = false]
-
 http_config:
   # Timeout specifies a time limit for requests made by s3 Client.
   # CLI flag: -s3.http.timeout
@@ -4569,11 +4564,6 @@ The `s3_storage_config` block configures the connection to Amazon S3 object stor
 # Disable https on s3 connection.
 # CLI flag: -<prefix>.storage.s3.insecure
 [insecure: <boolean> | default = false]
-
-# Enable AWS Server Side Encryption [Deprecated: Use .sse instead. if
-# s3.sse-encryption is enabled, it assumes .sse.type SSE-S3]
-# CLI flag: -<prefix>.storage.s3.sse-encryption
-[sse_encryption: <boolean> | default = false]
 
 http_config:
   # Timeout specifies a time limit for requests made by s3 Client.

--- a/docs/sources/configure/examples.md
+++ b/docs/sources/configure/examples.md
@@ -297,7 +297,6 @@ storage_config:
     access_key_id: s3_access_key_id
     secret_access_key: s3_secret_access_key
     insecure: false
-    sse_encryption: false
     http_config:
       idle_conn_timeout: 90s
       response_header_timeout: 0s
@@ -324,7 +323,6 @@ schema_config:
 storage_config:
   aws:
     s3: s3://access_key:secret_access_key@region/bucket_name
-    sse_encryption: true
     sse:
       type: SSE-KMS
       kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab

--- a/docs/sources/configure/examples/10-S3-And-DynamoDB-With-KMS-Snippet.yaml
+++ b/docs/sources/configure/examples/10-S3-And-DynamoDB-With-KMS-Snippet.yaml
@@ -11,7 +11,6 @@ schema_config:
 storage_config:
   aws:
     s3: s3://access_key:secret_access_key@region/bucket_name
-    sse_encryption: true
     sse:
       type: SSE-KMS
       kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab

--- a/docs/sources/configure/examples/9-Expanded-S3-Snippet.yaml
+++ b/docs/sources/configure/examples/9-Expanded-S3-Snippet.yaml
@@ -17,7 +17,6 @@ storage_config:
     access_key_id: s3_access_key_id
     secret_access_key: s3_secret_access_key
     insecure: false
-    sse_encryption: false
     http_config:
       idle_conn_timeout: 90s
       response_header_timeout: 0s

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -96,9 +96,10 @@ If you have a use-case that relies on strict parsing where you expect the parser
 logfmt parser doesn't include standalone keys(keys without a value) in the resulting label set anymore.
 You can use `--keep-empty` flag to retain them.
 
-#### deprecated query and engine timeout configs are now removed
-Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting. Also removes the `query_timeout` from the querier YAML section.
-Instead of configuring `query_timeout` under `querier`, you now configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
+#### deprecated configs are now removed
+1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting. 
+2. Also removes the `query_timeout` from the querier YAML section. Instead of configuring `query_timeout` under `querier`, you now configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
+3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type.
 
 ### Jsonnet
 

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -277,7 +277,6 @@ memberlist:
 				assert.Equal(t, "def789", actual.SecretAccessKey.String())
 				assert.Equal(t, "", actual.SessionToken.String())
 				assert.Equal(t, true, actual.Insecure)
-				assert.Equal(t, false, actual.SSEEncryption)
 				assert.Equal(t, 5*time.Minute, actual.HTTPConfig.ResponseHeaderTimeout)
 				assert.Equal(t, false, actual.HTTPConfig.InsecureSkipVerify)
 
@@ -336,7 +335,6 @@ memberlist:
 				assert.Equal(t, "def789", actual.SecretAccessKey.String())
 				assert.Equal(t, "456abc", actual.SessionToken.String())
 				assert.Equal(t, true, actual.Insecure)
-				assert.Equal(t, false, actual.SSEEncryption)
 				assert.Equal(t, 5*time.Minute, actual.HTTPConfig.ResponseHeaderTimeout)
 				assert.Equal(t, false, actual.HTTPConfig.InsecureSkipVerify)
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -176,10 +176,7 @@ func buildSSEParsedConfig(cfg S3Config) (*SSEParsedConfig, error) {
 		return NewSSEParsedConfig(cfg.SSEConfig)
 	}
 
-	// default behavior to return SSE-S3 type
-	return NewSSEParsedConfig(bucket_s3.SSEConfig{
-		Type: bucket_s3.SSES3,
-	})
+	return nil, nil
 }
 
 func buildS3Client(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (*s3.S3, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

AWS now defaults to SSE S3 for every bucket. All objects are automatically encrypted at no additional cost. Thus, this change will deprecate the enable toggle from Loki.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
