### PR TITLE
Fix bug in cache of the index object client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@
 ##### Enhancements
 
 #### Jsonnet
+## Unreleased
+
+### All Changes
+
+#### Loki
+
+##### Fixes
+
+* [10585](https://github.com/grafana/loki/pull/10585) **ashwanthgoli** / **chaudum**: Fix bug in index object client that could result in not showing all ingested logs in query results.
 
 ## 2.9.0 (2023-09-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ##### Fixes
 
+* [10585](https://github.com/grafana/loki/pull/10585) **ashwanthgoli** / **chaudum**: Fix bug in index object client that could result in not showing all ingested logs in query results.
 * [10314](https://github.com/grafana/loki/pull/10314) **bboreham**: Fix race conditions in indexshipper.
 
 ##### Changes
@@ -53,13 +54,6 @@
 #### Jsonnet
 ## Unreleased
 
-### All Changes
-
-#### Loki
-
-##### Fixes
-
-* [10585](https://github.com/grafana/loki/pull/10585) **ashwanthgoli** / **chaudum**: Fix bug in index object client that could result in not showing all ingested logs in query results.
 
 ## 2.9.0 (2023-09-06)
 


### PR DESCRIPTION
The bug could manifest in missing results when querying logs older than what is kept on ingesters.

This commit changes the behaviour of the caching in the storage client client used by the indexshipper to download indexes from object store.

The object store client maintains an internal, in-memory cache of tables (= per-day index directories) available on object storage to reduce the amount of expensive List operations. This cache gets updated in a regular interval (1m) by the table manager that uses the client. However, when the per-tenant setting `query_ready_index_num_days` is set the 0, which is the default (to disable index pre-fetching), the sync is only performed once on startup, but not subsequently. This leads to a stale list of table names in the cache and any new index directory added to the object storage is not added to the client cache.

This commit changes the object client to use a read-through caching strategy for listing tables. If a table is not found locally in cache, it performs a lookup against object storage. In this way, the cache is updated even without the regular sync described above.

**Special notes for your reviewer**:

This is a port of #10585 which was first applied on the 2.9 release branch.
