### PR TITLE
Make the Store field of the Loki struct an interface type

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -295,7 +295,7 @@ type Loki struct {
 	cacheGenerationLoader     queryrangebase.CacheGenNumberLoader
 	querierAPI                *querier.QuerierAPI
 	ingesterQuerier           *querier.IngesterQuerier
-	Store                     *storage.LokiStore
+	Store                     storage.Store
 	tableManager              *index.TableManager
 	frontend                  Frontend
 	ruler                     *base_ruler.Ruler


### PR DESCRIPTION
**What this PR does / why we need it**:

Applications that extends the `Loki` struct must be able to also override the `Store`. In order to allow this, the field must be an interface type, so any `storage.Store` implementation can be assigned.

**Special notes for your reviewer**:

This reverts the change from interface type to struct type made in PR #10435.
