### PR TITLE
[sharding] [bugfix] Correctly account for child groupings in count/min/max sharding

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -207,7 +207,7 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 			return m.wrappedShardedVectorAggr(expr, r)
 
 		case syntax.OpTypeMin, syntax.OpTypeMax:
-			if syntax.ReducesLabels(expr) {
+			if syntax.ReducesLabels(expr.Left) {
 				// skip sharding optimizations at this level. If labels are reduced,
 				// the same series may exist on multiple shards and must be aggregated
 				// together before a max|min is applied
@@ -247,7 +247,7 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 			}, bytesPerShard, nil
 
 		case syntax.OpTypeCount:
-			if syntax.ReducesLabels(expr) {
+			if syntax.ReducesLabels(expr.Left) {
 				// skip sharding optimizations at this level. If labels are reduced,
 				// the same series may exist on multiple shards and must be aggregated
 				// together before a count is applied

--- a/pkg/logql/syntax/extractor.go
+++ b/pkg/logql/syntax/extractor.go
@@ -25,20 +25,15 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 	var without bool
 	var noLabels bool
 
-	if r.Grouping != nil {
-		groups = r.Grouping.Groups
-		without = r.Grouping.Without
-		if len(groups) == 0 {
-			noLabels = true
-		}
-	}
-
-	// uses override if it exists
-	if override != nil {
-		groups = override.Groups
-		without = override.Without
-		if len(groups) == 0 {
-			noLabels = true
+	// TODO(owen-d|cyriltovena): override grouping (i.e. from a parent `sum`)
+	// technicaly can break the query.
+	// For intance, in  `sum by (foo) (max_over_time by (bar) (...))`
+	// the `by (bar)` grouping in the child is ignored in favor of the parent's `by (foo)`
+	for _, grp := range []*Grouping{r.Grouping, override} {
+		if grp != nil {
+			groups = grp.Groups
+			without = grp.Without
+			noLabels = grp.Singleton()
 		}
 	}
 


### PR DESCRIPTION
Previously, we didn't always consider that some label reductions from downstream vector|range-vector aggregations come from groupings. This is particularly useful in the min/max/count sharding mapper.

edit: also fixes an issue with the range extractor mishandling `without ()` as `by ()`