### PR TITLE
[Style] Data source as two words.

### DIFF
--- a/docs/sources/configure/examples/query-frontend.md
+++ b/docs/sources/configure/examples/query-frontend.md
@@ -144,7 +144,7 @@ spec:
 
 ### Grafana
 
-Once you've deployed these, point your Grafana datasource to the new frontend service. The service is available within the cluster at `http://query-frontend.<namespace>.svc.cluster.local:3100`.
+Once you've deployed these, point your Grafana data source to the new frontend service. The service is available within the cluster at `http://query-frontend.<namespace>.svc.cluster.local:3100`.
 
 ### GRPC Mode (Pull model)
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -63,11 +63,11 @@ The write component returns `ready` when you point a web browser at http://local
 ## Use Grafana and the test environment
 
 Use [Grafana](/docs/grafana/latest/) to query and observe the log lines captured in the Loki cluster by navigating a browser to http://localhost:3000.
-The Grafana instance has Loki configured as a [datasource](/docs/grafana/latest/datasources/loki/).
+The Grafana instance has Loki configured as a [data source](/docs/grafana/latest/datasources/loki/).
 
 Click on the Grafana instance's [Explore](/docs/grafana/latest/explore/) icon to bring up the explore pane.
 
-Use the Explore dropdown menu to choose the Loki datasource and bring up the Loki query browser.
+Use the Explore dropdown menu to choose the Loki data source and bring up the Loki query browser.
 
 Try some queries.
 Enter your query into the **Log browser** box, and click on the blue **Run query** button.

--- a/docs/sources/operations/query-fairness/_index.md
+++ b/docs/sources/operations/query-fairness/_index.md
@@ -113,9 +113,9 @@ In the examples above the client that invoked the query directly against Loki al
 HTTP header that controls where in the queue tree the sub-queries are enqueued. However, as an operator,
 you would usually want to avoid this scenario and control yourself where the header is set.
 
-When using Grafana as the Loki user interface, you can, for example, create multiple datasources
+When using Grafana as the Loki user interface, you can, for example, create multiple data sources
 with the same tenant, but with a different additional HTTP header
-`X-Loki-Scope-Actor` and restrict which Grafana user can use which datasource.
+`X-Loki-Scope-Actor` and restrict which Grafana user can use which data source.
 
 Alternatively, if you have a proxy for authentication in front of Loki, you can
 pass the (hashed) user from the authentication as downstream header to Loki.

--- a/docs/sources/operations/troubleshooting.md
+++ b/docs/sources/operations/troubleshooting.md
@@ -11,7 +11,7 @@ aliases:
 ## "Loki: Bad Gateway. 502"
 
 This error can appear in Grafana when Grafana Loki is added as a
-datasource, indicating that Grafana in unable to connect to Loki. There may
+data source, indicating that Grafana in unable to connect to Loki. There may
 one of many root causes:
 
 - If Loki is deployed with Docker, and Grafana and Loki are not running in the
@@ -24,7 +24,7 @@ one of many root causes:
 
 ## "Data source connected, but no labels received. Verify that Loki and Promtail is configured properly."
 
-This error can appear in Grafana when Loki is added as a datasource, indicating
+This error can appear in Grafana when Loki is added as a data source, indicating
 that although Grafana has connected to Loki, Loki hasn't received any logs from
 Promtail yet. There may be one of many root causes:
 

--- a/docs/sources/send-data/k6/query-scenario.md
+++ b/docs/sources/send-data/k6/query-scenario.md
@@ -22,7 +22,7 @@ Loki has 5 types of queries:
 * series query
 
 In a real-world use-case, such as querying Loki using it as a Grafana
-datasource, all of these queries are used. Each of them has a different
+data source, all of these queries are used. Each of them has a different
 [API]({{< relref "../../reference/api.md" >}}) endpoint. The xk6-loki extension
 provides a [Javascript API](https://github.com/grafana/xk6-loki#javascript-api)
 for all these query types.

--- a/docs/sources/visualize/grafana.md
+++ b/docs/sources/visualize/grafana.md
@@ -32,7 +32,7 @@ recent version to take advantage of [LogQL]({{< relref "../query/_index.md" >}})
    On Mac: `docker.for.mac.localhost` \
    On Windows: `docker.for.win.localhost`
 1. To see the logs, click <kbd>Explore</kbd> on the sidebar, select the Loki
-   datasource in the top-left dropdown, and then choose a log stream using the
+   data source in the top-left dropdown, and then choose a log stream using the
    <kbd>Log labels</kbd> button.
 1. Learn more about querying by reading about Loki's query language [LogQL]({{< relref "../query/_index.md" >}}).
 
@@ -40,6 +40,6 @@ Read more about Grafana's Explore feature in the
 [Grafana documentation](http://docs.grafana.org/features/explore) and on how to
 search and filter for logs with Loki.
 
-To configure Loki as a datasource via provisioning, see [Configuring Grafana via
+To configure Loki as a data source via provisioning, see [Configuring Grafana via
 Provisioning](http://docs.grafana.org/features/datasources/loki/#configure-the-datasource-with-provisioning).
 Set the URL in the provisioning.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating "datasource" to be "data source" per recent decision by Style Council.
