### PR TITLE
feat(logstash): Clients logstash structured metadata support

### DIFF
--- a/clients/cmd/logstash/lib/logstash/outputs/loki/batch.rb
+++ b/clients/cmd/logstash/lib/logstash/outputs/loki/batch.rb
@@ -52,7 +52,19 @@ module Loki
         def build_stream(stream)
             values = []
             stream['entries'].each { |entry|
-                values.append([entry['ts'].to_s, entry['line']])
+                if entry.key?('metadata')
+                    sorted_metadata = entry['metadata'].sort.to_h
+                    values.append([
+                        entry['ts'].to_s,
+                        entry['line'],
+                        sorted_metadata
+                    ])
+                else
+                    values.append([
+                        entry['ts'].to_s,
+                        entry['line']
+                    ])
+                end
             }
             return {
                 'stream'=>stream['labels'],

--- a/clients/cmd/logstash/lib/logstash/outputs/loki/entry.rb
+++ b/clients/cmd/logstash/lib/logstash/outputs/loki/entry.rb
@@ -5,7 +5,7 @@ module Loki
     class Entry
         include Loki
         attr_reader :labels, :entry
-        def initialize(event,message_field,include_fields)
+        def initialize(event,message_field,include_fields,metadata_fields)
             @entry = {
                 "ts" => to_ns(event.get("@timestamp")),
                 "line" => event.get(message_field).to_s
@@ -21,6 +21,22 @@ module Loki
                 next if include_fields.length() > 0 and not include_fields.include?(key)
                 @labels[key] = value.to_s
             }
+
+            # Unlike include_fields we should skip if no metadata_fields provided
+            if metadata_fields.length() > 0
+                @metadata = {}
+                event.to_hash.each { |key,value|
+                    next if key.start_with?('@')
+                    next if value.is_a?(Hash)
+                    next if metadata_fields.length() > 0 and not metadata_fields.include?(key)
+                    @metadata[key] = value.to_s
+                }
+
+                # Add @metadata to @entry if there was a match
+                if @metadata.size > 0
+                    @entry.merge!('metadata' => @metadata)
+                end
+            end
         end
     end
 end

--- a/clients/cmd/logstash/logstash-output-loki.gemspec
+++ b/clients/cmd/logstash/logstash-output-loki.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name    = 'logstash-output-loki'
-  s.version = '1.1.0'
+  s.version = '1.2.0'
   s.authors = ['Aditya C S','Cyril Tovena']
   s.email   = ['aditya.gnu@gmail.com','cyril.tovena@grafana.com']
 

--- a/clients/cmd/logstash/loki-metadata.conf
+++ b/clients/cmd/logstash/loki-metadata.conf
@@ -1,0 +1,15 @@
+input {
+    generator {
+        message => "Hello world!"
+        count => 10
+        add_field => {cluster=> "foo" namespace=>"bar" trace_id=> "trace_001"}
+    }
+}
+
+output {
+  loki {
+    url             => "http://localhost:3100"
+    include_fields  => ["cluster"]
+    metadata_fields => ["trace_id"]
+  }
+}

--- a/clients/cmd/logstash/loki.conf
+++ b/clients/cmd/logstash/loki.conf
@@ -15,6 +15,9 @@ output {
     # If include_fields is set, only fields in this list will be sent to Loki as labels.
     #include_fields => ["service","host","app","env"] #default empty array, all labels included.
 
+    # If metadata_fields is set, fields in this list will be sent to Loki as structured metadata for the associated log.
+    #metadata_fields => ["trace_id"] #default empty array, no structure metadata will be included
+
     #batch_wait => 1 ## in seconds #default 1 second
 
     #batch_size => 102400 #bytes #default 102400 bytes

--- a/clients/cmd/logstash/spec/outputs/loki/entry_spec.rb
+++ b/clients/cmd/logstash/spec/outputs/loki/entry_spec.rb
@@ -21,31 +21,40 @@ describe Loki::Entry do
                         {'@path' => '/path/to/file.log'},
                    },
               'host' => '172.0.0.1',
+              'trace_id' => 'trace_001',
               '@timestamp' => Time.now
             }
         )
       }
 
       it 'labels extracted should not contains object and metadata or timestamp' do
-        entry = Entry.new(event,"message", [])
-        expect(entry.labels).to eql({ 'agent' => 'filebeat', 'host' => '172.0.0.1', 'foo'=>'5'})
+        entry = Entry.new(event,"message", [], [])
+        expect(entry.labels).to eql({ 'agent' => 'filebeat', 'host' => '172.0.0.1', 'foo'=>'5', 'trace_id'=>'trace_001'})
         expect(entry.entry['ts']).to eql to_ns(event.get("@timestamp"))
         expect(entry.entry['line']).to eql 'hello'
       end
 
       it 'labels extracted should only contain allowlisted labels' do
-        entry = Entry.new(event, "message", %w[agent foo])
+        entry = Entry.new(event, "message", %w[agent foo], [])
         expect(entry.labels).to eql({ 'agent' => 'filebeat', 'foo'=>'5'})
         expect(entry.entry['ts']).to eql to_ns(event.get("@timestamp"))
         expect(entry.entry['line']).to eql 'hello'
+      end
+
+      it 'labels and structured metadata extracted should only contain allow listed labels and metadata' do
+        entry = Entry.new(event, "message", %w[agent foo], %w[trace_id])
+        expect(entry.labels).to eql({ 'agent' => 'filebeat', 'foo'=>'5'})
+        expect(entry.entry['ts']).to eql to_ns(event.get("@timestamp"))
+        expect(entry.entry['line']).to eql 'hello'
+        expect(entry.entry['metadata']).to eql({'trace_id' => 'trace_001'})
       end
   end
 
   context 'test batch generation with label order' do
     let (:entries)  {[
-        Entry.new(LogStash::Event.new({"message"=>"foobuzz","buzz"=>"bar","cluster"=>"us-central1","@timestamp"=>Time.at(1)}),"message", []),
-        Entry.new(LogStash::Event.new({"log"=>"foobar","bar"=>"bar","@timestamp"=>Time.at(2)}),"log", []),
-        Entry.new(LogStash::Event.new({"cluster"=>"us-central1","message"=>"foobuzz","buzz"=>"bar","@timestamp"=>Time.at(3)}),"message", []),
+        Entry.new(LogStash::Event.new({"message"=>"foobuzz","buzz"=>"bar","cluster"=>"us-central1","@timestamp"=>Time.at(1)}),"message", [], []),
+        Entry.new(LogStash::Event.new({"log"=>"foobar","bar"=>"bar","@timestamp"=>Time.at(2)}),"log", [], []),
+        Entry.new(LogStash::Event.new({"cluster"=>"us-central1","message"=>"foobuzz","buzz"=>"bar","@timestamp"=>Time.at(3)}),"message", [], []),
 
     ]}
     let (:expected) {

--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -32,6 +32,8 @@ For more information on how to push logs to Loki via the HTTP endpoint, refer to
 Alternatively, you can use the Grafana Agent or Promtail to extract and attach structured metadata to your log lines.
 See the [Promtail: Structured metadata stage]({{< relref "../../send-data/promtail/stages/structured_metadata" >}}) for more information.
 
+Support has been added to the logstash output starting with version 1.2.0.  See [logstash]({{< relref "../../send-data/logstash/_index.md" >}}) for more information.
+
 ## Querying structured metadata
 
 Structured metadata is extracted automatically for each returned log line and added to the labels returned for the query.
@@ -49,7 +51,7 @@ Of course, you can filter by multiple labels of structured metadata at the same 
 {job="example"} | trace_id="0242ac120002" | user_id="superUser123"
 ```
 
-Note that since structured metadata is extracted automatically to the results labels, some metric queries might return 
+Note that since structured metadata is extracted automatically to the results labels, some metric queries might return
 an error like `maximum of series (50000) reached for a single query`. You can use the [Keep]({{< relref "../../query/log_queries#keep-labels-expression" >}}) and [Drop]({{< relref "../../query/log_queries#drop-labels-expression" >}}) stages to filter out labels that you don't need.
 For example:
 

--- a/docs/sources/send-data/logstash/_index.md
+++ b/docs/sources/send-data/logstash/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Logstash plugin
-menuTitle:   
+menuTitle:
 description: Instructions to install, configure, and use the Logstash plugin to send logs to Loki.
-aliases: 
+aliases:
 - ../send-data/a/logstash/
 weight:  800
 ---
@@ -61,8 +61,10 @@ output {
     [tenant_id => string | default = nil | required=false]
 
     [message_field => string | default = "message" | required=false]
-    
+
     [include_fields => array | default = [] | required=false]
+
+    [metadata_fields => array | default = [] | required=false]
 
     [batch_wait => number | default = 1(s) | required=false]
 
@@ -111,8 +113,6 @@ Contains a `message` and `@timestamp` fields, which are respectively used to for
 
 All other fields (except nested fields) will form the label set (key value pairs) attached to the log line. [This means you're responsible for mutating and dropping high cardinality labels](/blog/2020/04/21/how-labels-in-loki-can-make-log-queries-faster-and-easier/) such as client IPs.
 You can usually do so by using a [`mutate`](https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html) filter.
-
-**Note:** In version 1.1.0 and greater of this plugin you can also specify a list of labels to allowlist via the `include_fields` configuration.
 
 For example the configuration below :
 
@@ -194,6 +194,13 @@ filter {
 }
 ```
 
+### Version Notes
+
+Important notes regarding versions:
+
+- Version 1.1.0 and greater of this plugin you can also specify a list of labels to allow list via the `include_fields` configuration.
+- Version 1.2.0 and greater of this plugin you can also specify a structured metadata via the `metadata_fields` configuration.
+
 ### Configuration Properties
 
 #### url
@@ -215,6 +222,10 @@ Message field to use for log lines. You can use logstash key accessor language t
 #### include_fields
 
 An array of fields which will be mapped to labels and sent to Loki, when this list is configured **only** these fields will be sent, all other fields will be ignored.
+
+#### metadata_fields
+
+An array of fields which will be mapped to [structured metadata]({{< relref "../../get-started/labels/structured-metadata.md" >}}) and sent to Loki for each log line
 
 #### batch_wait
 
@@ -246,7 +257,7 @@ Loki is a multi-tenant log storage platform and all requests sent must include a
 
 Specify a pair of client certificate and private key with `cert` and `key` if a reverse proxy with client certificate verification is configured in front of Loki. `ca_cert` can also be specified if the server uses custom certificate authority.
 
-### insecure_skip_verify
+#### insecure_skip_verify
 
 A flag to disable server certificate verification. By default it is set to `false`.
 
@@ -286,6 +297,7 @@ output {
     max_delay => 500
     message_field => "message"
     include_fields => ["container_name","namespace","pod","host"]
+    metadata_fields => ["pod"]
   }
   # stdout { codec => rubydebug }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for Loki Structured Metadata to the logstash output plugin.

**Special notes for your reviewer**:
Given that Structure Metadata is enabled as an experimental feature plugin changes were done in a way that is backward compatible for users not wanted structured metadata.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
