### PR TITLE
Log process startup and running time

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/log"
@@ -27,6 +28,8 @@ func exit(code int) {
 }
 
 func main() {
+	startTime := time.Now()
+
 	var config loki.ConfigWrapper
 
 	if loki.PrintVersion(os.Args[1:]) {
@@ -108,6 +111,6 @@ func main() {
 
 	level.Info(util_log.Logger).Log("msg", "Starting Loki", "version", version.Info())
 
-	err = t.Run(loki.RunOpts{})
+	err = t.Run(loki.RunOpts{StartTime: startTime})
 	util_log.CheckFatal("running loki", err, util_log.Logger)
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -399,6 +399,8 @@ func (t *Loki) ListTargets() {
 
 // Run starts Loki running, and blocks until a Loki stops.
 func (t *Loki) Run(opts RunOpts) error {
+	startTime := time.Now()
+
 	serviceMap, err := t.ModuleManager.InitModuleServices(t.Cfg.Target...)
 	if err != nil {
 		return err
@@ -443,8 +445,8 @@ func (t *Loki) Run(opts RunOpts) error {
 	t.Server.HTTP.Path("/loki/api/v1/format_query").Methods("GET", "POST").HandlerFunc(formatQueryHandler())
 
 	// Let's listen for events from this manager, and log them.
-	healthy := func() { level.Info(util_log.Logger).Log("msg", "Loki started") }
-	stopped := func() { level.Info(util_log.Logger).Log("msg", "Loki stopped") }
+	healthy := func() { level.Info(util_log.Logger).Log("msg", "Loki started", "startup_time", time.Since(startTime)) }
+	stopped := func() { level.Info(util_log.Logger).Log("msg", "Loki stopped", "running_time", time.Since(startTime)) }
 	serviceFailed := func(service services.Service) {
 		// if any service fails, stop entire Loki
 		sm.StopAsync()

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -445,8 +445,14 @@ func (t *Loki) Run(opts RunOpts) error {
 	t.Server.HTTP.Path("/loki/api/v1/format_query").Methods("GET", "POST").HandlerFunc(formatQueryHandler())
 
 	// Let's listen for events from this manager, and log them.
-	healthy := func() { level.Info(util_log.Logger).Log("msg", "Loki started", "startup_time", time.Since(startTime)) }
-	stopped := func() { level.Info(util_log.Logger).Log("msg", "Loki stopped", "running_time", time.Since(startTime)) }
+	healthy := func() {
+		level.Info(util_log.Logger).Log("msg", "Loki started", "startup_time", time.Since(startTime))
+		_ = util_log.Flush()
+	}
+	stopped := func() {
+		level.Info(util_log.Logger).Log("msg", "Loki stopped", "running_time", time.Since(startTime))
+		_ = util_log.Flush()
+	}
 	serviceFailed := func(service services.Service) {
 		// if any service fails, stop entire Loki
 		sm.StopAsync()

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -369,7 +369,7 @@ type RunOpts struct {
 	// If empty, default handlerFunc will be used.
 	CustomConfigEndpointHandlerFn func(http.ResponseWriter, *http.Request)
 	// StartTime is the time at which the main() function started executing.
-	// It is used to determin the startup time as well as the running time of the Loki process.
+	// It is used to determine the startup time as well as the running time of the Loki process.
 	StartTime time.Time
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This helps to get insights about slow startup of Loki, e.g. for the index gateway, which may pre-fetch a lot of data before it becomes ready.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
