### PR TITLE
LRU Cache wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,7 @@ require (
 	golang.org/x/text v0.13.0
 	google.golang.org/protobuf v1.31.0
 	k8s.io/apimachinery v0.28.1
+	k8s.io/utils v0.0.0-20230711102312-30195339c3c7
 )
 
 require (
@@ -324,7 +325,6 @@ require (
 	k8s.io/client-go v0.28.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230711102312-30195339c3c7 // indirect
 	rsc.io/binaryregexp v0.2.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect

--- a/pkg/util/cache/lru/lru.go
+++ b/pkg/util/cache/lru/lru.go
@@ -1,0 +1,70 @@
+package lru
+
+import (
+	"fmt"
+
+	lru_hashicorp "github.com/hashicorp/golang-lru"
+	"k8s.io/utils/keymutex"
+)
+
+func defaultKeyStringifier[K comparable](key K) string {
+	return fmt.Sprintf("%+v", key)
+}
+
+// Cache is a simple LRU cache wrapper that locks the key until the value supplier provides the value.
+// It can be used if it's necessary to make sure the value for the key was created/fetched only once even during concurrent access.
+type Cache[K comparable, V any] struct {
+	delegate       *lru_hashicorp.Cache
+	onKeyMissing   func(key K) (V, error)
+	keyLock        keymutex.KeyMutex
+	keyStringifier func(K) string
+}
+
+type valueSupplier[K comparable, V any] func(key K) (V, error)
+
+func NewCache[K comparable, V any](
+	size int,
+	onKeyMissing valueSupplier[K, V],
+	onEvicted func(key K, value V),
+) (*Cache[K, V], error) {
+	var onEvictedAdapter func(key, val any)
+	if onEvicted != nil {
+		onEvictedAdapter = func(key, val any) {
+			onEvicted(key.(K), val.(V))
+		}
+	}
+	c, err := lru_hashicorp.NewWithEvict(size, onEvictedAdapter)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LRU cache: %w", err)
+	}
+	return &Cache[K, V]{
+		delegate:       c,
+		onKeyMissing:   onKeyMissing,
+		keyLock:        keymutex.NewHashed(size),
+		keyStringifier: defaultKeyStringifier[K],
+	}, nil
+}
+
+func (c *Cache[K, V]) Get(key K) (V, error) {
+	value, ok := c.delegate.Get(key)
+	if ok {
+		return value.(V), nil
+	}
+
+	keyString := c.keyStringifier(key)
+	c.keyLock.LockKey(keyString)
+	defer func(keyLock keymutex.KeyMutex, keyString string) {
+		_ = keyLock.UnlockKey(keyString)
+	}(c.keyLock, keyString)
+	value, ok = c.delegate.Get(key)
+	if ok {
+		return value.(V), nil
+	}
+
+	value, err := c.onKeyMissing(key)
+	if err != nil {
+		return value.(V), fmt.Errorf("can not get the value for the key:'%v' due to error: %w", key, err)
+	}
+	c.delegate.Add(key, value)
+	return value.(V), nil
+}

--- a/pkg/util/cache/lru/lru_test.go
+++ b/pkg/util/cache/lru/lru_test.go
@@ -1,0 +1,170 @@
+package lru
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/bloomshipper"
+)
+
+var (
+	noopValueSupplier = func(key string) (string, error) {
+		return key, nil
+	}
+	noopEviction = func(key, value string) {}
+)
+
+func Test_Cache(t *testing.T) {
+	t.Run("cache must be created without error", func(t *testing.T) {
+		cache, err := NewCache[string, string](1, noopValueSupplier, noopEviction)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+	})
+	t.Run("expected error if cache size less than 1", func(t *testing.T) {
+		cache, err := NewCache[string, string](0, noopValueSupplier, noopEviction)
+		require.ErrorContains(t, err, "error creating LRU cache: must provide a positive size")
+		require.Nil(t, cache)
+	})
+
+	t.Run("expected error if value supplier returns error", func(t *testing.T) {
+		mockValueSupplier := func(key string) (string, error) {
+			return key, fmt.Errorf("error from value supplier")
+		}
+		cache, err := NewCache[string, string](1, mockValueSupplier, noopEviction)
+		require.NoError(t, err)
+		_, err = cache.Get("word")
+		require.ErrorContains(t, err, "can not get the value for the key:'word' due to error: error from value supplier")
+	})
+
+	t.Run("expected eviction function to be called", func(t *testing.T) {
+		mockCallsCount := 0
+		mockEvictionFunc := func(key, value string) {
+			mockCallsCount++
+		}
+		cache, err := NewCache[string, string](1, noopValueSupplier, mockEvictionFunc)
+		require.NoError(t, err)
+		for i := 0; i < 10; i++ {
+			_, err = cache.Get(fmt.Sprintf("word-%d", i))
+			require.NoError(t, err)
+		}
+		require.Equal(t, 9, mockCallsCount, "case size is 1, so the rest 9 keys must be evicted")
+	})
+
+	t.Run("value supplier must be called if value is not cached", func(t *testing.T) {
+		mockCallsCount := atomic.NewInt32(0)
+		mockValueSupplier := func(key string) (string, error) {
+			mockCallsCount.Inc()
+			return key, nil
+		}
+		cache, err := NewCache[string, string](1, mockValueSupplier, noopEviction)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+		fromCache, err := cache.Get("word")
+		require.NoError(t, err)
+		require.Equal(t, "word", fromCache)
+		require.Equal(t, int32(1), mockCallsCount.Load())
+	})
+
+	t.Run("value supplier must be called only once", func(t *testing.T) {
+		mockCallsCount := atomic.NewInt32(0)
+		mockValueSupplier := func(key string) (string, error) {
+			mockCallsCount.Inc()
+			return key, nil
+		}
+		cache, err := NewCache[string, string](1, mockValueSupplier, noopEviction)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+		group, _ := errgroup.WithContext(context.Background())
+		for i := 0; i < 100; i++ {
+			group.Go(func() error {
+				_, err := cache.Get("word")
+				return err
+			})
+		}
+		err = group.Wait()
+		require.NoError(t, err)
+		require.Equal(t, int32(1), mockCallsCount.Load())
+	})
+
+	t.Run("value supplier must be called only once even if key is a struct", func(t *testing.T) {
+		mockCallsCount := atomic.NewInt32(0)
+		mockValueSupplier := func(block bloomshipper.BlockRef) (string, error) {
+			mockCallsCount.Inc()
+			return "data for the block", nil
+		}
+		cache, err := NewCache[bloomshipper.BlockRef, string](1, mockValueSupplier, func(key bloomshipper.BlockRef, value string) {})
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+		group, _ := errgroup.WithContext(context.Background())
+		for i := 0; i < 100; i++ {
+			group.Go(func() error {
+				_, err := cache.Get(bloomshipper.BlockRef{
+					Ref: bloomshipper.Ref{
+						TenantID:       "fake",
+						TableName:      "19",
+						MinFingerprint: 0xaa,
+						MaxFingerprint: 0xff,
+						StartTimestamp: 100,
+						EndTimestamp:   300,
+						Checksum:       0xab,
+					},
+					IndexPath: "IndexPath",
+					BlockPath: "BlockPath",
+				})
+				return err
+			})
+		}
+		err = group.Wait()
+		require.NoError(t, err)
+		require.Equal(t, int32(1), mockCallsCount.Load())
+	})
+
+	t.Run("value supplier must be called each time if value supplier returns an error", func(t *testing.T) {
+		mockCallsCount := atomic.NewInt32(0)
+		mockValueSupplier := func(key string) (string, error) {
+			mockCallsCount.Inc()
+			return "", fmt.Errorf("error")
+		}
+		cache, err := NewCache[string, string](1, mockValueSupplier, noopEviction)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+		for i := 0; i < 100; i++ {
+			_, err = cache.Get("word")
+			require.Error(t, err)
+		}
+		require.Equal(t, int32(100), mockCallsCount.Load())
+	})
+
+	t.Run("other calls to the cache must not be blocked if value supplier is called for a different keys", func(t *testing.T) {
+		mockCallsCount := atomic.NewInt32(0)
+		mockValueSupplier := func(key string) (string, error) {
+			mockCallsCount.Inc()
+			time.Sleep(100 * time.Millisecond)
+			return key, nil
+		}
+		cache, err := NewCache[string, string](10, mockValueSupplier, noopEviction)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+		start := time.Now()
+		group, _ := errgroup.WithContext(context.Background())
+		for i := 0; i < 100; i++ {
+			current := i
+			group.Go(func() error {
+				_, err := cache.Get(fmt.Sprintf("word-%d", current%10))
+				return err
+			})
+		}
+		err = group.Wait()
+		require.NoError(t, err)
+		require.Equal(t, int32(10), mockCallsCount.Load(), "value supplier must be called 10 time because there are only 10 unique keys")
+		actualDuration := time.Since(start)
+		require.LessOrEqual(t, actualDuration, 200*time.Millisecond, "value suppliers must be called in parallel, so they must complete within 100ms. added 2x just to make the test stable")
+	})
+
+}

--- a/vendor/k8s.io/utils/keymutex/hashed.go
+++ b/vendor/k8s.io/utils/keymutex/hashed.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+import (
+	"hash/fnv"
+	"runtime"
+	"sync"
+)
+
+// NewHashed returns a new instance of KeyMutex which hashes arbitrary keys to
+// a fixed set of locks. `n` specifies number of locks, if n <= 0, we use
+// number of cpus.
+// Note that because it uses fixed set of locks, different keys may share same
+// lock, so it's possible to wait on same lock.
+func NewHashed(n int) KeyMutex {
+	if n <= 0 {
+		n = runtime.NumCPU()
+	}
+	return &hashedKeyMutex{
+		mutexes: make([]sync.Mutex, n),
+	}
+}
+
+type hashedKeyMutex struct {
+	mutexes []sync.Mutex
+}
+
+// Acquires a lock associated with the specified ID.
+func (km *hashedKeyMutex) LockKey(id string) {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
+}
+
+// Releases the lock associated with the specified ID.
+func (km *hashedKeyMutex) UnlockKey(id string) error {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Unlock()
+	return nil
+}
+
+func (km *hashedKeyMutex) hash(id string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(id))
+	return h.Sum32()
+}

--- a/vendor/k8s.io/utils/keymutex/keymutex.go
+++ b/vendor/k8s.io/utils/keymutex/keymutex.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+// KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.
+type KeyMutex interface {
+	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
+	LockKey(id string)
+
+	// Releases the lock associated with the specified ID.
+	// Returns an error if the specified ID doesn't exist.
+	UnlockKey(id string) error
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2177,6 +2177,7 @@ k8s.io/utils/clock
 k8s.io/utils/clock/testing
 k8s.io/utils/integer
 k8s.io/utils/internal/third_party/forked/golang/net
+k8s.io/utils/keymutex
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a simple LRU cache wrapper that locks the key until the value supplier provides the value
It will be used as a bloom-blocks cache that will provide guarantees that the block is downloaded only once.
