### PR TITLE
Remove -ingester.max-transfer-retries

### DIFF
--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -30,12 +30,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   ingester_args::
     $._config.commonArgs {
       target: 'ingester',
-    } + if $._config.stateful_ingesters then
-      {
-        // Disable chunk transfer when using statefulset since ingester which is going down won't find another
-        // ingester which is joining the ring for transferring chunks.
-        'ingester.max-transfer-retries': 0,
-      } else {},
+    },
 
   ingester_ports: $.util.defaultPorts,
 

--- a/production/ksonnet/loki/wal.libsonnet
+++ b/production/ksonnet/loki/wal.libsonnet
@@ -7,9 +7,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     stateful_ingesters: if $._config.wal_enabled then true else super.stateful_ingesters,
     loki+: with({
       ingester+: {
-        // disables transfers when running as statefulsets.
-        // pod rolling stragety will always fail transfers
-        // and the WAL supersedes this.
         wal+: {
           enabled: true,
           dir: '/loki/wal',


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/grafana/loki/pull/10709, we removed `-ingester.max-transfer-retries` in favor of the WAL. Then, in https://github.com/grafana/loki/pull/10844 we removed it from the config file but we did not remove it from the ingester args. This PR solves this by removing it.
