### PR TITLE
Remove split_queries_by_interval and forward_headers_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [10073](https://github.com/grafana/loki/pull/10073) **sandeepsukhani,salvacorts,vlad-diachenko** Support attaching non-indexed labels to log lines.
 * [10378](https://github.com/grafana/loki/pull/10378) **shantanualsi** Remove deprecated `ruler.wal-cleaer.period`
 * [10380](https://github.com/grafana/loki/pull/10380) **shantanualsi** Remove `experimental.ruler.enable-api` in favour of `ruler.enable-api`
+* [10395](https://github.com/grafana/loki/pull/10395/) **shantanualshi** Remove deprecated split_queries_by_interval and forward_headers_list configs in query_range
 
 ##### Fixes
 

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -775,10 +775,6 @@ The `frontend` block configures the Loki query-frontend.
 The `query_range` block configures the query splitting and caching in the Loki query-frontend.
 
 ```yaml
-# Deprecated: Use -querier.split-queries-by-interval instead. CLI flag:
-# -querier.split-queries-by-day. Split queries by day and execute in parallel.
-[split_queries_by_interval: <duration>]
-
 # Mutate incoming queries to align their start and end with their step.
 # CLI flag: -querier.align-querier-with-step
 [align_queries_with_step: <boolean> | default = false]
@@ -806,11 +802,6 @@ results_cache:
 # query ASTs. This feature is supported only by the chunks storage engine.
 # CLI flag: -querier.parallelise-shardable-queries
 [parallelise_shardable_queries: <boolean> | default = true]
-
-# Deprecated. List of headers forwarded by the query Frontend to downstream
-# querier.
-# CLI flag: -frontend.forward-headers-list
-[forward_headers_list: <list of strings> | default = []]
 
 # The downstream querier is required to answer in the accepted format. Can be
 # 'json' or 'protobuf'. Note: Both will still be routed over GRPC.

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -102,6 +102,8 @@ You can use `--keep-empty` flag to retain them.
 3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type. 
 4. `ruler.wal-cleaer.period` is removed. Use `ruler.wal-cleaner.period` instead.
 5. `experimental.ruler.enable-api` is removed. Use `ruler.enable-api` instead.
+6. `query_range.split_queries_by_interval` is now removed. Use the flag in `limits_config` instead.
+7. `query_range.forward_headers_list` is now removed
 
 ### Jsonnet
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -102,8 +102,8 @@ You can use `--keep-empty` flag to retain them.
 3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type. 
 4. `ruler.wal-cleaer.period` is removed. Use `ruler.wal-cleaner.period` instead.
 5. `experimental.ruler.enable-api` is removed. Use `ruler.enable-api` instead.
-6. `query_range.split_queries_by_interval` is now removed. Use the flag in `limits_config` instead.
-7. `query_range.forward_headers_list` is now removed
+6. `split_queries_by_interval` is removed from `query_range` YAML section. You can instead configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
+7. `frontend.forward-headers-list` CLI flag and its corresponding YAML setting are removed.
 
 ### Jsonnet
 

--- a/pkg/querier/queryrange/queryrangebase/roundtrip.go
+++ b/pkg/querier/queryrange/queryrangebase/roundtrip.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
 	"github.com/opentracing/opentracing-go"
@@ -38,19 +37,11 @@ var PassthroughMiddleware = MiddlewareFunc(func(next Handler) Handler {
 
 // Config for query_range middleware chain.
 type Config struct {
-	// Deprecated: SplitQueriesByInterval will be removed in the next major release
-	SplitQueriesByInterval time.Duration `yaml:"split_queries_by_interval" doc:"deprecated|description=Use -querier.split-queries-by-interval instead. CLI flag: -querier.split-queries-by-day. Split queries by day and execute in parallel."`
-
 	AlignQueriesWithStep bool               `yaml:"align_queries_with_step"`
 	ResultsCacheConfig   ResultsCacheConfig `yaml:"results_cache"`
 	CacheResults         bool               `yaml:"cache_results"`
 	MaxRetries           int                `yaml:"max_retries"`
 	ShardedQueries       bool               `yaml:"parallelise_shardable_queries"`
-
-	// TODO(karsten): remove used option ForwardHeaders with Loki 3.0 since
-	// it's a breaking change.
-	// List of headers which query_range middleware chain would forward to downstream querier.
-	ForwardHeaders flagext.StringSlice `yaml:"forward_headers_list"`
 
 	// Required format for querier responses
 	RequiredQueryResponseFormat string `yaml:"required_query_response_format"`
@@ -62,7 +53,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.AlignQueriesWithStep, "querier.align-querier-with-step", false, "Mutate incoming queries to align their start and end with their step.")
 	f.BoolVar(&cfg.CacheResults, "querier.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "querier.parallelise-shardable-queries", true, "Perform query parallelisations based on storage sharding configuration and query ASTs. This feature is supported only by the chunks storage engine.")
-	f.Var(&cfg.ForwardHeaders, "frontend.forward-headers-list", "Deprecated. List of headers forwarded by the query Frontend to downstream querier.")
 
 	f.StringVar(&cfg.RequiredQueryResponseFormat, "frontend.required-query-response-format", "json", "The downstream querier is required to answer in the accepted format. Can be 'json' or 'protobuf'. Note: Both will still be routed over GRPC.")
 
@@ -71,9 +61,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
-	if cfg.SplitQueriesByInterval != 0 {
-		return errors.New("the yaml flag `split_queries_by_interval` must now be set in the `limits_config` section instead of the `query_range` config section")
-	}
 	if cfg.CacheResults {
 		if err := cfg.ResultsCacheConfig.Validate(); err != nil {
 			return errors.Wrap(err, "invalid results_cache config")


### PR DESCRIPTION
…range config
Removed split_queries_by_interval and forward_headers_list from query_range config

The fields were deprecated and hence going to be removed in the next major version

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
