### PR TITLE
[docs] backport #10566

### DIFF
--- a/docs/sources/operations/_index.md
+++ b/docs/sources/operations/_index.md
@@ -9,3 +9,5 @@ weight: 900
 This section covers operational topics in Loki:
 
 {{< section >}}
+
+- [Upgrade Loki]({{< relref "../setup/upgrade" >}})


### PR DESCRIPTION
Manual backport of #10566, adding a link to the Upgrade docs to the Operations landing page.