### PR TITLE
[promtail] include the size of non-indexed labels into batch size

### DIFF
--- a/clients/pkg/promtail/client/batch_test.go
+++ b/clients/pkg/promtail/client/batch_test.go
@@ -58,8 +58,9 @@ func TestBatch_add(t *testing.T) {
 			inputEntries: []api.Entry{
 				{Labels: model.LabelSet{}, Entry: logEntries[0].Entry},
 				{Labels: model.LabelSet{}, Entry: logEntries[1].Entry},
+				{Labels: model.LabelSet{}, Entry: logEntries[7].Entry},
 			},
-			expectedSizeBytes: len(logEntries[0].Entry.Line) + len(logEntries[1].Entry.Line),
+			expectedSizeBytes: entrySize(logEntries[0]) + entrySize(logEntries[0]) + entrySize(logEntries[7]),
 		},
 		"multiple streams with multiple log entries": {
 			inputEntries: []api.Entry{

--- a/clients/pkg/promtail/client/client_test.go
+++ b/clients/pkg/promtail/client/client_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/grafana/loki/clients/pkg/promtail/api"
 	"github.com/grafana/loki/clients/pkg/promtail/utils"
-
 	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/push"
 	lokiflag "github.com/grafana/loki/pkg/util/flagext"
 )
 
@@ -34,6 +34,16 @@ var logEntries = []api.Entry{
 	{Labels: model.LabelSet{"__tenant_id__": "tenant-1"}, Entry: logproto.Entry{Timestamp: time.Unix(5, 0).UTC(), Line: "line5"}},
 	{Labels: model.LabelSet{"__tenant_id__": "tenant-2"}, Entry: logproto.Entry{Timestamp: time.Unix(6, 0).UTC(), Line: "line6"}},
 	{Labels: model.LabelSet{}, Entry: logproto.Entry{Timestamp: time.Unix(6, 0).UTC(), Line: "line0123456789"}},
+	{
+		Labels: model.LabelSet{},
+		Entry: logproto.Entry{
+			Timestamp: time.Unix(7, 0).UTC(),
+			Line:      "line7",
+			NonIndexedLabels: push.LabelsAdapter{
+				{Name: "trace_id", Value: "12345"},
+			},
+		},
+	},
 }
 
 func TestClient_Handle(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When we added non-indexed-labels support to the promtail, we forgot to adjust the batch size calculation which leads to the case when promtail thinks that batch size is `X` but when it sends it to Loki, Loki rejects it because the actual size of the payload is `X`+`N`(size of non-indexed labels).

**Special notes for your reviewer**:
This feature is not released yet, so, changelog update is not needed.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
