### PR TITLE
operator: Change default replication factor of 1x.medium to 2

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Main
 
-- [10720](https://github.com/grafana/loki/pull/10720) **JoaoBraveCoding**: Update default replication factor on 1xMedium from 3 to 2
+- [10720](https://github.com/grafana/loki/pull/10720) **JoaoBraveCoding**: Change default replication factor of 1x.medium to 2
 - [10600](https://github.com/grafana/loki/pull/10600) **periklis**: Update Loki operand to v2.9.1
 - [10545](https://github.com/grafana/loki/pull/10545) **xperimental**: Update gateway arguments to enable namespace extraction
 - [10558](https://github.com/grafana/loki/pull/10558) **periklis**: Upgrade dashboards for for Loki v2.9.0

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [10720](https://github.com/grafana/loki/pull/10720) **JoaoBraveCoding**: Update default replication factor on 1xMedium from 3 to 2
 - [10600](https://github.com/grafana/loki/pull/10600) **periklis**: Update Loki operand to v2.9.1
 - [10545](https://github.com/grafana/loki/pull/10545) **xperimental**: Update gateway arguments to enable namespace extraction
 - [10558](https://github.com/grafana/loki/pull/10558) **periklis**: Upgrade dashboards for for Loki v2.9.0

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -398,7 +398,7 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 	lokiv1.SizeOneXMedium: {
 		Size: lokiv1.SizeOneXMedium,
 		Replication: &lokiv1.ReplicationSpec{
-			Factor: 3,
+			Factor: 2,
 		},
 		Limits: &lokiv1.LimitsSpec{
 			Global: &lokiv1.LimitsTemplateSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

The default of replication factor of 3 does not make sense for the size 1xMedium, in a stack where the number of ingester replicas is 3, if one of the ingester pods is restarted this brings the stack down. A much better default is replication factor of 2. This PR is an alternative to https://github.com/grafana/loki/pull/10719, from my POV prefer this PR.

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/LOG-4507

**Special notes for your reviewer**:

Alternative PR: https://github.com/grafana/loki/pull/10719

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
