### PR TITLE
Handle proto type for volume endpoint response encoding

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1005,6 +1005,10 @@ func encodeResponseJSONTo(version loghttp.Version, res queryrangebase.Response, 
 		if err := marshal.WriteVolumeResponseJSON(response.Response, w); err != nil {
 			return err
 		}
+	case *logproto.VolumeResponse:
+		if err := marshal.WriteVolumeResponseJSON(response, w); err != nil {
+			return err
+		}
 	default:
 		return httpgrpc.Errorf(http.StatusInternalServerError, fmt.Sprintf("invalid response format, got (%T)", res))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the `invalid response format, got (*logproto.VolumeResponse)` error received when issuing requests against the `/loki/api/v1/index/volume` API.