### PR TITLE
Add missing object storage support in helm chart

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -24,6 +24,8 @@ This is the generated reference for the Loki Helm Chart values.
 
 <!-- Override default values table from helm-docs. See https://github.com/norwoodj/helm-docs/tree/master#advanced-table-rendering -->
 
+
+
 {{< responsive-table >}}
 <table>
 	<thead>
@@ -409,7 +411,7 @@ null
 			<td>string</td>
 			<td></td>
 			<td><pre lang="json">
-"{{- if .Values.enterprise.adminApi.enabled }}\n{{- if or .Values.minio.enabled (eq .Values.loki.storage.type \"s3\") (eq .Values.loki.storage.type \"gcs\") (eq .Values.loki.storage.type \"azure\") }}\nadmin_client:\n  storage:\n    s3:\n      bucket_name: {{ .Values.loki.storage.bucketNames.admin }}\n{{- end }}\n{{- end }}\nauth:\n  type: {{ .Values.enterprise.adminApi.enabled | ternary \"enterprise\" \"trust\" }}\nauth_enabled: {{ .Values.loki.auth_enabled }}\ncluster_name: {{ include \"loki.clusterName\" . }}\nlicense:\n  path: /etc/loki/license/license.jwt\n"
+"{{- if .Values.enterprise.adminApi.enabled }}\n{{- if or .Values.minio.enabled (eq .Values.loki.storage.type \"gcs\") (eq .Values.loki.storage.type \"s3\") (eq .Values.loki.storage.type \"azure\") (eq .Values.loki.storage.type \"alibabacloud\") (eq .Values.loki.storage.type \"cos\") (eq .Values.loki.storage.type \"swift\") (eq .Values.loki.storage.type \"bos\") }}\nadmin_client:\n  storage:\n    s3:\n      bucket_name: {{ .Values.loki.storage.bucketNames.admin }}\n{{- end }}\n{{- end }}\nauth:\n  type: {{ .Values.enterprise.adminApi.enabled | ternary \"enterprise\" \"trust\" }}\nauth_enabled: {{ .Values.loki.auth_enabled }}\ncluster_name: {{ include \"loki.clusterName\" . }}\nlicense:\n  path: /etc/loki/license/license.jwt\n"
 </pre>
 </td>
 		</tr>
@@ -2162,6 +2164,7 @@ null
 			<td>Storage config. Providing this will automatically populate all necessary storage configs in the templated config.</td>
 			<td><pre lang="json">
 {
+  "alibabacloud": {},
   "azure": {
     "accountKey": null,
     "accountName": null,
@@ -2171,11 +2174,13 @@ null
     "useManagedIdentity": false,
     "userAssignedId": null
   },
+  "bos": {},
   "bucketNames": {
     "admin": "admin",
     "chunks": "chunks",
     "ruler": "ruler"
   },
+  "cos": {},
   "filesystem": {
     "chunks_directory": "/var/loki/chunks",
     "rules_directory": "/var/loki/rules"
@@ -2196,6 +2201,7 @@ null
     "secretAccessKey": null,
     "signatureVersion": null
   },
+  "swift": {},
   "type": "s3"
 }
 </pre>
@@ -2204,7 +2210,7 @@ null
 		<tr>
 			<td>loki.storage_config</td>
 			<td>object</td>
-			<td>Additional storage config</td>
+			<td>Additional storage config (see https://grafana.com/docs/loki/latest/configure/#storage_config)</td>
 			<td><pre lang="json">
 {
   "hedging": {

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2162,10 +2162,6 @@ null
 			<td>Storage config. Providing this will automatically populate all necessary storage configs in the templated config.</td>
 			<td><pre lang="json">
 {
-  "alibabacloud": {
-	// Default to {}
-	// See https://grafana.com/docs/loki/latest/configure/#alibabacloud_storage_config for available values
-  },
   "azure": {
     "accountKey": null,
     "accountName": null,
@@ -2175,18 +2171,10 @@ null
     "useManagedIdentity": false,
     "userAssignedId": null
   },
-  "bos": {
-	// Default to {}
-	// See https://grafana.com/docs/loki/latest/configure/#bos_storage_config for available values
-  },
   "bucketNames": {
     "admin": "admin",
     "chunks": "chunks",
     "ruler": "ruler"
-  },
-  "cos": {
-	// Default to {}
-	// See https://grafana.com/docs/loki/latest/configure/#cos_storage_config for available values
   },
   "filesystem": {
     "chunks_directory": "/var/loki/chunks",
@@ -2207,10 +2195,6 @@ null
     "s3ForcePathStyle": false,
     "secretAccessKey": null,
     "signatureVersion": null
-  },
-  "swift": {
-	// Default to {}
-	// See https://grafana.com/docs/loki/latest/configure/#swift_storage_config for available value
   },
   "type": "s3"
 }

--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2162,6 +2162,10 @@ null
 			<td>Storage config. Providing this will automatically populate all necessary storage configs in the templated config.</td>
 			<td><pre lang="json">
 {
+  "alibabacloud": {
+	// Default to {}
+	// See https://grafana.com/docs/loki/latest/configure/#alibabacloud_storage_config for available values
+  },
   "azure": {
     "accountKey": null,
     "accountName": null,
@@ -2171,10 +2175,18 @@ null
     "useManagedIdentity": false,
     "userAssignedId": null
   },
+  "bos": {
+	// Default to {}
+	// See https://grafana.com/docs/loki/latest/configure/#bos_storage_config for available values
+  },
   "bucketNames": {
     "admin": "admin",
     "chunks": "chunks",
     "ruler": "ruler"
+  },
+  "cos": {
+	// Default to {}
+	// See https://grafana.com/docs/loki/latest/configure/#cos_storage_config for available values
   },
   "filesystem": {
     "chunks_directory": "/var/loki/chunks",
@@ -2195,6 +2207,10 @@ null
     "s3ForcePathStyle": false,
     "secretAccessKey": null,
     "signatureVersion": null
+  },
+  "swift": {
+	// Default to {}
+	// See https://grafana.com/docs/loki/latest/configure/#swift_storage_config for available value
   },
   "type": "s3"
 }

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.21.0
+
+- [ENHANCEMENT] Add support for _alibabacloud_, _cos_, _swift_ and _bos_ object storage backends in _Values.loki.storage_
+
 ## 5.20.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.8.0

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.0
-version: 5.20.0
+version: 5.21.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.20.0](https://img.shields.io/badge/Version-5.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 5.21.0](https://img.shields.io/badge/Version-5.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -276,16 +276,16 @@ azure:
 {{- end }}
 {{- else if eq .Values.loki.storage.type "alibabacloud" -}}
 alibabacloud:
-  {{- toYaml .Values.loki.storage.alibabacloud | nindent 2 }}
+  {{- toYaml (merge (dict "bucket" $.Values.loki.storage.bucketNames.chunks) .Values.loki.storage.alibabacloud) | nindent 2 }}
 {{- else if eq .Values.loki.storage.type "cos" -}}
 cos:
-  {{- toYaml .Values.loki.storage.cos | nindent 2 }}
+  {{- toYaml (merge (dict "bucketnames" $.Values.loki.storage.bucketNames.chunks) .Values.loki.storage.cos) | nindent 2 }}
 {{- else if eq .Values.loki.storage.type "swift" -}}
 swift:
-  {{- toYaml .Values.loki.storage.swift | nindent 2 }}
+  {{- toYaml (merge (dict "container_name" $.Values.loki.storage.bucketNames.chunks) .Values.loki.storage.swift) | nindent 2 }}
 {{- else if eq .Values.loki.storage.type "bos" -}}
 bos:
-  {{- toYaml .Values.loki.storage.bos | nindent 2 }}
+  {{- toYaml (merge (dict "bucket_name" $.Values.loki.storage.bucketNames.chunks) .Values.loki.storage.bos) | nindent 2 }}
 {{- else -}}
 {{- with .Values.loki.storage.filesystem }}
 filesystem:
@@ -356,6 +356,18 @@ azure:
   endpoint_suffix: {{ . }}
   {{- end }}
 {{- end -}}
+{{- else if eq .Values.loki.storage.type "alibabacloud" -}}
+alibabacloud:
+  {{- toYaml (merge (dict "bucket" $.Values.loki.storage.bucketNames.ruler) .Values.loki.storage.alibabacloud) | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "cos" -}}
+cos:
+  {{- toYaml (merge (dict "bucketnames" $.Values.loki.storage.bucketNames.ruler) .Values.loki.storage.cos) | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "swift" -}}
+swift:
+  {{- toYaml (merge (dict "container_name" $.Values.loki.storage.bucketNames.ruler) .Values.loki.storage.swift) | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "bos" -}}
+bos:
+  {{- toYaml (merge (dict "bucket_name" $.Values.loki.storage.bucketNames.ruler) .Values.loki.storage.bos) | nindent 2 }}
 {{- else }}
 type: "local"
 {{- end -}}

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -273,7 +273,19 @@ azure:
   {{- with .endpointSuffix }}
   endpoint_suffix: {{ . }}
   {{- end }}
-{{- end -}}
+{{- end }}
+{{- else if eq .Values.loki.storage.type "alibabacloud" -}}
+alibabacloud:
+  {{- toYaml .Values.loki.storage.alibabacloud | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "cos" -}}
+cos:
+  {{- toYaml .Values.loki.storage.cos | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "swift" -}}
+swift:
+  {{- toYaml .Values.loki.storage.swift | nindent 2 }}
+{{- else if eq .Values.loki.storage.type "bos" -}}
+bos:
+  {{- toYaml .Values.loki.storage.bos | nindent 2 }}
 {{- else -}}
 {{- with .Values.loki.storage.filesystem }}
 filesystem:
@@ -512,7 +524,7 @@ Create the service endpoint including port for MinIO.
 
 {{/* Determine if deployment is using object storage */}}
 {{- define "loki.isUsingObjectStorage" -}}
-{{- or (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "azure") -}}
+{{- or (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "azure") (eq .Values.loki.storage.type "alibabacloud") (eq .Values.loki.storage.type "cos") (eq .Values.loki.storage.type "swift") (eq .Values.loki.storage.type "bos") -}}
 {{- end -}}
 
 {{/* Configure the correct name for the memberlist service */}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -290,10 +290,10 @@ loki:
       userAssignedId: null
       requestTimeout: null
       endpointSuffix: null
-    alibabacloud: {} # See <alibabacloud_storage_config> at https://grafana.com/docs/loki/latest/configure/#alibabacloud_storage_config
-    cos: {} # See <cos_storage_config> at https://grafana.com/docs/loki/latest/configure/#cos_storage_config
-    swift: {} # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#swift_storage_config
-    bos: {} # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#bos_storage_config
+    alibabacloud: {}          # See <alibabacloud_storage_config> at https://grafana.com/docs/loki/latest/configure/#alibabacloud_storage_config
+    cos: {}                   # See <cos_storage_config> at https://grafana.com/docs/loki/latest/configure/#cos_storage_config
+    swift: {}                 # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#swift_storage_config
+    bos: {}                   # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#bos_storage_config
     filesystem:
       chunks_directory: /var/loki/chunks
       rules_directory: /var/loki/rules

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -320,7 +320,7 @@ loki:
   structuredConfig: {}
   # -- Additional query scheduler config
   query_scheduler: {}
-  # -- Additional storage config
+  # -- Additional storage config (see https://grafana.com/docs/loki/latest/configure/#storage_config)
   storage_config:
     hedging:
       at: "250ms"

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -290,6 +290,10 @@ loki:
       userAssignedId: null
       requestTimeout: null
       endpointSuffix: null
+    alibabacloud: {} # See <alibabacloud_storage_config> at https://grafana.com/docs/loki/latest/configure/#alibabacloud_storage_config
+    cos: {} # See <cos_storage_config> at https://grafana.com/docs/loki/latest/configure/#cos_storage_config
+    swift: {} # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#swift_storage_config
+    bos: {} # See <swift_storage_config> at https://grafana.com/docs/loki/latest/configure/#bos_storage_config
     filesystem:
       chunks_directory: /var/loki/chunks
       rules_directory: /var/loki/rules
@@ -366,7 +370,7 @@ enterprise:
   # enterprise specific sections of the config.yaml file
   config: |
     {{- if .Values.enterprise.adminApi.enabled }}
-    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "azure") }}
+    {{- if or .Values.minio.enabled (eq .Values.loki.storage.type "gcs") (eq .Values.loki.storage.type "s3") (eq .Values.loki.storage.type "azure") (eq .Values.loki.storage.type "alibabacloud") (eq .Values.loki.storage.type "cos") (eq .Values.loki.storage.type "swift") (eq .Values.loki.storage.type "bos") }}
     admin_client:
       storage:
         s3:


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki supports various object storage backend configs, namely _s3_, _gcs_, _azure_, _alibabacloud_, _cos_, _swift_, _bos_. Only the first three were supported in `Values.loki.storage`. This PR adds support for the last four.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
