### PR TITLE
Ingester: Change log line level and make jitter potentially longer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 ##### Changes
 
 * [10677](https://github.com/grafana/loki/pull/10677) **chaudum** Remove deprecated `stream_lag_labels` setting from both the `options` and `client` configuration sections.
-* [10689](https://github.com/grafana/loki/pull/10689) **dylanguedes**: Ingester: Make jitter to be 50% of flush check period instead of 1%.
+* [10689](https://github.com/grafana/loki/pull/10689) **dylanguedes**: Ingester: Make jitter to be 20% of flush check period instead of 1%.
 
 ##### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ##### Changes
 
 * [10677](https://github.com/grafana/loki/pull/10677) **chaudum** Remove deprecated `stream_lag_labels` setting from both the `options` and `client` configuration sections.
+* [10689](https://github.com/grafana/loki/pull/10689) **dylanguedes**: Ingester: Make jitter to be 50% of flush check period instead of 1%.
 
 ##### Fixes
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -584,7 +584,7 @@ func (i *Ingester) loop() {
 	initialDelay := time.NewTimer(jitter)
 	defer initialDelay.Stop()
 
-	level.Debug(util_log.Logger).Log("msg", "sleeping for initial delay before starting periodic flushing", "delay", jitter)
+	level.Info(util_log.Logger).Log("msg", "sleeping for initial delay before starting periodic flushing", "delay", jitter)
 
 	select {
 	case <-initialDelay.C:
@@ -594,8 +594,9 @@ func (i *Ingester) loop() {
 		return
 	}
 
-	// Add +/- 1% of flush interval as jitter
-	j := i.cfg.FlushCheckPeriod / 100
+	// Add +/- 50% of flush interval as jitter.
+	// The default flush check period is 30s so max jitter will be 15s.
+	j := i.cfg.FlushCheckPeriod / 50
 	flushTicker := util.NewTickerWithJitter(i.cfg.FlushCheckPeriod, j)
 	defer flushTicker.Stop()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -594,9 +594,9 @@ func (i *Ingester) loop() {
 		return
 	}
 
-	// Add +/- 50% of flush interval as jitter.
-	// The default flush check period is 30s so max jitter will be 15s.
-	j := i.cfg.FlushCheckPeriod / 2
+	// Add +/- 20% of flush interval as jitter.
+	// The default flush check period is 30s so max jitter will be 6s.
+	j := i.cfg.FlushCheckPeriod / 5
 	flushTicker := util.NewTickerWithJitter(i.cfg.FlushCheckPeriod, j)
 	defer flushTicker.Stop()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -596,7 +596,7 @@ func (i *Ingester) loop() {
 
 	// Add +/- 50% of flush interval as jitter.
 	// The default flush check period is 30s so max jitter will be 15s.
-	j := i.cfg.FlushCheckPeriod / 50
+	j := i.cfg.FlushCheckPeriod / 2
 	flushTicker := util.NewTickerWithJitter(i.cfg.FlushCheckPeriod, j)
 	defer flushTicker.Stop()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Change our sleep log line from `level=debug` to `level=info` to allow visibility of it without having to change the log line level of distributors as a whole
- Make the flush jitter to be 20% of flush check period instead of 1%. This means that, for the default 30s flush check period, the jitter will be at most 6s.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
