### PR TITLE
fix(pkg/logentry/stage): prevent data race processing entries

### DIFF
--- a/clients/pkg/logentry/stages/pipeline.go
+++ b/clients/pkg/logentry/stages/pipeline.go
@@ -27,6 +27,7 @@ type Pipeline struct {
 	logger    log.Logger
 	stages    []Stage
 	jobName   *string
+	mtx       sync.Mutex
 	dropCount *prometheus.CounterVec
 }
 
@@ -113,6 +114,8 @@ func RunWithSkipOrSendMany(input chan Entry, process func(e Entry) ([]Entry, boo
 // Run implements Stage
 func (p *Pipeline) Run(in chan Entry) chan Entry {
 	in = RunWith(in, func(e Entry) Entry {
+		p.mtx.Lock()
+		defer p.mtx.Unlock()
 		// Initialize the extracted map with the initial labels (ie. "filename"),
 		// so that stages can operate on initial labels too
 		for labelName, labelValue := range e.Labels {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent data race and eventual panic due to concurrent access of `labelSet` map for `Entry` structs

**Which issue(s) this PR fixes**:
Fixes #11065 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
