### PR TITLE
Pin grafana/docs-base image version.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -610,7 +610,7 @@ local manifest_ecr(apps, archs) = pipeline('manifest-ecr') {
       make('check-example-config-doc', container=false) { depends_on: ['clone'] },
       {
         name: 'build-docs-website',
-        image: 'grafana/docs-base:latest',
+        image: 'grafana/docs-base:e6ef023f8b8',
         commands: [
           'mkdir -p /hugo/content/docs/loki/latest',
           'cp -r docs/sources/* /hugo/content/docs/loki/latest/',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -225,7 +225,7 @@ steps:
   - mkdir -p /hugo/content/docs/loki/latest
   - cp -r docs/sources/* /hugo/content/docs/loki/latest/
   - cd /hugo && make prod
-  image: grafana/docs-base:latest
+  image: grafana/docs-base:e6ef023f8b8
   name: build-docs-website
 trigger:
   ref:
@@ -2017,6 +2017,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 054d25b1020b2552c1fd6ad12c32051a86abcfd81faa40678b5a337f8ee61cf7
+hmac: eb7db41065e88938a632f1629701027464c77f0cec6b3a93f39bec2b3dfadbec
 
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we use `grafana/base-docs:latest` which broke our build. We should pin the version to make CI builds reproducible and test version updates.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
