### PR TITLE
Add limits

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2719,9 +2719,17 @@ shard_streams:
 # CLI flag: -index-gateway.shard-size
 [index_gateway_shard_size: <int> | default = 0]
 
-# Allow user to send structured metadata (non-indexed labels) in push payload.
+# Allow user to send structured metadata in push payload.
 # CLI flag: -validation.allow-structured-metadata
 [allow_structured_metadata: <boolean> | default = false]
+
+# Maximum size accepted for structured metadata per log line.
+# CLI flag: -limits.max-structured-metadata-size
+[max_structured_metadata_size: <int> | default = 64KB]
+
+# Maximum number of structured metadata entries per log line.
+# CLI flag: -limits.max-structured-metadata-entries-count
+[max_structured_metadata_entries_count: <int> | default = 128]
 ```
 
 ### frontend_worker

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -28,4 +28,6 @@ type Limits interface {
 	IngestionRateBytes(userID string) float64
 	IngestionBurstSizeBytes(userID string) int
 	AllowStructuredMetadata(userID string) bool
+	MaxStructuredMetadataSize(userID string) int
+	MaxStructuredMetadataCount(userID string) int
 }

--- a/pkg/distributor/validator_test.go
+++ b/pkg/distributor/validator_test.go
@@ -95,6 +95,30 @@ func TestValidator_ValidateEntry(t *testing.T) {
 			logproto.Entry{Timestamp: testTime, Line: "12345678901", StructuredMetadata: push.LabelsAdapter{{Name: "foo", Value: "bar"}}},
 			fmt.Errorf(validation.DisallowedStructuredMetadataErrorMsg, testStreamLabels),
 		},
+		{
+			"structured metadata too big",
+			"test",
+			fakeLimits{
+				&validation.Limits{
+					AllowStructuredMetadata:   true,
+					MaxStructuredMetadataSize: 4,
+				},
+			},
+			logproto.Entry{Timestamp: testTime, Line: "12345678901", StructuredMetadata: push.LabelsAdapter{{Name: "foo", Value: "bar"}}},
+			fmt.Errorf(validation.StructuredMetadataTooLargeErrorMsg, testStreamLabels, 6, 4),
+		},
+		{
+			"structured metadata too many",
+			"test",
+			fakeLimits{
+				&validation.Limits{
+					AllowStructuredMetadata:           true,
+					MaxStructuredMetadataEntriesCount: 1,
+				},
+			},
+			logproto.Entry{Timestamp: testTime, Line: "12345678901", StructuredMetadata: push.LabelsAdapter{{Name: "foo", Value: "bar"}, {Name: "too", Value: "many"}}},
+			fmt.Errorf(validation.StructuredMetadataTooManyErrorMsg, testStreamLabels, 2, 1),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -62,6 +62,10 @@ const (
 	DuplicateLabelNamesErrorMsg          = "stream '%s' has duplicate label name: '%s'"
 	DisallowedStructuredMetadata         = "disallowed_structured_metadata"
 	DisallowedStructuredMetadataErrorMsg = "stream '%s' includes structured metadata, but this feature is disallowed. Please see `limits_config.structured_metadata` or contact your Loki administrator to enable it."
+	StructuredMetadataTooLarge           = "structured_metadata_too_large"
+	StructuredMetadataTooLargeErrorMsg   = "stream '%s' has structured metadata too large: '%d' bytes, limit: '%d' bytes. Please see `limits_config.structured_metadata_max_size` or contact your Loki administrator to increase it."
+	StructuredMetadataTooMany            = "structured_metadata_too_many"
+	StructuredMetadataTooManyErrorMsg    = "stream '%s' has too many structured metadata labels: '%d', limit: '%d'. Please see `limits_config.max_structured_metadata_entries_count` or contact your Loki administrator to increase it."
 )
 
 type ErrStreamRateLimit struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces two new limits for structured metadata:
- `max_structured_metadata_size`: Defaults to 64 KB. Limits the maximum size of the structured metadata attached to a log line.
- `max_structured_metadata_entries_count`: Default to 128. Limits the maximum number of structured metadata entries attached to a log line.

We discussed adding other limits like `max_structured_metadata_label_name_length` and `max_structured_metadata_label_value_length` but discarded this idea for now.
