### PR TITLE
Default build-image target arch to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,15 +101,15 @@ RM := --rm
 # in any custom cloudbuild.yaml files
 TTY := --tty
 
-DOCKER_BUILDKIT=1
+DOCKER_BUILDKIT ?= 1
 BUILD_IMAGE = BUILD_IMAGE=$(IMAGE_PREFIX)/loki-build-image:$(BUILD_IMAGE_VERSION)
 PUSH_OCI=docker push
 TAG_OCI=docker tag
 ifeq ($(CI), true)
 	OCI_PLATFORMS=--platform=linux/amd64,linux/arm64
-	BUILD_OCI=docker buildx build $(OCI_PLATFORMS) --build-arg $(BUILD_IMAGE)
+	BUILD_OCI=DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build $(OCI_PLATFORMS) --build-arg $(BUILD_IMAGE)
 else
-	BUILD_OCI=docker build --build-arg $(BUILD_IMAGE)
+	BUILD_OCI=DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --build-arg $(BUILD_IMAGE)
 endif
 
 binfmt:

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -7,7 +7,7 @@
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
 FROM golang:1.21.3-bullseye as helm
-ARG TARGETARCH="amd64"
+ARG TARGETARCH
 ARG HELM_VER="v3.2.3"
 RUN curl -L "https://get.helm.sh/helm-${HELM_VER}-linux-$TARGETARCH.tar.gz" | tar zx && \
     install -t /usr/local/bin "linux-$TARGETARCH/helm"
@@ -16,7 +16,7 @@ RUN BIN=$([ "$TARGETARCH" = "arm64" ] && echo "helm-docs_Linux_arm64" || echo "h
     install -t /usr/local/bin helm-docs
 
 FROM alpine:3.18.4 as lychee
-ARG TARGETARCH="amd64"
+ARG TARGETARCH
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/lychee-$LYCHEE_VER.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-x86_64-unknown-linux-gnu.tar.gz && \
@@ -39,7 +39,7 @@ FROM alpine:3.18.4 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 FROM golang:1.21.3-bullseye as drone
-ARG TARGETARCH="amd64"
+ARG TARGETARCH
 RUN curl -L "https://github.com/drone/drone-cli/releases/download/v1.7.0/drone_linux_$TARGETARCH".tar.gz | tar zx && \
     install -t /usr/local/bin drone
 

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -7,7 +7,7 @@
 
 # Install helm (https://helm.sh/) and helm-docs (https://github.com/norwoodj/helm-docs) for generating Helm Chart reference.
 FROM golang:1.21.3-bullseye as helm
-ARG TARGETARCH
+ARG TARGETARCH="amd64"
 ARG HELM_VER="v3.2.3"
 RUN curl -L "https://get.helm.sh/helm-${HELM_VER}-linux-$TARGETARCH.tar.gz" | tar zx && \
     install -t /usr/local/bin "linux-$TARGETARCH/helm"
@@ -16,7 +16,7 @@ RUN BIN=$([ "$TARGETARCH" = "arm64" ] && echo "helm-docs_Linux_arm64" || echo "h
     install -t /usr/local/bin helm-docs
 
 FROM alpine:3.18.4 as lychee
-ARG TARGETARCH
+ARG TARGETARCH="amd64"
 ARG LYCHEE_VER="0.7.0"
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/lychee-$LYCHEE_VER.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VER}/lychee-${LYCHEE_VER}-x86_64-unknown-linux-gnu.tar.gz && \
@@ -39,7 +39,7 @@ FROM alpine:3.18.4 as docker
 RUN apk add --no-cache docker-cli docker-cli-buildx
 
 FROM golang:1.21.3-bullseye as drone
-ARG TARGETARCH
+ARG TARGETARCH="amd64"
 RUN curl -L "https://github.com/drone/drone-cli/releases/download/v1.7.0/drone_linux_$TARGETARCH".tar.gz | tar zx && \
     install -t /usr/local/bin drone
 

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache curl && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.1
 
 FROM alpine:3.18.4 as buf
-ARG TARGETOS="Linux"
+ARG TARGETOS
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$TARGETOS-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache curl && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.1
 
 FROM alpine:3.18.4 as buf
-ARG TARGETOS
+ARG TARGETOS="Linux"
 RUN apk add --no-cache curl && \
     curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$TARGETOS-$(uname -m)" -o "/usr/bin/buf" && \
     chmod +x "/usr/bin/buf"


### PR DESCRIPTION
**What this PR does / why we need it**:

The changes in https://github.com/grafana/loki/pull/11130 broke `make build-image` and `make build-image-push`. This defaults the target arch added in #11130 so those make targets still work.