### PR TITLE
jsonnet: add index-gateway headless service

### DIFF
--- a/production/ksonnet/loki/index-gateway.libsonnet
+++ b/production/ksonnet/loki/index-gateway.libsonnet
@@ -69,4 +69,10 @@
   index_gateway_service: if $._config.use_index_gateway then
     k.util.serviceFor($.index_gateway_statefulset, $._config.service_ignored_labels)
   else {},
+
+  index_gateway_headless_service: if $._config.use_index_gateway then
+    k.util.serviceFor($.index_gateway_statefulset, $._config.service_ignored_labels) +
+    service.mixin.metadata.withName('index-gateway-headless') +
+    service.mixin.spec.withClusterIp('None')
+  else {},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In a recent PR we added support for the simple mode in the index gateway client to support a connection pool, a headless service is needed for resolving all the current gateways to be used in the pool

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
