### PR TITLE
chore(storage): Remove index gateway client singleton

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -43,7 +43,6 @@ import (
 )
 
 var (
-	indexGatewayClient index.Client
 	// singleton for each period
 	boltdbIndexClientsWithShipper = make(map[config.DayTime]index.Client)
 
@@ -101,11 +100,6 @@ func ResetBoltDBIndexClientsWithShipper() {
 	}
 
 	boltdbIndexClientsWithShipper = make(map[config.DayTime]index.Client)
-
-	if indexGatewayClient != nil {
-		indexGatewayClient.Stop()
-		indexGatewayClient = nil
-	}
 }
 
 // StoreLimits helps get Limits specific to Queries for Stores
@@ -412,17 +406,7 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 		switch periodCfg.IndexType {
 		case config.BoltDBShipperType:
 			if shouldUseIndexGatewayClient(cfg.BoltDBShipperConfig.Config) {
-				if indexGatewayClient != nil {
-					return indexGatewayClient, nil
-				}
-
-				gateway, err := gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, limits, logger)
-				if err != nil {
-					return nil, err
-				}
-
-				indexGatewayClient = gateway
-				return gateway, nil
+				return gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, limits, logger)
 			}
 
 			if client, ok := boltdbIndexClientsWithShipper[periodCfg.From]; ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Neither when using tsdb nor when using boltdb-shipper, the singleton instance of the index gateway client is required as the client is only instantiated once.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
