### PR TITLE
Pin version of plugins/manifest image in Drone pipeline

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -370,7 +370,7 @@ local manifest(apps) = pipeline('manifest') {
   steps: std.foldl(
     function(acc, app) acc + [{
       name: 'manifest-' + app,
-      image: 'plugins/manifest',
+      image: 'plugins/manifest:1.4.0',
       settings: {
         // the target parameter is abused for the app's name,
         // as it is unused in spec mode. See docker-manifest.tmpl
@@ -403,7 +403,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
   steps: std.foldl(
     function(acc, app) acc + [{
       name: 'manifest-' + app,
-      image: 'plugins/manifest',
+      image: 'plugins/manifest:1.4.0',
       volumes: [{
         name: 'dockerconf',
         path: '/.docker',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1134,7 +1134,7 @@ name: manifest
 steps:
 - depends_on:
   - clone
-  image: plugins/manifest
+  image: plugins/manifest:1.4.0
   name: manifest-promtail
   settings:
     ignore_missing: false
@@ -1147,7 +1147,7 @@ steps:
 - depends_on:
   - clone
   - manifest-promtail
-  image: plugins/manifest
+  image: plugins/manifest:1.4.0
   name: manifest-loki
   settings:
     ignore_missing: false
@@ -1160,7 +1160,7 @@ steps:
 - depends_on:
   - clone
   - manifest-loki
-  image: plugins/manifest
+  image: plugins/manifest:1.4.0
   name: manifest-loki-canary
   settings:
     ignore_missing: false
@@ -1568,7 +1568,7 @@ steps:
 - depends_on:
   - clone
   - ecr-login
-  image: plugins/manifest
+  image: plugins/manifest:1.4.0
   name: manifest-lambda-promtail
   settings:
     ignore_missing: true
@@ -1650,6 +1650,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 8e19cc1c8614108f3176d159a4a31d5db0af0a7cd06e8cfb04efbebdb86e5e4f
+hmac: 5720ddc8361c63323b102f91e0452056ac8399a5faf6f3c12297257905a67402
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:

This change has already made it into main and subsequently into the 2.8 and 2.9 release branches, but was never update in the 2.7 release branch.

This caused CI to fail to push the multi-arch Docker image manifest to Docker hub when releasing 2.7.6 and 2.7.7

Ref: https://drone.grafana.net/grafana/loki/27053/19/2
Ref: https://github.com/grafana/loki/issues/10122
Ref: https://github.com/grafana/loki/pull/9342