### PR TITLE
clients: update fluentd base container

### DIFF
--- a/clients/cmd/fluentd/Dockerfile
+++ b/clients/cmd/fluentd/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/loki
 WORKDIR /src/loki
 RUN make BUILD_IN_CONTAINER=false fluentd-plugin
 
-FROM fluent/fluentd:v1.14.0-debian-1.0
+FROM fluent/fluentd:v1.16-debian-1
 ENV LOKI_URL "https://logs-prod-us-central1.grafana.net"
 
 COPY --from=build /src/loki/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb /fluentd/plugins/out_loki.rb


### PR DESCRIPTION
1.14.0 is over 2 years old and the latest 1.16 continues to work just fine with loki