### PR TITLE
Fix ring start up errors

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1155,7 +1155,8 @@ func (t *Loki) initMemberlistKV() (services.Service, error) {
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.QueryScheduler.SchedulerRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Ruler.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-
+	t.Cfg.BloomGateway.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.BloomCompactor.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Server.HTTP.Handle("/memberlist", t.MemberlistKV)
 
 	if t.Cfg.InternalServer.Enable {


### PR DESCRIPTION
**What this PR does / why we need it**:
The errors below were introduced during adding initial service structure for BloomGateway https://github.com/grafana/loki/pull/10782 and BloomCompactor https://github.com/grafana/loki/pull/10748 components. 

```
docker-loki-read-3      | panic: runtime error: invalid memory address or nil pointer dereference
docker-loki-read-3      | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9e6d90]
docker-loki-read-3      |
docker-loki-read-3      | goroutine 1 [running]:
docker-loki-read-3      | github.com/grafana/dskit/kv.createClient({_, _}, {_, _}, {{{0x22f6128, 0xe}, {{0x0, 0x0}}, 0x4a817c800, 0x0, ...}, ...}, ...)
docker-loki-read-3      |       /src/loki/vendor/github.com/grafana/dskit/kv/client.go:158 +0x360
docker-loki-read-3      | github.com/grafana/dskit/kv.NewClient({{0x22ec444, 0xa}, {0x22ee95d, 0xb}, {{{0x22f6128, 0xe}, {{...}}, 0x4a817c800, 0x0, 0x3ff0000000000000, ...}, ...}, ...}, ...)
```

This PR initialies new components as part of MemberlistKV.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Tested on local via docker workflow

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->