### PR TITLE
helm: replace existingForSecret property and fix an issue where we could not provide loki configuration with an external ConfigMap

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -1847,15 +1847,6 @@ true
 </td>
 		</tr>
 		<tr>
-			<td>loki.existingSecretForConfig</td>
-			<td>string</td>
-			<td>Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`</td>
-			<td><pre lang="json">
-""
-</pre>
-</td>
-		</tr>
-		<tr>
 			<td>loki.externalConfigSecretName</td>
 			<td>string</td>
 			<td>Name of the Secret or ConfigMap that contains the configuration (used for naming even if config is internal).</td>
@@ -2231,6 +2222,15 @@ null
 			<td>Tenants list to be created on nginx htpasswd file, with name and password keys</td>
 			<td><pre lang="json">
 []
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>loki.useExternalConfig</td>
+			<td>bool</td>
+			<td>Specify if the configuration is consumed or generated. If true, overrides `loki.config`</td>
+			<td><pre lang="json">
+false
 </pre>
 </td>
 		</tr>

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -47,9 +47,9 @@ The previous default value `false` is applied.
 
 #### Deprecated configuration options are removed
 
-1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting. 
+1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting.
 2. Also removes the `query_timeout` from the querier YAML section. Instead of configuring `query_timeout` under `querier`, you now configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
-3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type. 
+3. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type.
 4. `ruler.wal-cleaer.period` is removed. Use `ruler.wal-cleaner.period` instead.
 5. `experimental.ruler.enable-api` is removed. Use `ruler.enable-api` instead.
 6. `split_queries_by_interval` is removed from `query_range` YAML section. You can instead configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,10 +13,14 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.22.0
+
+- [CHANGE] **BREAKING** Replace `loki.existingSecretForConfig` by `loki.useExternalConfig`.
+- [BUGFIX] Fix an issue where we could not provide loki configuration with an external ConfigMap.
+
 ## 5.21.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to v1.8.1
-
 
 ## 5.20.0
 
@@ -26,7 +30,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 5.19.0
 
 - [FEATURE] Add optional sidecard to load rules from ConfigMaps and Secrets.
-  
+
 ## 5.18.1
 
 - [ENHANCEMENT] #8627 Add service labels and annotations for all services.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.0
-version: 5.21.0
+version: 5.22.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.21.0](https://img.shields.io/badge/Version-5.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 5.22.0](https://img.shields.io/badge/Version-5.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/backend/statefulset-backend.yaml
+++ b/production/helm/loki/templates/backend/statefulset-backend.yaml
@@ -221,12 +221,7 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
           {{- include "loki.configVolume" . | nindent 10 }}
-          {{- end }}
         - name: runtime-config
           configMap:
             name: {{ template "loki.name" . }}-runtime

--- a/production/helm/loki/templates/config.yaml
+++ b/production/helm/loki/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.loki.existingSecretForConfig -}}
+{{- if not .Values.loki.useExternalConfig }}
 apiVersion: v1
 {{- if eq .Values.loki.configStorageType "Secret" }}
 kind: Secret

--- a/production/helm/loki/templates/read/deployment-read.yaml
+++ b/production/helm/loki/templates/read/deployment-read.yaml
@@ -137,12 +137,7 @@ spec:
         - name: data
           emptyDir: {}
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
           {{- include "loki.configVolume" . | nindent 10 }}
-          {{- end }}
         - name: runtime-config
           configMap:
             name: {{ template "loki.name" . }}-runtime

--- a/production/helm/loki/templates/read/statefulset-read.yaml
+++ b/production/helm/loki/templates/read/statefulset-read.yaml
@@ -139,13 +139,7 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
-          configMap:
-            name: {{ include "loki.name" . }}
-          {{- end }}
+          {{- include "loki.configVolume" . | nindent 10 }}
         - name: runtime-config
           configMap:
             name: {{ template "loki.name" . }}-runtime

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -153,12 +153,7 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
           {{- include "loki.configVolume" . | nindent 10 }}
-          {{- end }}
         - name: runtime-config
           configMap:
             name: {{ template "loki.name" . }}-runtime

--- a/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
+++ b/production/helm/loki/templates/table-manager/deployment-table-manager.yaml
@@ -106,12 +106,7 @@ spec:
       {{- end }}
       volumes:
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
           {{- include "loki.configVolume" . | nindent 10 }}
-          {{- end }}
         {{- with .Values.tableManager.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/write/statefulset-write.yaml
+++ b/production/helm/loki/templates/write/statefulset-write.yaml
@@ -155,12 +155,7 @@ spec:
       {{- end }}
       volumes:
         - name: config
-          {{- if .Values.loki.existingSecretForConfig }}
-          secret:
-            secretName: {{ .Values.loki.existingSecretForConfig }}
-          {{- else }}
           {{- include "loki.configVolume" . | nindent 10 }}
-          {{- end }}
         - name: runtime-config
           configMap:
             name: {{ template "loki.name" . }}-runtime

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -77,8 +77,8 @@ loki:
     allowPrivilegeEscalation: false
   # -- Should enableServiceLinks be enabled. Default to enable
   enableServiceLinks: true
-  # -- Specify an existing secret containing loki configuration. If non-empty, overrides `loki.config`
-  existingSecretForConfig: ""
+  # -- Specify if the configuration is consumed or generated. If true, overrides `loki.config`
+  useExternalConfig: false
   # -- Defines what kind of object stores the configuration, a ConfigMap or a Secret.
   # In order to move sensitive information (such as credentials) from the ConfigMap/Secret to a more secure location (e.g. vault), it is possible to use [environment variables in the configuration](https://grafana.com/docs/loki/latest/configuration/#use-environment-variables-in-the-configuration).
   # Such environment variables can be then stored in a separate Secret and injected via the global.extraEnvFrom value. For details about environment injection from a Secret please see [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables).


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where we are currently not able to provide an existing ConfigMap containing loki configuration.

```
...
loki:
  useExternalConfig: true # We do not want the loki-config ConfigMap to be created
  configStorageType: Secret
  externalConfigSecretName: loki-config
...
```

Templates rendered with this values do not contain the`loki-config` ConfigMap (like we expect it to be) but we still have the following section in some of the manifests which gives errors when deploying the chart
```
volumes:
- name: config
  secret:
    secretName: loki-config
```

To fix this, I took example on the `mimir-distributed` helm chart as the use case is pretty much the same. As a result, I renamed the `loki.existingSecretForConfig` property which was confusing to `loki.useExternalConfig`

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [X] `CHANGELOG.md` updated
  - [X] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [X] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
