### PR TITLE
Loki: fix mapping of non-retryable error codes

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -2,11 +2,11 @@ package logql
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -242,20 +242,10 @@ func (q *query) Exec(ctx context.Context) (logqlmodel.Result, error) {
 	statResult := statsCtx.Result(time.Since(start), queueTime, q.resultLength(data))
 	statResult.Log(level.Debug(spLogger))
 
-	status := "200"
-	if err != nil {
-		status = "500"
-		if errors.Is(err, logqlmodel.ErrParse) ||
-			errors.Is(err, logqlmodel.ErrPipeline) ||
-			errors.Is(err, logqlmodel.ErrLimit) ||
-			errors.Is(err, logqlmodel.ErrBlocked) ||
-			errors.Is(err, context.Canceled) {
-			status = "400"
-		}
-	}
+	status := logqlmodel.MapStatusCode(err)
 
 	if q.record {
-		RecordRangeAndInstantQueryMetrics(ctx, q.logger, q.params, status, statResult, data)
+		RecordRangeAndInstantQueryMetrics(ctx, q.logger, q.params, strconv.Itoa(status), statResult, data)
 	}
 
 	return logqlmodel.Result{

--- a/pkg/logqlmodel/error.go
+++ b/pkg/logqlmodel/error.go
@@ -1,6 +1,7 @@
 package logqlmodel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -93,4 +94,19 @@ func NewSeriesLimitError(limit int) *LimitError {
 // Is allows to use errors.Is(err,ErrLimit) on this error.
 func (e LimitError) Is(target error) bool {
 	return target == ErrLimit
+}
+
+func MapStatusCode(err error) int {
+	status := 200
+	if err != nil {
+		status = 500
+		if errors.Is(err, ErrParse) ||
+			errors.Is(err, ErrPipeline) ||
+			errors.Is(err, ErrLimit) ||
+			errors.Is(err, ErrBlocked) ||
+			errors.Is(err, context.Canceled) {
+			status = 400
+		}
+	}
+	return status
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fallout of a recent change to reduce complexity in our tripperware/middleware in #10688 lead to non-retryable errors being retried by the retry middleware in the frontend.

This PR is a solution to that problem, I'm not sure it's the best solution, but it's a solution....

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
  - [ ] If the change is worth mentioning in the release notes, add `add-to-release-notes` label
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
