### PR TITLE
Bloom/fuse queries

### DIFF
--- a/pkg/storage/bloom/v1/TODO.md
+++ b/pkg/storage/bloom/v1/TODO.md
@@ -1,5 +1,3 @@
-* Should be able to read bloom as a []byte without copying it during decoding
-  * It's immutable + partition offsets are calculable, etc
 * Less copying! I've taken some shortcuts we'll need to refactor to avoid copying []byte around in a few places
 * more sophisticated querying methods
 * queue access to blooms

--- a/pkg/storage/bloom/v1/TODO.md
+++ b/pkg/storage/bloom/v1/TODO.md
@@ -5,7 +5,10 @@
 * Queueing system for bloom access
 * bloom hierarchies (bloom per block, etc). Test a tree of blooms down the to individual series/chunk
 * memoize hashing & bucket lookups during queries
-* encode bloom parameters in block
+* versioning
+  * so we can change implementations
+  * encode bloom parameters in block: sbf params, hashing strategy, tokenizer
+* caching
 
 
 # merge querier for different blocks

--- a/pkg/storage/bloom/v1/TODO.md
+++ b/pkg/storage/bloom/v1/TODO.md
@@ -3,6 +3,10 @@
 * queue access to blooms
 * multiplex reads across blooms
 * Queueing system for bloom access
+* bloom hierarchies (bloom per block, etc). Test a tree of blooms down the to individual series/chunk
+* memoize hashing & bucket lookups during queries
+* encode bloom parameters in block
+
 
 # merge querier for different blocks
 * how to merge two block queriers with the same fp

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -501,7 +501,7 @@ func (mb *MergeBuilder) Build(builder *BlockBuilder) error {
 	}
 
 	// Turn the list of blocks into a single iterator that returns the next series
-	mergedBlocks := NewPeekingIter[*SeriesWithBloom](NewMergeBlockQuerier(xs...))
+	mergedBlocks := NewPeekingIter[*SeriesWithBloom](NewHeapIterForSeriesWithBloom(xs...))
 	// two overlapping blocks can conceivably have the same series, so we need to dedupe,
 	// preferring the one with the most chunks already indexed since we'll have
 	// to add fewer chunks to the bloom

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -509,6 +509,7 @@ func (mb *MergeBuilder) Build(builder *BlockBuilder) error {
 		func(a, b *SeriesWithBloom) bool {
 			return a.Series.Fingerprint == b.Series.Fingerprint
 		},
+		id[*SeriesWithBloom],
 		func(a, b *SeriesWithBloom) *SeriesWithBloom {
 			if len(a.Series.Chunks) > len(b.Series.Chunks) {
 				return a

--- a/pkg/storage/bloom/v1/builder.go
+++ b/pkg/storage/bloom/v1/builder.go
@@ -473,14 +473,18 @@ func SortBlocksIntoOverlappingGroups(xs []*Block) (groups [][]*Block) {
 // from a list of blocks and a store of series.
 type MergeBuilder struct {
 	// existing blocks
-	blocks []*Block
+	blocks []PeekingIterator[*SeriesWithBloom]
 	// store
 	store Iterator[*Series]
 	// Add chunks to a bloom
 	populate func(*Series, *Bloom) error
 }
 
-func NewMergeBuilder(blocks []*Block, store Iterator[*Series], populate func(*Series, *Bloom) error) *MergeBuilder {
+// NewMergeBuilder is a specific builder which does the following:
+//  1. merges multiple blocks into a single ordered querier,
+//     i) When two blocks have the same series, it will prefer the one with the most chunks already indexed
+//  2. iterates through the store, adding chunks to the relevant blooms via the `populate` argument
+func NewMergeBuilder(blocks []PeekingIterator[*SeriesWithBloom], store Iterator[*Series], populate func(*Series, *Bloom) error) *MergeBuilder {
 	return &MergeBuilder{
 		blocks:   blocks,
 		store:    store,
@@ -492,16 +496,11 @@ func NewMergeBuilder(blocks []*Block, store Iterator[*Series], populate func(*Se
 // but this gives us a good starting point.
 func (mb *MergeBuilder) Build(builder *BlockBuilder) error {
 	var (
-		xs           = make([]PeekingIterator[*SeriesWithBloom], 0, len(mb.blocks))
 		nextInBlocks *SeriesWithBloom
 	)
 
-	for _, block := range mb.blocks {
-		xs = append(xs, NewPeekingIter[*SeriesWithBloom](NewBlockQuerier(block)))
-	}
-
 	// Turn the list of blocks into a single iterator that returns the next series
-	mergedBlocks := NewPeekingIter[*SeriesWithBloom](NewHeapIterForSeriesWithBloom(xs...))
+	mergedBlocks := NewPeekingIter[*SeriesWithBloom](NewHeapIterForSeriesWithBloom(mb.blocks...))
 	// two overlapping blocks can conceivably have the same series, so we need to dedupe,
 	// preferring the one with the most chunks already indexed since we'll have
 	// to add fewer chunks to the bloom
@@ -567,6 +566,13 @@ func (mb *MergeBuilder) Build(builder *BlockBuilder) error {
 		if err := builder.AddSeries(*cur); err != nil {
 			return errors.Wrap(err, "adding series to block")
 		}
+	}
+
+	if err := builder.blooms.Close(); err != nil {
+		return errors.Wrap(err, "closing bloom file")
+	}
+	if err := builder.index.Close(); err != nil {
+		return errors.Wrap(err, "closing series file")
 	}
 	return nil
 }

--- a/pkg/storage/bloom/v1/builder_test.go
+++ b/pkg/storage/bloom/v1/builder_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -45,6 +46,17 @@ func mkBasicSeriesWithBlooms(nSeries, keysPerSeries int, fromFp, throughFp model
 		keysList = append(keysList, keys)
 	}
 	return
+}
+
+func EqualIterators[T any](t *testing.T, test func(a, b T), expected, actual Iterator[T]) {
+	for expected.Next() {
+		require.True(t, actual.Next())
+		a, b := expected.At(), actual.At()
+		test(a, b)
+	}
+	require.False(t, actual.Next())
+	require.Nil(t, expected.Err())
+	require.Nil(t, actual.Err())
 }
 
 func TestBlockBuilderRoundTrip(t *testing.T) {
@@ -123,4 +135,87 @@ func TestBlockBuilderRoundTrip(t *testing.T) {
 
 		})
 	}
+}
+
+func TestMergeBuilder(t *testing.T) {
+
+	nBlocks := 10
+	numSeries := 100
+	numKeysPerSeries := 100
+	blocks := make([]PeekingIterator[*SeriesWithBloom], 0, nBlocks)
+	data, _ := mkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
+	blockOpts := BlockOptions{
+		schema: Schema{
+			version:  DefaultSchemaVersion,
+			encoding: chunkenc.EncSnappy,
+		},
+		SeriesPageSize: 100,
+		BloomPageSize:  10 << 10,
+	}
+
+	// Build a list of blocks containing overlapping & duplicated parts of the dataset
+	for i := 0; i < nBlocks; i++ {
+		// references for linking in memory reader+writer
+		indexBuf := bytes.NewBuffer(nil)
+		bloomsBuf := bytes.NewBuffer(nil)
+
+		min := i * numSeries / nBlocks
+		max := (i + 2) * numSeries / nBlocks // allow some overlap
+		if max > len(data) {
+			max = len(data)
+		}
+
+		writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
+		reader := NewByteReader(indexBuf, bloomsBuf)
+
+		builder, err := NewBlockBuilder(
+			blockOpts,
+			writer,
+		)
+
+		require.Nil(t, err)
+		itr := NewSliceIter[SeriesWithBloom](data[min:max])
+		require.Nil(t, builder.BuildFrom(itr))
+		blocks = append(blocks, NewPeekingIter[*SeriesWithBloom](NewBlockQuerier(NewBlock(reader))))
+	}
+
+	// We're not testing the ability to extend a bloom in this test
+	pop := func(_ *Series, _ *Bloom) error {
+		return errors.New("not implemented")
+	}
+
+	// storage should contain references to all the series we ingested,
+	// regardless of block allocation/overlap.
+	storeItr := NewMapIter[SeriesWithBloom, *Series](
+		NewSliceIter[SeriesWithBloom](data),
+		func(swb SeriesWithBloom) *Series {
+			return swb.Series
+		},
+	)
+
+	// Ensure that the merge builder combines all the blocks correctly
+	mergeBuilder := NewMergeBuilder(blocks, storeItr, pop)
+	indexBuf := bytes.NewBuffer(nil)
+	bloomsBuf := bytes.NewBuffer(nil)
+	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
+	reader := NewByteReader(indexBuf, bloomsBuf)
+
+	builder, err := NewBlockBuilder(
+		blockOpts,
+		writer,
+	)
+	require.Nil(t, err)
+
+	require.Nil(t, mergeBuilder.Build(builder))
+	block := NewBlock(reader)
+	querier := NewBlockQuerier(block)
+
+	EqualIterators[*SeriesWithBloom](
+		t,
+		func(a, b *SeriesWithBloom) {
+			require.Equal(t, a.Series, b.Series, "expected %+v, got %+v", a, b)
+		},
+		NewSliceIter[*SeriesWithBloom](PointerSlice(data)),
+		querier,
+	)
 }

--- a/pkg/storage/bloom/v1/dedupe.go
+++ b/pkg/storage/bloom/v1/dedupe.go
@@ -1,55 +1,54 @@
 package v1
 
-// DedupeIter is a deduplicating iterator that merges adjacent elements
-// It's intended to be used when merging multiple blocks,
-// each of which may contain the same fingerprints
-type DedupeIter[T any] struct {
-	eq    func(T, T) bool
-	merge func(T, T) T
-	itr   PeekingIterator[T]
+// DedupeIter is a deduplicating iterator which creates an Iterator[B]
+// from a sequence of Iterator[A].
+type DedupeIter[A, B any] struct {
+	eq    func(A, B) bool // equality check
+	from  func(A) B       // convert A to B, used on first element
+	merge func(A, B) B    // merge A into B
+	itr   PeekingIterator[A]
 
-	tmp []T
+	tmp B
 }
 
-func NewDedupingIter[T any](
-	eq func(T, T) bool,
-	merge func(T, T) T,
-	itr PeekingIterator[T],
-) *DedupeIter[T] {
-	return &DedupeIter[T]{
+// general helper, in this case created for DedupeIter[T,T]
+func id[A any](a A) A { return a }
+
+func NewDedupingIter[A, B any](
+	eq func(A, B) bool,
+	from func(A) B,
+	merge func(A, B) B,
+	itr PeekingIterator[A],
+) *DedupeIter[A, B] {
+	return &DedupeIter[A, B]{
 		eq:    eq,
+		from:  from,
 		merge: merge,
 		itr:   itr,
 	}
 }
 
-func (it *DedupeIter[T]) Next() bool {
-	it.tmp = it.tmp[:0]
+func (it *DedupeIter[A, B]) Next() bool {
 	if !it.itr.Next() {
 		return false
 	}
-	it.tmp = append(it.tmp, it.itr.At())
+	it.tmp = it.from(it.itr.At())
 	for {
 		next, ok := it.itr.Peek()
-		if !ok || !it.eq(it.tmp[0], next) {
+		if !ok || !it.eq(next, it.tmp) {
 			break
 		}
 
 		it.itr.Next() // ensured via peek
-		it.tmp = append(it.tmp, it.itr.At())
-	}
-
-	// merge all the elements in tmp
-	for i := len(it.tmp) - 1; i > 0; i-- {
-		it.tmp[i-1] = it.merge(it.tmp[i-1], it.tmp[i])
+		it.tmp = it.merge(next, it.tmp)
 	}
 	return true
 }
 
-func (it *DedupeIter[T]) Err() error {
+func (it *DedupeIter[A, B]) Err() error {
 	return it.itr.Err()
 }
 
-func (it *DedupeIter[T]) At() T {
-	return it.tmp[0]
+func (it *DedupeIter[A, B]) At() B {
+	return it.tmp
 }

--- a/pkg/storage/bloom/v1/dedupe_test.go
+++ b/pkg/storage/bloom/v1/dedupe_test.go
@@ -26,8 +26,9 @@ func TestMergeDedupeIter(t *testing.T) {
 	merge := func(a, _ *SeriesWithBloom) *SeriesWithBloom {
 		return a
 	}
-	deduper := NewDedupingIter[*SeriesWithBloom](
+	deduper := NewDedupingIter[*SeriesWithBloom, *SeriesWithBloom](
 		eq,
+		id[*SeriesWithBloom],
 		merge,
 		NewPeekingIter[*SeriesWithBloom](mbq),
 	)

--- a/pkg/storage/bloom/v1/dedupe_test.go
+++ b/pkg/storage/bloom/v1/dedupe_test.go
@@ -19,7 +19,7 @@ func TestMergeDedupeIter(t *testing.T) {
 		queriers[i] = NewPeekingIter[*SeriesWithBloom](NewSliceIter[*SeriesWithBloom](dataPtr))
 	}
 
-	mbq := NewMergeBlockQuerier(queriers...)
+	mbq := NewHeapIterForSeriesWithBloom(queriers...)
 	eq := func(a, b *SeriesWithBloom) bool {
 		return a.Series.Fingerprint == b.Series.Fingerprint
 	}

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -14,8 +14,6 @@ type request struct {
 	response chan<- output
 }
 
-type inputs Iterator[request]
-
 type CancellableInputsIter struct {
 	ctx context.Context
 	Iterator[request]
@@ -39,19 +37,20 @@ type output struct {
 
 // Fuse combines multiple requests into a single loop iteration
 // over the data set and returns the corresponding outputs
-func (bq *BlockQuerier) Fuse(inputs []inputs) *FusedQuerier {
+func (bq *BlockQuerier) Fuse(inputs []Iterator[request]) *FusedQuerier {
 	return NewFusedQuerier(bq, inputs)
 }
 
 type FusedQuerier struct {
 	bq     *BlockQuerier
-	inputs []inputs
+	inputs Iterator[[]request]
 }
 
-func NewFusedQuerier(bq *BlockQuerier, inputs []inputs) *FusedQuerier {
+func NewFusedQuerier(bq *BlockQuerier, inputs []Iterator[request]) *FusedQuerier {
+	// heap := NewHeapIterator[request]()
 	return &FusedQuerier{
 		bq:     bq,
-		inputs: inputs,
+		inputs: nil,
 	}
 }
 

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/efficientgo/core/errors"
+	"github.com/prometheus/common/model"
+)
+
+type request struct {
+	fp       model.Fingerprint
+	chks     ChunkRefs
+	searches [][]byte
+	response chan<- output
+}
+
+type inputs Iterator[request]
+
+type CancellableInputsIter struct {
+	ctx context.Context
+	Iterator[request]
+}
+
+func (cii *CancellableInputsIter) Next() bool {
+	select {
+	case <-cii.ctx.Done():
+		return false
+	default:
+		return cii.Iterator.Next()
+	}
+}
+
+// output represents a chunk that failed to pass all searches
+// and must be downloaded
+type output struct {
+	fp   model.Fingerprint
+	chks ChunkRefs
+}
+
+// Fuse combines multiple requests into a single loop iteration
+// over the data set and returns the corresponding outputs
+func (bq *BlockQuerier) Fuse(inputs []inputs) *FusedQuerier {
+	return NewFusedQuerier(bq, inputs)
+}
+
+type FusedQuerier struct {
+	bq     *BlockQuerier
+	inputs []inputs
+}
+
+func NewFusedQuerier(bq *BlockQuerier, inputs []inputs) *FusedQuerier {
+	return &FusedQuerier{
+		bq:     bq,
+		inputs: inputs,
+	}
+}
+
+// returns a batch of inputs for the next fingerprint
+func (fq *FusedQuerier) nextFP() ([]request, error) {
+	return nil, nil
+}
+
+func (fq *FusedQuerier) Run() error {
+	for {
+		// find all queries for the next relevant fingerprint
+		nextBatch, err := fq.nextFP()
+		if err != nil {
+			return errors.Wrap(err, "getting next fingerprint")
+		}
+
+		if len(nextBatch) == 0 {
+			return nil
+		}
+
+		fp := nextBatch[0].fp
+
+		// advance the series iterator to the next fingerprint
+		if err := fq.bq.Seek(fp); err != nil {
+			return errors.Wrap(err, "seeking to fingerprint")
+		}
+
+		if !fq.bq.series.Next() {
+			// TODO(owen-d): fingerprint not found, can't remove chunks
+		}
+
+		series := fq.bq.series.At()
+		if series.Fingerprint != fp {
+			// TODO(owen-d): fingerprint not found, can't remove chunks
+		}
+
+		// Now that we've found the series, we need to find the unpack the bloom
+		fq.bq.blooms.Seek(series.Offset)
+		if !fq.bq.blooms.Next() {
+			// TODO(owen-d): fingerprint not found, can't remove chunks
+		}
+
+		bloom := fq.bq.blooms.At()
+		// test every input against this chunk
+		for _, input := range nextBatch {
+			mustCheck, inBlooms := input.chks.Compare(series.Chunks, true)
+
+		outer:
+			for _, chk := range inBlooms {
+				for _, search := range input.searches {
+					// TODO(owen-d): meld chunk + search into a single byte slice from the block schema
+					var combined = search
+
+					if !bloom.ScalableBloomFilter.Test(combined) {
+						continue outer
+					}
+				}
+				// chunk passed all searches, add to the list of chunks to download
+				mustCheck = append(mustCheck, chk)
+
+			}
+
+			input.response <- output{
+				fp:   fp,
+				chks: mustCheck,
+			}
+		}
+
+	}
+
+}

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"context"
-
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/common/model"
 )
@@ -11,21 +9,7 @@ type request struct {
 	fp       model.Fingerprint
 	chks     ChunkRefs
 	searches [][]byte
-	response chan<- output
-}
-
-type CancellableInputsIter struct {
-	ctx context.Context
-	Iterator[request]
-}
-
-func (cii *CancellableInputsIter) Next() bool {
-	select {
-	case <-cii.ctx.Done():
-		return false
-	default:
-		return cii.Iterator.Next()
-	}
+	response chan output
 }
 
 // output represents a chunk that failed to pass all searches
@@ -37,6 +21,7 @@ type output struct {
 
 // Fuse combines multiple requests into a single loop iteration
 // over the data set and returns the corresponding outputs
+// TODO(owen-d): better async control
 func (bq *BlockQuerier) Fuse(inputs []PeekingIterator[request]) *FusedQuerier {
 	return NewFusedQuerier(bq, inputs)
 }

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -132,4 +132,5 @@ func (fq *FusedQuerier) Run() error {
 
 	}
 
+	return nil
 }

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -91,3 +91,100 @@ func TestFusedQuerier(t *testing.T) {
 		}
 	}
 }
+
+func setupBlockForBenchmark(b *testing.B) (*BlockQuerier, [][]request) {
+	indexBuf := bytes.NewBuffer(nil)
+	bloomsBuf := bytes.NewBuffer(nil)
+	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
+	reader := NewByteReader(indexBuf, bloomsBuf)
+	numSeries := 10000
+	numKeysPerSeries := 100
+	data, _ := mkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffffff, 0, 10000)
+
+	builder, err := NewBlockBuilder(
+		BlockOptions{
+			schema: Schema{
+				version:  DefaultSchemaVersion,
+				encoding: chunkenc.EncSnappy,
+			},
+			SeriesPageSize: 256 << 10, // 256k
+			BloomPageSize:  1 << 20,   // 1MB
+		},
+		writer,
+	)
+	require.Nil(b, err)
+	itr := NewSliceIter[SeriesWithBloom](data)
+	require.Nil(b, builder.BuildFrom(itr))
+	block := NewBlock(reader)
+	querier := NewBlockQuerier(block)
+
+	numRequestChains := 100
+	seriesPerRequest := 100
+	var requestChains [][]request
+	for i := 0; i < numRequestChains; i++ {
+		var reqs []request
+		// ensure they use the same channel
+		ch := make(chan output)
+		// evenly spread out the series queried within a single request chain
+		// to mimic series distribution across keyspace
+		for j := 0; j < seriesPerRequest; j++ {
+			// add the chain index (i) for a little jitter
+			idx := numSeries*j/seriesPerRequest + i
+			if idx >= numSeries {
+				idx = numSeries - 1
+			}
+			reqs = append(reqs, request{
+				fp:       data[idx].Series.Fingerprint,
+				chks:     data[idx].Series.Chunks,
+				response: ch,
+			})
+		}
+		requestChains = append(requestChains, reqs)
+	}
+
+	return querier, requestChains
+}
+
+func BenchmarkBlockQuerying(b *testing.B) {
+	b.StopTimer()
+	querier, requestChains := setupBlockForBenchmark(b)
+	// benchmark
+	b.StartTimer()
+
+	b.Run("single-pass", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, chain := range requestChains {
+				for _, req := range chain {
+					_, _ = querier.CheckChunksForSeries(req.fp, req.chks, nil)
+				}
+			}
+		}
+
+	})
+	b.Run("fused", func(b *testing.B) {
+		// spin up some goroutines to consume the responses so they don't block
+		go func() {
+			concurrency.ForEachJob(
+				context.Background(),
+				len(requestChains), len(requestChains),
+				func(_ context.Context, idx int) error {
+					for range requestChains[idx][0].response {
+					}
+					return nil
+				},
+			)
+		}()
+
+		var itrs []PeekingIterator[request]
+
+		for i := 0; i < b.N; i++ {
+			itrs = itrs[:0]
+			for _, reqs := range requestChains {
+				itrs = append(itrs, NewPeekingIter[request](NewSliceIter[request](reqs)))
+			}
+			fused := querier.Fuse(itrs)
+			_ = fused.Run()
+		}
+	})
+
+}

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -1,0 +1,93 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/loki/pkg/chunkenc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFusedQuerier(t *testing.T) {
+	// references for linking in memory reader+writer
+	indexBuf := bytes.NewBuffer(nil)
+	bloomsBuf := bytes.NewBuffer(nil)
+	writer := NewMemoryBlockWriter(indexBuf, bloomsBuf)
+	reader := NewByteReader(indexBuf, bloomsBuf)
+	numSeries := 100
+	numKeysPerSeries := 10000
+	data, _ := mkBasicSeriesWithBlooms(numSeries, numKeysPerSeries, 0, 0xffff, 0, 10000)
+
+	builder, err := NewBlockBuilder(
+		BlockOptions{
+			schema: Schema{
+				version:  DefaultSchemaVersion,
+				encoding: chunkenc.EncSnappy,
+			},
+			SeriesPageSize: 100,
+			BloomPageSize:  10 << 10,
+		},
+		writer,
+	)
+	require.Nil(t, err)
+	itr := NewSliceIter[SeriesWithBloom](data)
+	require.Nil(t, builder.BuildFrom(itr))
+	block := NewBlock(reader)
+	querier := NewBlockQuerier(block)
+
+	nReqs := 10
+	var inputs [][]request
+	for i := 0; i < nReqs; i++ {
+		ch := make(chan output)
+		var reqs []request
+		// find 2 series for each
+		for j := 0; j < 2; j++ {
+			idx := numSeries/nReqs*i + j
+			reqs = append(reqs, request{
+				fp:       data[idx].Series.Fingerprint,
+				chks:     data[idx].Series.Chunks,
+				response: ch,
+			})
+		}
+		inputs = append(inputs, reqs)
+	}
+
+	var itrs []PeekingIterator[request]
+	for _, reqs := range inputs {
+		itrs = append(itrs, NewPeekingIter[request](NewSliceIter[request](reqs)))
+	}
+
+	resps := make([][]output, nReqs)
+	go func() {
+		concurrency.ForEachJob(
+			context.Background(),
+			len(resps),
+			len(resps),
+			func(_ context.Context, i int) error {
+				for v := range inputs[i][0].response {
+					resps[i] = append(resps[i], v)
+				}
+				return nil
+			},
+		)
+	}()
+
+	fused := querier.Fuse(itrs)
+	require.Nil(t, fused.Run())
+
+	for i, input := range inputs {
+		for j, req := range input {
+			resp := resps[i][j]
+			require.Equal(
+				t,
+				output{
+					fp:   req.fp,
+					chks: req.chks,
+				},
+				resp,
+			)
+		}
+	}
+}

--- a/pkg/storage/bloom/v1/merge_test.go
+++ b/pkg/storage/bloom/v1/merge_test.go
@@ -22,7 +22,7 @@ func TestMergeBlockQuerier_NonOverlapping(t *testing.T) {
 		queriers = append(queriers, NewPeekingIter[*SeriesWithBloom](NewSliceIter[*SeriesWithBloom](ptrs)))
 	}
 
-	mbq := NewMergeBlockQuerier(queriers...)
+	mbq := NewHeapIterForSeriesWithBloom(queriers...)
 
 	for i := 0; i < numSeries; i++ {
 		require.True(t, mbq.Next())
@@ -49,7 +49,7 @@ func TestMergeBlockQuerier_Overlapping(t *testing.T) {
 		queriers = append(queriers, NewPeekingIter[*SeriesWithBloom](NewSliceIter[*SeriesWithBloom](slices[i])))
 	}
 
-	mbq := NewMergeBlockQuerier(queriers...)
+	mbq := NewHeapIterForSeriesWithBloom(queriers...)
 
 	for i := 0; i < numSeries; i++ {
 		require.True(t, mbq.Next())

--- a/pkg/storage/bloom/v1/util.go
+++ b/pkg/storage/bloom/v1/util.go
@@ -167,6 +167,19 @@ func (it *SliceIter[T]) At() T {
 	return it.xs[it.cur]
 }
 
+type MapIter[A any, B any] struct {
+	Iterator[A]
+	f func(A) B
+}
+
+func NewMapIter[A any, B any](src Iterator[A], f func(A) B) *MapIter[A, B] {
+	return &MapIter[A, B]{Iterator: src, f: f}
+}
+
+func (it *MapIter[A, B]) At() B {
+	return it.f(it.Iterator.At())
+}
+
 type EmptyIter[T any] struct {
 	zero T
 }


### PR DESCRIPTION
Introduces a "Fuse" operation on a single block querier which multiplexes queries against a single block. This is advantageous for a few reasons:
* A "query" contains one of more series, with each series needing to test one or more chunks for some search string(s).
* Blocks are sorted by fingerprint, which are the result of a hash function. This means series are ~uniformly distributed across the hash keyspace (`uint64` in our case). Because of this, a query for some number of series are likely to be spread out across the block itself.
* Blocks are organized into individually compressed "pages". In essence, querying them requires Seeking to the correct offset, decompressing the page, then seeking within the page to the actual offset for a particular series.
* Since the series for any query are likely spread out across the block, performing `n` queries decompresses each page `n` times.
* By multiplexing many queries into a single pass iteration of the block, we amortize the cost of loading & decompressing

Misc:
Also introduces a bunch of generic-powered iterators. These can probably be optimized (I bet they use dynamic dispatch under the hood), but they're very convenient to prototype with and we can improve them in the future if it proves warranted.