### PR TITLE
Fix bug cache of the index object client

### DIFF
--- a/pkg/storage/stores/indexshipper/storage/cached_client.go
+++ b/pkg/storage/stores/indexshipper/storage/cached_client.go
@@ -90,17 +90,11 @@ func (c *cachedObjectClient) RefreshIndexTableNamesCache(ctx context.Context) {
 }
 
 func (c *cachedObjectClient) RefreshIndexTableCache(ctx context.Context, tableName string) {
-	tbl := c.getTable(tableName)
-	// if we did not find the table in the cache, let us force refresh the table names cache to see if we can find it.
+	tbl := c.getTable(ctx, tableName)
 	// It would be rare that a non-existent table name is being referred.
 	// Should happen only when a table got deleted by compactor due to retention policy or user issued delete requests.
 	if tbl == nil {
-		c.RefreshIndexTableNamesCache(ctx)
-		tbl = c.getTable(tableName)
-		// still can't find the table, let us return
-		if tbl == nil {
-			return
-		}
+		return
 	}
 
 	buildCacheOnce(&tbl.buildCacheWg, tbl.buildCacheChan, func() {
@@ -168,7 +162,7 @@ func (c *cachedObjectClient) listTableNames(ctx context.Context) ([]client.Stora
 }
 
 func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([]client.StorageObject, []client.StorageCommonPrefix, error) {
-	tbl := c.getTable(tableName)
+	tbl := c.getTable(ctx, tableName)
 	if tbl == nil {
 		return []client.StorageObject{}, []client.StorageCommonPrefix{}, nil
 	}
@@ -194,7 +188,7 @@ func (c *cachedObjectClient) listTable(ctx context.Context, tableName string) ([
 }
 
 func (c *cachedObjectClient) listUserIndexInTable(ctx context.Context, tableName, userID string) ([]client.StorageObject, error) {
-	tbl := c.getTable(tableName)
+	tbl := c.getTable(ctx, tableName)
 	if tbl == nil {
 		return []client.StorageObject{}, nil
 	}
@@ -275,11 +269,21 @@ func (c *cachedObjectClient) buildTableNamesCache(ctx context.Context, forceRefr
 	return nil
 }
 
-func (c *cachedObjectClient) getTable(tableName string) *table {
+func (c *cachedObjectClient) getCachedTable(tableName string) *table {
 	c.tablesMtx.RLock()
 	defer c.tablesMtx.RUnlock()
 
 	return c.tables[tableName]
+}
+
+func (c *cachedObjectClient) getTable(ctx context.Context, tableName string) *table {
+	// First, get the table from tables cache.
+	if t := c.getCachedTable(tableName); t != nil {
+		return t
+	}
+	// If we did not find the table in the cache, let us force refresh the table names cache to see if we can find it.
+	c.RefreshIndexTableNamesCache(ctx)
+	return c.getCachedTable(tableName)
 }
 
 func (t *table) buildCache(ctx context.Context, objectClient client.ObjectClient, forceRefresh bool) (err error) {


### PR DESCRIPTION
The bug manifested in missing results when querying logs older than what is kept on ingesters.

This commit changes the behaviour of the caching in the storage client client used by the indexshipper to download indexes from object store.

The object store client maintains an internal, in-memory cache of tables (= per-day index directories) available on object storage to reduce the amount of expensive List operations. This cache gets updated in a regular interval (1m) by the table manager that uses the client. However, when the per-tenant setting `query_ready_index_num_days` is set the 0, which is the default (to disable index pre-fetching), the sync is only performed once on startup, but not subsequently. This leads to a stale list of table names in the cache and any new index directory added to the object storage is not added to the client cache.

This commit changes the object client to use a read-through caching strategy for listing tables. If a table is not found locally in cache, it performs a lookup against object storage. In this way, the cache is updated even without the regular sync described above.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
