### PR TITLE
Don't allow unbounded parallelism when downloading indices

### DIFF
--- a/pkg/storage/stores/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/indexshipper/downloads/index_set.go
@@ -202,6 +202,7 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	defer t.indexMtx.rUnlock()
 
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(200)
 
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -39,6 +39,7 @@ func (xs IndexSlice) For(ctx context.Context, fn func(context.Context, Index) er
 			return fn(ctx, x)
 		})
 	}
+	g.SetLimit(200)
 	return g.Wait()
 }
 

--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -39,7 +39,6 @@ func (xs IndexSlice) For(ctx context.Context, fn func(context.Context, Index) er
 			return fn(ctx, x)
 		})
 	}
-	g.SetLimit(200)
 	return g.Wait()
 }
 


### PR DESCRIPTION
Index Gateways can stall when certain queries try to download tons of indices because. `ErrGroup` needs an explicit limit set on it. This PR sets the limit provisionally until a more configurable solution can be introduced.
