### PR TITLE
Spell out Kubernetes in docs

### DIFF
--- a/docs/sources/community/design-documents/2020-02-Promtail-Push-API.md
+++ b/docs/sources/community/design-documents/2020-02-Promtail-Push-API.md
@@ -60,7 +60,7 @@ rejected pushes. Users are recommended to do one of the following:
 
 1. Have a dedicated Promtail instance for receiving pushes. This also applies to
    using the syslog target.
-1. Have a separatee k8s service that always resolves to the same Promtail pod,
+1. Have a separate Kubernetes service that always resolves to the same Promtail pod,
    bypassing the load balancing issue.
 
 ## Implementation

--- a/docs/sources/send-data/fluentd/_index.md
+++ b/docs/sources/send-data/fluentd/_index.md
@@ -185,7 +185,7 @@ This plugin automatically adds a `fluentd_thread` label with the name of the buf
 
 ### `url`
 
-The URL of the Loki server to send logs to.  When sending data, the publish path (`../reference/api/loki/v1/push`) will automatically be appended.
+The URL of the Loki server to send logs to. When sending data, the publish path (`../reference/api/loki/v1/push`) will automatically be appended.
 By default the url is set to `https://logs-prod-us-central1.grafana.net`, the url of the Grafana Labs [hosted Loki](/products/cloud/) service.
 
 #### Proxy Support
@@ -199,10 +199,10 @@ If using the GrafanaLab's hosted Loki, the username needs to be set to your inst
 
 ### tenant
 
-All requests sent to Loki, a multi-tenant log storage platform, must include a tenant.  For some installations the tenant will be set automatically by an authenticating proxy.  Otherwise you can define a tenant to be passed through.
+All requests sent to Loki, a multi-tenant log storage platform, must include a tenant. For some installations the tenant will be set automatically by an authenticating proxy. Otherwise you can define a tenant to be passed through.
 The tenant can be any string value.
 
-The tenant field also supports placeholders, allowing it to dynamically change based on tag and record fields. Each placeholder must be added as a buffer chunk key. The following is an example of setting the tenant based on a k8s pod label:
+The tenant field also supports placeholders, allowing it to dynamically change based on tag and record fields. Each placeholder must be added as a buffer chunk key. The following is an example of setting the tenant based on a Kubernetes pod label:
 
 ```conf
 <match **>
@@ -253,7 +253,7 @@ A flag to disable server certificate verification. By default the `insecure_tls`
 
 ### Output format
 
-Loki is intended to index and group log streams using only a small set of labels.  It is not intended for full-text indexing.  When sending logs to Loki the majority of log message will be sent as a single log "line".
+Loki is intended to index and group log streams using only a small set of labels. It is not intended for full-text indexing. When sending logs to Loki the majority of log message will be sent as a single log "line".
 
 Several configuration settings are available to control the output format.
 

--- a/docs/sources/send-data/promtail/cloud/gcp/_index.md
+++ b/docs/sources/send-data/promtail/cloud/gcp/_index.md
@@ -273,7 +273,7 @@ We also exclude specific HTTP load balancer logs based on payload and status cod
 
 ```
 $ gcloud logging sinks create cloud-logs pubsub.googleapis.com/projects/my-project/topics/cloud-logs \
---log-filter='resource.type=("gcs_bucket OR k8s_cluster OR service_account OR iam_role OR api OR audited_resource OR http_load_balancer")' \
+--log-filter='resource.type=("gcs_bucket OR Kubernetes_cluster OR service_account OR iam_role OR api OR audited_resource OR http_load_balancer")' \
 --description="Cloud logs" \
 --exclusion='name=http_load_balancer,filter=<<EOF
 resource.type="http_load_balancer"

--- a/docs/sources/send-data/promtail/cloud/gcp/_index.md
+++ b/docs/sources/send-data/promtail/cloud/gcp/_index.md
@@ -273,7 +273,7 @@ We also exclude specific HTTP load balancer logs based on payload and status cod
 
 ```
 $ gcloud logging sinks create cloud-logs pubsub.googleapis.com/projects/my-project/topics/cloud-logs \
---log-filter='resource.type=("gcs_bucket OR Kubernetes_cluster OR service_account OR iam_role OR api OR audited_resource OR http_load_balancer")' \
+--log-filter='resource.type=("gcs_bucket OR k8s_cluster OR service_account OR iam_role OR api OR audited_resource OR http_load_balancer")' \
 --description="Cloud logs" \
 --exclusion='name=http_load_balancer,filter=<<EOF
 resource.type="http_load_balancer"

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -266,11 +266,11 @@ ruler:
 
 ### Querier
 
-#### query-frontend k8s headless service changed to load balanced service
+#### query-frontend Kubernetes headless service changed to load balanced service
 
 *Note:* This is relevant only if you are using [jsonnet for deploying Loki in Kubernetes](/docs/loki/latest/installation/tanka/)
 
-The `query-frontend` k8s service was previously headless and was used for two purposes:
+The `query-frontend` Kubernetes service was previously headless and was used for two purposes:
 * Distributing the Loki query requests amongst all the available Query Frontend pods.
 * Discover IPs of Query Frontend pods from Queriers to connect as workers.
 
@@ -278,7 +278,7 @@ The problem here is that a headless service does not support load balancing and 
 Additionally, a load-balanced service does not let us discover the IPs of the underlying pods.
 
 To meet both these requirements, we have made the following changes:
-* Changed the existing `query-frontend` k8s service from headless to load-balanced to have a fair load distribution on all the Query Frontend instances.
+* Changed the existing `query-frontend` Kubernetes service from headless to load-balanced to have a fair load distribution on all the Query Frontend instances.
 * Added `query-frontend-headless` to discover QF pod IPs from queriers to connect as workers.
 
 If you are deploying Loki with Query Scheduler by setting [query_scheduler_enabled](https://github.com/grafana/loki/blob/cc4ab7487ab3cd3b07c63601b074101b0324083b/production/ksonnet/loki/config.libsonnet#L18) config to `true`, then there is nothing to do here for this change.
@@ -1094,7 +1094,7 @@ and the Kubelet.
 This commit adds the same to the Loki scrape config. It also removes
 the container_name label. It is the same as the container label
 and was already added to Loki previously. However, the
-container_name label is deprecated and has disappeared in K8s 1.16,
+container_name label is deprecated and has disappeared in Kubernetes 1.16,
 so that it will soon become useless for direct joining.
 ````
 


### PR DESCRIPTION
Developers tend to abbreviate "Kubernetes" to just K8, but as a best practice it should be spelled out in the documentation.
