### PR TITLE
Fix fluentbit plugin for manifest step

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -695,7 +695,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   fluentd(),
   logstash(),
   querytee(),
-  manifest(['promtail', 'loki', 'loki-canary', 'fluent-bit', 'loki-canary-boringcrypto']) {
+  manifest(['promtail', 'loki', 'loki-canary', 'loki-canary-boringcrypto', 'fluent-bit-plugin-loki']) {
     trigger+: onTagOrMain,
   },
   manifest_operator('loki-operator') {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1418,19 +1418,6 @@ steps:
   - clone
   - manifest-loki-canary
   image: plugins/manifest:1.4.0
-  name: manifest-fluent-bit
-  settings:
-    ignore_missing: false
-    password:
-      from_secret: docker_password
-    spec: .drone/docker-manifest.tmpl
-    target: fluent-bit
-    username:
-      from_secret: docker_username
-- depends_on:
-  - clone
-  - manifest-fluent-bit
-  image: plugins/manifest:1.4.0
   name: manifest-loki-canary-boringcrypto
   settings:
     ignore_missing: false
@@ -1438,6 +1425,19 @@ steps:
       from_secret: docker_password
     spec: .drone/docker-manifest.tmpl
     target: loki-canary-boringcrypto
+    username:
+      from_secret: docker_username
+- depends_on:
+  - clone
+  - manifest-loki-canary-boringcrypto
+  image: plugins/manifest:1.4.0
+  name: manifest-fluent-bit-plugin-loki
+  settings:
+    ignore_missing: false
+    password:
+      from_secret: docker_password
+    spec: .drone/docker-manifest.tmpl
+    target: fluent-bit-plugin-loki
     username:
       from_secret: docker_username
 trigger:
@@ -2016,6 +2016,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: d53b81539e55f3be9f946e7270740c8f6c264ffb4030d7040b2fcb136927606c
+hmac: 6aff5ae73eeaed171dafbc08b599abaf9a4ef4c1d68212da1a1442f36f5c7d8b
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:
It appears that this commit (https://github.com/grafana/loki/commit/d484d31856926b9694d6d2d162ade10de3de247c) is causing a failure when on the manifest.manifest-fluent-bit step (2023/08/28 09:53:47 pushing by spec
time="2023-08-28T09:53:47Z" level=fatal msg="Inspect of image \"grafana/fluent-bit:main-586b904-amd64\" failed with error: errors:\ndenied: requested access to the resource is denied\nunauthorized: authentication required\n"
exit status 1).

Subsequent investigation has shown that the grafana/fluent-bit docker repo does not exist.  

This PR is to change the manifest step to reference 'fluent-bit-plugin-loki' instead of 'fluent-bit'.  The former is referenced for other steps in the Make process.

I have also moved the boringcrypto canary ahead of the fluent-bit step to put the canaries next to each other, and to further help debug this step, should this change not be correct.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
