### PR TITLE
Jsonnet: Update the 'cluster' label in the logs and operational dashboards as currently the custom one is not picked up

### DIFF
--- a/production/loki-mixin/dashboards/loki-logs.libsonnet
+++ b/production/loki-mixin/dashboards/loki-logs.libsonnet
@@ -61,6 +61,19 @@ local template = import 'grafonnet/template.libsonnet';
                           p {
                             targets: [
                               e {
+                                expr: std.strReplace(super.expr, 'cluster="$cluster", ', $._config.per_cluster_label + '="$cluster", '),
+                              }
+                              for e in p.targets
+                            ],
+                          }
+                          for p in super.panels
+                        ],
+                      } +
+                      {
+                        panels: [
+                          p {
+                            targets: [
+                              e {
                                 expr: if dashboards['loki-logs.json'].showMultiCluster then super.expr
                                 else std.strReplace(super.expr, $._config.per_cluster_label + '="$cluster", ', ''),
                               }

--- a/production/loki-mixin/dashboards/loki-operational.libsonnet
+++ b/production/loki-mixin/dashboards/loki-operational.libsonnet
@@ -60,6 +60,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                    else error 'no pod matchers'
                                  else error 'matcher must be either job or container',
 
+                               local replacePerClusterMatchers(expr) =
+                                 std.strReplace(expr, 'cluster="$cluster", ', $._config.per_cluster_label + '="$cluster", '),
+
                                local replaceClusterMatchers(expr) =
                                  if dashboards['loki-operational.json'].showMultiCluster
                                  then expr
@@ -143,7 +146,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 
                                local replaceAllMatchers(expr) =
-                                 replaceMatchers(replaceClusterMatchers(expr)),
+                                 replaceMatchers(replaceClusterMatchers(replacePerClusterMatchers(expr))),
 
                                local selectDatasource(ds) =
                                  if ds == null || ds == '' then ds


### PR DESCRIPTION
**What this PR does / why we need it**:

We use a custom label for the kubernetes cluster in our Loki set up, which we can do by making use of the config `per_cluster_label`. However, we have found that for 2 dashboards, the logs and operational ones, that the `cluster` label is not being overridden, I have added logic in their libsonnet files to override this value so that these dashboards can work for us when we store the cluster name in a different label.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
