### PR TITLE
WIP: Make metrics prefix configurable

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	// Create a new registerer to avoid registering duplicate metrics
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	clientMetrics := storage.NewClientMetrics()
+	clientMetrics := storage.NewClientMetrics("loki")
 	s, err := storage.NewStore(sourceConfig.StorageConfig, sourceConfig.ChunkStoreConfig, sourceConfig.SchemaConfig, limits, clientMetrics, prometheus.DefaultRegisterer, util_log.Logger)
 	if err != nil {
 		log.Println("Failed to create source store:", err)

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -45,7 +45,7 @@ func TestBloomGateway_StartStopService(t *testing.T) {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewRegistry()
 
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	t.Cleanup(cm.Unregister)
 
 	p := config.PeriodConfig{
@@ -104,7 +104,7 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 	reg := prometheus.NewRegistry()
 
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	t.Cleanup(cm.Unregister)
 
 	p := config.PeriodConfig{

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -404,7 +404,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 		return err
 	}
 
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	if useRemoteSchema {
 		client, err := GetObjectClient(conf, cm)
 		if err != nil {

--- a/pkg/logcli/query/query_test.go
+++ b/pkg/logcli/query/query_test.go
@@ -513,7 +513,7 @@ func TestLoadFromURL(t *testing.T) {
 	}
 
 	// Missing SharedStoreType should error
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	client, err := GetObjectClient(conf, cm)
 	require.Error(t, err)
 	require.Nil(t, client)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -109,11 +109,12 @@ type Config struct {
 	Common common.Config `yaml:"common,omitempty"`
 
 	ShutdownDelay time.Duration `yaml:"shutdown_delay" category:"experimental"`
+
+	MetricsPrefix string `yaml:"metrics_prefix"`
 }
 
 // RegisterFlags registers flag.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	c.Server.MetricsNamespace = "loki"
 	c.Server.ExcludeRequestInLog = true
 
 	// Set the default module list to 'all'
@@ -144,6 +145,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 		"The default will be flipped to false in the next Loki release.")
 
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Loki will report 503 Service Unavailable status via /ready endpoint.")
+
+	f.StringVar(&c.MetricsPrefix, "metrics-prefix", "loki", "Prefix of the metrics.")
 
 	c.registerServerFlagsWithChangedDefaultValues(f)
 	c.Common.RegisterFlags(f)
@@ -267,6 +270,8 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	c.MetricsPrefix = c.Server.MetricsNamespace
+
 	return nil
 }
 
@@ -332,7 +337,7 @@ type Loki struct {
 func New(cfg Config) (*Loki, error) {
 	loki := &Loki{
 		Cfg:                 cfg,
-		clientMetrics:       storage.NewClientMetrics(),
+		clientMetrics:       storage.NewClientMetrics(cfg.MetricsPrefix),
 		deleteClientMetrics: deletion.NewDeleteRequestClientMetrics(prometheus.DefaultRegisterer),
 	}
 	analytics.Edition("oss")

--- a/pkg/ruler/base/lifecycle_test.go
+++ b/pkg/ruler/base/lifecycle_test.go
@@ -24,7 +24,7 @@ func TestRulerShutdown(t *testing.T) {
 
 	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
 
-	m := storage.NewClientMetrics()
+	m := storage.NewClientMetrics("loki")
 	defer m.Unregister()
 	r := buildRuler(t, config, nil, m, nil)
 
@@ -59,7 +59,7 @@ func TestRuler_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 
 	ctx := context.Background()
 	config := defaultRulerConfig(t, newMockRuleStore(mockRules))
-	m := storage.NewClientMetrics()
+	m := storage.NewClientMetrics("loki")
 	defer m.Unregister()
 	r := buildRuler(t, config, nil, m, nil)
 	r.cfg.EnableSharding = true

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -230,7 +230,7 @@ func buildRuler(t *testing.T, rulerConfig Config, q storage.Querier, clientMetri
 }
 
 func newTestRuler(t *testing.T, rulerConfig Config) *Ruler {
-	m := loki_storage.NewClientMetrics()
+	m := loki_storage.NewClientMetrics("loki")
 	defer m.Unregister()
 	ruler := buildRuler(t, rulerConfig, nil, m, nil)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ruler))
@@ -471,7 +471,7 @@ func TestGetRules(t *testing.T) {
 						Mock: kvStore,
 					},
 				}
-				m := loki_storage.NewClientMetrics()
+				m := loki_storage.NewClientMetrics("loki")
 				defer m.Unregister()
 				r := buildRuler(t, cfg, nil, m, rulerAddrMap)
 				r.limits = ruleLimits{evalDelay: 0, tenantShard: tc.shuffleShardSize}
@@ -1415,7 +1415,7 @@ func TestSharding(t *testing.T) {
 					DisabledTenants:  tc.disabledUsers,
 				}
 
-				m := loki_storage.NewClientMetrics()
+				m := loki_storage.NewClientMetrics("loki")
 				defer m.Unregister()
 				r := buildRuler(t, cfg, nil, m, nil)
 				r.limits = ruleLimits{evalDelay: 0, tenantShard: tc.shuffleShardSize}
@@ -1768,7 +1768,7 @@ func TestRecoverAlertsPostOutage(t *testing.T) {
 	downAtActiveAtTime := currentTime.Add(time.Minute * -25)
 	downAtActiveSec := downAtActiveAtTime.Unix()
 
-	m := loki_storage.NewClientMetrics()
+	m := loki_storage.NewClientMetrics("loki")
 	defer m.Unregister()
 	// create a ruler but don't start it. instead, we'll evaluate the rule groups manually.
 	r := buildRuler(t, rulerCfg, &fakeQuerier{
@@ -1910,7 +1910,7 @@ func TestRuleGroupAlertsAndSeriesLimit(t *testing.T) {
 			}
 
 			rulerCfg := defaultRulerConfig(t, newMockRuleStore(mockRuleGroupList))
-			m := loki_storage.NewClientMetrics()
+			m := loki_storage.NewClientMetrics("loki")
 			defer m.Unregister()
 
 			r := buildRuler(tt, rulerCfg, &fakeQuerier{

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -147,10 +147,10 @@ type BlobStorageMetrics struct {
 }
 
 // NewBlobStorageMetrics creates the blob storage metrics struct and registers all of it's metrics.
-func NewBlobStorageMetrics() BlobStorageMetrics {
+func NewBlobStorageMetrics(metriceNamespace string) BlobStorageMetrics {
 	b := BlobStorageMetrics{
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "loki",
+			Namespace: metriceNamespace,
 			Name:      "azure_blob_request_duration_seconds",
 			Help:      "Time spent doing azure blob requests.",
 			// Latency seems to range from a few ms to a few secs and is
@@ -158,7 +158,7 @@ func NewBlobStorageMetrics() BlobStorageMetrics {
 			Buckets: prometheus.ExponentialBuckets(0.005, 4, 6),
 		}, []string{"operation", "status_code"}),
 		egressBytesTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "loki",
+			Namespace: metriceNamespace,
 			Name:      "azure_blob_egress_bytes_total",
 			Help:      "Total bytes downloaded from Azure Blob Storage.",
 		}),

--- a/pkg/storage/chunk/client/azure/blob_storage_client_test.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/loki/pkg/storage/chunk/client/hedging"
 )
 
-var metrics = NewBlobStorageMetrics()
+var metrics = NewBlobStorageMetrics("loki")
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
 

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -641,9 +641,9 @@ type ClientMetrics struct {
 	AzureMetrics azure.BlobStorageMetrics
 }
 
-func NewClientMetrics() ClientMetrics {
+func NewClientMetrics(metricsNamespace string) ClientMetrics {
 	return ClientMetrics{
-		AzureMetrics: azure.NewBlobStorageMetrics(),
+		AzureMetrics: azure.NewBlobStorageMetrics(metricsNamespace),
 	}
 }
 

--- a/pkg/storage/hack/main.go
+++ b/pkg/storage/hack/main.go
@@ -34,7 +34,7 @@ var (
 
 // fill up the local filesystem store with 1gib of data to run benchmark
 func main() {
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	defer cm.Unregister()
 	if _, err := os.Stat("/tmp/benchmark/chunks"); os.IsNotExist(err) {
 		if err := fillStore(cm); err != nil {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -41,7 +41,7 @@ var (
 	start      = model.Time(1523750400000)
 	m          runtime.MemStats
 	ctx        = user.InjectOrgID(context.Background(), "fake")
-	cm         = NewClientMetrics()
+	cm         = NewClientMetrics("loki")
 	chunkStore = getLocalStore(cm)
 )
 

--- a/pkg/storage/stores/series/series_store_test.go
+++ b/pkg/storage/stores/series/series_store_test.go
@@ -59,7 +59,7 @@ var (
 			},
 		},
 	}
-	cm = storage.NewClientMetrics()
+	cm = storage.NewClientMetrics("loki")
 )
 
 // newTestStore creates a new Store for testing.

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -511,7 +511,7 @@ func createShipper(t *testing.T) *BloomClient {
 	require.NoError(t, namedStores.Validate())
 	storageConfig := storage.Config{NamedStores: namedStores}
 
-	metrics := storage.NewClientMetrics()
+	metrics := storage.NewClientMetrics("loki")
 	t.Cleanup(metrics.Unregister)
 	bshipper, err := NewBloomClient(periodicConfigs, storageConfig, metrics)
 	require.NoError(t, err)

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/compacted_index_test.go
@@ -25,7 +25,7 @@ func TestCompactedIndex_IndexProcessor(t *testing.T) {
 	for _, tt := range allSchemas {
 		tt := tt
 		t.Run(tt.schema, func(t *testing.T) {
-			cm := storage.NewClientMetrics()
+			cm := storage.NewClientMetrics("loki")
 			defer cm.Unregister()
 			testSchema := config.SchemaConfig{Configs: []config.PeriodConfig{tt.config}}
 			store := newTestStore(t, cm)

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
@@ -26,7 +26,7 @@ func Test_ChunkIterator(t *testing.T) {
 	for _, tt := range allSchemas {
 		tt := tt
 		t.Run(tt.schema, func(t *testing.T) {
-			cm := storage.NewClientMetrics()
+			cm := storage.NewClientMetrics("loki")
 			defer cm.Unregister()
 			store := newTestStore(t, cm)
 			chunkfmt, headfmt, err := tt.config.ChunkFormat()
@@ -73,7 +73,7 @@ func Test_ChunkIterator(t *testing.T) {
 }
 
 func Test_ChunkIteratorContextCancelation(t *testing.T) {
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	defer cm.Unregister()
 	store := newTestStore(t, cm)
 
@@ -110,7 +110,7 @@ func Test_SeriesCleaner(t *testing.T) {
 	for _, tt := range allSchemas {
 		tt := tt
 		t.Run(tt.schema, func(t *testing.T) {
-			cm := storage.NewClientMetrics()
+			cm := storage.NewClientMetrics("loki")
 			defer cm.Unregister()
 			testSchema := config.SchemaConfig{Configs: []config.PeriodConfig{tt.config}}
 			store := newTestStore(t, cm)
@@ -233,7 +233,7 @@ func entryFromChunk(s config.SchemaConfig, c chunk.Chunk) retention.ChunkEntry {
 var chunkEntry retention.ChunkEntry
 
 func Benchmark_ChunkIterator(b *testing.B) {
-	cm := storage.NewClientMetrics()
+	cm := storage.NewClientMetrics("loki")
 	defer cm.Unregister()
 	store := newTestStore(b, cm)
 	chunkfmt, headfmt, err := allSchemas[0].config.ChunkFormat()

--- a/tools/tsdb/migrate-versions/main.go
+++ b/tools/tsdb/migrate-versions/main.go
@@ -49,7 +49,7 @@ func exit(code int) {
 // Ussage: TSDB_VERSION=3 TABLE_NUM_MIN=19464 TABLE_NUM_MAX=19465 NEW_TABLE_PREFIX=tsdb_v3_ go run tools/tsdb/migrate-versions/main.go --config.file /tmp/loki-config.yaml
 func main() {
 	lokiCfg := setup()
-	clientMetrics := storage.NewClientMetrics()
+	clientMetrics := storage.NewClientMetrics("loki")
 
 	if got := os.Getenv("TSDB_VERSION"); got != "" {
 		n, err := strconv.Atoi(got)

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -48,7 +48,7 @@ func TestMigrateTables(t *testing.T) {
 			Directory: tempDir,
 		},
 	}
-	clientMetrics := storage.NewClientMetrics()
+	clientMetrics := storage.NewClientMetrics("loki")
 
 	objClient, err := storage.NewObjectClient(pcfg.ObjectType, storageCfg, clientMetrics)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a prefix setting in the config. Use it as namespace for all the metrics.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->