### PR TITLE
Chore(storage): Simplify store interfaces and abstractions (pt 1)

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -295,7 +295,7 @@ type Loki struct {
 	cacheGenerationLoader     queryrangebase.CacheGenNumberLoader
 	querierAPI                *querier.QuerierAPI
 	ingesterQuerier           *querier.IngesterQuerier
-	Store                     storage.Store
+	Store                     *storage.LokiStore
 	tableManager              *index.TableManager
 	frontend                  Frontend
 	ruler                     *base_ruler.Ruler

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -622,7 +622,7 @@ func (q *SingleTenantQuerier) seriesForMatchers(
 
 // seriesForMatcher fetches series from the store for a given matcher
 func (q *SingleTenantQuerier) seriesForMatcher(ctx context.Context, from, through time.Time, matcher string, shards []string) ([]logproto.SeriesIdentifier, error) {
-	ids, err := q.store.Series(ctx, logql.SelectLogParams{
+	ids, err := q.store.SelectSeries(ctx, logql.SelectLogParams{
 		QueryRequest: &logproto.QueryRequest{
 			Selector:  matcher,
 			Limit:     1,

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -350,7 +350,7 @@ func (s *storeMock) GetSchemaConfigs() []config.PeriodConfig {
 	panic("don't call me please")
 }
 
-func (s *storeMock) Series(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error) {
+func (s *storeMock) SelectSeries(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error) {
 	args := s.Called(ctx, req)
 	res := args.Get(0)
 	if res == nil {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -243,7 +243,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 			func(store *storeMock, querier *queryClientMock, ingester *querierClientMock, limits validation.Limits, req *logproto.SeriesRequest) {
 				ingester.On("Series", mock.Anything, req, mock.Anything).Return(nil, errors.New("tst-err"))
 
-				store.On("Series", mock.Anything, mock.Anything).Return(nil, nil)
+				store.On("SelectSeries", mock.Anything, mock.Anything).Return(nil, nil)
 			},
 			func(t *testing.T, q *SingleTenantQuerier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -259,7 +259,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1"},
 				}), nil)
 
-				store.On("Series", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+				store.On("SelectSeries", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
 			},
 			func(t *testing.T, q *SingleTenantQuerier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -272,7 +272,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 			mkReq([]string{`{a="1"}`}),
 			func(store *storeMock, querier *queryClientMock, ingester *querierClientMock, limits validation.Limits, req *logproto.SeriesRequest) {
 				ingester.On("Series", mock.Anything, req, mock.Anything).Return(mockSeriesResponse(nil), nil)
-				store.On("Series", mock.Anything, mock.Anything).Return(nil, nil)
+				store.On("SelectSeries", mock.Anything, mock.Anything).Return(nil, nil)
 			},
 			func(t *testing.T, q *SingleTenantQuerier, req *logproto.SeriesRequest) {
 				ctx := user.InjectOrgID(context.Background(), "test")
@@ -290,7 +290,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1", "b": "3"},
 				}), nil)
 
-				store.On("Series", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
+				store.On("SelectSeries", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
 					{Labels: map[string]string{"a": "1", "b": "4"}},
 					{Labels: map[string]string{"a": "1", "b": "5"}},
 				}, nil)
@@ -315,7 +315,7 @@ func TestQuerier_SeriesAPI(t *testing.T) {
 					{"a": "1", "b": "2"},
 				}), nil)
 
-				store.On("Series", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
+				store.On("SelectSeries", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
 					{Labels: map[string]string{"a": "1", "b": "2"}},
 					{Labels: map[string]string{"a": "1", "b": "3"}},
 				}, nil)
@@ -825,7 +825,7 @@ func TestQuerier_RequestingIngesters(t *testing.T) {
 		},
 		"Series": {
 			ingesterMethod: "Series",
-			storeMethod:    "Series",
+			storeMethod:    "SelectSeries",
 		},
 	}
 
@@ -1100,7 +1100,7 @@ func setupIngesterQuerierMocks(conf Config, limits *validation.Overrides) (*quer
 	store.On("SelectSamples", mock.Anything, mock.Anything).Return(mockSampleIterator(querySampleClient), nil)
 	store.On("LabelValuesForMetricName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{"1", "2", "3"}, nil)
 	store.On("LabelNamesForMetricName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{"foo"}, nil)
-	store.On("Series", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
+	store.On("SelectSeries", mock.Anything, mock.Anything).Return([]logproto.SeriesIdentifier{
 		{Labels: map[string]string{"foo": "1"}},
 	}, nil)
 

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1760,7 +1760,7 @@ func Benchmark_store_OverlappingChunks(b *testing.B) {
 	require.NoError(b, err)
 
 	b.ReportAllocs()
-	st := &store{
+	st := &LokiStore{
 		chunkMetrics: NilMetrics,
 		cfg: Config{
 			MaxChunkBatchSize: 50,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -55,7 +55,6 @@ type SelectStore interface {
 type Store interface {
 	stores.Store
 	SelectStore
-	index.Filterable
 	GetSchemaConfigs() []config.PeriodConfig
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type store struct {
 	stores.Store
-	composite *stores.CompositeStore
 
 	cfg       Config
 	storeCfg  config.ChunkStoreConfig
@@ -141,7 +140,6 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 
 	s := &store{
 		Store:     stores,
-		composite: stores,
 		cfg:       cfg,
 		storeCfg:  storeCfg,
 		schemaCfg: schemaCfg,
@@ -188,7 +186,8 @@ func (s *store) init() error {
 			return err
 		}
 
-		s.composite.AddStore(p.From.Time, f, idx, w, stop)
+		// s.Store is always assigned the CompositeStore implementation of the Store interface
+		s.Store.(*stores.CompositeStore).AddStore(p.From.Time, f, idx, w, stop)
 	}
 
 	if s.cfg.EnableAsyncStore {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -875,7 +875,7 @@ func Test_ChunkFilterer(t *testing.T) {
 		v := mustParseLabels(it.Labels())["foo"]
 		require.NotEqual(t, "bazz", v)
 	}
-	ids, err := s.Series(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), nil, nil)})
+	ids, err := s.SelectSeries(ctx, logql.SelectLogParams{QueryRequest: newQuery("{foo=~\"ba.*\"}", from, from.Add(1*time.Hour), nil, nil)})
 	require.NoError(t, err)
 	for _, id := range ids {
 		v := id.Labels["foo"]
@@ -943,7 +943,7 @@ func Test_store_GetSeries(t *testing.T) {
 				chunkMetrics: NilMetrics,
 			}
 			ctx = user.InjectOrgID(context.Background(), "test-user")
-			out, err := s.Series(ctx, logql.SelectLogParams{QueryRequest: tt.req})
+			out, err := s.SelectSeries(ctx, logql.SelectLogParams{QueryRequest: tt.req})
 			if err != nil {
 				t.Errorf("store.GetSeries() error = %v", err)
 				return
@@ -1492,7 +1492,7 @@ func Test_GetSeries(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			series, err := store.Series(ctx, tt.req)
+			series, err := store.SelectSeries(ctx, tt.req)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedSeries, series)
 		})

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -485,7 +485,7 @@ func Test_store_SelectLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &store{
+			s := &LokiStore{
 				Store: storeFixture,
 				cfg: Config{
 					MaxChunkBatchSize: 10,
@@ -809,7 +809,7 @@ func Test_store_SelectSample(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &store{
+			s := &LokiStore{
 				Store: storeFixture,
 				cfg: Config{
 					MaxChunkBatchSize: 10,
@@ -845,7 +845,7 @@ func (f fakeChunkFilterer) ShouldFilter(metric labels.Labels) bool {
 }
 
 func Test_ChunkFilterer(t *testing.T) {
-	s := &store{
+	s := &LokiStore{
 		Store: storeFixture,
 		cfg: Config{
 			MaxChunkBatchSize: 10,
@@ -935,7 +935,7 @@ func Test_store_GetSeries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &store{
+			s := &LokiStore{
 				Store: newMockChunkStore(chunkfmt, headfmt, streamsFixture),
 				cfg: Config{
 					MaxChunkBatchSize: tt.batchSize,
@@ -1365,7 +1365,7 @@ func Test_OverlappingChunks(t *testing.T) {
 			},
 		}),
 	}
-	s := &store{
+	s := &LokiStore{
 		Store: &mockChunkStore{chunks: chunks, client: &mockChunkStoreClient{chunks: chunks}},
 		cfg: Config{
 			MaxChunkBatchSize: 10,
@@ -1407,7 +1407,7 @@ func Test_GetSeries(t *testing.T) {
 	require.NoError(t, err)
 
 	var (
-		store = &store{
+		store = &LokiStore{
 			Store: newMockChunkStore(chunkfmt, headfmt, []*logproto.Stream{
 				{
 					Labels: `{foo="bar",buzz="boo"}`,

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -9,21 +9,13 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/pkg/iter"
 	"github.com/grafana/loki/pkg/logproto"
-	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/storage/chunk"
 	"github.com/grafana/loki/pkg/storage/chunk/fetcher"
 	"github.com/grafana/loki/pkg/storage/stores/index"
 	"github.com/grafana/loki/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/pkg/util"
 )
-
-type ChunkReader interface {
-	SelectSamples(ctx context.Context, req logql.SelectSampleParams) (iter.SampleIterator, error)
-	SelectLogs(ctx context.Context, req logql.SelectLogParams) (iter.EntryIterator, error)
-	Series(ctx context.Context, req logql.SelectLogParams) ([]logproto.SeriesIdentifier, error)
-}
 
 type ChunkWriter interface {
 	Put(ctx context.Context, chunks []chunk.Chunk) error

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -38,21 +38,20 @@ type Store interface {
 // CompositeStore is a Store which delegates to various stores depending
 // on when they were activated.
 type CompositeStore struct {
-	compositeStore
 	limits StoreLimits
-}
-
-type compositeStore struct {
 	stores []compositeStoreEntry
 }
 
-// Ensure interface implementation of compositStore
-var _ Store = &compositeStore{}
+// Ensure interface implementation of CompositeStore
+var _ Store = &CompositeStore{}
 
 // NewCompositeStore creates a new Store which delegates to different stores depending
 // on time.
 func NewCompositeStore(limits StoreLimits) *CompositeStore {
-	return &CompositeStore{compositeStore{}, limits}
+	return &CompositeStore{
+		stores: make([]compositeStoreEntry, 0),
+		limits: limits,
+	}
 }
 
 func (c *CompositeStore) AddStore(start model.Time, fetcher *fetcher.Fetcher, index index.Reader, writer ChunkWriter, stop func()) {
@@ -76,7 +75,7 @@ func (c *CompositeStore) Stores() []Store {
 	return stores
 }
 
-func (c compositeStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
+func (c CompositeStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
 	for _, chunk := range chunks {
 		err := c.forStores(ctx, chunk.From, chunk.Through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 			return store.PutOne(innerCtx, from, through, chunk)
@@ -88,19 +87,19 @@ func (c compositeStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
 	return nil
 }
 
-func (c compositeStore) PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error {
+func (c CompositeStore) PutOne(ctx context.Context, from, through model.Time, chunk chunk.Chunk) error {
 	return c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		return store.PutOne(innerCtx, from, through, chunk)
 	})
 }
 
-func (c compositeStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+func (c CompositeStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
 	for _, store := range c.stores {
 		store.Store.SetChunkFilterer(chunkFilter)
 	}
 }
 
-func (c compositeStore) GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
+func (c CompositeStore) GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
 	var results []labels.Labels
 	found := map[uint64]struct{}{}
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
@@ -123,7 +122,7 @@ func (c compositeStore) GetSeries(ctx context.Context, userID string, from, thro
 }
 
 // LabelValuesForMetricName retrieves all label values for a single label name and metric name.
-func (c compositeStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
+func (c CompositeStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
 	var result util.UniqueStrings
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		labelValues, err := store.LabelValuesForMetricName(innerCtx, userID, from, through, metricName, labelName, matchers...)
@@ -137,7 +136,7 @@ func (c compositeStore) LabelValuesForMetricName(ctx context.Context, userID str
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
-func (c compositeStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
+func (c CompositeStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
 	var result util.UniqueStrings
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		labelNames, err := store.LabelNamesForMetricName(innerCtx, userID, from, through, metricName)
@@ -150,7 +149,7 @@ func (c compositeStore) LabelNamesForMetricName(ctx context.Context, userID stri
 	return result.Strings(), err
 }
 
-func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
+func (c CompositeStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
 	chunkIDs := [][]chunk.Chunk{}
 	fetchers := []*fetcher.Fetcher{}
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
@@ -171,7 +170,7 @@ func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, t
 	return chunkIDs, fetchers, err
 }
 
-func (c compositeStore) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
+func (c CompositeStore) Stats(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) (*stats.Stats, error) {
 	xs := make([]*stats.Stats, 0, len(c.stores))
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		x, err := store.Stats(innerCtx, userID, from, through, matchers...)
@@ -187,7 +186,7 @@ func (c compositeStore) Stats(ctx context.Context, userID string, from, through 
 	return &res, err
 }
 
-func (c compositeStore) Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
+func (c CompositeStore) Volume(ctx context.Context, userID string, from, through model.Time, limit int32, targetLabels []string, aggregateBy string, matchers ...*labels.Matcher) (*logproto.VolumeResponse, error) {
 	volumes := make([]*logproto.VolumeResponse, 0, len(c.stores))
 	err := c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		volume, err := store.Volume(innerCtx, userID, from, through, limit, targetLabels, aggregateBy, matchers...)
@@ -203,7 +202,7 @@ func (c compositeStore) Volume(ctx context.Context, userID string, from, through
 	return res, err
 }
 
-func (c compositeStore) GetChunkFetcher(tm model.Time) *fetcher.Fetcher {
+func (c CompositeStore) GetChunkFetcher(tm model.Time) *fetcher.Fetcher {
 	// find the schema with the lowest start _after_ tm
 	j := sort.Search(len(c.stores), func(j int) bool {
 		return c.stores[j].start > tm
@@ -219,13 +218,13 @@ func (c compositeStore) GetChunkFetcher(tm model.Time) *fetcher.Fetcher {
 	return nil
 }
 
-func (c compositeStore) Stop() {
+func (c CompositeStore) Stop() {
 	for _, store := range c.stores {
 		store.Stop()
 	}
 }
 
-func (c compositeStore) forStores(ctx context.Context, from, through model.Time, callback func(innerCtx context.Context, from, through model.Time, store Store) error) error {
+func (c CompositeStore) forStores(ctx context.Context, from, through model.Time, callback func(innerCtx context.Context, from, through model.Time, store Store) error) error {
 	if len(c.stores) == 0 {
 		return nil
 	}

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -73,7 +73,7 @@ func TestCompositeStore(t *testing.T) {
 			return nil
 		}
 	}
-	cs := compositeStore{
+	cs := CompositeStore{
 		stores: []compositeStoreEntry{
 			{model.TimeFromUnix(0), mockStore(1)},
 			{model.TimeFromUnix(100), mockStore(2)},
@@ -82,16 +82,18 @@ func TestCompositeStore(t *testing.T) {
 	}
 
 	for i, tc := range []struct {
-		cs            compositeStore
+		cs            CompositeStore
 		from, through int64
 		want          []result
 	}{
 		// Test we have sensible results when there are no schema's defined
-		{compositeStore{}, 0, 1, []result{}},
+		{
+			CompositeStore{}, 0, 1, []result{},
+		},
 
 		// Test we have sensible results when there is a single schema
 		{
-			compositeStore{
+			CompositeStore{
 				stores: []compositeStoreEntry{
 					{model.TimeFromUnix(0), mockStore(1)},
 				},
@@ -104,7 +106,7 @@ func TestCompositeStore(t *testing.T) {
 
 		// Test we have sensible results for negative (ie pre 1970) times
 		{
-			compositeStore{
+			CompositeStore{
 				stores: []compositeStoreEntry{
 					{model.TimeFromUnix(0), mockStore(1)},
 				},
@@ -113,7 +115,7 @@ func TestCompositeStore(t *testing.T) {
 			[]result{},
 		},
 		{
-			compositeStore{
+			CompositeStore{
 				stores: []compositeStoreEntry{
 					{model.TimeFromUnix(0), mockStore(1)},
 				},
@@ -126,7 +128,7 @@ func TestCompositeStore(t *testing.T) {
 
 		// Test we have sensible results when there is two schemas
 		{
-			compositeStore{
+			CompositeStore{
 				stores: []compositeStoreEntry{
 					{model.TimeFromUnix(0), mockStore(1)},
 					{model.TimeFromUnix(100), mockStore(2)},
@@ -206,7 +208,7 @@ func (m mockStoreLabel) LabelNamesForMetricName(_ context.Context, _ string, _, 
 func TestCompositeStoreLabels(t *testing.T) {
 	t.Parallel()
 
-	cs := compositeStore{
+	cs := CompositeStore{
 		stores: []compositeStoreEntry{
 			{model.TimeFromUnix(0), mockStore(1)},
 			{model.TimeFromUnix(20), mockStoreLabel{mockStore(1), []string{"b", "c", "e"}}},
@@ -256,7 +258,7 @@ func (m mockStoreGetChunkFetcher) GetChunkFetcher(_ model.Time) *fetcher.Fetcher
 }
 
 func TestCompositeStore_GetChunkFetcher(t *testing.T) {
-	cs := compositeStore{
+	cs := CompositeStore{
 		stores: []compositeStoreEntry{
 			{model.TimeFromUnix(10), mockStoreGetChunkFetcher{mockStore(0), &fetcher.Fetcher{}}},
 			{model.TimeFromUnix(20), mockStoreGetChunkFetcher{mockStore(1), &fetcher.Fetcher{}}},
@@ -311,7 +313,7 @@ func (m mockStoreVolume) Volume(_ context.Context, _ string, _, _ model.Time, _ 
 
 func TestVolume(t *testing.T) {
 	t.Run("it returns volumes from all stores", func(t *testing.T) {
-		cs := compositeStore{
+		cs := CompositeStore{
 			stores: []compositeStoreEntry{
 				{model.TimeFromUnix(10), mockStoreVolume{mockStore: mockStore(0), value: &logproto.VolumeResponse{
 					Volumes: []logproto.Volume{{Name: `{foo="bar"}`, Volume: 15}}, Limit: 10,
@@ -328,7 +330,7 @@ func TestVolume(t *testing.T) {
 	})
 
 	t.Run("it returns an error if any store returns an error", func(t *testing.T) {
-		cs := compositeStore{
+		cs := CompositeStore{
 			stores: []compositeStoreEntry{
 				{model.TimeFromUnix(10), mockStoreVolume{mockStore: mockStore(0), value: &logproto.VolumeResponse{
 					Volumes: []logproto.Volume{{Name: `{foo="bar"}`, Volume: 15}}, Limit: 10,


### PR DESCRIPTION
**What this PR does / why we need it**:

In an attempt to simplify the store abstractions/interfaces, this PR does the following cleanups:

* Remove duplicate store field in `pkg/storage.*store`
* Remove duplicate index.Filterable interface inheritance
* Remove nesting from CompositeStore
* Rename/move ChunkReader to ./pkg/storage.SelectStore

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
