### PR TITLE
[release-2.9.x][sharding] [bugfix] Correctly account for child groupings in count/mi…

### DIFF
--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -294,6 +294,16 @@ func TestMappingStrings(t *testing.T) {
 			in:  `sum(count_over_time({a=~".+"}[1s]) * ignoring () count_over_time({a=~".+"}[1s]))`,
 			out: `sum(downstream<sum((count_over_time({a=~".+"}[1s])*count_over_time({a=~".+"}[1s]))),shard=0_of_2>++downstream<sum((count_over_time({a=~".+"}[1s])*count_over_time({a=~".+"}[1s]))),shard=1_of_2>)`,
 		},
+		{
+			// shard the count since there is no label reduction in children
+			in:  `count by (foo) (rate({job="bar"}[1m]))`,
+			out: `sumby(foo)(downstream<countby(foo)(rate({job="bar"}[1m])),shard=0_of_2>++downstream<countby(foo)(rate({job="bar"}[1m])),shard=1_of_2>)`,
+		},
+		{
+			// don't shard the count since there is label reduction in children
+			in:  `count by (foo) (sum by (foo, bar) (rate({job="bar"}[1m])))`,
+			out: `countby(foo)(sumby(foo,bar)(downstream<sumby(foo,bar)(rate({job="bar"}[1m])),shard=0_of_2>++downstream<sumby(foo,bar)(rate({job="bar"}[1m])),shard=1_of_2>))`,
+		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			ast, err := syntax.ParseExpr(tc.in)

--- a/pkg/logql/syntax/extractor.go
+++ b/pkg/logql/syntax/extractor.go
@@ -25,20 +25,15 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 	var without bool
 	var noLabels bool
 
-	if r.Grouping != nil {
-		groups = r.Grouping.Groups
-		without = r.Grouping.Without
-		if len(groups) == 0 {
-			noLabels = true
-		}
-	}
-
-	// uses override if it exists
-	if override != nil {
-		groups = override.Groups
-		without = override.Without
-		if len(groups) == 0 {
-			noLabels = true
+	// TODO(owen-d|cyriltovena): override grouping (i.e. from a parent `sum`)
+	// technicaly can break the query.
+	// For intance, in  `sum by (foo) (max_over_time by (bar) (...))`
+	// the `by (bar)` grouping in the child is ignored in favor of the parent's `by (foo)`
+	for _, grp := range []*Grouping{r.Grouping, override} {
+		if grp != nil {
+			groups = grp.Groups
+			without = grp.Without
+			noLabels = grp.Singleton()
 		}
 	}
 


### PR DESCRIPTION
Manually backported 8e79c3a1a9280ab91b832df1d7506008bddffdc6 from https://github.com/grafana/loki/pull/10687 due to merge conflicts

---------------------

Previously, we didn't always consider that some label reductions from downstream vector|range-vector aggregations come from groupings. This is particularly useful in the min/max/count sharding mapper.

edit: also fixes an issue with the range extractor mishandling without () as by ()
