### PR TITLE
Reflect release 2.9.1 on main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ### All Changes
 
-##### Security
-
 #### Loki
 
 ##### Enhancements
+
 * [10295](https://github.com/grafana/loki/pull/10295) **changhyuni**: Storage: remove signatureversionv2 from s3.
 * [10140](https://github.com/grafana/loki/pull/10140) **dannykopping**: Dynamic client-side throttling to avoid object storage rate-limits (GCS only)
 * [10302](https://github.com/grafana/loki/pull/10302) **ashwanthgoli**: Removes already deprecated `-querier.engine.timeout` CLI flag and corresponding YAML setting as well as the `querier.query_timeout` YAML setting.
@@ -21,9 +20,6 @@
 
 ##### Fixes
 
-* [10585](https://github.com/grafana/loki/pull/10585) **ashwanthgoli** / **chaudum**: Fix bug in index object client that could result in not showing all ingested logs in query results.
-* [10314](https://github.com/grafana/loki/pull/10314) **bboreham**: Fix race conditions in indexshipper.
-
 ##### Changes
 
 * [10366](https://github.com/grafana/loki/pull/10366) **shantanualsi** Upgrade thanos objstore, dskit and other modules
@@ -32,6 +28,7 @@
 #### Promtail
 
 ##### Enhancements
+
 * [10416](https://github.com/grafana/loki/pull/10416) **lpugoy**: Lambda-Promtail: Add support for WAF logs in S3
 * [10301](https://github.com/grafana/loki/pull/10301) **wildum**: users can now define `additional_fields` in cloudflare configuration.
 
@@ -53,6 +50,23 @@
 
 #### Jsonnet
 ## Unreleased
+
+
+
+## 2.9.1 (2023-09-14)
+
+### All Changes
+
+#### Loki
+
+##### Security
+
+* [10573](https://github.com/grafana/loki/pull/10573) **DylanGuedes**: Bump Docker base images to Alpine version 3.18.3 to mitigate CVE-2022-48174
+
+##### Fixes
+
+* [10585](https://github.com/grafana/loki/pull/10585) **ashwanthgoli** / **chaudum**: Fix bug in index object client that could result in not showing all ingested logs in query results.
+* [10314](https://github.com/grafana/loki/pull/10314) **bboreham**: Fix race conditions in indexshipper.
 
 
 ## 2.9.0 (2023-09-06)

--- a/docs/sources/release-notes/v2-9.md
+++ b/docs/sources/release-notes/v2-9.md
@@ -29,3 +29,14 @@ Grafana Labs is excited to announce the release of Loki 2.9.0 Here's a summary o
   - The `-boltdb.shipper.compactor.*` CLI flags are deprecated in favor of `-compactor.*`.
   - The `-ingester.unordered-writes` CLI flag is deprecated and will always default to `true` in the next major release.
   - For the full list of deprecations, see CHANGELOG.md
+
+
+## Bug fixes
+
+### 2.9.1 (2023-09-14)
+
+* Update Docker base images to mitigate security vulnerability CVE-2022-48174
+* Fix bugs in indexshipper (`tsdb`, `boltdb-shipper`) that could result in not showing all ingested logs in query results.
+
+
+For a full list of all changes and fixes, look at the [CHANGELOG](https://github.com/grafana/loki/blob/release-2.9.x/CHANGELOG.md).

--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -29,7 +29,7 @@ The Docker plugin must be installed on each Docker host that will be running con
 Run the following command to install the plugin, updating the release version if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:2.8.2 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:2.9.1 --alias loki --grant-all-permissions
 ```
 
 To check installed plugins, use the `docker plugin ls` command. 
@@ -54,7 +54,7 @@ re-enabling and restarting Docker:
 
 ```bash
 docker plugin disable loki --force
-docker plugin upgrade loki grafana/loki-docker-driver:2.8.2 --grant-all-permissions
+docker plugin upgrade loki grafana/loki-docker-driver:2.9.1 --grant-all-permissions
 docker plugin enable loki
 systemctl restart docker
 ```

--- a/docs/sources/setup/install/docker.md
+++ b/docs/sources/setup/install/docker.md
@@ -25,10 +25,10 @@ The configuration acquired with these installation instructions run Loki as a si
 Copy and paste the commands below into your command line.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.9.0 -config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.0 -config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -d -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.9.1 -config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run --name promtail -d -v $(pwd):/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.1 -config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -43,10 +43,10 @@ Copy and paste the commands below into your terminal. Note that you will need to
 
 ```bash
 cd "<local-path>"
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
-docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.9.0 --config.file=/mnt/config/loki-config.yaml
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.0/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
-docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.0 --config.file=/mnt/config/promtail-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/cmd/loki/loki-local-config.yaml -O loki-config.yaml
+docker run --name loki -v <local-path>:/mnt/config -p 3100:3100 grafana/loki:2.9.1 --config.file=/mnt/config/loki-config.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/clients/cmd/promtail/promtail-docker-config.yaml -O promtail-config.yaml
+docker run -v <local-path>:/mnt/config -v /var/log:/var/log --link loki grafana/promtail:2.9.1 --config.file=/mnt/config/promtail-config.yaml
 ```
 
 When finished, `loki-config.yaml` and `promtail-config.yaml` are downloaded in the directory you chose. Docker containers are running Loki and Promtail using those config files.
@@ -58,6 +58,6 @@ Navigate to http://localhost:3100/metrics to view the output.
 Run the following commands in your command line. They work for Windows or Linux systems.
 
 ```bash
-wget https://raw.githubusercontent.com/grafana/loki/v2.9.0/production/docker-compose.yaml -O docker-compose.yaml
+wget https://raw.githubusercontent.com/grafana/loki/v2.9.1/production/docker-compose.yaml -O docker-compose.yaml
 docker-compose -f docker-compose.yaml up
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Reflect Loki 2.9.1 release on main branch to be up-to-date with latest released version.
