### PR TITLE
Use newest build image 0.31.2 with golangci-lint update.

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -93,14 +93,14 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-drone-drift
 - commands:
   - make BUILD_IN_CONTAINER=false check-generated-files
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-generated-files
 - commands:
   - cd ..
@@ -110,7 +110,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: clone-target-branch
   when:
     event:
@@ -121,14 +121,14 @@ steps:
   - clone-target-branch
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: test
 - commands:
   - cd ../loki-target-branch && BUILD_IN_CONTAINER=false make test
   depends_on:
   - clone-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: test-target-branch
   when:
     event:
@@ -141,7 +141,7 @@ steps:
   - test
   - test-target-branch
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: compare-coverage
   when:
     event:
@@ -159,7 +159,7 @@ steps:
     TOKEN:
       from_secret: github_token
     USER: grafanabot
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: report-coverage
   when:
     event:
@@ -169,7 +169,7 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: lint
 - commands:
   - make BUILD_IN_CONTAINER=false check-mod
@@ -177,7 +177,7 @@ steps:
   - test
   - lint
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-mod
 - commands:
   - apk add make bash && make lint-scripts
@@ -188,21 +188,21 @@ steps:
   depends_on:
   - check-generated-files
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: loki
 - commands:
   - make BUILD_IN_CONTAINER=false check-doc
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-doc
 - commands:
   - make BUILD_IN_CONTAINER=false check-format GIT_TARGET_BRANCH="$DRONE_TARGET_BRANCH"
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-format
   when:
     event:
@@ -212,14 +212,14 @@ steps:
   depends_on:
   - loki
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: validate-example-configs
 - commands:
   - make BUILD_IN_CONTAINER=false check-example-config-doc
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: check-example-config-doc
 - commands:
   - mkdir -p /hugo/content/docs/loki/latest
@@ -252,7 +252,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: loki-mixin-check
   when:
     event:
@@ -277,7 +277,7 @@ steps:
   depends_on:
   - clone
   environment: {}
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: documentation-helm-reference-check
 trigger:
   ref:
@@ -1683,7 +1683,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: write-key
 - commands:
   - make BUILD_IN_CONTAINER=false packages
@@ -1691,7 +1691,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: test packaging
 - commands:
   - ./tools/packaging/verify-deb-install.sh
@@ -1717,7 +1717,7 @@ steps:
     NFPM_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: publish
   when:
     event:
@@ -1752,7 +1752,7 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-  image: grafana/loki-build-image:0.30.1
+  image: grafana/loki-build-image:0.31.2
   name: build and push
   privileged: true
   volumes:
@@ -2017,6 +2017,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 7c5fb8417ab5efd5a15164aa57eef618e3cf79d2578078ce29c888b3eb01e7ff
+hmac: 446f2c171d5ebf6a59c4b0c13d2479b1ffdc3d324b6977de3997eb0b2431e2b1
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,5 +88,8 @@ issues:
     - Error return value of .*log\.Logger\)\.Log\x60 is not checked
     - Error return value of .*.Log.* is not checked
     - Error return value of `` is not checked
-
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters:
+        - goconst
   fix: true

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 BUILD_IN_CONTAINER ?= true
 
 # ensure you run `make drone` after changing this
-BUILD_IMAGE_VERSION := 0.30.1
+BUILD_IMAGE_VERSION ?= 0.31.2
 
 # Docker image info
 IMAGE_PREFIX ?= grafana

--- a/clients/pkg/logentry/stages/metrics.go
+++ b/clients/pkg/logentry/stages/metrics.go
@@ -179,6 +179,7 @@ func (m *metricStage) Name() string {
 }
 
 // recordCounter will update a counter metric
+// nolint:goconst
 func (m *metricStage) recordCounter(name string, counter *metric.Counters, labels model.LabelSet, v interface{}) {
 	// If value matching is defined, make sure value matches.
 	if counter.Cfg.Value != nil {

--- a/clients/pkg/logentry/stages/pack_test.go
+++ b/clients/pkg/logentry/stages/pack_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst
 package stages
 
 import (

--- a/clients/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget_test.go
@@ -1,6 +1,7 @@
 //go:build linux && cgo && promtail_journal_enabled
 // +build linux,cgo,promtail_journal_enabled
 
+// nolint:goconst
 package journal
 
 import (

--- a/clients/pkg/promtail/targets/journal/journaltarget_test.go
+++ b/clients/pkg/promtail/targets/journal/journaltarget_test.go
@@ -1,7 +1,6 @@
 //go:build linux && cgo && promtail_journal_enabled
 // +build linux,cgo,promtail_journal_enabled
 
-// nolint:goconst
 package journal
 
 import (

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/grafana/loki/integration/util"
+
 	"github.com/grafana/loki/pkg/loki"
 	"github.com/grafana/loki/pkg/storage"
 	"github.com/grafana/loki/pkg/storage/config"

--- a/pkg/bloomgateway/querier_test.go
+++ b/pkg/bloomgateway/querier_test.go
@@ -19,7 +19,7 @@ type noopClient struct {
 }
 
 // FilterChunks implements Client.
-func (c *noopClient) FilterChunks(ctx context.Context, tenant string, from, through model.Time, groups []*logproto.GroupedChunkRefs, filters ...*logproto.LineFilterExpression) ([]*logproto.GroupedChunkRefs, error) {
+func (c *noopClient) FilterChunks(ctx context.Context, tenant string, from, through model.Time, groups []*logproto.GroupedChunkRefs, filters ...*logproto.LineFilterExpression) ([]*logproto.GroupedChunkRefs, error) { // nolint:revive
 	c.callCount++
 	return groups, c.err
 }

--- a/pkg/bloomgateway/sharding.go
+++ b/pkg/bloomgateway/sharding.go
@@ -87,12 +87,13 @@ func (s *ShuffleShardingStrategy) FilterTenants(_ context.Context, tenantIDs []s
 	return filteredIDs, nil
 }
 
+// nolint:revive
 func getBucket(rangeMin, rangeMax, pos uint64) int {
 	return 0
 }
 
 // FilterBlocks implements ShardingStrategy.
-func (s *ShuffleShardingStrategy) FilterBlocks(ctx context.Context, tenantID string, blockRefs []BlockRef) ([]BlockRef, error) {
+func (s *ShuffleShardingStrategy) FilterBlocks(_ context.Context, tenantID string, blockRefs []BlockRef) ([]BlockRef, error) {
 	filteredBlockRefs := make([]BlockRef, 0, len(blockRefs))
 
 	subRing := GetShuffleShardingSubring(s.r, tenantID, s.limits)
@@ -152,11 +153,11 @@ func NewNoopStrategy() *NoopStrategy {
 }
 
 // FilterTenants implements ShardingStrategy.
-func (s *NoopStrategy) FilterTenants(ctx context.Context, tenantIDs []string) ([]string, error) {
+func (s *NoopStrategy) FilterTenants(_ context.Context, tenantIDs []string) ([]string, error) {
 	return tenantIDs, nil
 }
 
 // FilterBlocks implements ShardingStrategy.
-func (s *NoopStrategy) FilterBlocks(ctx context.Context, tenantID string, blockRefs []BlockRef) ([]BlockRef, error) {
+func (s *NoopStrategy) FilterBlocks(_ context.Context, _ string, blockRefs []BlockRef) ([]BlockRef, error) {
 	return blockRefs, nil
 }

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -324,6 +324,7 @@ func (c *DefaultClient) doRequest(path, query string, quiet bool, out interface{
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
+// nolint:goconst
 func (c *DefaultClient) getHTTPRequestHeader() (http.Header, error) {
 	h := make(http.Header)
 

--- a/pkg/logcli/query/part_file.go
+++ b/pkg/logcli/query/part_file.go
@@ -36,7 +36,7 @@ func (f *PartFile) Exists() (bool, error) {
 	} else if errors.Is(err, os.ErrNotExist) {
 		// File does not exist.
 		return false, nil
-	} else {
+	} else { // nolint:revive
 		// Unclear if file exists or not, we cannot stat it.
 		return false, fmt.Errorf("failed to check if part file exists: %s: %s", f.finalName, err)
 	}

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -439,6 +439,6 @@ func TestAttributesToLabels(t *testing.T) {
 
 type fakeRetention struct{}
 
-func (f fakeRetention) RetentionPeriodFor(userID string, lbs labels.Labels) time.Duration {
+func (f fakeRetention) RetentionPeriodFor(_ string, _ labels.Labels) time.Duration {
 	return time.Hour
 }

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -298,7 +298,7 @@ func (q *query) Eval(ctx context.Context) (promql_parser.Value, error) {
 		}
 
 		defer util.LogErrorWithContext(ctx, "closing iterator", itr.Close)
-		streams, err := readStreams(itr, q.params.Limit(), q.params.Direction(), q.params.Interval(), true)
+		streams, err := readStreams(itr, q.params.Limit(), q.params.Direction(), q.params.Interval())
 		return streams, err
 	default:
 		return nil, fmt.Errorf("unexpected type (%T): cannot evaluate", e)
@@ -508,7 +508,7 @@ func PopulateMatrixFromScalar(data promql.Scalar, params Params) promql.Matrix {
 // If categorizeLabels is true, the stream labels contains just the stream labels and entries inside each stream have their
 // structuredMetadata and parsed fields populated with structured metadata labels plus the parsed labels respectively.
 // Otherwise, the stream labels are the whole series labels including the stream labels, structured metadata labels and parsed labels.
-func readStreams(i iter.EntryIterator, size uint32, dir logproto.Direction, interval time.Duration, categorizeLabels bool) (logqlmodel.Streams, error) {
+func readStreams(i iter.EntryIterator, size uint32, dir logproto.Direction, interval time.Duration) (logqlmodel.Streams, error) {
 	streams := map[string]*logproto.Stream{}
 	respSize := uint32(0)
 	// lastEntry should be a really old time so that the first comparison is always true, we use a negative

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -740,7 +740,7 @@ func matchingSignature(sample promql.Sample, opts *syntax.BinOpOptions) uint64 {
 	} else if opts.VectorMatching.On {
 		return labels.NewBuilder(sample.Metric).Keep(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 	}
-	
+
 	return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 }
 

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -739,9 +739,9 @@ func matchingSignature(sample promql.Sample, opts *syntax.BinOpOptions) uint64 {
 		return sample.Metric.Hash()
 	} else if opts.VectorMatching.On {
 		return labels.NewBuilder(sample.Metric).Keep(opts.VectorMatching.MatchingLabels...).Labels().Hash()
-	} else {
-		return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 	}
+	
+	return labels.NewBuilder(sample.Metric).Del(opts.VectorMatching.MatchingLabels...).Labels().Hash()
 }
 
 func vectorBinop(op string, opts *syntax.BinOpOptions, lhs, rhs promql.Vector, lsigs, rsigs []uint64) (promql.Vector, error) {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -113,11 +113,11 @@ func (c *ConfigWrapper) ApplyDynamicConfig() cfg.Source {
 		}
 
 		if i := lastBoltdbShipperConfig(r.SchemaConfig.Configs); i != len(r.SchemaConfig.Configs) {
-			betterBoltdbShipperDefaults(r, &defaults, r.SchemaConfig.Configs[i])
+			betterBoltdbShipperDefaults(r)
 		}
 
 		if i := lastTSDBConfig(r.SchemaConfig.Configs); i != len(r.SchemaConfig.Configs) {
-			betterTSDBShipperDefaults(r, &defaults, r.SchemaConfig.Configs[i])
+			betterTSDBShipperDefaults(r)
 		}
 
 		applyEmbeddedCacheConfig(r)
@@ -575,7 +575,7 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 	return nil
 }
 
-func betterBoltdbShipperDefaults(cfg, defaults *ConfigWrapper, period config.PeriodConfig) {
+func betterBoltdbShipperDefaults(cfg *ConfigWrapper) {
 	if cfg.Common.PathPrefix != "" {
 		prefix := strings.TrimSuffix(cfg.Common.PathPrefix, "/")
 
@@ -589,7 +589,7 @@ func betterBoltdbShipperDefaults(cfg, defaults *ConfigWrapper, period config.Per
 	}
 }
 
-func betterTSDBShipperDefaults(cfg, defaults *ConfigWrapper, period config.PeriodConfig) {
+func betterTSDBShipperDefaults(cfg *ConfigWrapper) {
 	if cfg.Common.PathPrefix != "" {
 		prefix := strings.TrimSuffix(cfg.Common.PathPrefix, "/")
 

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -250,7 +250,7 @@ func (c *Config) Validate() error {
 	if err := c.CompactorConfig.Validate(); err != nil {
 		return errors.Wrap(err, "invalid compactor config")
 	}
-	if err := c.ChunkStoreConfig.Validate(util_log.Logger); err != nil {
+	if err := c.ChunkStoreConfig.Validate(); err != nil {
 		return errors.Wrap(err, "invalid chunk store config")
 	}
 	if err := c.QueryRange.Validate(); err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -782,7 +782,7 @@ func (t *Loki) setupAsyncStore() error {
 }
 
 func (t *Loki) initIngesterQuerier() (_ services.Service, err error) {
-	t.ingesterQuerier, err = querier.NewIngesterQuerier(t.Cfg.IngesterClient, t.ring, t.Cfg.Querier.ExtraQueryDelay, t.Cfg.MetricsNamespace)
+	t.ingesterQuerier, err = querier.NewIngesterQuerier(t.Cfg.IngesterClient, t.ring, t.Cfg.Querier.ExtraQueryDelay)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -228,7 +228,7 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 	}
 }
 
-func testFrontend(t *testing.T, config Config, handler queryrangebase.Handler, test func(addr string, frontend *Frontend), matchMaxConcurrency bool, reg prometheus.Registerer) {
+func testFrontend(t *testing.T, config Config, handler queryrangebase.Handler, test func(addr string, frontend *Frontend), _ bool, reg prometheus.Registerer) {
 	logger := log.NewNopLogger()
 
 	var workerConfig querier_worker.Config

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -201,10 +201,10 @@ func (q *QuerierAPI) TailHandler(w http.ResponseWriter, r *http.Request) {
 					break
 				} else if tailer.stopped {
 					return
-				} else {
-					level.Error(logger).Log("msg", "Unexpected error from client", "err", err)
-					break
 				}
+
+				level.Error(logger).Log("msg", "Unexpected error from client", "err", err)
+				break
 			}
 		}
 		doneChan <- struct{}{}

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -41,17 +41,17 @@ type IngesterQuerier struct {
 	extraQueryDelay time.Duration
 }
 
-func NewIngesterQuerier(clientCfg client.Config, ring ring.ReadRing, extraQueryDelay time.Duration, metricsNamespace string) (*IngesterQuerier, error) {
+func NewIngesterQuerier(clientCfg client.Config, ring ring.ReadRing, extraQueryDelay time.Duration) (*IngesterQuerier, error) {
 	factory := func(addr string) (ring_client.PoolClient, error) {
 		return client.New(clientCfg, addr)
 	}
 
-	return newIngesterQuerier(clientCfg, ring, extraQueryDelay, ring_client.PoolAddrFunc(factory), metricsNamespace)
+	return newIngesterQuerier(clientCfg, ring, extraQueryDelay, ring_client.PoolAddrFunc(factory))
 }
 
 // newIngesterQuerier creates a new IngesterQuerier and allows to pass a custom ingester client factory
 // used for testing purposes
-func newIngesterQuerier(clientCfg client.Config, ring ring.ReadRing, extraQueryDelay time.Duration, clientFactory ring_client.PoolFactory, metricsNamespace string) (*IngesterQuerier, error) {
+func newIngesterQuerier(clientCfg client.Config, ring ring.ReadRing, extraQueryDelay time.Duration, clientFactory ring_client.PoolFactory) (*IngesterQuerier, error) {
 	iq := IngesterQuerier{
 		ring:            ring,
 		pool:            clientpool.NewPool("ingester", clientCfg.PoolConfig, ring, clientFactory, util_log.Logger),

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
-	"github.com/grafana/loki/pkg/util/constants"
 )
 
 func TestIngesterQuerier_earlyExitOnQuorum(t *testing.T) {
@@ -105,7 +104,6 @@ func TestIngesterQuerier_earlyExitOnQuorum(t *testing.T) {
 					newReadRingMock(ringIngesters, 1),
 					mockQuerierConfig().ExtraQueryDelay,
 					newIngesterClientMockFactory(ingesterClient),
-					constants.Loki,
 				)
 				require.NoError(t, err)
 
@@ -205,7 +203,6 @@ func TestIngesterQuerier_earlyExitOnQuorum(t *testing.T) {
 					newReadRingMock(ringIngesters, 1),
 					mockQuerierConfig().ExtraQueryDelay,
 					newIngesterClientMockFactory(ingesterClient),
-					constants.Loki,
 				)
 				require.NoError(t, err)
 
@@ -303,7 +300,6 @@ func TestQuerier_tailDisconnectedIngesters(t *testing.T) {
 				newReadRingMock(testData.ringIngesters, 0),
 				mockQuerierConfig().ExtraQueryDelay,
 				newIngesterClientMockFactory(ingesterClient),
-				constants.Loki,
 			)
 			require.NoError(t, err)
 
@@ -366,7 +362,6 @@ func TestIngesterQuerier_Volume(t *testing.T) {
 			newReadRingMock([]ring.InstanceDesc{mockInstanceDesc("1.1.1.1", ring.ACTIVE), mockInstanceDesc("3.3.3.3", ring.ACTIVE)}, 0),
 			mockQuerierConfig().ExtraQueryDelay,
 			newIngesterClientMockFactory(ingesterClient),
-			constants.Loki,
 		)
 		require.NoError(t, err)
 
@@ -387,7 +382,6 @@ func TestIngesterQuerier_Volume(t *testing.T) {
 			newReadRingMock([]ring.InstanceDesc{mockInstanceDesc("1.1.1.1", ring.ACTIVE), mockInstanceDesc("3.3.3.3", ring.ACTIVE)}, 0),
 			mockQuerierConfig().ExtraQueryDelay,
 			newIngesterClientMockFactory(ingesterClient),
-			constants.Loki,
 		)
 		require.NoError(t, err)
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
 	"github.com/grafana/loki/pkg/storage"
-	"github.com/grafana/loki/pkg/util/constants"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -1287,7 +1286,7 @@ func TestQuerier_SelectSamplesWithDeletes(t *testing.T) {
 }
 
 func newQuerier(cfg Config, clientCfg client.Config, clientFactory ring_client.PoolFactory, ring ring.ReadRing, dg *mockDeleteGettter, store storage.Store, limits *validation.Overrides) (*SingleTenantQuerier, error) {
-	iq, err := newIngesterQuerier(clientCfg, ring, cfg.ExtraQueryDelay, clientFactory, constants.Loki)
+	iq, err := newIngesterQuerier(clientCfg, ring, cfg.ExtraQueryDelay, clientFactory)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -706,6 +706,7 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 	}
 }
 
+// nolint:goconst
 func (c Codec) Path(r queryrangebase.Request) string {
 	switch request := r.(type) {
 	case *LokiRequest:

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -333,9 +333,9 @@ func (confs ShardingConfigs) ValidRange(start, end int64) (config.PeriodConfig, 
 		} else if end < int64(confs[i+1].From.Time) {
 			// The request is entirely scoped into this shard config
 			return conf, nil
-		} else {
-			continue
 		}
+
+		continue
 	}
 
 	return config.PeriodConfig{}, errInvalidShardingRange

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -189,7 +189,7 @@ func NewMiddleware(
 		return nil, nil, err
 	}
 
-	instantMetricTripperware, err := NewInstantMetricTripperware(cfg, engineOpts, log, limits, schema, codec, metrics, indexStatsTripperware, metricsNamespace)
+	instantMetricTripperware, err := NewInstantMetricTripperware(cfg, engineOpts, log, limits, schema, metrics, indexStatsTripperware, metricsNamespace)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -704,7 +704,6 @@ func NewInstantMetricTripperware(
 	log log.Logger,
 	limits Limits,
 	schema config.SchemaConfig,
-	merger base.Merger,
 	metrics *Metrics,
 	indexStatsTripperware base.Middleware,
 	metricsNamespace string,

--- a/pkg/querier/worker_service_test.go
+++ b/pkg/querier/worker_service_test.go
@@ -16,7 +16,7 @@ import (
 		querier_worker "github.com/grafana/loki/pkg/querier/worker"
 	*/)
 
-func Test_InitQuerierService(t *testing.T) {
+func Test_InitQuerierService(_ *testing.T) {
 
 	// TODO: use in modules test
 	/*

--- a/pkg/storage/bloom/v1/bloom_tokenizer.go
+++ b/pkg/storage/bloom/v1/bloom_tokenizer.go
@@ -58,7 +58,7 @@ func (bt *BloomTokenizer) SetLineTokenizer(t Tokenizer) {
 }
 
 // TODO: Something real here with metrics
-func newMetrics(r prometheus.Registerer) *metrics {
+func newMetrics(_ prometheus.Registerer) *metrics {
 	return &metrics{}
 }
 

--- a/pkg/storage/bloom/v1/filter/buckets.go
+++ b/pkg/storage/bloom/v1/filter/buckets.go
@@ -184,7 +184,7 @@ func (b *Buckets) ReadFrom(stream io.Reader) (int64, error) {
 		return 0, err
 	}
 
-	var len uint64
+	var len uint64 // nolint:revive
 	err = binary.Read(stream, binary.BigEndian, &len)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/bloom/v1/filter/partitioned.go
+++ b/pkg/storage/bloom/v1/filter/partitioned.go
@@ -286,7 +286,7 @@ func (p *PartitionedBloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 		return 0, err
 	}
 
-	var len uint64
+	var len uint64 // nolint:revive
 	err = binary.Read(stream, binary.BigEndian, &len)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/bloom/v1/filter/scalable.go
+++ b/pkg/storage/bloom/v1/filter/scalable.go
@@ -309,7 +309,7 @@ func (s *ScalableBloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 		return 0, err
 	}
 
-	var len uint64
+	var len uint64 // nolint:revive
 	err = binary.Read(stream, binary.BigEndian, &len)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/bloom/v1/fuse_test.go
+++ b/pkg/storage/bloom/v1/fuse_test.go
@@ -178,6 +178,7 @@ func BenchmarkBlockQuerying(b *testing.B) {
 				context.Background(),
 				len(requestChains), len(requestChains),
 				func(_ context.Context, idx int) error {
+					// nolint:revive
 					for range requestChains[idx][0].response {
 					}
 					return nil

--- a/pkg/storage/chunk/client/congestion/config.go
+++ b/pkg/storage/chunk/client/congestion/config.go
@@ -38,6 +38,7 @@ func (c *ControllerConfig) RegisterFlags(f *flag.FlagSet) {
 	c.RegisterFlagsWithPrefix("", f)
 }
 
+// nolint:goconst
 func (c *ControllerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.Strategy, prefix+"strategy", "", "Congestion control strategy to use (default: none, options: 'aimd').")
 	f.UintVar(&c.AIMD.Start, prefix+"strategy.aimd.start", 2000, "AIMD starting throughput window size: how many requests can be sent per second (default: 2000).")

--- a/pkg/storage/config/store.go
+++ b/pkg/storage/config/store.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/pkg/storage/chunk/cache"
@@ -43,6 +42,6 @@ func (cfg *ChunkStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", "Cache index entries older than this period. 0 to disable.")
 }
 
-func (cfg *ChunkStoreConfig) Validate(logger log.Logger) error {
+func (cfg *ChunkStoreConfig) Validate() error {
 	return nil
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -420,7 +420,7 @@ func NewIndexClient(periodCfg config.PeriodConfig, tableRange config.TableRange,
 					return indexGatewayClient, nil
 				}
 
-				gateway, err := gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, limits, logger, metricsNamespace)
+				gateway, err := gatewayclient.NewGatewayClient(cfg.BoltDBShipperConfig.IndexGatewayClientConfig, registerer, limits, logger)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -266,7 +266,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 	if p.IndexType == config.TSDBType {
 		if shouldUseIndexGatewayClient(s.cfg.TSDBShipperConfig.Config) {
 			// inject the index-gateway client into the index store
-			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.limits, indexClientLogger, s.metricsNamespace)
+			gw, err := gatewayclient.NewGatewayClient(s.cfg.TSDBShipperConfig.IndexGatewayClientConfig, indexClientReg, s.limits, indexClientLogger)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/storage/stores/shipper/bloomshipper/store_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/store_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func TestBloomShipper(t *testing.T) {
+func TestBloomShipper(_ *testing.T) {
 }
 
-func TestBloomStore(t *testing.T) {
+func TestBloomStore(_ *testing.T) {
 }

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client.go
@@ -109,7 +109,7 @@ type GatewayClient struct {
 //
 // If it is configured to be in ring mode, a pool of GRPC connections to all Index Gateway instances is created using a ring.
 // Otherwise, it creates a GRPC connection pool to as many addresses as can be resolved from the given address.
-func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, limits indexgateway.Limits, logger log.Logger, metricsNamespace string) (*GatewayClient, error) {
+func NewGatewayClient(cfg IndexGatewayClientConfig, r prometheus.Registerer, limits indexgateway.Limits, logger log.Logger) (*GatewayClient, error) {
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: constants.Loki,
 		Name:      "index_gateway_request_duration_seconds",

--- a/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/gatewayclient/gateway_client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/storage/stores/series/index"
 	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/indexgateway"
-	"github.com/grafana/loki/pkg/util/constants"
 	"github.com/grafana/loki/pkg/validation"
 )
 
@@ -192,7 +191,7 @@ func TestGatewayClient_RingMode(t *testing.T) {
 		cfg.Mode = indexgateway.RingMode
 		cfg.Ring = igwRing
 
-		c, err := NewGatewayClient(cfg, nil, o, logger, constants.Loki)
+		c, err := NewGatewayClient(cfg, nil, o, logger)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -223,7 +222,7 @@ func TestGatewayClient_RingMode(t *testing.T) {
 		cfg.Mode = indexgateway.RingMode
 		cfg.Ring = igwRing
 
-		c, err := NewGatewayClient(cfg, nil, o, logger, constants.Loki)
+		c, err := NewGatewayClient(cfg, nil, o, logger)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -254,7 +253,7 @@ func TestGatewayClient(t *testing.T) {
 	cfg.PoolConfig = clientpool.PoolConfig{ClientCleanupPeriod: 500 * time.Millisecond}
 
 	overrides, _ := validation.NewOverrides(validation.Limits{}, nil)
-	gatewayClient, err := NewGatewayClient(cfg, prometheus.DefaultRegisterer, overrides, logger, constants.Loki)
+	gatewayClient, err := NewGatewayClient(cfg, prometheus.DefaultRegisterer, overrides, logger)
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), "fake")
@@ -441,11 +440,11 @@ func TestDoubleRegistration(t *testing.T) {
 		Address: "my-store-address:1234",
 	}
 
-	client, err := NewGatewayClient(clientCfg, r, o, logger, constants.Loki)
+	client, err := NewGatewayClient(clientCfg, r, o, logger)
 	require.NoError(t, err)
 	defer client.Stop()
 
-	client, err = NewGatewayClient(clientCfg, r, o, logger, constants.Loki)
+	client, err = NewGatewayClient(clientCfg, r, o, logger)
 	require.NoError(t, err)
 	defer client.Stop()
 }

--- a/tools/deprecated-config-checker/main.go
+++ b/tools/deprecated-config-checker/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+
 	"github.com/grafana/loki/tools/deprecated-config-checker/checker"
 )
 

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -37,6 +37,7 @@ func (w *specWriter) writeConfigBlock(b *parse.ConfigBlock, indent int) {
 	}
 }
 
+// nolint:goconst
 func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 	if e.Kind == parse.KindBlock {
 		// If the block is a root block it will have its dedicated section in the doc,

--- a/tools/tsdb/bloom-tester/concurrent.go
+++ b/tools/tsdb/bloom-tester/concurrent.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
 type pool struct {

--- a/tools/tsdb/bloom-tester/lib.go
+++ b/tools/tsdb/bloom-tester/lib.go
@@ -507,7 +507,7 @@ func writeSBFToFile(sbf *filter.ScalableBloomFilter, filename string) error {
 	return err
 }
 
-func writeSBFToObjectStorage(sbf *filter.ScalableBloomFilter, objectStorageFilename, localFilename string, objectClient client.ObjectClient) {
+func writeSBFToObjectStorage(_ *filter.ScalableBloomFilter, objectStorageFilename, localFilename string, objectClient client.ObjectClient) {
 	// Probably a better way to do this than to reopen the file, but it's late
 	file, err := os.Open(localFilename)
 	if err != nil {

--- a/tools/tsdb/bloom-tester/lrucache_test.go
+++ b/tools/tsdb/bloom-tester/lrucache_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/binary"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var num = 1000000

--- a/tools/tsdb/bloom-tester/main.go
+++ b/tools/tsdb/bloom-tester/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/go-kit/log/level"
-	util_log "github.com/grafana/loki/pkg/util/log"
 	"os"
 	"strings"
+
+	"github.com/go-kit/log/level"
+
+	util_log "github.com/grafana/loki/pkg/util/log"
 )
 
 // go build ./tools/tsdb/bloom-tester && HOSTNAME="bloom-tester-121" NUM_TESTERS="128" BUCKET="19625" DIR=/Users/progers/dev/bloom WRITE_MODE="false" BUCKET_PREFIX="new-experiments" ./tools/tsdb/bloom-tester/bloom-tester --config.file=/Users/progers/dev/bloom/config.yaml

--- a/tools/tsdb/bloom-tester/metrics.go
+++ b/tools/tsdb/bloom-tester/metrics.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	bt "github.com/grafana/loki/pkg/storage/bloom/v1"
-	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	bt "github.com/grafana/loki/pkg/storage/bloom/v1"
+	"github.com/grafana/loki/pkg/storage/bloom/v1/filter"
 )
 
 type Experiment struct {
@@ -36,7 +37,7 @@ func NewQueryExperiment(name string, searchString string) QueryExperiment {
 const ExperimentLabel = "experiment"
 const QueryExperimentLabel = "query_experiment"
 const LookupResultType = "lookup_result_type"
-const FalsePositive = "false_postive"
+const FalsePositive = "false_positive"
 const FalseNegative = "false_negative"
 const TruePositive = "true_positive"
 const TrueNegative = "true_negative"

--- a/tools/tsdb/bloom-tester/readlib.go
+++ b/tools/tsdb/bloom-tester/readlib.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/dskit/services"
+
 	"github.com/grafana/loki/pkg/chunkenc"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql/log"

--- a/tools/tsdb/bloom-tester/readlib_test.go
+++ b/tools/tsdb/bloom-tester/readlib_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchSbf(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This just updates the Loki build imaage changed in #11114.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
