### PR TITLE
[release-2.9.x] Fix alias to redirect `/docs/loki/<LOKI_VERSION>/configuration/` to `/docs/loki/<LOKI_VERSION>/configure/`

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2,10 +2,9 @@
 title: Grafana Loki configuration parameters
 menuTitle: Configure
 description: Configuration reference for the parameters used to configure Grafana Loki.
-aliases: 
-  - ../configuration
-  - ../configure
-weight: 500 
+aliases:
+  - ./configuration # /docs/loki/<LOKI_VERSION>/configuration/
+weight: 400
 ---
 
 # Grafana Loki configuration parameters

--- a/docs/sources/configure/index.template
+++ b/docs/sources/configure/index.template
@@ -2,10 +2,9 @@
 title: Grafana Loki configuration parameters
 menuTitle: Configure
 description: Configuration reference for the parameters used to configure Grafana Loki.
-aliases: 
-  - ../configuration
-  - ../configure
-weight: 500 
+aliases:
+  - ./configuration # /docs/loki/<LOKI_VERSION>/configuration/
+weight: 400
 ---
 
 # Grafana Loki configuration parameters


### PR DESCRIPTION
Backport 5408ec1c9c41f893aa4b3ba61705bc86c4df4929 from #10503

---

Tested locally with `make docs`

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
