### PR TITLE
Fix CLI flags for congestion control

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -1912,7 +1912,7 @@ hedging:
 
 congestion_control:
   # Use storage congestion control (default: disabled).
-  # CLI flag: -store.enabled
+  # CLI flag: -store.congestion-control.enabled
   [enabled: <boolean> | default = false]
 
   controller:
@@ -1939,11 +1939,11 @@ congestion_control:
   retry:
     # Congestion control retry strategy to use (default: none, options:
     # 'limited').
-    # CLI flag: -store.retry.strategy
+    # CLI flag: -store.congestion-control.retry.strategy
     [strategy: <string> | default = ""]
 
     # Maximum number of retries allowed.
-    # CLI flag: -store.retry.strategy.limited.limit
+    # CLI flag: -store.congestion-control.retry.strategy.limited.limit
     [limit: <int> | default = 2]
 
   hedging:
@@ -1956,7 +1956,7 @@ congestion_control:
 
     # Congestion control hedge strategy to use (default: none, options:
     # 'limited').
-    # CLI flag: -store.hedge.strategy
+    # CLI flag: -store.congestion-control.hedge.strategy
     [strategy: <string> | default = ""]
 
 # The cache block configures the cache backend.
@@ -3199,7 +3199,7 @@ storage:
 
   congestion_control:
     # Use storage congestion control (default: disabled).
-    # CLI flag: -common.storage.enabled
+    # CLI flag: -common.storage.congestion-control.enabled
     [enabled: <boolean> | default = false]
 
     controller:
@@ -3226,11 +3226,11 @@ storage:
     retry:
       # Congestion control retry strategy to use (default: none, options:
       # 'limited').
-      # CLI flag: -common.storage.retry.strategy
+      # CLI flag: -common.storage.congestion-control.retry.strategy
       [strategy: <string> | default = ""]
 
       # Maximum number of retries allowed.
-      # CLI flag: -common.storage.retry.strategy.limited.limit
+      # CLI flag: -common.storage.congestion-control.retry.strategy.limited.limit
       [limit: <int> | default = 2]
 
     hedging:
@@ -3243,7 +3243,7 @@ storage:
 
       # Congestion control hedge strategy to use (default: none, options:
       # 'limited').
-      # CLI flag: -common.storage.hedge.strategy
+      # CLI flag: -common.storage.congestion-control.hedge.strategy
       [strategy: <string> | default = ""]
 
 [persist_tokens: <boolean>]

--- a/pkg/storage/chunk/client/congestion/config.go
+++ b/pkg/storage/chunk/client/congestion/config.go
@@ -2,6 +2,7 @@ package congestion
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/grafana/loki/pkg/storage/chunk/client/hedging"
 )
@@ -14,9 +15,10 @@ type Config struct {
 }
 
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	prefix = fmt.Sprintf("%s.%s", prefix, "congestion-control.")
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "Use storage congestion control (default: disabled).")
 
-	c.Controller.RegisterFlagsWithPrefix(prefix+"congestion-control.", f)
+	c.Controller.RegisterFlagsWithPrefix(prefix, f)
 	c.Retry.RegisterFlagsWithPrefix(prefix+"retry.", f)
 	c.Hedge.RegisterFlagsWithPrefix(prefix+"hedge.", f)
 }

--- a/pkg/storage/chunk/client/congestion/config.go
+++ b/pkg/storage/chunk/client/congestion/config.go
@@ -15,7 +15,7 @@ type Config struct {
 }
 
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	prefix = fmt.Sprintf("%s.%s", prefix, "congestion-control.")
+	prefix = fmt.Sprintf("%s%s", prefix, "congestion-control.")
 	f.BoolVar(&c.Enabled, prefix+"enabled", false, "Use storage congestion control (default: disabled).")
 
 	c.Controller.RegisterFlagsWithPrefix(prefix, f)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `congestion-control` prefixes to new flags.

Currently to enable congestion control via a flag, one must use `-store.enabled` which is obviously misleading.