### PR TITLE
Fix docs for fluentd client

### DIFF
--- a/docs/sources/send-data/fluentd/_index.md
+++ b/docs/sources/send-data/fluentd/_index.md
@@ -80,8 +80,10 @@ In your Fluentd configuration, add `@type loki`. Additional configuration is opt
   username "#{ENV['LOKI_USERNAME']}"
   password "#{ENV['LOKI_PASSWORD']}"
   extra_labels {"env":"dev"}
-  flush_interval 10s
-  flush_at_shutdown true
+  <buffer>
+    flush_interval 10s
+    flush_at_shutdown true
+  </buffer>
   buffer_chunk_limit 1m
 </match>
 ```


### PR DESCRIPTION
Fluentd client configuration has changed recently. The default config already [reflects](https://github.com/grafana/loki/blob/main/clients/cmd/fluentd/docker/conf/loki.conf#L5-L8) the new syntax. However, the examples on the page haven't been updated yet.

