### PR TITLE
drone(docker-driver): Fetch tags before pushing image during release

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -911,7 +911,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       {
         name: 'build and push',
         image: 'grafana/loki-build-image:%s' % build_image_version,
-        depends_on: ['clone'],
+        depends_on: ['clone', 'image-tag'],
         environment: {
           DOCKER_USERNAME: { from_secret: docker_username_secret.name },
           DOCKER_PASSWORD: { from_secret: docker_password_secret.name },


### PR DESCRIPTION
**What this PR does / why we need it**:
We realized, loki-docker-driver image was not being pushed after 2.8.2. And looking into it's drone pipeline and comparing it with other steps, docker-driver step is not fetching the tags,[ thus the final hash calculated to push is some HEAD branch.](https://github.com/grafana/loki/blob/main/tools/image-tag#L13-L14)

e.g: even if we have tag 2.9.1, it pushes only with latest HEAD commit hash.

This PR fixes it.
![Screenshot 2023-09-21 at 08 14 09](https://github.com/grafana/loki/assets/3735252/31e4d031-d22f-4bed-8aa7-3e6136a6f10c)
![Screenshot 2023-09-21 at 08 14 24](https://github.com/grafana/loki/assets/3735252/1742b821-58a3-4ef5-96ae-80304126b8cb)
![Screenshot 2023-09-21 at 08 14 42](https://github.com/grafana/loki/assets/3735252/5e060eeb-e57a-4124-b29b-bc8ce73cc6d9)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
I would prefer this instead of https://github.com/grafana/loki/pull/10663. Because that would make fetching tags more repetitive in all the drone tasks (can also be expensive in terms of running time if we put all together)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
