### PR TITLE
pkg/loki: provide more help to users sending bad queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [10378](https://github.com/grafana/loki/pull/10378) **shantanualsi** Remove deprecated `ruler.wal-cleaer.period`
 * [10380](https://github.com/grafana/loki/pull/10380) **shantanualsi** Remove `experimental.ruler.enable-api` in favour of `ruler.enable-api`
 * [10395](https://github.com/grafana/loki/pull/10395/) **shantanualshi** Remove deprecated `split_queries_by_interval` and `forward_headers_list` configuration options in the `query_range` section
+* [10413](https://github.com/grafana/loki/pull/10413/) **kevinburkesegment** Provide more help to users who are sending invalid queries to the API.
 
 ##### Fixes
 

--- a/pkg/loki/format_query_handler.go
+++ b/pkg/loki/format_query_handler.go
@@ -3,6 +3,7 @@ package loki
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/loki/pkg/logql/syntax"
 	"github.com/grafana/loki/pkg/util/server"
@@ -22,6 +23,12 @@ func formatQueryHandler() http.HandlerFunc {
 			statusCode = http.StatusBadRequest
 			status = "invalid-query"
 			errStr = err.Error()
+			if strings.Contains(errStr, "parse error at line 1") && strings.Contains(errStr, "unexpected IDENTIFIER") {
+				// User probably sent a query like "foo", ie. they are trying
+				// to use a grep like syntax. Help them find the right place to
+				// submit a proper query
+				errStr += " (queries should use LogQL: https://grafana.com/docs/loki/latest/logql/log_queries/)"
+			}
 		}
 
 		if err == nil {

--- a/pkg/loki/format_query_handler_test.go
+++ b/pkg/loki/format_query_handler_test.go
@@ -33,6 +33,14 @@ func Test_formatQueryHandlerResponse(t *testing.T) {
 				Err:    "parse error at line 1, col 6: literal not terminated",
 			},
 		},
+		{
+			name:  "not-logql",
+			query: `trying-to-use-grep-syntax`,
+			expected: FormatQueryResponse{
+				Status: "invalid-query",
+				Err:    "parse error at line 1, col 1: syntax error: unexpected IDENTIFIER (queries should use LogQL: https://grafana.com/docs/loki/latest/logql/log_queries/)",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, if you have no idea you're supposed to use LogQL, and just send a random query to the API, here is the entirety of the HTTP response body you get back:

    parse error at line 1, col 1: syntax error: unexpected IDENTIFIER

This doesn't help users figure out what they did wrong, or explain what sort of syntax Loki is looking for, so attempt to provide more help by pointing people to the LogQL documentation.

**Which issue(s) this PR fixes**: No issue

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added (No documentation)
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label (Not needed)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (Not needed)
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213) (Not needed)
