### PR TITLE
Fix wrong Alpine version in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ##### Security
 
-* [10573](https://github.com/grafana/loki/pull/10573) **DylanGuedes**: Bump Docker base images to Alpine version 3.18.7 to mitigate CVE-2022-48174
+* [10573](https://github.com/grafana/loki/pull/10573) **DylanGuedes**: Bump Docker base images to Alpine version 3.18.3 to mitigate CVE-2022-48174
 
 #### Loki
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changelog entry contained the wrong Alpine version.