### PR TITLE
Restructure API reference documentation

### DIFF
--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -23,7 +23,7 @@ to extract at query time.
 ## Attaching structured metadata to log lines
 
 You have the option to attach structured metadata to log lines in the push payload along with each log line and the timestamp.
-For more information on how to push logs to Loki via the HTTP endpoint, refer to the [HTTP API documentation]({{< relref "../../reference/api#push-log-entries-to-loki" >}}).
+For more information on how to push logs to Loki via the HTTP endpoint, refer to the [HTTP API documentation]({{< relref "../../reference/api#ingest-logs" >}}).
 
 Alternatively, you can use the Grafana Agent or Promtail to extract and attach structured metadata to your log lines.
 See the [Promtail: Structured metadata stage]({{< relref "../../send-data/promtail/stages/structured_metadata" >}}) for more information.

--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -1,68 +1,79 @@
 ---
-title: Grafana Loki HTTP API
-menuTitle: "HTTP API"
-description: Loki exposes REST endpoints for operating on a Loki cluster. This section details the REST endpoints.
+title: Loki HTTP API
+menuTitle: HTTP API
+description: Loki exposes HTTP endpoints for data ingestion, data retrieval, as well for cluster management.
 aliases:
 - ../api/
 weight: 100
 ---
 
-# Grafana Loki HTTP API
+# Loki HTTP API
 
-Grafana Loki exposes an HTTP API for pushing, querying, and tailing log data.
-Note that authenticating against the API is
-out of scope for Loki.
+Loki exposes an HTTP API for pushing, querying, and tailing log data, as well
+as for viewing and managing cluster information.
 
-## Microservices mode
+**Note that authorization is not part of the Loki API.**
+Authorization needs to be done separately, for example, using an open-source load-balancer such as NGINX.
 
-When deploying Loki in microservices mode, the set of endpoints exposed by each
-component is different.
+## Endpoints
 
-These endpoints are exposed by all components:
+### Ingest endpoints
 
-- [`GET /ready`](#identify-ready-loki-instance)
-- [`GET /log_level`](#change-log-level-at-runtime)
-- [`GET /metrics`](#return-exposed-prometheus-metrics)
-- [`GET /config`](#list-current-configuration)
+These endpoints are exposed by the `distributor`, `write`, and `all` components:
+
+- [`POST /loki/api/v1/push`](#ingest-logs)
+
+A [list of clients]({{< relref "../send-data" >}}) can be found in the clients documentation.
+
+### Query endpoints
+
+These HTTP endpoints are exposed by the `querier`, `query-frontend`, `read`, and `all` components:
+
+- [`GET /loki/api/v1/query`](#query-logs-at-a-single-point-in-time)
+- [`GET /loki/api/v1/query_range`](#query-logs-within-a-range-of-time)
+- [`GET /loki/api/v1/labels`](#query-labels)
+- [`GET /loki/api/v1/label/<name>/values`](#query-label-values)
+- [`GET /loki/api/v1/series`](#query-streams)
+- [`GET /loki/api/v1/index/stats`](#query-log-statistics)
+- [`GET /loki/api/v1/index/volume`](#query-log-volume)
+- [`GET /loki/api/v1/index/volume_range`](#query-log-volume)
+- [`GET /loki/api/v1/tail`](#stream-logs)
+
+### Status endpoints
+
+These HTTP endpoints are exposed by all components and return the status of the component:
+
+- [`GET /ready`](#readiness-probe)
+- [`GET /log_level`](#change-log-level)
+- [`GET /metrics`](#prometheus-metrics)
+- [`GET /config`](#show-current-configuration)
 - [`GET /services`](#list-running-services)
-- [`GET /loki/api/v1/status/buildinfo`](#list-build-information)
-- [`GET /loki/api/v1/format_query`](#format-query)
+- [`GET /loki/api/v1/status/buildinfo`](#show-build-information)
 
-These endpoints are exposed by the querier and the query frontend:
+### Ring endpoints
 
-- [`GET /loki/api/v1/query`](#query-loki)
-- [`GET /loki/api/v1/query_range`](#query-loki-over-a-range-of-time)
-- [`GET /loki/api/v1/labels`](#list-labels-within-a-range-of-time)
-- [`GET /loki/api/v1/label/<name>/values`](#list-label-values-within-a-range-of-time)
-- [`GET /loki/api/v1/series`](#list-series)
-- [`GET /loki/api/v1/index/stats`](#index-stats)
-- [`GET /loki/api/v1/index/volume`](#volume)
-- [`GET /loki/api/v1/index/volume_range`](#volume)
-- [`GET /loki/api/v1/tail`](#stream-log-messages)
-- **Deprecated** [`GET /api/prom/tail`](#get-apipromtail)
-- **Deprecated** [`GET /api/prom/query`](#get-apipromquery)
-- **Deprecated** [`GET /api/prom/label`](#get-apipromlabel)
-- **Deprecated** [`GET /api/prom/label/<name>/values`](#get-apipromlabelnamevalues)
-- **Deprecated** [`GET /api/prom/series`](#list-series)
+These HTTP endpoints are exposed by their respective component that is part of the ring URL prefix:
 
-These endpoints are exposed by the distributor:
+- [`GET /distributor/ring`](#distributor-ring-status)
+- [`GET /indexgateway/ring`](#index-gateway-ring-status)
+- [`GET /ruler/ring`](#ruler-ring-status)
+- [`GET /compactor/ring`](#compactor-ring-status)
 
-- [`POST /loki/api/v1/push`](#push-log-entries-to-loki)
-- [`GET /distributor/ring`](#display-distributor-consistent-hash-ring-status)
-- **Deprecated** [`POST /api/prom/push`](#post-apiprompush)
+### Flush/shutdown endpoints
 
-These endpoints are exposed by the ingester:
+These HTTP endpoints are exposed by the `ingester`, `write`, and `all` components for flushing chunks and/or shutting down.
 
 - [`POST /flush`](#flush-in-memory-chunks-to-backing-store)
+- [`POST /ingester/prepare_shutdown`](#prepare-ingester-shutdown)
 - [`POST /ingester/shutdown`](#flush-in-memory-chunks-and-shut-down)
+- **Deprecated** [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
 
-The API endpoints starting with `/loki/` are [Prometheus API-compatible](https://prometheus.io/docs/prometheus/latest/querying/api/) and the result formats can be used interchangeably.
+### Rule endpoints
 
-These endpoints are exposed by the ruler:
+These HTTP endpoints are exposed by the `ruler` component:
 
-- [`GET /ruler/ring`](#ruler-ring-status)
 - [`GET /loki/api/v1/rules`](#list-rule-groups)
-- [`GET /loki/api/v1/rules/{namespace}`](#get-rule-groups-by-namespace)
+- [`GET /loki/api/v1/rules/({namespace}`](#get-rule-groups-by-namespace)
 - [`GET /loki/api/v1/rules/{namespace}/{groupName}`](#get-rule-group)
 - [`POST /loki/api/v1/rules/{namespace}`](#set-rule-group)
 - [`DELETE /loki/api/v1/rules/{namespace}/{groupName}`](#delete-rule-group)
@@ -76,53 +87,185 @@ These endpoints are exposed by the ruler:
 - [`GET /prometheus/api/v1/rules`](#list-rules)
 - [`GET /prometheus/api/v1/alerts`](#list-alerts)
 
-These endpoints are exposed by the compactor:
+API endpoints starting with `/api/prom` are [Prometheus API-compatible](https://prometheus.io/docs/prometheus/latest/querying/api/) and the result formats can be used interchangeably.
 
-- [`GET /compactor/ring`](#compactor-ring-status)
+### Log deletion endpoints
+
+These endpoints are exposed by the `compactor`, `backend`, and `all` components:
+
 - [`POST /loki/api/v1/delete`](#request-log-deletion)
 - [`GET /loki/api/v1/delete`](#list-log-deletion-requests)
 - [`DELETE /loki/api/v1/delete`](#request-cancellation-of-a-delete-request)
 
-A [list of clients]({{< relref "../send-data" >}}) can be found in the clients documentation.
+### Other endpoints
 
-## Matrix, vector, and streams
+These HTTP endpoints are exposed by all individual components:
+
+- [`GET /loki/api/v1/format_query`](#format-a-logql-query)
+
+### Deprecated endpoints
+
+{{% admonition type="note" %}}
+The following endpoints are deprecated.  While they still exist and work, they should not be used for new deployments.
+Existing deployments should upgrade to use the supported endpoints.
+{{% /admonition %}}
+
+| Deprecated | Replacement |
+| ---------- | ----------- |
+| `POST /api/prom/push` | [`POST /loki/api/v1/push`](#ingest-logs) |
+| `GET /api/prom/tail` | [`GET /loki/api/v1/tail`](#stream-logs) |
+| `GET /api/prom/query` | [`GET /loki/api/v1/query`](#query-logs-at-a-single-point-in-time) |
+| `GET /api/prom/label` | [`GET /loki/api/v1/labels`](#query-labels) |
+| `GET /api/prom/label/<name>/values` | [`GET /loki/api/v1/label/<name>/values`](#query-label-values) |
+| `GET /api/prom/series` | [`GET /loki/api/v1/series`](#query-streams) |
+
+## Format
+
+### Matrix, vector, and stream
 
 Some Loki API endpoints return a result of a matrix, a vector, or a stream:
 
-- Matrix: a table of values where each row represents a different label set
-  and the columns are each sample value for that row over the queried time.
+- **Matrix**: a table of values where each row represents a different label set
+  and the columns are each sample values for that row over the queried time.
   Matrix types are only returned when running a query that computes some value.
 
-- Instant Vector: denoted in the type as just `vector`, an Instant Vector
+- **Instant Vector**: denoted in the type as just `vector`, an Instant Vector
   represents the latest value of a calculation for a given labelset. Instant
   Vectors are only returned when doing a query against a single point in
   time.
 
-- Stream: a Stream is a set of all values (logs) for a given label set over the
+- **Stream**: a Stream is a set of all values (logs) for a given label set over the
   queried time range. Streams are the only type that will result in log lines
   being returned.
 
-## Timestamp formats
+### Timestamps
 
-The API accepts several formats for timestamps. An integer with ten or fewer digits is interpreted as a Unix timestamp in seconds. More than ten digits are interpreted as a Unix timestamp in nanoseconds. A floating point number is a Unix timestamp with fractions of a second.
+The API accepts several formats for timestamps:
 
-The timestamps can also be written in `RFC3339` and `RFC3339Nano` format, as supported by Go's [time](https://pkg.go.dev/time) package.
+* An integer with ten or fewer digits is interpreted as a Unix timestamp in seconds.
+* More than ten digits are interpreted as a Unix timestamp in nanoseconds.
+* A floating point number is a Unix timestamp with fractions of a second.
+* A string in `RFC3339` and `RFC3339Nano` format, as supported by Go's [time](https://pkg.go.dev/time) package.
 
-## Query Loki
+### Statistics
+
+Query endpoints such as `/loki/api/v1/query` and `/loki/api/v1/query_range` return a set of statistics about the query execution. Those statistics allow users to understand the amount of data processed and at which speed.
+
+The example below show all possible statistics returned with their respective description.
+
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "streams",
+    "result": [],
+    "stats": {
+      "ingester": {
+        "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by ingesters
+        "decompressedBytes": 0, // Total bytes decompressed and processed by ingesters
+        "decompressedLines": 0, // Total lines decompressed and processed by ingesters
+        "headChunkBytes": 0, // Total bytes read from ingesters head chunks
+        "headChunkLines": 0, // Total lines read from ingesters head chunks
+        "totalBatches": 0, // Total batches sent by ingesters
+        "totalChunksMatched": 0, // Total chunks matched by ingesters
+        "totalDuplicates": 0, // Total of duplicates found by ingesters
+        "totalLinesSent": 0, // Total lines sent by ingesters
+        "totalReached": 0 // Amount of ingesters reached.
+      },
+      "store": {
+        "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by the store
+        "decompressedBytes": 0, // Total bytes decompressed and processed by the store
+        "decompressedLines": 0, // Total lines decompressed and processed by the store
+        "chunksDownloadTime": 0, // Total time spent downloading chunks in seconds (float)
+        "totalChunksRef": 0, // Total chunks found in the index for the current query
+        "totalChunksDownloaded": 0, // Total of chunks downloaded
+        "totalDuplicates": 0 // Total of duplicates removed from replication
+      },
+      "summary": {
+        "bytesProcessedPerSecond": 0, // Total of bytes processed per second
+        "execTime": 0, // Total execution time in seconds (float)
+        "linesProcessedPerSecond": 0, // Total lines processed per second
+        "queueTime": 0, // Total queue time in seconds (float)
+        "totalBytesProcessed": 0, // Total amount of bytes processed overall for this request
+        "totalLinesProcessed": 0 // Total amount of lines processed overall for this request
+      }
+    }
+  }
+}
+```
+
+## Ingest logs
+
+```
+POST /loki/api/v1/push
+```
+
+`/loki/api/v1/push` is the endpoint used to send log entries to Loki. The default
+behavior is for the POST body to be a [Snappy](https://github.com/google/snappy)-compressed [Protocol Buffer](https://github.com/protocolbuffers/protobuf) message:
+
+- [Protocol Buffer definition](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto)
+- [Go client library](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go)
+
+These POST requests require the `Content-Type` HTTP header to be `application/x-protobuf`.
+
+Alternatively, if the `Content-Type` header is set to `application/json`, a JSON post body can be sent in the following format:
+
+```
+{
+  "streams": [
+    {
+      "stream": {
+        "label": "value"
+      },
+      "values": [
+          [ "<unix epoch in nanoseconds>", "<log line>" ],
+          [ "<unix epoch in nanoseconds>", "<log line>" ]
+      ]
+    }
+  ]
+}
+```
+
+You can set `Content-Encoding: gzip` request header and post gzipped JSON.
+
+You can optionally attach [structured metadata]({{< relref "../get-started/labels/structured-metadata" >}}) to each log line by adding a JSON object to the end of the log line array.
+The JSON object must be a valid JSON object with string keys and string values. The JSON object should not contain any nested object.
+The JSON object must be set immediately after the log line. Here is an example of a log entry with some structured metadata attached:
+
+```
+"values": [
+    [ "<unix epoch in nanoseconds>", "<log line>", {"trace_id": "0242ac120002", "user_id": "superUser123"}]
+]
+```
+
+In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
+
+### Examples
+
+The following cURL command pushes a stream with the label "foo=bar2" and a single log line "fizzbuzz" using JSON encoding:
+
+```bash
+curl -H "Content-Type: application/json" \
+  -s -X POST "http://localhost:3100/loki/api/v1/push" \
+  --data-raw '{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}'
+```
+
+## Query logs at a single point in time
 
 ```
 GET /loki/api/v1/query
 ```
 
-`/loki/api/v1/query` allows for doing queries against a single point in time. The URL
-query parameters support the following values:
+`/loki/api/v1/query` allows for doing queries against a single point in time.
+This type of query is often referred to as an instant query. Instant queries are mostly used for metric type LogQL queries.
+It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
-- `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
-- `time`: The evaluation time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now.
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform.
+- `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream (log lines) response.
+- `time`: The evaluation time for the query as a nanosecond Unix epoch or another [supported format](#timestamps). Defaults to now.
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward`.
 
-In microservices mode, `/loki/api/v1/query` is exposed by the querier and the frontend.
+In microservices mode, `/loki/api/v1/query` is exposed by the querier and the query frontend.
 
 Response format:
 
@@ -176,12 +319,11 @@ See [statistics](#statistics) for information about the statistics returned by L
 
 ### Examples
 
-This example query
+This example cURL command
 
 ```bash
 curl -G -s  "http://localhost:3100/loki/api/v1/query" \
-  --data-urlencode \
-  'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
 gave this response:
@@ -233,8 +375,7 @@ Here is the same example query for the single tenant called `Tenant1`:
 ```bash
 curl -H 'X-Scope-OrgID:Tenant1' \
   -G -s "http://localhost:3100/loki/api/v1/query" \
-  --data-urlencode \
-  'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
 To query against the three tenants `Tenant1`, `Tenant2`, and `Tenant3`,
@@ -243,8 +384,7 @@ specify the tenant names separated by the pipe (`|`) character:
 ```bash
 curl -H 'X-Scope-OrgID:Tenant1|Tenant2|Tenant3' \
   -G -s "http://localhost:3100/loki/api/v1/query" \
-  --data-urlencode \
-  'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
 The same example query for Grafana Enterprise Logs
@@ -256,29 +396,29 @@ defined in the `API_TOKEN` environment variable:
 ```bash
 curl -u "Tenant1|Tenant2|Tenant3:$API_TOKEN" \
   -G -s "http://localhost:3100/loki/api/v1/query" \
-  --data-urlencode \
-  'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
 ```
 
-## Query Loki over a range of time
+## Query logs within a range of time
 
 ```
 GET /loki/api/v1/query_range
 ```
 
-`/loki/api/v1/query_range` is used to do a query over a range of time and
-accepts the following query parameters in the URL:
+`/loki/api/v1/query_range` is used to do a query over a range of time.
+This type of query is often referred to as a range query. Range queries are used for both log and metric type LogQL queries.
+It accepts the following query parameters in the URL:
 
-- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
-- `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream(log lines) response.
-- `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to one hour ago. Loki returns results with timestamp greater or equal to this value.
-- `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamp-formats). Defaults to now. Loki returns results with timestamp lower than this value.
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform.
+- `limit`: The max number of entries to return. It defaults to `100`. Only applies to query types which produce a stream (log lines) response.
+- `start`: The start time for the query as a nanosecond Unix epoch or another [supported format](#timestamps). Defaults to one hour ago. Loki returns results with timestamp greater or equal to this value.
+- `end`: The end time for the query as a nanosecond Unix epoch or another [supported format](#timestamps). Defaults to now. Loki returns results with timestamp lower than this value.
 - `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
 - `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`. Only applies to query types which produce a matrix response.
-- `interval`: <span style="background-color:#f3f973;">This parameter is experimental; see the explanation under Step versus interval.</span> Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response.
+- `interval`: Only return entries at (or greater than) the specified interval, can be a `duration` format or float number of seconds. Only applies to queries which produce a stream response. Not to be confused with `step`, see the explanation under [Step versus interval](#step-versus-interval).
 - `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
 
-In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and the frontend.
+In microservices mode, `/loki/api/v1/query_range` is exposed by the querier and the query frontend.
 
 ### Step versus interval
 
@@ -286,9 +426,7 @@ Use the `step` parameter when making metric queries to Loki, or queries which re
 
 Use the `interval` parameter when making log queries to Loki, or queries which return a stream response. It is evaluated by returning a log entry at `start`, then the next entry will be returned an entry with timestampe >= `start + interval`, and again at `start + interval + interval` and so on until `end` is reached. It does not fill missing entries.
 
-<span style="background-color:#f3f973;">Note about the experimental nature of the interval parameter:</span> This flag may be removed in the future, if so it will likely be in favor of a LogQL expression to perform similar behavior, however that is uncertain at this time. [Issue 1779](https://github.com/grafana/loki/issues/1779) was created to track the discussion, if you are using `interval`, go add your use case and thoughts to that issue.
-
-Response:
+Response format:
 
 ```
 {
@@ -301,7 +439,7 @@ Response:
 }
 ```
 
-Where `<matrix value>` is:
+where `<matrix value>` is:
 
 ```
 {
@@ -345,8 +483,17 @@ See [statistics](#statistics) for information about the statistics returned by L
 
 ### Examples
 
+This example cURL command
+
 ```bash
-$ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' --data-urlencode 'step=300' | jq
+curl -G -s  "http://localhost:3100/loki/api/v1/query_range" \
+  --data-urlencode 'query=sum(rate({job="varlogs"}[10m])) by (level)' \
+  --data-urlencode 'step=300' | jq
+```
+
+gave this response:
+
+```json
 {
   "status": "success",
   "data": {
@@ -398,8 +545,16 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode '
 }
 ```
 
+This example cURL command
+
 ```bash
-$ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query={job="varlogs"}' | jq
+curl -G -s "http://localhost:3100/loki/api/v1/query_range" \
+  --data-urlencode 'query={job="varlogs"}' | jq
+```
+
+gave this response:
+
+```json
 {
   "status": "success",
   "data": {
@@ -430,7 +585,7 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode '
 }
 ```
 
-## List labels within a range of time
+## Query labels
 
 ```
 GET /loki/api/v1/labels
@@ -446,7 +601,7 @@ It accepts the following query parameters in the URL:
 
 In microservices mode, `/loki/api/v1/labels` is exposed by the querier.
 
-Response:
+Response format:
 
 ```
 {
@@ -460,8 +615,15 @@ Response:
 
 ### Examples
 
+This example cURL command
+
 ```bash
-$ curl -G -s  "http://localhost:3100/loki/api/v1/labels" | jq
+curl -G -s  "http://localhost:3100/loki/api/v1/labels" | jq
+```
+
+gave this response:
+
+```json
 {
   "status": "success",
   "data": [
@@ -472,7 +634,7 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/labels" | jq
 }
 ```
 
-## List label values within a range of time
+## Query label values
 
 ```
 GET /loki/api/v1/label/<name>/values
@@ -489,7 +651,7 @@ It accepts the following query parameters in the URL:
 
 In microservices mode, `/loki/api/v1/label/<name>/values` is exposed by the querier.
 
-Response:
+Response format:
 
 ```
 {
@@ -503,8 +665,15 @@ Response:
 
 ### Examples
 
+This example cURL command
+
 ```bash
-$ curl -G -s  "http://localhost:3100/loki/api/v1/label/foo/values" | jq
+curl -G -s  "http://localhost:3100/loki/api/v1/label/foo/values" | jq
+```
+
+gave this response:
+
+```json
 {
   "status": "success",
   "data": [
@@ -515,278 +684,18 @@ $ curl -G -s  "http://localhost:3100/loki/api/v1/label/foo/values" | jq
 }
 ```
 
-## Stream log messages
-
-```
-GET /loki/api/v1/tail
-```
-
-`/loki/api/v1/tail` is a WebSocket endpoint that will stream log messages based on
-a query. It accepts the following query parameters in the URL:
-
-- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
-- `delay_for`: The number of seconds to delay retrieving logs to let slow
-  loggers catch up. Defaults to 0 and cannot be larger than 5.
-- `limit`: The max number of entries to return. It defaults to `100`.
-- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
-
-In microservices mode, `/loki/api/v1/tail` is exposed by the querier.
-
-Response (streamed):
-
-```
-{
-  "streams": [
-    {
-      "stream": {
-        <label key-value pairs>
-      },
-      "values": [
-        [
-          <string: nanosecond unix epoch>,
-          <string: log line>
-        ]
-      ]
-    }
-  ],
-  "dropped_entries": [
-    {
-      "labels": {
-        <label key-value pairs>
-      },
-      "timestamp": "<nanosecond unix epoch>"
-    }
-  ]
-}
-```
-
-## Push log entries to Loki
-
-```
-POST /loki/api/v1/push
-```
-
-`/loki/api/v1/push` is the endpoint used to send log entries to Loki. The default
-behavior is for the POST body to be a snappy-compressed protobuf message:
-
-- [Protobuf definition](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto)
-- [Go client library](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go)
-
-Alternatively, if the `Content-Type` header is set to `application/json`, a
-JSON post body can be sent in the following format:
-
-```
-{
-  "streams": [
-    {
-      "stream": {
-        "label": "value"
-      },
-      "values": [
-          [ "<unix epoch in nanoseconds>", "<log line>" ],
-          [ "<unix epoch in nanoseconds>", "<log line>" ]
-      ]
-    }
-  ]
-}
-```
-
-You can optionally attach [structured metadata]({{< relref "../get-started/labels/structured-metadata" >}}) to each log line by adding a JSON object to the end of the log line array.
-The JSON object must be a valid JSON object with string keys and string values. The JSON object should not contain any nested object.
-The JSON object must be set immediately after the log line. Here is an example of a log entry with some structured metadata attached:
-
-```
-"values": [
-    [ "<unix epoch in nanoseconds>", "<log line>", {"trace_id": "0242ac120002", "user_id": "superUser123"}]
-]
-```
-
-You can set `Content-Encoding: gzip` request header and post gzipped JSON.
-
-In microservices mode, `/loki/api/v1/push` is exposed by the distributor.
-
-### Examples
-
-```console
-$ curl -v -H "Content-Type: application/json" -XPOST -s "http://localhost:3100/loki/api/v1/push" --data-raw \
-  '{"streams": [{ "stream": { "foo": "bar2" }, "values": [ [ "1570818238000000000", "fizzbuzz" ] ] }]}'
-```
-
-## Identify ready Loki instance
-
-```
-GET /ready
-```
-
-`/ready` returns HTTP 200 when the Loki instance is ready to accept traffic. If
-running Loki on Kubernetes, `/ready` can be used as a readiness probe.
-
-In microservices mode, the `/ready` endpoint is exposed by all components.
-
-## Change log level at runtime
-
-```
-GET /log_level
-POST /log_level
-```
-
-`/log_level` a `GET` returns the current log level and a `POST` lets you change the log level of a Loki process at runtime. This can be useful for accessing debugging information during an incident. Caution should be used when running at the `debug` log level, as this produces a large volume of data.
-
-Params:
-
-- `log_level`: A valid log level that can be passed as a URL param (`?log_level=<level>`) or as a form value in case of `POST`. Valid levels: [debug, info, warn, error]
-
-In microservices mode, the `/log_level` endpoint is exposed by all components.
-
-## Flush in-memory chunks to backing store
-
-```
-POST /flush
-```
-
-`/flush` triggers a flush of all in-memory chunks held by the ingesters to the
-backing store. Mainly used for local testing.
-
-In microservices mode, the `/flush` endpoint is exposed by the ingester.
-
-### Tell ingester to release all resources on next SIGTERM
-
-```
-GET, POST, DELETE /ingester/prepare_shutdown
-```
-
-After a `POST` to the `prepare_shutdown` endpoint returns, when the ingester process is stopped with `SIGINT` / `SIGTERM`,
-the ingester will be unregistered from the ring and in-memory time series data will be flushed to long-term storage.
-This endpoint supersedes any YAML configurations and isn't necessary if the ingester is already
-configured to unregister from the ring or to flush on shutdown.
-
-A `GET` to the `prepare_shutdown` endpoint returns the status of this configuration, either `set` or `unset`.
-
-A `DELETE` to the `prepare_shutdown` endpoint reverts the configuration of the ingester to its previous state
-(with respect to unregistering on shutdown and flushing of in-memory time series data to long-term storage).
-
-This API endpoint is usually used by Kubernetes-specific scale down automations such as the
-[rollout-operator](https://github.com/grafana/rollout-operator).
-
-## Flush in-memory chunks and shut down
-
-```
-POST /ingester/shutdown
-```
-
-`/ingester/shutdown` triggers a shutdown of the ingester and notably will _always_ flush any in memory chunks it holds.
-This is helpful for scaling down WAL-enabled ingesters where we want to ensure old WAL directories are not orphaned,
-but instead flushed to our chunk backend.
-
-It accepts three URL query parameters `flush`, `delete_ring_tokens`, and `terminate`.
-
-**URL query parameters:**
-
-- `flush=<bool>`:
-  Flag to control whether to flush any in-memory chunks the ingester holds. Defaults to `true`.
-- `delete_ring_tokens=<bool>`:
-  Flag to control whether to delete the file that contains the ingester ring tokens of the instance if the `-ingester.token-file-path` is specified. Defaults to `false.
-- `terminate=<bool>`:
-  Flag to control whether to terminate the Loki process after service shutdown. Defaults to `true`.
-
-This handler, in contrast to the deprecated `/ingester/flush_shutdown` handler, terminates the Loki process by default.
-This behaviour can be changed by setting the `terminate` query parameter to `false`.
-
-In microservices mode, the `/ingester/shutdown` endpoint is exposed by the ingester.
-
-## Display distributor consistent hash ring status
-
-```
-GET /distributor/ring
-```
-
-Displays a web page with the distributor hash ring status, including the state, healthy and last heartbeat time of each distributor.
-
-## Return exposed Prometheus metrics
-
-```
-GET /metrics
-```
-
-`/metrics` returns exposed Prometheus metrics. See
-[Observing Loki]({{< relref "../operations/observability" >}})
-for a list of exported metrics.
-
-In microservices mode, the `/metrics` endpoint is exposed by all components.
-
-## List current configuration
-
-```
-GET /config
-```
-
-`/config` exposes the current configuration. The optional `mode` query parameter can be used to
-modify the output. If it has the value `diff` only the differences between the default configuration
-and the current are returned. A value of `defaults` returns the default configuration.
-
-In microservices mode, the `/config` endpoint is exposed by all components.
-
-## List running services
-
-```
-GET /services
-```
-
-`/services` returns a list of all running services and their current states.
-
-Services can have the following states:
-
-- **New**: Service is new, not running yet (initial state)
-- **Starting**: Service is starting; if starting succeeds, service enters **Running** state
-- **Running**: Service is fully running now; when service stops running, it enters **Stopping** state
-- **Stopping**: Service is shutting down
-- **Terminated**: Service has stopped successfully (terminal state)
-- **Failed**: Service has failed in **Starting**, **Running** or **Stopping** state (terminal state)
-
-## List build information
-
-```
-GET /loki/api/v1/status/buildinfo
-```
-
-`/loki/api/v1/status/buildinfo` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `buildDate`, `buildUser`, and `goVersion`.
-
-## Format query
-
-```
-GET /loki/api/v1/format_query
-POST /loki/api/v1/format_query
-```
-
-Params:
-
-- `query`: A LogQL query string. Can be passed as URL param (`?query=<query>`) in case of both `GET` and `POST`. Or as form value in case of `POST`.
-
-The `/loki/api/v1/format_query` endpoint allows to format LogQL queries. It returns an error if the passed LogQL is invalid. It is exposed by all Loki components and helps to improve readability and the debugging experience of LogQL queries.
-
-The following example formats the expression LogQL `{foo=   "bar"}` into
-
-```json
-{
-   "status" : "success",
-   "data" : "{foo=\"bar\"}"
-}
-```
-
-## List series
+## Query streams
 
 The Series API is available under the following:
 
 - `GET /loki/api/v1/series`
 - `POST /loki/api/v1/series`
-- `GET /api/prom/series`
-- `POST /api/prom/series`
 
-This endpoint returns the list of time series that match a certain label set.
+This endpoint returns the list of streams (unique set of labels) that match a certain given selector.
 
 URL query parameters:
 
-- `match[]=<series_selector>`: Repeated log stream selector argument that selects the streams to return. At least one `match[]` argument must be provided.
+- `match[]=<selector>`: Repeated log stream selector argument that selects the streams to return. At least one `match[]` argument must be provided.
 - `start=<nanosecond Unix epoch>`: Start timestamp.
 - `end=<nanosecond Unix epoch>`: End timestamp.
 - `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
@@ -797,8 +706,17 @@ In microservices mode, these endpoints are exposed by the querier.
 
 ### Examples
 
-```console
-$ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match[]={container_name=~"prometheus.*", component="server"}' --data-urlencode 'match[]={app="loki"}' | jq '.'
+This example cURL command
+
+```bash
+curl -s "http://localhost:3100/loki/api/v1/series" \
+  --data-urlencode 'match[]={container_name=~"prometheus.*", component="server"}' \
+  --data-urlencode 'match[]={app="loki"}' | jq '.'
+```
+
+gave this response:
+
+```json
 {
   "status": "success",
   "data": [
@@ -847,13 +765,17 @@ $ curl -s "http://localhost:3100/loki/api/v1/series" --data-urlencode 'match[]={
 }
 ```
 
-## Index Stats
+## Query log statistics
+
+```
+GET `/loki/api/v1/index/stats`
+```
 
 The `/loki/api/v1/index/stats` endpoint can be used to query the index for the number of `streams`, `chunks`, `entries`, and `bytes` that a query resolves to.
 
 URL query parameters:
 
-- `query`: The [LogQL]({{< relref "../query" >}}) matchers to check (i.e. `{job="foo", env!="dev"}`)
+- `query`: The [LogQL]({{< relref "../query" >}}) matchers to check (that is, `{job="foo", env!="dev"}`)
 - `start=<nanosecond Unix epoch>`: Start timestamp.
 - `end=<nanosecond Unix epoch>`: End timestamp.
 
@@ -872,14 +794,19 @@ Response:
 
 It is an approximation with the following caveats:
 
-- It does not include data from the ingesters
-- It is a probabilistic technique
-- streams/chunks which span multiple period configurations may be counted twice.
+- It does not include data from the ingesters.
+- It is a probabilistic technique.
+- Streams/chunks which span multiple period configurations may be counted twice.
 
 These make it generally more helpful for larger queries.
 It can be used for better understanding the throughput requirements and data topology for a list of matchers over a period of time.
 
-## Volume
+## Query log volume
+
+```
+GET /loki/api/v1/index/volume
+GET /loki/api/v1/index/volume_range
+```
 
 The `/loki/api/v1/index/volume` and `/loki/api/v1/index/volume_range` endpoints can be used to query the index for volume information about label and label-value combinations. This is helpful in exploring the logs Loki has ingested to find high or low volume streams. The `volume` endpoint returns results for a single point in time, the time the query was processed. Each datapoint represents an aggregation of the matching label or series over the requested time period, returned in a Prometheus style vector response. The `volume_range` endoint returns a series of datapoints over a range of time, in Prometheus style matrix response, for each matching set of labels or series. The number of timestamps returned when querying `volume_range` will be determined by the provided `step` parameter and the requested time range.
 
@@ -891,62 +818,210 @@ The other way to change aggregations is with the `aggregateBy` parameter. The de
 
 URL query parameters:
 
-- `query`: The [LogQL]({{< relref "../query" >}}) matchers to check (i.e. `{job="foo", env=~".+"}`). This parameter is required.
+- `query`: The [LogQL]({{< relref "../query" >}}) matchers to check (that is, `{job="foo", env=~".+"}`). This parameter is required.
 - `start=<nanosecond Unix epoch>`: Start timestamp. This parameter is required.
 - `end=<nanosecond Unix epoch>`: End timestamp. This parameter is required.
-- `limit`: How many metric series to return. The parameter is optional, the default is 100.
+- `limit`: How many metric series to return. The parameter is optional, the default is `100`.
 - `step`: Query resolution step width in `duration` format or float number of seconds. `duration` refers to Prometheus duration strings of the form `[0-9]+[smhdwy]`. For example, 5m refers to a duration of 5 minutes. Defaults to a dynamic value based on `start` and `end`. Only applies when querying the `volume_range` endpoint, which will always return a Prometheus style matrix response. This parameter is optional, and only applicable for `query_range`. The default step configured for range queries will be used when not provided.
 - `targetLabels`: A comma separated list of labels to aggregate into. This parameter is optional. When not provided, volumes will be aggregated into the matching labels or label-value pairs.
 - `aggregateBy`: Whether to aggregate into labels or label-value pairs. This parameter is optional, the default is label-value pairs.
 
 You can URL-encode these parameters directly in the request body by using the POST method and `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large or dynamic number of stream selectors that may breach server-side URL character limits.
 
-## Statistics
+## Stream logs
 
-Query endpoints such as `/api/prom/query`, `/loki/api/v1/query` and `/loki/api/v1/query_range` return a set of statistics about the query execution. Those statistics allow users to understand the amount of data processed and at which speed.
+```
+GET /loki/api/v1/tail
+```
 
-The example belows show all possible statistics returned with their respective description.
+`/loki/api/v1/tail` is a WebSocket endpoint that streams log messages based on a query to the client.
+It accepts the following query parameters in the URL:
 
-```json
+- `query`: The [LogQL]({{< relref "../query" >}}) query to perform.
+- `delay_for`: The number of seconds to delay retrieving logs to let slow
+  loggers catch up. Defaults to 0 and cannot be larger than 5.
+- `limit`: The max number of entries to return. It defaults to `100`.
+- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
+
+In microservices mode, `/loki/api/v1/tail` is exposed by the querier.
+
+Response format (streamed):
+
+```
 {
-  "status": "success",
-  "data": {
-    "resultType": "streams",
-    "result": [],
-    "stats": {
-      "ingester": {
-        "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by ingesters
-        "decompressedBytes": 0, // Total bytes decompressed and processed by ingesters
-        "decompressedLines": 0, // Total lines decompressed and processed by ingesters
-        "headChunkBytes": 0, // Total bytes read from ingesters head chunks
-        "headChunkLines": 0, // Total lines read from ingesters head chunks
-        "totalBatches": 0, // Total batches sent by ingesters
-        "totalChunksMatched": 0, // Total chunks matched by ingesters
-        "totalDuplicates": 0, // Total of duplicates found by ingesters
-        "totalLinesSent": 0, // Total lines sent by ingesters
-        "totalReached": 0 // Amount of ingesters reached.
+  "streams": [
+    {
+      "stream": {
+        <label key-value pairs>
       },
-      "store": {
-        "compressedBytes": 0, // Total bytes of compressed chunks (blocks) processed by the store
-        "decompressedBytes": 0, // Total bytes decompressed and processed by the store
-        "decompressedLines": 0, // Total lines decompressed and processed by the store
-        "chunksDownloadTime": 0, // Total time spent downloading chunks in seconds (float)
-        "totalChunksRef": 0, // Total chunks found in the index for the current query
-        "totalChunksDownloaded": 0, // Total of chunks downloaded
-        "totalDuplicates": 0 // Total of duplicates removed from replication
-      },
-      "summary": {
-        "bytesProcessedPerSecond": 0, // Total of bytes processed per second
-        "execTime": 0, // Total execution time in seconds (float)
-        "linesProcessedPerSecond": 0, // Total lines processed per second
-        "queueTime": 0, // Total queue time in seconds (float)
-        "totalBytesProcessed": 0, // Total amount of bytes processed overall for this request
-        "totalLinesProcessed": 0 // Total amount of lines processed overall for this request
-      }
+      "values": [
+        [
+          <string: nanosecond unix epoch>,
+          <string: log line>
+        ]
+      ]
     }
-  }
+  ],
+  "dropped_entries": [
+    {
+      "labels": {
+        <label key-value pairs>
+      },
+      "timestamp": "<nanosecond unix epoch>"
+    }
+  ]
 }
 ```
+
+## Readiness probe
+
+```
+GET /ready
+```
+
+`/ready` returns HTTP 200 when the Loki instance is ready to accept traffic. If
+running Loki on Kubernetes, `/ready` can be used as a readiness probe.
+
+In microservices mode, the `/ready` endpoint is exposed by all components.
+
+## Change log level
+
+```
+GET /log_level
+POST /log_level
+```
+
+`/log_level` a `GET` returns the current log level and a `POST` lets you change the log level of a Loki process **at runtime**.
+This can be useful for accessing debugging information during an incident. Caution should be used when running at the `debug` log level, as this produces a large volume of data.
+
+The endpoint accepts the following query parameters in the URL:
+
+- `log_level`: A valid log level that can be passed as a URL param (`?log_level=<level>`) or as a form value in case of `POST`. Valid levels: [debug, info, warn, error]
+
+In microservices mode, the `/log_level` endpoint is exposed by all components.
+
+## Prometheus metrics
+
+```
+GET /metrics
+```
+
+`/metrics` returns exposed Prometheus metrics. See
+[Observing Loki]({{< relref "../operations/observability" >}})
+for a list of exported metrics.
+
+In microservices mode, the `/metrics` endpoint is exposed by all components.
+
+## Show current configuration
+
+```
+GET /config
+```
+
+`/config` exposes the current configuration. The optional `mode` query parameter can be used to
+modify the output. If it has the value `diff` only the differences between the default configuration
+and the current are returned. A value of `defaults` returns the default configuration.
+
+In microservices mode, the `/config` endpoint is exposed by all components.
+
+## List running services
+
+```
+GET /services
+```
+
+`/services` returns a list of all running services and their current states.
+
+Services can have the following states:
+
+- **New**: Service is new, not running yet (initial state)
+- **Starting**: Service is starting; if starting succeeds, service enters **Running** state
+- **Running**: Service is fully running now; when service stops running, it enters **Stopping** state
+- **Stopping**: Service is shutting down
+- **Terminated**: Service has stopped successfully (terminal state)
+- **Failed**: Service has failed in **Starting**, **Running** or **Stopping** state (terminal state)
+
+## Show build information
+
+```
+GET /loki/api/v1/status/buildinfo
+```
+
+`/loki/api/v1/status/buildinfo` exposes the build information in a JSON object. The fields are `version`, `revision`, `branch`, `buildDate`, `buildUser`, and `goVersion`.
+
+## Flush in-memory chunks to backing store
+
+```
+POST /flush
+```
+
+`/flush` triggers a flush of all in-memory chunks held by the ingesters to the
+backing store. Mainly used for local testing.
+
+In microservices mode, the `/flush` endpoint is exposed by the ingester.
+
+## Prepare ingester shutdown
+
+```
+GET, POST, DELETE /ingester/prepare_shutdown
+```
+
+This endpoint is used to tell the ingester to release all resources on receiving the next `SIGTERM` or `SIGINT` signal.
+
+A `POST` request to the `/ingester/prepare_shutdown` endpoint configures the ingester for a full shutdown and returns immediately.
+Only when the ingester process is stopped with `SIGINT` or `SIGTERM`, it will unregister from the ring, and in-memory data will be flushed to long-term storage.
+This endpoint supersedes any YAML configurations and isn't necessary if the ingester is already configured to unregister from the ring or to flush on shutdown.
+
+A `GET` request to the `/ingester/prepare_shutdown` endpoint returns the status of this configuration, either `set` or `unset`.
+
+A `DELETE` request to the `/ingester/prepare_shutdown` endpoint reverts the configuration of the ingester to its previous state
+(with respect to unregistering on shutdown and flushing of in-memory data to long-term storage).
+
+This API endpoint is usually used by Kubernetes-specific scale down automations such as the
+[rollout-operator](https://github.com/grafana/rollout-operator).
+
+## Flush in-memory chunks and shut down
+
+```
+POST /ingester/shutdown
+```
+
+`/ingester/shutdown` triggers a shutdown of the ingester and notably will _always_ flush any in memory chunks it holds.
+This is helpful for scaling down WAL-enabled ingesters where we want to ensure old WAL directories are not orphaned,
+but instead flushed to our chunk backend.
+
+It accepts three URL query parameters `flush`, `delete_ring_tokens`, and `terminate`.
+
+**URL query parameters:**
+
+- `flush=<bool>`:
+  Flag to control whether to flush any in-memory chunks the ingester holds. Defaults to `true`.
+- `delete_ring_tokens=<bool>`:
+  Flag to control whether to delete the file that contains the ingester ring tokens of the instance if the `-ingester.token-file-path` is specified. Defaults to `false`.
+- `terminate=<bool>`:
+  Flag to control whether to terminate the Loki process after service shutdown. Defaults to `true`.
+
+This handler, in contrast to the deprecated `/ingester/flush_shutdown` handler, terminates the Loki process by default.
+This behaviour can be changed by setting the `terminate` query parameter to `false`.
+
+In microservices mode, the `/ingester/shutdown` endpoint is exposed by the ingester.
+
+## Distributor ring status
+
+```
+GET /distributor/ring
+```
+
+Displays a web page with the distributor hash ring status, including the state, health, and last heartbeat time of each distributor.
+
+## Index gateway ring status
+
+```
+GET /indexgateway/ring
+```
+
+Displays a web page with the index gateway hash ring status, including the state, health, and last heartbeat time of each index gateway.
+
 
 ## Ruler
 
@@ -958,7 +1033,7 @@ The ruler API endpoints require to configure a backend object storage to store t
 GET /ruler/ring
 ```
 
-Displays a web page with the ruler hash ring status, including the state, healthy and last heartbeat time of each ruler.
+Displays a web page with the ruler hash ring status, including the state, health, and last heartbeat time of each ruler.
 
 ### List rule groups
 
@@ -1177,7 +1252,7 @@ This endpoint returns both processed and unprocessed deletion requests. It does 
 
 Example cURL command:
 
-```
+```bash
 curl -X GET \
   <compactor_addr>/loki/api/v1/delete \
   -H 'X-Scope-OrgID: <orgid>'
@@ -1235,237 +1310,24 @@ curl -u "Tenant1:$API_TOKEN" \
   '<compactor_addr>/loki/api/v1/delete?request_id=<request_id>'
 ```
 
-## Deprecated endpoints
+## Format a LogQL query
 
-### `GET /api/prom/tail`
+```
+GET /loki/api/v1/format_query
+POST /loki/api/v1/format_query
+```
 
-> **DEPRECATED**: `/api/prom/tail` is deprecated. Use `/loki/api/v1/tail`
-> instead.
+The endpoint accepts the following query parameters in the URL:
 
-`/api/prom/tail` is a WebSocket endpoint that will stream log messages based on
-a query. It accepts the following query parameters in the URL:
+- `query`: A LogQL query string. Can be passed as URL param (`?query=<query>`) in case of both `GET` and `POST`. Or as form value in case of `POST`.
 
-- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
-- `delay_for`: The number of seconds to delay retrieving logs to let slow
-  loggers catch up. Defaults to 0 and cannot be larger than 5.
-- `limit`: The max number of entries to return
-- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
+The `/loki/api/v1/format_query` endpoint lets you format LogQL queries. It returns an error if the passed LogQL is invalid. It is exposed by all Loki components and helps to improve readability and the debugging experience of LogQL queries.
 
-In microservices mode, `/api/prom/tail` is exposed by the querier.
-
-Response (streamed):
+The following example formats the expression LogQL `{foo=   "bar"}` into
 
 ```json
 {
-  "streams": [
-    {
-      "labels": "<LogQL label key-value pairs>",
-      "entries": [
-        {
-          "ts": "<RFC3339Nano timestamp>",
-          "line": "<log line>"
-        }
-      ]
-    }
-  ],
-  "dropped_entries": [
-    {
-      "Timestamp": "<RFC3339Nano timestamp>",
-      "Labels": "<LogQL label key-value pairs>"
-    }
-  ]
+   "status" : "success",
+   "data" : "{foo=\"bar\"}"
 }
-```
-
-`dropped_entries` will be populated when the tailer could not keep up with the
-amount of traffic in Loki. When present, it indicates that the entries received
-in the streams is not the full amount of logs that are present in Loki. Note
-that the keys in `dropped_entries` will be sent as uppercase `Timestamp`
-and `Labels` instead of `labels` and `ts` like in the entries for the stream.
-
-As the response is streamed, the object defined by the response format above
-will be sent over the WebSocket multiple times.
-
-### `GET /api/prom/query`
-
-> **WARNING**: `/api/prom/query` is DEPRECATED; use `/loki/api/v1/query_range`
-> instead.
-
-`/api/prom/query` supports doing general queries. The URL query parameters
-support the following values:
-
-- `query`: The [LogQL]({{< relref "../query" >}}) query to perform
-- `limit`: The max number of entries to return
-- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
-- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
-- `direction`: Determines the sort order of logs. Supported values are `forward` or `backward`. Defaults to `backward.`
-- `regexp`: a regex to filter the returned results
-
-In microservices mode, `/api/prom/query` is exposed by the querier and the frontend.
-
-Note that the larger the time span between `start` and `end` will cause
-additional load on Loki and the index store, resulting in slower queries.
-
-Response:
-
-```
-{
-  "streams": [
-    {
-      "labels": "<LogQL label key-value pairs>",
-      "entries": [
-        {
-          "ts": "<RFC3339Nano string>",
-          "line": "<log line>"
-        },
-        ...
-      ],
-    },
-    ...
-  ],
-  "stats": [<statistics>]
-}
-```
-
-See [statistics](#statistics) for information about the statistics returned by Loki.
-
-#### Examples
-
-```console
-$ curl -G -s "http://localhost:3100/api/prom/query" --data-urlencode 'query={foo="bar"}' | jq
-{
-  "streams": [
-    {
-      "labels": "{filename=\"/var/log/myproject.log\", job=\"varlogs\", level=\"info\"}",
-      "entries": [
-        {
-          "ts": "2019-06-06T19:25:41.972739Z",
-          "line": "foo"
-        },
-        {
-          "ts": "2019-06-06T19:25:41.972722Z",
-          "line": "bar"
-        }
-      ]
-    }
-  ],
-  "stats": {
-    ...
-  }
-}
-```
-
-### `GET /api/prom/label/<name>/values`
-
-> **WARNING**: `/api/prom/label/<name>/values` is DEPRECATED; use `/loki/api/v1/label/<name>/values`
-
-`/api/prom/label/<name>/values` retrieves the list of known values for a given
-label within a given time span. It accepts the following query parameters in
-the URL:
-
-- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
-
-In microservices mode, `/api/prom/label/<name>/values` is exposed by the querier.
-
-Response:
-
-```
-{
-  "values": [
-    <label value>,
-    ...
-  ]
-}
-```
-
-#### Examples
-
-```console
-$ curl -G -s  "http://localhost:3100/api/prom/label/foo/values" | jq
-{
-  "values": [
-    "cat",
-    "dog",
-    "axolotl"
-  ]
-}
-```
-
-### `GET /api/prom/label`
-
-> **WARNING**: `/api/prom/label` is DEPRECATED; use `/loki/api/v1/labels`
-
-`/api/prom/label` retrieves the list of known labels within a given time span. It
-accepts the following query parameters in the URL:
-
-- `start`: The start time for the query as a nanosecond Unix epoch. Defaults to 6 hours ago.
-- `end`: The end time for the query as a nanosecond Unix epoch. Defaults to now.
-- `since`: A `duration` used to calculate `start` relative to `end`. If `end` is in the future, `start` is calculated as this duration before now. Any value specified for `start` supersedes this parameter.
-
-In microservices mode, `/api/prom/label` is exposed by the querier.
-
-Response:
-
-```
-{
-  "values": [
-    <label string>,
-    ...
-  ]
-}
-```
-
-#### Examples
-
-```console
-$ curl -G -s  "http://localhost:3100/api/prom/label" | jq
-{
-  "values": [
-    "foo",
-    "bar",
-    "baz"
-  ]
-}
-```
-
-### `POST /api/prom/push`
-
-> **WARNING**: `/api/prom/push` is DEPRECATED; use `/loki/api/v1/push`
-> instead.
-
-`/api/prom/push` is the endpoint used to send log entries to Loki. The default
-behavior is for the POST body to be a snappy-compressed protobuf message:
-
-- [Protobuf definition](https://github.com/grafana/loki/blob/main/pkg/logproto/logproto.proto)
-- [Go client library](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go)
-
-Alternatively, if the `Content-Type` header is set to `application/json`, a
-JSON post body can be sent in the following format:
-
-```
-{
-  "streams": [
-    {
-      "labels": "<LogQL label key-value pairs>",
-      "entries": [
-        {
-          "ts": "<RFC3339Nano string>",
-          "line": "<log line>"
-        }
-      ]
-    }
-  ]
-}
-```
-
-In microservices mode, `/api/prom/push` is exposed by the distributor.
-
-#### Examples
-
-```console
-$ curl -H "Content-Type: application/json" -XPOST -s "https://localhost:3100/api/prom/push" --data-raw \
-  '{"streams": [{ "labels": "{foo=\"bar\"}", "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "fizzbuzz" }] }]}'
 ```

--- a/docs/sources/send-data/k6/_index.md
+++ b/docs/sources/send-data/k6/_index.md
@@ -84,12 +84,12 @@ The `Client` class exposes the following instance methods:
 | method | description |
 | ------ | ----------- |
 | `push()` | shortcut for `pushParameterized(5, 800*1024, 1024*1024)` |
-| `pushParameterized(streams, minSize, maxSize)` | execute push request ([POST /loki/api/v1/push]({{< relref "../../reference/api#push-log-entries-to-loki" >}})) |
-| `instantQuery(query, limit)` | execute instant query  ([GET /loki/api/v1/query]({{< relref "../../reference/api#query-loki" >}})) |
-| `client.rangeQuery(query, duration, limit)` | execute range query  ([GET /loki/api/v1/query_range]({{< relref "../../reference/api#query-loki-over-a-range-of-time" >}})) |
-| `client.labelsQuery(duration)` | execute labels query  ([GET /loki/api/v1/labels]({{< relref "../../reference/api#list-labels-within-a-range-of-time" >}})) |
-| `client.labelValuesQuery(label, duration)` | execute label values query  ([GET /loki/api/v1/label/\<name\>/values]({{< relref "../../reference/api#list-label-values-within-a-range-of-time" >}})) |
-| `client.seriesQuery(matchers, duration)` | execute series query  ([GET /loki/api/v1/series]({{< relref "../../reference/api#list-series" >}})) |
+| `pushParameterized(streams, minSize, maxSize)` | execute push request ([POST /loki/api/v1/push]({{< relref "../../reference/api#ingest-logs" >}})) |
+| `instantQuery(query, limit)` | execute instant query  ([GET /loki/api/v1/query]({{< relref "../../reference/api#query-logs-at-a-single-point-in-time" >}})) |
+| `client.rangeQuery(query, duration, limit)` | execute range query  ([GET /loki/api/v1/query_range]({{< relref "../../reference/api#query-logs-within-a-range-of-time" >}})) |
+| `client.labelsQuery(duration)` | execute labels query  ([GET /loki/api/v1/labels]({{< relref "../../reference/api#query-labels" >}})) |
+| `client.labelValuesQuery(label, duration)` | execute label values query  ([GET /loki/api/v1/label/\<name\>/values]({{< relref "../../reference/api#query-label-values" >}})) |
+| `client.seriesQuery(matchers, duration)` | execute series query  ([GET /loki/api/v1/series]({{< relref "../../reference/api#query-streams" >}})) |
 
 **Javascript load test example:**
 

--- a/docs/sources/send-data/promtail/_index.md
+++ b/docs/sources/send-data/promtail/_index.md
@@ -106,7 +106,7 @@ Important details are:
 
 ## Loki Push API
 
-Promtail can also be configured to receive logs from another Promtail or any Loki client by exposing the [Loki Push API]({{< relref "../../reference/api#push-log-entries-to-loki" >}}) with the [loki_push_api]({{< relref "./configuration#loki_push_api" >}}) scrape config.
+Promtail can also be configured to receive logs from another Promtail or any Loki client by exposing the [Loki Push API]({{< relref "../../reference/api#ingest-logs" >}}) with the [loki_push_api]({{< relref "./configuration#loki_push_api" >}}) scrape config.
 
 There are a few instances where this might be helpful:
 

--- a/docs/sources/send-data/promtail/configuration.md
+++ b/docs/sources/send-data/promtail/configuration.md
@@ -922,7 +922,7 @@ max_message_length: <int>
 
 ### loki_push_api
 
-The `loki_push_api` block configures Promtail to expose a [Loki push API]({{< relref "../../reference/api#push-log-entries-to-loki" >}}) server.
+The `loki_push_api` block configures Promtail to expose a [Loki push API]({{< relref "../../reference/api#ingest-logs" >}}) server.
 
 Each job configured with a `loki_push_api` will expose this API and will require a separate port.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleaning up the API reference documentation:
* Removed unsupported APIs
* Change order so it matches the list on top 
* Write better headings
* Make cURL examples consistent with command-response-blocks