### PR TITLE
Support categorized labels in Tailing

### DIFF
--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -136,8 +136,6 @@ func (t *tailer) send(stream logproto.Stream, lbs labels.Labels) {
 
 func (t *tailer) processStream(stream logproto.Stream, lbs labels.Labels) []*logproto.Stream {
 	// Optimization: skip filtering entirely, if no filter is set
-	// Note: returns the stream regardless of structured metadata. This is fine,
-	// the querier will take care of properly returning the structured metadata.
 	if log.IsNoopPipeline(t.pipeline) {
 		return []*logproto.Stream{&stream}
 	}

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -268,11 +268,7 @@ func Test_StructuredMetadata(t *testing.T) {
 			}, 30*time.Second, 1*time.Second, "stream was not received")
 
 			responses := server.GetResponses()
-			require.Equal(t, len(responses), len(tc.expectedResponses))
-			for i := range responses {
-				require.Equal(t, tc.expectedResponses[i].Stream, responses[i].Stream)
-				require.Equal(t, tc.expectedResponses[i].DroppedStreams, responses[i].DroppedStreams)
-			}
+			require.ElementsMatch(t, tc.expectedResponses, responses)
 
 			tail.close()
 			wg.Wait()

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -153,7 +153,7 @@ func Test_IsMatching(t *testing.T) {
 	}
 }
 
-func Test_CategorizeLabels(t *testing.T) {
+func Test_StructuredMetadata(t *testing.T) {
 	lbs := makeRandomLabels()
 
 	for _, tc := range []struct {
@@ -189,55 +189,6 @@ func Test_CategorizeLabels(t *testing.T) {
 								Timestamp: time.Unix(0, 1),
 								Line:      "foo=1",
 							},
-							{
-								Timestamp:          time.Unix(0, 2),
-								Line:               "foo=2",
-								StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
-							},
-						},
-					},
-					DroppedStreams: nil,
-				},
-			},
-		},
-		{
-			name:  "filter pipeline",
-			query: `{app="foo"} |= "foo"`,
-			sentStream: logproto.Stream{
-				Labels: lbs.String(),
-				Entries: []logproto.Entry{
-					{
-						Timestamp: time.Unix(0, 1),
-						Line:      "foo=1",
-					},
-					{
-						Timestamp:          time.Unix(0, 2),
-						Line:               "foo=2",
-						StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
-					},
-					{
-						Timestamp: time.Unix(0, 3),
-						Line:      "bar",
-					},
-				},
-			},
-			expectedResponses: []logproto.TailResponse{
-				{
-					Stream: &logproto.Stream{
-						Labels: lbs.String(),
-						Entries: []logproto.Entry{
-							{
-								Timestamp: time.Unix(0, 1),
-								Line:      "foo=1",
-							},
-						},
-					},
-					DroppedStreams: nil,
-				},
-				{
-					Stream: &logproto.Stream{
-						Labels: labels.NewBuilder(lbs).Set("traceID", "123").Labels().String(),
-						Entries: []logproto.Entry{
 							{
 								Timestamp:          time.Unix(0, 2),
 								Line:               "foo=2",

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -114,7 +114,7 @@ func (f *fakeTailServer) Reset() {
 }
 
 func Test_TailerSendRace(t *testing.T) {
-	tail, err := newTailer("foo", `{app="foo"} |= "foo"`, &fakeTailServer{}, 10, nil)
+	tail, err := newTailer("foo", `{app="foo"} |= "foo"`, &fakeTailServer{}, 10)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -299,7 +299,7 @@ func Test_CategorizeLabels(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var server fakeTailServer
-			tail, err := newTailer("foo", tc.query, &server, 10, nil)
+			tail, err := newTailer("foo", tc.query, &server, 10)
 			require.NoError(t, err)
 
 			var wg sync.WaitGroup

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -93,13 +93,28 @@ func Test_dropstream(t *testing.T) {
 	}
 }
 
-type fakeTailServer struct{}
+type fakeTailServer struct {
+	responses []logproto.TailResponse
+}
 
-func (f *fakeTailServer) Send(*logproto.TailResponse) error { return nil }
-func (f *fakeTailServer) Context() context.Context          { return context.Background() }
+func (f *fakeTailServer) Send(response *logproto.TailResponse) error {
+	f.responses = append(f.responses, *response)
+	return nil
+
+}
+
+func (f *fakeTailServer) Context() context.Context { return context.Background() }
+
+func (f *fakeTailServer) GetResponses() []logproto.TailResponse {
+	return f.responses
+}
+
+func (f *fakeTailServer) Reset() {
+	f.responses = f.responses[:0]
+}
 
 func Test_TailerSendRace(t *testing.T) {
-	tail, err := newTailer("foo", `{app="foo"} |= "foo"`, &fakeTailServer{}, 10)
+	tail, err := newTailer("foo", `{app="foo"} |= "foo"`, &fakeTailServer{}, 10, nil)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -134,6 +149,182 @@ func Test_IsMatching(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.matches, isMatching(tt.lbs, tt.matchers))
+		})
+	}
+}
+
+func Test_CategorizeLabels(t *testing.T) {
+	lbs := makeRandomLabels()
+
+	for _, tc := range []struct {
+		name              string
+		query             string
+		sentStream        logproto.Stream
+		expectedResponses []logproto.TailResponse
+	}{
+		{
+			// Optimization will make the same stream to be returned regardless of structured metadata.
+			name:  "noop pipeline",
+			query: `{app="foo"}`,
+			sentStream: logproto.Stream{
+				Labels: lbs.String(),
+				Entries: []logproto.Entry{
+					{
+						Timestamp: time.Unix(0, 1),
+						Line:      "foo=1",
+					},
+					{
+						Timestamp:          time.Unix(0, 2),
+						Line:               "foo=2",
+						StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+					},
+				},
+			},
+			expectedResponses: []logproto.TailResponse{
+				{
+					Stream: &logproto.Stream{
+						Labels: lbs.String(),
+						Entries: []logproto.Entry{
+							{
+								Timestamp: time.Unix(0, 1),
+								Line:      "foo=1",
+							},
+							{
+								Timestamp:          time.Unix(0, 2),
+								Line:               "foo=2",
+								StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+							},
+						},
+					},
+					DroppedStreams: nil,
+				},
+			},
+		},
+		{
+			name:  "filter pipeline",
+			query: `{app="foo"} |= "foo"`,
+			sentStream: logproto.Stream{
+				Labels: lbs.String(),
+				Entries: []logproto.Entry{
+					{
+						Timestamp: time.Unix(0, 1),
+						Line:      "foo=1",
+					},
+					{
+						Timestamp:          time.Unix(0, 2),
+						Line:               "foo=2",
+						StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+					},
+					{
+						Timestamp: time.Unix(0, 3),
+						Line:      "bar",
+					},
+				},
+			},
+			expectedResponses: []logproto.TailResponse{
+				{
+					Stream: &logproto.Stream{
+						Labels: lbs.String(),
+						Entries: []logproto.Entry{
+							{
+								Timestamp: time.Unix(0, 1),
+								Line:      "foo=1",
+							},
+						},
+					},
+					DroppedStreams: nil,
+				},
+				{
+					Stream: &logproto.Stream{
+						Labels: labels.NewBuilder(lbs).Set("traceID", "123").Labels().String(),
+						Entries: []logproto.Entry{
+							{
+								Timestamp:          time.Unix(0, 2),
+								Line:               "foo=2",
+								StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+							},
+						},
+					},
+					DroppedStreams: nil,
+				},
+			},
+		},
+		{
+			name:  "parse pipeline labels",
+			query: `{app="foo"} | logfmt`,
+			sentStream: logproto.Stream{
+				Labels: lbs.String(),
+				Entries: []logproto.Entry{
+					{
+						Timestamp: time.Unix(0, 1),
+						Line:      "foo=1",
+					},
+					{
+						Timestamp:          time.Unix(0, 2),
+						Line:               "foo=2",
+						StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+					},
+				},
+			},
+			expectedResponses: []logproto.TailResponse{
+				{
+					Stream: &logproto.Stream{
+						Labels: labels.NewBuilder(lbs).Set("foo", "1").Labels().String(),
+						Entries: []logproto.Entry{
+							{
+								Timestamp: time.Unix(0, 1),
+								Line:      "foo=1",
+								Parsed:    logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "1")),
+							},
+						},
+					},
+					DroppedStreams: nil,
+				},
+				{
+					Stream: &logproto.Stream{
+						Labels: labels.NewBuilder(lbs).Set("traceID", "123").Set("foo", "2").Labels().String(),
+						Entries: []logproto.Entry{
+							{
+								Timestamp:          time.Unix(0, 2),
+								Line:               "foo=2",
+								StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+								Parsed:             logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "2")),
+							},
+						},
+					},
+					DroppedStreams: nil,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var server fakeTailServer
+			tail, err := newTailer("foo", tc.query, &server, 10, nil)
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				tail.loop()
+				wg.Done()
+			}()
+
+			tail.send(tc.sentStream, lbs)
+
+			// Wait for the stream to be received by the server.
+			require.Eventually(t, func() bool {
+				return len(server.GetResponses()) > 0
+			}, 30*time.Second, 1*time.Second, "stream was not received")
+
+			responses := server.GetResponses()
+			require.Equal(t, len(responses), len(tc.expectedResponses))
+			for i := range responses {
+				require.Equal(t, tc.expectedResponses[i].Stream, responses[i].Stream)
+				require.Equal(t, tc.expectedResponses[i].DroppedStreams, responses[i].DroppedStreams)
+			}
+
+			tail.close()
+			wg.Wait()
 		})
 	}
 }

--- a/pkg/iter/categorized_labels_iterator.go
+++ b/pkg/iter/categorized_labels_iterator.go
@@ -3,9 +3,10 @@ package iter
 import (
 	"fmt"
 
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/syntax"
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 type categorizeLabelsIterator struct {

--- a/pkg/iter/categorized_labels_iterator.go
+++ b/pkg/iter/categorized_labels_iterator.go
@@ -1,0 +1,70 @@
+package iter
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type categorizeLabelsIterator struct {
+	EntryIterator
+	currEntry        logproto.Entry
+	currStreamLabels string
+	currHash         uint64
+	currErr          error
+}
+
+func NewCategorizeLabelsIterator(wrap EntryIterator) EntryIterator {
+	return &categorizeLabelsIterator{
+		EntryIterator: wrap,
+	}
+}
+
+func (c *categorizeLabelsIterator) Next() bool {
+	if !c.EntryIterator.Next() {
+		return false
+	}
+
+	c.currEntry = c.Entry()
+	if len(c.currEntry.StructuredMetadata) == 0 && len(c.currEntry.Parsed) == 0 {
+		c.currStreamLabels = c.EntryIterator.Labels()
+		c.currHash = c.EntryIterator.StreamHash()
+		return true
+	}
+
+	// We need to remove the structured metadata labels and parsed labels from the stream labels.
+	streamLabels := c.EntryIterator.Labels()
+	lbls, err := syntax.ParseLabels(streamLabels)
+	if err != nil {
+		c.currErr = fmt.Errorf("failed to parse series labels to categorize labels: %w", err)
+		return false
+	}
+
+	builder := labels.NewBuilder(lbls)
+	for _, label := range c.currEntry.StructuredMetadata {
+		builder.Del(label.Name)
+	}
+	for _, label := range c.currEntry.Parsed {
+		builder.Del(label.Name)
+	}
+
+	newLabels := builder.Labels()
+	c.currStreamLabels = newLabels.String()
+	c.currHash = newLabels.Hash()
+
+	return true
+}
+
+func (c *categorizeLabelsIterator) Error() error {
+	return c.currErr
+}
+
+func (c *categorizeLabelsIterator) Labels() string {
+	return c.currStreamLabels
+}
+
+func (c *categorizeLabelsIterator) StreamHash() uint64 {
+	return c.currHash
+}

--- a/pkg/iter/categorized_labels_iterator_test.go
+++ b/pkg/iter/categorized_labels_iterator_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/logproto"
 )
 
 func TestNewCategorizeLabelsIterator(t *testing.T) {

--- a/pkg/iter/categorized_labels_iterator_test.go
+++ b/pkg/iter/categorized_labels_iterator_test.go
@@ -1,0 +1,144 @@
+package iter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCategorizeLabelsIterator(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		inner           EntryIterator
+		expectedStreams []logproto.Stream
+	}{
+		{
+			name: "no structured metadata nor parsed labels",
+			inner: NewSortEntryIterator([]EntryIterator{
+				NewStreamIterator(logproto.Stream{
+					Labels: labels.FromStrings("namespace", "default").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Unix(0, 1),
+							Line:      "foo=1",
+						},
+						{
+							Timestamp: time.Unix(0, 2),
+							Line:      "foo=2",
+						},
+					},
+				}),
+			}, logproto.FORWARD),
+			expectedStreams: []logproto.Stream{
+				{
+					Labels: labels.FromStrings("namespace", "default").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Unix(0, 1),
+							Line:      "foo=1",
+						},
+						{
+							Timestamp: time.Unix(0, 2),
+							Line:      "foo=2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "structured metadata and parsed labels",
+			inner: NewSortEntryIterator([]EntryIterator{
+				NewStreamIterator(logproto.Stream{
+					Labels: labels.FromStrings("namespace", "default").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Unix(0, 1),
+							Line:      "foo=1",
+						},
+					},
+				}),
+				NewStreamIterator(logproto.Stream{
+					Labels: labels.FromStrings("namespace", "default", "traceID", "123").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp:          time.Unix(0, 2),
+							Line:               "foo=2",
+							StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+						},
+					},
+				}),
+				NewStreamIterator(logproto.Stream{
+					Labels: labels.FromStrings("namespace", "default", "foo", "3").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Unix(0, 3),
+							Line:      "foo=3",
+							Parsed:    logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "3")),
+						},
+					},
+				}),
+				NewStreamIterator(logproto.Stream{
+					Labels: labels.FromStrings("namespace", "default", "traceID", "123", "foo", "4").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp:          time.Unix(0, 4),
+							Line:               "foo=4",
+							StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+							Parsed:             logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "4")),
+						},
+					},
+				}),
+			}, logproto.FORWARD),
+			expectedStreams: []logproto.Stream{
+				{
+					Labels: labels.FromStrings("namespace", "default").String(),
+					Entries: []logproto.Entry{
+						{
+							Timestamp: time.Unix(0, 1),
+							Line:      "foo=1",
+						},
+						{
+							Timestamp:          time.Unix(0, 2),
+							Line:               "foo=2",
+							StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+						},
+						{
+							Timestamp: time.Unix(0, 3),
+							Line:      "foo=3",
+							Parsed:    logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "3")),
+						},
+						{
+							Timestamp:          time.Unix(0, 4),
+							Line:               "foo=4",
+							StructuredMetadata: logproto.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "123")),
+							Parsed:             logproto.FromLabelsToLabelAdapters(labels.FromStrings("foo", "4")),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			itr := NewCategorizeLabelsIterator(tc.inner)
+
+			streamsEntries := make(map[string][]logproto.Entry)
+			for itr.Next() {
+				streamsEntries[itr.Labels()] = append(streamsEntries[itr.Labels()], itr.Entry())
+				require.NoError(t, itr.Error())
+			}
+
+			var streams []logproto.Stream
+			for lbls, entries := range streamsEntries {
+				streams = append(streams, logproto.Stream{
+					Labels:  lbls,
+					Entries: entries,
+				})
+			}
+
+			require.ElementsMatch(t, tc.expectedStreams, streams)
+		})
+	}
+}

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -146,6 +146,9 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	encodingFlags := httpreq.ExtractEncodingFlags(r)
+	version := loghttp.GetVersion(r.RequestURI)
+
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error in upgrading websocket", "err", err)
@@ -164,7 +167,7 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	tailer, err := q.querier.Tail(r.Context(), req)
+	tailer, err := q.querier.Tail(r.Context(), req, encodingFlags.Has(httpreq.FlagCategorizeLabels))
 	if err != nil {
 		if err := conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, err.Error())); err != nil {
 			level.Error(logger).Log("msg", "Error connecting to ingesters for tailing", "err", err)
@@ -179,6 +182,8 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 
 	ticker := time.NewTicker(wsPingPeriod)
 	defer ticker.Stop()
+
+	connJsonWriter := marshal.NewWebsocketJSONWriter(conn)
 
 	var response *loghttp_legacy.TailResponse
 	responseChan := tailer.getResponseChan()
@@ -210,8 +215,8 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 		select {
 		case response = <-responseChan:
 			var err error
-			if loghttp.GetVersion(r.RequestURI) == loghttp.VersionV1 {
-				err = marshal.WriteTailResponseJSON(*response, conn)
+			if version == loghttp.VersionV1 {
+				err = marshal.WriteTailResponseJSON(*response, connJsonWriter, encodingFlags)
 			} else {
 				err = marshal_legacy.WriteTailResponseJSON(*response, conn)
 			}

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -183,7 +183,7 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 	ticker := time.NewTicker(wsPingPeriod)
 	defer ticker.Stop()
 
-	connJsonWriter := marshal.NewWebsocketJSONWriter(conn)
+	connWriter := marshal.NewWebsocketJSONWriter(conn)
 
 	var response *loghttp_legacy.TailResponse
 	responseChan := tailer.getResponseChan()
@@ -216,7 +216,7 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 		case response = <-responseChan:
 			var err error
 			if version == loghttp.VersionV1 {
-				err = marshal.WriteTailResponseJSON(*response, connJsonWriter, encodingFlags)
+				err = marshal.WriteTailResponseJSON(*response, connWriter, encodingFlags)
 			} else {
 				err = marshal_legacy.WriteTailResponseJSON(*response, conn)
 			}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -88,7 +88,7 @@ type Querier interface {
 	logql.Querier
 	Label(ctx context.Context, req *logproto.LabelRequest) (*logproto.LabelResponse, error)
 	Series(ctx context.Context, req *logproto.SeriesRequest) (*logproto.SeriesResponse, error)
-	Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer, error)
+	Tail(ctx context.Context, req *logproto.TailRequest, categorizedLabels bool) (*Tailer, error)
 	IndexStats(ctx context.Context, req *loghttp.RangeQuery) (*stats.Stats, error)
 	Volume(ctx context.Context, req *logproto.VolumeRequest) (*logproto.VolumeResponse, error)
 }
@@ -434,7 +434,7 @@ func (*SingleTenantQuerier) Check(_ context.Context, _ *grpc_health_v1.HealthChe
 }
 
 // Tail keeps getting matching logs from all ingesters for given query
-func (q *SingleTenantQuerier) Tail(ctx context.Context, req *logproto.TailRequest) (*Tailer, error) {
+func (q *SingleTenantQuerier) Tail(ctx context.Context, req *logproto.TailRequest, categorizedLabels bool) (*Tailer, error) {
 	err := q.checkTailRequestLimit(ctx)
 	if err != nil {
 		return nil, err
@@ -496,6 +496,7 @@ func (q *SingleTenantQuerier) Tail(ctx context.Context, req *logproto.TailReques
 		},
 		q.cfg.TailMaxDuration,
 		tailerWaitEntryThrottle,
+		categorizedLabels,
 		q.metrics,
 	), nil
 }

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -530,7 +530,7 @@ func (q *querierMock) Series(ctx context.Context, req *logproto.SeriesRequest) (
 	return args.Get(0).(func() *logproto.SeriesResponse)(), args.Error(1)
 }
 
-func (q *querierMock) Tail(_ context.Context, _ *logproto.TailRequest) (*Tailer, error) {
+func (q *querierMock) Tail(_ context.Context, _ *logproto.TailRequest, _ bool) (*Tailer, error) {
 	return nil, errors.New("querierMock.Tail() has not been mocked")
 }
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -117,7 +117,7 @@ func TestQuerier_Tail_QueryTimeoutConfigFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), "test")
-	_, err = q.Tail(ctx, &request)
+	_, err = q.Tail(ctx, &request, false)
 	require.NoError(t, err)
 
 	calls := ingesterClient.GetMockedCallsByMethod("Query")
@@ -511,7 +511,7 @@ func TestQuerier_concurrentTailLimits(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := user.InjectOrgID(context.Background(), "test")
-			_, err = q.Tail(ctx, &request)
+			_, err = q.Tail(ctx, &request, false)
 			assert.Equal(t, testData.expectedError, err)
 		})
 	}

--- a/pkg/util/httpreq/encoding_flags.go
+++ b/pkg/util/httpreq/encoding_flags.go
@@ -71,11 +71,7 @@ func AddEncodingFlagsToContext(ctx context.Context, flags EncodingFlags) context
 
 func ExtractEncodingFlags(req *http.Request) EncodingFlags {
 	rawValue := req.Header.Get(LokiEncodingFlagsHeader)
-	if rawValue == "" {
-		return nil
-	}
-
-	return parseEncodingFlags(rawValue)
+	return ParseEncodingFlags(rawValue)
 }
 
 func ExtractEncodingFlagsFromProto(req *httpgrpc.HTTPRequest) EncodingFlags {
@@ -83,11 +79,7 @@ func ExtractEncodingFlagsFromProto(req *httpgrpc.HTTPRequest) EncodingFlags {
 	for _, header := range req.GetHeaders() {
 		if header.GetKey() == LokiEncodingFlagsHeader {
 			rawValue = header.GetValues()[0]
-			if rawValue == "" {
-				return nil
-			}
-
-			return parseEncodingFlags(rawValue)
+			return ParseEncodingFlags(rawValue)
 		}
 	}
 
@@ -100,10 +92,14 @@ func ExtractEncodingFlagsFromCtx(ctx context.Context) EncodingFlags {
 		return nil
 	}
 
-	return parseEncodingFlags(rawValue)
+	return ParseEncodingFlags(rawValue)
 }
 
-func parseEncodingFlags(rawFlags string) EncodingFlags {
+func ParseEncodingFlags(rawFlags string) EncodingFlags {
+	if rawFlags == "" {
+		return nil
+	}
+
 	split := strings.Split(rawFlags, EncodeFlagsDelimiter)
 	flags := make(EncodingFlags, len(split))
 	for _, rawFlag := range split {

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"unsafe"
 
-	legacy "github.com/grafana/loki/pkg/loghttp/legacy"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -14,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/pkg/loghttp"
+	legacy "github.com/grafana/loki/pkg/loghttp/legacy"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logqlmodel"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"

--- a/pkg/util/marshal/query.go
+++ b/pkg/util/marshal/query.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	legacy "github.com/grafana/loki/pkg/loghttp/legacy"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -191,6 +192,60 @@ func EncodeResult(data parser.Value, statistics stats.Result, s *jsoniter.Stream
 	return nil
 }
 
+func EncodeTailResult(data legacy.TailResponse, s *jsoniter.Stream, encodeFlags httpreq.EncodingFlags) error {
+	s.WriteObjectStart()
+	s.WriteObjectField("streams")
+	err := encodeStreams(data.Streams, s, encodeFlags)
+	if err != nil {
+		return err
+	}
+
+	if len(data.DroppedEntries) > 0 {
+		s.WriteMore()
+		s.WriteObjectField("dropped_entries")
+		err = encodeDroppedEntries(data.DroppedEntries, s)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(encodeFlags) > 0 {
+		s.WriteMore()
+		s.WriteObjectField("encodingFlags")
+		if err := encodeEncodingFlags(s, encodeFlags); err != nil {
+			return err
+		}
+	}
+
+	s.WriteObjectEnd()
+	return nil
+}
+
+func encodeDroppedEntries(entries []legacy.DroppedEntry, s *jsoniter.Stream) error {
+	s.WriteArrayStart()
+	defer s.WriteArrayEnd()
+
+	for i, entry := range entries {
+		if i > 0 {
+			s.WriteMore()
+		}
+
+		ds, err := NewDroppedStream(&entry)
+		if err != nil {
+			return err
+		}
+
+		jsonEntry, err := ds.MarshalJSON()
+		if err != nil {
+			return err
+		}
+
+		s.WriteRaw(string(jsonEntry))
+	}
+
+	return nil
+}
+
 func encodeEncodingFlags(s *jsoniter.Stream, flags httpreq.EncodingFlags) error {
 	s.WriteArrayStart()
 	defer s.WriteArrayEnd()
@@ -329,7 +384,6 @@ func encodeStream(stream logproto.Stream, s *jsoniter.Stream, encodeFlags httpre
 	encodeLabels(logproto.FromLabelsToLabelAdapters(lbls), s)
 
 	s.WriteObjectEnd()
-	s.Flush()
 
 	s.WriteMore()
 	s.WriteObjectField("values")
@@ -373,8 +427,6 @@ func encodeStream(stream logproto.Stream, s *jsoniter.Stream, encodeFlags httpre
 			s.WriteObjectEnd()
 		}
 		s.WriteArrayEnd()
-
-		s.Flush()
 	}
 
 	s.WriteArrayEnd()

--- a/pkg/util/marshal/tail.go
+++ b/pkg/util/marshal/tail.go
@@ -5,32 +5,6 @@ import (
 	legacy "github.com/grafana/loki/pkg/loghttp/legacy"
 )
 
-// NewTailResponse constructs a TailResponse from a legacy.TailResponse
-func NewTailResponse(r legacy.TailResponse) (loghttp.TailResponse, error) {
-	var err error
-	ret := loghttp.TailResponse{
-		Streams:        make([]loghttp.Stream, len(r.Streams)),
-		DroppedStreams: make([]loghttp.DroppedStream, len(r.DroppedEntries)),
-	}
-
-	for i, s := range r.Streams {
-		ret.Streams[i], err = NewStream(s)
-
-		if err != nil {
-			return loghttp.TailResponse{}, err
-		}
-	}
-
-	for i, d := range r.DroppedEntries {
-		ret.DroppedStreams[i], err = NewDroppedStream(&d)
-		if err != nil {
-			return loghttp.TailResponse{}, err
-		}
-	}
-
-	return ret, nil
-}
-
 // NewDroppedStream constructs a DroppedStream from a legacy.DroppedEntry
 func NewDroppedStream(s *legacy.DroppedEntry) (loghttp.DroppedStream, error) {
 	l, err := NewLabelSet(s.Labels)

--- a/pkg/util/unmarshal/unmarshal_test.go
+++ b/pkg/util/unmarshal/unmarshal_test.go
@@ -224,7 +224,7 @@ func (ws *websocket) ReadMessage() (int, []byte, error) {
 
 func Test_ReadTailResponse(t *testing.T) {
 	ws := &websocket{}
-	wsJson := marshal.NewWebsocketJSONWriter(ws)
+	wsJSON := marshal.NewWebsocketJSONWriter(ws)
 	require.NoError(t, marshal.WriteTailResponseJSON(legacy_loghttp.TailResponse{
 		Streams: []logproto.Stream{
 			{Labels: `{app="bar"}`, Entries: []logproto.Entry{{Timestamp: time.Unix(0, 2), Line: "2"}}},
@@ -232,7 +232,7 @@ func Test_ReadTailResponse(t *testing.T) {
 		DroppedEntries: []legacy_loghttp.DroppedEntry{
 			{Timestamp: time.Unix(0, 1), Labels: `{app="foo"}`},
 		},
-	}, wsJson, nil))
+	}, wsJSON, nil))
 	res := &loghttp.TailResponse{}
 	require.NoError(t, ReadTailResponseJSON(res, ws))
 

--- a/pkg/util/unmarshal/unmarshal_test.go
+++ b/pkg/util/unmarshal/unmarshal_test.go
@@ -224,6 +224,7 @@ func (ws *websocket) ReadMessage() (int, []byte, error) {
 
 func Test_ReadTailResponse(t *testing.T) {
 	ws := &websocket{}
+	wsJson := marshal.NewWebsocketJSONWriter(ws)
 	require.NoError(t, marshal.WriteTailResponseJSON(legacy_loghttp.TailResponse{
 		Streams: []logproto.Stream{
 			{Labels: `{app="bar"}`, Entries: []logproto.Entry{{Timestamp: time.Unix(0, 2), Line: "2"}}},
@@ -231,7 +232,7 @@ func Test_ReadTailResponse(t *testing.T) {
 		DroppedEntries: []legacy_loghttp.DroppedEntry{
 			{Timestamp: time.Unix(0, 1), Labels: `{app="foo"}`},
 		},
-	}, ws))
+	}, wsJson, nil))
 	res := &loghttp.TailResponse{}
 	require.NoError(t, ReadTailResponseJSON(res, ws))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow-up PR for https://github.com/grafana/loki/pull/10419 adding support for tailing.

I tested it on a dev cell and works fine.
<img width="1296" alt="image" src="https://github.com/grafana/loki/assets/8354290/6177e0ca-02ce-48cd-a17f-0739dc3caa0a">


**Note**: With these changes, the JSON marshal unmarshal functions for the tail are no longer used ([example][1]) so I think we can remove them. Also, the new Tail response is no longer used, so we can also make it an alias to the _legacy_ one. Let's do it on a follow-up PR to avoid making this one bigger.

[1]: https://github.com/grafana/loki/blob/52a3f16039dd5ff655fc3681257d99794f620ec4/pkg/loghttp/entry.go#L210-L238