### PR TITLE
Helm: Update memcached configuration options for chunk-cache and result-cache

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.22.1
+
+- [ENHANCEMENT] Allow for more memcached chunk-cache and results-cache configuration options.
+
 ## 5.22.0
 
 - [CHANGE] Changed version of Loki to 2.9.1

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.1
-version: 5.22.0
+version: 5.22.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.22.0](https://img.shields.io/badge/Version-5.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 5.22.1](https://img.shields.io/badge/Version-5.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -185,6 +185,9 @@ loki:
         cache:
           default_validity: {{ .default_validity }}
           memcached_client:
+            {{- if .consistent_hash }}
+            consistent_hash: true
+            {{- end }}
             {{- if .host }}
             host: {{ .host }}
             {{- end }}
@@ -193,6 +196,8 @@ loki:
             {{- end }}
             service: {{ .service }}
             timeout: {{ .timeout }}
+            max_idle_conns: {{ .max_idle_conns }}
+            update_interval: {{ .update_interval }}
       {{- end }}
     {{- end }}
 
@@ -304,10 +309,13 @@ loki:
       parallelism: 10
     results_cache:
       enabled: false
+      consistent_hash: true
       host: ""
       service: "memcached-client"
       timeout: "500ms"
       default_validity: "12h"
+      max_idle_conns: 16
+      update_interval: "1m"
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig: {}
   # -- Check https://grafana.com/docs/loki/latest/configuration/#ruler for more info on configuring ruler


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow all chunk-cache and result-cache options described in https://github.com/grafana/loki/blob/main/docs/sources/operations/caching.md to be configurable in chart.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
