### PR TITLE
BACKPORT to k173: Return empty responses for logproto request types from (#11029)

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -276,6 +276,10 @@ func (m *IndexStatsRequest) LogToSpan(sp opentracing.Span) {
 	)
 }
 
+func (i *IndexStatsResponse) GetHeaders() []*definitions.PrometheusResponseHeader {
+	return nil
+}
+
 // Satisfy definitions.Request for Volume
 
 // GetStart returns the start timestamp of the request in milliseconds.

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1515,6 +1515,10 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 				ResultType: loghttp.ResultTypeStream,
 			},
 		}, nil
+	case *logproto.IndexStatsRequest:
+		return &logproto.IndexStatsResponse{}, nil
+	case *logproto.VolumeRequest:
+		return &logproto.VolumeResponse{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -277,6 +278,48 @@ func Test_MaxQueryLookBack(t *testing.T) {
 
 	_, err = tpw(rt).RoundTrip(req)
 	require.NoError(t, err)
+}
+
+func Test_MaxQueryLookBack_Types(t *testing.T) {
+	m := NewLimitsMiddleware(fakeLimits{
+		maxQueryLookback:    1 * time.Hour,
+		maxQueryParallelism: 1,
+	})
+
+	now := time.Now()
+	type tcase struct {
+		request          base.Request
+		expectedResponse base.Response
+	}
+	cases := []tcase{
+		{
+			request: &logproto.IndexStatsRequest{
+				From:    model.Time(now.UnixMilli()),
+				Through: model.Time(now.Add(-90 * time.Minute).UnixMilli()),
+			},
+			expectedResponse: &logproto.IndexStatsResponse{},
+		},
+		{
+			request: &logproto.VolumeRequest{
+				From:    model.Time(now.UnixMilli()),
+				Through: model.Time(now.Add(-90 * time.Minute).UnixMilli()),
+			},
+			expectedResponse: &logproto.VolumeResponse{},
+		},
+	}
+
+	ctx := user.InjectOrgID(context.Background(), "1")
+
+	h := base.HandlerFunc(func(context.Context, base.Request) (base.Response, error) {
+		return nil, nil
+	})
+
+	for _, tcase := range cases {
+		resp, err := m.Wrap(h).Do(ctx, tcase.request)
+		require.NoError(t, err)
+
+		require.Equal(t, reflect.TypeOf(tcase.expectedResponse), reflect.TypeOf(resp))
+	}
 }
 
 func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {


### PR DESCRIPTION
This backports #11029 to k173 since the automation failed: https://github.com/grafana/loki/pull/11029#issuecomment-1781939157