### PR TITLE
Add urls to connect Grafana (on Docker) to Loki (local buid instance)

### DIFF
--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -27,7 +27,10 @@ recent version to take advantage of [LogQL]({{< relref "../query/_index.md" >}})
 1. The http URL field should be the address of your Loki server. For example,
    when running locally or with Docker using port mapping, the address is
    likely `http://localhost:3100`. When running with docker-compose or
-   Kubernetes, the address is likely `http://loki:3100`.
+   Kubernetes, the address is likely `http://loki:3100`.\
+   When running Grafana (with Docker) and trying to connect to a locally built Loki instance, the address (for the URL field) is:\
+   On Mac: `docker.for.mac.localhost` \
+   On Windows: `docker.for.win.localhost`
 1. To see the logs, click <kbd>Explore</kbd> on the sidebar, select the Loki
    datasource in the top-left dropdown, and then choose a log stream using the
    <kbd>Log labels</kbd> button.


### PR DESCRIPTION
10692 - Added urls for Mac and Windows when connecting a Grafana running on Docker to a locally built Loki instance

**What this PR does / why we need it**:
I've added 2 URLs (mac and windows) that needs to be used if the user is running a Grafana with docker and trying to connect to a locally built Loki running on localhost (not Docker). When trying to figure out how to run the buids, it was very confusing as to why it's not working, I had to research to try to make the connection work. zDocumentation in setting up a local development environemtn can actually use some improvement as well as I had to moved from one section to another.

**Which issue(s) this PR fixes**:
Fixes #10692

**Special notes for your reviewer**:



**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
