### PR TITLE
Remove that the Ruler WAL is a coming soon feature

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -373,7 +373,6 @@ Yaml files are expected to be [Prometheus-compatible](https://prometheus.io/docs
 
 There are a few things coming to increase the robustness of this service. In no particular order:
 
-- WAL for recording rule.
 - Backend metric stores adapters for generated alert rule data.
 
 ## Misc Details: Metrics backends vs in-memory


### PR DESCRIPTION
Based on what we have written here:
https://grafana.com/docs/loki/latest/operations/recording-rules/#write-ahead-log-wal

A WAL for the Loki Ruler already has been implemented, so lets no longer leave it as a "future improvement"
