### PR TITLE
Force new build of build image

### DIFF
--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -2,7 +2,8 @@
 # pipelines.
 # If you make changes to this Dockerfile you also need to update the
 # tag of the Docker image in `../.drone/drone.jsonnet` and run `make drone`.
-# See ../docs/sources/maintaining/release-loki-build-image.md
+# See ../docs/sources/maintaining/release-loki-build-image.md for instructions
+# on how to publish a new build image.
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
 FROM golang:1.21.2-bullseye as helm


### PR DESCRIPTION
**What this PR does / why we need it**:

Once more with a change to the dockerfile to force a new build of the build image.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
