### PR TITLE
add loong64 support && fix bug

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/boltdb/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/table.go
@@ -110,7 +110,7 @@ func (lt *Table) Snapshot() error {
 		level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("checking db %s for snapshot", name))
 		srcWriteCount := 0
 		err := db.View(func(tx *bbolt.Tx) error {
-			srcWriteCount = db.Stats().TxStats.Write
+			srcWriteCount = int(db.Stats().TxStats.Write)
 			return nil
 		})
 		if err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/table.go
@@ -110,7 +110,7 @@ func (lt *Table) Snapshot() error {
 		level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("checking db %s for snapshot", name))
 		srcWriteCount := 0
 		err := db.View(func(tx *bbolt.Tx) error {
-			srcWriteCount = int(db.Stats().TxStats.Write)
+			srcWriteCount = db.Stats().TxStats.Write
 			return nil
 		})
 		if err != nil {

--- a/vendor/go.etcd.io/bbolt/bolt_loong64.go
+++ b/vendor/go.etcd.io/bbolt/bolt_loong64.go
@@ -1,0 +1,10 @@
+//go:build loong64
+// +build loong64
+
+package bbolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #10964 

**Special notes for your reviewer**:
add loongarch support 
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
