### PR TITLE
Helm: add missing aws s3 server-side encryption parameters

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -2194,7 +2194,9 @@ null
     "s3": null,
     "s3ForcePathStyle": false,
     "secretAccessKey": null,
-    "signatureVersion": null
+    "signatureVersion": null,
+	"sseEncryption": null,
+	"sse": {}
   },
   "type": "s3"
 }

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.22.1
+
+- [CHANGE] Add missing AWS S3 encryption parameters
+
 ## 5.22.0
 
 - [CHANGE] Changed version of Loki to 2.9.1

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.1
-version: 5.22.0
+version: 5.22.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.22.0](https://img.shields.io/badge/Version-5.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 5.22.1](https://img.shields.io/badge/Version-5.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -230,6 +230,21 @@ s3:
   {{- end }}
   s3forcepathstyle: {{ .s3ForcePathStyle }}
   insecure: {{ .insecure }}
+  {{- with .sseEncryption }}
+  sse_encryption: {{ . }}
+  {{- end }}
+  {{- with .sse }}
+    sse:
+      {{- with .type }}
+      type: {{ . }}
+      {{- end }}
+      {{- with .kmsKeyId }}
+      kms_key_id: {{ . }}
+      {{- end }}
+      {{- with .kmsEncryptionContext }}
+      kms_encryption_context: {{ . }}
+      {{- end }}
+  {{- end }}
   {{- with .http_config}}
   http_config:
     {{- with .idle_conn_timeout }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -277,6 +277,11 @@ loki:
       signatureVersion: null
       s3ForcePathStyle: false
       insecure: false
+      sseEncryption: null
+      sse:
+        type: null
+        kmsKeyId: null
+        kmsEncryptionContext: null
       http_config: {}
     gcs:
       chunkBufferSize: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
This MR adds and fixes missing encryption parameters of AWS S3 (KMS)

Example:

values.yaml (**HELM**)

```yaml
  storage:
    bucketNames:
      chunks: XXXXXX-LOKI-S3-BUCKET/chunks
      ruler: XXXXXX-LOKI-S3-BUCKET/ruler
      admin: XXXXXX-LOKI-S3-BUCKET/admin
    type: s3
    s3:
      s3: "s3://us-west-2"
      region: us-west-2
      insecure: false
      s3ForcePathStyle: false
      signatureVersion: v4
      sseEncryption: true
      sse:
        type: SSE-KMS
        kmsKeyId: xxxxx-xxxx-xxxx-xxxx-xxxxxx
        kmsEncryptionContext: 
```

Generated config (**Loki**) - https://grafana.com/docs/loki/latest/configure/#aws_storage_config

```yaml
      ...
      signature_version: v4
      sse_encryption: true
      sse:
        type: SSE-KMS
        kms_key_id: xxxxx-xxxx-xxxx-xxxx-xxxxxx
        kms_encryption_context: xxxxxx
        
```

**Which issue(s) this PR fixes**:
- https://github.com/grafana/loki/issues/9018

**Special notes for your reviewer**:
- Superseded this one: https://github.com/grafana/loki/pull/10238

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
