### PR TITLE
Jsonnet: update index gateway client to use headless service, fix a bug in index gateway storage config application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,20 +56,15 @@
 
 #### LogCLI
 
-##### Fixes
-
 #### Mixins
-
-#### Enhancements
 
 #### Fixes
 
 #### FluentD
 
-##### Enhancements
-
 #### Jsonnet
-## Unreleased
+
+* [10784](https://github.com/grafana/loki/pull/10894) **slim-bean** Update index gateway client to use a headless service.
 
 
 

--- a/production/ksonnet/loki/index-gateway.libsonnet
+++ b/production/ksonnet/loki/index-gateway.libsonnet
@@ -8,12 +8,12 @@
       storage_config+: if $._config.use_index_gateway then {
         boltdb_shipper+: {
           index_gateway_client+: {
-            server_address: 'dns:///index-gateway.%s.svc.cluster.local:9095' % $._config.namespace,
+            server_address: 'dns+index-gateway-headless.%s.svc.cluster.local:9095' % $._config.namespace,
           },
         },
         tsdb_shipper+: {
           index_gateway_client+: {
-            server_address: 'dns:///index-gateway.%s.svc.cluster.local:9095' % $._config.namespace,
+            server_address: 'dns+index-gateway-headless.%s.svc.cluster.local:9095' % $._config.namespace,
           },
         },
       } else {},

--- a/production/ksonnet/loki/shipper.libsonnet
+++ b/production/ksonnet/loki/shipper.libsonnet
@@ -30,13 +30,13 @@
           active_index_directory: '/data/index',
           cache_location: '/data/boltdb-cache',
         },
-      } else {} + if $._config.using_tsdb_shipper then {
+      } + if $._config.using_tsdb_shipper then {
         tsdb_shipper+: {
           shared_store: $._config.tsdb_shipper_shared_store,
           active_index_directory: '/data/tsdb-index',
           cache_location: '/data/tsdb-cache',
         },
-      } else {},
+      },
       compactor+: {
         working_directory: '/data/compactor',
         // prefer tsdb index over boltdb


### PR DESCRIPTION
fixes a bug in applying the storage_config for tsdb (the else{} prevented the configs from applying, don't know why.

Updates the index gateway client to use the new headless service.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
