### PR TITLE
Index gateway simple mode connection pool

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2029,6 +2029,10 @@ boltdb_shipper:
     [grpc_client_config: <grpc_client>]
 
     # Hostname or IP of the Index Gateway gRPC server running in simple mode.
+    # Can also be prefixed with dns+, dnssrv+, or dnssrvnoa+ to resolve a DNS A
+    # record with multiple IP's, a DNS SRV record with a followup A record
+    # lookup, or a DNS SRV record without a followup A record lookup,
+    # respectively.
     # CLI flag: -boltdb.shipper.index-gateway-client.server-address
     [server_address: <string> | default = ""]
 
@@ -2091,6 +2095,10 @@ tsdb_shipper:
     [grpc_client_config: <grpc_client>]
 
     # Hostname or IP of the Index Gateway gRPC server running in simple mode.
+    # Can also be prefixed with dns+, dnssrv+, or dnssrvnoa+ to resolve a DNS A
+    # record with multiple IP's, a DNS SRV record with a followup A record
+    # lookup, or a DNS SRV record without a followup A record lookup,
+    # respectively.
     # CLI flag: -tsdb.shipper.index-gateway-client.server-address
     [server_address: <string> | default = ""]
 

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
@@ -366,6 +366,11 @@ func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logprot
 	if err != nil {
 		return err
 	}
+
+	if len(addrs) == 0 {
+		return fmt.Errorf("no index gateway instances found for tenant %s", userID)
+	}
+
 	var lastErr error
 	for _, addr := range addrs {
 		if s.cfg.LogGatewayRequests {

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
@@ -6,14 +6,17 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/ring"
 	ring_client "github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,13 +26,16 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/indexgateway"
-	util_log "github.com/grafana/loki/pkg/util/log"
 	util_math "github.com/grafana/loki/pkg/util/math"
 )
 
 const (
 	maxQueriesPerGrpc      = 100
 	maxConcurrentGrpcCalls = 10
+)
+
+var (
+	ErrIndexGatewayDNSLookupTimeout = errors.New("index gateway DNS lookup timeout")
 )
 
 // IndexGatewayClientConfig configures the Index Gateway client used to
@@ -76,7 +82,7 @@ type IndexGatewayClientConfig struct {
 // Flags that are used by both, client and server, are defined in the indexgateway package.
 func (i *IndexGatewayClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	i.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+".grpc", f)
-	f.StringVar(&i.Address, prefix+".server-address", "", "Hostname or IP of the Index Gateway gRPC server running in simple mode.")
+	f.StringVar(&i.Address, prefix+".server-address", "", "Hostname or IP of the Index Gateway gRPC server running in simple mode. Can also be prefixed with dns+, dnssrv+, or dnssrvnoa+ to resolve a DNS A record with multiple IP's, a DNS SRV record with a followup A record lookup, or a DNS SRV record without a followup A record lookup, respectively.")
 	f.BoolVar(&i.LogGatewayRequests, prefix+".log-gateway-requests", false, "Whether requests sent to the gateway should be logged or not.")
 }
 
@@ -85,12 +91,13 @@ func (i *IndexGatewayClientConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 type GatewayClient struct {
+	logger log.Logger
+
 	cfg IndexGatewayClientConfig
 
 	storeGatewayClientRequestDuration *prometheus.HistogramVec
 
-	conn       *grpc.ClientConn
-	grpcClient logproto.IndexGatewayClient
+	dnsProvider *dns.Provider
 
 	pool *ring_client.Pool
 
@@ -101,8 +108,8 @@ type GatewayClient struct {
 
 // NewGatewayClient instantiates a new client used to communicate with an Index Gateway instance.
 //
-// If it is configured to be in ring mode, a pool of GRPC connections to all Index Gateway instances is created.
-// Otherwise, it creates a single GRPC connection to an Index Gateway instance running in simple mode.
+// If it is configured to be in ring mode, a pool of GRPC connections to all Index Gateway instances is created using a ring.
+// Otherwise, it creates a GRPC connection pool to as many addresses which can be resolved from the given address.
 func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, limits indexgateway.Limits, logger log.Logger) (*GatewayClient, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "loki",
@@ -122,6 +129,7 @@ func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, lim
 	}
 
 	sgClient := &GatewayClient{
+		logger:                            logger,
 		cfg:                               cfg,
 		storeGatewayClientRequestDuration: latency,
 		ring:                              cfg.Ring,
@@ -132,36 +140,69 @@ func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, lim
 	if err != nil {
 		return nil, errors.Wrap(err, "index gateway grpc dial option")
 	}
+	factory := func(addr string) (ring_client.PoolClient, error) {
+		igPool, err := NewIndexGatewayGRPCPool(addr, dialOpts)
+		if err != nil {
+			return nil, errors.Wrap(err, "new index gateway grpc pool")
+		}
+
+		return igPool, nil
+	}
 
 	if sgClient.cfg.Mode == indexgateway.RingMode {
-		factory := func(addr string) (ring_client.PoolClient, error) {
-			igPool, err := NewIndexGatewayGRPCPool(addr, dialOpts)
-			if err != nil {
-				return nil, errors.Wrap(err, "new index gateway grpc pool")
-			}
-
-			return igPool, nil
-		}
-
 		sgClient.pool = clientpool.NewPool(cfg.PoolConfig, sgClient.ring, factory, logger)
 	} else {
-		sgClient.conn, err = grpc.Dial(cfg.Address, dialOpts...)
-		if err != nil {
-			return nil, errors.Wrap(err, "index gateway grpc dial")
+		// Note we don't use clientpool.NewPool because we want to provide our own discovery function
+		poolCfg := ring_client.PoolConfig{
+			CheckInterval:      cfg.PoolConfig.ClientCleanupPeriod,
+			HealthCheckEnabled: cfg.PoolConfig.HealthCheckIngesters,
+			HealthCheckTimeout: cfg.PoolConfig.RemoteTimeout,
 		}
+		clients := prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki",
+			Name:      "index_gateway_clients",
+			Help:      "The current number of index gateway clients.",
+		})
+		if r != nil {
+			err := r.Register(clients)
+			if err != nil {
+				alreadyErr, ok := err.(prometheus.AlreadyRegisteredError)
+				if !ok {
+					return nil, err
+				}
+				clients = alreadyErr.ExistingCollector.(prometheus.Gauge)
+			}
+		}
+		//TODO(ewelch) we can't use metrics in the provider because of duplicate registration errors
+		dnsProvider := dns.NewProvider(logger, nil, dns.GolangResolverType)
+		sgClient.dnsProvider = dnsProvider
+		address := []string{cfg.Address}
+		discovery := func() ([]string, error) {
+			ctx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, ErrIndexGatewayDNSLookupTimeout)
+			defer cancel()
+			err := dnsProvider.Resolve(ctx, address)
+			return dnsProvider.Addresses(), err
+		}
+		sgClient.pool = ring_client.NewPool("index gateway", poolCfg, discovery, factory, clients, logger)
 
-		sgClient.grpcClient = logproto.NewIndexGatewayClient(sgClient.conn)
+	}
+
+	// We have to start the pool service, it will handle removing stale clients in the background
+	err = services.StartAndAwaitRunning(context.Background(), sgClient.pool)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start index gateway connection pool")
 	}
 
 	return sgClient, nil
 }
 
 // Stop stops the execution of this gateway client.
-//
-// If it is in simple mode, the single GRPC connection is closed. Otherwise, nothing happens.
 func (s *GatewayClient) Stop() {
-	if s.cfg.Mode == indexgateway.SimpleMode {
-		s.conn.Close()
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, errors.New("service shutdown timeout expired"))
+	defer cancel()
+	err := services.StopAndAwaitTerminated(ctx, s.pool)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "failed to stop index gateway connection pool", "err", err)
 	}
 }
 
@@ -184,93 +225,75 @@ func (s *GatewayClient) QueryIndex(_ context.Context, _ *logproto.QueryIndexRequ
 }
 
 func (s *GatewayClient) GetChunkRef(ctx context.Context, in *logproto.GetChunkRefRequest, opts ...grpc.CallOption) (*logproto.GetChunkRefResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.GetChunkRefResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.GetChunkRef(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.GetChunkRef(ctx, in, opts...)
+	var (
+		resp *logproto.GetChunkRefResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.GetChunkRef(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) GetSeries(ctx context.Context, in *logproto.GetSeriesRequest, opts ...grpc.CallOption) (*logproto.GetSeriesResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.GetSeriesResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.GetSeries(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.GetSeries(ctx, in, opts...)
+	var (
+		resp *logproto.GetSeriesResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.GetSeries(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) LabelNamesForMetricName(ctx context.Context, in *logproto.LabelNamesForMetricNameRequest, opts ...grpc.CallOption) (*logproto.LabelResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.LabelResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.LabelNamesForMetricName(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.LabelNamesForMetricName(ctx, in, opts...)
+	var (
+		resp *logproto.LabelResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.LabelNamesForMetricName(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) LabelValuesForMetricName(ctx context.Context, in *logproto.LabelValuesForMetricNameRequest, opts ...grpc.CallOption) (*logproto.LabelResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.LabelResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.LabelValuesForMetricName(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.LabelValuesForMetricName(ctx, in, opts...)
+	var (
+		resp *logproto.LabelResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.LabelValuesForMetricName(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) GetStats(ctx context.Context, in *logproto.IndexStatsRequest, opts ...grpc.CallOption) (*logproto.IndexStatsResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.IndexStatsResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.GetStats(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.GetStats(ctx, in, opts...)
+	var (
+		resp *logproto.IndexStatsResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.GetStats(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) GetVolume(ctx context.Context, in *logproto.VolumeRequest, opts ...grpc.CallOption) (*logproto.VolumeResponse, error) {
-	if s.cfg.Mode == indexgateway.RingMode {
-		var (
-			resp *logproto.VolumeResponse
-			err  error
-		)
-		err = s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			resp, err = client.GetVolume(ctx, in, opts...)
-			return err
-		})
-		return resp, err
-	}
-	return s.grpcClient.GetVolume(ctx, in, opts...)
+	var (
+		resp *logproto.VolumeResponse
+		err  error
+	)
+	err = s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		resp, err = client.GetVolume(ctx, in, opts...)
+		return err
+	})
+	return resp, err
 }
 
 func (s *GatewayClient) doQueries(ctx context.Context, queries []index.Query, callback index.QueryPagesCallback) error {
@@ -288,13 +311,10 @@ func (s *GatewayClient) doQueries(ctx context.Context, queries []index.Query, ca
 		})
 	}
 
-	if s.cfg.Mode == indexgateway.RingMode {
-		return s.ringModeDo(ctx, func(client logproto.IndexGatewayClient) error {
-			return s.clientDoQueries(ctx, gatewayQueries, queryKeyQueryMap, callback, client)
-		})
-	}
+	return s.poolDo(ctx, func(client logproto.IndexGatewayClient) error {
+		return s.clientDoQueries(ctx, gatewayQueries, queryKeyQueryMap, callback, client)
+	})
 
-	return s.clientDoQueries(ctx, gatewayQueries, queryKeyQueryMap, callback, s.grpcClient)
 }
 
 // clientDoQueries send a query request to an Index Gateway instance using the given gRPC client.
@@ -318,7 +338,7 @@ func (s *GatewayClient) clientDoQueries(ctx context.Context, gatewayQueries []*l
 		}
 		query, ok := queryKeyQueryMap[resp.QueryKey]
 		if !ok {
-			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("unexpected %s QueryKey received, expected queries %s", resp.QueryKey, fmt.Sprint(queryKeyQueryMap)))
+			level.Error(s.logger).Log("msg", fmt.Sprintf("unexpected %s QueryKey received, expected queries %s", resp.QueryKey, fmt.Sprint(queryKeyQueryMap)))
 			return fmt.Errorf("unexpected %s QueryKey received", resp.QueryKey)
 		}
 		if !callback(query, &readBatch{resp}) {
@@ -329,9 +349,9 @@ func (s *GatewayClient) clientDoQueries(ctx context.Context, gatewayQueries []*l
 	return nil
 }
 
-// ringModeDo executes the given function for each Index Gateway instance in the ring mapping to the correct tenant in the index.
+// poolDo executes the given function for each Index Gateway instance in the ring mapping to the correct tenant in the index.
 // In case of callback failure, we'll try another member of the ring for that tenant ID.
-func (s *GatewayClient) ringModeDo(ctx context.Context, callback func(client logproto.IndexGatewayClient) error) error {
+func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logproto.IndexGatewayClient) error) error {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return errors.Wrap(err, "index gateway client get tenant ID")
@@ -343,19 +363,19 @@ func (s *GatewayClient) ringModeDo(ctx context.Context, callback func(client log
 	var lastErr error
 	for _, addr := range addrs {
 		if s.cfg.LogGatewayRequests {
-			level.Debug(util_log.Logger).Log("msg", "sending request to gateway", "gateway", addr, "tenant", userID)
+			level.Debug(s.logger).Log("msg", "sending request to gateway", "gateway", addr, "tenant", userID)
 		}
 
 		genericClient, err := s.pool.GetClientFor(addr)
 		if err != nil {
-			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("failed to get client for instance %s", addr), "err", err)
+			level.Error(s.logger).Log("msg", fmt.Sprintf("failed to get client for instance %s", addr), "err", err)
 			continue
 		}
 
 		client := (genericClient.(logproto.IndexGatewayClient))
 		if err := callback(client); err != nil {
 			lastErr = err
-			level.Error(util_log.Logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
+			level.Error(s.logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
 			continue
 		}
 
@@ -366,13 +386,21 @@ func (s *GatewayClient) ringModeDo(ctx context.Context, callback func(client log
 }
 
 func (s *GatewayClient) getServerAddresses(tenantID string) ([]string, error) {
-	r := indexgateway.GetShuffleShardingSubring(s.ring, tenantID, s.limits)
-	rs, err := r.GetReplicationSetForOperation(indexgateway.IndexesRead)
-	if err != nil {
-		return nil, errors.Wrap(err, "index gateway get ring")
+	var addrs []string
+	// The GRPC pool we use only does discovery calls when cleaning up already existing connections,
+	// so the list of addresses should always be provided from the external provider (ring or DNS)
+	// and not from the RegisteredAddresses method as this list is only populated after a call to GetClientFor
+	if s.cfg.Mode == indexgateway.RingMode {
+		r := indexgateway.GetShuffleShardingSubring(s.ring, tenantID, s.limits)
+		rs, err := r.GetReplicationSetForOperation(indexgateway.IndexesRead)
+		if err != nil {
+			return nil, errors.Wrap(err, "index gateway get ring")
+		}
+		addrs = rs.GetAddresses()
+	} else {
+		addrs = s.dnsProvider.Addresses()
 	}
 
-	addrs := rs.GetAddresses()
 	// shuffle addresses to make sure we don't always access the same Index Gateway instances in sequence for same tenant.
 	rand.Shuffle(len(addrs), func(i, j int) {
 		addrs[i], addrs[j] = addrs[j], addrs[i]

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
@@ -396,6 +396,7 @@ func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logprot
 	}
 
 	if len(addrs) == 0 {
+		level.Error(s.logger).Log("msg", fmt.Sprintf("no index gateway instances found for tenant %s", userID))
 		return fmt.Errorf("no index gateway instances found for tenant %s", userID)
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
@@ -149,6 +149,12 @@ func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, lim
 		return igPool, nil
 	}
 
+	//FIXME(ewelch) we don't expose the pool configs nor set defaults, and register flags is kind of messed up with remote config being defined somewhere else
+	//make a separate PR to make the pool config generic so it can be used with proper names in multiple places.
+	cfg.PoolConfig.RemoteTimeout = 1 * time.Second
+	cfg.PoolConfig.ClientCleanupPeriod = 15 * time.Second
+	cfg.PoolConfig.HealthCheckIngesters = true
+
 	if sgClient.cfg.Mode == indexgateway.RingMode {
 		sgClient.pool = clientpool.NewPool(cfg.PoolConfig, sgClient.ring, factory, logger)
 	} else {

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
@@ -256,16 +256,7 @@ func TestGatewayClient(t *testing.T) {
 	gatewayClient, err := NewGatewayClient(cfg, prometheus.DefaultRegisterer, overrides, logger)
 	require.NoError(t, err)
 
-	// There is kind of a chicken and egg problem with how the pool works in simple mode
-	// A background thread will call the resolve function as part of the code that cleans up
-	// stale connections, so until this runs there are no addresses in the resolver.
-	// To work around that for the test we will just manually resolve the address
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	err = gatewayClient.dnsProvider.Resolve(context.Background(), []string{storeAddress})
-	require.NoError(t, err)
-
-	ctx = user.InjectOrgID(context.Background(), "fake")
+	ctx := user.InjectOrgID(context.Background(), "fake")
 
 	queries := []index.Query{}
 	for i := 0; i < 10; i++ {

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/grafana/loki/pkg/distributor/clientpool"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/indexgateway"
@@ -249,12 +250,22 @@ func TestGatewayClient(t *testing.T) {
 	cfg.Mode = indexgateway.SimpleMode
 	flagext.DefaultValues(&cfg)
 	cfg.Address = storeAddress
+	cfg.PoolConfig = clientpool.PoolConfig{ClientCleanupPeriod: 500 * time.Millisecond}
 
 	overrides, _ := validation.NewOverrides(validation.Limits{}, nil)
 	gatewayClient, err := NewGatewayClient(cfg, prometheus.DefaultRegisterer, overrides, logger)
 	require.NoError(t, err)
 
-	ctx := user.InjectOrgID(context.Background(), "fake")
+	// There is kind of a chicken and egg problem with how the pool works in simple mode
+	// A background thread will call the resolve function as part of the code that cleans up
+	// stale connections, so until this runs there are no addresses in the resolver.
+	// To work around that for the test we will just manually resolve the address
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = gatewayClient.dnsProvider.Resolve(context.Background(), []string{storeAddress})
+	require.NoError(t, err)
+
+	ctx = user.InjectOrgID(context.Background(), "fake")
 
 	queries := []index.Query{}
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of "simple mode" (which does not use the ring for gateway discovery) only makes a single connection at startup to a single query. This doesn't lend to the best load balancing when running with many gateways.

This PR introduces the same pool we use for ring mode with a DNS based discovery mechanism.

Note: outside of the scope of this PR, we create a connection pool per index schema period.  This isn't really a problem but I think it would be better to revisit this some day to only have a single connection pool per querier.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
