### PR TITLE
modules: add dependency on server for bloom compactor ring

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -631,6 +631,7 @@ func (t *Loki) setupModuleManager() error {
 		Compactor:                {Server, Overrides, MemberlistKV, Analytics},
 		IndexGateway:             {Server, Store, IndexGatewayRing, IndexGatewayInterceptors, Analytics},
 		BloomGateway:             {Server, BloomGatewayRing, Analytics},
+		BloomCompactorRing:       {Server},
 		BloomCompactor:           {Server, BloomCompactorRing, Analytics},
 		IngesterQuerier:          {Ring},
 		QuerySchedulerRing:       {Overrides, MemberlistKV},


### PR DESCRIPTION
**What this PR does / why we need it**:

bloom compactor ring relies on the [server](https://github.com/grafana/loki/blob/d1a7d9b86097c6dcf21181739fa6bc1ffa028054/pkg/loki/modules.go#L1371), initing the ring before the server is up would result in a panic. This pr adds server as a dependency for bloom compactor ring

fixes flaky test `TestIndexGatewayRingMode_when_TargetIsLegacyReadOrBackend` that was running into panics

```
panic({0x102ff9f40?, 0x104974530?})                                                                                                                                                   [240/9420]
        /opt/homebrew/Cellar/go/1.21.2/libexec/src/runtime/panic.go:914 +0x218
github.com/grafana/loki/pkg/loki.(*Loki).initBloomCompactorRing(0x140008ea000)
        /Users/grafana/Workspace/loki/pkg/loki/modules.go:1371 +0xd4
github.com/grafana/dskit/modules.(*Manager).initModule(0x1400000e438, {0x1025a7e90, 0x4}, 0x1031c3340?, 0x14000abf818?)
        /Users/grafana/Workspace/loki/vendor/github.com/grafana/dskit/modules/modules.go:136 +0x1a4
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
