### PR TITLE
Docs: Update fluentd doc

### DIFF
--- a/docs/sources/send-data/fluentd/_index.md
+++ b/docs/sources/send-data/fluentd/_index.md
@@ -83,8 +83,9 @@ In your Fluentd configuration, add `@type loki`. Additional configuration is opt
   password "#{ENV['LOKI_PASSWORD']}"
   extra_labels {"env":"dev"}
   <buffer>
-    flush_interval 10s
-    flush_at_shutdown true
+    chunk_limit_size   8m
+    flush_interval     10s
+    flush_at_shutdown  true
   </buffer>
   buffer_chunk_limit 1m
 </match>


### PR DESCRIPTION
The current configuration on your documentation is for fluentd v0.12

Now fluentd v1 is commonly used, I propose you to adap your configuration. You can see here the config used : https://github.com/grafana/loki/blob/main/clients/cmd/fluentd/docker/conf/loki.conf
