### PR TITLE
Update cristalhq/hedgedhttp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
-	github.com/cristalhq/hedgedhttp v0.7.2
+	github.com/cristalhq/hedgedhttp v0.9.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v24.0.4+incompatible
 	github.com/docker/go-plugins-helpers v0.0.0-20181025120712-1e6269c305b8

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristalhq/hedgedhttp v0.7.2 h1:RbQacI2n+1fIOslNq/pjgOfBe1RfjAa7hqHpojopCic=
-github.com/cristalhq/hedgedhttp v0.7.2/go.mod h1:XkqWU6qVMutbhW68NnzjWrGtH8NUx1UfYqGYtHVKIsI=
+github.com/cristalhq/hedgedhttp v0.9.1 h1:g68L9cf8uUyQKQJwciD0A1Vgbsz+QgCjuB1I8FAsCDs=
+github.com/cristalhq/hedgedhttp v0.9.1/go.mod h1:XkqWU6qVMutbhW68NnzjWrGtH8NUx1UfYqGYtHVKIsI=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/storage/chunk/client/hedging/hedging.go
+++ b/pkg/storage/chunk/client/hedging/hedging.go
@@ -107,11 +107,11 @@ func (cfg *Config) RoundTripperWithRegisterer(next http.RoundTripper, reg promet
 		reg.MustRegister(totalRateLimitedHedgeRequests)
 		reg.MustRegister(requestsWon)
 	})
-	return hedgedhttp.NewRoundTripper(
-		cfg.At,
-		cfg.UpTo,
-		newWinnerTrackingRoundTripper(newLimitedHedgingRoundTripper(cfg.MaxPerSecond, next)),
-	)
+	return hedgedhttp.New(hedgedhttp.Config{
+		Delay:     cfg.At,
+		Upto:      cfg.UpTo,
+		Transport: newWinnerTrackingRoundTripper(newLimitedHedgingRoundTripper(cfg.MaxPerSecond, next)),
+	})
 }
 
 // RoundTripper returns a hedged roundtripper.

--- a/vendor/github.com/cristalhq/hedgedhttp/README.md
+++ b/vendor/github.com/cristalhq/hedgedhttp/README.md
@@ -10,7 +10,7 @@ Hedged HTTP client which helps to reduce tail latency at scale.
 
 ## Rationale
 
-See paper [Tail at Scale](https://cacm.acm.org/magazines/2013/2/160173-the-tail-at-scale/fulltext) by Jeffrey Dean, Luiz André Barroso. In short: the client first sends one request, but then sends an additional request after a timeout if the previous hasn't returned an answer in the expected time. The client cancels remaining requests once the first result is received.
+See paper [Tail at Scale](https://www.barroso.org/publications/TheTailAtScale.pdf) by Jeffrey Dean, Luiz André Barroso. In short: the client first sends one request, but then sends an additional request after a timeout if the previous hasn't returned an answer in the expected time. The client cancels remaining requests once the first result is received.
 
 ## Acknowledge
 

--- a/vendor/github.com/cristalhq/hedgedhttp/stats.go
+++ b/vendor/github.com/cristalhq/hedgedhttp/stats.go
@@ -16,6 +16,8 @@ type Stats struct {
 	requestedRoundTrips      atomicCounter
 	actualRoundTrips         atomicCounter
 	failedRoundTrips         atomicCounter
+	originalRequestWins      atomicCounter
+	hedgedRequestWins        atomicCounter
 	canceledByUserRoundTrips atomicCounter
 	canceledSubRequests      atomicCounter
 	_                        cacheLine
@@ -24,6 +26,8 @@ type Stats struct {
 func (s *Stats) requestedRoundTripsInc()      { atomic.AddUint64(&s.requestedRoundTrips.count, 1) }
 func (s *Stats) actualRoundTripsInc()         { atomic.AddUint64(&s.actualRoundTrips.count, 1) }
 func (s *Stats) failedRoundTripsInc()         { atomic.AddUint64(&s.failedRoundTrips.count, 1) }
+func (s *Stats) originalRequestWinsInc()      { atomic.AddUint64(&s.originalRequestWins.count, 1) }
+func (s *Stats) hedgedRequestWinsInc()        { atomic.AddUint64(&s.hedgedRequestWins.count, 1) }
 func (s *Stats) canceledByUserRoundTripsInc() { atomic.AddUint64(&s.canceledByUserRoundTrips.count, 1) }
 func (s *Stats) canceledSubRequestsInc()      { atomic.AddUint64(&s.canceledSubRequests.count, 1) }
 
@@ -40,6 +44,16 @@ func (s *Stats) ActualRoundTrips() uint64 {
 // FailedRoundTrips returns count of requests that failed.
 func (s *Stats) FailedRoundTrips() uint64 {
 	return atomic.LoadUint64(&s.failedRoundTrips.count)
+}
+
+// OriginalRequestWins returns count of original requests that were faster than the original.
+func (s *Stats) OriginalRequestWins() uint64 {
+	return atomic.LoadUint64(&s.originalRequestWins.count)
+}
+
+// HedgedRequestWins returns count of hedged requests that were faster than the original.
+func (s *Stats) HedgedRequestWins() uint64 {
+	return atomic.LoadUint64(&s.hedgedRequestWins.count)
 }
 
 // CanceledByUserRoundTrips returns count of requests that were canceled by user, using request context.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -464,7 +464,7 @@ github.com/coreos/go-systemd/sdjournal
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/journal
-# github.com/cristalhq/hedgedhttp v0.7.2
+# github.com/cristalhq/hedgedhttp v0.9.1
 ## explicit; go 1.16
 github.com/cristalhq/hedgedhttp
 # github.com/d4l3k/messagediff v1.2.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates cristalhq/hedgedhttp library to use new API. Old is still present but probably will be removed in the future.

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
Similar to https://github.com/grafana/dskit/pull/418

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->