### PR TITLE
Stop using transfer-retries flag

### DIFF
--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -30,12 +30,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   ingester_args::
     $._config.commonArgs {
       target: 'ingester',
-    } + if $._config.stateful_ingesters then
-      {
-        // Disable chunk transfer when using statefulset since ingester which is going down won't find another
-        // ingester which is joining the ring for transferring chunks.
-        'ingester.max-transfer-retries': 0,
-      } else {},
+    },
 
   ingester_ports: $.util.defaultPorts,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of https://github.com/grafana/loki/pull/10844; PR 10844 modifies our jsonnet lib to not use the config anymore but I overlooked the flag being used.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
