### PR TITLE
chore: add 2.9.x entry to  release-notes index page

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,6 +8,7 @@ weight: 100
 Release notes for Loki are in the CHANGELOG for the release and
 listed here by version number.
 
+- [V2.9 release notes]({{< relref "./v2-9" >}})
 - [V2.8 release notes]({{< relref "./v2-8" >}})
 - [V2.7 release notes]({{< relref "./v2-7" >}})
 - [V2.6 release notes]({{< relref "./v2-6" >}})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds 2.9.x release to release notes page

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
