### PR TITLE
[10728] - Added zip decompression format support to Promtail

### DIFF
--- a/clients/pkg/promtail/targets/file/decompresser.go
+++ b/clients/pkg/promtail/targets/file/decompresser.go
@@ -36,7 +36,7 @@ func supportedCompressedFormats() map[string]struct{} {
 		".tar.gz": {},
 		".z":      {},
 		".bz2":    {},
-		// TODO: add support for .zip extension.
+		".zip":    {},
 	}
 }
 

--- a/docs/sources/send-data/promtail/configuration.md
+++ b/docs/sources/send-data/promtail/configuration.md
@@ -379,7 +379,7 @@ decompression:
   # Especially useful in scenarios where compressed files are found before the compression is finished.
   [initial_delay: <duration> | default = 0s]
 
-  # Compression format. Supported formats are: 'gz', 'bz2' and 'z.
+  # Compression format. Supported formats are: 'gz', 'bz2', 'zip' and 'z.
   [format: <string> | default = ""]
 
 # Describes how to scrape logs from the journal.


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR is to add the support for zip decompression format to Promtail and we need to add this format because it will help to process logs that are rotated and compressed when loki is down

**Which issue(s) this PR fixes**:
Fixes #10728 

**Special notes for your reviewer**:
- To check the newly added changes.

**Checklist**
- [-] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [-] Documentation added
- [-] Tests updated
- [-] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
