### PR TITLE
Lambda Promtail: Add logs:PutSubscriptionFilter to Lambda Promtail role

### DIFF
--- a/tools/lambda-promtail/template.yaml
+++ b/tools/lambda-promtail/template.yaml
@@ -76,6 +76,7 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
+            - logs:PutSubscriptionFilter
             Resource: arn:aws:logs:*:*:*
       RoleName: iam_for_lambda
   LambdaPromtailFunction:
@@ -123,6 +124,7 @@ Resources:
   # additional CloudWatch Log Groups.
   MainLambdaPromtailSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    DependsOn: LambdaPromtailPermissions
     Properties:
       DestinationArn: !GetAtt LambdaPromtailFunction.Arn
       FilterPattern: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

I ran into the below error during the CloudFormation stack creation when trying to use the [example CloudFormation config](https://github.com/grafana/loki/blob/main/tools/lambda-promtail/template.yaml):

`"Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function"`

The issue is that the config does not give the `logs:PutSubscriptionFilter` permission to the Lambda Promtail Role. This adds that permission to fix the error

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
