### PR TITLE
dependabot: Fix accessing secerets via environmental variables.

### DIFF
--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -31,4 +31,4 @@ jobs:
           --approve -b "Auto approve dependencies bump PR"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          GITHUB_TOKEN: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed, the dependencies auto-merge is breaking with error.
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```
https://github.com/grafana/loki/actions/runs/6222148810/job/16885518452?pr=10623

After some investigation. The suspect is secerets are not properly imported into the GH actions (NOTE from above GH run, the env `GITHUB_TOKEN` is set empty).

Also from the docs, this token can be set either by `GITHUB_TOKEN` or `GH_TOKEN`. `GITHUB_TOKEN` will get higher priority.
https://cli.github.com/manual/gh_help_environment
**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
