### PR TITLE
Fix alias to redirect `/docs/loki/<LOKI_VERSION>/best-practices/` to `/docs/loki/latest/get-started/labels/bp-labels/`

### DIFF
--- a/docs/sources/get-started/labels/bp-labels.md
+++ b/docs/sources/get-started/labels/bp-labels.md
@@ -2,8 +2,8 @@
 title: Label best practices
 menuTitle:  Label best practices
 description: Grafana Loki label best practices
-aliases: 
-- ../best-practices/
+aliases:
+- ../../best-practices/ # /docs/loki/<LOKI_VERSION>/best-practices/
 weight: 700
 ---
 # Label best practices


### PR DESCRIPTION
Tested locally with `make docs`

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
