### PR TITLE
feat(mixin): allow including TSDB graphs via cfg var in jsonnet

### DIFF
--- a/clients/pkg/promtail/wal/wal.go
+++ b/clients/pkg/promtail/wal/wal.go
@@ -39,7 +39,7 @@ func New(cfg Config, log log.Logger, registerer prometheus.Registerer) (WAL, err
 	// yet. This will attest for the lack of buffering in the channel Writer exposes.
 	tsdbWAL, err := wlog.NewSize(log, registerer, cfg.Dir, wlog.DefaultSegmentSize, false)
 	if err != nil {
-		return nil, fmt.Errorf("failde to create tsdb WAL: %w", err)
+		return nil, fmt.Errorf("failed to create tsdb WAL: %w", err)
 	}
 	return &wrapper{
 		wal: tsdbWAL,

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -28,5 +28,11 @@
       // The prefix used to match the write and read pods on SSD mode.
       pod_prefix_matcher: '(loki|enterprise-logs)',
     },
+
+    // TSDB related configuration for dashboards.
+    show_tsdb_graphs: {
+      // Add TSDB related rows/panels when compiling dashboards.
+      enabled: true
+    }
   },
 }

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -13,6 +13,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                showMultiCluster:: true,
                                clusterLabel:: $._config.per_cluster_label,
 
+                               // TODO: Toggle on/off TSDB-related rows/panels once metrics
+                               // for TSBD shipper got implemented (https://github.com/grafana/loki/issues/9719)  
                                hiddenRows:: [
                                  'Cassandra',
                                ] + if !$._config.ssd.enabled then [] else [

--- a/production/loki-mixin/mixin.libsonnet
+++ b/production/loki-mixin/mixin.libsonnet
@@ -2,4 +2,10 @@
 (import 'alerts.libsonnet') +
 (import 'recording_rules.libsonnet') + {
   grafanaDashboardFolder: 'Loki',
+
+  _config+:: {
+    show_tsdb_graphs+: {
+      enabled: true,
+    }
+  }
 }


### PR DESCRIPTION
## PR description
Partially implements #9772 

Add draft configuration variable `show_tsdb_graphs` to include future TSDB-related graphs for Loki's mix-in dashboards.
Default to showing TSDB-related graphs when compiling dashboards.