### PR TITLE
Return `StepResult` from `StepEvaluator.Next()`.

### DIFF
--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -397,11 +397,11 @@ func (e *ConcatStepEvaluator) Next() (bool, int64, StepResult) {
 		ok  bool
 		ts  int64
 	)
-	vec := PromVec{}
+	vec := SampleVector{}
 	for _, eval := range e.evaluators {
 		ok, ts, cur = eval.Next()
 		if ok {
-			vec = append(vec, cur.PromVec()...)
+			vec = append(vec, cur.SampleVector()...)
 		}
 	}
 	return ok, ts, vec

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -391,11 +391,18 @@ func NewConcatStepEvaluator(evaluators []StepEvaluator) *ConcatStepEvaluator {
 	return &ConcatStepEvaluator{evaluators}
 }
 
-func (e *ConcatStepEvaluator) Next() (ok bool, ts int64, vec promql.Vector) {
-	var cur promql.Vector
+func (e *ConcatStepEvaluator) Next() (bool, int64, StepResult) {
+	var (
+		cur StepResult
+		ok  bool
+		ts  int64
+	)
+	vec := PromVec{}
 	for _, eval := range e.evaluators {
 		ok, ts, cur = eval.Next()
-		vec = append(vec, cur...)
+		if ok {
+			vec = append(vec, cur.PromVec()...)
+		}
 	}
 	return ok, ts, vec
 }

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -295,7 +295,7 @@ func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
 		streams, err := readStreams(iter, q.params.Limit(), q.params.Direction(), q.params.Interval())
 		return streams, err
 	default:
-		return nil, errors.New("Unexpected type (%T): cannot evaluate")
+		return nil, fmt.Errorf("unexpected type (%T): cannot evaluate", e)
 	}
 }
 
@@ -339,7 +339,6 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	if err != nil {
 		return nil, err
 	}
-
 	stepEvaluator, err := q.evaluator.NewStepEvaluator(ctx, q.evaluator, expr, q.params)
 	if err != nil {
 		return nil, err
@@ -348,9 +347,11 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 
 	maxSeriesCapture := func(id string) int { return q.limits.MaxQuerySeries(ctx, id) }
 	maxSeries := validation.SmallestPositiveIntPerTenant(tenantIDs, maxSeriesCapture)
+
 	seriesIndex := map[uint64]*promql.Series{}
 
-	next, ts, vec := stepEvaluator.Next()
+	next, ts, r := stepEvaluator.Next()
+	vec := r.PromVec()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
 	}
@@ -377,6 +378,7 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	}
 
 	for next {
+		vec = r.PromVec()
 		for _, p := range vec {
 			var (
 				series *promql.Series
@@ -401,7 +403,7 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 		if len(seriesIndex) > maxSeries {
 			return nil, logqlmodel.NewSeriesLimitError(maxSeries)
 		}
-		next, ts, vec = stepEvaluator.Next()
+		next, ts, r = stepEvaluator.Next()
 		if stepEvaluator.Error() != nil {
 			return nil, stepEvaluator.Error()
 		}

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -351,7 +351,7 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	seriesIndex := map[uint64]*promql.Series{}
 
 	next, ts, r := stepEvaluator.Next()
-	vec := r.PromVec()
+	vec := r.SampleVector()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
 	}
@@ -378,7 +378,7 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	}
 
 	for next {
-		vec = r.PromVec()
+		vec = r.SampleVector()
 		for _, p := range vec {
 			var (
 				series *promql.Series

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -22,6 +22,8 @@ import (
 
 type QueryRangeType string
 
+const trueString = "true"
+
 var (
 	InstantType QueryRangeType = "instant"
 	RangeType   QueryRangeType = "range"
@@ -268,16 +270,17 @@ type VectorAggEvaluator struct {
 	lb            *labels.Builder
 }
 
-func (e *VectorAggEvaluator) Next() (bool, int64, promql.Vector) {
-	next, ts, vec := e.nextEvaluator.Next()
+func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
+	next, ts, r := e.nextEvaluator.Next()
 
 	if !next {
-		return false, 0, promql.Vector{}
+		return false, 0, PromVec{}
 	}
+	vec := r.PromVec()
 	result := map[uint64]*groupedAggregation{}
 	if e.expr.Operation == syntax.OpTypeTopK || e.expr.Operation == syntax.OpTypeBottomK {
 		if e.expr.Params < 1 {
-			return next, ts, promql.Vector{}
+			return next, ts, PromVec{}
 		}
 	}
 	for _, s := range vec {
@@ -460,7 +463,7 @@ func (e *VectorAggEvaluator) Next() (bool, int64, promql.Vector) {
 			F:      aggr.value,
 		})
 	}
-	return next, ts, vec
+	return next, ts, PromVec(vec)
 }
 
 func (e *VectorAggEvaluator) Close() error {
@@ -477,6 +480,7 @@ func newRangeAggEvaluator(
 	q Params,
 	o time.Duration,
 ) (StepEvaluator, error) {
+
 	iter, err := newRangeVectorIterator(
 		it, expr,
 		expr.Left.Interval.Nanoseconds(),
@@ -507,17 +511,17 @@ type RangeVectorEvaluator struct {
 	err error
 }
 
-func (r *RangeVectorEvaluator) Next() (bool, int64, promql.Vector) {
+func (r *RangeVectorEvaluator) Next() (bool, int64, StepResult) {
 	next := r.iter.Next()
 	if !next {
-		return false, 0, promql.Vector{}
+		return false, 0, PromVec{}
 	}
 	ts, vec := r.iter.At()
-	for _, s := range vec {
+	for _, s := range vec.PromVec() {
 		// Errors are not allowed in metrics unless they've been specifically requested.
-		if s.Metric.Has(logqlmodel.ErrorLabel) && s.Metric.Get(logqlmodel.PreserveErrorLabel) != "true" {
+		if s.Metric.Has(logqlmodel.ErrorLabel) && s.Metric.Get(logqlmodel.PreserveErrorLabel) != trueString {
 			r.err = logqlmodel.NewPipelineErr(s.Metric)
-			return false, 0, promql.Vector{}
+			return false, 0, PromVec{}
 		}
 	}
 	return true, ts, vec
@@ -539,24 +543,24 @@ type AbsentRangeVectorEvaluator struct {
 	err error
 }
 
-func (r *AbsentRangeVectorEvaluator) Next() (bool, int64, promql.Vector) {
+func (r *AbsentRangeVectorEvaluator) Next() (bool, int64, StepResult) {
 	next := r.iter.Next()
 	if !next {
-		return false, 0, promql.Vector{}
+		return false, 0, PromVec{}
 	}
 	ts, vec := r.iter.At()
-	for _, s := range vec {
+	for _, s := range vec.PromVec() {
 		// Errors are not allowed in metrics unless they've been specifically requested.
-		if s.Metric.Has(logqlmodel.ErrorLabel) && s.Metric.Get(logqlmodel.PreserveErrorLabel) != "true" {
+		if s.Metric.Has(logqlmodel.ErrorLabel) && s.Metric.Get(logqlmodel.PreserveErrorLabel) != trueString {
 			r.err = logqlmodel.NewPipelineErr(s.Metric)
-			return false, 0, promql.Vector{}
+			return false, 0, PromVec{}
 		}
 	}
-	if len(vec) > 0 {
-		return next, ts, promql.Vector{}
+	if len(vec.PromVec()) > 0 {
+		return next, ts, PromVec{}
 	}
 	// values are missing.
-	return next, ts, promql.Vector{
+	return next, ts, PromVec{
 		promql.Sample{
 			T:      ts,
 			F:      1.,
@@ -657,27 +661,30 @@ type BinOpStepEvaluator struct {
 	lastErr error
 }
 
-func (e *BinOpStepEvaluator) Next() (bool, int64, promql.Vector) {
+func (e *BinOpStepEvaluator) Next() (bool, int64, StepResult) {
 	var (
 		ts       int64
 		next     bool
 		lhs, rhs promql.Vector
+		r        StepResult
 	)
-	next, ts, rhs = e.rse.Next()
+	next, ts, r = e.rse.Next()
 	// These should _always_ happen at the same step on each evaluator.
 	if !next {
 		return next, ts, nil
 	}
+	rhs = r.PromVec()
 	// build matching signature for each sample in right vector
 	rsigs := make([]uint64, len(rhs))
 	for i, sample := range rhs {
 		rsigs[i] = matchingSignature(sample, e.expr.Opts)
 	}
 
-	next, ts, lhs = e.lse.Next()
+	next, ts, r = e.lse.Next()
 	if !next {
 		return next, ts, nil
 	}
+	lhs = r.PromVec()
 	// build matching signature for each sample in left vector
 	lsigs := make([]uint64, len(lhs))
 	for i, sample := range lhs {
@@ -695,7 +702,7 @@ func (e *BinOpStepEvaluator) Next() (bool, int64, promql.Vector) {
 	default:
 		results, e.lastErr = vectorBinop(e.expr.Op, e.expr.Opts, lhs, rhs, lsigs, rsigs)
 	}
-	return true, ts, results
+	return true, ts, PromVec(results)
 }
 
 func (e *BinOpStepEvaluator) Close() (lastError error) {
@@ -943,8 +950,9 @@ type LiteralStepEvaluator struct {
 	returnBool bool
 }
 
-func (e *LiteralStepEvaluator) Next() (bool, int64, promql.Vector) {
-	ok, ts, vec := e.nextEv.Next()
+func (e *LiteralStepEvaluator) Next() (bool, int64, StepResult) {
+	ok, ts, r := e.nextEv.Next()
+	vec := r.PromVec()
 	results := make(promql.Vector, 0, len(vec))
 	for _, sample := range vec {
 
@@ -974,7 +982,7 @@ func (e *LiteralStepEvaluator) Next() (bool, int64, promql.Vector) {
 		}
 	}
 
-	return ok, ts, results
+	return ok, ts, PromVec(results)
 }
 
 func (e *LiteralStepEvaluator) Close() error {
@@ -1007,7 +1015,7 @@ func newVectorIterator(val float64,
 	}
 }
 
-func (r *VectorIterator) Next() (bool, int64, promql.Vector) {
+func (r *VectorIterator) Next() (bool, int64, StepResult) {
 	r.currentMs = r.currentMs + r.stepMs
 	if r.currentMs > r.endMs {
 		return false, 0, nil
@@ -1015,7 +1023,7 @@ func (r *VectorIterator) Next() (bool, int64, promql.Vector) {
 	results := make(promql.Vector, 0)
 	vectorPoint := promql.Sample{T: r.currentMs, F: r.val}
 	results = append(results, vectorPoint)
-	return true, r.currentMs, results
+	return true, r.currentMs, PromVec(results)
 }
 
 func (r *VectorIterator) Close() error {
@@ -1052,10 +1060,11 @@ type LabelReplaceEvaluator struct {
 	buf           []byte
 }
 
-func (e *LabelReplaceEvaluator) Next() (bool, int64, promql.Vector) {
-	next, ts, vec := e.nextEvaluator.Next()
+func (e *LabelReplaceEvaluator) Next() (bool, int64, StepResult) {
+	next, ts, r := e.nextEvaluator.Next()
+	vec := r.PromVec()
 	if !next {
-		return false, 0, promql.Vector{}
+		return false, 0, PromVec{}
 	}
 	if e.labelCache == nil {
 		e.labelCache = make(map[uint64]labels.Labels, len(vec))
@@ -1084,7 +1093,7 @@ func (e *LabelReplaceEvaluator) Next() (bool, int64, promql.Vector) {
 		e.labelCache[hash] = outLbs
 		vec[i].Metric = outLbs
 	}
-	return next, ts, vec
+	return next, ts, PromVec(vec)
 }
 
 func (e *LabelReplaceEvaluator) Close() error {

--- a/pkg/logql/matrix.go
+++ b/pkg/logql/matrix.go
@@ -31,7 +31,7 @@ func NewMatrixStepEvaluator(start, end time.Time, step time.Duration, m promql.M
 	}
 }
 
-func (m *MatrixStepEvaluator) Next() (bool, int64, promql.Vector) {
+func (m *MatrixStepEvaluator) Next() (bool, int64, StepResult) {
 	m.ts = m.ts.Add(m.step)
 	if m.ts.After(m.end) {
 		return false, 0, nil
@@ -55,7 +55,7 @@ func (m *MatrixStepEvaluator) Next() (bool, int64, promql.Vector) {
 		m.m[i].Floats = m.m[i].Floats[1:]
 	}
 
-	return true, ts, vec
+	return true, ts, PromVec(vec)
 }
 
 func (m *MatrixStepEvaluator) Close() error { return nil }

--- a/pkg/logql/matrix.go
+++ b/pkg/logql/matrix.go
@@ -55,7 +55,7 @@ func (m *MatrixStepEvaluator) Next() (bool, int64, StepResult) {
 		m.m[i].Floats = m.m[i].Floats[1:]
 	}
 
-	return true, ts, PromVec(vec)
+	return true, ts, SampleVector(vec)
 }
 
 func (m *MatrixStepEvaluator) Close() error { return nil }

--- a/pkg/logql/matrix_test.go
+++ b/pkg/logql/matrix_test.go
@@ -91,7 +91,7 @@ func TestMatrixStepper(t *testing.T) {
 		ok, ts, vec := s.Next()
 		require.Equal(t, ok, true)
 		require.Equal(t, start.Add(step*time.Duration(i)).UnixNano()/int64(time.Millisecond), ts)
-		require.Equal(t, expected[i], vec.PromVec())
+		require.Equal(t, expected[i], vec.SampleVector())
 	}
 
 	ok, _, _ := s.Next()
@@ -123,7 +123,7 @@ func Test_SingleStepMatrix(t *testing.T) {
 	require.Equal(t, promql.Vector{promql.Sample{
 		T: start.UnixNano(), F: 10,
 		Metric: labels.EmptyLabels(),
-	}}, vec.PromVec())
+	}}, vec.SampleVector())
 
 	ok, _, _ = s.Next()
 	require.False(t, ok)

--- a/pkg/logql/matrix_test.go
+++ b/pkg/logql/matrix_test.go
@@ -91,7 +91,7 @@ func TestMatrixStepper(t *testing.T) {
 		ok, ts, vec := s.Next()
 		require.Equal(t, ok, true)
 		require.Equal(t, start.Add(step*time.Duration(i)).UnixNano()/int64(time.Millisecond), ts)
-		require.Equal(t, expected[i], vec)
+		require.Equal(t, expected[i], vec.PromVec())
 	}
 
 	ok, _, _ := s.Next()
@@ -123,7 +123,7 @@ func Test_SingleStepMatrix(t *testing.T) {
 	require.Equal(t, promql.Vector{promql.Sample{
 		T: start.UnixNano(), F: 10,
 		Metric: labels.EmptyLabels(),
-	}}, vec)
+	}}, vec.PromVec())
 
 	ok, _, _ = s.Next()
 	require.False(t, ok)

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -34,7 +34,7 @@ type RangeStreamingAgg interface {
 // To fetch the current vector use `At` with a `BatchRangeVectorAggregator` or `RangeStreamingAgg`.
 type RangeVectorIterator interface {
 	Next() bool
-	At() (int64, promql.Vector)
+	At() (int64, StepResult)
 	Close() error
 	Error() error
 }
@@ -186,7 +186,7 @@ func (r *batchRangeVectorIterator) load(start, end int64) {
 		_ = r.iter.Next()
 	}
 }
-func (r *batchRangeVectorIterator) At() (int64, promql.Vector) {
+func (r *batchRangeVectorIterator) At() (int64, StepResult) {
 	if r.at == nil {
 		r.at = make([]promql.Sample, 0, len(r.window))
 	}
@@ -200,7 +200,7 @@ func (r *batchRangeVectorIterator) At() (int64, promql.Vector) {
 			Metric: series.Metric,
 		})
 	}
-	return ts, r.at
+	return ts, PromVec(r.at)
 }
 
 var seriesPool sync.Pool
@@ -580,7 +580,7 @@ func (r *streamRangeVectorIterator) load(start, end int64) {
 	}
 }
 
-func (r *streamRangeVectorIterator) At() (int64, promql.Vector) {
+func (r *streamRangeVectorIterator) At() (int64, StepResult) {
 	if r.at == nil {
 		r.at = make([]promql.Sample, 0, len(r.windowRangeAgg))
 	}
@@ -594,7 +594,7 @@ func (r *streamRangeVectorIterator) At() (int64, promql.Vector) {
 			Metric: r.metrics[lbs],
 		})
 	}
-	return ts, r.at
+	return ts, PromVec(r.at)
 }
 
 func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, error) {

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -200,7 +200,7 @@ func (r *batchRangeVectorIterator) At() (int64, StepResult) {
 			Metric: series.Metric,
 		})
 	}
-	return ts, PromVec(r.at)
+	return ts, SampleVector(r.at)
 }
 
 var seriesPool sync.Pool
@@ -594,7 +594,7 @@ func (r *streamRangeVectorIterator) At() (int64, StepResult) {
 			Metric: r.metrics[lbs],
 		})
 	}
-	return ts, PromVec(r.at)
+	return ts, SampleVector(r.at)
 }
 
 func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, error) {

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -413,7 +413,7 @@ func Test_InstantQueryRangeVectorAggregations(t *testing.T) {
 			for it.Next() {
 			}
 			_, value := it.At()
-			require.Equal(t, tt.expectedValue, value[0].F)
+			require.Equal(t, tt.expectedValue, value.PromVec()[0].F)
 		})
 	}
 }

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -413,7 +413,7 @@ func Test_InstantQueryRangeVectorAggregations(t *testing.T) {
 			for it.Next() {
 			}
 			_, value := it.At()
-			require.Equal(t, tt.expectedValue, value.PromVec()[0].F)
+			require.Equal(t, tt.expectedValue, value.SampleVector()[0].F)
 		})
 	}
 }

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -5,14 +5,14 @@ import (
 )
 
 type StepResult interface {
-	PromVec() promql.Vector
+	SampleVector() promql.Vector
 }
 
-type PromVec promql.Vector
+type SampleVector promql.Vector
 
-var _ StepResult = PromVec{}
+var _ StepResult = SampleVector{}
 
-func (p PromVec) PromVec() promql.Vector {
+func (p SampleVector) SampleVector() promql.Vector {
 	return promql.Vector(p)
 }
 

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -4,10 +4,22 @@ import (
 	"github.com/prometheus/prometheus/promql"
 )
 
+type StepResult interface {
+	PromVec() promql.Vector
+}
+
+type PromVec promql.Vector
+
+var _ StepResult = PromVec{}
+
+func (p PromVec) PromVec() promql.Vector {
+	return promql.Vector(p)
+}
+
 // StepEvaluator evaluate a single step of a query.
 type StepEvaluator interface {
 	// while Next returns a promql.Value, the only acceptable types are Scalar and Vector.
-	Next() (ok bool, ts int64, vec promql.Vector)
+	Next() (ok bool, ts int64, r StepResult)
 	// Close all resources used.
 	Close() error
 	// Reports any error

--- a/pkg/logql/vector.go
+++ b/pkg/logql/vector.go
@@ -79,10 +79,10 @@ func NewVectorStepEvaluator(start time.Time, data promql.Vector) *VectorStepEval
 	}
 }
 
-func (e *VectorStepEvaluator) Next() (bool, int64, promql.Vector) {
+func (e *VectorStepEvaluator) Next() (bool, int64, StepResult) {
 	if !e.exhausted {
 		e.exhausted = true
-		return true, e.start.UnixNano() / int64(time.Millisecond), e.data
+		return true, e.start.UnixNano() / int64(time.Millisecond), PromVec(e.data)
 	}
 	return false, 0, nil
 }

--- a/pkg/logql/vector.go
+++ b/pkg/logql/vector.go
@@ -82,7 +82,7 @@ func NewVectorStepEvaluator(start time.Time, data promql.Vector) *VectorStepEval
 func (e *VectorStepEvaluator) Next() (bool, int64, StepResult) {
 	if !e.exhausted {
 		e.exhausted = true
-		return true, e.start.UnixNano() / int64(time.Millisecond), PromVec(e.data)
+		return true, e.start.UnixNano() / int64(time.Millisecond), SampleVector(e.data)
 	}
 	return false, 0, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change makes the `StepEvaluator` more flexible for changes like #10417 that introduce a different step result. With the interface `StepResult` we can support other vector types in the future.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
