### PR TITLE
Rename NewShipper to NewIndexClient

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -440,13 +440,13 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 			if shardingStrategy != nil {
 				filterFn = shardingStrategy.FilterTenants
 			}
-			shipper, err := shipper.NewShipper(cfg.BoltDBShipperConfig, objectClient, limits, filterFn, tableRange, registerer, logger)
+			indexClient, err := shipper.NewIndexClient(cfg.BoltDBShipperConfig, objectClient, limits, filterFn, tableRange, registerer, logger)
 			if err != nil {
 				return nil, err
 			}
 
-			boltdbIndexClientsWithShipper[periodCfg.From] = shipper
-			return shipper, nil
+			boltdbIndexClientsWithShipper[periodCfg.From] = indexClient
+			return indexClient, nil
 
 		case config.TSDBType:
 			// TODO(chaudum): Move TSDB index client creation into this code path

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -45,7 +45,7 @@ import (
 var (
 	indexGatewayClient index.Client
 	// singleton for each period
-	boltdbIndexClientsWithShipper = make(map[config.DayTime]index.Client)
+	boltdbIndexClientsWithShipper = make(map[config.DayTime]*shipper.IndexClient)
 
 	supportedIndexTypes = []string{
 		config.BoltDBShipperType,
@@ -100,7 +100,7 @@ func ResetBoltDBIndexClientsWithShipper() {
 		client.Stop()
 	}
 
-	boltdbIndexClientsWithShipper = make(map[config.DayTime]index.Client)
+	boltdbIndexClientsWithShipper = make(map[config.DayTime]*shipper.IndexClient)
 
 	if indexGatewayClient != nil {
 		indexGatewayClient.Stop()


### PR DESCRIPTION
The constructor function name is misleading as it suggests that the returned object is a [shipper](https://github.com/grafana/loki/blob/main/pkg/storage/stores/shipper/index/table_manager.go#L48), rather than an index client.

Also, change the return type to be a struct pointer, rather than an interface.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
