### PR TITLE
Fixed LokiCanary can not be disabled, validation fails

### DIFF
--- a/docs/sources/setup/upgrade/upgrade-from-2x/index.md
+++ b/docs/sources/setup/upgrade/upgrade-from-2x/index.md
@@ -35,7 +35,7 @@ loki:
     type: 'filesystem'
 ```
 
-You will need to 1. Update the grafana helm repo, 2. delete the exsiting stateful set, and 3. updgrade making sure to have the values above included in your `values.yaml`. If you installed `grafana/loki` as `loki` in namespace `loki`, the commands would be:
+You will need to 1. Update the grafana helm repo, 2. delete the exsiting stateful set, and 3. upgrade making sure to have the values above included in your `values.yaml`. If you installed `grafana/loki` as `loki` in namespace `loki`, the commands would be:
 
 ```console
 helm repo update grafana

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -508,7 +508,7 @@ rbac:
   namespaced: false
 # -- Section for configuring optional Helm test
 test:
-  enabled: true
+  enabled: false
   # -- Address of the prometheus server to query for the test
   prometheusAddress: "http://prometheus:9090"
   # -- Number of times to retry the test before failing


### PR DESCRIPTION

**Which issue(s) this PR fixes**:
Fixes #9849 
