### PR TITLE
Jsonnet: Fix unit used by per-pod latency panel

### DIFF
--- a/production/loki-mixin-compiled-ssd/dashboards/loki-reads.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-reads.json
@@ -209,14 +209,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 3,
@@ -482,14 +485,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 6,

--- a/production/loki-mixin-compiled/dashboards/loki-reads.json
+++ b/production/loki-mixin-compiled/dashboards/loki-reads.json
@@ -209,14 +209,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 3,
@@ -482,14 +485,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 6,
@@ -755,14 +761,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 9,
@@ -1028,14 +1037,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 12,
@@ -1301,14 +1313,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 15,
@@ -1574,14 +1589,17 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fieldConfig": {
-                     "custom": {
-                        "fillOpacity": 50,
-                        "showPoints": "never",
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
+                     "defaults": {
+                        "custom": {
+                           "fillOpacity": 50,
+                           "showPoints": "never",
+                           "stacking": {
+                              "group": "A",
+                              "mode": "normal"
+                           }
                         }
-                     }
+                     },
+                     "unit": "ms"
                   },
                   "fill": 1,
                   "id": 18,

--- a/production/loki-mixin/dashboards/loki-reads.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads.libsonnet
@@ -28,14 +28,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         ],
         fieldConfig+: {
-          custom+: {
-            fillOpacity: 50,
-            showPoints: 'never',
-            stacking: {
-              group: 'A',
-              mode: 'normal',
+          defaults+: {
+            custom+: {
+              fillOpacity: 50,
+              showPoints: 'never',
+              stacking: {
+                group: 'A',
+                mode: 'normal',
+              },
             },
           },
+          unit: 'ms',
         },
       },
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The per-pod latency panel should use "ms" as the unit, instead of the default (which is "short").
I'm also wrapping everything around "defaults", because that's how it is used everywhere. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
