### PR TITLE
Update alpine versions (#10573)

### DIFF
--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false clients/cmd/docker-driver/docker-driver
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates tzdata
 COPY --from=build /src/loki/clients/cmd/docker-driver/docker-driver /bin/docker-driver
 WORKDIR /bin/

--- a/clients/cmd/promtail/Dockerfile.debug
+++ b/clients/cmd/promtail/Dockerfile.debug
@@ -9,7 +9,7 @@ WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false PROMTAIL_JOURNAL_ENABLED=true promtail-debug
 
 
-FROM       alpine:3.16.7
+FROM       alpine:3.18.3
 RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /src/loki/clients/cmd/promtail/promtail-debug /usr/bin/promtail-debug
 COPY       --from=build /usr/bin/dlv /usr/bin/dlv

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false logcli
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/logql-analyzer/Dockerfile
+++ b/cmd/logql-analyzer/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && CGO_ENABLED=0 go build ./cmd/logql-analyzer/
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki-canary-boringcrypto/Dockerfile
+++ b/cmd/loki-canary-boringcrypto/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.20.6 as build
+
+COPY . /src/loki
+WORKDIR /src/loki
+RUN go env GOARCH > /goarch
+RUN make clean && make GOARCH=$(cat /goarch) BUILD_IN_CONTAINER=true GOEXPERIMENT=boringcrypto loki-canary-boringcrypto
+
+FROM alpine:3.18.3
+RUN apk add --update --no-cache ca-certificates
+RUN apk add --no-cache libc6-compat
+COPY --from=build /src/loki/cmd/loki-canary-boringcrypto/loki-canary-boringcrypto /usr/bin/loki-canary
+ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki-canary/Dockerfile
+++ b/cmd/loki-canary/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-canary
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 ENTRYPOINT [ "/usr/bin/loki-canary" ]

--- a/cmd/loki/Dockerfile
+++ b/cmd/loki/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates libcap
 

--- a/cmd/loki/Dockerfile.cross
+++ b/cmd/loki/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki
 
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -15,7 +15,7 @@ WORKDIR /src/loki
 RUN make clean && \
     GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-debug
 
-FROM       alpine:3.18.2
+FROM       alpine:3.18.3
 RUN        apk add --update --no-cache ca-certificates
 COPY       --from=build /src/loki/cmd/loki/loki-debug /usr/bin/loki-debug
 COPY       --from=goenv /go/bin/dlv /usr/bin/dlv

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -3,7 +3,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false migrate
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/migrate/migrate /usr/bin/migrate
 #ENTRYPOINT [ "/usr/bin/migrate" ]

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -12,7 +12,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-querytee
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 RUN apk add --update --no-cache ca-certificates
 COPY --from=build /src/loki/cmd/querytee/querytee /usr/bin/querytee
 ENTRYPOINT [ "/usr/bin/querytee" ]

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linu
     rm -rf /tmp/linux-amd64 /tmp/helm-$HELM_VER.tgz
 RUN GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 
-FROM alpine:3.16.7 as lychee
+FROM alpine:3.18.3 as lychee
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/lychee-$LYCHEE_VER.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-x86_64-unknown-linux-gnu.tar.gz && \
@@ -21,18 +21,18 @@ RUN apk add --no-cache curl && \
     mv /tmp/lychee /usr/bin/lychee && \
     rm -rf /tmp/linux-amd64 /tmp/lychee-$LYCHEE_VER.tgz
 
-FROM alpine:3.16.7 as golangci
+FROM alpine:3.18.3 as golangci
 RUN apk add --no-cache curl && \
     cd / && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
 
-FROM alpine:3.16.7 as buf
+FROM alpine:3.18.3 as buf
 
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$(uname -s)-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"
 
-FROM alpine:3.16.7 as docker
+FROM alpine:3.18.3 as docker
 RUN apk add --no-cache docker-cli
 
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above

--- a/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-boltdb-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20.4
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0
 
-FROM alpine:3.16.4
+FROM alpine:3.18.3
 
 RUN     mkdir /loki
 WORKDIR /loki

--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 RUN go build -o ./main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 
 
-FROM alpine:3.16.7
+FROM alpine:3.18.3
 
 WORKDIR /app
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The alpine version was updated and this backports it to the release 2.8.x branch.

The merge removed the file cmd/loki-canary-boringcrypto/Dockerfile. Given this is there in 2.9 as well I've re-added it. It shouldn't make much of a difference.