### PR TITLE
Index Gateway: Set some concurrency limits around concurrent index table processing

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -202,7 +202,7 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	defer t.indexMtx.rUnlock()
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(200)
+	g.SetLimit(4)
 
 	logger := util_log.WithContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -75,6 +75,11 @@ func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.I
 		return nil, err
 	}
 
+	maxConcurrent := runtime.GOMAXPROCS(0) / 2
+	if maxConcurrent == 0 {
+		maxConcurrent = 1
+	}
+
 	is := indexSet{
 		openIndexFileFunc: openIndexFileFunc,
 		baseIndexSet:      baseIndexSet,
@@ -82,7 +87,7 @@ func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.I
 		userID:            userID,
 		cacheLocation:     cacheLocation,
 		logger:            logger,
-		maxConcurrent:     runtime.GOMAXPROCS(0) / 2,
+		maxConcurrent:     maxConcurrent,
 		lastUsedAt:        time.Now(),
 		index:             map[string]index.Index{},
 		indexMtx:          newMtxWithReadiness(),
@@ -205,6 +210,9 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 	defer t.indexMtx.rUnlock()
 
 	g, ctx := errgroup.WithContext(ctx)
+	if t.maxConcurrent == 0 {
+		panic("maxConcurrent cannot be 0, indexSet is being initialized without setting maxConcurrent")
+	}
 	g.SetLimit(t.maxConcurrent)
 
 	logger := util_log.WithContext(ctx, t.logger)

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -148,6 +148,7 @@ func (t *table) Close() {
 
 func (t *table) ForEachConcurrent(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(4)
 
 	// iterate through both user and common index
 	users := []string{userID, ""}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -57,6 +57,11 @@ type table struct {
 // NewTable just creates an instance of table without trying to load files from local storage or object store.
 // It is used for initializing table at query time.
 func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics) Table {
+	maxConcurrent := runtime.GOMAXPROCS(0) / 2
+	if maxConcurrent == 0 {
+		maxConcurrent = 1
+	}
+
 	table := table{
 		name:               name,
 		cacheLocation:      cacheLocation,
@@ -66,7 +71,7 @@ func NewTable(name, cacheLocation string, storageClient storage.Client, openInde
 		logger:             log.With(util_log.Logger, "table-name", name),
 		openIndexFileFunc:  openIndexFileFunc,
 		metrics:            metrics,
-		maxConcurrent:      runtime.GOMAXPROCS(0) / 2,
+		maxConcurrent:      maxConcurrent,
 		indexSets:          map[string]IndexSet{},
 	}
 
@@ -86,6 +91,11 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		return nil, err
 	}
 
+	maxConcurrent := runtime.GOMAXPROCS(0) / 2
+	if maxConcurrent == 0 {
+		maxConcurrent = 1
+	}
+
 	table := table{
 		name:               name,
 		cacheLocation:      cacheLocation,
@@ -96,6 +106,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		indexSets:          map[string]IndexSet{},
 		openIndexFileFunc:  openIndexFileFunc,
 		metrics:            metrics,
+		maxConcurrent:      maxConcurrent,
 	}
 
 	level.Debug(table.logger).Log("msg", fmt.Sprintf("opening locally present files for table %s", name), "files", fmt.Sprint(dirEntries))
@@ -151,6 +162,9 @@ func (t *table) Close() {
 
 func (t *table) ForEachConcurrent(ctx context.Context, userID string, callback index.ForEachIndexCallback) error {
 	g, ctx := errgroup.WithContext(ctx)
+	if t.maxConcurrent == 0 {
+		panic("maxConcurrent cannot be 0, downloads.table is being initialized without setting maxConcurrent")
+	}
 	g.SetLimit(t.maxConcurrent)
 
 	// iterate through both user and common index

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -224,6 +224,7 @@ func (s *indexShipper) ForEach(ctx context.Context, tableName, userID string, ca
 func (s *indexShipper) ForEachConcurrent(ctx context.Context, tableName, userID string, callback index.ForEachIndexCallback) error {
 
 	g, ctx := errgroup.WithContext(ctx)
+	// E.Welch not setting a bound on the errgroup here because we set one inside the downloadsManager.ForEachConcurrent
 
 	if s.downloadsManager != nil {
 		g.Go(func() error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1658,12 +1658,7 @@ func (r *Reader) lookupSymbol(o uint32) (string, error) {
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
-	l, err := r.symbols.Lookup(o)
-	if err != nil {
-		return "", err
-	}
-	r.nameSymbols[o] = l
-	return l, nil
+	return r.symbols.Lookup(o)
 }
 
 func (r *Reader) Bounds() (int64, int64) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1255,9 +1255,8 @@ type Reader struct {
 	postingsV1 map[string]map[string]uint64
 
 	symbols     *Symbols
-	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
+	nameSymbols sync.Map // Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
-	nameSymbolsMtx sync.RWMutex
 
 	fingerprintOffsets FingerprintOffsets
 
@@ -1405,7 +1404,7 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		}
 	}
 
-	r.nameSymbols = make(map[uint32]string, len(r.postings))
+	//r.nameSymbols = make(map[uint32]string, len(r.postings))
 	for k := range r.postings {
 		if k == "" {
 			continue
@@ -1414,7 +1413,8 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "reverse symbol lookup")
 		}
-		r.nameSymbols[off] = k
+		r.nameSymbols.Store(off, k)
+		//r.nameSymbols[off] = k
 	}
 
 	r.fingerprintOffsets, err = readFingerprintOffsetsTable(r.b, r.toc.FingerprintOffsets)
@@ -1656,12 +1656,14 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) lookupSymbol(o uint32) (string, error) {
-	r.nameSymbolsMtx.RLock()
-	s, ok := r.nameSymbols[o]
-	r.nameSymbolsMtx.RUnlock()
+	//r.nameSymbolsMtx.RLock()
+	//s, ok := r.nameSymbols[o]
+	//r.nameSymbolsMtx.RUnlock()
+
+	s, ok := r.nameSymbols.Load(o)
 
 	if ok {
-		return s, nil
+		return s.(string), nil
 	}
 
 	l, err := r.symbols.Lookup(o)
@@ -1669,9 +1671,12 @@ func (r *Reader) lookupSymbol(o uint32) (string, error) {
 		return "", err
 	}
 
-	r.nameSymbolsMtx.Lock()
-	r.nameSymbols[o] = l
-	r.nameSymbolsMtx.Unlock()
+	//r.nameSymbolsMtx.Lock()
+
+	//r.nameSymbols[o] = l
+	//r.nameSymbolsMtx.Unlock()
+
+	r.nameSymbols.Store(o, l)
 	return l, nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1658,7 +1658,12 @@ func (r *Reader) lookupSymbol(o uint32) (string, error) {
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
-	return r.symbols.Lookup(o)
+	l, err := r.symbols.Lookup(o)
+	if err != nil {
+		return "", err
+	}
+	r.nameSymbols[o] = l
+	return l, nil
 }
 
 func (r *Reader) Bounds() (int64, int64) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1257,7 +1257,7 @@ type Reader struct {
 	symbols     *Symbols
 	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
-	nameSymbolsMtx sync.RWMutex
+	nameSymbolsMtx sync.Mutex
 
 	fingerprintOffsets FingerprintOffsets
 
@@ -1656,22 +1656,16 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) lookupSymbol(o uint32) (string, error) {
-	r.nameSymbolsMtx.RLock()
-	s, ok := r.nameSymbols[o]
-	r.nameSymbolsMtx.RUnlock()
-
-	if ok {
+	r.nameSymbolsMtx.Lock()
+	defer r.nameSymbolsMtx.Unlock()
+	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
-
 	l, err := r.symbols.Lookup(o)
 	if err != nil {
 		return "", err
 	}
-
-	r.nameSymbolsMtx.Lock()
 	r.nameSymbols[o] = l
-	r.nameSymbolsMtx.Unlock()
 	return l, nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1257,7 +1257,6 @@ type Reader struct {
 	symbols     *Symbols
 	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
-	nameSymbolsMtx sync.Mutex
 
 	fingerprintOffsets FingerprintOffsets
 
@@ -1656,8 +1655,6 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) lookupSymbol(o uint32) (string, error) {
-	r.nameSymbolsMtx.Lock()
-	defer r.nameSymbolsMtx.Unlock()
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1257,6 +1257,7 @@ type Reader struct {
 	symbols     *Symbols
 	nameSymbols map[uint32]string // Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
+	nameSymbolsMtx sync.Mutex
 
 	fingerprintOffsets FingerprintOffsets
 
@@ -1655,6 +1656,8 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) lookupSymbol(o uint32) (string, error) {
+	r.nameSymbolsMtx.Lock()
+	defer r.nameSymbolsMtx.Unlock()
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
@@ -33,7 +33,7 @@ func newIndexShipperQuerier(shipper indexShipperIterator, tableRange config.Tabl
 
 type indexIterFunc func(func(context.Context, Index) error) error
 
-func (i indexIterFunc) For(_ context.Context, f func(context.Context, Index) error) error {
+func (i indexIterFunc) For(_ context.Context, _ int, f func(context.Context, Index) error) error {
 	return i(f)
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -33,6 +33,7 @@ type IndexSlice []Index
 
 func (xs IndexSlice) For(ctx context.Context, fn func(context.Context, Index) error) error {
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(4)
 	for i := range xs {
 		x := xs[i]
 		g.Go(func() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This addresses an issue we've seen with index gateways when handling queries that touch a large number of series, although these are improvements not necessarily solutions.

We've seen a tremendous amount of goroutines being spawned while processing GetChunkRefs requests, specifically when the gateways have recently found a lot of uncompacted recent ingester tables.

This PR puts some limits on the parallelism of processing tables, the implementation is a bit arbitrary, we limit the concurrent iterations to GOMAXPROCS/2

In practice this is potentially still too much as an index gateway will be serving many requests in parallel witch each able to do parallel table iteration, however it's a more reasonable line in the sand than having no limits and eases some pressure on the Go scheduler.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
