### PR TITLE
fix(tools/lambda-promtail): not evaluate empty string for drop_labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [10727](https://github.com/grafana/loki/pull/10727) **sandeepsukhani** Native otlp ingestion support
 * [11051](https://github.com/grafana/loki/pull/11051) Refactor to not use global logger in modules
 ##### Fixes
+* [11074](https://github.com/grafana/loki/pull/11074) **hainenber** Fix panic in lambda-promtail due to mishandling of empty DROP_LABELS env var.
 
 ##### Changes
 

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -137,14 +137,15 @@ func parseExtraLabels(extraLabelsRaw string, omitPrefix bool) (model.LabelSet, e
 func getDropLabels() ([]model.LabelName, error) {
 	var result []model.LabelName
 
-	dropLabelsRaw = os.Getenv("DROP_LABELS")
-	dropLabelsRawSplit := strings.Split(dropLabelsRaw, ",")
-	for _, dropLabelRaw := range dropLabelsRawSplit {
-		dropLabel := model.LabelName(dropLabelRaw)
-		if !dropLabel.IsValid() {
-			return []model.LabelName{}, fmt.Errorf("invalid label name %s", dropLabelRaw)
+	if dropLabelsRaw = os.Getenv("DROP_LABELS"); dropLabelsRaw != "" {
+		dropLabelsRawSplit := strings.Split(dropLabelsRaw, ",")
+		for _, dropLabelRaw := range dropLabelsRawSplit {
+			dropLabel := model.LabelName(dropLabelRaw)
+			if !dropLabel.IsValid() {
+				return []model.LabelName{}, fmt.Errorf("invalid label name %s", dropLabelRaw)
+			}
+			result = append(result, dropLabel)
 		}
-		result = append(result, dropLabel)
 	}
 
 	return result, nil

--- a/tools/lambda-promtail/lambda-promtail/main_test.go
+++ b/tools/lambda-promtail/lambda-promtail/main_test.go
@@ -37,7 +37,8 @@ func TestLambdaPromtail_TestParseLabelsNoneProvided(t *testing.T) {
 }
 
 func TestLambdaPromtail_TestDropLabels(t *testing.T) {
-	os.Setenv("DROP_LABELS", "A1,A2")
+	// Simulate default env var set in Terraform
+	os.Setenv("DROP_LABELS", "")
 
 	// Reset the shared global variables
 	defer func() {
@@ -46,6 +47,10 @@ func TestLambdaPromtail_TestDropLabels(t *testing.T) {
 	}()
 
 	var err error
+	dropLabels, err = getDropLabels()
+	require.Nil(t, err)
+
+	os.Setenv("DROP_LABELS", "A1,A2")
 	dropLabels, err = getDropLabels()
 	require.Nil(t, err)
 	require.Contains(t, dropLabels, model.LabelName("A1"))


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #11005 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. <!-- TODO(salvacorts): Add example PR -->