### PR TITLE
Add changelog for non-indexed labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [10308](https://github.com/grafana/loki/pull/10308) **bboreham** Tracing: elide small traces for Stats call.
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
-* [10073](https://github.com/grafana/loki/pull/10073) **sandeepsukhani,salvacorts,vlad-diachenko** Support receiving non-indexed labels attached to each log line. Return these non-index labels in log and metric queries results. Allow filtering by non-indexed labels in LogQL.
+* [10073](https://github.com/grafana/loki/pull/10073) **sandeepsukhani,salvacorts,vlad-diachenko** Support attaching non-indexed labels to log lines.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,7 @@
 * [10308](https://github.com/grafana/loki/pull/10308) **bboreham** Tracing: elide small traces for Stats call.
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
-* [9694](https://github.com/grafana/loki/pull/9694) **sandeepsukhani,salvacorts,vlad-diachenko** Support receiving non-indexed labels attached to each log line.
-* [9700](https://github.com/grafana/loki/pull/9700) **sandeepsukhani,salvacorts,vlad-diachenko** Create new chunk and head formats to support writing and reading non-indexed labels.
-* [9702](https://github.com/grafana/loki/pull/9702) **sandeepsukhani,salvacorts,vlad-diachenko** Return non-indexed labels in log and metric queries and support filtering in LogQL.
+* [10073](https://github.com/grafana/loki/pull/10073) **sandeepsukhani,salvacorts,vlad-diachenko** Support receiving non-indexed labels attached to each log line. Return these non-index labels in log and metric queries results. Allow filtering by non-indexed labels in LogQL.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
 * [10308](https://github.com/grafana/loki/pull/10308) **bboreham** Tracing: elide small traces for Stats call.
 * [10341](https://github.com/grafana/loki/pull/10341) **ashwanthgoli** Deprecate older index types and non-object stores - `aws-dynamo, gcp, gcp-columnkey, bigtable, bigtable-hashed, cassandra, grpc`
 * [10344](https://github.com/grafana/loki/pull/10344) **ashwanthgoli**  Compactor: deprecate `-boltdb.shipper.compactor.` prefix in favor of `-compactor.`.
+* [9694](https://github.com/grafana/loki/pull/9694) **sandeepsukhani,salvacorts,vlad-diachenko** Support receiving non-indexed labels attached to each log line.
+* [9700](https://github.com/grafana/loki/pull/9700) **sandeepsukhani,salvacorts,vlad-diachenko** Create new chunk and head formats to support writing and reading non-indexed labels.
+* [9702](https://github.com/grafana/loki/pull/9702) **sandeepsukhani,salvacorts,vlad-diachenko** Return non-indexed labels in log and metric queries and support filtering in LogQL.
 
 ##### Fixes
 
@@ -96,6 +99,7 @@
 * [8474](https://github.com/grafana/loki/pull/8787) **andriikushch**: Promtail: Add a new target for the Azure Event Hubs
 * [8874](https://github.com/grafana/loki/pull/8874) **rfratto**: Promtail: Support expoential backoff when polling unchanged files for logs.
 * [9508](https://github.com/grafana/loki/pull/9508) **farodin91**: Promtail: improve behavior of partial lines.
+* [9986](https://github.com/grafana/loki/pull/9986) **vlad-diachenko**: Promtail: Add `non_indexed_labels` stage to attach non-indexed labels to each log line.
 
 ##### Fixes
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently implemented a new feature to support attaching and querying non-indexed labels attached to each log line.
This PR updates the changelog with entries referencing the main PRs of this feature.
