### PR TITLE
Rename and move index and chunk store interfaces

### DIFF
--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/validation"
 )
@@ -361,7 +362,7 @@ func (s *testStore) GetSchemaConfigs() []config.PeriodConfig {
 
 func (s *testStore) Stop() {}
 
-func (s *testStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
+func (s *testStore) SetChunkFilterer(_ indexstore.RequestChunkFilterer) {}
 
 func (s *testStore) Stats(_ context.Context, _ string, _, _ model.Time, _ ...*labels.Matcher) (*stats.Stats, error) {
 	return &stats.Stats{}, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
 	index_stats "github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/util"
@@ -104,7 +105,7 @@ type Config struct {
 
 	WAL WALConfig `yaml:"wal,omitempty" doc:"description=The ingester WAL (Write Ahead Log) records incoming logs and stores them on the local file systems in order to guarantee persistence of acknowledged data in the event of a process crash."`
 
-	ChunkFilterer chunk.RequestChunkFilterer `yaml:"-"`
+	ChunkFilterer indexstore.RequestChunkFilterer `yaml:"-"`
 	// Optional wrapper that can be used to modify the behaviour of the ingester
 	Wrapper Wrapper `yaml:"-"`
 
@@ -240,7 +241,7 @@ type Ingester struct {
 
 	wal WAL
 
-	chunkFilter chunk.RequestChunkFilterer
+	chunkFilter indexstore.RequestChunkFilterer
 
 	streamRateCalculator *StreamRateCalculator
 
@@ -319,7 +320,7 @@ func New(cfg Config, clientConfig client.Config, store ChunkStore, limits Limits
 	return i, nil
 }
 
-func (i *Ingester) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (i *Ingester) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	i.chunkFilter = chunkFilter
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/validation"
@@ -441,7 +442,7 @@ func (s *mockStore) GetSchemaConfigs() []config.PeriodConfig {
 	return defaultPeriodConfigs
 }
 
-func (s *mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
+func (s *mockStore) SetChunkFilterer(_ indexstore.RequestChunkFilterer) {
 }
 
 // chunk.Store methods

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/querier/astmapper"
 	loki_runtime "github.com/grafana/loki/pkg/runtime"
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/pkg/validation"
 )
@@ -627,7 +627,7 @@ func Test_Iterator(t *testing.T) {
 
 type testFilter struct{}
 
-func (t *testFilter) ForRequest(_ context.Context) chunk.Filterer {
+func (t *testFilter) ForRequest(_ context.Context) indexstore.Filterer {
 	return t
 }
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/util"
 	"github.com/grafana/loki/pkg/validation"
@@ -299,7 +300,7 @@ func newStoreMock() *storeMock {
 	return &storeMock{}
 }
 
-func (s *storeMock) SetChunkFilterer(chunk.RequestChunkFilterer) {}
+func (s *storeMock) SetChunkFilterer(indexstore.RequestChunkFilterer) {}
 
 func (s *storeMock) SelectLogs(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error) {
 	args := s.Called(ctx, req)

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
@@ -86,7 +87,7 @@ type batchChunkIterator struct {
 	lastOverlapping []*LazyChunk
 	metrics         *ChunkMetrics
 	matchers        []*labels.Matcher
-	chunkFilterer   chunk.Filterer
+	chunkFilterer   indexstore.Filterer
 
 	begun      bool
 	ctx        context.Context
@@ -105,7 +106,7 @@ func newBatchChunkIterator(
 	start, end time.Time,
 	metrics *ChunkMetrics,
 	matchers []*labels.Matcher,
-	chunkFilterer chunk.Filterer,
+	chunkFilterer indexstore.Filterer,
 ) *batchChunkIterator {
 	// __name__ is not something we filter by because it's a constant in loki
 	// and only used for upstream compatibility; therefore remove it.
@@ -325,7 +326,7 @@ func newLogBatchIterator(
 	pipeline syntax.Pipeline,
 	direction logproto.Direction,
 	start, end time.Time,
-	chunkFilterer chunk.Filterer,
+	chunkFilterer indexstore.Filterer,
 ) (iter.EntryIterator, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return &logBatchIterator{
@@ -470,7 +471,7 @@ func newSampleBatchIterator(
 	matchers []*labels.Matcher,
 	extractor syntax.SampleExtractor,
 	start, end time.Time,
-	chunkFilterer chunk.Filterer,
+	chunkFilterer indexstore.Filterer,
 ) (iter.SampleIterator, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return &sampleBatchIterator{
@@ -607,7 +608,7 @@ func fetchChunkBySeries(
 	metrics *ChunkMetrics,
 	chunks []*LazyChunk,
 	matchers []*labels.Matcher,
-	chunkFilter chunk.Filterer,
+	chunkFilter indexstore.Filterer,
 ) (map[model.Fingerprint][][]*LazyChunk, error) {
 	chksBySeries := partitionBySeriesChunks(chunks)
 
@@ -643,7 +644,7 @@ func fetchChunkBySeries(
 func filterSeriesByMatchers(
 	chks map[model.Fingerprint][][]*LazyChunk,
 	matchers []*labels.Matcher,
-	chunkFilterer chunk.Filterer,
+	chunkFilterer indexstore.Filterer,
 	metrics *ChunkMetrics,
 ) map[model.Fingerprint][][]*LazyChunk {
 	var filteredSeries, filteredChks int

--- a/pkg/storage/chunk/interface.go
+++ b/pkg/storage/chunk/interface.go
@@ -17,12 +17,10 @@
 package chunk
 
 import (
-	"context"
 	"errors"
 	"io"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/pkg/util/filter"
 )
@@ -57,14 +55,4 @@ type Data interface {
 	// Entries returns the number of entries in a chunk
 	Entries() int
 	Utilization() float64
-}
-
-// RequestChunkFilterer creates ChunkFilterer for a given request context.
-type RequestChunkFilterer interface {
-	ForRequest(ctx context.Context) Filterer
-}
-
-// Filterer filters chunks based on the metric.
-type Filterer interface {
-	ShouldFilter(metric labels.Labels) bool
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -49,7 +49,7 @@ var (
 
 type Store interface {
 	stores.Store
-	chunkstore.Reader
+	chunkstore.ReadStore
 	indexstore.Filterable
 	GetSchemaConfigs() []config.PeriodConfig
 }
@@ -235,7 +235,7 @@ func shouldUseIndexGatewayClient(cfg indexshipper.Config) bool {
 	return true
 }
 
-func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher) (chunkstore.Writer, indexstore.ReaderWriter, func(), error) {
+func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher) (chunkstore.WriteStore, indexstore.ReaderWriter, func(), error) {
 	indexClientReg := prometheus.WrapRegistererWith(
 		prometheus.Labels{
 			"component": fmt.Sprintf(

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -235,7 +235,7 @@ func shouldUseIndexGatewayClient(cfg indexshipper.Config) bool {
 	return true
 }
 
-func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher) (chunkstore.WriteStore, indexstore.ReaderWriter, func(), error) {
+func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRange, chunkClient client.Client, f *fetcher.Fetcher) (chunkstore.WriteStore, indexstore.ReadWriteStore, func(), error) {
 	indexClientReg := prometheus.WrapRegistererWith(
 		prometheus.Labels{
 			"component": fmt.Sprintf(
@@ -271,7 +271,7 @@ func (s *store) storeForPeriod(p config.PeriodConfig, tableRange config.TableRan
 			return nil, nil, nil, err
 		}
 
-		var backupIndexWriter indexstore.Writer
+		var backupIndexWriter indexstore.WriteStore
 		backupStoreStop := func() {}
 		if s.cfg.TSDBShipperConfig.UseBoltDBShipperAsBackup {
 			pCopy := p

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper"
 	"github.com/grafana/loki/pkg/storage/stores/shipper"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb"
@@ -836,7 +837,7 @@ func Test_store_SelectSample(t *testing.T) {
 
 type fakeChunkFilterer struct{}
 
-func (f fakeChunkFilterer) ForRequest(_ context.Context) chunk.Filterer {
+func (f fakeChunkFilterer) ForRequest(_ context.Context) indexstore.Filterer {
 	return f
 }
 

--- a/pkg/storage/stores/chunk/chunkstore.go
+++ b/pkg/storage/stores/chunk/chunkstore.go
@@ -13,23 +13,23 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 )
 
-// Reader is an interface for a chunk store that reads data
-type Reader interface {
+// ReadStore is an interface for a chunk store that reads data
+type ReadStore interface {
 	SelectSamples(ctx context.Context, req logql.SelectSampleParams) (iter.SampleIterator, error)
 	SelectLogs(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error)
 	Series(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error)
 }
 
-// Writer is an interface for a chunk store that writes data
-type Writer interface {
+// WriteStore is an interface for a chunk store that writes data
+type WriteStore interface {
 	Put(ctx context.Context, chunks []chunk.Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error
 }
 
-// ReaderWriter is an interface for a chunk store that reads and writes data
-type ReaderWriter interface {
-	Reader
-	Writer
+// ReadWriteStore is an interface for a chunk store that reads and writes data
+type ReadWriteStore interface {
+	ReadStore
+	WriteStore
 }
 
 // Fetcher is an interface for a chunk store that needs to fetch chunks
@@ -37,4 +37,9 @@ type ReaderWriter interface {
 type Fetcher interface {
 	GetChunkFetcher(tm model.Time) *fetcher.Fetcher
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error)
+}
+
+type Store interface {
+	ReadWriteStore
+	Fetcher
 }

--- a/pkg/storage/stores/chunk/chunkstore.go
+++ b/pkg/storage/stores/chunk/chunkstore.go
@@ -26,7 +26,7 @@ type Writer interface {
 	PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error
 }
 
-// ChunkWriter is an interface for a chunk store that reads and writes data
+// ReaderWriter is an interface for a chunk store that reads and writes data
 type ReaderWriter interface {
 	Reader
 	Writer

--- a/pkg/storage/stores/chunk/chunkstore.go
+++ b/pkg/storage/stores/chunk/chunkstore.go
@@ -1,0 +1,40 @@
+package chunk
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql"
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
+)
+
+// Reader is an interface for a chunk store that reads data
+type Reader interface {
+	SelectSamples(ctx context.Context, req logql.SelectSampleParams) (iter.SampleIterator, error)
+	SelectLogs(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error)
+	Series(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error)
+}
+
+// Writer is an interface for a chunk store that writes data
+type Writer interface {
+	Put(ctx context.Context, chunks []chunk.Chunk) error
+	PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error
+}
+
+// ChunkWriter is an interface for a chunk store that reads and writes data
+type ReaderWriter interface {
+	Reader
+	Writer
+}
+
+// Fetcher is an interface for a chunk store that needs to fetch chunks
+// from a local or remote location
+type Fetcher interface {
+	GetChunkFetcher(tm model.Time) *fetcher.Fetcher
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error)
+}

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -21,7 +21,7 @@ import (
 type Store interface {
 	indexstore.BaseReader
 	indexstore.Filterable
-	chunkstore.Writer
+	chunkstore.WriteStore
 	chunkstore.Fetcher
 	Stop()
 }
@@ -46,13 +46,13 @@ func NewCompositeStore(limits StoreLimits) *CompositeStore {
 	return &CompositeStore{compositeStore{}, limits}
 }
 
-func (c *CompositeStore) AddStore(start model.Time, fetcher *fetcher.Fetcher, index indexstore.Reader, writer chunkstore.Writer, stop func()) {
+func (c *CompositeStore) AddStore(start model.Time, fetcher *fetcher.Fetcher, index indexstore.Reader, writer chunkstore.WriteStore, stop func()) {
 	c.stores = append(c.stores, compositeStoreEntry{
 		start: start,
 		Store: &storeEntry{
 			fetcher:     fetcher,
 			indexReader: index,
-			Writer:      writer,
+			WriteStore:  writer,
 			limits:      c.limits,
 			stop:        stop,
 		},

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Store interface {
-	indexstore.BaseReader
+	indexstore.ReadStoreBase
 	indexstore.Filterable
 	chunkstore.WriteStore
 	chunkstore.Fetcher
@@ -46,7 +46,7 @@ func NewCompositeStore(limits StoreLimits) *CompositeStore {
 	return &CompositeStore{compositeStore{}, limits}
 }
 
-func (c *CompositeStore) AddStore(start model.Time, fetcher *fetcher.Fetcher, index indexstore.Reader, writer chunkstore.WriteStore, stop func()) {
+func (c *CompositeStore) AddStore(start model.Time, fetcher *fetcher.Fetcher, index indexstore.ReadStore, writer chunkstore.WriteStore, stop func()) {
 	c.stores = append(c.stores, compositeStoreEntry{
 		start: start,
 		Store: &storeEntry{

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -39,7 +39,7 @@ type storeEntry struct {
 	limits      StoreLimits
 	stop        func()
 	fetcher     *fetcher.Fetcher
-	indexReader indexstore.Reader
+	indexReader indexstore.ReadStore
 	chunkstore.WriteStore
 }
 

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -40,7 +40,7 @@ type storeEntry struct {
 	stop        func()
 	fetcher     *fetcher.Fetcher
 	indexReader indexstore.Reader
-	chunkstore.Writer
+	chunkstore.WriteStore
 }
 
 func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -17,7 +17,8 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/errors"
-	"github.com/grafana/loki/pkg/storage/stores/index"
+	chunkstore "github.com/grafana/loki/pkg/storage/stores/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	util_log "github.com/grafana/loki/pkg/util/log"
 	"github.com/grafana/loki/pkg/util/spanlogger"
@@ -38,8 +39,8 @@ type storeEntry struct {
 	limits      StoreLimits
 	stop        func()
 	fetcher     *fetcher.Fetcher
-	indexReader index.Reader
-	ChunkWriter
+	indexReader indexstore.Reader
+	chunkstore.Writer
 }
 
 func (c *storeEntry) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
@@ -80,7 +81,7 @@ func (c *storeEntry) GetSeries(ctx context.Context, userID string, from, through
 	return c.indexReader.GetSeries(ctx, userID, from, through, matchers...)
 }
 
-func (c *storeEntry) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (c *storeEntry) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	c.indexReader.SetChunkFilterer(chunkFilter)
 }
 

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 )
 
@@ -34,7 +35,7 @@ func (m mockStore) LabelValuesForMetricName(_ context.Context, _ string, _, _ mo
 	return nil, nil
 }
 
-func (m mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
+func (m mockStore) SetChunkFilterer(_ indexstore.RequestChunkFilterer) {}
 
 func (m mockStore) GetChunkRefs(_ context.Context, _ string, _, _ model.Time, _ ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
 	return nil, nil, nil

--- a/pkg/storage/stores/index/index.go
+++ b/pkg/storage/stores/index/index.go
@@ -14,34 +14,6 @@ import (
 	loki_instrument "github.com/grafana/loki/pkg/util/instrument"
 )
 
-type Filterable interface {
-	// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
-}
-
-type BaseReader interface {
-	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
-	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
-	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
-	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
-	Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error)
-}
-
-type Reader interface {
-	BaseReader
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
-	Filterable
-}
-
-type Writer interface {
-	IndexChunk(ctx context.Context, from, through model.Time, chk chunk.Chunk) error
-}
-
-type ReaderWriter interface {
-	Reader
-	Writer
-}
-
 type monitoredReaderWriter struct {
 	rw      ReaderWriter
 	metrics *metrics
@@ -133,7 +105,7 @@ func (m monitoredReaderWriter) Volume(ctx context.Context, userID string, from, 
 	return vol, nil
 }
 
-func (m monitoredReaderWriter) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (m monitoredReaderWriter) SetChunkFilterer(chunkFilter RequestChunkFilterer) {
 	m.rw.SetChunkFilterer(chunkFilter)
 }
 

--- a/pkg/storage/stores/index/index.go
+++ b/pkg/storage/stores/index/index.go
@@ -15,11 +15,11 @@ import (
 )
 
 type monitoredReaderWriter struct {
-	rw      ReaderWriter
+	rw      ReadWriteStore
 	metrics *metrics
 }
 
-func NewMonitoredReaderWriter(rw ReaderWriter, reg prometheus.Registerer) ReaderWriter {
+func NewMonitoredReaderWriter(rw ReadWriteStore, reg prometheus.Registerer) ReadWriteStore {
 	return &monitoredReaderWriter{
 		rw:      rw,
 		metrics: newMetrics(reg),

--- a/pkg/storage/stores/index/indexstore.go
+++ b/pkg/storage/stores/index/indexstore.go
@@ -1,0 +1,50 @@
+package index
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/storage/chunk"
+	"github.com/grafana/loki/pkg/storage/stores/index/stats"
+)
+
+// RequestChunkFilterer creates ChunkFilterer for a given request context.
+type RequestChunkFilterer interface {
+	ForRequest(ctx context.Context) Filterer
+}
+
+// Filterer filters chunks based on the metric.
+type Filterer interface {
+	ShouldFilter(metric labels.Labels) bool
+}
+
+type Filterable interface {
+	// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
+	SetChunkFilterer(filterer RequestChunkFilterer)
+}
+
+type BaseReader interface {
+	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
+	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
+	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
+	Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error)
+	Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error)
+}
+
+type Reader interface {
+	BaseReader
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
+	Filterable
+}
+
+type Writer interface {
+	IndexChunk(ctx context.Context, from, through model.Time, chk chunk.Chunk) error
+}
+
+type ReaderWriter interface {
+	Reader
+	Writer
+}

--- a/pkg/storage/stores/index/indexstore.go
+++ b/pkg/storage/stores/index/indexstore.go
@@ -26,7 +26,7 @@ type Filterable interface {
 	SetChunkFilterer(filterer RequestChunkFilterer)
 }
 
-type BaseReader interface {
+type ReadStoreBase interface {
 	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
 	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
 	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
@@ -34,17 +34,17 @@ type BaseReader interface {
 	Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error)
 }
 
-type Reader interface {
-	BaseReader
-	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
+type ReadStore interface {
+	ReadStoreBase
 	Filterable
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]logproto.ChunkRef, error)
 }
 
-type Writer interface {
+type WriteStore interface {
 	IndexChunk(ctx context.Context, from, through model.Time, chk chunk.Chunk) error
 }
 
-type ReaderWriter interface {
-	Reader
-	Writer
+type ReadWriteStore interface {
+	ReadStore
+	WriteStore
 }

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -22,7 +22,7 @@ type IndexGatewayClientStore struct {
 	logger log.Logger
 }
 
-func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, logger log.Logger) index.ReaderWriter {
+func NewIndexGatewayClientStore(client logproto.IndexGatewayClient, logger log.Logger) index.ReadWriteStore {
 	return &IndexGatewayClientStore{
 		client: client,
 		logger: logger,

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -111,7 +111,7 @@ func (c *IndexGatewayClientStore) Volume(ctx context.Context, _ string, from, th
 	})
 }
 
-func (c *IndexGatewayClientStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
+func (c *IndexGatewayClientStore) SetChunkFilterer(_ index.RequestChunkFilterer) {
 	level.Warn(c.logger).Log("msg", "SetChunkFilterer called on index gateway client store, but it does not support it")
 }
 

--- a/pkg/storage/stores/series/series_index_store.go
+++ b/pkg/storage/stores/series/series_index_store.go
@@ -68,7 +68,7 @@ type indexReaderWriter struct {
 	index            series_index.Client
 	schemaCfg        config.SchemaConfig
 	fetcher          *fetcher.Fetcher
-	chunkFilterer    chunk.RequestChunkFilterer
+	chunkFilterer    index.RequestChunkFilterer
 	chunkBatchSize   int
 	writeDedupeCache cache.Cache
 }
@@ -192,7 +192,7 @@ func (c *indexReaderWriter) GetChunkRefs(ctx context.Context, userID string, fro
 	return chunks, nil
 }
 
-func (c *indexReaderWriter) SetChunkFilterer(f chunk.RequestChunkFilterer) {
+func (c *indexReaderWriter) SetChunkFilterer(f index.RequestChunkFilterer) {
 	c.chunkFilterer = f
 }
 
@@ -231,7 +231,7 @@ func (c *indexReaderWriter) chunksToSeries(ctx context.Context, in []logproto.Ch
 		split = len(chunksBySeries)
 	}
 
-	var chunkFilterer chunk.Filterer
+	var chunkFilterer index.Filterer
 	if c.chunkFilterer != nil {
 		chunkFilterer = c.chunkFilterer.ForRequest(ctx)
 	}

--- a/pkg/storage/stores/series/series_index_store.go
+++ b/pkg/storage/stores/series/series_index_store.go
@@ -74,7 +74,7 @@ type indexReaderWriter struct {
 }
 
 func NewIndexReaderWriter(schemaCfg config.SchemaConfig, schema series_index.SeriesStoreSchema, index series_index.Client,
-	fetcher *fetcher.Fetcher, chunkBatchSize int, writeDedupeCache cache.Cache) index.ReaderWriter {
+	fetcher *fetcher.Fetcher, chunkBatchSize int, writeDedupeCache cache.Cache) index.ReadWriteStore {
 	return &indexReaderWriter{
 		schema:           schema,
 		index:            index,

--- a/pkg/storage/stores/series_store_write.go
+++ b/pkg/storage/stores/series_store_write.go
@@ -37,6 +37,7 @@ var (
 	})
 )
 
+// Writer implements pkg/storage/stores/chunk.ChunkWriter
 type Writer struct {
 	schemaCfg                 config.SchemaConfig
 	DisableIndexDeduplication bool
@@ -45,7 +46,7 @@ type Writer struct {
 	fetcher     *fetcher.Fetcher
 }
 
-func NewChunkWriter(fetcher *fetcher.Fetcher, schemaCfg config.SchemaConfig, indexWriter index.Writer, disableIndexDeduplication bool) ChunkWriter {
+func NewChunkWriter(fetcher *fetcher.Fetcher, schemaCfg config.SchemaConfig, indexWriter index.Writer, disableIndexDeduplication bool) *Writer {
 	return &Writer{
 		schemaCfg:                 schemaCfg,
 		DisableIndexDeduplication: disableIndexDeduplication,
@@ -54,7 +55,6 @@ func NewChunkWriter(fetcher *fetcher.Fetcher, schemaCfg config.SchemaConfig, ind
 	}
 }
 
-// Put implements Store
 func (c *Writer) Put(ctx context.Context, chunks []chunk.Chunk) error {
 	for _, chunk := range chunks {
 		if err := c.PutOne(ctx, chunk.From, chunk.Through, chunk); err != nil {

--- a/pkg/storage/stores/series_store_write.go
+++ b/pkg/storage/stores/series_store_write.go
@@ -42,11 +42,11 @@ type Writer struct {
 	schemaCfg                 config.SchemaConfig
 	DisableIndexDeduplication bool
 
-	indexWriter index.Writer
+	indexWriter index.WriteStore
 	fetcher     *fetcher.Fetcher
 }
 
-func NewChunkWriter(fetcher *fetcher.Fetcher, schemaCfg config.SchemaConfig, indexWriter index.Writer, disableIndexDeduplication bool) *Writer {
+func NewChunkWriter(fetcher *fetcher.Fetcher, schemaCfg config.SchemaConfig, indexWriter index.WriteStore, disableIndexDeduplication bool) *Writer {
 	return &Writer{
 		schemaCfg:                 schemaCfg,
 		DisableIndexDeduplication: disableIndexDeduplication,

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -19,8 +19,8 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/storage/config"
-	"github.com/grafana/loki/pkg/storage/stores"
-	"github.com/grafana/loki/pkg/storage/stores/index"
+	chunkstore "github.com/grafana/loki/pkg/storage/stores/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	seriesindex "github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/util"
 	"github.com/grafana/loki/pkg/util/spanlogger"
@@ -31,8 +31,8 @@ const (
 )
 
 type IndexQuerier interface {
-	stores.ChunkFetcher
-	index.BaseReader
+	chunkstore.Fetcher
+	indexstore.BaseReader
 	Stop()
 }
 

--- a/pkg/storage/stores/shipper/indexgateway/gateway.go
+++ b/pkg/storage/stores/shipper/indexgateway/gateway.go
@@ -32,7 +32,7 @@ const (
 
 type IndexQuerier interface {
 	chunkstore.Fetcher
-	indexstore.BaseReader
+	indexstore.ReadStoreBase
 	Stop()
 }
 

--- a/pkg/storage/stores/tsdb/head_manager.go
+++ b/pkg/storage/stores/tsdb/head_manager.go
@@ -21,8 +21,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"go.uber.org/atomic"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/client/util"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/grafana/loki/pkg/util/wal"
 )
@@ -627,7 +627,7 @@ type tenantHeads struct {
 	locks       []sync.RWMutex
 	tenants     []map[string]*Head
 	log         log.Logger
-	chunkFilter chunk.RequestChunkFilterer
+	chunkFilter indexstore.RequestChunkFilterer
 	metrics     *Metrics
 }
 
@@ -713,7 +713,7 @@ func (t *tenantHeads) shardForTenant(userID string) uint64 {
 
 func (t *tenantHeads) Close() error { return nil }
 
-func (t *tenantHeads) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (t *tenantHeads) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	t.chunkFilter = chunkFilter
 }
 

--- a/pkg/storage/stores/tsdb/index.go
+++ b/pkg/storage/stores/tsdb/index.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/indexshipper"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
@@ -49,7 +49,7 @@ type shouldIncludeChunk func(index.ChunkMeta) bool
 
 type Index interface {
 	Bounded
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
+	indexstore.Filterable
 	Close() error
 	// GetChunkRefs accepts an optional []ChunkRef argument.
 	// If not nil, it will use that slice to build the result,
@@ -93,7 +93,7 @@ func (NoopIndex) Stats(_ context.Context, _ string, _, _ model.Time, _ IndexStat
 	return nil
 }
 
-func (NoopIndex) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
+func (NoopIndex) SetChunkFilterer(_ indexstore.RequestChunkFilterer) {}
 
 func (NoopIndex) Volume(_ context.Context, _ string, _, _ model.Time, _ VolumeAccumulator, _ *index.ShardAnnotation, _ shouldIncludeChunk, _ []string, _ string, _ ...*labels.Matcher) error {
 	return nil

--- a/pkg/storage/stores/tsdb/index_client.go
+++ b/pkg/storage/stores/tsdb/index_client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -13,8 +11,9 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/querier/astmapper"
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
+	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 	"github.com/grafana/loki/pkg/util"
@@ -290,7 +289,7 @@ func (c *IndexClient) Volume(ctx context.Context, userID string, from, through m
 // SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
 // This is only used for GetSeries implementation.
 // Todo we might want to pass it as a parameter to GetSeries instead.
-func (c *IndexClient) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (c *IndexClient) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	c.idx.SetChunkFilterer(chunkFilter)
 }
 

--- a/pkg/storage/stores/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/tsdb/index_shipper_querier.go
@@ -10,8 +10,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/config"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	shipper_index "github.com/grafana/loki/pkg/storage/stores/indexshipper/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
@@ -23,7 +23,7 @@ type indexShipperIterator interface {
 // indexShipperQuerier is used for querying index from the shipper.
 type indexShipperQuerier struct {
 	shipper     indexShipperIterator
-	chunkFilter chunk.RequestChunkFilterer
+	chunkFilter indexstore.RequestChunkFilterer
 	tableRange  config.TableRange
 }
 
@@ -74,7 +74,7 @@ func (i *indexShipperQuerier) Bounds() (model.Time, model.Time) {
 	return 0, math.MaxInt64
 }
 
-func (i *indexShipperQuerier) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (i *indexShipperQuerier) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	i.chunkFilter = chunkFilter
 }
 

--- a/pkg/storage/stores/tsdb/lazy_index.go
+++ b/pkg/storage/stores/tsdb/lazy_index.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -21,7 +21,7 @@ func (f LazyIndex) Bounds() (model.Time, model.Time) {
 	return i.Bounds()
 }
 
-func (f LazyIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (f LazyIndex) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	i, err := f()
 	if err == nil {
 		i.SetChunkFilterer(chunkFilter)

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -9,13 +9,13 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
 type MultiIndex struct {
 	iter     IndexIter
-	filterer chunk.RequestChunkFilterer
+	filterer indexstore.RequestChunkFilterer
 }
 
 type IndexIter interface {
@@ -73,7 +73,7 @@ func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 	return lowest, highest
 }
 
-func (i *MultiIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (i *MultiIndex) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	i.filterer = chunkFilter
 }
 

--- a/pkg/storage/stores/tsdb/multitenant.go
+++ b/pkg/storage/stores/tsdb/multitenant.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/storage/chunk"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -45,7 +45,7 @@ func withoutTenantLabel(ls labels.Labels) labels.Labels {
 
 func (m *MultiTenantIndex) Bounds() (model.Time, model.Time) { return m.idx.Bounds() }
 
-func (m *MultiTenantIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (m *MultiTenantIndex) SetChunkFilterer(chunkFilter indexstore.RequestChunkFilterer) {
 	m.idx.SetChunkFilterer(chunkFilter)
 }
 

--- a/pkg/storage/stores/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/tsdb/single_file_index_test.go
@@ -7,16 +7,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/storage/chunk"
-	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
-	"github.com/grafana/loki/pkg/storage/stores/index/stats"
-
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/pkg/logproto"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
+	"github.com/grafana/loki/pkg/storage/stores/index/seriesvolume"
+	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/storage/stores/tsdb/index"
 )
 
@@ -749,7 +748,7 @@ func TestTSDBIndex_Volume(t *testing.T) {
 
 type filterAll struct{}
 
-func (f *filterAll) ForRequest(_ context.Context) chunk.Filterer {
+func (f *filterAll) ForRequest(_ context.Context) indexstore.Filterer {
 	return &filterAllFilterer{}
 }
 

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -30,10 +30,10 @@ type IndexWriter interface {
 }
 
 type store struct {
-	index.Reader
+	index.ReadStore
 	indexShipper      indexshipper.IndexShipper
 	indexWriter       IndexWriter
-	backupIndexWriter index.Writer
+	backupIndexWriter index.WriteStore
 	logger            log.Logger
 	stopOnce          sync.Once
 }
@@ -47,12 +47,12 @@ func NewStore(
 	objectClient client.ObjectClient,
 	limits downloads.Limits,
 	tableRange config.TableRange,
-	backupIndexWriter index.Writer,
+	backupIndexWriter index.WriteStore,
 	reg prometheus.Registerer,
 	logger log.Logger,
 	idxCache cache.Cache,
 ) (
-	index.ReaderWriter,
+	index.ReadWriteStore,
 	func(),
 	error,
 ) {
@@ -151,7 +151,7 @@ func (s *store) init(name string, indexCfg IndexCfg, schemaCfg config.SchemaConf
 	indices = append(indices, newIndexShipperQuerier(s.indexShipper, tableRange))
 	multiIndex := NewMultiIndex(IndexSlice(indices))
 
-	s.Reader = NewIndexClient(multiIndex, opts, limits)
+	s.ReadStore = NewIndexClient(multiIndex, opts, limits)
 
 	return nil
 }

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/config"
 	"github.com/grafana/loki/pkg/storage/stores"
+	indexstore "github.com/grafana/loki/pkg/storage/stores/index"
 	index_stats "github.com/grafana/loki/pkg/storage/stores/index/stats"
 	loki_util "github.com/grafana/loki/pkg/util"
 	util_log "github.com/grafana/loki/pkg/util/log"
@@ -155,7 +156,7 @@ type mockChunkStore struct {
 	schemas config.SchemaConfig
 	chunks  []chunk.Chunk
 	client  *mockChunkStoreClient
-	f       chunk.RequestChunkFilterer
+	f       indexstore.RequestChunkFilterer
 }
 
 // mockChunkStore cannot implement both chunk.Store and chunk.Client,
@@ -212,7 +213,7 @@ func (m *mockChunkStore) LabelNamesForMetricName(_ context.Context, _ string, _,
 	return nil, nil
 }
 
-func (m *mockChunkStore) SetChunkFilterer(f chunk.RequestChunkFilterer) {
+func (m *mockChunkStore) SetChunkFilterer(f indexstore.RequestChunkFilterer) {
 	m.f = f
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a first PR of a series to simplify and streamline the "store interfaces" to make them easier to understand and speed up development of new features.

**Special notes for your reviewer**:

This PR does not change any functionality or interface functions. Changes are:

- `RequestChunkFilterer` moved from `pkg/storage/chunk` to `pkg/storage/stores/index`
- `Filterer` moved from `pkg/storage/chunk` to `pkg/storage/stores/index`
- `RequestChunkFilterer` and `Filterer` are now in the same place as `Filterable`
- `ChunkReader`, `ChunkWriter`, `ChunkReaderWriter` and `ChunkFetcher` are renamed to `ReadStore`, `WriteStore`, `ReadWriteStore`, and `Fetcher` respectively and move from `pkg/storage/stores` to `pkg/storage/stores/chunk`
- `pkg/storage/stores/index` is usually aliased as `indexstore` when imported (to not confuse it with other `index` packages. the package contains the index store interfaces
- `pkg/storage/stores/chunk` is usually aliased as `chunkstore` when imported (to not confuse it with other `chunk` packages. the package contains the chunk store interfaces