### PR TITLE
Remove `GetHeaders` from `logproto.VolumeResponse`.

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -323,7 +323,3 @@ func (m *VolumeRequest) LogToSpan(sp opentracing.Span) {
 		otlog.String("end", timestamp.Time(int64(m.Through)).String()),
 	)
 }
-
-func (*VolumeResponse) GetHeaders() []*definitions.PrometheusResponseHeader {
-	return nil
-}

--- a/pkg/querier/handler.go
+++ b/pkg/querier/handler.go
@@ -94,7 +94,11 @@ func (h *Handler) Do(ctx context.Context, req queryrangebase.Request) (queryrang
 		}
 		return &queryrange.IndexStatsResponse{Response: result}, nil
 	case *logproto.VolumeRequest:
-		return h.api.VolumeHandler(ctx, concrete)
+		result, err := h.api.VolumeHandler(ctx, concrete)
+		if err != nil {
+			return nil, err
+		}
+		return &queryrange.VolumeResponse{Response: result}, nil
 	default:
 		return nil, fmt.Errorf("unsupported query type %T", req)
 	}

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1535,7 +1535,7 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 	case *logproto.IndexStatsRequest:
 		return &logproto.IndexStatsResponse{}, nil
 	case *logproto.VolumeRequest:
-		return &logproto.VolumeResponse{}, nil
+		return &VolumeResponse{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -280,7 +280,7 @@ func Test_MaxQueryLookBack_Types(t *testing.T) {
 				From:    model.Time(now.UnixMilli()),
 				Through: model.Time(now.Add(-90 * time.Minute).UnixMilli()),
 			},
-			expectedResponse: &logproto.VolumeResponse{},
+			expectedResponse: &VolumeResponse{},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces https://github.com/grafana/loki/pull/11048/. We would return `logproto.VolumeResponse` but not match it in the codec. 

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->