### PR TITLE
Check for nil StepResult.

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -351,9 +351,12 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	seriesIndex := map[uint64]*promql.Series{}
 
 	next, ts, r := stepEvaluator.Next()
-	vec := r.SampleVector()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
+	}
+	vec := promql.Vector{}
+	if next {
+		vec = r.SampleVector()
 	}
 
 	// fail fast for the first step or instant query

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -952,6 +952,9 @@ type LiteralStepEvaluator struct {
 
 func (e *LiteralStepEvaluator) Next() (bool, int64, StepResult) {
 	ok, ts, r := e.nextEv.Next()
+	if !ok {
+		return ok, ts, r
+	}
 	vec := r.SampleVector()
 	results := make(promql.Vector, 0, len(vec))
 	for _, sample := range vec {

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -1062,10 +1062,10 @@ type LabelReplaceEvaluator struct {
 
 func (e *LabelReplaceEvaluator) Next() (bool, int64, StepResult) {
 	next, ts, r := e.nextEvaluator.Next()
-	vec := r.SampleVector()
 	if !next {
 		return false, 0, SampleVector{}
 	}
+	vec := r.SampleVector()
 	if e.labelCache == nil {
 		e.labelCache = make(map[uint64]labels.Labels, len(vec))
 	}

--- a/pkg/logql/evaluator_test.go
+++ b/pkg/logql/evaluator_test.go
@@ -252,3 +252,46 @@ func TestEvaluator_mergeBinOpComparisons(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyNestedEvaluator(t *testing.T) {
+
+	for _, tc := range []struct {
+		desc string
+		ev   StepEvaluator
+	}{
+		{
+			desc: "LiteralStepEvaluator",
+			ev:   &LiteralStepEvaluator{nextEv: &emptyEvaluator{}},
+		},
+		{
+			desc: "LabelReplaceEvaluator",
+			ev:   &LabelReplaceEvaluator{nextEvaluator: &emptyEvaluator{}},
+		},
+		{
+			desc: "BinOpStepEvaluator",
+			ev:   &BinOpStepEvaluator{rse: &emptyEvaluator{}},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ok, _, _ := tc.ev.Next()
+			require.False(t, ok)
+		})
+	}
+
+}
+
+type emptyEvaluator struct{}
+
+func (*emptyEvaluator) Next() (ok bool, ts int64, r StepResult) {
+	return false, 0, nil
+}
+
+func (*emptyEvaluator) Close() error {
+	return nil
+}
+
+func (*emptyEvaluator) Error() error {
+	return nil
+}
+
+func (*emptyEvaluator) Explain(Node) {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow up to #10701 and checks in all evaluators if the nested evaluator returned a result or not.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
