### PR TITLE
Overrides default replication factor when 1xMedium size is picked

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [10719](https://github.com/grafana/loki/pull/10719) **JoaoBraveCoding**: Overrides default replication factor when 1xMedium size is picked
 - [10600](https://github.com/grafana/loki/pull/10600) **periklis**: Update Loki operand to v2.9.1
 - [10545](https://github.com/grafana/loki/pull/10545) **xperimental**: Update gateway arguments to enable namespace extraction
 - [10558](https://github.com/grafana/loki/pull/10558) **periklis**: Upgrade dashboards for for Loki v2.9.0

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2023-09-15T08:01:27Z"
+    createdAt: "2023-09-26T11:20:04Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -173,7 +173,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: loki-operator.v0.1.0
+  name: loki-operator.v0.1.0-fcd5dce0e
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1639,7 +1639,7 @@ spec:
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
                   value: quay.io/observatorium/opa-openshift:latest
-                image: quay.io/openshift-logging/loki-operator:0.1.0
+                image: quay.io/jmarcal/loki-operator:0.1.0-fcd5dce0e
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -1763,7 +1763,7 @@ spec:
     name: gateway
   - image: quay.io/observatorium/opa-openshift:latest
     name: opa
-  version: 0.1.0
+  version: 0.1.0-fcd5dce0e
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/openshift-logging/loki-operator
-  newTag: 0.1.0
+  newName: quay.io/jmarcal/loki-operator
+  newTag: 0.1.0-fcd5dce0e

--- a/operator/internal/manifests/build.go
+++ b/operator/internal/manifests/build.go
@@ -129,10 +129,10 @@ func ApplyDefaultSettings(opts *Options) error {
 		},
 	}
 
-	// nolint:staticcheck
-	// In a zone aware deployment if the T-Shirt is 1xmedium then we will want
-	// to not set the default value of factor 3 but 2 instead to not bring the
-	// stack down if 1 zone goes down
+	// nolint:staticcheck 
+	// In a zone-aware deployment, if the T-shirt size is 1x.medium then we will
+	// want to modify the replication factor to 2 instead of the default value
+	// of 3, in order to keep the stack functioning in case a zone goes down.
 	if opts.Stack.Size == lokiv1.SizeOneXMedium && opts.Stack.Replication != nil && opts.Stack.Replication.Factor == 0 && opts.Stack.ReplicationFactor == 0 {
 		strictOverrides.Replication = &lokiv1.ReplicationSpec{
 			Factor: 2,

--- a/operator/internal/manifests/build.go
+++ b/operator/internal/manifests/build.go
@@ -129,6 +129,16 @@ func ApplyDefaultSettings(opts *Options) error {
 		},
 	}
 
+	// nolint:staticcheck
+	// In a zone aware deployment if the T-Shirt is 1xmedium then we will want
+	// to not set the default value of factor 3 but 2 instead to not bring the
+	// stack down if 1 zone goes down
+	if opts.Stack.Size == lokiv1.SizeOneXMedium && opts.Stack.Replication != nil && opts.Stack.Replication.Factor == 0 && opts.Stack.ReplicationFactor == 0 {
+		strictOverrides.Replication = &lokiv1.ReplicationSpec{
+			Factor: 2,
+		}
+	}
+
 	if err := mergo.Merge(spec, strictOverrides, mergo.WithOverride); err != nil {
 		return kverrors.Wrap(err, "failed to merge strict defaults")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In a zone aware deployment if the T-Shirt is 1xMedium then we will want
to not set the default value of factor to 3 but to 2 instead to not bring the
stack down if 1 zone goes down

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/LOG-4507

**Special notes for your reviewer**:

Alternative PR: https://github.com/grafana/loki/pull/10720

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
