### PR TITLE
fix(lambda-promtail): Add asterisk to log group ARN to allow writing to log streams

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch" {
       "logs:PutLogEvents",
     ]
     resources = [
-      aws_cloudwatch_log_group.this.arn,
+      "${aws_cloudwatch_log_group.this.arn}:*",
     ]
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The current ARN format in `aws_iam_policy_document.lambda_cloudwatch`  which is `aws_cloudwatch_log_group.this.arn` doesn't allow to write logs because it's missing permissions for logs streams. Instead, an `*` should be appended to fix this permission like in `"${aws_cloudwatch_log_group.this.arn}:*"`

**Which issue(s) this PR fixes**:
No issue created.

**Special notes for your reviewer**:
Tested with 
```hcl
module "lambda_promtail" {
  source = "github.com/gmeligio/loki//tools/lambda-promtail?ref=promtail-loggroup-arn"

  bucket_names          = local.bucket_names
  lambda_promtail_image = "my-image"
  write_address         = var.write_address
  username              = var.username
  password              = var.password
}
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
