### PR TITLE
Return time of prepare shutdown

### DIFF
--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -661,7 +661,7 @@ the ingester will be unregistered from the ring and in-memory time series data w
 This endpoint supersedes any YAML configurations and isn't necessary if the ingester is already
 configured to unregister from the ring or to flush on shutdown.
 
-A `GET` to the `prepare_shutdown` endpoint returns the status of this configuration, either `set` or `unset`.
+A `GET` to the `prepare_shutdown` endpoint returns the status of this configuration, either `set` or `unset`, plus the timestamp in RFC3339 format.
 
 A `DELETE` to the `prepare_shutdown` endpoint reverts the configuration of the ingester to its previous state
 (with respect to unregistering on shutdown and flushing of in-memory time series data to long-term storage).

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -101,7 +102,11 @@ func TestPrepareShutdown(t *testing.T) {
 		resp := httptest.NewRecorder()
 		i.PrepareShutdown(resp, httptest.NewRequest("GET", "/ingester/prepare-shutdown", nil))
 		require.Equal(t, 200, resp.Code)
-		require.Equal(t, "set", resp.Body.String())
+		splits := strings.SplitN(resp.Body.String(), " ", 2)
+		require.Len(t, splits, 2)
+		require.Equal(t, "set", splits[0])
+		_, err := time.Parse(time.RFC3339, splits[1])
+		require.NoError(t, err)
 	})
 
 	t.Run("DELETE", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Return the time of the prepare shutdown in the GET request.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
