### PR TITLE
Helm: Fix service paths in ingress for ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ##### Fixes
 
+* [11017](https://github.com/grafana/loki/pull/11017) **fernandocarletti**: Helm: Fix service paths in ingress for ruler
+
 ##### Changes
 
 * [10366](https://github.com/grafana/loki/pull/10366) **shantanualsi** Upgrade thanos objstore, dskit and other modules

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 [//]: # (<AUTOMATED_UPDATES_LOCATOR> : do not remove this line. This locator is used by the CI pipeline to automatically create a changelog entry for each new Loki release. Add other chart versions and respective changelog entries bellow this line.)
 
+## 5.35.1
+
+- [BUGFIX] Fix service paths in ingress for ruler
+
 ## 5.35.0
 
 - [FEATURE] Add support for configuring distributor.

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.9.2
-version: 5.35.0
+version: 5.35.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 5.35.0](https://img.shields.io/badge/Version-5.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
+![Version: 5.35.1](https://img.shields.io/badge/Version-5.35.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 Helm chart for Grafana Loki in simple, scalable mode
 

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -453,6 +453,7 @@ Generate list of ingress service paths based on deployment type
 Ingress service paths for scalable deployment
 */}}
 {{- define "loki.ingress.scalableServicePaths" -}}
+{{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "backend" "paths" .Values.ingress.paths.backend )}}
 {{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "read" "paths" .Values.ingress.paths.read )}}
 {{- include "loki.ingress.servicePath" (dict "ctx" . "svcName" "write" "paths" .Values.ingress.paths.write )}}
 {{- end -}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1201,6 +1201,11 @@ ingress:
   labels: {}
   #    blackbox.monitoring.exclude: "true"
   paths:
+    backend:
+      - /api/prom/rules
+      - /loki/api/v1/rules
+      - /prometheus/api/v1/rules
+      - /prometheus/api/v1/alerts
     write:
       - /api/prom/push
       - /loki/api/v1/push
@@ -1208,10 +1213,6 @@ ingress:
       - /api/prom/tail
       - /loki/api/v1/tail
       - /loki/api
-      - /api/prom/rules
-      - /loki/api/v1/rules
-      - /prometheus/api/v1/rules
-      - /prometheus/api/v1/alerts
     singleBinary:
       - /api/prom/push
       - /loki/api/v1/push


### PR DESCRIPTION
**What this PR does / why we need it**: The ingress is routing connections for the ruler to the wrong service (read). This change forward those connections related to the ruler to the backend component.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->

This is my first contribution here. Please let me know if I missed anything for a Helm chart change. I'm not 100% if this change will affect existing deployments in a bad way (although in my case, it didn't).