### PR TITLE
compactor: pick index storage client from index storage config

### DIFF
--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -245,6 +245,6 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			_, err = gw.FilterChunkRefs(ctx, req)
 			require.NoError(t, err)
 		}
-		require.Equal(t, tenants, gw.activeUsers.ActiveUsers())
+		require.ElementsMatch(t, tenants, gw.activeUsers.ActiveUsers())
 	})
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -769,3 +769,21 @@ func NewObjectClient(name string, cfg Config, clientMetrics ClientMetrics) (clie
 		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: %v, %v, %v, %v, %v, %v, %v, %v, %v", name, config.StorageTypeAWS, config.StorageTypeS3, config.StorageTypeGCS, config.StorageTypeAzure, config.StorageTypeAlibabaCloud, config.StorageTypeSwift, config.StorageTypeBOS, config.StorageTypeCOS, config.StorageTypeFileSystem)
 	}
 }
+
+// NewIndexObjectClient makes a new StorageClient based on the SharedStoreType storage config.
+func NewIndexObjectClient(periodCfg config.PeriodConfig, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
+	objectType := periodCfg.ObjectType
+
+	switch periodCfg.IndexType {
+	case config.BoltDBShipperType:
+		if cfg.BoltDBShipperConfig.SharedStoreType != "" {
+			objectType = cfg.BoltDBShipperConfig.SharedStoreType
+		}
+	case config.TSDBType:
+		if cfg.TSDBShipperConfig.SharedStoreType != "" {
+			objectType = cfg.TSDBShipperConfig.SharedStoreType
+		}
+	}
+
+	return NewObjectClient(objectType, cfg, clientMetrics)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
indexStorageClient should be picked from shared_store of the index storage config.

**Which issue(s) this PR fixes**:
Fixes #10985 