### PR TITLE
chore(docs): Fix structured_metadata usage

### DIFF
--- a/docs/sources/send-data/promtail/stages/structured_metadata.md
+++ b/docs/sources/send-data/promtail/stages/structured_metadata.md
@@ -19,7 +19,7 @@ Structured metadata will be rejected by Loki unless you enable the `allow_struct
 ## Schema
 
 ```yaml
-structured-metadata:
+structured_metadata:
   # Key is REQUIRED and the name for the label of structured metadata that will be created.
   # Value is optional and will be the name from extracted data whose value
   # will be used for the value of the label. If empty, the value will be
@@ -38,7 +38,7 @@ For the given pipeline:
       traceID: traceID
 - labels:
     stream:
-- structured-metadata:
+- structured_metadata:
     traceID:
 ```
 
@@ -50,4 +50,4 @@ Given the following log line:
 
 The first stage would extract `stream` with a value of `stderr` and `traceID` with a value of `0242ac120002` into
 the extracted data set. The `labels` stage would turn that `stream` and `stderr` key-value pair into a stream label.
-The `structured-metadata` stage would attach the `traceID` and `0242ac120002` key-value pair as a structured metadata to the log line.
+The `structured_metadata` stage would attach the `traceID` and `0242ac120002` key-value pair as a structured metadata to the log line.


### PR DESCRIPTION
**What this PR does / why we need it**:

According to the code the pipeline name uses `_` not `-` for the name

https://github.com/grafana/loki/blob/main/clients/pkg/logentry/stages/stage.go#L46C38-L46C38

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
