### PR TITLE
index gateway: spawn fewer goroutines

### DIFF
--- a/pkg/storage/stores/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/tsdb/multi_file_index.go
@@ -32,6 +32,11 @@ type IndexIter interface {
 type IndexSlice []Index
 
 func (xs IndexSlice) For(ctx context.Context, fn func(context.Context, Index) error) error {
+	// avoid spawning goroutines if the slice contains a single index.
+	if len(xs) == 1 {
+		return fn(ctx, xs[0])
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	for i := range xs {
 		x := xs[i]


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid spawning new go routines in the following code paths when we only wait on a single unit of work

- `IndexSlice` would only contain a [single index](https://github.com/grafana/loki/blob/641c9ee48a5cac7c57f081a2b73c16d5a8c1953b/pkg/storage/stores/tsdb/store.go#L146) in read mode.
- `IndexShipper` only uses [downloads manager ](https://github.com/grafana/loki/blob/641c9ee48a5cac7c57f081a2b73c16d5a8c1953b/pkg/storage/stores/indexshipper/shipper.go#L230)in read mode.
- user `IndexSet` would contain 1 compacted index file most of the time.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
