### PR TITLE
bugfix/promtail.sh: Updated script to work better by default in k8s environment

### DIFF
--- a/tools/promtail.sh
+++ b/tools/promtail.sh
@@ -5,7 +5,7 @@ APIKEY="${2:-}"
 INSTANCEURL="${3:-}"
 NAMESPACE="${4:-default}"
 CONTAINERROOT="${5:-/var/lib/docker}"
-PARSER="${6:-- docker:}"
+PARSER="${6:-- cri: {}}"
 VERSION="${PROMTAIL_VERSION:-2.7.1}"
 
 if [ -z "${INSTANCEID}" ] || [ -z "${APIKEY}" ] || [ -z "${INSTANCEURL}" ] || [ -z "${NAMESPACE}" ] || [ -z "${CONTAINERROOT}" ] || [ -z "${PARSER}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug in [promtail.sh](https://github.com/grafana/loki/blob/94a5f94cf408e2da3e4293e8163e18c47c74e4d6/tools/promtail.sh). 

promtail.sh is a script to deploy promtail in kubernetes clusters as a daemonset. The defaults should make sense in that environment. 

Currently, The default log parser in pipeline stages is, `- docker: `. Kubernetes uses CRI format so it makes more sense to default to CRI parser and this PR does exactly that.


This PR does not affect any existing users of loki and it'll improve it for people who decide to use this script with the default arguments in the future because kubernetes uses cri format and grafana can't parse JSON logs properly if they were fed to loki with docker parser instead of the more appropriate cri parser.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
