### PR TITLE
config: Change default value of `query_ready_index_num_days` to 7

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2751,10 +2751,10 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # CLI flag: -frontend.max-queriers-per-tenant
 [max_queriers_per_tenant: <int> | default = 0]
 
-# Number of days of index to be kept always downloaded for queries. Applies only
-# to per user index in boltdb-shipper index store. 0 to disable.
+# Number of days of index to be kept always downloaded for queries. 0 to
+# disable.
 # CLI flag: -store.query-ready-index-num-days
-[query_ready_index_num_days: <int> | default = 0]
+[query_ready_index_num_days: <int> | default = 10]
 
 # Timeout when querying backends (ingesters or storage) during the execution of
 # a query request. When a specific per-tenant timeout is used, the global

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -2754,7 +2754,7 @@ The `limits_config` block configures global and per-tenant limits in Loki.
 # Number of days of index to be kept always downloaded for queries. 0 to
 # disable.
 # CLI flag: -store.query-ready-index-num-days
-[query_ready_index_num_days: <int> | default = 10]
+[query_ready_index_num_days: <int> | default = 7]
 
 # Timeout when querying backends (ingesters or storage) during the execution of
 # a query request. When a specific per-tenant timeout is used, the global

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -47,9 +47,9 @@ The previous default value `false` is applied.
 
 #### Deprecated configuration options are removed
 
-1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting. 
+1. Removes already deprecated `-querier.engine.timeout` CLI flag and the corresponding YAML setting.
 1. Also removes the `query_timeout` from the querier YAML section. Instead of configuring `query_timeout` under `querier`, you now configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
-1. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type. 
+1. `s3.sse-encryption` is removed. AWS now defaults encryption of all buckets to SSE-S3. Use `sse.type` to set SSE type.
 1. `ruler.wal-cleaer.period` is removed. Use `ruler.wal-cleaner.period` instead.
 1. `experimental.ruler.enable-api` is removed. Use `ruler.enable-api` instead.
 1. `split_queries_by_interval` is removed from `query_range` YAML section. You can instead configure it in [Limits Config](/docs/loki/latest/configuration/#limits_config).
@@ -97,6 +97,7 @@ This new metric will provide a more clear signal that there is an issue with ing
 | `querier.tsdb-max-query-parallelism`                   | 128         | 512         | - |
 | `query-scheduler.max-outstanding-requests-per-tenant`  | 32000       | 100         | - |
 | `validation.max-label-names-per-series`                | 15          | 30          | - |
+| `-store.query-ready-index-num-days    `                | 7           | 0           | - | Now by default, we make sure 7 days of indexes are pre-fetched both during startup and every `shipper.resync-interval`
 {{% /responsive-table %}}
 
 #### Write dedupe cache is deprecated

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -271,7 +271,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.MaxStatsCacheFreshness, "frontend.max-stats-cache-freshness", "Do not cache requests with an end time that falls within Now minus this duration. 0 disables this feature (default).")
 
 	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
-	f.IntVar(&l.QueryReadyIndexNumDays, "store.query-ready-index-num-days", 0, "Number of days of index to be kept always downloaded for queries. Applies only to per user index in boltdb-shipper index store. 0 to disable.")
+	f.IntVar(&l.QueryReadyIndexNumDays, "store.query-ready-index-num-days", 10, "Number of days of index to be kept always downloaded for queries. 0 to disable.")
 
 	_ = l.RulerEvaluationDelay.Set("0s")
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Deprecated. Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -271,7 +271,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.MaxStatsCacheFreshness, "frontend.max-stats-cache-freshness", "Do not cache requests with an end time that falls within Now minus this duration. 0 disables this feature (default).")
 
 	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
-	f.IntVar(&l.QueryReadyIndexNumDays, "store.query-ready-index-num-days", 10, "Number of days of index to be kept always downloaded for queries. 0 to disable.")
+	f.IntVar(&l.QueryReadyIndexNumDays, "store.query-ready-index-num-days", 7, "Number of days of index to be kept always downloaded for queries. 0 to disable.")
 
 	_ = l.RulerEvaluationDelay.Set("0s")
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Deprecated. Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")


### PR DESCRIPTION
**What this PR does / why we need it**:
Rationale being to have sane default value for this config going forward. worth noting having default value 0 caused some issues in the past.

Also updates the doc, removing the assumption it can only be used with boltdb shipper index store.

**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:
Related issues and PR
https://github.com/grafana/loki/pull/10587

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added

