### PR TITLE
Recover querier handler from panic.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -507,7 +507,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	svc, err := querier.InitWorkerService(
 		querierWorkerServiceConfig,
 		prometheus.DefaultRegisterer,
-		handler,
+		serverutil.RecoveryMiddleware.Wrap(handler),
 		t.Codec,
 	)
 	if err != nil {

--- a/pkg/util/server/recovery_test.go
+++ b/pkg/util/server/recovery_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
 )
 
 func Test_onPanic(t *testing.T) {
@@ -32,6 +34,13 @@ func Test_onPanic(t *testing.T) {
 		panic("foo")
 	}))
 	require.Error(t, err)
+
+	_, err = RecoveryMiddleware.
+		Wrap(queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (res queryrangebase.Response, err error) {
+			panic("foo")
+		})).
+		Do(context.Background(), nil)
+	require.ErrorContains(t, err, "foo")
 }
 
 type fakeStream struct{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Commit 56437fa0c44efae3727f05972ab1d7e54ef59f64 introduced a querier handler that would work without an HTTP layer. This removed the HTTP recovery middleware that would catch panics and return them as HTTP 500 errors. This change introduces a new middlware for the querier handler that has the same behviour.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->