### PR TITLE
add note about boltdb_shipper deprecation (#10524)

### DIFF
--- a/docs/sources/get-started/architecture.md
+++ b/docs/sources/get-started/architecture.md
@@ -95,8 +95,7 @@ Symbols store references to the actual strings containing label names and values
 
 ### Single Store
 
-Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`boltdb_shipper`]({{< relref "../operations/storage/boltdb-shipper" >}}) to store the `index` in object storage (the same way we store `chunks`).
-Note: tsdb_shipper was introduced in 2.8 and it deprecated the previous boltdb_shipper
+Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`shipper`]({{< relref "../operations/storage/tsdb" >}}) to store the index files in object storage the same way we store the chunk files. It works with both TSDB (`tsdb`, recommended) and BoltDB (`boltdb-shipper`, legacy) index types.
 
 ###  Deprecated: Multi-store
 

--- a/docs/sources/get-started/architecture.md
+++ b/docs/sources/get-started/architecture.md
@@ -95,7 +95,7 @@ Symbols store references to the actual strings containing label names and values
 
 ### Single Store
 
-Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`shipper`]({{< relref "../operations/storage/tsdb" >}}) to store the index files in object storage the same way we store the chunk files. It works with both TSDB (`tsdb`, recommended) and BoltDB (`boltdb-shipper`, legacy) index types.
+Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`TSDB`]({{< relref "../operations/storage/tsdb" >}}) to store the index files in object storage the same way we store the chunk files. 
 
 ###  Deprecated: Multi-store
 

--- a/docs/sources/get-started/architecture.md
+++ b/docs/sources/get-started/architecture.md
@@ -96,6 +96,7 @@ Symbols store references to the actual strings containing label names and values
 ### Single Store
 
 Loki stores all data in a single object storage backend. This mode of operation became generally available with Loki 2.0 and is fast, cost-effective, and simple, not to mention where all current and future development lies. This mode uses an adapter called [`boltdb_shipper`]({{< relref "../operations/storage/boltdb-shipper" >}}) to store the `index` in object storage (the same way we store `chunks`).
+Note: tsdb_shipper was introduced in 2.8 and it deprecated the previous boltdb_shipper
 
 ###  Deprecated: Multi-store
 


### PR DESCRIPTION
The doc is being reviewed by grafana team but in the mean time a small note can avoid confusing new users

**What this PR does / why we need it**: Add a note about boltdb_shipper being deprecated in favor of tsdb_shipper

**Which issue(s) this PR fixes**: 10524
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
