### PR TITLE
helm: omit annotation section when empty

### DIFF
--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "loki.backendLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- with .Values.backend.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
 {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.backend.replicas }}

--- a/production/helm/loki/templates/gateway/deployment-gateway.yaml
+++ b/production/helm/loki/templates/gateway/deployment-gateway.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -13,6 +14,7 @@ metadata:
     {{- with .Values.gateway.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
 {{- if not .Values.gateway.autoscaling.enabled }}
   replicas: {{ .Values.gateway.replicas }}

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -18,10 +18,10 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- with .annotations }}
       annotations:
-        {{- with .annotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "loki-canary.selectorLabels" $ | nindent 8 }}
         {{- with .podLabels }}

--- a/production/helm/loki/templates/loki-canary/serviceaccount.yaml
+++ b/production/helm/loki/templates/loki-canary/serviceaccount.yaml
@@ -8,8 +8,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "loki-canary.labels" $ | nindent 4 }}
-  annotations:
   {{- with .annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ $.Values.serviceAccount.automountServiceAccountToken }}

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: memberlist
     {{- include "loki.readLabels" . | nindent 4 }}
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- with .Values.read.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   {{- if not .Values.read.autoscaling.enabled }}
   replicas: {{ .Values.read.replicas }}

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "loki.singleBinaryLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- with .Values.singleBinary.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   replicas: {{ include "loki.singleBinaryReplicas" . }}
   podManagementPolicy: Parallel

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "loki.writeLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
+  {{- if or (not (empty .Values.loki.annotations)) (not (empty .Values.backend.annotations))}}
   annotations:
     {{- with .Values.loki.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -15,6 +16,7 @@ metadata:
     {{- with .Values.write.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
 {{- if not .Values.write.autoscaling.enabled }}
   replicas: {{ .Values.write.replicas }}


### PR DESCRIPTION
This is a small, nit-picky stylistic change to the helm chart. When there are no annotations for a template, this omits the `annotations` key, rather than having an empty `annotations` section in the rendered template.