### PR TITLE
Jsonnet: Update shipper config to allow use of both boltdb and tsdb shippers for transitioning to tsdb from boltdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@
 * [8855](https://github.com/grafana/loki/pull/8855) **JoaoBraveCoding**: Add gRPC port to loki compactor mixin
 * [8880](https://github.com/grafana/loki/pull/8880) **JoaoBraveCoding**: Normalize headless service name for query-frontend/scheduler
 * [9978](https://github.com/grafana/loki/pull/9978) ****vlad-diachenko****: replaced deprecated `policy.v1beta1` with `policy.v1`.
+* [10442](https://github.com/grafana/loki/pull/10442) **liam-howe-maersk**: Allow use of both `use_boltdb_shipper` and `use_tsdb_shipper` to configure necessary config for both shippers.
 
 ## 2.8.3 (2023-07-21)
 

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -9,10 +9,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   ruler_args:: $._config.commonArgs {
     target: 'ruler',
-  } + if $._config.using_boltdb_shipper && !$._config.using_tsdb_shipper then {
-    // Use PVC for caching
-    'boltdb.shipper.cache-location': '/data/boltdb-cache',
-  } else {},
+  },
 
   _config+:: {
     // run rulers as statefulsets when using boltdb-shipper to avoid using node disk for storing the index.

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -9,7 +9,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   ruler_args:: $._config.commonArgs {
     target: 'ruler',
-  } + if $._config.using_boltdb_shipper then {
+  } + if $._config.using_boltdb_shipper && !$._config.using_tsdb_shipper then {
     // Use PVC for caching
     'boltdb.shipper.cache-location': '/data/boltdb-cache',
   } else {},


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows configuring both boltdb and tsdb by setting both `using_boltdb_shipper` and `using_tsdb_shipper` to true and setting the necessary config for both. If you transition from boltdb to tsdb for the shipper there will still be some data in the boltdb index and so we must be able to support both until no more data is retained in boltdb.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
