### PR TITLE
WIP: return empty responses for logproto request types from

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -276,6 +276,10 @@ func (m *IndexStatsRequest) LogToSpan(sp opentracing.Span) {
 	)
 }
 
+func (i *IndexStatsResponse) GetHeaders() []*definitions.PrometheusResponseHeader {
+	return nil
+}
+
 // Satisfy definitions.Request for Volume
 
 // GetStart returns the start timestamp of the request in milliseconds.

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1532,6 +1532,10 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 				ResultType: loghttp.ResultTypeStream,
 			},
 		}, nil
+	case *logproto.IndexStatsRequest:
+		return &logproto.IndexStatsResponse{}, nil
+	case *logproto.VolumeRequest:
+		return &logproto.VolumeResponse{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}


### PR DESCRIPTION
We need to return empty responses for logproto request types from NewEmptyResponse based on types that can be returned from DecodeRequest.