### PR TITLE
Fix regression when parsing numbers in Push request

### DIFF
--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -69,15 +69,8 @@ func (s *LogProtoStream) UnmarshalJSON(data []byte) error {
 	err := jsonparser.ObjectEach(data, func(key, val []byte, ty jsonparser.ValueType, _ int) error {
 		switch string(key) {
 		case "stream":
-			labels := make(LabelSet)
-			err := jsonparser.ObjectEach(val, func(key, val []byte, dataType jsonparser.ValueType, _ int) error {
-				if dataType != jsonparser.String {
-					return jsonparser.MalformedStringError
-				}
-				labels[string(key)] = string(val)
-				return nil
-			})
-			if err != nil {
+			var labels LabelSet
+			if err := labels.UnmarshalJSON(val); err != nil {
 				return err
 			}
 			s.Labels = labels.String()


### PR DESCRIPTION
**What this PR does / why we need it**:
Even though the[ Loki HTTP API docs for the push endpoint][1] state that the stream label values should be strings, we previously didn't enforce this requirement. With https://github.com/grafana/loki/pull/9694, we started enforcing this requirement, and that broke some users.

In this PR we are reverting this type of assertion and adding a bunch of tests to avoid the regression in the future.


[1]: https://grafana.com/docs/loki/latest/reference/api/#push-log-entries-to-loki