### PR TITLE
docs(promtail): add use_rfc5424_message flag in yaml reference

### DIFF
--- a/docs/sources/send-data/promtail/configuration.md
+++ b/docs/sources/send-data/promtail/configuration.md
@@ -904,6 +904,10 @@ labels:
 # Default is false
 use_incoming_timestamp: <bool>
 
+# Whether to use RFC5424 syslog message standard.
+# Default is false
+use_rfc5424_message: <bool>
+
 # Sets the maximum limit to the length of syslog messages
 max_message_length: <int>
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `use_rfc5424_message` flag in Promtail YAML configuration reference.

**Which issue(s) this PR fixes**:
Fixes #9543 

**Special notes for your reviewer**:
Is `use_rfc5424_message` flag set to `false` by default is intended?

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
