### PR TITLE
[Docs] Add upgrade link to Manage page.

### DIFF
--- a/docs/sources/operations/_index.md
+++ b/docs/sources/operations/_index.md
@@ -12,3 +12,5 @@ This section describes the decisions Loki operators and users make and the actio
 This section includes the following topics for managing and tuning Loki:
 
 {{< section >}}
+
+- [Upgrade Loki]({{< relref "../setup/upgrade" >}})


### PR DESCRIPTION
The new information architecture moved the Upgrade docs under "Setup."  

Based on feedback received via Slack, adding a link to the Upgrade docs to the Manage/Operations landing page to help users find the Upgrade docs.  

**Special notes for your reviewer:**
Note that because how the page is structured (the list is a Hugo "section") this is a bit of a workaround.  The link to the Upgrade docs is at the bottom, not in alphabetical order.
