### PR TITLE
Fix flaky bloomgateway test case

### DIFF
--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -245,6 +245,6 @@ func TestBloomGateway_FilterChunkRefs(t *testing.T) {
 			_, err = gw.FilterChunkRefs(ctx, req)
 			require.NoError(t, err)
 		}
-		require.Equal(t, tenants, gw.activeUsers.ActiveUsers())
+		require.ElementsMatch(t, tenants, gw.activeUsers.ActiveUsers())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The order of active users is non-deterministic, so we need to check for matching elements, rather than for equal slice.

Failed test run: https://drone.grafana.net/grafana/loki/29579/3/6
Passed test run: https://drone.grafana.net/grafana/loki/29577/3/6


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->