### PR TITLE
Remove backup index writer from TSDB configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [10380](https://github.com/grafana/loki/pull/10380) **shantanualsi** Remove `experimental.ruler.enable-api` in favour of `ruler.enable-api`
 * [10395](https://github.com/grafana/loki/pull/10395/) **shantanualshi** Remove deprecated `split_queries_by_interval` and `forward_headers_list` configuration options in the `query_range` section
 * [10456](https://github.com/grafana/loki/pull/10456) **dannykopping** Add `loki_distributor_ingester_append_timeouts_total` metric, remove `loki_distributor_ingester_append_failures_total` metric
+* [10534](https://github.com/grafana/loki/pull/10534) **chaudum** Remove configuration `use_boltdb_shipper_as_backup`
 
 ##### Fixes
 

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2036,11 +2036,6 @@ boltdb_shipper:
     # CLI flag: -boltdb.shipper.index-gateway-client.log-gateway-requests
     [log_gateway_requests: <boolean> | default = false]
 
-  # Use boltdb-shipper index store as backup for indexing chunks. When enabled,
-  # boltdb-shipper needs to be configured under storage_config
-  # CLI flag: -boltdb.shipper.use-boltdb-shipper-as-backup
-  [use_boltdb_shipper_as_backup: <boolean> | default = false]
-
   [ingestername: <string> | default = ""]
 
   [mode: <string> | default = ""]
@@ -2102,11 +2097,6 @@ tsdb_shipper:
     # Whether requests sent to the gateway should be logged or not.
     # CLI flag: -tsdb.shipper.index-gateway-client.log-gateway-requests
     [log_gateway_requests: <boolean> | default = false]
-
-  # Use boltdb-shipper index store as backup for indexing chunks. When enabled,
-  # boltdb-shipper needs to be configured under storage_config
-  # CLI flag: -tsdb.shipper.use-boltdb-shipper-as-backup
-  [use_boltdb_shipper_as_backup: <boolean> | default = false]
 
   [ingestername: <string> | default = ""]
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -38,7 +38,15 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ### Loki
 
-#### deprecated configs are now removed
+#### Configuration `use_boltdb_shipper_as_backup` is removed
+
+The setting `use_boltdb_shipper_as_backup` (`-tsdb.shipper.use-boltdb-shipper-as-backup`) was a remnant from the development of the TSDB storage.
+It was used to allow writing to both TSDB and BoltDB when TSDB was still highly experimental.
+Since TSDB is now stable and the recommended index type, the setting has become irrelevant and therefore was removed.
+The previous default value `false` is applied.
+
+#### Deprecated configuration options are removed
+
 1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting. 
 2. Also removes the `query_timeout` from the querier YAML section. Instead of configuring `query_timeout` under `querier`, you now configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
 3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type. 

--- a/pkg/storage/stores/indexshipper/shipper.go
+++ b/pkg/storage/stores/indexshipper/shipper.go
@@ -66,7 +66,6 @@ type Config struct {
 	ResyncInterval           time.Duration                          `yaml:"resync_interval"`
 	QueryReadyNumDays        int                                    `yaml:"query_ready_num_days"`
 	IndexGatewayClientConfig gatewayclient.IndexGatewayClientConfig `yaml:"index_gateway_client"`
-	UseBoltDBShipperAsBackup bool                                   `yaml:"use_boltdb_shipper_as_backup"`
 
 	IngesterName           string
 	Mode                   Mode
@@ -88,7 +87,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.CacheTTL, prefix+"shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, prefix+"shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
 	f.IntVar(&cfg.QueryReadyNumDays, prefix+"shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
-	f.BoolVar(&cfg.UseBoltDBShipperAsBackup, prefix+"shipper.use-boltdb-shipper-as-backup", false, "Use boltdb-shipper index store as backup for indexing chunks. When enabled, boltdb-shipper needs to be configured under storage_config")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/storage/stores/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/tsdb/head_manager_test.go
@@ -529,7 +529,7 @@ func TestBuildLegacyWALs(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				store, stop, err := NewStore(tc.store, IndexCfg{Config: shipperCfg}, schemaCfg, nil, fsObjectClient, &zeroValueLimits{}, tc.tableRange, nil, nil, log.NewNopLogger(), nil)
+				store, stop, err := NewStore(tc.store, IndexCfg{Config: shipperCfg}, schemaCfg, nil, fsObjectClient, &zeroValueLimits{}, tc.tableRange, nil, log.NewNopLogger(), nil)
 				require.Nil(t, err)
 				refs, err := store.GetChunkRefs(
 					context.Background(),

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -184,9 +184,3 @@ type failingIndexWriter struct{}
 func (f failingIndexWriter) Append(_ string, _ labels.Labels, _ uint64, _ tsdb_index.ChunkMetas) error {
 	return fmt.Errorf("index writer is not initialized due to tsdb store being initialized in read-only mode")
 }
-
-type noopBackupIndexWriter struct{}
-
-func (n noopBackupIndexWriter) IndexChunk(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
-	return nil
-}

--- a/pkg/storage/stores/tsdb/store.go
+++ b/pkg/storage/stores/tsdb/store.go
@@ -31,11 +31,10 @@ type IndexWriter interface {
 
 type store struct {
 	index.Reader
-	indexShipper      indexshipper.IndexShipper
-	indexWriter       IndexWriter
-	backupIndexWriter index.Writer
-	logger            log.Logger
-	stopOnce          sync.Once
+	indexShipper indexshipper.IndexShipper
+	indexWriter  IndexWriter
+	logger       log.Logger
+	stopOnce     sync.Once
 }
 
 // NewStore creates a new tsdb index ReaderWriter.
@@ -47,7 +46,6 @@ func NewStore(
 	objectClient client.ObjectClient,
 	limits downloads.Limits,
 	tableRange config.TableRange,
-	backupIndexWriter index.Writer,
 	reg prometheus.Registerer,
 	logger log.Logger,
 	idxCache cache.Cache,
@@ -56,13 +54,9 @@ func NewStore(
 	func(),
 	error,
 ) {
-	if backupIndexWriter == nil {
-		backupIndexWriter = noopBackupIndexWriter{}
-	}
 
 	storeInstance := &store{
-		backupIndexWriter: backupIndexWriter,
-		logger:            logger,
+		logger: logger,
 	}
 
 	if err := storeInstance.init(name, indexShipperCfg, schemaCfg, objectClient, limits, tableRange, reg, idxCache); err != nil {
@@ -182,8 +176,7 @@ func (s *store) IndexChunk(ctx context.Context, from model.Time, through model.T
 	if err := s.indexWriter.Append(chk.UserID, chk.Metric, chk.ChunkRef.Fingerprint, metas); err != nil {
 		return errors.Wrap(err, "writing index entry")
 	}
-
-	return s.backupIndexWriter.IndexChunk(ctx, from, through, chk)
+	return nil
 }
 
 type failingIndexWriter struct{}


### PR DESCRIPTION
**What this PR does / why we need it**:

The setting `use_boltdb_shipper_as_backup` (`-tsdb.shipper.use-boltdb-shipper-as-backup`) was a remnant from the development of the TSDB storage.
It was used to allow writing to both TSDB and BoltDB when TSDB was still highly experimental.
Since TSDB is now stable and the recommended index type, the setting has become irrelevant and therefore was removed.
The previous default value `false` is applied.

**Which issue(s) this PR fixes**:

Also closes https://github.com/grafana/loki/issues/9603, but a fix needs to be backported to 2.9 and 2.8

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
