### PR TITLE
Remove timeout parameter

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config "${CT_CONFIGFILE}" --check-version-increment=false
+        timeout-minutes: 10
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.8.0

--- a/production/helm/ct.yaml
+++ b/production/helm/ct.yaml
@@ -7,6 +7,5 @@ chart-repos:
   - grafana=https://grafana.github.io/helm-charts
   - minio=https://charts.min.io
   - prometheus-community=https://prometheus-community.github.io/helm-charts
-helm-extra-args: --timeout 600s
 check-version-increment: false
 validate-maintainers: false


### PR DESCRIPTION
**What this PR does / why we need it**:

The `helm-extra-args` causes an error with the new version of ct lint. This change removes the timeout parameter specified in there and adds a timeout in the CI step configuration.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
