### PR TITLE
Docs: Remove experimental flag from GELF support in Promtail

### DIFF
--- a/docs/sources/send-data/promtail/scraping.md
+++ b/docs/sources/send-data/promtail/scraping.md
@@ -422,8 +422,6 @@ Read the [configuration]({{< relref "./configuration#kafka" >}}) section for mor
 
 ## GELF
 
-<span style="background-color:#f3f973;">GELF support in Promtail is an experimental feature.</span>
-
 Promtail supports listening message using the [GELF](https://docs.graylog.org/docs/gelf) UDP protocol.
 The GELF targets can be configured using the `gelf` stanza:
 


### PR DESCRIPTION
GELF support in Promtail is not experimental (any more).

**Special notes for your reviewer**:

Nothing really worth mentioning in the changelog or release notes.
