### PR TITLE
Extract query tags from HTTP requests.

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -378,6 +378,11 @@ func (Codec) DecodeHTTPGrpcRequest(ctx context.Context, r *httpgrpc.HTTPRequest)
 		}
 	}
 
+	// Add query tags
+	if queryTags := httpreq.ExtractQueryTagsFromHTTP(httpReq); queryTags != "" {
+		ctx = httpreq.InjectQueryTags(ctx, queryTags)
+	}
+
 	// If there is not encoding flags in the context, we try the HTTP request.
 	if encFlags := httpreq.ExtractEncodingFlagsFromCtx(ctx); encFlags == nil {
 		encFlags = httpreq.ExtractEncodingFlagsFromProto(r)

--- a/pkg/util/httpreq/tags.go
+++ b/pkg/util/httpreq/tags.go
@@ -25,16 +25,24 @@ func ExtractQueryTagsMiddleware() middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
-			tags := req.Header.Get(string(QueryTagsHTTPHeader))
-			tags = safeQueryTags.ReplaceAllString(tags, "_")
 
-			if tags != "" {
-				ctx = context.WithValue(ctx, QueryTagsHTTPHeader, tags)
+			if tags := ExtractQueryTagsFromHTTP(req); tags != "" {
+				ctx = InjectQueryTags(ctx, tags)
 				req = req.WithContext(ctx)
 			}
 			next.ServeHTTP(w, req)
 		})
 	})
+}
+
+func ExtractQueryTagsFromHTTP(req *http.Request) string {
+	tags := req.Header.Get(string(QueryTagsHTTPHeader))
+	return safeQueryTags.ReplaceAllString(tags, "_")
+}
+
+func InjectQueryTags(ctx context.Context, tags string) context.Context {
+	tags = safeQueryTags.ReplaceAllString(tags, "_")
+	return context.WithValue(ctx, QueryTagsHTTPHeader, tags)
 }
 
 func ExtractQueryMetricsMiddleware() middleware.Interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/grafana/loki/pull/10858 removed the code that would inject query tags into the context of the querier. This change adds an extraction in the decode method.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
