### PR TITLE
[release-2.8.x] update build image to use go1.20.10

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: clone-target-branch
   when:
     event:
@@ -121,7 +121,7 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: test
 - commands:
   - cd ../loki-target-branch
@@ -129,7 +129,7 @@ steps:
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: test-target-branch
   when:
     event:
@@ -142,7 +142,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: compare-coverage
   when:
     event:
@@ -160,7 +160,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: report-coverage
   when:
     event:
@@ -170,7 +170,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -178,7 +178,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -189,28 +189,28 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false validate-example-configs
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -243,7 +243,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: loki-mixin-check
   when:
     event:
@@ -268,7 +268,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1431,7 +1431,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1439,7 +1439,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1465,7 +1465,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: publish
   when:
     event:
@@ -1500,7 +1500,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.29.3-golangci.1.51.2
+  image: grafana/loki-build-image:0.29.3-go1.20.10
   name: build and push
   privileged: true
   volumes:
@@ -1765,6 +1765,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: a390d78bcf16c83fec281e7e06e144e73f376d9fe221683017907d345311be74
+hmac: ad5a4e4a80718da3bdb6725694ef96c7c274c1cd1eb70bd630bf9491f85fff8d
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.29.3-golangci.1.51.2
+BUILD_IMAGE_VERSION := 0.29.3-go1.20.10
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
+++ b/clients/pkg/promtail/targets/syslog/syslogtarget_test.go
@@ -757,7 +757,7 @@ func testSyslogTargetWithTLSVerifyClientCertificate(t *testing.T, fmtFunc format
 
 		buf := make([]byte, 1)
 		_, err = c.Read(buf)
-		require.EqualError(t, err, "remote error: tls: certificate required")
+		require.EqualError(t, err, "remote error: tls: bad certificate")
 	})
 
 	t.Run("WithClientCertificate", func(t *testing.T) {

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,7 +5,7 @@
 # See ../docs/sources/maintaining/release-loki-build-image.md
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
-FROM golang:1.20.6-bullseye as helm
+FROM golang:1.20.10-bullseye as helm
 ARG HELM_VER="v3.2.3"
 RUN curl -L -o /tmp/helm-$HELM_VER.tgz https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz && \
     tar -xz -C /tmp -f /tmp/helm-$HELM_VER.tgz && \
@@ -38,7 +38,7 @@ RUN apk add --no-cache docker-cli
 # TODO this should be fixed to download and extract the specific release binary from github as we do for golangci and helm above
 # however we need a commit which hasn't been released yet: https://github.com/drone/drone-cli/commit/1fad337d74ca0ecf420993d9d2d7229a1c99f054
 # Read the comment below regarding GO111MODULE=on and why it is necessary
-FROM golang:1.20.6-bullseye as drone
+FROM golang:1.20.10-bullseye as drone
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
 
@@ -47,32 +47,32 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.4.0/drone_li
 # Error:
 # github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM golang:1.20.6-bullseye as faillint
+FROM golang:1.20.10-bullseye as faillint
 RUN GO111MODULE=on go install github.com/fatih/faillint@v1.11.0
 
-FROM golang:1.20.6-bullseye as delve
+FROM golang:1.20.10-bullseye as delve
 RUN GO111MODULE=on go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install ghr used to push binaries and template the release
 # This collides with the version of go tools used in the base image, thus we install it in its own image and copy it over.
-FROM golang:1.20.6-bullseye as ghr
+FROM golang:1.20.10-bullseye as ghr
 RUN GO111MODULE=on go install github.com/tcnksm/ghr@9349474
 
 # Install nfpm (https://nfpm.goreleaser.com) for creating .deb and .rpm packages.
-FROM golang:1.20.6-bullseye as nfpm
+FROM golang:1.20.10-bullseye as nfpm
 RUN GO111MODULE=on go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.11.3
 
 # Install gotestsum
-FROM golang:1.20.6-bullseye as gotestsum
+FROM golang:1.20.10-bullseye as gotestsum
 RUN GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2
 
 # Install tools used to compile jsonnet.
-FROM golang:1.20.6-bullseye as jsonnet
+FROM golang:1.20.10-bullseye as jsonnet
 RUN GO111MODULE=on go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 RUN GO111MODULE=on go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066
 RUN GO111MODULE=on go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
 
-FROM golang:1.20.6-bullseye
+FROM golang:1.20.10-bullseye
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg ragel \


### PR DESCRIPTION
**What this PR does / why we need it**:
`loki-build-image:0.29.3-go1.20.10` that uses go1.20.10 is published.
pr updates drone to use the updated build image on the release branch

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
