### PR TITLE
operator: Update example configurations to use demo size

### DIFF
--- a/operator/apis/loki/v1beta1/lokistack_types.go
+++ b/operator/apis/loki/v1beta1/lokistack_types.go
@@ -651,7 +651,7 @@ const (
 	// ConditionReady defines the condition that all components in the Loki deployment are ready.
 	ConditionReady LokiStackConditionType = "Ready"
 
-	// ConditionPending defines the conditioin that some or all components are in pending state.
+	// ConditionPending defines the condition that some or all components are in pending state.
 	ConditionPending LokiStackConditionType = "Pending"
 
 	// ConditionFailed defines the condition that components in the Loki deployment failed to roll out.

--- a/operator/docs/enhancements/retention_support.md
+++ b/operator/docs/enhancements/retention_support.md
@@ -142,7 +142,7 @@ spec:
     secret:
       name: test
       type: s3
-  storageClassName: gp2
+  storageClassName: gp3-csi
   retention: 
     deleteDelay: 
   limits:

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -5649,7 +5649,7 @@ are degraded or the cluster cannot connect to object storage.</p>
 <td><p>ConditionFailed defines the condition that components in the Loki deployment failed to roll out.</p>
 </td>
 </tr><tr><td><p>&#34;Pending&#34;</p></td>
-<td><p>ConditionPending defines the conditioin that some or all components are in pending state.</p>
+<td><p>ConditionPending defines the condition that some or all components are in pending state.</p>
 </td>
 </tr><tr><td><p>&#34;Ready&#34;</p></td>
 <td><p>ConditionReady defines the condition that all components in the Loki deployment are ready.</p>

--- a/operator/hack/lokistack_dev.yaml
+++ b/operator/hack/lokistack_dev.yaml
@@ -3,7 +3,7 @@ kind: LokiStack
 metadata:
   name: lokistack-dev
 spec:
-  size: 1x.extra-small
+  size: 1x.demo
   storage:
     schemas:
     - version: v12

--- a/operator/hack/lokistack_gateway_dev.yaml
+++ b/operator/hack/lokistack_gateway_dev.yaml
@@ -11,7 +11,7 @@ kind: LokiStack
 metadata:
   name: lokistack-dev
 spec:
-  size: 1x.extra-small
+  size: 1x.demo
   storage:
     schemas:
     - version: v12

--- a/operator/hack/lokistack_gateway_ocp.yaml
+++ b/operator/hack/lokistack_gateway_ocp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: lokistack-dev
   namespace: openshift-logging
 spec:
-  size: 1x.extra-small
+  size: 1x.demo
   storage:
     schemas:
     - version: v12
@@ -12,7 +12,7 @@ spec:
     secret:
       name: test
       type: s3
-  storageClassName: gp2
+  storageClassName: gp3-csi
   tenants:
     mode: openshift-logging
   rules:

--- a/operator/internal/external/k8s/client.go
+++ b/operator/internal/external/k8s/client.go
@@ -41,7 +41,7 @@ type StatusWriter interface {
 	Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error
 }
 
-// StatusWriter is a kubernetes status writer interface used internally. It copies functions from
+// SubResourceClient is a kubernetes status writer interface used internally. It copies functions from
 // sigs.k8s.io/controller-runtime/pkg/client
 //
 //counterfeiter:generate . SubResourceClient

--- a/operator/internal/manifests/rules_config.go
+++ b/operator/internal/manifests/rules_config.go
@@ -17,7 +17,7 @@ type RuleName struct {
 	filename string
 }
 
-// RulesConfigMap returns a ConfigMap resource that contains
+// RulesConfigMapShards returns a ConfigMap resource that contains
 // all loki alerting and recording rules as YAML data.
 // If the size of the data is more than 1MB, the ConfigMap will
 // be split into multiple shards, and this function will return

--- a/operator/internal/validation/lokistack.go
+++ b/operator/internal/validation/lokistack.go
@@ -88,7 +88,7 @@ func (v *LokiStackValidator) validate(ctx context.Context, obj runtime.Object) e
 	)
 }
 
-func (v LokiStackValidator) validateReplicationSpec(ctx context.Context, stack lokiv1.LokiStackSpec) field.ErrorList {
+func (v *LokiStackValidator) validateReplicationSpec(ctx context.Context, stack lokiv1.LokiStackSpec) field.ErrorList {
 	if stack.Replication == nil {
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Changes the size of the example LokiStack configurations to `1.demo`
- Updates the `storageClassName` to `gp3-csi` where `gp2` was used before
- Fix a few typos
- Correct the receiver of a method in validation code (receiver is unused in that method though)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I think we can skip the changelog for this one.

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] `CHANGELOG.md` updated
