### PR TITLE
add scan-vulnerabilities make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ pkg/loki/wal
 
 # nix
 nix/result
+
+# snyk
+.dccache

--- a/Makefile
+++ b/Makefile
@@ -831,5 +831,14 @@ dev-k3d-down:
 	$(MAKE) -C $(CURDIR)/tools/dev/k3d down
 
 # Trivy is used to scan images for vulnerabilities
+.PHONY: trivy
 trivy: loki-image
 	trivy i $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+
+# Synk is also used to scan for vulnerabilities, and detects things that trivy might miss
+.PHONY: snyk
+snyk: loki-image
+	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+
+.PHONY: scan-vulnerabilities
+scan-vulnerabilities: trivy snyk

--- a/Makefile
+++ b/Makefile
@@ -839,6 +839,7 @@ trivy: loki-image
 .PHONY: snyk
 snyk: loki-image
 	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG)
+	snyk code test
 
 .PHONY: scan-vulnerabilities
 scan-vulnerabilities: trivy snyk


### PR DESCRIPTION
**What this PR does / why we need it**:
 
Adds a make file target for running both trivy and snyk to scan our images for vulnerabilities during/before releases.