### PR TITLE
Don't use unsafe string for label names in the UnpackParser

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -717,7 +717,7 @@ func (u *UnpackParser) unpack(entry []byte, lbs *LabelsBuilder) ([]byte, error) 
 				return nil
 			}
 			key, ok := u.keys.Get(key, func() (string, bool) {
-				field := unsafeGetString(key)
+				field := string(key)
 				if lbs.BaseHas(field) {
 					field = field + duplicateSuffix
 				}


### PR DESCRIPTION
We've had [some reports](https://github.com/grafana/loki/issues/8936) that `unpack` is mangling label names. We're using `unsafeGetString` to generate these so, when the underlying byte slice changes, the label name is also changed. This change incurs an alloc to make sure the generated string wont change when the underlying bytes do.

fixes #8936