### PR TITLE
Return empty responses for logproto request types from (#11029)

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -276,6 +276,10 @@ func (m *IndexStatsRequest) LogToSpan(sp opentracing.Span) {
 	)
 }
 
+func (i *IndexStatsResponse) GetHeaders() []*definitions.PrometheusResponseHeader {
+	return nil
+}
+
 // Satisfy definitions.Request for Volume
 
 // GetStart returns the start timestamp of the request in milliseconds.

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -1515,6 +1515,10 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 				ResultType: loghttp.ResultTypeStream,
 			},
 		}, nil
+	case *logproto.IndexStatsRequest:
+		return &logproto.IndexStatsResponse{}, nil
+	case *logproto.VolumeRequest:
+		return &logproto.VolumeResponse{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -288,8 +288,8 @@ func Test_MaxQueryLookBack_Types(t *testing.T) {
 
 	now := time.Now()
 	type tcase struct {
-		request          base.Request
-		expectedResponse base.Response
+		request          queryrangebase.Request
+		expectedResponse queryrangebase.Response
 	}
 	cases := []tcase{
 		{
@@ -310,7 +310,7 @@ func Test_MaxQueryLookBack_Types(t *testing.T) {
 
 	ctx := user.InjectOrgID(context.Background(), "1")
 
-	h := base.HandlerFunc(func(context.Context, base.Request) (base.Response, error) {
+	h := queryrangebase.HandlerFunc(func(context.Context, queryrangebase.Request) (queryrangebase.Response, error) {
 		return nil, nil
 	})
 

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -277,6 +278,48 @@ func Test_MaxQueryLookBack(t *testing.T) {
 
 	_, err = tpw(rt).RoundTrip(req)
 	require.NoError(t, err)
+}
+
+func Test_MaxQueryLookBack_Types(t *testing.T) {
+	m := NewLimitsMiddleware(fakeLimits{
+		maxQueryLookback:    1 * time.Hour,
+		maxQueryParallelism: 1,
+	})
+
+	now := time.Now()
+	type tcase struct {
+		request          base.Request
+		expectedResponse base.Response
+	}
+	cases := []tcase{
+		{
+			request: &logproto.IndexStatsRequest{
+				From:    model.Time(now.UnixMilli()),
+				Through: model.Time(now.Add(-90 * time.Minute).UnixMilli()),
+			},
+			expectedResponse: &logproto.IndexStatsResponse{},
+		},
+		{
+			request: &logproto.VolumeRequest{
+				From:    model.Time(now.UnixMilli()),
+				Through: model.Time(now.Add(-90 * time.Minute).UnixMilli()),
+			},
+			expectedResponse: &logproto.VolumeResponse{},
+		},
+	}
+
+	ctx := user.InjectOrgID(context.Background(), "1")
+
+	h := base.HandlerFunc(func(context.Context, base.Request) (base.Response, error) {
+		return nil, nil
+	})
+
+	for _, tcase := range cases {
+		resp, err := m.Wrap(h).Do(ctx, tcase.request)
+		require.NoError(t, err)
+
+		require.Equal(t, reflect.TypeOf(tcase.expectedResponse), reflect.TypeOf(resp))
+	}
 }
 
 func Test_GenerateCacheKey_NoDivideZero(t *testing.T) {


### PR DESCRIPTION
We need to return empty responses for logproto request types from NewEmptyResponse based on types that can be returned from DecodeRequest.

---------

Signed-off-by: Callum Styan <callumstyan@gmail.com>
(cherry picked from commit 0d7b6b2622f9bcf5d9d151dc3d25a8c97c3f2039)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->