### PR TITLE
[Docs] Update warning on structured metadata topic

### DIFF
--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -6,7 +6,7 @@ description: Attaching metadata to logs.
 # What is structured metadata
 
 {{% admonition type="warning" %}}
-Structured metadata is an experimental feature and is subject to change in future releases of Grafana Loki.
+Structured metadata is an experimental feature and is subject to change in future releases of Grafana Loki. This feature is not yet available for Cloud Logs users.
 {{% /admonition %}}
 
 One of the powerful features of Loki is parsing logs at query time to extract metadata and build labels out of it.


### PR DESCRIPTION
Updates the warning at the top of the structured metadata topic to explicitly state that the feature is not yet available for Cloud Logs users.
