### PR TITLE
operator: Update gateway arguments to enable namespace extraction

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [10545](https://github.com/grafana/loki/pull/10545) **xperimental**: Update gateway arguments to enable namespace extraction
 - [10418](https://github.com/grafana/loki/pull/10418) **btaani**: Use a condition to warn when labels for zone-awareness are empty
 - [9468](https://github.com/grafana/loki/pull/9468) **periklis**: Add support for reconciling loki-mixin dashboards on OpenShift Console
 - [9942](https://github.com/grafana/loki/pull/9942) **btaani**: Use a condition to warn when there are no nodes with matching labels for zone-awareness

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -718,7 +718,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.extract-selector-labels=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name",
 									},
 								},
 								{
@@ -827,7 +827,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.extract-selector-labels=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name",
 									},
 								},
 								{
@@ -1164,7 +1164,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.extract-selector-labels=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name",
 									},
 								},
 								{
@@ -1261,7 +1261,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 								{
 									Name: gatewayContainerName,
 									Args: []string{
-										"--logs.extract-selector-labels=kubernetes_namespace_name",
+										"--logs.auth.extract-selectors=kubernetes_namespace_name",
 									},
 								},
 								{

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -717,6 +717,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: gatewayContainerName,
+									Args: []string{
+										"--logs.extract-selector-labels=kubernetes_namespace_name",
+									},
 								},
 								{
 									Name:  "opa",
@@ -823,6 +826,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: gatewayContainerName,
+									Args: []string{
+										"--logs.extract-selector-labels=kubernetes_namespace_name",
+									},
 								},
 								{
 									Name:  "opa",
@@ -1157,6 +1163,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: gatewayContainerName,
+									Args: []string{
+										"--logs.extract-selector-labels=kubernetes_namespace_name",
+									},
 								},
 								{
 									Name:  "opa",
@@ -1251,6 +1260,9 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: gatewayContainerName,
+									Args: []string{
+										"--logs.extract-selector-labels=kubernetes_namespace_name",
+									},
 								},
 								{
 									Name:  "opa",

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -81,7 +81,7 @@ func ConfigureGatewayDeployment(
 			}
 
 			d.Spec.Template.Spec.Containers[i].Args = append(d.Spec.Template.Spec.Containers[i].Args,
-				"--logs.extract-selector-labels=kubernetes_namespace_name",
+				fmt.Sprintf("--logs.extract-selector-labels=%s", opaDefaultLabelMatcher),
 			)
 		}
 	}

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -81,7 +81,7 @@ func ConfigureGatewayDeployment(
 			}
 
 			d.Spec.Template.Spec.Containers[i].Args = append(d.Spec.Template.Spec.Containers[i].Args,
-				fmt.Sprintf("--logs.extract-selector-labels=%s", opaDefaultLabelMatcher),
+				fmt.Sprintf("--logs.auth.extract-selectors=%s", opaDefaultLabelMatcher),
 			)
 		}
 	}

--- a/operator/internal/manifests/openshift/configure.go
+++ b/operator/internal/manifests/openshift/configure.go
@@ -73,6 +73,19 @@ func ConfigureGatewayDeployment(
 		return kverrors.Wrap(err, "failed to merge sidecar container spec ")
 	}
 
+	if mode == lokiv1.OpenshiftLogging {
+		// enable extraction of namespace selector
+		for i, c := range d.Spec.Template.Spec.Containers {
+			if c.Name != "gateway" {
+				continue
+			}
+
+			d.Spec.Template.Spec.Containers[i].Args = append(d.Spec.Template.Spec.Containers[i].Args,
+				"--logs.extract-selector-labels=kubernetes_namespace_name",
+			)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the new "query selector extraction" feature of observatorium/api when `openshift-logging` tenant mode is enabled.

Depends on observatorium/api#555

**Which issue(s) this PR fixes**:

Refs [LOG-4296](https://issues.redhat.com/browse/LOG-4296)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] `CHANGELOG.md` updated
