### PR TITLE
Fix internal reference in API docs

### DIFF
--- a/docs/sources/reference/api.md
+++ b/docs/sources/reference/api.md
@@ -66,7 +66,6 @@ These HTTP endpoints are exposed by the `ingester`, `write`, and `all` component
 - [`POST /flush`](#flush-in-memory-chunks-to-backing-store)
 - [`POST /ingester/prepare_shutdown`](#prepare-ingester-shutdown)
 - [`POST /ingester/shutdown`](#flush-in-memory-chunks-and-shut-down)
-- **Deprecated** [`POST /ingester/flush_shutdown`](#post-ingesterflush_shutdown)
 
 ### Rule endpoints
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When I rebased https://github.com/grafana/loki/pull/10654 before merging I did not resolve the merge conflict correctly. I forgot to remove the link to the section that was removed on main already with a previous commit.

Resolves https://github.com/grafana/loki/pull/10654#discussion_r1334601729