### PR TITLE
promtail/client: note client config is not deprecated

### DIFF
--- a/clients/pkg/promtail/client/config.go
+++ b/clients/pkg/promtail/client/config.go
@@ -23,6 +23,10 @@ const (
 
 // Config describes configuration for an HTTP pusher client.
 type Config struct {
+	// Note even though the command line flag arguments which use this config
+	// are deprecated, this struct is still the primary way to configure
+	// a promtail client
+
 	Name      string `yaml:"name,omitempty"`
 	URL       flagext.URLValue
 	BatchWait time.Duration `yaml:"batchwait"`


### PR DESCRIPTION




**What this PR does / why we need it**:

Because the block of code immediately below `*Config` indicates that all arguments are deprecated, I incorrectly assumed that the `*Config` itself was deprecated and went hunting for a replacement. But the `*Config` struct is still how a client is expected to be configured.

**Which issue(s) this PR fixes**: Updates #10702.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [x] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
