### PR TITLE
Instrument querier inflight requests.

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -515,7 +515,12 @@ func (t *Loki) initQuerier() (services.Service, error) {
 
 	internalHandler := queryrangebase.MergeMiddlewares(
 		serverutil.RecoveryMiddleware,
-		queryrange.Instrument{},
+		queryrange.Instrument{
+			QueryHandlerMetrics: queryrange.NewQueryHandlerMetrics(
+				prometheus.DefaultRegisterer,
+				t.Cfg.MetricsNamespace,
+			),
+		},
 	).Wrap(handler)
 
 	svc, err := querier.InitWorkerService(

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -513,10 +513,15 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	t.Server.HTTP.Path("/loki/api/v1/tail").Methods("GET", "POST").Handler(httpMiddleware.Wrap(http.HandlerFunc(t.querierAPI.TailHandler)))
 	t.Server.HTTP.Path("/api/prom/tail").Methods("GET", "POST").Handler(httpMiddleware.Wrap(http.HandlerFunc(t.querierAPI.TailHandler)))
 
+	internalHandler := queryrangebase.MergeMiddlewares(
+		serverutil.RecoveryMiddleware,
+		queryrange.Instrument{},
+	).Wrap(handler)
+
 	svc, err := querier.InitWorkerService(
 		querierWorkerServiceConfig,
 		prometheus.DefaultRegisterer,
-		serverutil.RecoveryMiddleware.Wrap(handler),
+		internalHandler,
 		t.Codec,
 	)
 	if err != nil {

--- a/pkg/querier/queryrange/instrument.go
+++ b/pkg/querier/queryrange/instrument.go
@@ -1,0 +1,47 @@
+package queryrange
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/pkg/querier/queryrange/queryrangebase"
+)
+
+const (
+	gRPC = "gRPC"
+)
+
+type QueryHandlerMetrics struct {
+	InflightRequests *prometheus.GaugeVec
+}
+
+func NewQueryHandlerMetrics(registerer prometheus.Registerer, metricsNamespace string) *QueryHandlerMetrics {
+	return &QueryHandlerMetrics{
+		InflightRequests: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "inflight_requests",
+			Help:      "Current number of inflight requests.",
+		}, []string{"method", "route"}),
+	}
+}
+
+type Instrument struct {
+	*QueryHandlerMetrics
+}
+
+var _ queryrangebase.Middleware = Instrument{}
+
+// Wrap implements the queryrangebase.Middleware
+func (i Instrument) Wrap(next queryrangebase.Handler) queryrangebase.Handler {
+	return queryrangebase.HandlerFunc(func(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+		route := fmt.Sprintf("%T", r)
+		inflight := i.InflightRequests.WithLabelValues(gRPC, route)
+		inflight.Inc()
+		defer inflight.Dec()
+
+		return next.Do(ctx, r)
+	})
+}

--- a/pkg/querier/queryrange/metrics.go
+++ b/pkg/querier/queryrange/metrics.go
@@ -14,6 +14,7 @@ type Metrics struct {
 	*SplitByMetrics
 	*LogResultCacheMetrics
 	*queryrangebase.ResultsCacheMetrics
+	*QueryHandlerMetrics
 }
 
 type MiddlewareMapperMetrics struct {
@@ -36,5 +37,6 @@ func NewMetrics(registerer prometheus.Registerer, metricsNamespace string) *Metr
 		SplitByMetrics:              NewSplitByMetrics(registerer),
 		LogResultCacheMetrics:       NewLogResultCacheMetrics(registerer),
 		ResultsCacheMetrics:         queryrangebase.NewResultsCacheMetrics(registerer),
+		QueryHandlerMetrics:         NewQueryHandlerMetrics(registerer, metricsNamespace),
 	}
 }

--- a/pkg/querier/queryrange/metrics.go
+++ b/pkg/querier/queryrange/metrics.go
@@ -14,7 +14,6 @@ type Metrics struct {
 	*SplitByMetrics
 	*LogResultCacheMetrics
 	*queryrangebase.ResultsCacheMetrics
-	*QueryHandlerMetrics
 }
 
 type MiddlewareMapperMetrics struct {
@@ -37,6 +36,5 @@ func NewMetrics(registerer prometheus.Registerer, metricsNamespace string) *Metr
 		SplitByMetrics:              NewSplitByMetrics(registerer),
 		LogResultCacheMetrics:       NewLogResultCacheMetrics(registerer),
 		ResultsCacheMetrics:         queryrangebase.NewResultsCacheMetrics(registerer),
-		QueryHandlerMetrics:         NewQueryHandlerMetrics(registerer, metricsNamespace),
 	}
 }

--- a/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-boltdb-storage-s3/config/loki.yaml
@@ -123,7 +123,6 @@ storage_config:
         cache_location: /data/boltdb-cache
         index_gateway_client:
             server_address: index-gateway:9008
-        shared_store: s3
     aws:
       s3: s3://loki:supersecret@minio:9000/loki
       s3forcepathstyle: true


### PR DESCRIPTION
**What this PR does / why we need it**:
#10858 removed the HTTP and gRPC server from the querier workers. That means inflight requests are not instrumented anymore. This change adds a middleware that does that.

This will add metrics such as 
```
# HELP cortex_inflight_requests Current number of inflight requests.
# TYPE cortex_inflight_requests gauge
cortex_inflight_requests{method="gRPC",route="*logproto.IndexStatsRequest"} 0
cortex_inflight_requests{method="gRPC",route="*queryrange.LabelRequest"} 0
cortex_inflight_requests{method="gRPC",route="*queryrange.LokiRequest"} 0
cortex_inflight_requests{method="gRPC",route="*queryrange.LokiSeriesRequest"} 0
```

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
