### PR TITLE
lambda-promtail: Enable assume role to get from S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 #### Promtail
 
 ##### Enhancements
+* [10464](https://github.com/grafana/loki/pull/10464) **lpugoy**: Lambda-Promtail: Enable assume role to get from S3
 * [10416](https://github.com/grafana/loki/pull/10416) **lpugoy**: Lambda-Promtail: Add support for WAF logs in S3
 * [10301](https://github.com/grafana/loki/pull/10301) **wildum**: users can now define `additional_fields` in cloudflare configuration.
 

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -37,6 +37,7 @@ var (
 	extraLabels                                               model.LabelSet
 	skipTlsVerify                                             bool
 	printLogLine                                              bool
+	s3AssumeRole                                              string
 )
 
 func setupArguments() {
@@ -99,6 +100,8 @@ func setupArguments() {
 	if strings.EqualFold(print, "false") {
 		printLogLine = false
 	}
+
+	s3AssumeRole = os.Getenv("S3_ASSUME_ROLE")
 	s3Clients = make(map[string]*s3.Client)
 }
 

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 type parserConfig struct {
@@ -134,6 +136,11 @@ func getS3Client(ctx context.Context, region string) (*s3.Client, error) {
 		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 		if err != nil {
 			return nil, err
+		}
+		if s3AssumeRole != "" {
+			stsClient := sts.NewFromConfig(cfg)
+			creds := stscreds.NewAssumeRoleProvider(stsClient, s3AssumeRole)
+			cfg.Credentials = aws.NewCredentialsCache(creds)
 		}
 		s3Client = s3.NewFromConfig(cfg)
 		s3Clients[region] = s3Client

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -125,3 +125,9 @@ variable "sqs_queue_name_prefix" {
   description = "Name prefix for SQS queues"
   default     = "s3-to-lambda-promtail"
 }
+
+variable "s3_assume_role" {
+  type        = string
+  description = "Role to assume to get files from S3 buckets"
+  default     = ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In our organization, direct cross account access to S3 buckets is not allowed. We need to assume a role in the account that owns the S3 buckets to download from them.

In the Terraform, the policy to download from the S3 bucket is not created when an assume role is given. Rather, a policy to enable role assumption is added.

Management of the assume role is not added to the Terraform. It is assumed that the permissions to download from the S3 bucket and the trust policies to allow the Lambda to assume it will be managed separately.

This also assumes that a single role is assumed to download from all the S3 buckets. It might be more correct to set a role for each bucket, including none for direct access, but that could complicate the solution.

The IAM policy to download from the S3 bucket is not created in the CloudFormation template, so I also didn't modify it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
